### PR TITLE
feature(license-list): improve UI and allow more agents

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,22 +68,31 @@ Vagrant.configure("2") do |config|
   config.vm.box = "trusty64"
   config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 
-  config.vm.provider :virtualbox do |vbox|
-    vbox.customize ["modifyvm", :id, "--memory", "1024"]
+  config.vm.provider "virtualbox" do |vbox|
+    vbox.customize ["modifyvm", :id, "--memory", "4096"]
     vbox.customize ["modifyvm", :id, "--cpus", "2"]
   end
 
-  config.vm.network :forwarded_port, guest: 80, host: 8081
+  config.vm.network "forwarded_port", guest: 80, host: 8081
+  config.vm.network "forwarded_port", guest: 5432, host: 5432
 
   # use proxy from host if environment variable PROXY=true
   if ENV['PROXY']
     if ENV['PROXY'] == 'true'
-      config.vm.provision :shell, :inline => $add_proxy_settings
+      config.vm.provision "shell" do |s|
+        s.inline = $add_proxy_settings
+      end
     end
   end
 
   # call the script
-  config.vm.provision :shell, :inline => $build_and_test
+  config.vm.provision "shell" do |s|
+    s.inline = $build_and_test
+  end
+  
+  config.vm.provision "shell", run: "always" do |s|
+    s.inline = "service fossology start"
+  end
 
   # fix "stdin: is not a tty" issue
 #  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"

--- a/src/cli/Makefile
+++ b/src/cli/Makefile
@@ -8,9 +8,10 @@ DEPS = $(TOP)/Makefile.deps
 include $(VARS)
 
 WRAP = cp2foss \
-       fossjobs schema-export \
-       fo_nomos_license_list fo_copyright_list fo_bucket_list \
-       fossupload_status fo_usergroup fo_import_licenses fo_chmod fo_folder
+	fossjobs schema-export \
+	fo_monk_licnese_list fo_nomos_license_list fo_ninka_license_list \
+	fo_copyright_list fo_bucket_list \
+	fossupload_status fo_usergroup fo_import_licenses fo_chmod fo_folder
 COPY = $(WRAP:=.php)
 
 DOCS = cp2foss.pod fossjobs.pod

--- a/src/cli/fo_monk_license_list.php
+++ b/src/cli/fo_monk_license_list.php
@@ -111,7 +111,7 @@ if (empty($return_value))
 
 
 /**
- * @brief get nomos license list of one specified uploadtree_id
+ * @brief get monk license list of one specified uploadtree_id
  *
  * @param int $uploadtree_pk - uploadtree id
  * @param int $upload_pk - upload id
@@ -135,11 +135,11 @@ function GetLicenseList($uploadtree_pk, $upload_pk, $showContainer, $excluding, 
       $uploadtree_pk = $uploadtreeRec['uploadtree_pk'];
   }
 
-  /* get last nomos agent_pk that has data for this upload */
-  $AgentRec = AgentARSList("nomos_ars", $upload_pk, 1);
+  /* get last monk agent_pk that has data for this upload */
+  $AgentRec = AgentARSList("monk_ars", $upload_pk, 1);
   if ($AgentRec === false)
   {
-    echo _("No data available\n");
+    echo _("No data available \n");
     return;
   }
   $agent_pk = $AgentRec[0]["agent_fk"];

