### PR TITLE
uniform and fixed micromenu

### DIFF
--- a/src/buckets/ui/ui-buckets.php
+++ b/src/buckets/ui/ui-buckets.php
@@ -19,6 +19,7 @@
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\UI\Component\MicroMenu;
 
 class ui_buckets extends FO_Plugin
 {
@@ -102,26 +103,16 @@ class ui_buckets extends FO_Plugin
   function RegisterMenus()
   {
     // For all other menus, permit coming back here.
-    $URI = $this->Name . Traceback_parm_keep(array("format","page","upload","item","bp"));
     $Item = GetParm("item",PARM_INTEGER);
     $Upload = GetParm("upload",PARM_INTEGER);
     $bucketpool_pk = GetParm("bp",PARM_INTEGER);
     if (!empty($Item) && !empty($Upload))
     {
-      if (GetParm("mod",PARM_STRING) == $this->Name)
-      {
-        menu_insert("Browse::Bucket Browser",1);
-        menu_insert("View::Bucket Browser",1);
-        //menu_insert("Browse::[BREAK]",100);
-        $text = _("Clear");
-        //menu_insert("Browse::Clear",101,NULL,NULL,NULL,"<a href='javascript:LicColor(\"\",\"\",\"\",\"\");'>$text</a>");
-      }
-      else
-      {
-        $text = _("Browse by buckets");
-        menu_insert("Browse::Bucket Browser",10,$URI,$text);
-        menu_insert("View::Bucket Browser",10,$URI,$text);
-      }
+      $menuText = "Bucket";
+      $menuPosition = 55;
+      $URI = $this->Name . Traceback_parm_keep(array("format","page","upload","item","bp"));
+      $tooltipText = _("Browse by buckets");
+      $this->microMenu->insert(array(MicroMenu::VIEW_META, MicroMenu::VIEW), $menuText, $menuPosition, $this->getName(), $URI, $tooltipText);
     }
   } // RegisterMenus()
 

--- a/src/buckets/ui/ui-buckets.php
+++ b/src/buckets/ui/ui-buckets.php
@@ -554,8 +554,8 @@ return;
       $V .= "<font class='text'>\n";
 
       $Children = GetNonArtifactChildren($Item, $this->uploadtree_tablename);
-      if (count($Children) == 0) // no children, display View micromenu
-        $V .= Dir2Browse($this->Name,$Item,NULL,1,"View", -1, '', '', $this->uploadtree_tablename) . "<P />\n";
+      if (count($Children) == 0) // no children, display View-Meta micromenu
+        $V .= Dir2Browse($this->Name,$Item,NULL,1,"View-Meta", -1, '', '', $this->uploadtree_tablename) . "<P />\n";
       else // has children, display Browse micormenu
         $V .= Dir2Browse($this->Name,$Item,NULL,1,"Browse", -1, '', '', $this->uploadtree_tablename) . "<P />\n";
 

--- a/src/composer.json
+++ b/src/composer.json
@@ -26,6 +26,7 @@
     "autoload": {
         "psr-4": {
             "Fossology\\Lib\\": "lib/php",
+            "Fossology\\Agent\\Copyright\\UI\\": "copyright/ui",
             "Fossology\\DeciderJob\\UI\\": "deciderjob/ui",
             "Fossology\\Decider\\UI\\": "decider/ui",
             "Fossology\\UI\\Page\\": "www/ui/page"

--- a/src/copyright/ui/CopyrightView.php
+++ b/src/copyright/ui/CopyrightView.php
@@ -17,10 +17,9 @@
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-use Fossology\Lib\Dao\AgentDao;
-use Fossology\Lib\Data\Highlight;
+namespace Fossology\Agent\Copyright\UI;
 
-require_once('Xpview.php');
+use Fossology\Lib\Data\Highlight;
 
 class CopyrightView extends Xpview
 {
@@ -43,7 +42,7 @@ class CopyrightView extends Xpview
         'email' => Highlight::EMAIL,
         'url' => Highlight::URL,
         'author' => Highlight::AUTHOR);
-    parent::__construct(self::NAME,array(
+    parent::__construct(self::NAME, array(
         self::TITLE => _("View Copyright/Email/Url Analysis")
     ));
   }
@@ -59,9 +58,7 @@ class CopyrightView extends Xpview
   {
     if (empty($agentId))
     {
-      /** @var AgentDao $agentDao */
-      $agentDao = $GLOBALS['container']->get('dao.agent');
-      $agentMap = $agentDao->getLatestAgentResultForUpload($uploadId,array('copyright'));
+      $agentMap = $this->agentDao->getLatestAgentResultForUpload($uploadId,array('copyright'));
       $agentId = array_key_exists('copyright',$agentMap) ? $agentMap['copyright'] : 0;
     }
     

--- a/src/copyright/ui/EccView.php
+++ b/src/copyright/ui/EccView.php
@@ -56,6 +56,7 @@ class EccView extends Xpview
     $uploadId = GetParm("upload", PARM_INTEGER);
     if (!empty($itemId) && !empty($uploadId)) {
       $menuText = "ECC";
+      $tooltipText = "Export Control Classification";
       $menuPosition = 56;
       $URI = EccView::NAME . Traceback_parm_keep(array("show", "format", "page", "upload", "item"));
       $this->microMenu->insert(MicroMenu::TARGET_DEFAULT, $menuText, $menuPosition, $this->getName(), $URI, $tooltipText);

--- a/src/copyright/ui/EccView.php
+++ b/src/copyright/ui/EccView.php
@@ -16,9 +16,11 @@
  with this program; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-use Fossology\Lib\Data\Highlight;
 
-require_once('Xpview.php');
+namespace Fossology\Agent\Copyright\UI;
+
+use Fossology\Lib\Data\Highlight;
+use Fossology\Lib\UI\Component\MicroMenu;
 
 class EccView extends Xpview
 {
@@ -36,8 +38,32 @@ class EccView extends Xpview
     $this->typeToHighlightTypeMap = array('ecc' => Highlight::ECC);
     $this->xptext = 'export restriction';
     parent::__construct(self::NAME, array(
-        self::TITLE => _("View Export Control and Customs Analysis")
+      self::TITLE => _("View Export Control and Customs Analysis")
     ));
+  }
+
+  /**
+   * \brief Customize submenus.
+   */
+  function RegisterMenus()
+  {
+    $itemId = GetParm("item", PARM_INTEGER);
+    $textFormat = $this->microMenu->getFormatParameter($itemId);
+    $pageNumber = GetParm("page", PARM_INTEGER);
+    $this->microMenu->addFormatMenuEntries($textFormat, $pageNumber);
+
+    // For all other menus, permit coming back here.
+    $uploadId = GetParm("upload", PARM_INTEGER);
+    if (!empty($itemId) && !empty($uploadId)) {
+      $menuText = "ECC";
+      $menuPosition = 56;
+      $URI = EccView::NAME . Traceback_parm_keep(array("show", "format", "page", "upload", "item"));
+      $this->microMenu->insert(MicroMenu::TARGET_DEFAULT, $menuText, $menuPosition, $this->getName(), $URI, $tooltipText);
+    }
+    $licId = GetParm("lic", PARM_INTEGER);
+    if (!empty($licId)) {
+      $this->NoMenu = 1;
+    }
   }
 }
 

--- a/src/copyright/ui/oneshot.php
+++ b/src/copyright/ui/oneshot.php
@@ -187,11 +187,13 @@ class agent_copyright_once extends FO_Plugin {
       {
         menu_insert("Main::Upload::One-Shot Copyright/Email/URL", $this->MenuOrder, $this->Name, $this->MenuTarget);
 
-        $text = _("Copyright/Email/URL One-shot, real-time analysis");
-        menu_insert("View::[BREAK]", 100);
-        menu_insert("View::One-Shot Copyright/Email/URL", 101, $this->Name, $text);
-        menu_insert("View-Meta::[BREAK]", 100);
-        menu_insert("View-Meta::One-Shot Copyright/Email/URL", 101, $this->Name, $text);
+        $tooltipText = _("Copyright/Email/URL One-shot, real-time analysis");
+        $menuText = "One-Shot Copyright/Email/URL";
+        $menuPosition = 100;
+        menu_insert("View::[BREAK]", $menuPosition);
+        menu_insert("View::{$menuText}", $menuPosition + 1, $this->Name, $tooltipText);
+        menu_insert("View-Meta::[BREAK]", $menuPosition);
+        menu_insert("View-Meta::{$menuText}", $menuPosition + 1, $this->Name, $tooltipText);
       }
     }
   } // RegisterMenus()

--- a/src/lib/php/Plugin/DefaultPlugin.php
+++ b/src/lib/php/Plugin/DefaultPlugin.php
@@ -21,6 +21,7 @@ namespace Fossology\Lib\Plugin;
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\UI\Component\Menu;
+use Fossology\Lib\UI\Component\MicroMenu;
 use Monolog\Logger;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
@@ -51,6 +52,8 @@ abstract class DefaultPlugin implements Plugin
   private $logger;
   /** @var Menu */
   private $menu;
+  /** @var MicroMenu */
+  protected $microMenu;
   /** @var string */
   private $name;
   /** @var string */
@@ -89,6 +92,7 @@ abstract class DefaultPlugin implements Plugin
     $this->renderer = $this->getObject('twig.environment');
     $this->logger = $this->getObject('logger');
     $this->menu = $this->getObject('ui.component.menu');
+    $this->microMenu = $this->getObject('ui.component.micro-menu');
   }
 
   private function setParameter($key, $value)

--- a/src/lib/php/Plugin/DefaultPlugin.php
+++ b/src/lib/php/Plugin/DefaultPlugin.php
@@ -92,7 +92,7 @@ abstract class DefaultPlugin implements Plugin
     $this->renderer = $this->getObject('twig.environment');
     $this->logger = $this->getObject('logger');
     $this->menu = $this->getObject('ui.component.menu');
-    $this->microMenu = $this->getObject('ui.component.micro-menu');
+    $this->microMenu = $this->getObject('ui.component.micromenu');
   }
 
   private function setParameter($key, $value)

--- a/src/lib/php/Plugin/FO_Plugin.php
+++ b/src/lib/php/Plugin/FO_Plugin.php
@@ -19,6 +19,7 @@
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Plugin\Plugin;
+use Fossology\Lib\UI\Component\MicroMenu;
 use Fossology\Lib\UI\Component\Menu;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -103,6 +104,9 @@ class FO_Plugin implements Plugin
 
   /** @var Menu */
   private $menu;
+
+  /** @var MicroMenu */
+  protected $microMenu;
 
   /** @var Twig_Environment */
   protected $renderer;
@@ -210,6 +214,7 @@ class FO_Plugin implements Plugin
 
     global $container;
     $this->menu = $container->get('ui.component.menu');
+    $this->microMenu = $container->get('ui.component.micro-menu');
     $this->renderer = $container->get('twig.environment');
   }
 

--- a/src/lib/php/Plugin/FO_Plugin.php
+++ b/src/lib/php/Plugin/FO_Plugin.php
@@ -214,7 +214,7 @@ class FO_Plugin implements Plugin
 
     global $container;
     $this->menu = $container->get('ui.component.menu');
-    $this->microMenu = $container->get('ui.component.micro-menu');
+    $this->microMenu = $container->get('ui.component.micromenu');
     $this->renderer = $container->get('twig.environment');
   }
 

