### PR TITLE
copyright filter error correction

### DIFF
--- a/src/copyright/ui/ajax-copyright-hist.php
+++ b/src/copyright/ui/ajax-copyright-hist.php
@@ -170,7 +170,7 @@ class CopyrightHistogramProcessPost extends FO_Plugin
 
     $join = "";
     $filterQuery = "";
-    if ($type == 'statement' && $filter == "nolics")
+    if ($type == 'statement' && $filter == "nolic")
     {
       $noLicStr = "No_license_found";
       $voidLicStr = "Void";

--- a/src/copyright/ui/list.php
+++ b/src/copyright/ui/list.php
@@ -171,7 +171,7 @@ class copyright_list extends FO_Plugin
       }
 
       /* apply filters */
-      if (($filter == "nolics") and ($rf_clause))
+      if (($filter == "nolic") and ($rf_clause))
       {
         /* discard file unless it has no license */
         $sql = "select rf_fk from license_file where ($rf_clause) and pfile_fk={$row['pf']}";


### PR DESCRIPTION
copyright agent Show files without licenses
shows the same content as All option
due to filter typo.