### PR TITLE
fix(security) cp2foss SQL injection vulnerability

### DIFF
--- a/src/cli/cp2foss.php
+++ b/src/cli/cp2foss.php
@@ -156,7 +156,7 @@ function GetBucketFolder($UploadName, $BucketGroupSize) {
  * This is recursive!
  */
 function GetFolder($FolderPath, $Parent = NULL) {
-  global $PG_CONN;
+  $dbManager = $GLOBALS['container']->get('db.manager');
   global $Verbose;
   global $Test;
   if (empty($Parent)) {
@@ -175,19 +175,16 @@ function GetFolder($FolderPath, $Parent = NULL) {
   }
   /* See if it exists */
   $SQLFolder = str_replace("'", "''", $folderHead);
-  $SQL = "SELECT * FROM folder
+  $SQL = "SELECT folder_pk FROM folder
   INNER JOIN foldercontents ON child_id = folder_pk
   AND foldercontents_mode = '1'
-  WHERE foldercontents.parent_fk = '$Parent' AND folder_name='$SQLFolder'";
+  WHERE foldercontents.parent_fk = $1 AND folder_name=$2";
   if ($Verbose) {
-    print "SQL=\n$SQL\n";
+    print "SQL=\n$SQL $1=$Parent $2=$SQLFolder\n";
   }
-  $result = pg_query($PG_CONN, $SQL);
-  DBCheckResult($result, $SQL, __FILE__, __LINE__);
-  $row = pg_fetch_assoc($result);
-  $row_count = pg_num_rows($result);
 
-  if ($row_count <= 0) {
+  $row = $dbManager->getSingleRow($SQL, array($Parent, $SQLFolder), __METHOD__.".GetFolder.exists");
+  if (empty($row)) {
     /* Need to create folder */
     global $Plugins;
     $P = & $Plugins[plugin_find_id("folder_create") ];
@@ -200,14 +197,10 @@ function GetFolder($FolderPath, $Parent = NULL) {
     }
     if (!$Test) {
       $P->create($Parent, $folderHead, "");
-      pg_free_result($result);
-      $result = pg_query($PG_CONN, $SQL);
-      DBCheckResult($result, $SQL, __FILE__, __LINE__);
-      $row = pg_fetch_assoc($result);
+      $row = $dbManager->getSingleRow($SQL, array($Parent, $SQLFolder), __METHOD__.".GetFolder.exists");
     }
   }
   $Parent = $row['folder_pk'];
-  pg_free_result($result);
   return (GetFolder($folderTail, $Parent));
 } /* GetFolder() */
 
@@ -222,13 +215,13 @@ function GetFolder($FolderPath, $Parent = NULL) {
  * \return 1: error, 0: success
  */
 function UploadOne($FolderPath, $UploadArchive, $UploadName, $UploadDescription, $TarSource = NULL) {
+  $dbManager = $GLOBALS['container']->get('db.manager');
   global $Verbose;
   global $Test;
   global $QueueList;
   global $fossjobs_command;
   global $public_flag;
   global $SysConf;
-  global $PG_CONN;
   global $VCS;
   global $vcsuser;
   global $vcspass;
@@ -359,15 +352,13 @@ function UploadOne($FolderPath, $UploadArchive, $UploadName, $UploadDescription,
     $waitCount = 0;
     while ($working && ($waitCount++ < 30)) {
       sleep(3);
-      $SQL = "select * from jobqueue inner join job on job.job_pk = jobqueue.jq_job_fk where job_upload_fk = '$UploadPk' and jq_end_bits = 0 and jq_type = 'wget_agent'";
+      $SQL = "select 1 from jobqueue inner join job on job.job_pk = jobqueue.jq_job_fk where job_upload_fk = $1 and jq_end_bits = 0 and jq_type = 'wget_agent'";
 
-      $result = pg_query($PG_CONN, $SQL);
-      DBCheckResult($result, $SQL, __FILE__, __LINE__);
-      $row_count = pg_num_rows($result);
-      pg_free_result($result);
-      if ($row_count == 0) {
+      $row = $dbManager->getSingleRow($SQL, array($UploadPk), __METHOD__.".UploadOne");
+      if (empty($row)) {
         $working = false;
       }
+
     }
     if ($working) {
       echo "Gave up waiting for copy completion. Is the scheduler running?";

--- a/src/cli/cp2foss.php
+++ b/src/cli/cp2foss.php
@@ -174,16 +174,15 @@ function GetFolder($FolderPath, $Parent = NULL) {
     return (GetFolder($folderTail, $Parent));
   }
   /* See if it exists */
-  $SQLFolder = str_replace("'", "''", $folderHead);
   $SQL = "SELECT folder_pk FROM folder
   INNER JOIN foldercontents ON child_id = folder_pk
   AND foldercontents_mode = '1'
-  WHERE foldercontents.parent_fk = $1 AND folder_name=$2";
+  WHERE foldercontents.parent_fk = $1 AND folder_name = $2";
   if ($Verbose) {
-    print "SQL=\n$SQL $1=$Parent $2=$SQLFolder\n";
+    print "SQL=\n$SQL\n$1=$Parent\n$2=$folderHead\n";
   }
 
-  $row = $dbManager->getSingleRow($SQL, array($Parent, $SQLFolder), __METHOD__.".GetFolder.exists");
+  $row = $dbManager->getSingleRow($SQL, array($Parent, $folderHead), __METHOD__.".GetFolder.exists");
   if (empty($row)) {
     /* Need to create folder */
     global $Plugins;
@@ -197,7 +196,7 @@ function GetFolder($FolderPath, $Parent = NULL) {
     }
     if (!$Test) {
       $P->create($Parent, $folderHead, "");
-      $row = $dbManager->getSingleRow($SQL, array($Parent, $SQLFolder), __METHOD__.".GetFolder.exists");
+      $row = $dbManager->getSingleRow($SQL, array($Parent, $folderHead), __METHOD__.".GetFolder.exists");
     }
   }
   $Parent = $row['folder_pk'];


### PR DESCRIPTION
Two SQL queries in the cp2foss utility insert variables into the SQL string, which creates an SQL injection vulnerability. This PR converts those queries into prepared statements using DbManager. SELECT * has also been replaced with SELECT <fields> for efficiency.