--- a/src/lib/php/Plugin/test/DefaultPluginTest.php
+++ b/src/lib/php/Plugin/test/DefaultPluginTest.php
@@ -112,7 +112,7 @@ class DefaultPluginTest extends \PHPUnit_Framework_TestCase
     $this->logger = M::mock('Monolog\Logger');
 
     $container->shouldReceive('get')->with('ui.component.menu')->andReturn($this->menu);
-    $container->shouldReceive('get')->with('ui.component.micro-menu')->andReturn($this->microMenu);
+    $container->shouldReceive('get')->with('ui.component.micromenu')->andReturn($this->microMenu);
     $container->shouldReceive('get')->with('twig.environment')->andReturn($this->twigEnvironment);
     $container->shouldReceive('get')->with('logger')->andReturn($this->logger);
     $container->shouldReceive('get')->with('session')->andReturn($this->session);

--- a/src/lib/php/Plugin/test/DefaultPluginTest.php
+++ b/src/lib/php/Plugin/test/DefaultPluginTest.php
@@ -22,6 +22,7 @@ namespace Fossology\Lib\Plugin;
 use Exception;
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\UI\Component\Menu;
+use Fossology\Lib\UI\Component\MicroMenu;
 use Monolog\Logger;
 use Symfony\Component\DependencyInjection\Container;
 use Mockery as M;