--- a/src/cli/fo_ninka_license_list.php
+++ b/src/cli/fo_ninka_license_list.php
@@ -111,7 +111,7 @@ if (empty($return_value))
 
 
 /**
- * @brief get ninka license list of one specified uploadtree_id
+ * @brief get monk license list of one specified uploadtree_id
  *
  * @param int $uploadtree_pk - uploadtree id
  * @param int $upload_pk - upload id
@@ -135,8 +135,8 @@ function GetLicenseList($uploadtree_pk, $upload_pk, $showContainer, $excluding, 
       $uploadtree_pk = $uploadtreeRec['uploadtree_pk'];
   }
 
-  /* get last ninka agent_pk that has data for this upload */
-  $AgentRec = AgentARSList("ninka_ars", $upload_pk, 1);
+  /* get last monk agent_pk that has data for this upload */
+  $AgentRec = AgentARSList("monk_ars", $upload_pk, 1);
   if ($AgentRec === false)
   {
     echo _("No data available \n");

--- a/src/cli/fo_ninka_license_list.php
+++ b/src/cli/fo_ninka_license_list.php
@@ -111,7 +111,7 @@ if (empty($return_value))
 
 
 /**
- * @brief get nomos license list of one specified uploadtree_id
+ * @brief get ninka license list of one specified uploadtree_id
  *
  * @param int $uploadtree_pk - uploadtree id
  * @param int $upload_pk - upload id
@@ -135,11 +135,11 @@ function GetLicenseList($uploadtree_pk, $upload_pk, $showContainer, $excluding, 
       $uploadtree_pk = $uploadtreeRec['uploadtree_pk'];
   }
 
-  /* get last nomos agent_pk that has data for this upload */
-  $AgentRec = AgentARSList("nomos_ars", $upload_pk, 1);
+  /* get last ninka agent_pk that has data for this upload */
+  $AgentRec = AgentARSList("ninka_ars", $upload_pk, 1);
   if ($AgentRec === false)
   {
-    echo _("No data available\n");
+    echo _("No data available \n");
     return;
   }
   $agent_pk = $AgentRec[0]["agent_fk"];

--- a/src/lib/php/Dao/LicenseDao.php
+++ b/src/lib/php/Dao/LicenseDao.php
@@ -324,7 +324,7 @@ class LicenseDao extends Object
                                                    $selectedAgentIds=null,
                                                    $includeSubfolders=true,
                                                    $excluding='',
-                                                   $ignore=0)
+                                                   $ignore=false)
   {
     $uploadTreeTableName = $itemTreeBounds->getUploadTreeTableName();
     $statementName = __METHOD__ . '.' . $uploadTreeTableName;
@@ -399,7 +399,7 @@ ORDER BY lft asc
       {
         continue;
       }
-      
+
       $this->updateStackState($pathStack, $rgtStack, $lastLft, $row);
       $path = implode($pathStack,'/');
       $this->addToLicensesPerFileName($licensesPerFileName, $path, $row, $ignore);

--- a/src/lib/php/Dao/LicenseDao.php
+++ b/src/lib/php/Dao/LicenseDao.php
@@ -33,7 +33,7 @@ use Monolog\Logger;
 class LicenseDao extends Object
 {
   const NO_LICENSE_FOUND = 'No_license_found';
-  
+
   /** @var DbManager */
   private $dbManager;
   /** @var Logger */
@@ -60,7 +60,7 @@ class LicenseDao extends Object
     $statementName = __METHOD__ . ".$uploadTreeTableName.$usageId";
     $params = array($itemTreeBounds->getUploadId(), $itemTreeBounds->getLeft(), $itemTreeBounds->getRight());
     if($usageId==LicenseMap::TRIVIAL)
-    {    
+    {
       $licenseJoin = "ONLY license_ref mlr ON license_file.rf_fk = mlr.rf_pk";
     }
     else
@@ -183,8 +183,8 @@ class LicenseDao extends Object
     $this->dbManager->freeResult($result);
     return $licenseRefs;
   }
-  
-  
+
+
   /**
    * @return LicenseRef[]
    */
@@ -224,7 +224,7 @@ class LicenseDao extends Object
     $this->dbManager->freeResult($result);
     return $licenseRefs;
   }
-  
+
 
   /**
    * @return array
@@ -249,7 +249,7 @@ class LicenseDao extends Object
     return $licenseRefs;
   }
 
-  
+
   /**
    * @param ItemTreeBounds $itemTreeBounds
    * @param int $selectedAgentId
@@ -273,6 +273,7 @@ class LicenseDao extends Object
         $condition .= " AND ufile_name BETWEEN $4 and $5";
         $param[] = $nameRange[0];
         $param[] = $nameRange[1];
+        $statementName .= ".nameRange";
       }
     }
     else
@@ -309,6 +310,135 @@ class LicenseDao extends Object
 
     $this->dbManager->freeResult($result);
     return $licensesPerFileId;
+  }
+
+  /**
+   * @param ItemTreeBounds $itemTreeBounds
+   * @param Array(int) $selectedAgentIds
+   * @param bool $includeSubFolders
+   * @param String $excluding
+   * @param bool $ignore ignore files without license
+   * @return array
+   */
+  public function getLicensesPerFileNameForAgentId(ItemTreeBounds $itemTreeBounds,
+                                                   $selectedAgentIds=null,
+                                                   $includeSubfolders=true,
+                                                   $excluding='',
+                                                   $ignore=0)
+  {
+    $uploadTreeTableName = $itemTreeBounds->getUploadTreeTableName();
+    $statementName = __METHOD__ . '.' . $uploadTreeTableName;
+    $param = array();
+
+    $condition = " (ufile_mode & (1<<28)) = 0";
+    if ($includeSubfolders)
+    {
+      $param[] = $itemTreeBounds->getLeft();
+      $param[] = $itemTreeBounds->getRight();
+      $condition .= " AND lft BETWEEN $1 AND $2";
+      $statementName .= ".subfolders";
+    }
+    else
+    {
+      $param[] = $itemTreeBounds->getItemId();
+      $condition .= " AND realparent = $1";
+    }
+
+    if ('uploadtree_a' == $uploadTreeTableName)
+    {
+      $param[] = $itemTreeBounds->getUploadId();
+      $condition .= " AND upload_fk=$".count($param);
+    }
+
+    $agentSelect = "";
+    if ($selectedAgentIds !== null)
+    {
+      $statementName .= ".".count($selectedAgentIds)."agents";
+      $agentSelect = "WHERE agent_fk IS NULL";
+      foreach($selectedAgentIds as $selectedAgentId)
+      {
+        $param[] = $selectedAgentId;
+        $agentSelect .= " OR agent_fk = $".count($param);
+      }
+    }
+
+    $sql = "
+SELECT ufile_name, lft, rgt, ufile_mode,
+       rf_shortname, agent_fk
+FROM (SELECT
+        ufile_name,
+        lft, rgt, ufile_mode, pfile_fk
+      FROM $uploadTreeTableName
+      WHERE $condition) AS subselect1
+LEFT JOIN (SELECT rf_shortname,pfile_fk,agent_fk
+           FROM license_file, license_ref
+           WHERE rf_fk = rf_pk) AS subselect2
+  ON subselect1.pfile_fk = subselect2.pfile_fk
+$agentSelect
+ORDER BY lft asc
+";
+
+    $this->dbManager->prepare($statementName, $sql);
+    $result = $this->dbManager->execute($statementName, $param);
+    $licensesPerFileName = array();
+
+    $row = $this->dbManager->fetchArray($result);
+    $pathStack = array($row['ufile_name']);
+    $rgtStack = array($row['rgt']);
+    $lastLft = $row['lft'];
+    $path = implode($pathStack,'/');
+    $this->addToLicensesPerFileName($licensesPerFileName, $path, $row, $ignore);
+    while ($row = $this->dbManager->fetchArray($result))
+    {
+      if (!empty($excluding) && false!==strpos("/$row[ufile_name]/", $excluding))
+      {
+        $lastLft = $row['rgt'] + 1;
+        continue;
+      }
+      if ($row['lft'] < $lastLft)
+      {
+        continue;
+      }
+      
+      $this->updateStackState($pathStack, $rgtStack, $lastLft, $row);
+      $path = implode($pathStack,'/');
+      $this->addToLicensesPerFileName($licensesPerFileName, $path, $row, $ignore);
+    }
+    $this->dbManager->freeResult($result);
+    return array_reverse($licensesPerFileName);
+  }
+
+  private function updateStackState(&$pathStack, &$rgtStack, &$lastLft, $row)
+  {
+    if ($row['lft'] >= $lastLft)
+    {
+      while(count($rgtStack) > 0 && $row['lft'] > $rgtStack[count($rgtStack)-1])
+      {
+        array_pop($pathStack);
+        array_pop($rgtStack);
+      }
+      if ($row['lft'] > $lastLft)
+      {
+        array_push($pathStack, $row['ufile_name']);
+        array_push($rgtStack, $row['rgt']);
+        $lastLft = $row['lft'];
+      }
+    }
+  }
+
+  private function addToLicensesPerFileName(&$licensesPerFileName, $path, $row, $ignore)
+  {
+    if (($row['ufile_mode']&(1<<29)) ==0)
+    {
+      if($row['rf_shortname'])
+      {
+        $licensesPerFileName[$path][] = $row['rf_shortname'];
+      }
+    }
+    else if (!$ignore)
+    {
+      $licensesPerFileName[$path] = false;
+    }
   }
 
   /**
@@ -366,7 +496,7 @@ class LicenseDao extends Object
                 }, $filterLicenses)) . ")";
 
     $statementName = __METHOD__ . '.' . $uploadTreeTableName;
-    
+
     $agentFilter = '';
     if(is_array($latestSuccessfulAgentIds))
     {
@@ -464,7 +594,7 @@ class LicenseDao extends Object
       return -1;
     }
     $bulkId = $licenseRefBulkIdResult['lrb_pk'];
-    
+
     $stmt = __METHOD__ . '.insertAction';
     $this->dbManager->prepare($stmt, "INSERT INTO license_set_bulk (lrb_fk, rf_fk, removing) VALUES ($1,$2,$3)");
     foreach($licenseRemovals as $licenseId=>$removing)
@@ -477,7 +607,7 @@ class LicenseDao extends Object
 
   /**
    * @param string $newShortname
-   * @param int $groupId 
+   * @param int $groupId
    * @return bool
    */
   public function isNewLicense($newShortname, $groupId)
@@ -513,7 +643,7 @@ class LicenseDao extends Object
     $this->dbManager->getSingleRow('UPDATE license_candidate SET rf_shortname=$2, rf_fullname=$3, rf_text=$4, rf_url=$5, marydone=$6, rf_risk=$7 WHERE rf_pk=$1',
         array($rf_pk, $shortname, $fullname, $rfText, $url, $marydone, $riskLvl), __METHOD__);
   }
