### PR TITLE
Dev/fix showjobs for `&upload=-1` in the url

### DIFF
--- a/Makefile.conf
+++ b/Makefile.conf
@@ -152,8 +152,8 @@ PHPUNIT_BOOT = $(FOSRCDIR)/phpunit-bootstrap.php
 WriteVERSIONFile = echo "writing VERSION file for $(1)"; \
    {\
     echo "[$(1)]";\
-    echo "VERSION=$(VERSION)";\
-    echo "BRANCH=$(BRANCH)";\
+    echo "VERSION=\"$(VERSION)\"";\
+    echo "BRANCH=\"$(BRANCH)\"";\
     echo "COMMIT_HASH=$(COMMIT_HASH)";\
     echo BUILD_DATE=`date +"%Y/%m/%d %R %Z"`;\
     git show -s --format="%ct.%h" 2>/dev/null | {\

--- a/src/lib/php/Dao/JobDao.php
+++ b/src/lib/php/Dao/JobDao.php
@@ -39,10 +39,16 @@ class JobDao extends Object
     $result = array();
     $stmt = __METHOD__;
     $this->dbManager->prepare($stmt,
-      "SELECT jobqueue.jq_pk as jq_pk, jobqueue.jq_end_bits as end_bits
-      FROM jobqueue INNER JOIN job ON jobqueue.jq_job_fk = job.job_pk
-      LEFT JOIN group_user_member gm ON gm.user_fk = job_user_fk
-      WHERE job.job_upload_fk = $1 AND (job_user_fk = $2 OR gm.group_fk = $3)");
+      "SELECT jobqueue.jq_pk as jq_pk,
+              jobqueue.jq_end_bits as end_bits
+       FROM jobqueue
+         INNER JOIN job
+           ON jobqueue.jq_job_fk = job.job_pk
+         LEFT JOIN group_user_member gm
+           ON gm.user_fk = job_user_fk
+       WHERE job.job_upload_fk = $1
+         AND (job_user_fk = $2
+              OR gm.group_fk = $3)");
 
     $res = $this->dbManager->execute($stmt, array($uploadId, $userId, $groupId));
     while ($row = $this->dbManager->fetchArray($res))
@@ -54,4 +60,26 @@ class JobDao extends Object
     return $result;
   }
 
+  public function hasActionPermissionsOnJob($jobId, $userId, $groupId)
+  {
+    $result = array();
+    $stmt = __METHOD__;
+    $this->dbManager->prepare($stmt,
+      "SELECT *
+       FROM job
+         LEFT JOIN group_user_member gm
+           ON gm.user_fk = job_user_fk
+       WHERE job_pk = $1
+         AND (job_user_fk = $2
+              OR gm.group_fk = $3)");
+
+    $res = $this->dbManager->execute($stmt, array($jobId, $userId, $groupId));
+    while ($row = $this->dbManager->fetchArray($res))
+    {
+      $result[$row['jq_pk']] = $row['end_bits'];
+    }
+    $this->dbManager->freeResult($res);
+
+    return $result;
+  }
 }

--- a/src/lib/php/Dao/ShowJobsDao.php
+++ b/src/lib/php/Dao/ShowJobsDao.php
@@ -307,4 +307,19 @@ class ShowJobsDao extends Object
     } 
   }/* getEstimatedTime() */
 
+  /** 
+   * @brief Return total Job data with time elapsed
+   * @param $job_pk
+   * @return $row
+   */
+  public function getDataForASingleJob($job_pk)
+  {
+    $statementName = __METHOD__."getDataForASingleJob";
+    $this->dbManager->prepare($statementName,
+    "SELECT *, jq_endtime-jq_starttime as elapsed FROM jobqueue LEFT JOIN job ON job.job_pk = jobqueue.jq_job_fk WHERE jobqueue.jq_pk =$1");
+    $result = $this->dbManager->execute($statementName, array($job_pk));
+    $row = $this->dbManager->fetchArray($result);
+    $this->dbManager->freeResult($result);
+    return $row;
+  } /* getDataForASingleJob */
 }