@@ -93,6 +94,9 @@ class DefaultPluginTest extends \PHPUnit_Framework_TestCase
   /** @var Menu|M\MockInterface */
   private $menu;
 
+  /** @var MicroMenu|M\MockInterface */
+  private $microMenu;
+
   /** @var TestPlugin */
   private $plugin;
 
@@ -108,6 +112,7 @@ class DefaultPluginTest extends \PHPUnit_Framework_TestCase
     $this->logger = M::mock('Monolog\Logger');
 
     $container->shouldReceive('get')->with('ui.component.menu')->andReturn($this->menu);
+    $container->shouldReceive('get')->with('ui.component.micro-menu')->andReturn($this->microMenu);
     $container->shouldReceive('get')->with('twig.environment')->andReturn($this->twigEnvironment);
     $container->shouldReceive('get')->with('logger')->andReturn($this->logger);
     $container->shouldReceive('get')->with('session')->andReturn($this->session);

--- a/src/lib/php/UI/Component/MicroMenu.php
+++ b/src/lib/php/UI/Component/MicroMenu.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Fossology\Lib\UI\Component;
+
+class MicroMenu
+{
+  const VIEW = 'View';
+  const VIEW_META = 'View-Meta';
+
+  const FORMAT_HEX = 'hex';
+  const FORMAT_TEXT = 'text';
+  const FORMAT_FLOW = 'flow';
+
+  const TARGET_DEFAULT = 'default';
+  const TARGET_VIEW = 'view';
+
+  private $formatOptions = array(self::FORMAT_FLOW, self::FORMAT_TEXT, self::FORMAT_HEX);
+
+  private $textFormats = array(self::FORMAT_HEX, self::FORMAT_TEXT, self::FORMAT_FLOW);
+
+  private $targets = array(
+    self::TARGET_DEFAULT => array(MicroMenu::VIEW_META, MicroMenu::VIEW),
+    self::TARGET_VIEW => array(MicroMenu::VIEW)
+  );
+
+  public function insert($groups, $name, $position, $module, $uri, $tooltip)
+  {
+    if (!is_array($groups)) {
+      $groups = $this->targets[$groups];
+    }
+
+    $showLink = GetParm("mod", PARM_STRING) !== $module;
+
+    foreach ($groups as $group) {
+      $menuKey = $group . MENU_PATH_SEPARATOR . $name;
+      if ($showLink) {
+        menu_insert($menuKey, $position, $uri, $tooltip);
+      } else {
+        menu_insert($menuKey, $position);
+      }
+    }
+  }
+
+  /**
+   * @param $itemId
+   * @return string
+   */
+  public function getFormatParameter($itemId = NULL)
+  {
+    $selectedFormat = GetParm("format", PARM_STRING);
+
+    if (in_array($selectedFormat, $this->formatOptions)) {
+      return $selectedFormat;
+    }
+    if (empty($itemId))
+      return self::FORMAT_FLOW;
+    else {
+      $mimeType = GetMimeType($itemId);
+      list($type, $dummy) = explode("/", $mimeType, 2);
+      return $type == 'text' ? self::FORMAT_TEXT : self::FORMAT_FLOW;
+    }
+  }
+
+  /**
+   * @param $selectedFormat
+   * @return string
+   */
+  public function addFormatMenuEntries($selectedFormat, $pageNumber, $menuKey = self::VIEW, $hexFactor = 10)
+  {
+    $uri = Traceback_parm();
+    $uri = preg_replace("/&format=[a-zA-Z0-9]*/", "", $uri);
+    $uri = preg_replace("/&page=[0-9]*/", "", $uri);
+
+    $pageNumberHex = NULL;
+    $pageNumberText = NULL;
+
+    $tooltipTexts = array(
+      self::FORMAT_HEX => _("View as a hex dump"),
+      self::FORMAT_TEXT => _("View as unformatted text"),
+      self::FORMAT_FLOW => _("View as formatted text")
+    );
+
+    $menuTexts = array(
+      self::FORMAT_HEX => "Hex",
+      self::FORMAT_TEXT => "Text",
+      self::FORMAT_FLOW => "Formatted"
+    );
+
+    $menuPosition = -9;
+    menu_insert("$menuKey::[BREAK]", $menuPosition--);
+
+    foreach ($this->textFormats as $currentFormat) {
+      $menuName = $menuKey . MENU_PATH_SEPARATOR . $menuTexts[$currentFormat];
+      if ($currentFormat == $selectedFormat) {
+        menu_insert($menuName, $menuPosition--);
+      } else {
+        $targetPageNumber = $currentFormat == self::FORMAT_HEX ? $hexFactor * $pageNumberHex : $pageNumber;
+        menu_insert($menuName, $menuPosition--, "$uri&format=$currentFormat&pageNumber=$targetPageNumber", $tooltipTexts[$currentFormat]);
+      }
+    }
+    menu_insert("$menuKey::[BREAK]", $menuPosition);
+  }
+}

