### PR TITLE
Fix non-portable regexp syntax

### DIFF
--- a/src/nomos/agent/STRINGS.in
+++ b/src/nomos/agent/STRINGS.in
@@ -8009,7 +8009,7 @@ k
 #
 %ENTRY% _TITLE_OPEN_CASCADE
 %KEY%	"licen[cs]e"
-%STR%	"open cascade (technology |)public licen[cs]e"
+%STR%	"open cascade (technology )?public licen[cs]e"
 #
 %ENTRY%	_MISC_DEBDATA
 %KEY%	=NULL=


### PR DESCRIPTION
In some regexp libraries implementations syntax "... |)" is not valid
and lead to errors similar to shown below:

$ nomossa *.c
Compile failed, regex #1679
regex = "open cascade (technology |)public licen[cs]e"
FATAL nomos_regex.c.49: regcomp failure: empty (sub)expression
$

This was reported few years back in defect #5907 and fixed for
majority of cases in commit 0885a419.
This commit fixes issue re-introduced by commit 8f2a3b9a.