--- a/src/scheduler/agent/database.c
+++ b/src/scheduler/agent/database.c
@@ -193,7 +193,7 @@ static gboolean email_replace(const GMatchInfo* match, GString* ret,
    */
   else if(strcmp(m_str, "SCHEDULERLOG") == 0)
   {
-    g_string_append_printf(ret, "http://%s?mod=showjobs&show=job&job=%d",
+    g_string_append_printf(ret, "http://%s?mod=showjobs&job=%d",
         fossy_url, job->id);
   }
 

--- a/src/www/ui/ajax-showjobs.php
+++ b/src/www/ui/ajax-showjobs.php
@@ -90,7 +90,7 @@ class AjaxShowJobs extends FO_Plugin
    * @param $job_pk
    * @return Return job and jobqueue record data in an html table.
    **/
-  protected function showJobDB($job_pk)
+  protected function getGeekyScanDetailsForJob($job_pk)
   {    
     $i=0;
     $fields=array('jq_pk'=>'jq_pk',
@@ -111,12 +111,7 @@ class AjaxShowJobs extends FO_Plugin
                   'Log'=>'jq_log');
     $uri = Traceback_uri() . "?mod=showjobs&upload=";
 
-    $statementName = __METHOD__."ShowJobDBforjob";
-    $this->dbManager->prepare($statementName,
-    "SELECT *, jq_endtime-jq_starttime as elapsed FROM jobqueue LEFT JOIN job ON job.job_pk = jobqueue.jq_job_fk WHERE jobqueue.jq_pk =$1");
-    $result = $this->dbManager->execute($statementName, array($job_pk));
-    $row = $this->dbManager->fetchArray($result);
-    $this->dbManager->freeResult($result);
+    $row = $this->showJobsDao->getDataForASingleJob($job_pk);
 
     $table = array();
     foreach($fields as $labelKey=>$field){
@@ -194,17 +189,18 @@ class AjaxShowJobs extends FO_Plugin
                                   'iTotalRecords' => count($tableData),
                                   'iTotalDisplayRecords' => count($tableData)));
     
-  } // showJobDB()
+  } /* getGeekyScanDetailsForJob() */
 
   /**
    * @brief Returns an upload job status in html
-   * @param $jobData
+   * @param $jobData, $page, $allusers
    * @return Returns an upload job status in html
    **/
-  protected function show($jobData, $page, $allusers)
+  protected function getShowJobsForEachJob($jobData, $page, $allusers)
   {
     $outBuf = '';
     $pagination = '';
+    $uploadtree_pk = 0;
     $numJobs = count($jobData);
     if ($numJobs == 0){
       return array('showJobsData' => "There are no jobs to display");
@@ -391,7 +387,7 @@ class AjaxShowJobs extends FO_Plugin
     }
 
     return array('showJobsData' => $outBuf, 'pagination' => $pagination);
-  }
+  } /* getShowJobsForEachJob() */
 
   /**
    * @brief Are there any unfinished jobqueues in this job?
@@ -477,7 +473,7 @@ class AjaxShowJobs extends FO_Plugin
     $jobsInfo = $this->showJobsDao->getJobInfo($jobs, $page);
     usort($jobsInfo, array($this,"compareJobsInfo"));
       
-    $showJobData = $this->show($jobsInfo, $page, $allusers);
+    $showJobData = $this->getShowJobsForEachJob($jobsInfo, $page, $allusers);
     return new JsonResponse($showJobData);
   } /* getJobs()*/
 
@@ -506,7 +502,7 @@ class AjaxShowJobs extends FO_Plugin
         break;
       case "showSingleJob":
         $job_pk1 = GetParm('jobId',PARM_INTEGER);
-        return $this->showJobDB($job_pk1);
+        return $this->getGeekyScanDetailsForJob($job_pk1);
     }
   }
 }

--- a/src/www/ui/async/AjaxFileBrowser.php
+++ b/src/www/ui/async/AjaxFileBrowser.php
@@ -203,7 +203,6 @@ class AjaxFileBrowser extends DefaultPlugin
     $baseUri = Traceback_uri().'?mod=fileBrowse'.Traceback_parm_keep(array('upload','folder','show'));
 
     $tableData = array();    
