### PR TITLE
fix(SPDX2): use implodedLicenses in tagValue format

### DIFF
--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -20,7 +20,7 @@
       <directory suffix="Test.php">deciderjob/agent_tests/Functional</directory>
       <directory suffix="Test.php">monk/agent_tests/Functional</directory>
       <directory suffix="Test.php">ninka/agent_tests/Functional</directory>
-      <directory suffix="Test.php">spdx2/agent_tests/Functional</directory>
+      <directory suffix="Test.php">spdx2/agent_tests</directory>
     </testsuite>
 
   </testsuites>

--- a/src/spdx2/agent/Makefile
+++ b/src/spdx2/agent/Makefile
@@ -14,7 +14,7 @@ MOD_NAME = spdx2
 MOD_SUBDIR = agent
 MOD_NAMES = spdx2 spdx2tv dep5
 
-EXE=spdx2.php version.php services.php
+EXE=spdx2.php version.php services.php spdx2utils.php
 
 all: version.php spdx2
 

--- a/src/spdx2/agent/spdx2utils.php
+++ b/src/spdx2/agent/spdx2utils.php
@@ -1,0 +1,86 @@
+<?php
+/*
+ * Copyright (C) 2016, Siemens AG
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+namespace Fossology\SpdxTwo;
+
+class SpdxTwoUtils
+{
+  /**
+   * @param string[] $args
+   * @param string $key1
+   * @param string $key2
+   *
+   * @return string[] $args
+   */
+  static public function preWorkOnArgsFlp($args,$key1,$key2)
+  {
+    $needle = ' --'.$key2.'=';
+    if (is_array($args) &&
+        array_key_exists($key1, $args) &&
+        strpos($args[$key1],$needle) !== false) {
+      $exploded = explode($needle,$args[$key1]);
+      $args[$key1] = trim($exploded[0]);
+      $args[$key2] = trim($exploded[1]);
+    }
+    return $args;
+  }
+
+  /**
+   * @param string[] $licenses
+   * @param string="" $prefix
+   *
+   * @return string
+   */
+  static public function implodeLicenses($licenses, $prefix="")
+  {
+    if(!$licenses || !is_array($licenses) || sizeof($licenses) == 0)
+    {
+      return "";
+    }
+
+    $licenses = array_map(function ($license) use ($prefix)
+    {
+      if(strpos($license, " OR ") !== false)
+      {
+        return "(" . $license . ")";
+      }
+      else
+      {
+        if(substr($license, 0, strlen($prefix)) === $prefix)
+        {
+          return $license;
+        }
+        else
+        {
+          return $prefix . $license;
+        }
+      }
+    },$licenses);
+    sort($licenses, SORT_NATURAL | SORT_FLAG_CASE);
+
+    if(count($licenses) == 3 &&
+       ($index = array_search($prefix . "Dual-license",$licenses)) !== false)
+    {
+      return $licenses[$index===0?1:0] . " OR " . $licenses[$index===2?1:2];
+    }
+    else
+    {
+      // Add prefixes where needed, enclose statments containing ' OR ' with parantheses
+      return implode(" AND ", $licenses);
+    }
+  }
+}

--- a/src/spdx2/agent/template/spdx2tv-file.twig
+++ b/src/spdx2/agent/template/spdx2tv-file.twig
@@ -16,9 +16,7 @@ FileChecksum: MD5: {{ md5 }}
 {% if concludedLicenses|default is empty %}
 LicenseConcluded: NONE
 {% else %}
-LicenseConcluded: LicenseRef-{{ concludedLicenses|join('UNIQUESTRINGTOREPLACE')
-                                                 |replace({' ':'-'})
-                                                 |replace({'UNIQUESTRINGTOREPLACE':' OR LicenseRef-'}) }}
+LicenseConcluded: {{ concludedLicense }}
 {% endif%}
 {% else %}
 LicenseConcluded: NOASSERTION

--- a/src/spdx2/agent/template/spdx2tv-package.twig
+++ b/src/spdx2/agent/template/spdx2tv-package.twig
@@ -19,12 +19,8 @@ PackageChecksum: MD5: {{ md5  }}
 PackageLicenseConcluded: NOASSERTION
 PackageLicenseDeclared: NOASSERTION
 {% else %}
