### PR TITLE
fossupload_status print usage on error or --help

### DIFF
--- a/src/cli/fossupload_status.php
+++ b/src/cli/fossupload_status.php
@@ -29,16 +29,23 @@ global $Plugins;
 error_reporting(E_NOTICE & E_STRICT);
 
 $Usage = "Usage: " . basename($argv[0]) . " [options]
+  --help      = display this help text
   --username  = user name
   --password  = password
   --groupname = a group the user belongs to (default active group)
   --uploadId  = id of upload
 ";
 
-$opts = getopt("c:", array("username:", "groupname:", "uploadId:", "password:"));
+$opts = getopt("c:", array("help", "username:", "groupname:", "uploadId:", "password:"));
+
+if (array_key_exists("help", $opts)) {
+  echo $Usage;
+  exit (1);
+}
 
 if (!array_key_exists("uploadId", $opts)) {
   echo "no uploadId supplied\n";
+  echo $Usage;
   exit (1);
 }
 $uploadId = $opts["uploadId"];


### PR DESCRIPTION
Currently the usage information is coded but never printed. If --uploadId is not
provided, the error 'no uploadId supplied' is printed and the program exits. With
this change, usage is printed after this error, and also if the --help flag is used.