### PR TITLE
generate SPDX v2.0 rdf report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,7 @@ variable.list
 /src/copyright/agent/ecc
 /src/copyright/VERSION-ecc
 /src/copyright/VERSION-copyright
+/src/spdx2/agent_tests/Functional/SPDXTools-v2.0.0.zip
+/src/spdx2/agent_tests/Functional/test-tool/
+/src/spdx2/agent/version.php
+/src/spdx2/agent/spdx2

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,6 +25,7 @@ DIRS = \
 	readmeoss \
 	reuser \
 	scheduler \
+	spdx2 \
 	ununpack \
 	wget_agent \
 	www

--- a/src/lib/php/Dao/TreeDao.php
+++ b/src/lib/php/Dao/TreeDao.php
@@ -60,7 +60,7 @@ class TreeDao extends Object
         WITH RECURSIVE file_tree(uploadtree_pk, parent, ufile_name, path, file_path, cycle) AS (
           SELECT ut.uploadtree_pk, ut.parent, ut.ufile_name,
             ARRAY[ut.uploadtree_pk],
-            ut.ufile_name,
+            CASE WHEN ut.ufile_mode & (1<<28) = 0 THEN ut.ufile_name ELSE '' END,
             false
           FROM $tableName ut
           WHERE ut.uploadtree_pk = $1
@@ -76,20 +76,13 @@ class TreeDao extends Object
         $params, $statementName);
 
     if (false === $row) {
-      throw new \Exception("could not find path of $itemId:\n$sql");
+      throw new \Exception("could not find path of $itemId:\n$sql--".print_r($params,true));
     }
 
     return $row['file_path'];
   }
 
-  /** @deprecated it takes too long: use getRealParent + getFull with a parent */
-  public function getShortPath($itemId, $tableName, $uploadId)
-  {
-    $parentId = $this->getRealParent($uploadId, $tableName);
-    return $this->getFullPath($itemId, $tableName, $parentId);
-  }
-
-  public function getRealParent($uploadId, $tableName)
+  public function getMinimalCoveringItem($uploadId, $tableName)
   {
     $statementName = __METHOD__.".".$tableName;
 
@@ -97,7 +90,7 @@ class TreeDao extends Object
       "SELECT uploadtree_pk FROM $tableName ut WHERE ut.upload_fk = $1
       AND NOT EXISTS (
         SELECT 1 FROM $tableName ut2 WHERE ut2.upload_fk = $1
-        AND (NOT (ut2.lft BETWEEN ut.lft AND ut.rgt))
+        AND NOT (ut2.lft BETWEEN ut.lft AND ut.rgt)
         AND (ut2.ufile_mode & (3<<28) = 0)
       )
       ORDER BY ut.lft DESC LIMIT 1",
@@ -106,6 +99,17 @@ class TreeDao extends Object
      );
 
      return $row ? $row['uploadtree_pk'] : 0;
+  }
+  
+  /**
+   * @param int $uploadtreeId
+   * @return array with keys sha1, md5
+   */
+  public function getItemHashes($uploadtreeId, $uploadtreeTablename='uploadtree')
+  {
+    $pfile = $this->dbManager->getSingleRow("SELECT pfile.* FROM $uploadtreeTablename, pfile WHERE uploadtree_pk=$1 AND pfile_fk=pfile_pk",
+        array($uploadtreeId), __METHOD__);
+    return array('sha1'=>$pfile['pfile_sha1'],'md5'=>$pfile['pfile_md5']);
   }
   
   public function getRepoPathOfPfile($pfileId, $repo="files")

--- a/src/lib/php/Dao/UploadDao.php
+++ b/src/lib/php/Dao/UploadDao.php
@@ -170,9 +170,12 @@ class UploadDao extends Object
     return $uploadStatus->getMap();
   }
 
-  public function getStatus($uploadId, $userId)
+  /**
+   * @brief unused function
+   */
+  public function getStatus($uploadId, $groupId)
   {
-    if (GetUploadPerm($uploadId, $userId) >= Auth::PERM_READ) {
+    if ($this->isAccessible($uploadId, $groupId)) {
       $row = $this->dbManager->getSingleRow("SELECT status_fk FROM upload_clearing WHERE upload_fk = $1", array($uploadId));
       if (false === $row) {
         throw new \Exception("cannot find uploadId=$uploadId");
@@ -280,7 +283,7 @@ class UploadDao extends Object
 
   /**
    * @param $uploadId
-   * @return mixed
+   * @return int uploadtreeId of top item
    */
   public function getUploadParent($uploadId)
   {
@@ -288,9 +291,12 @@ class UploadDao extends Object
     $statementname = __METHOD__ . $uploadTreeTableName;
 
     $parent = $this->dbManager->getSingleRow(
-        "select uploadtree_pk
-            from $uploadTreeTableName
-            where upload_fk=$1 and lft=1", array($uploadId), $statementname);
+        "SELECT uploadtree_pk
+            FROM $uploadTreeTableName
+            WHERE upload_fk=$1 AND parent IS NULL", array($uploadId), $statementname);
+    if(false === $parent) {
+      throw new \Exception("Missing upload tree parent for upload");
+    }
     return $parent['uploadtree_pk'];
   }
 
@@ -446,6 +452,17 @@ class UploadDao extends Object
         array($uploadId, $groupId), __METHOD__);
     return $perm['perm']>Auth::PERM_NONE;
   }
+  
+  public function isEditable($uploadId, $groupId) 
+  {
+    if ($_SESSION[Auth::USER_LEVEL] == PLUGIN_DB_ADMIN) {
+      return true;
+    }
+
+    $perm = $this->dbManager->getSingleRow('SELECT perm FROM perm_upload WHERE upload_fk=$1 AND group_fk=$2',
+        array($uploadId, $groupId), __METHOD__);
+    return $perm['perm']>=Auth::PERM_WRITE;
+  }
  
   public function makeAccessibleToAllGroupsOf($uploadId, $userId, $perm=null)
   {
@@ -459,4 +476,14 @@ class UploadDao extends Object
                array($perm, $uploadId, $userId), __METHOD__.'.insert');   
   }
  
+  /**
+   * @param int $uploadId
+   * @return array with keys sha1, md5
+   */
+  public function getUploadHashes($uploadId)
+  {
+    $pfile = $this->dbManager->getSingleRow('SELECT pfile.* FROM upload, pfile WHERE upload_pk=$1 AND pfile_fk=pfile_pk',
+        array($uploadId), __METHOD__);
+    return array('sha1'=>$pfile['pfile_sha1'],'md5'=>$pfile['pfile_md5']);
+  }
 }

--- a/src/lib/php/Dao/test/TreeDaoTest.php
+++ b/src/lib/php/Dao/test/TreeDaoTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Copyright (C) 2014, Siemens AG
+Copyright (C) 2014-2015, Siemens AG
 Author: Steffen Weber, Johannes Najjar
 
 This program is free software; you can redistribute it and/or
@@ -19,7 +19,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 namespace Fossology\Lib\Dao;
 
-use Fossology\Lib\Data\Tree\ItemTreeBounds;
 use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Test\TestPgDb;
 use Mockery as M;
@@ -38,55 +37,63 @@ class TreeDaoTest extends \PHPUnit_Framework_TestCase
     $this->testDb = new TestPgDb();
     $this->dbManager = &$this->testDb->getDbManager();
 
-    $this->testDb->createPlainTables(
-        array(
-            'upload',
-            'uploadtree',
-        ));
-
-    $this->testDb->insertData(
-        array());
+    $this->testDb->createPlainTables(array('upload','uploadtree'));
 
     $this->dbManager->prepare($stmt = 'insert.upload',
         "INSERT INTO upload (upload_pk, uploadtree_tablename) VALUES ($1, $2)");
-    $uploadArray = array(array(1, 'uploadtree'), array(2, 'uploadtree_a'));
+    $uploadArray = array(array(1, 'uploadtree'), array(32, 'uploadtree'));
     foreach ($uploadArray as $uploadEntry)
     {
       $this->dbManager->freeResult($this->dbManager->execute($stmt, $uploadEntry));
     }
     $this->treeDao = new TreeDao($this->dbManager);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
   }
 
   public function tearDown()
   {
+    $this->addToAssertionCount(\Hamcrest\MatcherAssert::getCount()-$this->assertCountBefore);
+        
     $this->testDb = null;
     $this->dbManager = null;
 
     M::close();
   }
-
-  public function testGetShortPathFromSingleFolderUpload()
+  
+  public function testGetMinimalCoveringItem()
   {
-    $this->prepareModularTable(array(array(6,5,1,0,0,5,6,"file")));
-
-    $path = $this->treeDao->getShortPath(6, "uploadtree", 1);
-    $this->assertEquals("file", $path);
+    $this->prepareModularTable(array());
+    $coverContainer = $this->treeDao->getMinimalCoveringItem(1, "uploadtree");
+    assertThat($coverContainer,equalTo(5));
+    
+    $this->prepareUploadTree(array(array($item=99,null,$upload=32,88,0x0,1,2,'plainFile',null)));
+    $coverSelf = $this->treeDao->getMinimalCoveringItem($upload, "uploadtree");
+    assertThat($coverSelf,equalTo($item));
+  }
+  
+  public function testGetFullPathFromSingleFolderUpload()
+  {
+    $this->prepareModularTable(array(array(6,5,1,0,0,5,6,$fName="file",5)));
+    $cover = $this->treeDao->getMinimalCoveringItem(1, "uploadtree");
+    assertThat($cover,equalTo(5));
+    $path = $this->treeDao->getFullPath(6, "uploadtree", $cover);
+    assertThat($path,equalTo($fName));
   }
 
-  public function testGetShortPathFromSingleFolderUploadWithAFileOutside()
+  public function testGetFullPathFromSingleFolderUploadWithAFileOutside()
   {
     $this->prepareModularTable(array(
-      array(6,5,1,0,0,5,6,"file"),
-      array(11,4,1,0,0,11,12,"file2")
+      array(6,5,1,0,0,5,6,"file",5),
+      array(11,4,1,0,0,11,12,"file2",3)
     ));
-    // file2 is outside of archive/ , but inside archive.tar.gz
+    $cover = $this->treeDao->getMinimalCoveringItem(1, "uploadtree");
+    assertThat($cover,equalTo(4));
 
-    $path = $this->treeDao->getShortPath(6, "uploadtree", 1);
-    $this->assertEquals("archive/file", $path);
+    $pathInsideArchive = $this->treeDao->getFullPath(6, "uploadtree", $cover);
+    assertThat($pathInsideArchive,equalTo("archive/file"));
 
-    $this->assertEquals(4, $this->treeDao->getRealParent(1, "uploadtree"));
-    $path = $this->treeDao->getShortPath(11, "uploadtree", 1);
-    $this->assertEquals("file2", $path);
+    $pathOutsideArchive = $this->treeDao->getFullPath(11, "uploadtree", $cover);
+    assertThat($pathOutsideArchive,equalTo("file2"));
   }
 
   /**
@@ -96,7 +103,7 @@ class TreeDaoTest extends \PHPUnit_Framework_TestCase
   protected function prepareUploadTree($uploadTreeArray = array())
   {
     $this->dbManager->prepare($stmt = 'insert.uploadtree',
-        "INSERT INTO uploadtree (uploadtree_pk, parent, upload_fk, pfile_fk, ufile_mode, lft, rgt, ufile_name) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)");
+        "INSERT INTO uploadtree (uploadtree_pk, parent, upload_fk, pfile_fk, ufile_mode, lft, rgt, ufile_name, realparent) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)");
     foreach ($uploadTreeArray as $uploadTreeEntry)
     {
       $this->dbManager->freeResult($this->dbManager->execute($stmt, $uploadTreeEntry));
@@ -114,63 +121,13 @@ class TreeDaoTest extends \PHPUnit_Framework_TestCase
 
     $uploadTreeArray = array_merge(
         array(
-            array(1, null, 1, 1, 536904704, 1, $right_base + 5, 'archive.tar.gz'),
-            array(2, 1, 1, 0, 805323776, 2, $right_base + 4, 'artifact.dir'),
-            array(3, 2, 1, 2, 536903680, 3, $right_base + 3, 'archive.tar'),
-            array(4, 3, 1, 0, 805323776, 4, $right_base + 2, 'artifact.dir'),
-            array(5, 4, 1, 0, 536888320, 5, $right_base + 1, 'archive')),
+            array(1, null, 1, 1, 0x20008400, 1, $right_base + 5, 'archive.tar.gz', null),
+            array(2,    1, 1, 0, 0x30004400, 2, $right_base + 4, 'artifact.dir', 1),
+            array(3,    2, 1, 2, 0x20008000, 3, $right_base + 3, 'archive.tar', 1),
+            array(4,    3, 1, 0, 0x30004400, 4, $right_base + 2, 'artifact.dir', 3),
+            array(5,    4, 1, 0, 0x20004400, 5, $right_base + 1, 'archive', 3)),
         $subentries);
     $this->prepareUploadTree($uploadTreeArray);
-  }
-
-  /**
-   * @return array
-   */
-  protected function getSubentriesForSingleFile()
-  {
-    return array(array(6, 5, 1, 3, 33188, 6, 10, 'README'));
-  }
-
-  /**
-   * @return array
-   */
-  protected function getSubentriesForNestedFile()
-  {
-    return array(
-        array(6, 5, 1, 0, 536888320, 7, 12, 'docs'),
-        array(7, 6, 1, 0, 536888320, 8, 11, 'txt'),
-        array(8, 7, 1, 3, 33188, 9, 10, 'README')
-    );
-  }
-
-  /**
-   * @return array
-   */
-  protected function getSubentriesForFileAfterEmptyDirectory()
-  {
-    /**
-     * docs      <-dir
-     * docs/txt  <-dir
-     * README    <-file
-     */
-
-    return array(
-        array(6, 5, 1, 0, 536888320, 7, 10, 'docs'),
-        array(7, 6, 1, 0, 536888320, 8, 9, 'txt'),
-        array(8, 5, 1, 3, 33188, 11, 12, 'README')
-    );
-  }
-
-  /**
-   * @return array
-   */
-  protected function getSubentriesForMultipleFiles()
-  {
-    return array(
-        array(6, 5, 1, 3, 33188, 7, 8, 'INSTALL'),
-        array(7, 5, 1, 4, 33188, 8, 9, 'README'),
-        array(8, 5, 1, 5, 33188, 9, 10, 'COPYING')
-    );
   }
 
   /**
@@ -212,72 +169,78 @@ class TreeDaoTest extends \PHPUnit_Framework_TestCase
    * P/P2/P2a                                           12               3658
    * P/P3                                               13               3660
    * R                                                  14               3686
-
    */
