### PR TITLE
fix(ununpack): remove extraneous parentheses

### DIFF
--- a/src/ununpack/agent/traverse.c
+++ b/src/ununpack/agent/traverse.c
@@ -494,7 +494,7 @@ int	Traverse	(char *Filename, char *Basename,
         strcat(Queue[Index].ChildRecurse,".unpacked");
         strcat(CI.PartnameNew,".unpacked");
         Queue[Index].PI.ChildRecurseArtifact=1;
-        if ((CMD[CI.PI.Cmd].Type == CMD_PACK))
+        if (CMD[CI.PI.Cmd].Type == CMD_PACK)
         {
           CI.IsCompressed = 1;
         }


### PR DESCRIPTION
extraneous parentheses caused build error when using clang:
https://travis-ci.org/fossology/fossology/jobs/93645065