--- a/src/lib/php/common-menu.php
+++ b/src/lib/php/common-menu.php
@@ -20,6 +20,7 @@
  * \brief common menu functions
  */
 const MENU_PATH_SEPARATOR = "::";
+const MENU_BREAK = "[BREAK]";
 
 /**
  * \brief
@@ -196,11 +197,11 @@ function menu_insert_r(&$menuItems, $path, $pathRemainder, $LastOrder, $Target, 
   if ($menuItemsExist) {
     foreach($menuItems as &$menuItem) {
       // need to escape the [ ] or the string will not match
-      if (!strcmp($menuItem->Name, $pathElement) && strcmp($menuItem->Name, "\\[BREAK\\]")) {
+      if (!strcmp($menuItem->Name, $pathElement) && strcmp($menuItem->Name, MENU_BREAK)) {
         $currentMenuItem = $menuItem;
         break;
       }
-      else if (!strcmp($menuItem->Name, "\\[BREAK\\]") && ($menuItem->Order == $LastOrder)) {
+      else if (!strcmp($menuItem->Name, MENU_BREAK) && ($menuItem->Order == $LastOrder)) {
         $currentMenuItem = $menuItem;
         break;
       }
@@ -348,14 +349,22 @@ function menu_to_1html($Menu, $ShowRefresh = 1, $ShowTraceback = 0, $ShowAll = 1
   $First = 1;
   if (!empty($Menu)) {
     foreach($Menu as $Val) {
-      if ($Val->Name == "[BREAK]") {
+      if ($Val->Name == MENU_BREAK) {
         if (!$First) {
-          $V.= " &nbsp;&nbsp;&bull;&nbsp;&nbsp; ";
+          $V .= " &nbsp;&nbsp;&bull;";
+          if ($showFullName) {
+            $V .= getFullNameAddition($Val);
+          }
+          $V .= "&nbsp;&nbsp; ";
         }
         $First = 1;
       }
       else if (!empty($Val->HTML)) {
         $V.= $Val->HTML;
+        if ($showFullName) {
+          $V .= getFullNameAddition($Val);
+
+        }
         $First = 0;
       }
       else if (!empty($Val->URI)) {
@@ -368,7 +377,7 @@ function menu_to_1html($Menu, $ShowRefresh = 1, $ShowTraceback = 0, $ShowAll = 1
         }
         $V.= ">";
         if ($showFullName) {
-          $V.= $Val->FullName . "(" . $Val->Order . ")";
+          $V.= $Val->FullName . getFullNameAddition($Val);
         }
         else {
           $V.= $Val->Name;
@@ -381,7 +390,7 @@ function menu_to_1html($Menu, $ShowRefresh = 1, $ShowTraceback = 0, $ShowAll = 1
           $V.= " | ";
         }
         if ($showFullName) {
-          $V.= $Val->FullName . "(" . $Val->Order . ")";
+          $V.= $Val->FullName . getFullNameAddition($Val);
         }
         else {
           $V.= $Val->Name;
@@ -399,6 +408,15 @@ function menu_to_1html($Menu, $ShowRefresh = 1, $ShowTraceback = 0, $ShowAll = 1
   }
   $menu_to_1html_counter++;
   return ("<div id='menu1html-$menu_to_1html_counter' align='right' style='padding:0px 5px 0px 5px'><small>$V</small></div>");
+}
+
+/**
+ * @param $menu menu
+ * @return string
+ */
+function getFullNameAddition(menu $menu)
+{
+  return "(" . $menu->Order . ")";
 } // menu_to_1html()
 
 

