### PR TITLE
fix(ui): repair error, which emerges in PHP <= 5.4

### DIFF
--- a/src/www/ui/page/UploadSrvPage.php
+++ b/src/www/ui/page/UploadSrvPage.php
@@ -48,7 +48,7 @@ class UploadSrvPage extends UploadPageBase
     }
     else
     {
-      $hostList = ["localhost"];
+      $hostList = array("localhost");
     }
 
     return in_array($host,$hostList);


### PR DESCRIPTION
Just replace array bracket syntax by `array(...)`

this closes #604