-  
+
   public function getLicenseParentById($licenseId, $groupId=null)
   {
     return $this->getLicenseByCondition(" rf_pk=(SELECT rf_parent FROM license_map WHERE usage=$1 AND rf_fk=$2 AND rf_fk!=rf_parent)",

--- a/src/lib/php/Dao/test/LicenseDaoTest.php
+++ b/src/lib/php/Dao/test/LicenseDaoTest.php
@@ -40,7 +40,7 @@ class LicenseDaoTest extends \PHPUnit_Framework_TestCase
     $this->dbManager = $this->testDb->getDbManager();
     $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
   }
-  
+
   protected function tearDown()
   {
     $this->testDb = null;
@@ -77,16 +77,16 @@ class LicenseDaoTest extends \PHPUnit_Framework_TestCase
     $licDao = new LicenseDao($this->dbManager);
     $itemTreeBounds = new ItemTreeBounds($uploadtreeId,"uploadtree",$uploadID,$left,$right);
     $matches = $licDao->getAgentFileLicenseMatches($itemTreeBounds);
-    
+
     $licenseRef = new LicenseRef($licenseRefNumber, $lic0['rf_shortname'], $lic0['rf_fullname']);
     $agentRef = new AgentRef($agentId, $agentName, $agentRev);
     $expected = array( new LicenseMatch($pfileId, $licenseRef, $agentRef, $licenseFileId, $matchPercent) );
-    
+
     assertThat($matches, equalTo($expected));
     assertThat($matches[0], is(anInstanceOf(LicenseMatch::classname())) );
     $this->addToAssertionCount(\Hamcrest\MatcherAssert::getCount()-$this->assertCountBefore);
   }
-  
+
 
   public function testGetLicenseByShortName()
   {
@@ -130,7 +130,7 @@ class LicenseDaoTest extends \PHPUnit_Framework_TestCase
     $this->assertEquals($cntA['cnt'], count($licAll));
     $this->assertInstanceOf('Fossology\Lib\Data\LicenseRef', $licAll[0]);
   }
-  
+
   public function testGetLicenseShortnamesContained()
   {
     $this->testDb->createPlainTables(array('license_ref','license_file','uploadtree'));
@@ -166,18 +166,18 @@ class LicenseDaoTest extends \PHPUnit_Framework_TestCase
     $licDao = new LicenseDao($this->dbManager);
     $itemTreeBounds = new ItemTreeBounds($uploadtreeId,"uploadtree",$uploadId,$left,$right);
     $licenses = $licDao->getLicenseShortnamesContained($itemTreeBounds);
-    
+
     assertThat($licenses, is(arrayContainingInAnyOrder(array_values($licAll))));
-    
+
     $licensesForBadAgent = $licDao->getLicenseShortnamesContained($itemTreeBounds,array(2*$agentId));
     assertThat($licensesForBadAgent, is(emptyArray()));
 
     $licensesForNoAgent = $licDao->getLicenseShortnamesContained($itemTreeBounds,array());
     assertThat($licensesForNoAgent, is(emptyArray()));
-    
+
     $this->addToAssertionCount(\Hamcrest\MatcherAssert::getCount()-$this->assertCountBefore);
   }
-  
+
 
   public function testGetLicenseIdPerPfileForAgentId()
   {
@@ -189,7 +189,7 @@ class LicenseDaoTest extends \PHPUnit_Framework_TestCase
     $rf_pk_all = array_keys($licAll);
     $rf_pk =  $rf_pk_all[0];
     $uploadtreetable_name = 'uploadtree';
-    $this->dbManager->insertInto('license_file', 
+    $this->dbManager->insertInto('license_file',
             'fl_pk, rf_fk, agent_fk, rf_match_pct, rf_timestamp, pfile_fk, server_fk',
             array(1, $rf_pk, $agentId = 5, $matchPercent = 50, $mydate = "'2014-06-04 14:01:30.551093+02'", $pfileId=42, 1) );
     $uploadtreeId= 512;
@@ -206,14 +206,14 @@ class LicenseDaoTest extends \PHPUnit_Framework_TestCase
     $this->dbManager->insertTableRow('uploadtree',
             array('uploadtree_pk'=>$uploadtreeId+2, 'upload_fk'=>$uploadId, 'pfile_fk'=>$pfileId,
                 'lft'=>$left+2, 'rgt'=>$left+3, 'parent'=>$uploadtreeId+1, 'ufile_mode'=>0));
-    
+
     $licDao = new LicenseDao($this->dbManager);
     $itemTreeBounds = new ItemTreeBounds($uploadtreeId,$uploadtreetable_name,$uploadId,$left,$left+5);
 
     $row = array('pfile_id'=>$pfileId,'license_id'=>$rf_pk,'match_percentage'=>$matchPercent,'agent_id'=>$agentId,'uploadtree_pk'=>$nonArtifactChildId);
     $expected = array($pfileId=>array($rf_pk=>$row));
     $itemRestriction = array($nonArtifactChildId, $nonArtifactChildId+7);
-    
+
     $licensesForGoodAgent = $licDao->getLicenseIdPerPfileForAgentId($itemTreeBounds, $selectedAgentId = $agentId, $itemRestriction);
     assertThat($licensesForGoodAgent, is(equalTo($expected)));
 
@@ -222,6 +222,137 @@ class LicenseDaoTest extends \PHPUnit_Framework_TestCase
 
     $licensesOutside = $licDao->getLicenseIdPerPfileForAgentId($itemTreeBounds, $selectedAgentId = $agentId, array());
     assertThat($licensesOutside, is(equalTo(array())));
+
+    $this->addToAssertionCount(\Hamcrest\MatcherAssert::getCount()-$this->assertCountBefore);
+  }
+
+  public function testGetLicensesPerFileNameForAgentId()
+  {
+    $this->testDb->createPlainTables(array('license_ref','license_file','uploadtree','agent'));
+    $this->testDb->insertData(array('agent'));
+    $this->testDb->createViews(array('license_file_ref'));
+    $this->testDb->insertData_license_ref($limit=3);
+    $licAll = $this->dbManager->createMap('license_ref', 'rf_pk','rf_shortname');
+    $rf_pk_all = array_keys($licAll);
+
+    $uploadtreetable_name = 'uploadtree';
+    //  uploadtree_pk | parent | realparent | upload_fk | pfile_fk | ufile_mode | lft | rgt |    ufile_name
+    // ---------------+--------+------------+-----------+----------+------------+-----+-----+------------------
+    //          80895 |        |            |        16 |    70585 |  536904704 |   1 |  36 | project.tar.gz
+    //          80896 |  80895 |      80895 |        16 |        0 |  805323776 |   2 |  35 | artifact.dir
+    //          80897 |  80896 |      80895 |        16 |    70586 |  536903680 |   3 |  34 | project.tar
+    //          80898 |  80897 |      80897 |        16 |        0 |  805323776 |   4 |  33 | artifact.dir
+    //          80899 |  80898 |      80897 |        16 |        0 |  536888320 |   5 |  32 | project
+    //          80900 |  80899 |      80899 |        16 |        0 |  536888320 |   6 |   7 | folderA
+    //          80905 |  80899 |      80899 |        16 |        0 |  536888320 |   8 |  23 | folderB
+    //          80907 |  80905 |      80905 |        16 |        0 |  536888320 |   9 |  10 | subBfolderA
+    //          80908 |  80905 |      80905 |        16 |        0 |  536888320 |  11 |  20 | subBfolderB
+    //          80909 |  80908 |      80908 |        16 |        0 |  536888320 |  12 |  19 | subBBsubBfolderA
+    //          80912 |  80909 |      80909 |        16 |    70592 |      33152 |  13 |  14 | BBBfileA
+    //          80911 |  80909 |      80909 |        16 |    70591 |      33152 |  15 |  16 | BBBfileB
+    //          80910 |  80909 |      80909 |        16 |    70590 |      33152 |  17 |  18 | BBBfileC
+    //          80906 |  80905 |      80905 |        16 |        0 |  536888320 |  21 |  22 | subBfolderC
+    //          80901 |  80899 |      80899 |        16 |        0 |  536888320 |  24 |  31 | folderC
+    //          80903 |  80901 |      80901 |        16 |    70588 |      33152 |  25 |  26 | CfileA
+    //          80904 |  80901 |      80901 |        16 |    70589 |      33152 |  27 |  28 | CfileB
+    //          80902 |  80901 |      80901 |        16 |    70587 |      33152 |  29 |  30 | CfileC
+    $mainUploadtreeId = 80895;
+    $uploadtreeId = $mainUploadtreeId;
+    $uploadId = 16;
+    /* 80895 */ $this->dbManager->insertTableRow($uploadtreetable_name, array('uploadtree_pk'=>$uploadtreeId++, 'upload_fk'=>$uploadId, 'pfile_fk'=>70585, 'lft'=>1, 'rgt'=>36, 'ufile_mode'=>536904704, 'ufile_name'=>'project.tar.gz'));
+    /* 80896 */ $this->dbManager->insertTableRow($uploadtreetable_name, array('uploadtree_pk'=>$uploadtreeId++, 'upload_fk'=>$uploadId, 'parent'=>80895, 'realparent'=>80895, 'pfile_fk'=>0, 'lft'=>2, 'rgt'=>35, 'ufile_mode'=>805323776, 'ufile_name'=>'artifact.dir'));
+    /* 80897 */ $this->dbManager->insertTableRow($uploadtreetable_name, array('uploadtree_pk'=>$uploadtreeId++, 'upload_fk'=>$uploadId, 'parent'=>80896, 'realparent'=>80895, 'pfile_fk'=>70586, 'lft'=>3, 'rgt'=>34, 'ufile_mode'=>536903680, 'ufile_name'=>'project.tar'));
+    /* 80898 */ $this->dbManager->insertTableRow($uploadtreetable_name, array('uploadtree_pk'=>$uploadtreeId++, 'upload_fk'=>$uploadId, 'parent'=>80897, 'realparent'=>80897, 'pfile_fk'=>0, 'lft'=>4, 'rgt'=>33, 'ufile_mode'=>805323776, 'ufile_name'=>'artifact.dir'));
+    /* 80899 */ $this->dbManager->insertTableRow($uploadtreetable_name, array('uploadtree_pk'=>$uploadtreeId++, 'upload_fk'=>$uploadId, 'parent'=>80898, 'realparent'=>80897, 'pfile_fk'=>0, 'lft'=>5, 'rgt'=>32, 'ufile_mode'=>536888320, 'ufile_name'=>'project'));
+    /* 80900 */ $this->dbManager->insertTableRow($uploadtreetable_name, array('uploadtree_pk'=>$uploadtreeId++, 'upload_fk'=>$uploadId, 'parent'=>80899, 'realparent'=>80899, 'pfile_fk'=>0, 'lft'=>6, 'rgt'=>7, 'ufile_mode'=>536888320, 'ufile_name'=>'folderA'));
+    /* 80901 */ $this->dbManager->insertTableRow($uploadtreetable_name, array('uploadtree_pk'=>$uploadtreeId++, 'upload_fk'=>$uploadId, 'parent'=>80899, 'realparent'=>80899, 'pfile_fk'=>0, 'lft'=>24, 'rgt'=>31, 'ufile_mode'=>536888320, 'ufile_name'=>'folderC'));
+    /* 80902 */ $this->dbManager->insertTableRow($uploadtreetable_name, array('uploadtree_pk'=>$uploadtreeId++, 'upload_fk'=>$uploadId, 'parent'=>80901, 'realparent'=>80901, 'pfile_fk'=>70587, 'lft'=>29, 'rgt'=>30, 'ufile_mode'=>33152, 'ufile_name'=>'CfileC'));
+    /* 80903 */ $this->dbManager->insertTableRow($uploadtreetable_name, array('uploadtree_pk'=>$uploadtreeId++, 'upload_fk'=>$uploadId, 'parent'=>80901, 'realparent'=>80901, 'pfile_fk'=>70588, 'lft'=>25, 'rgt'=>26, 'ufile_mode'=>33152, 'ufile_name'=>'CfileA'));
+    /* 80904 */ $this->dbManager->insertTableRow($uploadtreetable_name, array('uploadtree_pk'=>$uploadtreeId++, 'upload_fk'=>$uploadId, 'parent'=>80901, 'realparent'=>80901, 'pfile_fk'=>70589, 'lft'=>27, 'rgt'=>28, 'ufile_mode'=>33152, 'ufile_name'=>'CfileB'));
+    /* 80905 */ $this->dbManager->insertTableRow($uploadtreetable_name, array('uploadtree_pk'=>$uploadtreeId++, 'upload_fk'=>$uploadId, 'parent'=>80899, 'realparent'=>80899, 'pfile_fk'=>0, 'lft'=>8, 'rgt'=>23, 'ufile_mode'=>536888320, 'ufile_name'=>'folderB'));
+    /* 80906 */ $this->dbManager->insertTableRow($uploadtreetable_name, array('uploadtree_pk'=>$uploadtreeId++, 'upload_fk'=>$uploadId, 'parent'=>80905, 'realparent'=>80905, 'pfile_fk'=>0, 'lft'=>21, 'rgt'=>22, 'ufile_mode'=>536888320, 'ufile_name'=>'subBfolderC'));
+    /* 80907 */ $this->dbManager->insertTableRow($uploadtreetable_name, array('uploadtree_pk'=>$uploadtreeId++, 'upload_fk'=>$uploadId, 'parent'=>80905, 'realparent'=>80905, 'pfile_fk'=>0, 'lft'=>9, 'rgt'=>10, 'ufile_mode'=>536888320, 'ufile_name'=>'subBfolderA'));
+    /* 80908 */ $this->dbManager->insertTableRow($uploadtreetable_name, array('uploadtree_pk'=>$uploadtreeId++, 'upload_fk'=>$uploadId, 'parent'=>80905, 'realparent'=>80905, 'pfile_fk'=>0, 'lft'=>11, 'rgt'=>20, 'ufile_mode'=>536888320, 'ufile_name'=>'subBfolderB'));
+    /* 80909 */ $this->dbManager->insertTableRow($uploadtreetable_name, array('uploadtree_pk'=>$uploadtreeId++, 'upload_fk'=>$uploadId, 'parent'=>80908, 'realparent'=>80908, 'pfile_fk'=>0, 'lft'=>12, 'rgt'=>19, 'ufile_mode'=>536888320, 'ufile_name'=>'subBBsubBfolderA'));
+    /* 80910 */ $this->dbManager->insertTableRow($uploadtreetable_name, array('uploadtree_pk'=>$uploadtreeId++, 'upload_fk'=>$uploadId, 'parent'=>80909, 'realparent'=>80909, 'pfile_fk'=>70590, 'lft'=>17, 'rgt'=>18, 'ufile_mode'=>33152, 'ufile_name'=>'BBBfileC'));
+    /* 80911 */ $this->dbManager->insertTableRow($uploadtreetable_name, array('uploadtree_pk'=>$uploadtreeId++, 'upload_fk'=>$uploadId, 'parent'=>80909, 'realparent'=>80909, 'pfile_fk'=>70591, 'lft'=>15, 'rgt'=>16, 'ufile_mode'=>33152, 'ufile_name'=>'BBBfileB'));
+    /* 80912 */ $this->dbManager->insertTableRow($uploadtreetable_name, array('uploadtree_pk'=>$uploadtreeId++, 'upload_fk'=>$uploadId, 'parent'=>80909, 'realparent'=>80909, 'pfile_fk'=>70592, 'lft'=>13, 'rgt'=>14, 'ufile_mode'=>33152, 'ufile_name'=>'BBBfileA'));
+
+    $agentId = 5;
+    //  fl_pk  |     rf_fk     |   agent_fk   | rf_match_pct |         rf_timestamp          | pfile_fk | server_fk | fl_ref_start_byte | fl_ref_end_byte | fl_start_byte | fl_end_byte
+    // --------+---------------+--------------+--------------+-------------------------------+----------+-----------+-------------------+-----------------+---------------+-------------
+    //       1 | $rf_pk_all[0] | $agentId     |              | 2016-02-08 16:08:59.333096+00 |    70592 |         1 |                   |                 |               |
+    //       2 | $rf_pk_all[1] | $agentId + 1 |              | 2016-02-08 16:08:59.333096+00 |    70591 |         1 |                   |                 |               |
+    //       3 | $rf_pk_all[0] | $agentId     |              | 2016-02-08 16:08:59.333096+00 |    70590 |         1 |                   |                 |               |
+    //       4 | $rf_pk_all[1] | $agentId     |              | 2016-02-08 16:08:59.333096+00 |    70590 |         1 |                   |                 |               |
+    $someDate = "'2016-02-08 16:08:59.333096+00'";
+    /* 1 */ $this->dbManager->insertInto('license_file', 'fl_pk, rf_fk, agent_fk, rf_timestamp, pfile_fk, server_fk', array(1, $rf_pk_all[0], $agentId, $someDate, 70592, 1) );
+    /* 2 */ $this->dbManager->insertInto('license_file', 'fl_pk, rf_fk, agent_fk, rf_timestamp, pfile_fk, server_fk', array(2, $rf_pk_all[1], $agentId+1, $someDate, 70591, 1) );
+    /* 3 */ $this->dbManager->insertInto('license_file', 'fl_pk, rf_fk, agent_fk, rf_timestamp, pfile_fk, server_fk', array(3, $rf_pk_all[0], $agentId, $someDate, 70590, 1) );
+    /* 4 */ $this->dbManager->insertInto('license_file', 'fl_pk, rf_fk, agent_fk, rf_timestamp, pfile_fk, server_fk', array(4, $rf_pk_all[1], $agentId, $someDate, 70590, 1) );
+
+    $licDao = new LicenseDao($this->dbManager);
+    $itemTreeBounds = new ItemTreeBounds($mainUploadtreeId,$uploadtreetable_name,$uploadId,1,36);
+
+    //**************************************************************************
+    // Test with minimal input
+    $result = $licDao->getLicensesPerFileNameForAgentId($itemTreeBounds);
+
+    $key = "project.tar.gz/project.tar/project/folderB/subBfolderB/subBBsubBfolderA/BBBfileA";
+    $this->assertArrayHasKey($key, $result);
+    $expected = array($licAll[$rf_pk_all[0]]);
+    assertThat($result[$key], is(equalTo($expected)));
+
+    $key = "project.tar.gz/project.tar/project/folderB/subBfolderB/subBBsubBfolderA/BBBfileB";
+    $this->assertArrayHasKey($key, $result);
+
+    $key = "project.tar.gz/project.tar/project/folderB/subBfolderB/subBBsubBfolderA/BBBfileC";
+    $this->assertArrayHasKey($key, $result);
+    $this->assertContains($licAll[$rf_pk_all[0]],$result[$key]);
+    $this->assertContains($licAll[$rf_pk_all[1]],$result[$key]);
+
+    $key = "project.tar.gz";
+    $this->assertArrayHasKey($key, $result);
+
+    //**************************************************************************
+    // Test with empty agent list
+    $result = $licDao->getLicensesPerFileNameForAgentId($itemTreeBounds, array(),true,'',true);
+
+    $expected = array();
+    assertThat($result, is(equalTo($expected)));
+
+    //**************************************************************************
+    // Test with only one agent
+    $result = $licDao->getLicensesPerFileNameForAgentId($itemTreeBounds, array($agentId));
+
+    $key = "project.tar.gz/project.tar/project/folderB/subBfolderB/subBBsubBfolderA/BBBfileA";
+    $this->assertArrayHasKey($key, $result);
+
+    $key = "project.tar.gz/project.tar/project/folderB/subBfolderB/subBBsubBfolderA/BBBfileB";
+    $this->assertArrayNotHasKey($key, $result);
+
+    //**************************************************************************
+    // Test with excluding
+    $result = $licDao->getLicensesPerFileNameForAgentId($itemTreeBounds, array($agentId),true,"fileC");
+
+    $key = "project.tar.gz/project.tar/project/folderB/subBfolderB/subBBsubBfolderA/BBBfileA";
+    $this->assertArrayHasKey($key, $result);
+
+    $key = "project.tar.gz/project.tar/project/folderB/subBfolderB/subBBsubBfolderA/BBBfileB";
+    $this->assertArrayNotHasKey($key, $result);
+
+    $key = "project.tar.gz/project.tar/project/folderB/subBfolderB/subBBsubBfolderA/BBBfileC";
+    $this->assertArrayNotHasKey($key, $result);
+
+    //**************************************************************************
+    // Test with container
+    $result = $licDao->getLicensesPerFileNameForAgentId($itemTreeBounds, array($agentId));
+
+    $key = "project.tar.gz";
+    $this->assertArrayHasKey($key, $result);
+
+    $key = "project.tar.gz/project.tar";
+    $this->assertArrayHasKey($key, $result);
 
     $this->addToAssertionCount(\Hamcrest\MatcherAssert::getCount()-$this->assertCountBefore);
   }
@@ -247,13 +378,13 @@ class LicenseDaoTest extends \PHPUnit_Framework_TestCase
     assertThat($licDao->isNewLicense($licCandi['rf_shortname'],$groupId), equalTo(FALSE));
     assertThat($licDao->isNewLicense($licCandi['rf_shortname'],$groupId+1), equalTo(TRUE));
     assertThat($licDao->isNewLicense($licCandi['rf_shortname'],0), equalTo(TRUE));
-    
+
     assertThat($licDao->isNewLicense('(a new shortname)',$groupId), equalTo(TRUE));
     assertThat($licDao->isNewLicense('(a new shortname)',0), equalTo(TRUE));
-    
+
     $this->addToAssertionCount(\Hamcrest\MatcherAssert::getCount()-$this->assertCountBefore);
-  }  
-  
+  }
+
   public function testGetAgentFileLicenseMatchesWithLicenseMapping()
   {
     $this->testDb->createPlainTables(array('license_ref','uploadtree','license_file','agent','license_map'));
@@ -286,11 +417,11 @@ class LicenseDaoTest extends \PHPUnit_Framework_TestCase
     $licDao = new LicenseDao($this->dbManager);
     $itemTreeBounds = new ItemTreeBounds($uploadtreeId,"uploadtree",$uploadID,$left,$right);
     $matches = $licDao->getAgentFileLicenseMatches($itemTreeBounds,LicenseMap::CONCLUSION);
-    
+
     $licenseRef = new LicenseRef($licRefId, $lic0['rf_shortname'], $lic0['rf_fullname']);
     $agentRef = new AgentRef($agentId, $agentName, $agentRev);
     $expected = array( new LicenseMatch($pfileId, $licenseRef, $agentRef, $licenseFileId, $matchPercent) );
-    
+
     assertThat($matches, equalTo($expected));
     $this->addToAssertionCount(\Hamcrest\MatcherAssert::getCount()-$this->assertCountBefore);
   }

