### PR TITLE
fix(dashboard): missing $this-> in method call

### DIFF
--- a/src/www/ui/admin-dashboard.php
+++ b/src/www/ui/admin-dashboard.php
@@ -118,12 +118,12 @@ function GetLastAnalyzeTimeOrVacTime($queryPart,$TableName)
 
 function GetLastVacTime($TableName)
 {
-  return GetLastAnalyzeTimeOrVacTime("last_vacuum, last_autovacuum",$TableName);
+  return $this->GetLastAnalyzeTimeOrVacTime("last_vacuum, last_autovacuum",$TableName);
 }
   
 function GetLastAnalyzeTime($TableName)
 {
-  return GetLastAnalyzeTimeOrVacTime("last_analyze, last_autoanalyze",$TableName);
+  return $this->GetLastAnalyzeTimeOrVacTime("last_analyze, last_autoanalyze",$TableName);
 }
 
 


### PR DESCRIPTION
Bug introduced in cf2a177f7f731f35e8587bec2e4f1cbe5a251edd. This is breaking the Dashboard page.
Tested on version `3.0.0-167-ge9e4a36`