### PR TITLE
Write correct version of DB-scheme to DB

### DIFF
--- a/install/fossinit.php
+++ b/install/fossinit.php
@@ -295,9 +295,9 @@ if($isUpdating && (empty($sysconfig['Release']) || $sysconfig['Release']=='2.6.3
   renameLicensesForSpdxValidation($Verbose);
 }
 
-if($sysconfig['Release']=='2.6.3' || $sysconfig['Release']=='2.6.3.1' || $sysconfig['Release']=='2.6.3.2')
+if($sysconfig['Release']=='2.6.3' || $sysconfig['Release']=='2.6.3.1' || $sysconfig['Release']=='2.6.3.2' || $sysconfig['Release'] == '2.6.3.3')
 {
-  $sysconfig['Release'] = '2.6.3.3';
+  $sysconfig['Release'] = '3.0.0';
 }
 
 $dbManager->begin();


### PR DESCRIPTION
* the scheme is equivalent to version 2.6.3.3
* this value is displayed under `/?mod=foconfig`

This pull request is mentioned in #550

### TODO

update other version strings from `trunk` to `3.0.0`, for example in
* `/VERSION`
* `/VERSIONSTRING`
* `/variable.list`