### PR TITLE
Include -v switch support. Fixes bug #7911

### DIFF
--- a/src/wget_agent/agent/main.c
+++ b/src/wget_agent/agent/main.c
@@ -137,7 +137,9 @@ int main  (int argc, char *argv[])
       case 'C':
         CmdlineFlag = 1;
         break;
-      case 'v': break;
+      case 'v':
+        agent_verbose++;   // global agent verbose flag.
+        break;
       case 'V': 
        printf("%s", BuildVersion);
        SafeExit(0);


### PR DESCRIPTION
This simple change adds support for the verbosity switch (-v) from the command line into the wget_agent code.