-
-  private $entries = array(
-      3653, 3668, 3683, 3685, 3671, 3665, 3676, 3675, 3681, 3677, 3673, 3658, 3660, 3686,
-  );
 
   protected function getTestFileStructure()
   {
     return array(
-        array(3675, 3674, 32, 3299, 33188, 23, 24, 'N3'),
-        array(3674, 3652, 32, 0, 536888320, 22, 37, 'N'),
-        array(3673, 3652, 32, 3298, 33188, 38, 39, 'O'),
-        array(3671, 3669, 32, 3296, 33188, 9, 10, 'J'),
-        array(3669, 3652, 32, 0, 536888320, 4, 11, 'H'),
-        array(3668, 3652, 32, 3294, 33188, 42, 43, 'C'),
-        array(3662, 3661, 32, 0, 536888320, 45, 48, 'L3'),
-        array(3666, 3661, 32, 0, 536888320, 49, 52, 'L1'),
-        array(3665, 3664, 32, 3292, 33188, 54, 55, 'L2a'),
-        array(3664, 3661, 32, 0, 536888320, 53, 56, 'L2'),
-        array(3661, 3652, 32, 0, 536888320, 44, 57, 'L'),
-        array(3658, 3657, 32, 3288, 33188, 60, 61, 'P2a'),
-        array(3657, 3656, 32, 0, 536888320, 59, 62, 'P2'),
-        array(3660, 3656, 32, 3290, 33188, 65, 66, 'P3'),
-        array(3656, 3652, 32, 0, 536888320, 58, 67, 'P'),
-        array(3655, 3654, 32, 0, 536888320, 69, 70, 'M1'),
-        array(3654, 3652, 32, 0, 536888320, 68, 71, 'M'),
-        array(3653, 3652, 32, 3287, 33188, 72, 73, 'A'),
-        array(3652, 3651, 32, 0, 536888320, 3, 74, 'uploadDaoTest'),
-        array(3651, 3650, 32, 0, 805323776, 2, 75, 'artifact.dir'),
-        array(3650, NULL, 32, 3286, 536904704, 1, 76, 'uploadDaoTest.tar'),
-        array(3686, 3652, 32, 3306, 33188, 12, 13, 'R'),
-        array(3683, 3682, 32, 3303, 33188, 15, 16, 'E'),
-        array(3685, 3682, 32, 3305, 33188, 17, 18, 'G'),
-        array(3682, 3652, 32, 0, 536888320, 14, 21, 'D'),
-        array(3677, 3674, 32, 3300, 33188, 25, 26, 'N5'),
-        array(3676, 3674, 32, 3293, 33188, 27, 28, 'N1'),
-        array(3678, 3674, 32, 0, 536888320, 29, 32, 'N2'),
-        array(3681, 3680, 32, 3302, 33188, 34, 35, 'N4a'),
-        array(3680, 3674, 32, 0, 536888320, 33, 36, 'N4'),
+        array(3675, 3674, 32, 3299, 33188, 23, 24, 'N3',3674),
+        array(3674, 3652, 32, 0, 0x20004400, 22, 37, 'N',3652),
+        array(3673, 3652, 32, 3298, 33188, 38, 39, 'O',3652),
+        array(3671, 3669, 32, 3296, 33188, 9, 10, 'J',3669),
+        array(3669, 3652, 32, 0, 0x20004400, 4, 11, 'H',3652),
+        array(3668, 3652, 32, 3294, 33188, 42, 43, 'C',3652),
+        array(3662, 3661, 32, 0, 0x20004400, 45, 48, 'L3',3661),
+        array(3666, 3661, 32, 0, 0x20004400, 49, 52, 'L1',3661),
+        array(3665, 3664, 32, 3292, 33188, 54, 55, 'L2a',3664),
+        array(3664, 3661, 32, 0, 0x20004400, 53, 56, 'L2',3661),
+        array(3661, 3652, 32, 0, 0x20004400, 44, 57, 'L',3652),
+        array(3658, 3657, 32, 3288, 33188, 60, 61, 'P2a',3657),
+        array(3657, 3656, 32, 0, 0x20004400, 59, 62, 'P2',3656),
+        array(3660, 3656, 32, 3290, 33188, 65, 66, 'P3',6356),
+        array(3656, 3652, 32, 0, 0x20004400, 58, 67, 'P',3652),
+        array(3655, 3654, 32, 0, 0x20004400, 69, 70, 'M1',3654),
+        array(3654, 3652, 32, 0, 0x20004400, 68, 71, 'M',3652),
+        array(3653, 3652, 32, 3287, 33188, 72, 73, 'A',3652),
+        array(3652, 3651, 32, 0, 0x20004400, 3, 74, 'uploadDaoTest',3650),
+        array(3651, 3650, 32, 0, 0x30004400, 2, 75, 'artifact.dir',3650),
+        array(3650, NULL, 32, 3286, 0x20008400, 1, 76, 'uploadDaoTest.tar',null),
+        array(3686, 3652, 32, 3306, 33188, 12, 13, 'R',3652),
+        array(3683, 3682, 32, 3303, 33188, 15, 16, 'E',3682),
+        array(3685, 3682, 32, 3305, 33188, 17, 18, 'G',3682),
+        array(3682, 3652, 32, 0, 0x20004400, 14, 21, 'D',3652),
+        array(3677, 3674, 32, 3300, 33188, 25, 26, 'N5',3674),
+        array(3676, 3674, 32, 3293, 33188, 27, 28, 'N1',3674),
+        array(3678, 3674, 32, 0, 0x20004400, 29, 32, 'N2',3674),
+        array(3681, 3680, 32, 3302, 33188, 34, 35, 'N4a',3680),
+        array(3680, 3674, 32, 0, 0x20004400, 33, 36, 'N4',3674),
     );
   }
 
-  public function testWithComlpexStructureFromFolder()
+  public function testGetFullPathWithComlpexStructureFromFolder()
   {
     $this->prepareUploadTree($this->getTestFileStructure());
-
-    $this->assertEquals("L/L1", $this->treeDao->getShortPath(3666, "uploadtree", 32));
+    $cover = $this->treeDao->getMinimalCoveringItem(32, "uploadtree");
+    assertThat($cover,equalTo(3652));
+    assertThat($this->treeDao->getFullPath(3666, "uploadtree", $cover),equalTo("L/L1"));
   }
 
-  public function testWithComlpexStructureFromFile()
+  public function testGetFullPathWithComlpexStructureFromFile()
   {
     $this->prepareUploadTree($this->getTestFileStructure());
-
-    $path = $this->treeDao->getShortPath(3665, "uploadtree", 32);
-    $this->assertEquals("L/L2/L2a", $path);
-    $this->assertEquals("uploadDaoTest.tar/uploadDaoTest/L/L2/L2a", $this->treeDao->getFullPath(3665, "uploadtree"));
+    $cover = $this->treeDao->getMinimalCoveringItem(32, "uploadtree");
+    assertThat($cover,equalTo(3652));
+    assertThat($this->treeDao->getFullPath(3665, "uploadtree", $cover),equalTo("L/L2/L2a"));
+    assertThat($this->treeDao->getFullPath(3665, "uploadtree"),equalTo("uploadDaoTest.tar/uploadDaoTest/L/L2/L2a"));
   }
 
-  public function testWithComlpexStructureFromFileAndOtherUpload()
+  public function testGetFullPathWithComlpexStructureFromFileAndOtherUpload()
   {
     $this->prepareUploadTree($this->getTestFileStructure());
-    $this->prepareModularTable(array(array(6,5,1,0,0,5,6,"file")));
-
-    $path = $this->treeDao->getShortPath(3665, "uploadtree", 32);
-    $this->assertEquals("L/L2/L2a", $path);
-    $this->assertEquals("uploadDaoTest.tar/uploadDaoTest/L/L2/L2a", $this->treeDao->getFullPath(3665, "uploadtree"));
+    $this->prepareModularTable(array(array(6,5,1,0,0,5,6,"file",6)));
+    $cover = $this->treeDao->getMinimalCoveringItem(32, "uploadtree");
+    assertThat($cover,equalTo(3652));
+    assertThat($this->treeDao->getFullPath(3665, "uploadtree", $cover),equalTo("L/L2/L2a"));
+    assertThat($this->treeDao->getFullPath(3665, "uploadtree"),equalTo("uploadDaoTest.tar/uploadDaoTest/L/L2/L2a"));
+  }
+  
+  public function testGetUploadHashes()
+  {
+    $this->testDb->createPlainTables(array('pfile'));
+    $this->dbManager->queryOnce('ALTER TABLE uploadtree RENAME TO uploadtree_a');
+    $this->testDb->insertData(array('uploadtree_a','pfile'));
+    // (pfile_pk, pfile_md5, pfile_sha1, pfile_size) := (4, '59CACDFCE5051CD8A1D8A1F2DCCE40A5', '04621571BCBABCE75C4DD1C6445B87DEC0995734', 12320);
+    $hashes = $this->treeDao->getItemHashes(7,'uploadtree_a');
+    assertThat($hashes,equalTo(array('md5'=>'59CACDFCE5051CD8A1D8A1F2DCCE40A5','sha1'=>'04621571BCBABCE75C4DD1C6445B87DEC0995734')));
   }
 }

