### PR TITLE
Unrolled loop query

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -76,25 +76,19 @@ class ClearingDao extends Object
   }
 
   /**
-   * \brief get all the licenses for a single file or uploadtree
-   *
    * @param FileTreeBounds $fileTreeBounds
    * @return ClearingDecision[]
    */
   function getFileClearingsFolder(FileTreeBounds $fileTreeBounds)
   {
-
     //The first join to uploadtree is to find out if this is the same upload <= this needs to be uploadtree
     //The second gives all the clearing decisions which correspond to a filehash in the folder <= we can use the special upload table
-    $uploadTreeTable=$fileTreeBounds->getUploadTreeTableName();
+    $uploadTreeTable = $fileTreeBounds->getUploadTreeTableName();
 
     $sql_upload="";
     if ('uploadtree_a' == $uploadTreeTable) {
       $sql_upload = "ut.upload_fk=$1  and ";
     }
-
-    $secondJoin = " INNER JOIN ".$uploadTreeTable." ut ON CD.pfile_fk = ut.pfile_fk
-           WHERE $sql_upload ut.lft BETWEEN $2 and $3 ";
 
     $statementName = __METHOD__.$uploadTreeTable;
 
@@ -110,45 +104,97 @@ class ClearingDao extends Object
            CD.reportinfo AS reportinfo,
            CD.date_added AS date_added,
            ut2.upload_fk = $1 AS same_upload,
-           ut2.upload_fk = $1 and ut2.lft BETWEEN $2 and $3 AS is_local
+           ut2.upload_fk = $1 and ut2.lft BETWEEN $2 and $3 AS is_local,
+           LR.rf_pk as license_id,
+           LR.rf_shortname as shortname,
+           LR.rf_fullname  as fullname
          FROM clearing_decision CD
-         LEFT JOIN clearing_decision_types CD_types ON CD.type_fk=CD_types.type_pk
-         LEFT JOIN clearing_decision_scopes CD_scopes ON CD.scope_fk=CD_scopes.scope_pk
          LEFT JOIN users ON CD.user_fk=users.user_pk
          INNER JOIN uploadtree ut2 ON CD.uploadtree_fk = ut2.uploadtree_pk
-         $secondJoin
-         GROUP BY id,uploadtree_id,pfile_id,user_name,user_id,type,scope,comment,reportinfo,date_added,same_upload,is_local
+         INNER JOIN ".$uploadTreeTable." ut ON CD.pfile_fk = ut.pfile_fk
+         LEFT JOIN clearing_licenses CL on CL.clearing_fk = CD.clearing_pk
+         LEFT JOIN license_ref LR on CL.rf_fk=LR.rf_pk
+         LEFT JOIN clearing_decision_types CD_types ON CD.type_fk=CD_types.type_pk
+         LEFT JOIN clearing_decision_scopes CD_scopes ON CD.scope_fk=CD_scopes.scope_pk
+           WHERE ".$sql_upload." ut.lft BETWEEN $2 and $3
+         GROUP BY id,uploadtree_id,pfile_id,user_name,user_id,type,scope,comment,reportinfo,date_added,same_upload,is_local,
+         license_id, shortname, fullname
          ORDER by CD.pfile_fk, CD.clearing_pk desc";
 
-    $this->dbManager->prepare($statementName,
-     $sql);
+    $this->dbManager->prepare($statementName, $sql);
 
     // the array needs to be sorted with the newest clearingDecision first.
     $result = $this->dbManager->execute($statementName, array($fileTreeBounds->getUploadId(), $fileTreeBounds->getLeft(), $fileTreeBounds->getRight()));
     $clearingsWithLicensesArray = array();
 
+    $previousClearingId  = -1;
+    $licenses=array();
+    $clearingDecisionBuilder = ClearingDecisionBuilder::create();
+    $firstMatch = true;
     while ($row = $this->dbManager->fetchArray($result))
     {
-      $clearingDec = ClearingDecisionBuilder::create()
-          ->setSameUpload($this->dbManager->booleanFromDb($row['same_upload']))
-          ->setSameFolder($this->dbManager->booleanFromDb($row['is_local']))
-          ->setLicenses($this->getFileClearingLicenses($row['id']))
-          ->setClearingId($row['id'])
-          ->setUploadTreeId($row['uploadtree_id'])
-          ->setPfileId($row['pfile_id'])
-          ->setUserName($row['user_name'])
-          ->setUserId($row['user_id'])
-          ->setType($row['type'])
-          ->setComment($row['comment'])
-          ->setReportinfo($row['reportinfo'])
-          ->setScope($row['scope'])
-          ->setDateAdded($row['date_added'])
-          ->build();
+      $clearingId = $row['id'];
+      $licenseId = $row['license_id'];
+      $licenseShortName = $row['shortname'];
+      $licenseName = $row['fullname'];
+      $licenseIsRemoved = $row['removed'];
 
+
+      if($clearingId === $previousClearingId) {
+        //append To last finding
+        $this->appendToLicenses($licenseId, $licenseShortName, $licenseName, $licenseIsRemoved, $licenses);
+      }
+      else {
+        //store the old one
+        if(!$firstMatch) {
+          $clearingDec =$clearingDecisionBuilder->setLicenses($licenses)
+                                                ->build();
+          $clearingsWithLicensesArray[] = $clearingDec;
+        }
+
+        $firstMatch = false;
+        //prepare the new one
+        $previousClearingId  = $clearingId;
+        $licenses=array();
+        $clearingDecisionBuilder = ClearingDecisionBuilder::create()
+                                    ->setSameUpload($this->dbManager->booleanFromDb($row['same_upload']))
+                                    ->setSameFolder($this->dbManager->booleanFromDb($row['is_local']))
+                                    ->setClearingId($row['id'])
+                                    ->setUploadTreeId($row['uploadtree_id'])
+                                    ->setPfileId($row['pfile_id'])
+                                    ->setUserName($row['user_name'])
+                                    ->setUserId($row['user_id'])
+                                    ->setType($row['type_id'])
+                                    ->setScope($this->dbManager->booleanFromDb($row['is_global']) ? "global" : "upload")
+                                    ->setDateAdded($row['date_added']);
+
+        $this->appendToLicenses($licenseId, $licenseShortName, $licenseName, $licenseIsRemoved, $licenses);
+
+      }
+    }
+
+    //! Add the last match
+    if(!$firstMatch)
+    {
+      $clearingDec = $clearingDecisionBuilder->setLicenses($licenses)
+          ->build();
       $clearingsWithLicensesArray[] = $clearingDec;
     }
+
     $this->dbManager->freeResult($result);
     return $clearingsWithLicensesArray;
+  }
+
+  /**
+   * @param $licenseId
+   * @param $licenseShortName
+   * @param $licenseName
+   * @param $licenses
+   */
+  protected function appendToLicenses($licenseId, $licenseShortName, $licenseName,  &$licenses)
+  {
+    $licenseRef = new LicenseRef($licenseId, $licenseShortName, $licenseName);
+    $licenses[] = $licenseRef;
   }
 
   /**


### PR DESCRIPTION
This addresses Bug #7809

The remaining use of uploadtree is unfortunately unavoidable as it tries to find out if the decision is made on the same upload.

I created a new pull request  where I have unrolled the loop  for the licenses in the decision. We have made good experiences with this kind of performance optimizations.
