### PR TITLE
repair bug, which prevents wildcards from working in wget_agent

### DIFF
--- a/src/wget_agent/agent/wget_agent.c
+++ b/src/wget_agent/agent/wget_agent.c
@@ -712,7 +712,7 @@ int Archivefs(char *Path, char *TempFile, char *TempFileDir, struct stat Status)
     memset(CMD, '\0', MAXCMD);
     /* for the wildcards upload, keep the path */
     /* copy * files to TempFileDir/temp primarily */
-    snprintf(CMD,MAXCMD-1, "mkdir -p '%s/temp'  > /dev/null 2>&1 && cp -r \"%s\"  '%s/temp' > /dev/null 2>&1", TempFileDir, Path, TempFileDir);
+    snprintf(CMD,MAXCMD-1, "mkdir -p '%s/temp'  > /dev/null 2>&1 && cp -r %s '%s/temp' > /dev/null 2>&1", TempFileDir, Path, TempFileDir);
     rc_system = system(CMD);
     if (rc_system != 0)
     {


### PR DESCRIPTION
this bug was introduced by myself in the pull request #532

* this solution may cause problems due to word splitting.
* for bash there would be a [better solution](http://stackoverflow.com/questions/17510339/how-can-i-force-bash-to-expand-a-variable-to-pass-it-as-an-argument) using arrays.