### PR TITLE
[#580] improved protocol inference

### DIFF
--- a/src/www/ui/core-auth.php
+++ b/src/www/ui/core-auth.php
@@ -227,7 +227,16 @@ class core_auth extends FO_Plugin
       global $Plugins;
       $this->vars['info'] = $Plugins[$initPluginId]->infoFirstTimeUsage();
     }
-    $this->vars['protocol'] = preg_replace("@/.*@", "", @$_SERVER['SERVER_PROTOCOL']);
+
+    if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != "off")
+    {
+      $this->vars['protocol'] = "HTTPS";
+    }
+    else
+    {
+      $this->vars['protocol'] = preg_replace("@/.*@", "", @$_SERVER['SERVER_PROTOCOL']);
+    }
+
     $this->vars['referrer'] = $referrer;
     $this->vars['loginFailure'] = !empty($userName) || !empty($password);
     if (!empty($userName) && $userName!='Default User') {

--- a/src/www/ui/page/HomePage.php
+++ b/src/www/ui/page/HomePage.php
@@ -48,10 +48,19 @@ class HomePage extends DefaultPlugin
     $vars = array('isSecure' => $request->isSecure());
     if (array_key_exists('User', $_SESSION) && $_SESSION['User']=="Default User" && plugin_find_id("auth")>=0)
     {
-      $vars['protocol'] = preg_replace("@/.*@", "", @$_SERVER['SERVER_PROTOCOL']);
+      if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != "off")
+      {
+        $vars['protocol'] = "HTTPS";
+      }
+      else
+      {
+        $vars['protocol'] = preg_replace("@/.*@", "", @$_SERVER['SERVER_PROTOCOL']);
+      }
+
       $vars['referrer'] = "?mod=browse";
       $vars['authUrl'] = "?mod=auth";
     }
+
     return $this->render("home.html.twig", $this->mergeWithDefault($vars));
   }
 }


### PR DESCRIPTION
`$_SERVER['SERVER_PROTOCOL']` does not reliably provide a means for inferring the use of HTTPS. `$_SERVER['HTTPS']` is set on many web servers if HTTPS is being used, so check that first.

This fixes #580