--- a/src/lib/php/services.xml.in
+++ b/src/lib/php/services.xml.in
@@ -146,7 +146,7 @@ without any warranty.
         <service id="ui.component.menu" class="Fossology\Lib\UI\Component\Menu">
             <argument type="service" id="twig.environment"/>
         </service>
-        <service id="ui.component.micro-menu" class="Fossology\Lib\UI\Component\MicroMenu">
+        <service id="ui.component.micromenu" class="Fossology\Lib\UI\Component\MicroMenu">
         </service>
         <service id="ui.folder.nav" class="Fossology\Lib\UI\FolderNav">
             <argument type="service" id="db.manager"/>

--- a/src/lib/php/services.xml.in
+++ b/src/lib/php/services.xml.in
@@ -146,6 +146,8 @@ without any warranty.
         <service id="ui.component.menu" class="Fossology\Lib\UI\Component\Menu">
             <argument type="service" id="twig.environment"/>
         </service>
+        <service id="ui.component.micro-menu" class="Fossology\Lib\UI\Component\MicroMenu">
+        </service>
         <service id="ui.folder.nav" class="Fossology\Lib\UI\FolderNav">
             <argument type="service" id="db.manager"/>
             <argument type="service" id="dao.folder"/>

--- a/src/nomos/ui/agent-nomos-once.php
+++ b/src/nomos/ui/agent-nomos-once.php
@@ -127,8 +127,8 @@ class agent_nomos_once extends FO_Plugin
          * the data from coming through.  Or there was an apache redirect,
          * which removes the POST data.
          */
