### PR TITLE
./delagent fixes #271 and #272

### DIFF
--- a/src/delagent/agent/delagent.c
+++ b/src/delagent/agent/delagent.c
@@ -144,7 +144,7 @@ int main (int argc, char *argv[])
   fo_GetAgentKey(db_conn, basename(argv[0]), 0, agent_rev, agent_desc);
   
   if (ListProj) ListUploads(user_id, user_perm);
-  if (ListFolder) ListFolders();
+  if (ListFolder) ListFolders(user_id);
 
   alarm(60);  /* from this point on, handle the alarm */
   if (DelUpload) 

--- a/src/delagent/agent/delagent.h
+++ b/src/delagent/agent/delagent.h
@@ -48,7 +48,7 @@ void DeleteLicense(long UploadId);
 void DeleteUpload(long UploadId);
 void ListFoldersRecurse(long Parent, int Depth, long Row, int DelFlag);
 int UnlinkContent (long child, long parent, int mode);
-void ListFolders();
+void ListFolders(int user_id);
 void ListUploads (int user_id, int user_perm);
 void DeleteFolder(long FolderId);
 int ReadParameter(char *Parm);

--- a/src/delagent/agent/util.c
+++ b/src/delagent/agent/util.c
@@ -875,7 +875,7 @@ int check_permission_del(long upload_id, int user_id, int user_perm)
   PGresult *result = NULL;
   int count = 0;
 
-  snprintf(SQL,sizeof(SQL),"SELECT count(*) FROM upload where upload_pk = %ld;", upload_id);
+  snprintf(SQL,sizeof(SQL),"SELECT count(*) FROM upload join users on (users.user_pk = upload.user_fk or users.user_perm = 10) where upload_pk = %ld and users.user_pk = %d;", upload_id, user_id);
   result = PQexec(db_conn, SQL);
   if (fo_checkPQresult(db_conn, result, SQL, __FILE__, __LINE__)) return -1;
   count = atoi(PQgetvalue(result, 0, 0)); 
@@ -930,7 +930,7 @@ int authentication(char *user, char * password, int *user_id, int *user_perm)
   }
   else return -1;
   int i = 0;
-  char temp[2] = {0};
+  char temp[256] = {0};
   for (i = 0; i < strlen((char *)hash_value); i++)
   {
     sprintf(temp, "%02x", hash_value[i]);

--- a/src/delagent/agent/util.c
+++ b/src/delagent/agent/util.c
@@ -923,6 +923,9 @@ int authentication(char *user, char * password, int *user_id, int *user_perm)
   snprintf(SQL,sizeof(SQL),"SELECT user_seed, user_pass, user_perm, user_pk from users where user_name='%s';", user);
   result = PQexec(db_conn, SQL);
   if (fo_checkPQresult(db_conn, result, SQL, __FILE__, __LINE__)) return -1;
+  if (!PQntuples(result)){
+    return 0;
+  }
   strcpy(user_seed, PQgetvalue(result, 0, 0));
   strcpy(pass_hash_valid, PQgetvalue(result, 0, 1));
   *user_perm = atoi(PQgetvalue(result, 0, 2));


### PR DESCRIPTION
#271 :: a none permission user can get an upload list via /delagent -f  

#272 :: any user who is not the owner can delete any upload via /delagent -U  :: fixed with only owners and group admins can delete the upload now.