-    global $Plugins;
     $latestSuccessfulAgentIds = $scanJobProxy->getLatestSuccessfulAgentIds();
     foreach ($descendants as $child)
     {
@@ -269,7 +268,7 @@ class AjaxFileBrowser extends DefaultPlugin
 
     /* Populate the output ($VF) - file list */
     /* id of each element is its uploadtree_pk */
-    $fileName = $child['ufile_name'];
+    $fileName = htmlspecialchars($child['ufile_name']);
     if ($isContainer)
     {
       $fileName = "<a href='$linkUri'><span style='color: darkblue'> <b>$fileName</b> </span></a>";

--- a/src/www/ui/scripts/job-queue-poll.js
+++ b/src/www/ui/scripts/job-queue-poll.js
@@ -77,5 +77,5 @@ function queueUpdateCheck(jqPk, callbacksucess, callbackfail) {
 
 
 function linkToJob(jqPk) {
-  return "<a href='?mod=showjobs&show=job&job=" + jqPk + "'>job #" + jqPk + "</a>";
+  return "<a href='?mod=showjobs&job=" + jqPk + "'>job #" + jqPk + "</a>";
 }

--- a/src/www/ui/showjobs.php
+++ b/src/www/ui/showjobs.php
@@ -52,19 +52,24 @@ class showjobs extends FO_Plugin
   {
     menu_insert("Main::Jobs::My Recent Jobs",$this->MenuOrder -1,$this->Name, $this->MenuTarget);
 
-    if ($_SESSION[Auth::USER_LEVEL] != PLUGIN_DB_ADMIN) return;
+    if ($_SESSION[Auth::USER_LEVEL] == PLUGIN_DB_ADMIN)
+    {
+      $URIpart = $this->Name . Traceback_parm_keep(array( "page")) . "&allusers=";
 
-    if (GetParm("mod", PARM_STRING) == $this->Name){
-      /* Set micro menu to select either all users or this user */
-      $allusers = GetParm("allusers",PARM_INTEGER);
-      if ($allusers == 0){
-        $text = _("Show uploads from all users");
-        $URI = $this->Name . Traceback_parm_keep(array( "page" )) . "&allusers=1";
-      }else{
-        $text = _("Show only your own uploads");
-        $URI = $this->Name . Traceback_parm_keep(array( "page")) . "&allusers=0";
+      menu_insert("Main::Jobs::All Recent Jobs",$this->MenuOrder -2,$URIpart . '1', $this->MenuTarget);
+
+      if (GetParm("mod", PARM_STRING) == $this->Name){
+        /* Set micro menu to select either all users or this user */
+        $allusers = GetParm("allusers",PARM_INTEGER);
+        if ($allusers == 0){
+          $text = _("Show uploads from all users");
+          $URI = $URIpart . "1";
+        }else{
+          $text = _("Show only your own uploads");
+          $URI = $URIpart . "0";
+        }
+        menu_insert("showjobs::$text", 1, $URI, $text);
       }
-      menu_insert("showjobs::$text", 1, $URI, $text);
     }
 
   } // RegisterMenus()

--- a/src/www/ui/showjobs.php
+++ b/src/www/ui/showjobs.php
@@ -146,7 +146,7 @@ class showjobs extends FO_Plugin
       $jq_pk = GetParm("jobid",PARM_INTEGER);
       $action = GetParm("action",PARM_STRING);
       $uploadPk = GetParm("upload",PARM_INTEGER);
-      if (!empty($uploadPk) && !$this->uploadDao->isEditable($uploadPk, Auth::getGroupId())){
+      if (!(empty($uploadPk) || $uploadPk === -1) && !$this->uploadDao->isEditable($uploadPk, Auth::getGroupId())){
         $text = _("Permission Denied");
         return "<h2>$text</h2>";
       }

--- a/src/www/ui/template/ui-showjobs-jobqueue-row.html.twig
+++ b/src/www/ui/template/ui-showjobs-jobqueue-row.html.twig
@@ -7,11 +7,11 @@
 
 <tr class="{{ class }}">
   <td>
-    <a href="{{ uriFull }}&show=job&job={{ jqId }}">{{ jqId }}</a>
+    <a href="{{ uriFull }}&job={{ jqId }}">{{ jqId }}</a>
     {% if depends is not empty %}
       {% for depend_jq_pk in depends %}{#
       #}{% if loop.index0==0 %} / {% else %}, {% endif %}
-        <a href="{{ uriFull }}&show=job&job={{ depend_jq_pk }}">{{ depend_jq_pk }}</a>{#
+        <a href="{{ uriFull }}&job={{ depend_jq_pk }}">{{ depend_jq_pk }}</a>{#
       #}{% endfor %}
     {% endif %}
   </td>


### PR DESCRIPTION
For users without admin permissions the geeky scan details was broken in some cases, i.e. it looked like
![tmp](https://cloud.githubusercontent.com/assets/1187050/13808837/591f3bb6-eb68-11e5-9dba-00fdbc020193.png)

#### How to reproduce:
visit as read-write user the url
<pre>
http://localhost:8081/repo/?mod=showjobs&<b>upload=-1</b>&job=49
</pre>
for a valid `jobId`.

#### Hotfix
the hotfix was to remove the part `upload=-1` from the url.