-        $text = _("FATAL: your file did not get passed throught.  Make sure this page wasn't a result of a web server redirect, or that it didn't exceed your php POST limit.");
-        echo $text;
+        $tooltipText = _("FATAL: your file did not get passed throught.  Make sure this page wasn't a result of a web server redirect, or that it didn't exceed your php POST limit.");
+        echo $tooltipText;
       }
     }
 
@@ -143,12 +143,13 @@ class agent_nomos_once extends FO_Plugin
           "format",
           "item"
         ));
-        menu_insert("View::[BREAK]", 100);
-        $text = _("One-shot License, real-time license analysis");
-        menu_insert("View::One-Shot License", 101, $URI, $text);
-        menu_insert("View-Meta::[BREAK]", 100);
-        $text = _("Nomos One-shot, real-time license analysis");
-        menu_insert("View-Meta::One-Shot License", 101, $URI, $text);
+        $menuText = "One-Shot License";
+        $menuPosition = 100;
+        $tooltipText = _("One-shot License, real-time license analysis");
+        menu_insert("View::[BREAK]", $menuPosition);
+        menu_insert("View::{$menuText}", $menuPosition + 1, $URI, $tooltipText);
+        menu_insert("View-Meta::[BREAK]", $menuPosition);
+        menu_insert("View-Meta::{$menuText}", $menuPosition + 1, $URI, $tooltipText);
       }
     }
   } // RegisterMenus()