--- a/src/lib/php/Proxy/LicenseViewProxy.php
+++ b/src/lib/php/Proxy/LicenseViewProxy.php
@@ -20,6 +20,8 @@ namespace Fossology\Lib\Proxy;
 
 class LicenseViewProxy extends DbViewProxy
 {
+  const CANDIDATE_PREFIX = 'candidatePrefix';
+  const OPT_COLUMNS = 'columns';
   /** @var int */
   private $groupId;
   /** @var array */
@@ -51,12 +53,12 @@ class LicenseViewProxy extends DbViewProxy
   
   private function queryLicenseCandidate($options)
   {
-    $columns = array_key_exists('columns', $options) ? $options['columns'] : $this->allColumns;
-    if(array_key_exists('candidatePrefix',$options)){
+    $columns = array_key_exists(self::OPT_COLUMNS, $options) ? $options[self::OPT_COLUMNS] : $this->allColumns;
+    if(array_key_exists(self::CANDIDATE_PREFIX,$options)){
       $shortnameId = array_search('rf_shortname',$columns);
-      if ($shortnameId)
+      if ($shortnameId!==false)
       {
-        $columns[$shortnameId] = "'". pg_escape_string($options['candidatePrefix']). '\'||rf_shortname AS rf_shortname';
+        $columns[$shortnameId] = "'". pg_escape_string($options[self::CANDIDATE_PREFIX]). '\'||rf_shortname AS rf_shortname';
       }
     }
     $gluedColumns = implode(',', $columns);
@@ -69,7 +71,7 @@ class LicenseViewProxy extends DbViewProxy
 }
   
   private function queryOnlyLicenseRef($options){
-    $columns = array_key_exists('columns', $options) ? $options['columns'] : $this->allColumns;
+    $columns = array_key_exists(self::OPT_COLUMNS, $options) ? $options[self::OPT_COLUMNS] : $this->allColumns;
     $groupFkPos = array_search('group_fk',$columns);
     if($groupFkPos){
       $columns[$groupFkPos] = '0 AS group_fk';

--- a/src/lib/php/Proxy/test/LicenseViewProxyTest.php
+++ b/src/lib/php/Proxy/test/LicenseViewProxyTest.php
@@ -73,8 +73,13 @@ class LicenseViewProxyTest extends \PHPUnit_Framework_TestCase
     $options2 = array('extraCondition'=>'rf_pk<100');
     $query2 = $method->invoke($licenseViewProxy,$options2);
     assertThat($query2, is("SELECT $this->almostAllColumns,group_fk FROM license_candidate WHERE group_fk=$groupId AND rf_pk<100"));
+    
+    $prefix = '#';
+    $options3 = array(LicenseViewProxy::CANDIDATE_PREFIX=>$prefix,'columns'=>array('rf_shortname'));
+    $query3 = $method->invoke($licenseViewProxy,$options3);
+    assertThat($query3, is("SELECT '". pg_escape_string($prefix). "'||rf_shortname AS rf_shortname FROM license_candidate WHERE group_fk=$groupId"));
   }
-
+  
   public function testConstruct()
   {
     $licenseViewProxy0 = new LicenseViewProxy(0);

--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -15,7 +15,8 @@
     <testsuite name="Fossology PhpUnit Agent Test Suite">
       <directory suffix="Test.php">decider/agent_tests</directory>
       <directory suffix="Test.php">deciderjob/agent_tests/Functional</directory>
-      <directory suffix="Test.php">monk/agent_tests/Functional</directory>    
+      <directory suffix="Test.php">monk/agent_tests/Functional</directory>
+      <directory suffix="Test.php">spdx2/agent_tests/Functional</directory>
     </testsuite>
   
     <!--             

--- a/src/spdx2/Makefile
+++ b/src/spdx2/Makefile
@@ -1,0 +1,50 @@
+# Copyright Siemens AG 2015
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+TOP = ../..
+VARS = $(TOP)/Makefile.conf
+include $(VARS)
+
+MOD_NAME = spdx2
+
+DIRS = agent ui
+TESTDIRS = agent_tests
+
+DIR_LOOP = @set -e; for dir in $(DIRS); do $(MAKE) -s -C $$dir $(1); done
+TESTDIR_LOOP = @set -e; for dir in $(TESTDIRS); do $(MAKE) -s -C $$dir $(1); done
+
+all: VERSIONFILE
+	$(call DIR_LOOP, )
+
+test: all
+	$(MAKE) -C $(TESTDIR) test
+
+coverage: all
+	@echo "nothing to do"
+
+VERSIONFILE:
+	$(call WriteVERSIONFile,$(MOD_NAME))
+
+install: all
+	$(call DIR_LOOP,install)
+	$(INSTALL_DATA) VERSION $(DESTDIR)$(MODDIR)/$(MOD_NAME)/VERSION
+	$(INSTALL_DATA) $(MOD_NAME).conf $(DESTDIR)$(MODDIR)/$(MOD_NAME)/$(MOD_NAME).conf
+	mkdir -p $(DESTDIR)$(SYSCONFDIR)/mods-enabled
+	if test ! -e $(DESTDIR)$(SYSCONFDIR)/mods-enabled/$(MOD_NAME); then \
+		ln -s $(MODDIR)/$(MOD_NAME) $(DESTDIR)$(SYSCONFDIR)/mods-enabled; \
+	fi
+
+uninstall:
+	$(call DIR_LOOP,uninstall)
+	rm -rf $(DESTDIR)$(MODDIR)/$(MOD_NAME)
+	rm -f $(DESTDIR)$(SYSCONFDIR)/mods-enabled/$(MOD_NAME)
+
+clean:
+	$(call DIR_LOOP,clean)
+	rm -f VERSION
+
+.PHONY: all test coverage VERSIONFILE install uninstall clean

--- a/src/spdx2/agent/Makefile
+++ b/src/spdx2/agent/Makefile
@@ -1,0 +1,53 @@
+# Copyright Siemens AG 2015
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+TOP=../../..
+VARS=$(TOP)/Makefile.conf
+DEPS=$(TOP)/Makefile.deps
+include $(VARS)
+
+MOD_NAME = spdx2
+MOD_SUBDIR = agent
+
+EXE=spdx2.php version.php services.php
+WRAP=spdx2
+
+all: version.php spdx2
+
+version.php: version-process_php
+
+# include the preprocessing stuff
+include $(TOP)/Makefile.process
+
+spdx2:
+	@echo "making locally runnable report (only for testing)"
+	$(MAKE) -C $(FOCLIDIR) fo_wrapper
+	ln -sf $(FOCLIDIR)/fo_wrapper.php $(MOD_NAME)
+
+install: all
+	$(INSTALL_PROGRAM) -d $(DESTDIR)$(MODDIR)/$(MOD_NAME)/$(MOD_SUBDIR)/
+	for file in $(EXE); do \
+		echo "installing $$file"; \
+		$(INSTALL_PROGRAM) $$file $(DESTDIR)$(MODDIR)/$(MOD_NAME)/$(MOD_SUBDIR)/$$file; \
+	done
+	for file in $(WRAP); do \
+		echo "Making wrapper for $$file"; \
+		ln -sf $(LIBEXECDIR)/fo_wrapper  $(DESTDIR)$(MODDIR)/$(MOD_NAME)/agent/$$file; \
+	done
+	find template/ -type f -exec $(INSTALL_DATA) {} $(DESTDIR)$(MODDIR)/$(MOD_NAME)/$(MOD_SUBDIR)/{} \;
+
+uninstall:
+	for file in $(WRAP); do \
+		rm -rf $(DESTDIR)$(MODDIR)/$(MOD_NAME)/$(MOD_SUBDIR)/$$file; \
+	done
+
+clean:
+	rm -f core version.php $(WRAP)
+
+.PHONY: all install uninstall clean
+
+include $(DEPS)

--- a/src/spdx2/agent/services.php
+++ b/src/spdx2/agent/services.php
@@ -1,0 +1,12 @@
+<?php
+/*
+ Copyright Siemens AG 2015
+
+ Copying and distribution of this file, with or without modification,
+ are permitted in any medium without royalty provided the copyright
+ notice and this notice are preserved. This file is offered as-is,
+ without any warranty.
+ */
+global $container;
+$loader = $container->get('twig.loader');
+$loader->addPath(dirname(__FILE__).'/template');

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -1,0 +1,272 @@
+<?php
+/*
+ * Copyright (C) 2015, Siemens AG
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+namespace Fossology\SpdxTwo;
+
+use Fossology\Lib\Agent\Agent;
+use Fossology\Lib\BusinessRules\LicenseMap;
+use Fossology\Lib\Dao\ClearingDao;
+use Fossology\Lib\Dao\CopyrightDao;
+use Fossology\Lib\Dao\TreeDao;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Data\ClearingDecision;
+use Fossology\Lib\Data\DecisionTypes;
+use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\Proxy\LicenseViewProxy;
+use Fossology\Lib\Proxy\ScanJobProxy;
+
+include_once(__DIR__ . "/version.php");
+include_once(__DIR__ . "/services.php");
+
+class SpdxTwoAgent extends Agent
+{
+  const UPLOAD_ADDS = "uploadsAdd";
+  /** @var UploadDao */
+  private $uploadDao;
+  /** @var ClearingDao */
+  private $clearingDao;
+  /** @var DbManager */
+  protected $dbManager;
+  /** @var Twig_Environment */
+  protected $renderer;
+  /** @var LicenseMap */
+  private $licenseMap;
+  /** @var array */
+  protected $agentNames = array('nomos' => 'N', 'monk' => 'M');
+  /** @var array */
+  protected $includedLicenseIds = array();
+  /** @var string */
+  protected $uri;
+
+  function __construct()
+  {
+    parent::__construct('spdx2', AGENT_VERSION, AGENT_REV);
+
+    $this->uploadDao = $this->container->get('dao.upload');
+    $this->clearingDao = $this->container->get('dao.clearing');
+    $this->dbManager = $this->container->get('db.manager');
+    $this->renderer = $this->container->get('twig.environment');
+    $this->renderer->setCache(false);
+
+    $this->agentSpecifLongOptions[] = self::UPLOAD_ADDS.':';
+  }
+
+
+  function processUploadId($uploadId)
+  {
+    $this->licenseMap = new LicenseMap($this->dbManager, $this->groupId, LicenseMap::REPORT, true);
+    $this->computeUri($uploadId);
+    
+    $packageNodes = $this->renderPackage($uploadId);
+    $additionalUploadIds = array_key_exists(self::UPLOAD_ADDS,$this->args) ? explode(',',$this->args[self::UPLOAD_ADDS]) : array();
+    foreach($additionalUploadIds as $additionalId)
+    {
+      $packageNodes .= $this->renderPackage($additionalId);
+    }
+   
+    $this->writeReport($packageNodes, $uploadId);
+    return true;    
+  }
+  
+  protected function renderPackage($uploadId)
+  {
+    $uploadTreeTableName = $this->uploadDao->getUploadtreeTableName($uploadId);
+    $itemTreeBounds = $this->uploadDao->getParentItemBounds($uploadId,$uploadTreeTableName);
+    $clearingDecisions = $this->clearingDao->getFileClearingsFolder($itemTreeBounds, $this->groupId);
+    
+    $filesWithLicenses = array();
+    foreach ($clearingDecisions as $clearingDecision) {
+      if($clearingDecision->getType() == DecisionTypes::IRRELEVANT)
+      {
+        continue;
+      }
+      /** @var ClearingDecision $clearingDecision */
+      foreach ($clearingDecision->getClearingLicenses() as $clearingLicense) {
+        if ($clearingLicense->isRemoved())
+        {
+          continue;
+        }
+        $reportedLicenseId = $this->licenseMap->getProjectedId($clearingLicense->getLicenseId());
+        $this->includedLicenseIds[$reportedLicenseId] = $reportedLicenseId;
+        $filesWithLicenses[$clearingDecision->getUploadTreeId()]['concluded'][] = 
+                                                 $this->licenseMap->getProjectedShortname($reportedLicenseId);
+      }
+    }
+
+    $licenseComment = $this->addScannerResults($filesWithLicenses, $uploadId);
+    $this->addCopyrightResults($filesWithLicenses, $uploadId);
+    $this->heartbeat(count($filesWithLicenses));
+    
+    $upload = $this->uploadDao->getUpload($uploadId);
+    $fileNodes = $this->generateFileNodes($filesWithLicenses, $upload->getTreeTableName());
+    
+    $mainLicenseIds = $this->clearingDao->getMainLicenseIds($uploadId, $this->groupId);
+    $mainLicenses = array();
+    foreach($mainLicenseIds as $licId)
+    {
+      $reportedLicenseId = $this->licenseMap->getProjectedId($licId);
+      $this->includedLicenseIds[$reportedLicenseId] = $reportedLicenseId;
+      $mainLicenses[] = $this->licenseMap->getProjectedShortname($reportedLicenseId);
+    }
+
+    $hashes = $this->uploadDao->getUploadHashes($uploadId);
+    return $this->renderString('spdx-package.xml.twig',array(
+        'uploadId'=>$uploadId,
+        'uri'=>$this->uri,
+        'packageName'=>$upload->getFilename(),
+        'uploadName'=>$upload->getFilename(),
+        'sha1'=>$hashes['sha1'],
+        'md5'=>$hashes['md5'],
+        'mainLicenses'=>$mainLicenses,
+        'licenseComments'=>$licenseComment,
+        'fileNodes'=>$fileNodes)
+            );
+  }
+
+  protected function addScannerResults(&$filesWithLicenses, $uploadId)
+  {
+    $scannerAgents = array_keys($this->agentNames);
+    $scanJobProxy = new ScanJobProxy($this->container->get('dao.agent'), $uploadId);
+    $scanJobProxy->createAgentStatus($scannerAgents);
+    $scannerIds = $scanJobProxy->getLatestSuccessfulAgentIds();
+    if(empty($scannerIds))
+    {
+      return;
+    }
+    $selectedScanners = '{'.implode(',',$scannerIds).'}';
+    $sql= "SELECT uploadtree_pk,rf_fk FROM uploadtree_a ut, license_file
+      WHERE ut.pfile_fk=license_file.pfile_fk AND rf_fk IS NOT NULL AND agent_fk=any($1) GROUP BY uploadtree_pk,rf_fk";
+    $stmt = __METHOD__ .'.scanner_findings';
+    $this->dbManager->prepare($stmt, $sql);
+    $res = $this->dbManager->execute($stmt,array($selectedScanners));
+    while($row=$this->dbManager->fetchArray($res))
+    {
+      $reportedLicenseId = $this->licenseMap->getProjectedId($row['rf_fk']);
+      $shortName = $this->licenseMap->getProjectedShortname($reportedLicenseId);
+      if ($shortName != 'No_license_found' && $shortName != 'Void') {
+        $filesWithLicenses[$row['uploadtree_pk']]['scanner'][] = $shortName;
+        $this->includedLicenseIds[$reportedLicenseId] = $reportedLicenseId;
+      }
+    }
+    $this->dbManager->freeResult($res);
+    return "licenseInfoInFile determined by Scanners $selectedScanners";
+  }
+  
+  protected function addCopyrightResults(&$filesWithLicenses, $uploadId)
+  {
+    /* @var $copyrightDao CopyrightDao */
+    $copyrightDao = $this->container->get('dao.copyright');
+    $uploadtreeTable = $this->uploadDao->getUploadtreeTableName($uploadId);
+    $allEntries = $copyrightDao->getAllEntries('copyright', $uploadId, $uploadtreeTable, $type='skipcontent', $onlyCleared=true, DecisionTypes::IDENTIFIED, 'textfinding!=\'\'');
+    foreach ($allEntries as $finding) {
+      $filesWithLicenses[$finding['uploadtree_pk']]['copyrights'][] = $finding['textfinding'];
+    }
+  }       
+
+  protected function computeUri($uploadId)
+  {
+    global $SysConf;
+    $upload = $this->uploadDao->getUpload($uploadId);
+    $packageName = $upload->getFilename();
+
+    $fileBase = $SysConf['FOSSOLOGY']['path']."/report/";
+    $fileName = $fileBase. "SPDX2_".$packageName.'_'.time().".rdf" ;
+    
+    $this->uri = $fileName;
+  }
+  
+  protected function writeReport($packageNodes, $uploadId)
+  {
+    $fileBase = dirname($this->uri);
+            
+    if(!is_dir($fileBase)) {
+      mkdir($fileBase, 0777, true);
+    }
+    umask(0133);
+    
+    $message = $this->renderString('spdx-document.xml.twig',array(
+        'documentName'=>$fileBase,
+        'uri'=>$this->uri,
+        'userName'=>$this->container->get('dao.user')->getUserName($this->userId),
+        'organisation'=>'',
+        'packageNodes'=>$packageNodes,
+        'licenseTexts'=>$this->getLicenseTexts())
+            );
+    file_put_contents($this->uri, $message);
+    $this->updateReportTable($uploadId, $this->jobId, $this->uri);
+  }
+
+  protected function updateReportTable($uploadId, $jobId, $fileName){
+    $this->dbManager->insertTableRow('reportgen',
+            array('upload_fk'=>$uploadId, 'job_fk'=>$jobId, 'filepath'=>$fileName),
+            __METHOD__);
+  }
+
+  /**
+   * @param string $templateName
+   * @param array $vars
+   * @return string
+   */
+  protected function renderString($templateName, $vars)
+  {
+    return $this->renderer->loadTemplate($templateName)->render($vars);
+  }  
+  
+  protected function generateFileNodes($filesWithLicenses, $treeTableName)
+  {
+    /* @var $treeDao TreeDao */
+    $treeDao = $this->container->get('dao.tree');
+    $content = '';
+    foreach($filesWithLicenses as $fileId=>$licenses) {
+      $hashes = $treeDao->getItemHashes($fileId);
+      $content .= $this->renderString('spdx-file.xml.twig',array(
+          'fileId'=>$fileId,
+          'sha1'=>$hashes['sha1'],
+          'md5'=>$hashes['md5'],
+          'uri'=>$this->uri,
+          'fileName'=>$treeDao->getFullPath($fileId,$treeTableName),
+          'concludedLicenses'=>$licenses['concluded'],
+          'scannerLicenses'=>$licenses['scanner'],
+          'copyrights'=>$licenses['copyrights'])
+              );
+    }
+    return $content;
+  }
+
+  /**
+   * @return string[] with keys being shortname
+   */
+  protected function getLicenseTexts() {
+    $licenseTexts = array();
+    $licenseViewProxy = new LicenseViewProxy($this->groupId,array(LicenseViewProxy::OPT_COLUMNS=>array('rf_pk','rf_shortname','rf_text')));
+    $this->dbManager->prepare($stmt=__METHOD__, $licenseViewProxy->getDbViewQuery());
+    $res = $this->dbManager->execute($stmt);
+    while($row=$this->dbManager->fetchArray($res))
+    {
+      if (array_key_exists($row['rf_pk'], $this->includedLicenseIds)) {
+        $licenseTexts[$row['rf_shortname']] = $row['rf_text'];
+      }
+    }
+    $this->dbManager->freeResult($res);
+    return $licenseTexts;
+  }
+}
+
+$agent = new SpdxTwoAgent();
+$agent->scheduler_connect();
+$agent->run_scheduler_event_loop();
+$agent->scheduler_disconnect(0);

--- a/src/spdx2/agent/template/spdx-document.xml.twig
+++ b/src/spdx2/agent/template/spdx-document.xml.twig
@@ -1,0 +1,36 @@
+{# Copyright 2015 Siemens AG
+
+   Copying and distribution of this file, with or without modification,
+   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
+   This file is offered as-is, without any warranty.
+#}
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:spdx="http://spdx.org/rdf/terms#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+<spdx:SpdxDocument rdf:about="{{ uri }}#SPDXRef-DOCUMENT">
+  <spdx:specVersion>SPDX-2.0</spdx:specVersion>
+  <spdx:dataLicense rdf:resource="http://spdx.org/licenses/CC0-1.0" />
+  <spdx:creationInfo>
+    <spdx:CreationInfo>
+      <spdx:licenseListVersion>2.0</spdx:licenseListVersion> 
+      <spdx:creator>Person: {{ userName }}</spdx:creator>
+      <spdx:creator>Organization: {{ organisation }}</spdx:creator>
+      <spdx:creator>Tool: spxd2</spdx:creator>
+      <spdx:created>{{ 'now'|date('Y-m-d\\TH:i:s\\Z')}}{# date('c') for ISO 8601 is not parsed by spdxTool #}</spdx:created>
+    </spdx:CreationInfo>
+  </spdx:creationInfo>
+  <spdx:name>{{ documentName }}</spdx:name>
+  <rdfs:comment> 
+    This document was created using SPDX 2.0 using licenses from Fossology.
+  </rdfs:comment>
+  {% for licenseId,extractedText in licenseTexts %}
+  <spdx:hasExtractedLicensingInfo>
+    <spdx:ExtractedLicensingInfo rdf:about="{{ uri }}#LicenseRef-{{ licenseId }}">
+      <spdx:licenseId>LicenseRef-{{ licenseId }}</spdx:licenseId>
+      <spdx:extractedText>{{ extractedText|e }}</spdx:extractedText>
+    </spdx:ExtractedLicensingInfo>
+  </spdx:hasExtractedLicensingInfo>
+  {% endfor %}
+  {{ packageNodes|replace({'\n':'\n  '}) }}
+</spdx:SpdxDocument>
+</rdf:RDF>

--- a/src/spdx2/agent/template/spdx-file.xml.twig
+++ b/src/spdx2/agent/template/spdx-file.xml.twig
@@ -1,0 +1,48 @@
+{# Copyright 2015 Siemens AG
+
+   Copying and distribution of this file, with or without modification,
+   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
+   This file is offered as-is, without any warranty.
+#}
+<spdx:hasFile>
+  <spdx:File rdf:about="{{ uri }}#SPDXRef-item{{ fileId }}">
+    <spdx:fileName>{{ fileName }}</spdx:fileName>
+    <spdx:checksum>
+      <spdx:Checksum>
+        <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+        <spdx:checksumValue>{{ sha1 }}</spdx:checksumValue>
+      </spdx:Checksum>
+    </spdx:checksum>
+    <spdx:checksum> 
+      <spdx:Checksum>
+        <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_md5"/>
+        <spdx:checksumValue>{{ md5 }}</spdx:checksumValue>
+      </spdx:Checksum>
+    </spdx:checksum>
+  {% if concludedLicenses is empty %}
+    <spdx:licenseConcluded rdf:resource="http://spdx.org/rdf/terms#none" />
+  {% else %}
+    <spdx:licenseConcluded>
+      <spdx:DisjunctiveLicenseSet>
+  {% for res in concludedLicenses %}
+        <spdx:member rdf:resource="{{ uri }}#LicenseRef-{{ res }}"/>
+  {% endfor %}
+      </spdx:DisjunctiveLicenseSet>
+    </spdx:licenseConcluded>
+  {% endif %}
+  {% if scannerLicenses is empty %}
+    <spdx:licenseInfoInFile rdf:resource="http://spdx.org/rdf/terms#noassertion" />
+  {% else %}{% for res in scannerLicenses %}
+    <spdx:licenseInfoInFile rdf:resource="{{ uri }}#LicenseRef-{{ res }}" />
+  {% endfor %}{% endif %}
+    <spdx:copyrightText>
+  {% if copyrights is empty %}
+      NOASSERTION
+  {% else %}
+    {% for cp in copyrights %}
+      {{ cp|e }}
+    {% endfor %}
+  {% endif %}
+    </spdx:copyrightText>
+  </spdx:File>
+</spdx:hasFile>

--- a/src/spdx2/agent/template/spdx-package.xml.twig
+++ b/src/spdx2/agent/template/spdx-package.xml.twig
@@ -1,0 +1,43 @@
+{# Copyright 2015 Siemens AG
+
+   Copying and distribution of this file, with or without modification,
+   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
+   This file is offered as-is, without any warranty.
+#}
+<spdx:relationship>
+  <spdx:Relationship>
+    <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes" />
+    <spdx:relatedSpdxElement>
+      <spdx:Package rdf:about="{{ uri }}#SPDXRef-upload{{ uploadId }}">
+        <spdx:name>{{ packageName }}</spdx:name>
+        <spdx:packageFileName>{{ uploadName }}</spdx:packageFileName>
+        <spdx:downloadLocation rdf:resource="http://spdx.org/rdf/terms#noassertion" />
+        <spdx:checksum>
+          <spdx:Checksum>
+            <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+            <spdx:checksumValue>{{ sha1 }}</spdx:checksumValue>
+          </spdx:Checksum>
+        </spdx:checksum>
+        <spdx:checksum> 
+          <spdx:Checksum>
+            <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_md5"/>
+            <spdx:checksumValue>{{ md5 }}</spdx:checksumValue>
+          </spdx:Checksum>
+        </spdx:checksum>
+        <spdx:licenseConcluded>
+          <spdx:DisjunctiveLicenseSet>
+  {% for res in mainLicenses %}
+            <spdx:member rdf:resource="{{ uri }}#LicenseRef-{{ res }}"/>
+  {% endfor %}
+          </spdx:DisjunctiveLicenseSet>
+        </spdx:licenseConcluded>
+        {% if licenseComments %}<spdx:licenseComments>{{ licenseComments }}</spdx:licenseComments>
+        <spdx:licenseDeclared rdf:resource="http://spdx.org/rdf/terms#noassertion" />
+        <spdx:licenseConcluded rdf:resource="http://spdx.org/rdf/terms#noassertion" />
+        <spdx:licenseInfoFromFiles rdf:resource="http://spdx.org/rdf/terms#noassertion" />
+        <spdx:copyrightText rdf:resource="http://spdx.org/rdf/terms#noassertion" />
+        {% endif %}{{ fileNodes|replace({'\n':'\n          '}) }}
+      </spdx:Package>
+    </spdx:relatedSpdxElement>
+  </spdx:Relationship>
+</spdx:relationship>

--- a/src/spdx2/agent/version.php.in
+++ b/src/spdx2/agent/version.php.in
@@ -1,0 +1,11 @@
+<?php
+/*
+ Copyright Siemens AG 2015
+
+ Copying and distribution of this file, with or without modification,
+ are permitted in any medium without royalty provided the copyright
+ notice and this notice are preserved. This file is offered as-is,
+ without any warranty.
+ */
+define("AGENT_VERSION", "{$VERSION}");
+define("AGENT_REV", "{$SVN_REV}");

--- a/src/spdx2/agent_tests/Functional/Makefile
+++ b/src/spdx2/agent_tests/Functional/Makefile
@@ -1,0 +1,32 @@
+# Copyright Siemens AG 2015
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+TOP = ../../../..
+VARS = $(TOP)/Makefile.conf
+include $(VARS)
+
+LOCALAGENTDIR = ../../agent
+
+all: version
+	$(MAKE) -C $(LOCALAGENTDIR) all
+
+version:
+	$(MAKE) -C $(TOP) VERSIONFILE
+	$(MAKE) -C $(LOCALAGENTDIR)/.. VERSIONFILE
+
+test-sched:
+	@echo "make functional tests for scheduler mode"
+	$(PHPUNIT) --bootstrap $(PHPUNIT_BOOT) schedulerTest.php
+
+test: all test-sched
+
+coverage: all test-sched
+
+clean:
+	@echo "nothing to do"
+
+.PHONY: all test coverage clean

--- a/src/spdx2/agent_tests/Functional/SchedulerTestRunner.php
+++ b/src/spdx2/agent_tests/Functional/SchedulerTestRunner.php
@@ -1,0 +1,24 @@
+<?php
+/*
+Copyright (C) 2015, Siemens AG
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+namespace Fossology\SpdxTwo\Test;
+
+interface SchedulerTestRunner
+{
+  public function run($uploadId, $userId = 2, $groupId = 2, $jobId = 1, $args = "");
+}

--- a/src/spdx2/agent_tests/Functional/SchedulerTestRunnerCli.php
+++ b/src/spdx2/agent_tests/Functional/SchedulerTestRunnerCli.php
@@ -1,0 +1,64 @@
+<?php
+/*
+Copyright (C) 2015, Siemens AG
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+namespace Fossology\SpdxTwo\Test;
+
+use Fossology\Lib\Test\TestPgDb;
+
+include_once(__DIR__.'/../../../lib/php/Test/Agent/AgentTestMockHelper.php');
+include_once(__DIR__.'/SchedulerTestRunner.php');
+
+class SchedulerTestRunnerCli implements SchedulerTestRunner
+{
+  /** @var TestPgDb */
+  private $testDb;
+  
+  public function __construct(TestPgDb $testDb)
+  {
+    $this->testDb = $testDb;
+  }
+  
+  public function run($uploadId, $userId=2, $groupId=2, $jobId=1, $args="")
+  {
+    $sysConf = $this->testDb->getFossSysConf();
+
+    $agentName = "spdx2";
+
+    $agentDir = dirname(dirname(__DIR__));
+    $execDir = "$agentDir/agent";
+
+    $pipeFd = popen($cmd = "echo $uploadId | $execDir/$agentName --userID=$userId --groupID=$groupId --jobId=$jobId --scheduler_start -c $sysConf $args", "r");
+    $success = $pipeFd !== false;
+
+    $output = "";
+    $retCode = -1;
+    if ($success) 
+    {
+      while (($buffer = fgets($pipeFd, 4096)) !== false) {
+        $output .= $buffer;
+      }
+      $retCode = pclose($pipeFd);
+    }
+    else 
+    {
+      print "failed opening pipe to $cmd";
+    }
+
+    return array($success, $output, $retCode);
+  }
+}

--- a/src/spdx2/agent_tests/Functional/fo_report.sql
+++ b/src/spdx2/agent_tests/Functional/fo_report.sql
@@ -1,0 +1,588 @@
+
+INSERT INTO agent VALUES (1, 'nomos', '2.4.1-ng.695dd8', 'License Scanner', true, NULL, '2015-05-04 11:37:39.12504+02');
+INSERT INTO agent VALUES (2, 'delagent', '2.4.1-ng.695dd8', '(null)', true, NULL, '2015-05-04 11:42:21.477678+02');
+INSERT INTO agent VALUES (3, 'maintagent', '2.4.1-ng.695dd8', '(null)', true, NULL, '2015-05-04 11:42:21.597601+02');
+INSERT INTO agent VALUES (4, 'mimetype', '2.4.1-ng.695dd8', '(null)', true, NULL, '2015-05-04 11:42:21.623748+02');
+INSERT INTO agent VALUES (5, 'reportgen', '2.4.1-ng.695dd8', '(null)', true, NULL, '2015-05-04 11:42:21.62586+02');
+INSERT INTO agent VALUES (6, 'adj2nest', '2.4.1-ng.695dd8', '(null)', true, NULL, '2015-05-04 11:42:21.636537+02');
+INSERT INTO agent VALUES (7, 'monkbulk', '2.4.1-ng.695dd8', '(null)', true, NULL, '2015-05-04 11:42:21.637863+02');
+INSERT INTO agent VALUES (8, 'monk', '2.4.1-ng.695dd8', '(null)', true, NULL, '2015-05-04 11:42:21.642129+02');
+INSERT INTO agent VALUES (10, 'pkgagent', '2.4.1-ng.695dd8', '(null)', true, NULL, '2015-05-04 11:42:21.669964+02');
+INSERT INTO agent VALUES (11, 'ecc', '2.4.1-ng.695dd8', '(null)', true, NULL, '2015-05-04 11:42:21.6724+02');
+INSERT INTO agent VALUES (12, 'buckets', '2.4.1-ng.695dd8', '(null)', true, NULL, '2015-05-04 11:42:21.673072+02');
+INSERT INTO agent VALUES (13, 'wget_agent', '2.4.1-ng.695dd8', '(null)', true, NULL, '2015-05-04 11:42:21.681217+02');
+INSERT INTO agent VALUES (14, 'ununpack', '2.4.1-ng.695dd8', '(null)', true, NULL, '2015-05-04 11:42:21.732657+02');
+INSERT INTO agent VALUES (15, 'copyright', '2.4.1-ng.695dd8', '(null)', true, NULL, '2015-05-04 11:42:21.820557+02');
+INSERT INTO agent VALUES (16, 'ninka', '2.4.1-ng.695dd8', '(null)', true, NULL, '2015-05-04 11:42:21.820836+02');
+INSERT INTO agent VALUES (17, 'deciderjob', '2.4.1-ng.695dd8', 'deciderjob agent', true, NULL, '2015-05-04 11:42:22.130801+02');
+INSERT INTO agent VALUES (18, 'report', '2.4.1-ng.695dd8', 'report agent', true, NULL, '2015-05-04 11:42:22.155375+02');
+INSERT INTO agent VALUES (19, 'readmeoss', '2.4.1-ng.695dd8', 'readmeoss agent', true, NULL, '2015-05-04 11:42:22.170878+02');
+INSERT INTO agent VALUES (20, 'decider', '2.4.1-ng.695dd8', 'decider agent', true, NULL, '2015-05-04 11:42:22.24854+02');
+INSERT INTO agent VALUES (21, 'reuser', '2.4.1-ng.695dd8', 'reuser agent', true, NULL, '2015-05-04 11:42:22.306605+02');
+
+
+INSERT INTO upload VALUES (1, '', 'ReportTestfiles.tar', 2, 104, '2015-05-04 11:43:14.866898+02', 1, 'ReportTestfiles.tar', 'uploadtree_a', NULL, NULL, 0);
+
+
+INSERT INTO bucketpool VALUES (1, 'GPL Demo bucket pool', 1, 'Y', 'Demonstration of a very simple GPL/non-gpl bucket pool');
+
+
+INSERT INTO bucket_def VALUES (1, 'GPL Licenses (Demo)', 'orange', 50, 50, 1, 3, '(affero|gpl)', NULL, 'N', 'f');
+INSERT INTO bucket_def VALUES (2, 'non-gpl (Demo)', 'yellow', 50, 1000, 1, 99, NULL, NULL, 'N', 'f');
+
+
+INSERT INTO groups VALUES (1, 'Default User');
+INSERT INTO groups VALUES (2, 'fossy');
+
+
+INSERT INTO mimetype VALUES (1, 'application/gzip');
+INSERT INTO mimetype VALUES (2, 'application/x-gzip');
+INSERT INTO mimetype VALUES (3, 'application/x-compress');
+INSERT INTO mimetype VALUES (4, 'application/x-bzip');
+INSERT INTO mimetype VALUES (5, 'application/x-bzip2');
+INSERT INTO mimetype VALUES (6, 'application/x-upx');
+INSERT INTO mimetype VALUES (7, 'application/pdf');
+INSERT INTO mimetype VALUES (8, 'application/x-pdf');
+INSERT INTO mimetype VALUES (9, 'application/x-zip');
+INSERT INTO mimetype VALUES (10, 'application/zip');
+INSERT INTO mimetype VALUES (11, 'application/x-tar');
+INSERT INTO mimetype VALUES (12, 'application/x-gtar');
+INSERT INTO mimetype VALUES (13, 'application/x-cpio');
+INSERT INTO mimetype VALUES (14, 'application/x-rar');
+INSERT INTO mimetype VALUES (15, 'application/x-cab');
+INSERT INTO mimetype VALUES (16, 'application/x-7z-compressed');
+INSERT INTO mimetype VALUES (17, 'application/x-7z-w-compressed');
+INSERT INTO mimetype VALUES (18, 'application/x-rpm');
+INSERT INTO mimetype VALUES (19, 'application/x-archive');
+INSERT INTO mimetype VALUES (20, 'application/x-debian-package');
+INSERT INTO mimetype VALUES (21, 'application/x-iso');
+INSERT INTO mimetype VALUES (22, 'application/x-iso9660-image');
+INSERT INTO mimetype VALUES (23, 'application/x-fat');
+INSERT INTO mimetype VALUES (24, 'application/x-ntfs');
+INSERT INTO mimetype VALUES (25, 'application/x-ext2');
+INSERT INTO mimetype VALUES (26, 'application/x-ext3');
+INSERT INTO mimetype VALUES (27, 'application/x-x86_boot');
+INSERT INTO mimetype VALUES (28, 'application/x-debian-source');
+INSERT INTO mimetype VALUES (29, 'application/x-xz');
+INSERT INTO mimetype VALUES (30, 'application/jar');
+INSERT INTO mimetype VALUES (31, 'application/x-dosexec');
+
+
+INSERT INTO pfile VALUES (1, '149FD9DAC3A1FF6AD491F95F49E90BF2', '403C2B25B9B02A2EBB6817C459B37AFC1F9BA3B5', 35328, 11);
+INSERT INTO pfile VALUES (2, '8F4010C5B689A6EA4A28671FD1907F23', '75E8FBDFAB38D5406BD718711D8FDDDB530CA174', 6880, NULL);
+INSERT INTO pfile VALUES (3, 'C2047D353D61BCE5D6335CC1C30C1780', '2634F1C5473C7A9E9B9238EC2AAB1FCA468911A8', 6894, NULL);
+INSERT INTO pfile VALUES (4, 'BE09F57E1E58119F1537439BA545835C', 'FD7D17CFA15074F73F183C086B1983EB9F31781F', 296, NULL);
+INSERT INTO pfile VALUES (5, '39C379E9C7F5BB524754C4DEF5FEF135', '840B588279248271D93ACA3092AD5F4DC724BDA4', 285, NULL);
+INSERT INTO pfile VALUES (6, '2702A657B801333C3150BDC8BE642F9B', '798826BF3EB294E5D514ECFA3222CCF09BBCD985', 14554, NULL);
+
+
+INSERT INTO users VALUES (1, 'Default User', 1, 'Default User when nobody is logged in', 'Seed', 'Pass', 0, NULL, 'y', NULL, NULL, 'simple', NULL, NULL, NULL);
+INSERT INTO users VALUES (2, 'fossy', 1, 'Default Administrator', '14272952581103610285', 'cdd40d0517419e8495a6e40b14369b6a39031581', 10, 'y', 'y', NULL, NULL, 'simple', NULL, NULL, NULL);
+
+
+INSERT INTO clearing_decision (clearing_decision_pk, uploadtree_fk, pfile_fk, user_fk, group_fk, decision_type, scope, date_added) VALUES (2, 4, 2, 2, 2, 5, 1, '2015-05-04 11:43:18.276425+02');
+INSERT INTO clearing_decision (clearing_decision_pk, uploadtree_fk, pfile_fk, user_fk, group_fk, decision_type, scope, date_added) VALUES (4, 5, 3, 2, 2, 5, 1, '2015-05-04 11:43:18.297719+02');
+INSERT INTO clearing_decision (clearing_decision_pk, uploadtree_fk, pfile_fk, user_fk, group_fk, decision_type, scope, date_added) VALUES (7, 10, 6, 2, 2, 5, 0, '2015-05-04 11:44:10.097161+02');
+INSERT INTO clearing_decision (clearing_decision_pk, uploadtree_fk, pfile_fk, user_fk, group_fk, decision_type, scope, date_added) VALUES (8, 10, 6, 2, 2, 4, 0, '2015-05-04 11:45:11.88761+02');
+INSERT INTO clearing_decision (clearing_decision_pk, uploadtree_fk, pfile_fk, user_fk, group_fk, decision_type, scope, date_added) VALUES (10, 7, 4, 2, 2, 5, 0, '2015-05-04 11:45:30.851906+02');
+INSERT INTO clearing_decision (clearing_decision_pk, uploadtree_fk, pfile_fk, user_fk, group_fk, decision_type, scope, date_added) VALUES (12, 8, 5, 2, 2, 5, 0, '2015-05-04 11:45:34.941938+02');
+INSERT INTO clearing_decision (clearing_decision_pk, uploadtree_fk, pfile_fk, user_fk, group_fk, decision_type, scope, date_added) VALUES (14, 5, 3, 2, 2, 5, 0, '2015-05-04 11:46:26.59626+02');
+INSERT INTO clearing_decision (clearing_decision_pk, uploadtree_fk, pfile_fk, user_fk, group_fk, decision_type, scope, date_added) VALUES (16, 4, 2, 2, 2, 5, 0, '2015-05-04 11:47:10.946366+02');
+
+
+
+INSERT INTO clearing_decision_event VALUES (1, 2);
+INSERT INTO clearing_decision_event VALUES (2, 4);
+INSERT INTO clearing_decision_event VALUES (4, 7);
+INSERT INTO clearing_decision_event VALUES (3, 7);
+INSERT INTO clearing_decision_event VALUES (3, 8);
+INSERT INTO clearing_decision_event VALUES (4, 8);
+INSERT INTO clearing_decision_event VALUES (5, 10);
+INSERT INTO clearing_decision_event VALUES (6, 12);
+INSERT INTO clearing_decision_event VALUES (7, 14);
+INSERT INTO clearing_decision_event VALUES (8, 16);
+
+
+
+INSERT INTO clearing_event VALUES (1, 4, 485, false, 2, 2, NULL, 3, '', '', '2015-05-04 11:43:18.276425+02');
+INSERT INTO clearing_event VALUES (2, 5, 272, false, 2, 2, NULL, 3, '', '', '2015-05-04 11:43:18.297719+02');
+INSERT INTO clearing_event VALUES (3, 10, 561, true, 2, 2, NULL, 1, '', '', '2015-05-04 11:44:07.229472+02');
+INSERT INTO clearing_event VALUES (4, 10, 560, false, 2, 2, NULL, 3, '', '', '2015-05-04 11:44:10.097161+02');
+INSERT INTO clearing_event VALUES (5, 7, 199, false, 2, 2, NULL, 3, '', '', '2015-05-04 11:45:30.851906+02');
+INSERT INTO clearing_event VALUES (6, 8, 199, false, 2, 2, NULL, 3, '', '', '2015-05-04 11:45:34.941938+02');
+INSERT INTO clearing_event VALUES (7, 5, 272, false, 2, 2, NULL, 3, 'all Nomos findings are within the Monk findings', '', '2015-05-04 11:46:22.698323+02');
+INSERT INTO clearing_event VALUES (8, 4, 485, false, 2, 2, NULL, 3, '', 'Here is an alternative license text.', '2015-05-04 11:47:09.615748+02');
+
+
+
+INSERT INTO copyright VALUES (1, 15, 4, 'Copyright:
+', '82b9c4a898c9c8e7dd3b2f12c9efe2f1', 'statement', 85, 96);
+INSERT INTO copyright VALUES (2, 15, 4, 'Copyright 2004 XXX 3dfx Interactive. conspicuously and appropriately publish on each copy of a derivative work">
+', '257e7a16fdea45af00db34b34901297e', 'statement', 98, 212);
+INSERT INTO copyright VALUES (3, 15, 2, 'Copyright © 1990-2007 Condor Team, Computer Sciences Department, University of Wisconsin-Madison, Madison, WI. All Rights Reserved. For more information contact: Condor Team, Attention: Professor Miron Livny, Dept of Computer Sciences, 1210 W. Dayton St., Madison, WI 53706-1685, (608) 262-0856 or miron@cs.wisc.edu.', '38fed8260a51272cce26cb9a9e8ae150', 'statement', 288, 605);
+INSERT INTO copyright VALUES (4, 15, 2, 'Copyright (c) 1999 University of Chicago and The University of Southern California. All Rights Reserved.', '838e7addcd532fd109fcf9046b830fcb', 'statement', 6315, 6419);
+INSERT INTO copyright VALUES (5, 15, 2, 'http://www.condorproject.org/', '7b3bded8d05be4f8f286137d781671c5', 'url', 816, 845);
+INSERT INTO copyright VALUES (6, 15, 2, 'http://www.condorproject.org/)"', '5f99b6394b68ba3efd6355d001cf5c9c', 'url', 1537, 1568);
+INSERT INTO copyright VALUES (7, 15, 2, 'http://pages.cs.wisc.edu/~miron/miron.html', '8c35167907ce1778906c09d05ecf2008', 'url', 6096, 6138);
+INSERT INTO copyright VALUES (8, 15, 2, 'http://www.globus.org/)', '01792705aacafab69309d1a5b10a1ff3', 'url', 6238, 6261);
+INSERT INTO copyright VALUES (9, 15, 2, 'http://www.gnu.org/software/libc/', '0083c8b416c911ebd402eb58b58d6aee', 'url', 6569, 6602);
+INSERT INTO copyright VALUES (10, 15, 2, 'miron@cs.wisc.edu', '1102feddb903c81db7bd06a95548f49f', 'email', 587, 604);
+INSERT INTO copyright VALUES (11, 15, 2, 'condor-admin@cs.wisc.edu', '330bfb156248b5c4a07d7bb14b2e7b86', 'email', 2245, 2269);
+INSERT INTO copyright VALUES (12, 15, 2, 'miron@cs.wisc.edu', '1102feddb903c81db7bd06a95548f49f', 'email', 6078, 6095);
+INSERT INTO copyright VALUES (13, 15, 2, 'CONTRIBUTORS', '98f07bc20cb66328be238119df96c490', 'author', 3686, 3698);
+INSERT INTO copyright VALUES (14, 15, 2, 'CONTRIBUTORS MAKE NO REPRESENTATION THAT THE SOFTWARE, MODIFICATIONS, ENHANCEMENTS OR DERIVATIVE WORKS THEREOF, WILL NOT INFRINGE ANY PATENT, COPYRIGHT, TRADEMARK, TRADE SECRET OR OTHER PROPRIETARY RIGHT.', 'f024c21e035ed961f01c504644199975', 'author', 3931, 4135);
+INSERT INTO copyright VALUES (15, 15, 2, 'CONTRIBUTORS SHALL HAVE NO LIABILITY TO LICENSEE OR OTHER PERSONS FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, LOSS OF USE, DATA OR PROFITS, OR BUSINESS INTERRUPTION, HOWEVER CAUSED AND ON ANY THEORY OF CONTRACT, WARRANTY, TORT', '9d35c5020b1a224f65a49c8615821d91', 'author', 4196, 4560);
+INSERT INTO copyright VALUES (16, 15, 5, 'Copyright:
+', '82b9c4a898c9c8e7dd3b2f12c9efe2f1', 'statement', 79, 90);
+INSERT INTO copyright VALUES (17, 15, 5, 'Copyright 2004 XXX 3dfx Interactive. conspicuously and appropriately publish on each copy of a derivative work">
+', '257e7a16fdea45af00db34b34901297e', 'statement', 92, 206);
+INSERT INTO copyright VALUES (18, 15, 6, 'Copyright (C) 1991-2, RSA Data Security, Inc. Created 1991. All rights reserved.', 'b3a0b78c4f3bda49400c03e2dc4af2fe', 'statement', 343, 426);
+INSERT INTO copyright VALUES (19, 15, 6, 'phk@login.dknet.dk', 'be9a31b6132e46a413774b36859fb540', 'email', 1685, 1703);
+INSERT INTO copyright VALUES (20, 15, 6, 'andersen@uclibc.org', 'b80a70781d6e6a7bba4953b6ecd2e214', 'email', 2185, 2204);
+INSERT INTO copyright VALUES (21, 15, 3, 'Copyright (c) 1990-2006 Condor Team, Computer Sciences Department, University of Wisconsin-Madison, Madison, WI. All Rights Reserved. For more information contact: Condor Team, Attention: Professor Miron Livny, Dept of Computer Sciences, 1210 W. Dayton St., Madison, WI 53706-1685, 608) 262-0856 or miron@cs.wisc.edu.', '80b1b708b6c123ebcbab66818e432351', 'statement', 54, 370);
+INSERT INTO copyright VALUES (23, 15, 3, 'http://www.condorproject.org/', '7b3bded8d05be4f8f286137d781671c5', 'url', 820, 849);
+INSERT INTO copyright VALUES (24, 15, 3, 'http://www.condorproject.org/)"', '5f99b6394b68ba3efd6355d001cf5c9c', 'url', 1545, 1576);
+INSERT INTO copyright VALUES (25, 15, 3, 'http://www.cs.wisc.edu/~miron/miron.html', 'a9731964cbb7701ae0191d610f8d2224', 'url', 6363, 6403);
+INSERT INTO copyright VALUES (26, 15, 3, 'http://www.globus.org/)', '01792705aacafab69309d1a5b10a1ff3', 'url', 6509, 6532);
+INSERT INTO copyright VALUES (27, 15, 3, 'http://www.gnu.org/software/libc/', '0083c8b416c911ebd402eb58b58d6aee', 'url', 6858, 6891);
+INSERT INTO copyright VALUES (28, 15, 3, 'miron@cs.wisc.edu', '1102feddb903c81db7bd06a95548f49f', 'email', 352, 369);
+INSERT INTO copyright VALUES (29, 15, 3, 'condor-admin@cs.wisc.edu', '330bfb156248b5c4a07d7bb14b2e7b86', 'email', 2295, 2319);
+INSERT INTO copyright VALUES (30, 15, 3, 'miron@cs.wisc.edu', '1102feddb903c81db7bd06a95548f49f', 'email', 6345, 6362);
+INSERT INTO copyright VALUES (31, 15, 3, 'authority', '873e9c0b50183b613336eea1020f4369', 'author', 570, 579);
+INSERT INTO copyright VALUES (32, 15, 3, 'Contributors and the University', '1b9da6873af4fafcecb86a7778e976b8', 'author', 730, 761);
+INSERT INTO copyright VALUES (33, 15, 3, 'CONTRIBUTORS AND THE UNIVERSITY', 'ef6a95f6baea2c6f551161de39c4a67f', 'author', 3826, 3863);
+INSERT INTO copyright VALUES (34, 15, 3, 'CONTRIBUTORS AND THE UNIVERSITY MAKE NO REPRESENTATION THAT THE', '57d9c9d62a47e75d9f90ba05c82748e5', 'author', 4120, 4183);
+INSERT INTO copyright VALUES (35, 15, 3, 'CONTRIBUTORS AND ANY OTHER OFFICER', '1cb39133d8d92e45813cd58562660ee1', 'author', 4426, 4460);
+
+
+INSERT INTO copyright_ars VALUES (2, 15, 1, true, NULL, '2015-05-04 11:43:17.244277+02', '2015-05-04 11:43:17.304726+02');
+
+
+INSERT INTO copyright_decision VALUES (1, 2, 2, 5, '', '', '');
+INSERT INTO copyright_decision VALUES (2, 2, 3, 4, '', '', '');
+INSERT INTO copyright_decision VALUES (3, 2, 6, 4, '', '', '');
+INSERT INTO copyright_decision VALUES (4, 2, 3, 5, '', '', '');
+
+
+
+INSERT INTO decider_ars VALUES (5, 20, 1, true, NULL, '2015-05-04 11:43:18.236117+02', '2015-05-04 11:43:18.305526+02');
+
+
+
+INSERT INTO folder VALUES (1, NULL, 'Software Repository', 'Top Folder', NULL);
+
+
+
+INSERT INTO foldercontents VALUES (1, 1, 0, 0);
+INSERT INTO foldercontents VALUES (2, 1, 2, 1);
+
+
+INSERT INTO group_user_member VALUES (1, 1, 1, 1);
+INSERT INTO group_user_member VALUES (2, 2, 2, 1);
+
+
+
+INSERT INTO highlight VALUES ('L ', 867, 71, 3, NULL, NULL);
+INSERT INTO highlight VALUES ('L ', 234, 34, 3, NULL, NULL);
+INSERT INTO highlight VALUES ('M ', 234, 5709, 4, 0, 5666);
+INSERT INTO highlight VALUES ('M0', 0, 1129, 6, 0, 1137);
+INSERT INTO highlight VALUES ('M+', 1134, 2, 6, 1141, 0);
+INSERT INTO highlight VALUES ('M0', 1137, 230, 6, 1141, 221);
+INSERT INTO highlight VALUES ('M+', 1372, 2, 6, 1364, 0);
+INSERT INTO highlight VALUES ('M0', 1375, 363, 6, 1364, 322);
+INSERT INTO highlight VALUES ('M+', 1743, 2, 6, 1690, 0);
+INSERT INTO highlight VALUES ('M0', 1746, 172, 6, 1690, 166);
+INSERT INTO highlight VALUES ('M+', 1923, 2, 6, 1858, 0);
+INSERT INTO highlight VALUES ('M0', 1926, 398, 6, 1858, 383);
+INSERT INTO highlight VALUES ('M+', 2329, 2, 6, 2243, 0);
+INSERT INTO highlight VALUES ('M0', 2332, 1417, 6, 2243, 1330);
+INSERT INTO highlight VALUES ('M+', 3754, 2, 6, 3577, 0);
+INSERT INTO highlight VALUES ('M0', 3757, 608, 6, 3577, 554);
+INSERT INTO highlight VALUES ('M+', 4370, 2, 6, 4135, 0);
+INSERT INTO highlight VALUES ('M0', 4373, 695, 6, 4135, 635);
+INSERT INTO highlight VALUES ('M+', 5073, 2, 6, 4774, 0);
+INSERT INTO highlight VALUES ('M0', 5076, 568, 6, 4774, 544);
+INSERT INTO highlight VALUES ('M+', 5649, 2, 6, 5320, 0);
+INSERT INTO highlight VALUES ('M0', 5652, 755, 6, 5320, 746);
+INSERT INTO highlight VALUES ('L ', 871, 71, 7, NULL, NULL);
+INSERT INTO highlight VALUES ('L ', 0, 34, 7, NULL, NULL);
+INSERT INTO highlight VALUES ('L ', 98, 36, 8, NULL, NULL);
+INSERT INTO highlight VALUES ('L ', 136, 73, 8, NULL, NULL);
+INSERT INTO highlight VALUES ('L ', 92, 36, 9, NULL, NULL);
+INSERT INTO highlight VALUES ('L ', 130, 73, 9, NULL, NULL);
+INSERT INTO highlight VALUES ('L ', 353, 35, 11, NULL, NULL);
+INSERT INTO highlight VALUES ('L ', 691, 29, 11, NULL, NULL);
+INSERT INTO highlight VALUES ('L ', 1639, 269, 10, NULL, NULL);
+
+
+
+INSERT INTO highlight_keyword VALUES (2, 1619, 14);
+INSERT INTO highlight_keyword VALUES (2, 1657, 14);
+INSERT INTO highlight_keyword VALUES (2, 3700, 5);
+INSERT INTO highlight_keyword VALUES (2, 39, 9);
+INSERT INTO highlight_keyword VALUES (2, 288, 9);
+INSERT INTO highlight_keyword VALUES (2, 298, 2);
+INSERT INTO highlight_keyword VALUES (2, 3664, 9);
+INSERT INTO highlight_keyword VALUES (2, 3909, 9);
+INSERT INTO highlight_keyword VALUES (2, 4073, 9);
+INSERT INTO highlight_keyword VALUES (2, 4174, 9);
+INSERT INTO highlight_keyword VALUES (2, 6315, 9);
+INSERT INTO highlight_keyword VALUES (2, 6325, 3);
+INSERT INTO highlight_keyword VALUES (2, 6504, 2);
+INSERT INTO highlight_keyword VALUES (2, 4343, 7);
+INSERT INTO highlight_keyword VALUES (2, 4712, 7);
+INSERT INTO highlight_keyword VALUES (2, 2665, 6);
+INSERT INTO highlight_keyword VALUES (2, 4017, 6);
+INSERT INTO highlight_keyword VALUES (2, 909, 9);
+INSERT INTO highlight_keyword VALUES (2, 1131, 9);
+INSERT INTO highlight_keyword VALUES (2, 1420, 9);
+INSERT INTO highlight_keyword VALUES (2, 2154, 9);
+INSERT INTO highlight_keyword VALUES (2, 6430, 9);
+INSERT INTO highlight_keyword VALUES (2, 2429, 5);
+INSERT INTO highlight_keyword VALUES (2, 3295, 5);
+INSERT INTO highlight_keyword VALUES (2, 3473, 5);
+INSERT INTO highlight_keyword VALUES (2, 4154, 10);
+INSERT INTO highlight_keyword VALUES (2, 4222, 10);
+INSERT INTO highlight_keyword VALUES (2, 4592, 10);
+INSERT INTO highlight_keyword VALUES (2, 4962, 10);
+INSERT INTO highlight_keyword VALUES (2, 53, 6);
+INSERT INTO highlight_keyword VALUES (2, 248, 6);
+INSERT INTO highlight_keyword VALUES (2, 1047, 6);
+INSERT INTO highlight_keyword VALUES (2, 1074, 6);
+INSERT INTO highlight_keyword VALUES (2, 1227, 6);
+INSERT INTO highlight_keyword VALUES (2, 2309, 6);
+INSERT INTO highlight_keyword VALUES (2, 2489, 6);
+INSERT INTO highlight_keyword VALUES (2, 2695, 6);
+INSERT INTO highlight_keyword VALUES (2, 2919, 6);
+INSERT INTO highlight_keyword VALUES (2, 3019, 6);
+INSERT INTO highlight_keyword VALUES (2, 3073, 6);
+INSERT INTO highlight_keyword VALUES (2, 3345, 6);
+INSERT INTO highlight_keyword VALUES (2, 3423, 6);
+INSERT INTO highlight_keyword VALUES (2, 3547, 6);
+INSERT INTO highlight_keyword VALUES (2, 4236, 6);
+INSERT INTO highlight_keyword VALUES (2, 4726, 6);
+INSERT INTO highlight_keyword VALUES (2, 4852, 6);
+INSERT INTO highlight_keyword VALUES (2, 4932, 6);
+INSERT INTO highlight_keyword VALUES (2, 5179, 6);
+INSERT INTO highlight_keyword VALUES (2, 5293, 6);
+INSERT INTO highlight_keyword VALUES (2, 5390, 6);
+INSERT INTO highlight_keyword VALUES (2, 5482, 6);
+INSERT INTO highlight_keyword VALUES (2, 5497, 6);
+INSERT INTO highlight_keyword VALUES (2, 5654, 6);
+INSERT INTO highlight_keyword VALUES (2, 5821, 6);
+INSERT INTO highlight_keyword VALUES (2, 5935, 6);
+INSERT INTO highlight_keyword VALUES (2, 2295, 6);
+INSERT INTO highlight_keyword VALUES (2, 2508, 6);
+INSERT INTO highlight_keyword VALUES (2, 2688, 6);
+INSERT INTO highlight_keyword VALUES (2, 2892, 6);
+INSERT INTO highlight_keyword VALUES (2, 2912, 6);
+INSERT INTO highlight_keyword VALUES (2, 3109, 6);
+INSERT INTO highlight_keyword VALUES (2, 3255, 6);
+INSERT INTO highlight_keyword VALUES (2, 3338, 6);
+INSERT INTO highlight_keyword VALUES (2, 3540, 6);
+INSERT INTO highlight_keyword VALUES (2, 4065, 6);
+INSERT INTO highlight_keyword VALUES (2, 2088, 7);
+INSERT INTO highlight_keyword VALUES (2, 4816, 7);
+INSERT INTO highlight_keyword VALUES (2, 6629, 7);
+INSERT INTO highlight_keyword VALUES (2, 973, 17);
+INSERT INTO highlight_keyword VALUES (2, 2628, 11);
+INSERT INTO highlight_keyword VALUES (2, 6528, 11);
+INSERT INTO highlight_keyword VALUES (2, 1087, 10);
+INSERT INTO highlight_keyword VALUES (2, 6674, 20);
+INSERT INTO highlight_keyword VALUES (2, 3734, 7);
+INSERT INTO highlight_keyword VALUES (2, 3789, 7);
+INSERT INTO highlight_keyword VALUES (2, 4546, 7);
+INSERT INTO highlight_keyword VALUES (2, 4379, 13);
+INSERT INTO highlight_keyword VALUES (3, 1628, 14);
+INSERT INTO highlight_keyword VALUES (3, 1672, 14);
+INSERT INTO highlight_keyword VALUES (3, 3865, 5);
+INSERT INTO highlight_keyword VALUES (3, 54, 9);
+INSERT INTO highlight_keyword VALUES (3, 708, 9);
+INSERT INTO highlight_keyword VALUES (3, 3804, 9);
+INSERT INTO highlight_keyword VALUES (3, 4092, 9);
+INSERT INTO highlight_keyword VALUES (3, 4293, 9);
+INSERT INTO highlight_keyword VALUES (3, 4404, 9);
+INSERT INTO highlight_keyword VALUES (3, 6590, 9);
+INSERT INTO highlight_keyword VALUES (3, 6600, 3);
+INSERT INTO highlight_keyword VALUES (3, 6789, 2);
+INSERT INTO highlight_keyword VALUES (3, 4651, 7);
+INSERT INTO highlight_keyword VALUES (3, 5056, 7);
+INSERT INTO highlight_keyword VALUES (3, 2732, 6);
+INSERT INTO highlight_keyword VALUES (3, 4231, 6);
+INSERT INTO highlight_keyword VALUES (3, 913, 9);
+INSERT INTO highlight_keyword VALUES (3, 1137, 9);
+INSERT INTO highlight_keyword VALUES (3, 1414, 9);
+INSERT INTO highlight_keyword VALUES (3, 2201, 9);
+INSERT INTO highlight_keyword VALUES (3, 6711, 9);
+INSERT INTO highlight_keyword VALUES (3, 2487, 5);
+INSERT INTO highlight_keyword VALUES (3, 3401, 5);
+INSERT INTO highlight_keyword VALUES (3, 3597, 5);
+INSERT INTO highlight_keyword VALUES (3, 4382, 10);
+INSERT INTO highlight_keyword VALUES (3, 4518, 10);
+INSERT INTO highlight_keyword VALUES (3, 4924, 10);
+INSERT INTO highlight_keyword VALUES (3, 5598, 10);
+INSERT INTO highlight_keyword VALUES (3, 14, 6);
+INSERT INTO highlight_keyword VALUES (3, 1051, 6);
+INSERT INTO highlight_keyword VALUES (3, 1072, 6);
+INSERT INTO highlight_keyword VALUES (3, 1236, 6);
+INSERT INTO highlight_keyword VALUES (3, 2361, 6);
+INSERT INTO highlight_keyword VALUES (3, 2550, 6);
+INSERT INTO highlight_keyword VALUES (3, 2765, 6);
+INSERT INTO highlight_keyword VALUES (3, 2998, 6);
+INSERT INTO highlight_keyword VALUES (3, 3104, 6);
+INSERT INTO highlight_keyword VALUES (3, 3160, 6);
+INSERT INTO highlight_keyword VALUES (3, 3457, 6);
+INSERT INTO highlight_keyword VALUES (3, 3541, 6);
+INSERT INTO highlight_keyword VALUES (3, 3677, 6);
+INSERT INTO highlight_keyword VALUES (3, 4538, 6);
+INSERT INTO highlight_keyword VALUES (3, 5230, 6);
+INSERT INTO highlight_keyword VALUES (3, 5273, 6);
+INSERT INTO highlight_keyword VALUES (3, 5491, 6);
+INSERT INTO highlight_keyword VALUES (3, 5612, 6);
+INSERT INTO highlight_keyword VALUES (3, 5729, 6);
+INSERT INTO highlight_keyword VALUES (3, 5745, 6);
+INSERT INTO highlight_keyword VALUES (3, 5908, 6);
+INSERT INTO highlight_keyword VALUES (3, 6084, 6);
+INSERT INTO highlight_keyword VALUES (3, 6201, 6);
+INSERT INTO highlight_keyword VALUES (3, 2347, 6);
+INSERT INTO highlight_keyword VALUES (3, 2569, 6);
+INSERT INTO highlight_keyword VALUES (3, 2758, 6);
+INSERT INTO highlight_keyword VALUES (3, 2971, 6);
+INSERT INTO highlight_keyword VALUES (3, 2991, 6);
+INSERT INTO highlight_keyword VALUES (3, 3203, 6);
+INSERT INTO highlight_keyword VALUES (3, 3361, 6);
+INSERT INTO highlight_keyword VALUES (3, 3450, 6);
+INSERT INTO highlight_keyword VALUES (3, 3670, 6);
+INSERT INTO highlight_keyword VALUES (3, 4285, 6);
+INSERT INTO highlight_keyword VALUES (3, 2127, 7);
+INSERT INTO highlight_keyword VALUES (3, 5220, 7);
+INSERT INTO highlight_keyword VALUES (3, 977, 17);
+INSERT INTO highlight_keyword VALUES (3, 2695, 11);
+INSERT INTO highlight_keyword VALUES (3, 6813, 11);
+INSERT INTO highlight_keyword VALUES (3, 1091, 10);
+INSERT INTO highlight_keyword VALUES (3, 3899, 7);
+INSERT INTO highlight_keyword VALUES (3, 3960, 7);
+INSERT INTO highlight_keyword VALUES (3, 4872, 7);
+INSERT INTO highlight_keyword VALUES (3, 5297, 7);
+INSERT INTO highlight_keyword VALUES (3, 4693, 13);
+INSERT INTO highlight_keyword VALUES (4, 85, 9);
+INSERT INTO highlight_keyword VALUES (4, 98, 9);
+INSERT INTO highlight_keyword VALUES (4, 194, 6);
+INSERT INTO highlight_keyword VALUES (5, 79, 9);
+INSERT INTO highlight_keyword VALUES (5, 92, 9);
+INSERT INTO highlight_keyword VALUES (5, 188, 6);
+INSERT INTO highlight_keyword VALUES (6, 1101, 5);
+INSERT INTO highlight_keyword VALUES (6, 123, 2);
+INSERT INTO highlight_keyword VALUES (6, 250, 2);
+INSERT INTO highlight_keyword VALUES (6, 261, 2);
+INSERT INTO highlight_keyword VALUES (6, 279, 2);
+INSERT INTO highlight_keyword VALUES (6, 343, 9);
+INSERT INTO highlight_keyword VALUES (6, 353, 3);
+INSERT INTO highlight_keyword VALUES (6, 1300, 2);
+INSERT INTO highlight_keyword VALUES (6, 1968, 2);
+INSERT INTO highlight_keyword VALUES (6, 4647, 2);
+INSERT INTO highlight_keyword VALUES (6, 4682, 3);
+INSERT INTO highlight_keyword VALUES (6, 4780, 2);
+INSERT INTO highlight_keyword VALUES (6, 4815, 3);
+INSERT INTO highlight_keyword VALUES (6, 4913, 2);
+INSERT INTO highlight_keyword VALUES (6, 4948, 3);
+INSERT INTO highlight_keyword VALUES (6, 5046, 2);
+INSERT INTO highlight_keyword VALUES (6, 5081, 3);
+INSERT INTO highlight_keyword VALUES (6, 5322, 2);
+INSERT INTO highlight_keyword VALUES (6, 5627, 2);
+INSERT INTO highlight_keyword VALUES (6, 6890, 2);
+INSERT INTO highlight_keyword VALUES (6, 6944, 2);
+INSERT INTO highlight_keyword VALUES (6, 7087, 2);
+INSERT INTO highlight_keyword VALUES (6, 7133, 2);
+INSERT INTO highlight_keyword VALUES (6, 7179, 2);
+INSERT INTO highlight_keyword VALUES (6, 7225, 2);
+INSERT INTO highlight_keyword VALUES (6, 7335, 2);
+INSERT INTO highlight_keyword VALUES (6, 7338, 2);
+INSERT INTO highlight_keyword VALUES (6, 7384, 2);
+INSERT INTO highlight_keyword VALUES (6, 7459, 2);
+INSERT INTO highlight_keyword VALUES (6, 7520, 2);
+INSERT INTO highlight_keyword VALUES (6, 7523, 2);
+INSERT INTO highlight_keyword VALUES (6, 7609, 2);
+INSERT INTO highlight_keyword VALUES (6, 7670, 2);
+INSERT INTO highlight_keyword VALUES (6, 7673, 2);
+INSERT INTO highlight_keyword VALUES (6, 7759, 2);
+INSERT INTO highlight_keyword VALUES (6, 7820, 2);
+INSERT INTO highlight_keyword VALUES (6, 7823, 2);
+INSERT INTO highlight_keyword VALUES (6, 7909, 2);
+INSERT INTO highlight_keyword VALUES (6, 7970, 2);
+INSERT INTO highlight_keyword VALUES (6, 7973, 2);
+INSERT INTO highlight_keyword VALUES (6, 8026, 2);
+INSERT INTO highlight_keyword VALUES (6, 8091, 2);
+INSERT INTO highlight_keyword VALUES (6, 8141, 2);
+INSERT INTO highlight_keyword VALUES (6, 8179, 2);
+INSERT INTO highlight_keyword VALUES (6, 8229, 2);
+INSERT INTO highlight_keyword VALUES (6, 8324, 2);
+INSERT INTO highlight_keyword VALUES (6, 8374, 2);
+INSERT INTO highlight_keyword VALUES (6, 8412, 2);
+INSERT INTO highlight_keyword VALUES (6, 8462, 2);
+INSERT INTO highlight_keyword VALUES (6, 8557, 2);
+INSERT INTO highlight_keyword VALUES (6, 8607, 2);
+INSERT INTO highlight_keyword VALUES (6, 8645, 2);
+INSERT INTO highlight_keyword VALUES (6, 8695, 2);
+INSERT INTO highlight_keyword VALUES (6, 8790, 2);
+INSERT INTO highlight_keyword VALUES (6, 8840, 2);
+INSERT INTO highlight_keyword VALUES (6, 8878, 2);
+INSERT INTO highlight_keyword VALUES (6, 8928, 2);
+INSERT INTO highlight_keyword VALUES (6, 9060, 2);
+INSERT INTO highlight_keyword VALUES (6, 9112, 2);
+INSERT INTO highlight_keyword VALUES (6, 9152, 2);
+INSERT INTO highlight_keyword VALUES (6, 9204, 2);
+INSERT INTO highlight_keyword VALUES (6, 9256, 2);
+INSERT INTO highlight_keyword VALUES (6, 9308, 2);
+INSERT INTO highlight_keyword VALUES (6, 9348, 2);
+INSERT INTO highlight_keyword VALUES (6, 9400, 2);
+INSERT INTO highlight_keyword VALUES (6, 9452, 2);
+INSERT INTO highlight_keyword VALUES (6, 9504, 2);
+INSERT INTO highlight_keyword VALUES (6, 9545, 2);
+INSERT INTO highlight_keyword VALUES (6, 9598, 2);
+INSERT INTO highlight_keyword VALUES (6, 9651, 2);
+INSERT INTO highlight_keyword VALUES (6, 9704, 2);
+INSERT INTO highlight_keyword VALUES (6, 9745, 2);
+INSERT INTO highlight_keyword VALUES (6, 9798, 2);
+INSERT INTO highlight_keyword VALUES (6, 9924, 2);
+INSERT INTO highlight_keyword VALUES (6, 9977, 2);
+INSERT INTO highlight_keyword VALUES (6, 10018, 2);
+INSERT INTO highlight_keyword VALUES (6, 10071, 2);
+INSERT INTO highlight_keyword VALUES (6, 10124, 2);
+INSERT INTO highlight_keyword VALUES (6, 10177, 2);
+INSERT INTO highlight_keyword VALUES (6, 10218, 2);
+INSERT INTO highlight_keyword VALUES (6, 10271, 2);
+INSERT INTO highlight_keyword VALUES (6, 10324, 2);
+INSERT INTO highlight_keyword VALUES (6, 10377, 2);
+INSERT INTO highlight_keyword VALUES (6, 10418, 2);
+INSERT INTO highlight_keyword VALUES (6, 10471, 2);
+INSERT INTO highlight_keyword VALUES (6, 10524, 2);
+INSERT INTO highlight_keyword VALUES (6, 10577, 2);
+INSERT INTO highlight_keyword VALUES (6, 10618, 2);
+INSERT INTO highlight_keyword VALUES (6, 10671, 2);
+INSERT INTO highlight_keyword VALUES (6, 10798, 2);
+INSERT INTO highlight_keyword VALUES (6, 10851, 2);
+INSERT INTO highlight_keyword VALUES (6, 10892, 2);
+INSERT INTO highlight_keyword VALUES (6, 10945, 2);
+INSERT INTO highlight_keyword VALUES (6, 10998, 2);
+INSERT INTO highlight_keyword VALUES (6, 11051, 2);
+INSERT INTO highlight_keyword VALUES (6, 11092, 2);
+INSERT INTO highlight_keyword VALUES (6, 11145, 2);
+INSERT INTO highlight_keyword VALUES (6, 11198, 2);
+INSERT INTO highlight_keyword VALUES (6, 11251, 2);
+INSERT INTO highlight_keyword VALUES (6, 11292, 2);
+INSERT INTO highlight_keyword VALUES (6, 11345, 2);
+INSERT INTO highlight_keyword VALUES (6, 11398, 2);
+INSERT INTO highlight_keyword VALUES (6, 11451, 2);
+INSERT INTO highlight_keyword VALUES (6, 11492, 2);
+INSERT INTO highlight_keyword VALUES (6, 11545, 2);
+INSERT INTO highlight_keyword VALUES (6, 11672, 2);
+INSERT INTO highlight_keyword VALUES (6, 11725, 2);
+INSERT INTO highlight_keyword VALUES (6, 11766, 2);
+INSERT INTO highlight_keyword VALUES (6, 11819, 2);
+INSERT INTO highlight_keyword VALUES (6, 11872, 2);
+INSERT INTO highlight_keyword VALUES (6, 11925, 2);
+INSERT INTO highlight_keyword VALUES (6, 11966, 2);
+INSERT INTO highlight_keyword VALUES (6, 12019, 2);
+INSERT INTO highlight_keyword VALUES (6, 12072, 2);
+INSERT INTO highlight_keyword VALUES (6, 12125, 2);
+INSERT INTO highlight_keyword VALUES (6, 12166, 2);
+INSERT INTO highlight_keyword VALUES (6, 12219, 2);
+INSERT INTO highlight_keyword VALUES (6, 12272, 2);
+INSERT INTO highlight_keyword VALUES (6, 12325, 2);
+INSERT INTO highlight_keyword VALUES (6, 12366, 2);
+INSERT INTO highlight_keyword VALUES (6, 12419, 2);
+INSERT INTO highlight_keyword VALUES (6, 12515, 2);
+INSERT INTO highlight_keyword VALUES (6, 704, 6);
+INSERT INTO highlight_keyword VALUES (6, 474, 5);
+INSERT INTO highlight_keyword VALUES (6, 680, 5);
+INSERT INTO highlight_keyword VALUES (6, 433, 6);
+INSERT INTO highlight_keyword VALUES (6, 664, 6);
+INSERT INTO highlight_keyword VALUES (6, 1623, 6);
+INSERT INTO highlight_keyword VALUES (6, 1653, 6);
+INSERT INTO highlight_keyword VALUES (6, 3019, 7);
+INSERT INTO highlight_keyword VALUES (6, 1138, 7);
+
+INSERT INTO job VALUES (1, '2015-05-04 11:43:14.909163+02', 0, NULL, 'ReportTestfiles.tar', 1, NULL, 2, 2);
+
+
+INSERT INTO jobqueue VALUES (1, 1, 'ununpack', '1', '2015-05-04 11:43:14.952183+02', '2015-05-04 11:43:16.129263+02', 'Completed', 1, NULL, 10, NULL, NULL, NULL, NULL);
+INSERT INTO jobqueue VALUES (2, 1, 'adj2nest', '1', '2015-05-04 11:43:16.154304+02', '2015-05-04 11:43:16.167857+02', 'Completed', 1, NULL, 10, NULL, NULL, NULL, NULL);
+INSERT INTO jobqueue VALUES (3, 1, 'copyright', '1', '2015-05-04 11:43:17.209319+02', '2015-05-04 11:43:17.317435+02', 'Completed', 1, NULL, 5, NULL, NULL, NULL, NULL);
+INSERT INTO jobqueue VALUES (4, 1, 'monk', '1', '2015-05-04 11:43:17.19792+02', '2015-05-04 11:43:17.864866+02', 'Completed', 1, NULL, 5, NULL, NULL, NULL, NULL);
+INSERT INTO jobqueue VALUES (5, 1, 'nomos', '1', '2015-05-04 11:43:17.205995+02', '2015-05-04 11:43:18.096835+02', 'Completed', 1, NULL, 5, NULL, NULL, NULL, NULL);
+INSERT INTO jobqueue VALUES (6, 1, 'decider', '1', '2015-05-04 11:43:18.233253+02', '2015-05-04 11:43:19.307912+02', 'Completed', 1, NULL, 2, NULL, NULL, NULL, '-r1');
+INSERT INTO jobqueue VALUES (7, 1, 'report', '1', '2015-05-04 11:53:18.233253+02', NULL, '', 0, NULL, 2, NULL, NULL, NULL, NULL);
+
+
+INSERT INTO jobdepends VALUES (2, 1);
+INSERT INTO jobdepends VALUES (3, 2);
+INSERT INTO jobdepends VALUES (4, 2);
+INSERT INTO jobdepends VALUES (5, 2);
+INSERT INTO jobdepends VALUES (6, 2);
+INSERT INTO jobdepends VALUES (6, 5);
+INSERT INTO jobdepends VALUES (6, 4);
+INSERT INTO jobdepends VALUES (6, 2);
+
+
+INSERT INTO license_file VALUES (1, NULL, 8, NULL, '2015-05-04 11:43:17.700032+02', 6, 1, NULL, NULL, NULL, NULL);
+INSERT INTO license_file VALUES (2, NULL, 8, NULL, '2015-05-04 11:43:17.703617+02', 4, 1, NULL, NULL, NULL, NULL);
+INSERT INTO license_file VALUES (3, 485, 1, NULL, '2015-05-04 11:43:17.711948+02', 2, 1, NULL, NULL, NULL, NULL);
+INSERT INTO license_file VALUES (4, 485, 8, 100, '2015-05-04 11:43:17.816367+02', 2, 1, NULL, NULL, NULL, NULL);
+INSERT INTO license_file VALUES (5, NULL, 8, NULL, '2015-05-04 11:43:17.835671+02', 5, 1, NULL, NULL, NULL, NULL);
+INSERT INTO license_file VALUES (6, 272, 8, 98, '2015-05-04 11:43:17.850531+02', 3, 1, NULL, NULL, NULL, NULL);
+INSERT INTO license_file VALUES (7, 272, 1, NULL, '2015-05-04 11:43:17.957299+02', 3, 1, NULL, NULL, NULL, NULL);
+INSERT INTO license_file VALUES (8, 199, 1, NULL, '2015-05-04 11:43:17.997061+02', 4, 1, NULL, NULL, NULL, NULL);
+INSERT INTO license_file VALUES (9, 199, 1, NULL, '2015-05-04 11:43:18.014822+02', 5, 1, NULL, NULL, NULL, NULL);
+INSERT INTO license_file VALUES (10, 560, 1, NULL, '2015-05-04 11:43:18.064022+02', 6, 1, NULL, NULL, NULL, NULL);
+INSERT INTO license_file VALUES (11, 561, 1, NULL, '2015-05-04 11:43:18.066447+02', 6, 1, NULL, NULL, NULL, NULL);
+
+
+INSERT INTO license_ref VALUES (485, 'lic A', 'Text of license A.', 'http://www.opensource.org', NULL, NULL, NULL, 'License A', NULL, NULL, NULL, '', NULL, false, false, false, 'eb59014579b4dda6991d5e9838506749', 1, NULL);
+INSERT INTO license_ref VALUES (272, 'lic B', 'License by Nomos.', NULL, NULL, NULL, NULL, 'License B', NULL, NULL, NULL, NULL, NULL, false, true, false, NULL, 2, NULL);
+INSERT INTO license_ref VALUES (199, 'lic C', 'License by Nomos.', NULL, NULL, NULL, NULL, 'License C', NULL, NULL, NULL, NULL, NULL, false, true, false, NULL, 2, NULL);
+INSERT INTO license_ref VALUES (560, 'lic Cpp', 'License by Nomos plus plus.', NULL, NULL, NULL, NULL, 'License Cpp', NULL, NULL, NULL, NULL, NULL, false, true, false, NULL, 2, NULL);
+INSERT INTO license_ref VALUES (561, 'lic D', 'License by Nomos.', NULL, NULL, NULL, NULL, 'License D', NULL, NULL, NULL, NULL, NULL, false, true, false, NULL, 2, NULL);
+
+
+INSERT INTO monk_ars VALUES (4, 8, 1, true, NULL, '2015-05-04 11:43:17.619778+02', '2015-05-04 11:43:17.863761+02');
+
+
+INSERT INTO nomos_ars VALUES (3, 1, 1, true, NULL, '2015-05-04 11:43:17.251076+02', '2015-05-04 11:43:18.095804+02');
+
+
+INSERT INTO perm_upload VALUES (1, 10, 1, 2);
+
+
+INSERT INTO sysconfig VALUES (1, 'SupportEmailLabel', 'Support', 'Support Email Label', 2, 'Support', 1, 'e.g. "Support"<br>Text that the user clicks on to create a new support email. This new email will be preaddressed to this support email address and subject.  HTML is ok.', '');
+INSERT INTO sysconfig VALUES (2, 'SupportEmailAddr', NULL, 'Support Email Address', 2, 'Support', 2, 'e.g. "support@mycompany.com"<br>Individual or group email address to those providing FOSSology support.', 'check_email_address');
+INSERT INTO sysconfig VALUES (3, 'SupportEmailSubject', 'FOSSology Support', 'Support Email Subject line', 2, 'Support', 3, 'e.g. "fossology support"<br>Subject line to use on support email.', '');
+INSERT INTO sysconfig VALUES (4, 'BannerMsg', NULL, 'Banner message', 3, 'Banner', 1, 'This is message will be displayed on every page with a banner.  HTML is ok.', '');
+INSERT INTO sysconfig VALUES (5, 'LogoImage', NULL, 'Logo Image URL', 2, 'Logo', 1, 'e.g. "http://mycompany.com/images/companylogo.png" or "images/mylogo.png"<br>This image replaces the fossology project logo. Image is constrained to 150px wide.  80-100px high is a good target.  If you change this URL, you MUST also enter a logo URL.', 'check_logo_image_url');
+INSERT INTO sysconfig VALUES (6, 'LogoLink', NULL, 'Logo URL', 2, 'Logo', 2, 'e.g. "http://mycompany.com/fossology"<br>URL a person goes to when they click on the logo.  If you change the Logo URL, you MUST also enter a Logo Image.', 'check_logo_url');
+INSERT INTO sysconfig VALUES (7, 'FOSSologyURL', 'vagrant-VirtualBox/repo/', 'FOSSology URL', 2, 'URL', 1, 'URL of this FOSSology server, e.g. vagrant-VirtualBox/repo/', 'check_fossology_url');
+INSERT INTO sysconfig VALUES (8, 'NomostListNum', '2200', 'Number of Nomost List', 2, 'Number', 4, 'For the Nomos List/Nomost List Download, you can set the number of lines to list/download. Default 2200.', NULL);
+INSERT INTO sysconfig VALUES (9, 'ShowJobsAutoRefresh', '10', 'ShowJobs Auto Refresh Time', 2, 'Number', NULL, 'No of seconds to refresh ShowJobs', NULL);
+INSERT INTO sysconfig VALUES (10, 'Release', '2.6.3.1', 'Release', 2, 'Release', NULL, '', NULL);
+
+
+INSERT INTO ununpack_ars VALUES (1, 14, 1, true, NULL, '2015-05-04 11:43:15.048687+02', '2015-05-04 11:43:15.1256+02');
+
+
+INSERT INTO upload_clearing VALUES (1, 2, 1, 2, 1, NULL);
+
+
+INSERT INTO upload_clearing_license VALUES (1, 2, 199);
+
+
+INSERT INTO uploadtree_a (uploadtree_pk,realparent,parent,upload_fk,pfile_fk,ufile_mode,lft,rgt,ufile_name) VALUES (7, 6, 6, 1, 4, 33188, 4, 5, 'test1.dtd');
+INSERT INTO uploadtree_a (uploadtree_pk,realparent,parent,upload_fk,pfile_fk,ufile_mode,lft,rgt,ufile_name) VALUES (8, 6, 6, 1, 5, 33188, 6, 7, 'test2.dtd');
+INSERT INTO uploadtree_a (uploadtree_pk,realparent,parent,upload_fk,pfile_fk,ufile_mode,lft,rgt,ufile_name) VALUES (6, 1, 2, 1, 0, 536888320, 3, 8, '3DFX');
+INSERT INTO uploadtree_a (uploadtree_pk,realparent,parent,upload_fk,pfile_fk,ufile_mode,lft,rgt,ufile_name) VALUES (10, 9, 9, 1, 6, 33188, 10, 11, 'hash_md5prime.c');
+INSERT INTO uploadtree_a (uploadtree_pk,realparent,parent,upload_fk,pfile_fk,ufile_mode,lft,rgt,ufile_name) VALUES (9, 1, 2, 1, 0, 536888320, 9, 12, 'Beerware');
+INSERT INTO uploadtree_a (uploadtree_pk,realparent,parent,upload_fk,pfile_fk,ufile_mode,lft,rgt,ufile_name) VALUES (4, 3, 3, 1, 2, 33188, 14, 15, 'Condor-1.0');
+INSERT INTO uploadtree_a (uploadtree_pk,realparent,parent,upload_fk,pfile_fk,ufile_mode,lft,rgt,ufile_name) VALUES (5, 3, 3, 1, 3, 33188, 16, 17, 'condor-1.1');
+INSERT INTO uploadtree_a (uploadtree_pk,realparent,parent,upload_fk,pfile_fk,ufile_mode,lft,rgt,ufile_name) VALUES (3, 1, 2, 1, 0, 536888320, 13, 18, 'Condor');
+INSERT INTO uploadtree_a (uploadtree_pk,realparent,parent,upload_fk,pfile_fk,ufile_mode,lft,rgt,ufile_name) VALUES (2, 1, 1, 1, 0, 805323776, 2, 19, 'artifact.dir');
+INSERT INTO uploadtree_a (uploadtree_pk,realparent,parent,upload_fk,pfile_fk,ufile_mode,lft,rgt,ufile_name) VALUES (1, NULL, NULL, 1, 1, 536904704, 1, 20, 'ReportTestfiles.tar');
+

--- a/src/spdx2/agent_tests/Functional/schedulerTest.php
+++ b/src/spdx2/agent_tests/Functional/schedulerTest.php
@@ -1,0 +1,165 @@
+<?php
+/*
+Copyright (C) 2015, Siemens AG
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+namespace Fossology\SpdxTwo\Test;
+
+use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\Test\TestInstaller;
+use Fossology\Lib\Test\TestPgDb;
+
+include_once(__DIR__.'/../../../lib/php/Test/Agent/AgentTestMockHelper.php');
+include_once(__DIR__.'/SchedulerTestRunnerCli.php');
+
+class SchedulerTest extends \PHPUnit_Framework_TestCase
+{
+  /** @var int */
+  private $userId = 2;
+  /** @var int */
+  private $groupId = 2;
+  
+  /** @var TestPgDb */
+  private $testDb;
+  /** @var DbManager */
+  private $dbManager;
+  /** @var TestInstaller */
+  private $testInstaller;
+  /** @var SchedulerTestRunnerCli */
+  private $runnerCli;
+
+  public function setUp()
+  {
+    $this->testDb = new TestPgDb("spdx2test");
+    $this->dbManager = $this->testDb->getDbManager();
+
+    $this->runnerCli = new SchedulerTestRunnerCli($this->testDb);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+    
+    $this->agentDir = dirname(dirname(__DIR__));
+  }
+
+  public function tearDown()
+  {
+    $this->testDb->fullDestruct();
+    $this->testDb = null;
+    $this->dbManager = null;
+  }
+
+  private function setUpRepo()
+  {
+    $sysConf = $this->testDb->getFossSysConf();
+    $this->testInstaller = new TestInstaller($sysConf);
+    $this->testInstaller->init();
+    $this->testInstaller->cpRepo();
+    $this->testInstaller->install($this->agentDir);
+  }
+
+  private function rmRepo()
+  {
+    $this->testInstaller->uninstall($this->agentDir);
+    $this->testInstaller->rmRepo();
+    $this->testInstaller->clear();
+  }
+
+  private function setUpTables()
+  {
+    $this->testDb->createPlainTables(array(),true);
+    $this->testDb->createInheritedTables();
+    $this->dbManager->queryOnce("CREATE TABLE copyright_ars () INHERITS (ars_master)");
+    
+    $this->testDb->createSequences(array('agent_agent_pk_seq','pfile_pfile_pk_seq','upload_upload_pk_seq','nomos_ars_ars_pk_seq','license_file_fl_pk_seq','license_ref_rf_pk_seq','license_ref_bulk_lrb_pk_seq','clearing_decision_clearing_decision_pk_seq','clearing_event_clearing_event_pk_seq'));
+    $this->testDb->createConstraints(array('agent_pkey','pfile_pkey','upload_pkey_idx','FileLicense_pkey','clearing_event_pkey'));
+    $this->testDb->alterTables(array('agent','pfile','upload','ars_master','license_ref_bulk','clearing_event','clearing_decision','license_file','highlight'));
+    
+    $this->testDb->insertData(array('mimetype_ars','pkgagent_ars','ununpack_ars','decider_ars'),true,__DIR__.'/fo_report.sql');
+    // $this->testDb->insertData_license_ref();
+    $this->testDb->resetSequenceAsMaxOf('agent_agent_pk_seq', 'agent', 'agent_pk');
+  }
+
+  private function getHeartCount($output)
+  {
+    $matches = array();
+    if (preg_match("/.*HEART: ([0-9]*).*/", $output, $matches))
+    {
+      return intval($matches[1]);
+    } else
+    {
+      return -1;
+    }
+  }
+
+  /** @group Functional */
+  public function testReport()
+  {
+    $this->setUpTables();
+    $this->setUpRepo();
+
+    list($success,$output,$retCode) = $this->runnerCli->run($uploadId=1, $this->userId, $this->groupId, $jobId=7);
+
+    assertThat('cannot run runner', $success, equalTo(true));
+    assertThat( 'report failed: "'.$output.'"', $retCode, equalTo(0));
+    assertThat($this->getHeartCount($output), greaterThan(0));
+    
+    $row = $this->dbManager->getSingleRow("SELECT upload_fk,job_fk,filepath FROM reportgen WHERE job_fk = $1", array($jobId), "reportFileName");
+    assertThat($row, hasKeyValuePair('upload_fk', $uploadId));
+    assertThat($row, hasKeyValuePair('job_fk', $jobId));
+    $filepath = $row['filepath'];
+    assertThat($filepath, endsWith('.rdf'));
+    $this->addToAssertionCount(\Hamcrest\MatcherAssert::getCount()-$this->assertCountBefore);
+        
+    $this->verifyRdf($filepath);
+    unlink($filepath);
+    $this->rmRepo();
+  }
+  
+  protected function verifyRdf($filepath)
+  {
+    exec('which java', $lines, $returnVar);
+    $this->assertEquals(0,$returnVar,'java required for this test');
+    
+    $toolDir = __DIR__.'/test-tool/';
+
+    if(!is_dir($toolDir))
+    {
+      $this->pullSpdxTools($toolDir);
+    }
+
+    $toolJarFile = $toolDir.'/SPDXTools-v2.0.0/spdx-tools-2.0.0-jar-with-dependencies.jar';
+    $tagFile = __DIR__."/out.tag";
+    exec("java -jar $toolJarFile RdfToTag $filepath $tagFile");
+    
+    $this->assertFileExists($tagFile, 'SPDXTools failed');
+    assertThat(filesize($tagFile),is(greaterThan(42)));
+    unlink($tagFile);
+  }
+  
+  protected function pullSpdxTools($toolDir)
+  {        
+    $toolZipFile = __DIR__."/SPDXTools-v2.0.0.zip";    
+    if(!file_exists($toolZipFile))
+    {
+      file_put_contents($toolZipFile, fopen("http://spdx.org/sites/spdx/files/SPDXTools-v2.0.0.zip", 'r'));
+    }
+    $this->assertFileExists($toolZipFile, 'could not find SPDXTools');
+    
+    $zip = new \ZipArchive();
+    $zip->open($toolZipFile);
+    $this->assertTrue( $zip->extractTo($toolDir), 'could not unzip SPDXTools');
+    $zip->close();
+  }
+
+}

--- a/src/spdx2/agent_tests/Makefile
+++ b/src/spdx2/agent_tests/Makefile
@@ -1,0 +1,29 @@
+# Copyright Siemens AG 2015
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+TOP = ../../..
+VARS = $(TOP)/Makefile.conf
+include $(VARS)
+
+DIRS = Functional
+LOCALAGENTDIR = ../agent/
+
+DIR_LOOP = @set -e; for dir in $(DIRS); do $(MAKE) -s -C $$dir $(1); done
+
+all:
+	$(call DIR_LOOP, )
+
+test:
+	$(call DIR_LOOP,test)
+
+coverage:
+	$(call DIR_LOOP,coverage)
+
+clean:
+	$(call DIR_LOOP,clean)
+
+.PHONY: all test coverage clean

--- a/src/spdx2/spdx2.conf
+++ b/src/spdx2/spdx2.conf
@@ -1,0 +1,26 @@
+; Copyright Siemens AG 2015
+
+; Copying and distribution of this file, with or without modification,
+; are permitted in any medium without royalty provided the copyright
+; notice and this notice are preserved. This file is offered as-is,
+; without any warranty.
+
+; scheduler configure file for this agent
+[default]
+
+; name: The name of the agent from the agent table
+name = spdx2
+
+; command: The command that the scheduler will use when creating an instance of this agent. 
+; This will be parsed like a normal Unix command line.
+command = spdx2
+
+; max: The maximum number of this agent that is allowed to exist at any one time. 
+; This is set to -1 if there is no limit on the number of instances of the agent.
+max = -1
+
+; special: Scheduler directive for special agent attributes.
+; A comma separated list of values.
+; Directives:
+;     EXCLUSIVE: the agent cannot run concurrently with any other agent. 
+special[] = 

--- a/src/spdx2/ui/Makefile
+++ b/src/spdx2/ui/Makefile
@@ -1,0 +1,28 @@
+# Copyright Siemens AG 2014
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+TOP = ../../..
+VARS = $(TOP)/Makefile.conf
+include $(VARS)
+
+MOD_NAME = spdx2
+MOD_SUBDIR = ui
+
+all:
+	@echo "nothing to do"
+
+install:
+	mkdir -p $(DESTDIR)$(MODDIR)/$(MOD_NAME)/$(MOD_SUBDIR)
+	$(INSTALL_DATA) ./*.php $(DESTDIR)$(MODDIR)/$(MOD_NAME)/$(MOD_SUBDIR)
+
+uninstall:
+	rm -rf $(DESTDIR)$(MODDIR)/$(MOD_NAME)/$(MOD_SUBDIR)
+
+clean:
+	@echo "nothing to do"
+
+.PHONY: all install uninstall clean

--- a/src/spdx2/ui/SpdxTwoAgentPlugin.php
+++ b/src/spdx2/ui/SpdxTwoAgentPlugin.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ Copyright (C) 2015 Siemens AG
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace Fossology\SpdxTwo;
+
+use Fossology\Lib\Plugin\AgentPlugin;
+
+class SpdxTwoAgentPlugin extends AgentPlugin
+{
+  public function __construct() {
+    $this->Name = "agent_spdx2";
+    $this->Title =  _("SPDX generation");
+    $this->AgentName = "spdx2";
+    
+    parent::__construct();
+  }
+
+  function preInstall()
+  {
+    // no AgentCheckBox
+  }
+  
+  public function uploadsAdd($uploads)
+  {
+    if (count($uploads) == 0) {
+      return '';
+    }
+    return '--uploadsAdd='. implode(',', array_keys($uploads));
+  }
+}
+
+register_plugin(new SpdxTwoAgentPlugin());

--- a/src/spdx2/ui/SpdxTwoGeneratorUi.php
+++ b/src/spdx2/ui/SpdxTwoGeneratorUi.php
@@ -1,0 +1,154 @@
+<?php
+/*
+ Copyright (C) 2015 Siemens AG
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace Fossology\SpdxTwo;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Data\Upload\Upload;
+use Fossology\Lib\Plugin\DefaultPlugin;
+use Symfony\Component\HttpFoundation\Request;
+
+class SpdxTwoGeneratorUi extends DefaultPlugin
+{
+  const NAME = 'ui_spdx2';
+  
+  function __construct()
+  {
+    parent::__construct(self::NAME, array(
+        self::TITLE => _("SPDX generation"),
+        self::PERMISSION => Auth::PERM_WRITE,
+        self::REQUIRES_LOGIN => true
+    ));
+  }
+
+  function preInstall()
+  {
+    $text = _("Generate ReadMe_OSS");
+    menu_insert("Browse-Pfile::SPDX", 0, self::NAME, $text);
+    
+    menu_insert("UploadMulti::Generate&nbsp;SPDX", 0, self::NAME, $text);
+  }
+
+  protected function handle(Request $request)
+  {
+    $groupId = Auth::getGroupId();
+    $uploadIds = $request->get('uploads') ?: array();
+    $uploadIds[] = intval($request->get('upload'));
+    $addUploads = array();
+    foreach($uploadIds as $uploadId)
+    {
+      if (empty($uploadId)) {
+        continue;
+      }
+      try
+      {
+        $addUploads[$uploadId] = $this->getUpload($uploadId, $groupId);
+      }
+      catch(Exception $e)
+      {
+        return $this->flushContent($e->getMessage());
+      }
+    }
+    $folderId = $request->get('folder');
+    if(!empty($folderId))
+    {
+      /* @var $folderDao FolderDao */
+      $folderDao = $this->getObject('dao.folder');
+      $folderUploads = $folderDao->getFolderUploads($folderId, $groupId);
+      foreach($folderUploads as $uploadProgress)
+      {
+        $addUploads[$uploadProgress->getId()] = $uploadProgress;
+      }
+    }
+    if (empty($addUploads)) {
+      return $this->flushContent(_('No upload selected'));
+    }
+    $upload = array_pop($addUploads);
+    try
+    {
+      list($jobId,$jobQueueId) = $this->getJobAndJobqueue($groupId, $upload, $addUploads);
+    }
+    catch (Exception $ex) {
+      return $this->flushContent($ex->getMessage());
+    }
+
+    $vars = array('jqPk' => $jobQueueId,
+                  'downloadLink' => Traceback_uri(). "?mod=download&report=".$jobId,
+                  'reportType' => "SPDX 2");
+    $text = sprintf(_("Generating SPDX v2.0 report for '%s'"), $upload->getFilename());
+    $vars['content'] = "<h2>".$text."</h2>";
+    return $this->render("report.html.twig",$this->mergeWithDefault($vars));
+  }
+  
+  protected function getJobAndJobqueue($groupId, $upload, $addUploads)
+  {
+    $uploadId = $upload->getId();
+    $spdxTwoAgent = plugin_find('agent_spdx2');
+    $userId = Auth::getUserId();
+    $jqCmdArgs = $spdxTwoAgent->uploadsAdd($addUploads);
+    $dbManager = $this->getObject('db.manager');
+    $sql = 'SELECT jq_pk,job_pk FROM jobqueue, job '
+         . 'WHERE jq_job_fk=job_pk AND jq_type=$1 AND job_group_fk=$4 AND job_user_fk=$3 AND jq_args=$2 AND jq_endtime IS NULL';
+    $params = array($spdxTwoAgent->AgentName,$uploadId,$userId,$groupId);
+    $log = __METHOD__;
+    if ($jqCmdArgs) {
+      $sql .= ' AND jq_cmd_args=$5';
+      $params[] = $jqCmdArgs;
+      $log .= '.args';
+    }
+    else {
+      $sql .= ' AND jq_cmd_args IS NULL';
+    }
+    $scheduled = $dbManager->getSingleRow($sql,$params,$log);
+    if (!empty($scheduled)) {
+      return array($scheduled['job_pk'],$scheduled['jq_pk']);
+    }
+    $jobId = JobAddJob($userId, $groupId, $upload->getFilename(), $uploadId);
+    $error = "";
+    $jobQueueId = $spdxTwoAgent->AgentAdd($jobId, $uploadId, $error, array(), $jqCmdArgs);
+    if ($jobQueueId<0)
+    {
+      throw new Exception(_("Cannot schedule").": ".$error);
+    }
+    return array($jobId,$jobQueueId);
+  }
+  
+  protected function getUpload($uploadId, $groupId)
+  {  
+    if ($uploadId <=0)
+    {
+      throw new Exception(_("parameter error: $uploadId"));
+    }
+    /* @var $uploadDao UploadDao */
+    $uploadDao = $this->getObject('dao.upload');
+    if (!$uploadDao->isAccessible($uploadId, $groupId))
+    {
+      throw new Exception(_("permission denied"));
+    }
+    /** @var Upload */
+    $upload = $uploadDao->getUpload($uploadId);
+    if ($upload === null)
+    {
+      throw new Exception(_('cannot find uploadId'));
+    }
+    return $upload;
+  }
+}
+
+register_plugin(new SpdxTwoGeneratorUi());

--- a/src/www/ui/ajax-showjobs.php
+++ b/src/www/ui/ajax-showjobs.php
@@ -386,6 +386,9 @@ class AjaxShowJobs extends FO_Plugin
           case 'readmeoss':
             $varJobQueueRow['download'] = "ReadMeOss";
             break;
+          case 'spdx2':
+             $varJobQueueRow['download'] = "SPDX";
+             break;
           default:
             $varJobQueueRow['download'] = "";
         }


### PR DESCRIPTION
This generates an SPDX v2.0 rdf report.
The SPDXTools-v2.0.0 (http://spdx.org/sites/spdx/files/SPDXTools-v2.0.0.zip) can be used to transform the report into other formats.
The test in spdx2/agent_tests/Functional/schedulerTest.php uses this official tool for verifying one generated rdf report.