### PR TITLE
repair paths of log-files

### DIFF
--- a/src/lib/php/Test/TestLiteDb.php
+++ b/src/lib/php/Test/TestLiteDb.php
@@ -58,7 +58,7 @@ class TestLiteDb extends TestAbstractDb
 
     global $container;
     $logger = $container->get('logger');
-    $this->logFileName = dirname(dirname(dirname(dirname(dirname(__FILE__))))) . 'db.sqlite.log';
+    $this->logFileName = dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/db.sqlite.log';
     $logger->pushHandler(new StreamHandler($this->logFileName, Logger::DEBUG));    
     
     $sqlite3Connection = new SQLite3($this->dbFileName, SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE);

--- a/src/lib/php/tests/test_common_license_file.php
+++ b/src/lib/php/tests/test_common_license_file.php
@@ -79,7 +79,7 @@ class test_common_license_file extends PHPUnit_Framework_TestCase
     $PG_CONN = DBconnect($db_conf);
 
     $logger = new Monolog\Logger('default');
-    $this->logFileName = dirname(dirname(dirname(dirname(dirname(__FILE__))))) . 'db.sqlite.log';
+    $this->logFileName = dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/db.sqlite.log';
     $logger->pushHandler(new Monolog\Handler\StreamHandler($this->logFileName, Monolog\Logger::ERROR));
     $this->dbManager = new ModernDbManager($logger);
     $this->dbManager->setDriver(new Fossology\Lib\Db\Driver\Postgres($PG_CONN));


### PR DESCRIPTION
On the vagrant machine the values 
```
$this->logFileName = dirname(dirname(dirname(dirname(dirname(__FILE__))))) . 'db.sqlite.log';
```
get evaluated to **"/vagrantdb.sqlite.log"**, and the corresponding tests fail due to write permission problems.

With this fix they are evaluated to **"/vagrant/db.sqlite.log"** (but i think there is no cleaning mechanism, which would delete this file)