--- a/src/www/ui/template/ui-license-list-form.html.twig
+++ b/src/www/ui/template/ui-license-list-form.html.twig
@@ -1,0 +1,67 @@
+{# Copyright 2016 Siemens AG
+
+   Copying and distribution of this file, with or without modification,
+   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
+   This file is offered as-is, without any warranty.
+#}
+<form method='POST'>
+  <ol>
+    <li>
+      <span>
+        {{ "Which agents do you want to include?"|trans }}
+      </span>
+      <ul>
+        <li>
+            <label>
+            <input type="checkbox" name="agentToInclude_monk" value="yes" {% if agentToInclude_monk %}checked{% endif %}>
+            Monk
+            </label>
+        </li>
+        <li>
+            <label>
+            <input type="checkbox" name="agentToInclude_nomos" value="yes" {% if agentToInclude_nomos %}checked{% endif %}>
+            Nomos
+            </label>
+        </li>
+        <li>
+            <label>
+            <input type="checkbox" name="agentToInclude_ninka" value="yes" {% if agentToInclude_ninka %}checked{% endif %}>
+            Ninka
+            </label>
+        </li>
+      </ul>
+    </li>
+    <li>
+      <label>
+        <input type="checkbox" name="doNotIncludeSubfolder" value="yes" {% if not includeSubfolder %}checked{% endif %}>
+        Do not include subdirectories?
+      </label>
+    </li>
+    <li>
+      <label>
+        <input type="checkbox" name="showContainers" value="yes" {% if showContainers %}checked{% endif %}>
+        Show directories and containers?
+      </label>
+    </li>
+    <li>
+      <label>
+        Exclude:
+        <input name="exclude" value="{{ exclude|e }}">
+        <br/>
+        Exclude files containing some substring in the path. 'mac' and it should
+        exclude all files and directories containing the substring 'mac'.
+      </label>
+    </li>
+    <li>
+      <label>
+        <input type="checkbox" name="output" value="dltext" {% if dltext %}checked{% endif %}>
+        Download list after creation?
+      </label>
+    </li>
+  </ol>
+  With this tool you will only be able to obtain a list with at maximum {{ NomostListNum }} entries.
+  For a full list run fo_nomos_license_list from the command line.
+  This Limit can be modified by the administrator.
+  <br/>
+  <input type='submit' value='{{ "Generate list"|trans }}'>
+</form>

--- a/src/www/ui/ui-license-list.php
+++ b/src/www/ui/ui-license-list.php
@@ -18,13 +18,16 @@
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Dao\LicenseDao;
 use Symfony\Component\HttpFoundation\Response;
 
 class ui_license_list extends FO_Plugin
 {
   /** @var UploadDao */
   private $uploadDao;
-  
+  /** @var LicenseDao */
+  private $licenseDao;
+
   function __construct()
   {
     $this->Name = "license-list";
@@ -35,6 +38,7 @@ class ui_license_list extends FO_Plugin
     $this->NoHeader = 0;
     parent::__construct();
     $this->uploadDao = $GLOBALS['container']->get('dao.upload');
+    $this->licenseDao = $GLOBALS['container']->get('dao.license');
   }
   /**
    * \brief Customize submenus.
@@ -50,7 +54,6 @@ class ui_license_list extends FO_Plugin
                 "item",
     ));
     $MenuDisplayString = _("License List");
-    $MenuDisplayStringDL = _("License List Download");
     $Item = GetParm("item", PARM_INTEGER);
     $Upload = GetParm("upload", PARM_INTEGER);
     if (empty($Item) || empty($Upload))
@@ -60,12 +63,10 @@ class ui_license_list extends FO_Plugin
     if (GetParm("mod", PARM_STRING) == $this->Name)
     {
       menu_insert("Browse::$MenuDisplayString", 1);
-      menu_insert("Browse::$MenuDisplayStringDL", 1, $URI . "&output=dltext");
     }
     else
     {
       menu_insert("Browse::$MenuDisplayString", 1, $URI, $MenuDisplayString);
-      menu_insert("Browse::$MenuDisplayStringDL", 1, $URI . "&output=dltext", $MenuDisplayStringDL);
       /* bobg - This is to use a select list in the micro menu to replace the above List
         and Download, but put this select list in a form
         $LicChoices = array("Lic Download" => "Download", "Lic display" => "Display");
@@ -75,85 +76,139 @@ class ui_license_list extends FO_Plugin
     }
   }
 
+  function getAgentPksFromRequest($upload_pk)
+  {
+    $agents = array("monk","nomos","ninka");
+    $agent_pks = array();
+
+    foreach($agents as $agent)
+    {
+      if(GetParm("agentToInclude_".$agent, PARM_STRING))
+      {
+        /* get last nomos agent_pk that has data for this upload */
+        $AgentRec = AgentARSList($agent."_ars", $upload_pk, 1);
+        if ($AgentRec !== false)
+        {
+          $agent_pks[$agent] = $AgentRec[0]["agent_fk"];
+        }
+        else
+        {
+          $agent_pks[$agent] = false;
+        }
+      }
+    }
+    return $agent_pks;
+  }
+
+  function createListOfLines($uploadtreeTablename, $uploadtree_pk, $agent_pks, $NomostListNum, $includeSubfolder, $exclude, $ignore)
+  {
+    /** @var ItemTreeBounds */
+    $itemTreeBounds = $this->uploadDao->getItemTreeBounds($uploadtree_pk, $uploadtreeTablename);
+    $licensesPerFileName = $this->licenseDao->getLicensesPerFileNameForAgentId($itemTreeBounds, $agent_pks, $includeSubfolder, array(), $exclude, $ignore);
+
+    /* how many lines of data do you want to display */
+    $currentNum = 0;
+    foreach($licensesPerFileName as $fileName => $licenseNames){
+      if ($licenseNames !== false && count($licenseNames) > 0) {
+        if(++$currentNum > $NomostListNum){
+          $lines["warn"] = _("<br><b>Warning: Only the first $NomostListNum lines are displayed.  To see the whole list, run fo_nomos_license_list from the command line.</b><br>");
+          // TODO: the following should be done using a "LIMIT" statement in the sql query
+          break;
+        }
+
+        $lines[] = $fileName .': '.implode($licenseNames,', ') . '';
+      }
+      if (!$ignore && $licenseNames === false)
+      {
+        $lines[] = $fileName;
+      }
+    }
+    return $lines;
+  }
+
   /**
    * \brief This function returns the scheduler status.
    */
   function Output()
   {
-    global $SysConf;
     global $PG_CONN;
+    global $SysConf;
+    $V = "";
+    $formVars = array();
     if (!$PG_CONN)
     {
       echo _("NO DB connection");
     }
 
     if ($this->State != PLUGIN_STATE_READY)
+    {
       return (0);
-    $V = "";
+    }
     $uploadtree_pk = GetParm("item", PARM_INTEGER);
     if (empty($uploadtree_pk))
+    {
       return;
+    }
 
     $upload_pk = GetParm("upload", PARM_INTEGER);
     if (empty($upload_pk))
+    {
       return;
+    }
     if (!$this->uploadDao->isAccessible($upload_pk, Auth::getGroupId()))
     {
       $text = _("Permission Denied");
       return "<h2>$text</h2>";
     }
+    $uploadtreeTablename = GetUploadtreeTableName($upload_pk);
+
+    $warnings = array();
+    $agent_pks_dict = $this->getAgentPksFromRequest($upload_pk);
+    $agent_pks = array();
+    foreach ($agent_pks_dict as $agent_name => $agent_pk)
+    {
+      if ($agent_pk === false)
+      {
+        $warnings[] = _("No information for agent: $agent_name");
+      }
+      else
+      {
+        $agent_pks[] = $agent_pk;
+        $formVars["agentToInclude_".$agent_name] = "1";
+      }
+    }
 
     $dltext = (GetParm("output", PARM_STRING) == 'dltext');
+    $formVars["dltext"] = $dltext;
 
-    /* get last nomos agent_pk that has data for this upload */
-    $AgentRec = AgentARSList("nomos_ars", $upload_pk, 1);
-    $agent_pk = $AgentRec[0]["agent_fk"];
-    if ($AgentRec === false)
-    {
-      return _("No data available");
-    }
-
-    /* how many lines of data do you want to display */
     $NomostListNum = @$SysConf['SYSCONFIG']['NomostListNum'];
+    $formVars["NomostListNum"] = $NomostListNum;
 
-    /* get the top of tree */
-    $toprow = $this->uploadDao->getUploadEntry($uploadtree_pk);
+    $includeSubfolder = (GetParm("doNotIncludeSubfolder", PARM_STRING) !== "yes");
+    $formVars["includeSubfolder"] = $includeSubfolder;
 
-    /* loop through all the records in this tree */
-    $sql = "select uploadtree_pk, ufile_name, lft, rgt from uploadtree
-              where upload_fk='$toprow[upload_fk]' 
-                    and lft>'$toprow[lft]'  and rgt<'$toprow[rgt]'
-                    and (ufile_mode & (3<<28)) = 0 limit $NomostListNum";
-    $outerresult = pg_query($PG_CONN, $sql);
-    DBCheckResult($outerresult, $sql, __FILE__, __LINE__);
+    $ignore = (GetParm("showContainers", PARM_STRING) !== "yes");
+    $formVars["showContainers"] = !$ignore;
+    $exclude = GetParm("exclude", PARM_STRING);
+    $formVars["exclude"] = $exclude;
 
-    /* Select each uploadtree row in this tree, write out text:
-     * filepath : license list
-     * e.g. Pound-2.4.tgz/Pound-2.4/svc.c: GPL_v3+, Indemnity
-     */
-    $uploadtreeTablename = $this->uploadDao->getUploadtreeTableName($toprow['upload_fk']);
+    $V .= $this->renderString("ui-license-list-form.html.twig",$formVars);
 
-    $lines = array();
-    while ($row = pg_fetch_assoc($outerresult)) {
-      $filepatharray = Dir2Path($row['uploadtree_pk'], $uploadtreeTablename);
-      $filepath = "";
-      foreach ($filepatharray as $uploadtreeRow)
-      {
-        if (!empty($filepath))
-          $filepath .= "/";
-        $filepath .= $uploadtreeRow['ufile_name'];
-      }
-      $lines[] = $filepath . ": " . GetFileLicenses_string($agent_pk, 0, $row['uploadtree_pk'], $uploadtreeTablename);
-    }
-    $RealNumber = pg_num_rows($outerresult);
-    pg_free_result($outerresult);
+    $V .= "<hr/>";
+    $lines = $this->createListOfLines($uploadtreeTablename, $uploadtree_pk, $agent_pks, $NomostListNum, $includeSubfolder, $exclude, $ignore);
 
-    if ($RealNumber == $NomostListNum)
+    if (array_key_exists("warn",$lines))
     {
-      $V .= _("<br><b>Warning: Only the last $NomostListNum lines are displayed.  To see the whole list, run fo_nomos_license_list from the command line.</b><br>");
+      $warnings[] = $lines["warn"];
+      unset($lines["warn"]);
+    }
+    foreach($warnings as $warning)
+    {
+      $V .= "<br><b>$warning</b><br>";
     }
 
-    if ($dltext) {
+    if ($dltext)
+    {
       $request = $this->getRequest();
       $itemId = intval($request->get('item'));
       $path = Dir2Path($itemId, $uploadtreeTablename);
@@ -166,7 +221,9 @@ class ui_license_list extends FO_Plugin
 
       $response = new Response(implode("\n", $lines), Response::HTTP_OK, $headers);
       return $response;
-    } else {
+    }
+    else
+    {
       return $V . '<pre>' . implode("\n", $lines) . '</pre>';
     }
   }


### PR DESCRIPTION
This PR introduces many new features to the **license-list** UI and CLI.

### UI
It now looks like
![tmp](https://cloud.githubusercontent.com/assets/1187050/12976114/f7e4271e-d0c1-11e5-9e29-355a4fa05b0d.png)
and grants access to many options which were previously only reachable from the cli, i.e.
* excluding of files using a simple pattern and
* ecluding of subfolders.
One is now also able to choose which agents to include. (Previously only Nomos was used)

### CLI
For the CLI there were also two new commands `fo_monk_license_list` and `fo_ninka_license_list` introduced (They all could simply be combined to a single command line tool).

### misc
All interfaces use a common function `getLicensesPerFileNameForAgentId` in **LicenseDao.php** (Previously there were two different implementations in **fo_nomos_lisense_list.php** and **ui-license-list.php**).


### Performance comparison for CLI (for a random example)
the old implementation took:
```
real    0m9.492s
user    0m0.070s
sys     0m1.536s
``` 
the new implementation takes:
```
real    0m1.464s
user    0m0.226s
sys     0m0.073s
```
and a diff shows that the results are (up to order of the lines and up to order of individual licenses) excactly the same.

--
~~This PR will be squashed before merge.~~ DONE