--- a/src/www/ui/ui-browse-license.php
+++ b/src/www/ui/ui-browse-license.php
@@ -77,7 +77,6 @@ class ui_browse_license extends DefaultPlugin
    */
   function RegisterMenus()
   {
-    return 0;
     // For all other menus, permit coming back here.
     $URI = $this->Name . Traceback_parm_keep(array("upload", "item"));
 

--- a/src/www/ui/ui-browse-license.php
+++ b/src/www/ui/ui-browse-license.php
@@ -77,6 +77,7 @@ class ui_browse_license extends DefaultPlugin
    */
   function RegisterMenus()
   {
+    return 0;
     // For all other menus, permit coming back here.
     $URI = $this->Name . Traceback_parm_keep(array("upload", "item"));
 
@@ -88,13 +89,16 @@ class ui_browse_license extends DefaultPlugin
     $menuName = $this->Title;
     if (GetParm("mod", PARM_STRING) == self::NAME)
     {
-      menu_insert("Browse::$menuName", 100);
+      menu_insert("Browse::$menuName", 99);
+      menu_insert("View::$menuName", 99);
+      menu_insert("View-Meta::$menuName", 99);
     }
     else
     {
       $text = _("license histogram");
-      menu_insert("Browse::$menuName", 100, $URI, $text);
-      menu_insert("View::$menuName", 100, $viewLicenseURI, $text);
+      menu_insert("Browse::$menuName", 99, $URI, $text);
+      menu_insert("View::$menuName", 99, $viewLicenseURI, $text);
+      menu_insert("View-Meta::$menuName", 99, $viewLicenseURI, $text);
     }
   }
 

--- a/src/www/ui/ui-clearing-view.php
+++ b/src/www/ui/ui-clearing-view.php
@@ -34,6 +34,7 @@ use Fossology\Lib\Data\Highlight;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
 use Fossology\Lib\Proxy\ScanJobProxy;
 use Fossology\Lib\Proxy\UploadTreeProxy;
+use Fossology\Lib\UI\Component\MicroMenu;
 use Fossology\Lib\View\HighlightProcessor;
 use Fossology\Lib\View\HighlightRenderer;
 use Monolog\Logger;
@@ -235,7 +236,7 @@ class ClearingView extends FO_Plugin
     $uploadTreeTableName = $this->uploadDao->getUploadtreeTableName($uploadId);
     $itemTreeBounds = $this->uploadDao->getItemTreeBounds($uploadTreeId, $uploadTreeTableName);
 
-    $this->vars['micromenu'] = Dir2Browse('license', $uploadTreeId, NULL, $showBox = 0, "View-Meta", -1, '', '', $uploadTreeTableName);
+    $this->vars['micromenu'] = Dir2Browse('license', $uploadTreeId, NULL, $showBox = 0, "View", -1, '', '', $uploadTreeTableName);
 
     global $Plugins;
     /** @var ui_view $view */
@@ -377,9 +378,15 @@ class ClearingView extends FO_Plugin
    */
   function RegisterMenus()
   {
-    $text = _("Set the concluded licenses for this upload");
-    menu_insert("Browse-Pfile::Clearing", 0, $this->Name, $text);
-    menu_insert("View::Audit", 35, $this->Name . Traceback_parm_keep(array("upload", "item", "show")), $text);
+    $menuText="Licenses";
+    $menuPosition = 58;
+    $uri = $this->Name . Traceback_parm_keep(array("upload", "item", "show"));
+    $tooltipText = _("Set the concluded licenses for this upload");
+    $this->microMenu->insert(array(MicroMenu::VIEW, MicroMenu::VIEW_META), $menuText, $menuPosition, $this->Name, $uri, $tooltipText );
+
+    if (GetParm("mod", PARM_STRING) != $this->Name) {
+      menu_insert("Browse-Pfile::$menuText", 0, $this->Name, $tooltipText);
+    }
     return 0;
   }
 

--- a/src/www/ui/ui-view-info.php
+++ b/src/www/ui/ui-view-info.php
@@ -41,23 +41,36 @@ class ui_view_info extends FO_Plugin
    */
   function RegisterMenus()
   {
-    $text = _("View file information");
-    menu_insert("Browse-Pfile::Info",5,$this->Name,$text);
+    $tooltipText = _("View file information");
+    menu_insert("Browse-Pfile::Info",5,$this->Name,$tooltipText);
     // For the Browse menu, permit switching between detail and summary.
     $Parm = Traceback_parm_keep(array("upload","item","format"));
     $URI = $this->Name . $Parm;
+
+    $menuPosition = 60;
+    $menuText = "Info";
     if (GetParm("mod",PARM_STRING) == $this->Name)
     {
-      menu_insert("View::Info",1);
-      menu_insert("View-Meta::Info",1);
+      menu_insert("View::[BREAK]", 61);
+      menu_insert("View::[BREAK]", 50);
+      menu_insert("View::{$menuText}", $menuPosition);
+      menu_insert("View-Meta::[BREAK]", 61);
+      menu_insert("View-Meta::[BREAK]", 50);
+      menu_insert("View-Meta::{$menuText}", $menuPosition);
+
       menu_insert("Browse::Info",-3);
     }
     else
     {
-      $text = _("View information about this file");
-      menu_insert("View::Info",1,$URI,$text);
-      menu_insert("View-Meta::Info",1,$URI,$text);
-      menu_insert("Browse::Info",-3,$URI,$text);
+      $tooltipText = _("View information about this file");
+      menu_insert("View::[BREAK]", 61);
+      menu_insert("View::[BREAK]", 50);
+      menu_insert("View::{$menuText}", $menuPosition, $URI, $tooltipText);
+      menu_insert("View-Meta::[BREAK]", 61);
+      menu_insert("View-Meta::[BREAK]", 50);
+      menu_insert("View-Meta::{$menuText}", $menuPosition, $URI, $tooltipText);
+
+      menu_insert("Browse::Info", -3, $URI, $tooltipText);
     }
   } // RegisterMenus()
 


### PR DESCRIPTION
This hopfully makes the micromenu more usable. For example some file viewing plugins do not contain the format part and the order of the items is not the same in all cases.

This PR sets the micromenu `View` to be used for all views showing file contents (e. g. View, Copyright, Audit) and the micromenu `View-Meta` to be used for views showing meta-information of a file.

Currently in the `View` case:
> One-Shot Copyright/Email/URL | One-Shot License   •   Info | View | Audit | Copyright/Email/Url/Author | ECC | Bucket   •   Hex | Text | Formatted   •   Refresh

And in the `View-Meta` case:
> One-Shot Copyright/Email/URL | One-Shot License   •   Info | View | Audit | Copyright/Email/Url/Author | ECC   •   Refresh

Basically, the view settings are missing here.

The menu generating code inside the plugins could still be abstracted. Discussion is welcome.
