### PR TITLE
correct argument usage for memset() in wget_agent. Fixes bug #7917

### DIFF
--- a/src/wget_agent/agent/wget_agent.c
+++ b/src/wget_agent/agent/wget_agent.c
@@ -664,7 +664,7 @@ int Archivefs(char *Path, char *TempFile, char *TempFileDir, struct stat Status)
 
   if (S_ISDIR(Status.st_mode)) /** directory? */
   {
-    memset(CMD, MAXCMD, 0);
+    memset(CMD,'\0', MAXCMD);
     snprintf(CMD,MAXCMD-1, "tar -cvvf  '%s' -C '%s' ./ %s >/dev/null 2>&1", TempFile, Path, GlobalParam);
     rc_system = system(CMD);
     if (rc_system != 0)
@@ -674,7 +674,7 @@ int Archivefs(char *Path, char *TempFile, char *TempFileDir, struct stat Status)
     }
   } else if (strstr(Path, "*"))  // wildcards
   {
-    memset(CMD, MAXCMD, 0);
+    memset(CMD, '\0', MAXCMD);
     /* for the wildcards upload, keep the path */
     /* copy * files to TempFileDir/temp primarily */
     snprintf(CMD,MAXCMD-1, "mkdir -p %s/temp  > /dev/null 2>&1 && cp %s  %s/temp > /dev/null 2>&1", TempFileDir, Path, TempFileDir);
@@ -684,7 +684,7 @@ int Archivefs(char *Path, char *TempFile, char *TempFileDir, struct stat Status)
       LOG_FATAL("rc_system is:%d, CMD is:%s\n", rc_system, CMD);
       return 0;
     }
-    memset(CMD, MAXCMD, 0);
+    memset(CMD, '\0', MAXCMD);
     snprintf(CMD,MAXCMD-1, "tar -cvvf  '%s' -C %s/temp ./  > /dev/null 2>&1 && rm -rf %s/temp  > /dev/null 2>&1", TempFile, TempFileDir, TempFileDir);
     rc_system = system(CMD);
     if (rc_system != 0)
@@ -694,7 +694,7 @@ int Archivefs(char *Path, char *TempFile, char *TempFileDir, struct stat Status)
     }
   } else if(S_ISREG(Status.st_mode)) /** regular file? */
   {
-    memset(CMD, MAXCMD, 0);
+    memset(CMD, '\0', MAXCMD);
     snprintf(CMD,MAXCMD-1, "cp '%s' '%s' >/dev/null 2>&1", Path, TempFile);
     rc_system = system(CMD);
     if (rc_system != 0)


### PR DESCRIPTION
Corrected the 4 memset() instances in wget_agent that make was flagging. Ran make and confirmed no more error messages. Ran wget_agent from command line and confirmed correct operation.