-PackageLicenseConcluded: (LicenseRef-{{ mainLicenses|join('UNIQUESTRINGTOREPLACE')
-                                                    |replace({' ':'-'})
-                                                    |replace({'UNIQUESTRINGTOREPLACE':' OR LicenseRef-'}) }})
-PackageLicenseDeclared: (LicenseRef-{{ mainLicenses|join('UNIQUESTRINGTOREPLACE')
-                                                   |replace({' ':'-'})
-                                                   |replace({'UNIQUESTRINGTOREPLACE':' OR LicenseRef-'}) }})
+PackageLicenseConcluded: {{ mainLicense }}
+PackageLicenseDeclared: {{ mainLicense }}
 {% endif %}
 {% if licenseComments %}PackageLicenseComments: <text> {{ licenseComments|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'}) }} </text>
 {% endif %}

--- a/src/spdx2/agent_tests/Unit/Makefile
+++ b/src/spdx2/agent_tests/Unit/Makefile
@@ -1,0 +1,23 @@
+# Copyright Siemens AG 2014
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+TOP = ../../../..
+VARS = $(TOP)/Makefile.conf
+include $(VARS)
+
+LOCALAGENTDIR = ../../agent
+
+all:
+
+test:
+	$(PHPUNIT) --bootstrap $(PHPUNIT_BOOT) *.php
+
+coverage: test
+
+clean:
+
+.PHONY: all test coverage clean

--- a/src/spdx2/agent_tests/Unit/spdx2utilTest.php
+++ b/src/spdx2/agent_tests/Unit/spdx2utilTest.php
@@ -1,0 +1,174 @@
+<?php
+/*
+Copyright (C) 2016, Siemens AG
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+namespace Fossology\SpdxTwo;
+
+require_once(__DIR__ . '/../../agent/spdx2utils.php');
+
+class spdx2Test extends \PHPUnit_Framework_TestCase
+{
+  public function testPreWorkOnArgsFlpZero()
+  {
+    $args = array();
+    assertThat(SpdxTwoUtils::preWorkOnArgsFlp($args,"key1","key2"), equalTo($args));
+  }
+
+  public function testPreWorkOnArgsFlpId()
+  {
+    $args = array("key1" => "value");
+    assertThat(SpdxTwoUtils::preWorkOnArgsFlp($args,"key1","key2"), equalTo($args));
+  }
+
+  public function testPreWorkOnArgsFlpRealWork()
+  {
+    $args = array("key1" => "value --key2=anotherValue");
+    $result = SpdxTwoUtils::preWorkOnArgsFlp($args,"key1","key2");
+    assertThat($result["key1"], equalTo("value"));
+    assertThat($result["key2"], equalTo("anotherValue"));
+  }
+
+  public function testImplodeLicensesEmpty()
+  {
+    assertThat(SpdxTwoUtils::implodeLicenses(null), equalTo(""));
+    assertThat(SpdxTwoUtils::implodeLicenses(array()), equalTo(""));
+  }
+
+  public function testImplodeLicensesSingle()
+  {
+    assertThat(SpdxTwoUtils::implodeLicenses(array("LIC1")), equalTo("LIC1"));
+  }
+
+  public function testImplodeLicensesMultiple()
+  {
+    $lics = array("LIC1","LIC2","LIC3");
+    $result = SpdxTwoUtils::implodeLicenses($lics);
+    // should be something like "LIC1 AND LIC2 AND LIC3"
+
+    $exploded = array_map("trim", explode("AND",$result));
+    foreach ($exploded as $e)
+    {
+      assertThat(in_array($e,$lics,true), equalTo(true));
+    }
+    foreach ($lics as $l)
+    {
+      assertThat(in_array($l, $exploded, true), equalTo(true));
+    }
+  }
+
+  public function testImplodeLicensesDualLicense()
+  {
+    $lics = array("LIC1", "Dual-license", "LIC3");
+    $result = SpdxTwoUtils::implodeLicenses($lics);
+    // should be something like "LIC1 OR LIC3"
+
+    $exploded = array_map("trim", explode("OR",$result));
+    foreach ($exploded as $e)
+    {
+      assertThat(in_array($e,$lics,true));
+    }
+    foreach ($lics as $l)
+    {
+      if ($l !== "Dual-license")
+      {
+        assertThat(in_array($l, $exploded, true));
+      }
+    }
+  }
+
+  public function testImplodeLicensesMultipleAndImplodedDualLicense()
+  {
+    $lics = array("LIC1","LIC2 OR LIC3");
+    $result = SpdxTwoUtils::implodeLicenses($lics);
+    // should be something like "LIC1 AND (LIC2 OR LIC3)"
+
+    $exploded = array_map("trim", explode("AND",$result));
+    foreach ($exploded as $e)
+    {
+      if(strpos($e, " OR ") !== false)
+      {
+        $eWithoutBraces = trim(substr($e,1,-1));
+        assertThat(in_array($eWithoutBraces,$lics,true));
+      }
+      else
+      {
+        assertThat(in_array($e,$lics,true));
+      }
+    }
+    foreach ($lics as $l)
+    {
+      if(strpos($l, " OR ") !== false)
+      {
+        $lWithBraces = "($l)";
+        assertThat(in_array($lWithBraces,$exploded,true));
+      }
+      else
+      {
+        assertThat(in_array($l, $exploded, true));
+      }
+    }
+  }
+
+  public function testPrefixImplodeLicensesMultipleAndImplodedDualLicense()
+  {
+    $lics = array("LIC1","pre-LIC2 OR pre-LIC3");
+    $prefix = "pre-";
+    $result = SpdxTwoUtils::implodeLicenses($lics, $prefix);
+    // should be something like "pre-LIC1 AND (pre-LIC2 OR pre-LIC3)"
+
+    $exploded = array_map("trim", explode("AND",$result));
+    foreach ($exploded as $e)
+    {
+      if(strpos($e, " OR ") !== false)
+      {
+        $eWithoutBraces = trim(substr($e,1,-1));
+        assertThat(in_array($eWithoutBraces,$lics,true));
+      }
+      else
+      {
+        assertThat(in_array(substr($e,strlen($prefix)),$lics,true));
+      }
+    }
+    foreach ($lics as $l)
+    {
+      if(strpos($l, " OR ") !== false)
+      {
+        $lWithBraces = "($l)";
+        assertThat(in_array($lWithBraces,$exploded,true));
+      }
+      else
+      {
+        assertThat(in_array($prefix.$l, $exploded, true));
+      }
+    }
+  }
+
+  public function testImplodeLicensesDualLicenseAndImplodedDualLicense()
+  {
+    $lics = array("LIC1","LIC2 OR LIC3", "Dual-license");
+    $result = SpdxTwoUtils::implodeLicenses($lics);
+    // should be something like "LIC1 OR (LIC2 OR LIC3)"
+
+    foreach ($lics as $l)
+    {
+      if ($l !== "Dual-license")
+      {
+        assertThat(strpos($result, $l) !== false);
+      }
+    }
+  }
+}


### PR DESCRIPTION
The `OR`s and `AND`s in tag:value were flipped