### PR TITLE
fix(security) SQL injection vulnerability in read_permission

### DIFF
--- a/src/lib/php/common-auth.php
+++ b/src/lib/php/common-auth.php
@@ -143,29 +143,38 @@ function account_check(&$user, &$passwd, &$group = "")
  */
 function read_permission($upload, $user)
 {
-  global $PG_CONN;
   $ADMIN_PERMISSION = 10;
+  $dbManager = $GLOBALS['container']->get('db.manager');
 
   /** check if the user if the owner of this upload */
-  $SQL = "SELECT * FROM upload where upload_pk = $upload and user_fk = (SELECT user_pk from users where user_name = '$user');";
-  $result = pg_query($PG_CONN, $SQL);
-  DBCheckResult($result, $SQL, __FILE__, __LINE__);
-  $row = pg_fetch_assoc($result);
-  pg_free_result($result);
-  if(!empty($row)) {
+  $row = $dbManager->getSingleRow(
+    "SELECT 1
+    FROM upload INNER JOIN users ON users.user_pk = upload.user_fk
+    WHERE users.user_name = $1 AND upload.upload_pk = $2",
+    array($user, $upload),
+    __METHOD__.".checkUpload"
+  );
+
+  if (!empty($row)) {
+    /** user has permission */
     return 1;
   }
 
   /** check if the user is administrator */
-  $SQL = "SELECT * FROM users where user_name = '$user' and user_perm = $ADMIN_PERMISSION;";
-  $result = pg_query($PG_CONN, $SQL);
-  DBCheckResult($result, $SQL, __FILE__, __LINE__);
-  $row = pg_fetch_assoc($result);
-  pg_free_result($result);
-  if(!empty($row)) {
+  $row = $dbManager->getSingleRow(
+    "SELECT 1
+    FROM users
+    WHERE user_name = $1 AND user_perm = $2",
+    array($user, $ADMIN_PERMISSION),
+    __METHOD__.".checkPerm"
+  );
+
+  if (!empty($row)) {
+    /** user has permission */
     return 1;
   }
 
+  /** user does not have permission */
   return 0;
 }
   


### PR DESCRIPTION
The `read_permission` function used by command line tools does not sanitize inputs before using them in SQL statements. This change uses the DbManager class instead, passing the inputs as parameters. This does not change any functionality; it only removes this SQL injection vulnerability. Style reflects usage in other parts of the file.