### PR TITLE
Remove extra spaces from the end of usage messages

### DIFF
--- a/src/cli/cp2foss.php
+++ b/src/cli/cp2foss.php
@@ -100,7 +100,7 @@ $Usage = "Usage: " . basename($argv[0]) . " [options] [archives]
     -R         = (deprecated and ignored)
     -w         = (deprecated and ignored)
     -W         = (deprecated and ignored)
-  ";
+";
 /* Load command-line options */
 global $PG_CONN;
 $Verbose = 0;

--- a/src/cli/fo_bucket_list.php
+++ b/src/cli/fo_bucket_list.php
@@ -38,7 +38,7 @@ $Usage = "Usage: " . basename($argv[0]) . "
                          'mac' and it should exclude all files in any directory containing the substring 'mac'
                          '/mac' and it should exclude all files in any directory that starts with 'mac'
   -h  help, this message
-  ";
+";
 
 $upload = $item = $bucket = $bucket_agent = $nomos_agent = "";
 

--- a/src/cli/fo_import_licenses.php
+++ b/src/cli/fo_import_licenses.php
@@ -30,7 +30,7 @@ $usage = "Usage: " . basename($argv[0]) . " [options]
   --delimiter = delimiter, default is ','
   --enclosure = enclosure, default is '\"'
   --csv       = csv file to import
-  ";
+";
 $opts = getopt("h", array('username:', 'password:', 'delimiter:', 'enclosure:', "csv:"));
 
 if(array_key_exists('h',$opts))

--- a/src/cli/fo_nomos_license_list.php
+++ b/src/cli/fo_nomos_license_list.php
@@ -34,7 +34,7 @@ $Usage = "Usage: " . basename($argv[0]) . "
                          'mac' and it should exclude all files in any directory containing the substring 'mac'
                          '/mac' and it should exclude all files in any directory that starts with 'mac'
   -h  help, this message
-  ";
+";
 $upload = ""; // upload id
 $item = ""; // uploadtree id
 $showContainer = 0; // include container or not, 1: yes, 0: no (default)

--- a/src/cli/fo_usergroup.php
+++ b/src/cli/fo_usergroup.php
@@ -36,7 +36,7 @@ $usage = "Usage: " . basename($argv[0]) . " [options]
   --permlvl   = group permission level (-1: None, ".UserDao::USER.": User, ".UserDao::ADMIN.": Admin, ".UserDao::ADVISOR.": Advisor)
   --accesslvl   = user database permission level (".Auth::PERM_NONE.": None, ".Auth::PERM_READ.": Read, ".Auth::PERM_WRITE.": Write, ".Auth::PERM_ADMIN.": Admin)
   --folder  = root folder
-  ";
+";
 $opts = getopt("h", array('username:', 'password:', 'uname:', 'gname:', 'upasswd:', 'permlvl:', 'accesslvl:', 'folder:'));
 
 if(array_key_exists('h',$opts))

--- a/src/cli/fossupload_status.php
+++ b/src/cli/fossupload_status.php
@@ -33,7 +33,7 @@ $Usage = "Usage: " . basename($argv[0]) . " [options]
   --password  = password
   --groupname = a group the user belongs to (default active group)
   --uploadId  = id of upload
-  ";
+";
 
 $opts = getopt("c:", array("username:", "groupname:", "uploadId:", "password:"));
 


### PR DESCRIPTION
The usage message from some command line tools print extra spaces at the end, which indents the next prompt. For example:

    root@1055d6e47489:/# fo_nomos_license_list -h
    Usage: fo_nomos_license_list
      -u upload id        :: upload id
      -t uploadtree id    :: uploadtree id
      -c sysconfdir       :: Specify the directory for the system configuration
      --username username :: username
      --password password :: password
      --container         :: include container or not, 1: yes, 0: no (default)
      -x                  :: do not show files which have unuseful license 'No_license_found' or no license
      -X excluding        :: Exclude files containing [free text] in the path.
                             'mac/' should exclude all files in the mac directory.
                             'mac' and it should exclude all files in any directory containing the substring 'mac'
                             '/mac' and it should exclude all files in any directory that starts with 'mac'
      -h  help, this message
      root@1055d6e47489:/# <<<--- extra spaces here
    root@1055d6e47489:/#

Six tools add these extra spaces, removed by this PR.