### PR TITLE
feat(docker): add Dockerfile and Docker compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# FOSSology Dockerfile
+# Copyright Siemens AG 2016, fabio.huser@siemens.com
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Description: Docker container image recipe
+
+FROM debian:stable
+
+MAINTAINER Fossology <fossology@fossology.org>
+
+WORKDIR /fossology
+ADD . .
+
+RUN apt-get update && \
+    apt-get install -y lsb-release sudo postgresql php5-curl libpq-dev libdbd-sqlite3-perl libspreadsheet-writeexcel-perl && \
+    /fossology/utils/fo-installdeps -e -y && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://getcomposer.org/installer | php && \
+    mv composer.phar /usr/local/bin/composer
+
+RUN /fossology/install/scripts/install-spdx-tools.sh
+
+RUN /fossology/install/scripts/install-ninka.sh
+
+RUN make install
+
+RUN cp /fossology/install/src-install-apache-example.conf /etc/apache2/conf-available/fossology.conf && \
+    ln -s /etc/apache2/conf-available/fossology.conf /etc/apache2/conf-enabled/fossology.conf
+
+RUN /fossology/install/scripts/php-conf-fix.sh --overwrite
+
+EXPOSE 80
+
+RUN chmod +x /fossology/docker-entrypoint.sh
+ENTRYPOINT ["/fossology/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,32 @@ installation packages for Debian, RHEL/CentOS, Ubuntu, and Fedora, and a source 
   
 For installation instructions see http://www.fossology.org/projects/fossology/wiki
 
+## Docker
+FOSSology comes with a Dockerfile allowing the containerized execution
+both as single instance or in combination with an external PostgreSQL database.
+**Note:** It is strongly recommended to use an external database for production
+use, since the the standalone image does not take care of data persistency.
+
+A pre-built Docker image is available from [Docker Hub](https://hub.docker.com/r/fossology/fossology/) and can be run using following command:
+``` sh
+docker run -p 8081:80 fossology/fossology
+```
+
+Execution with external database container can be done using Docker Compose.
+The Docker Compose file is located under the `/install` folder can can be run using following command:
+``` sh
+cd install
+docker-compose up
+```
+
+The Docker image allows configuration of it's database connection over a set of environment variables.
+
+- **FOSSOLOGY_DB_HOST:** Hostname of the PostgreSQL database server.
+  An integrated PostgreSQL instance is used if not defined or set to `localhost`.
+- **FOSSOLOGY_DB_NAME:** Name of the PostgreSQL database. Defaults to `fossology`.
+- **FOSSOLOGY_DB_USER:** User to be used for PostgreSQL connection. Defaults to `fossy`.
+- **FOSSOLOGY_DB_PASSWORD:** Password to be used for PostgreSQL connection. Defaults to `fossy`.
+
 ## Documentation
 We are currently migrating our documentation to github.  At this stage you can find general documentation at:
 http://www.fossology.org/projects/fossology/wiki/User_Documentation

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# FOSSology docker-entrypoint script
+# Copyright Siemens AG 2016, fabio.huser@siemens.com
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Description: startup helper script for the FOSSology Docker container
+
+db_host="localhost"
+db_name="fossology"
+db_user="fossy"
+db_password="fossy"
+
+if [ "$FOSSOLOGY_DB_HOST" ]; then
+	db_host="$FOSSOLOGY_DB_HOST"
+fi
+if [ "$FOSSOLOGY_DB_NAME" ]; then
+	db_name="$FOSSOLOGY_DB_NAME"
+fi
+if [ "$FOSSOLOGY_DB_USER" ]; then
+	db_user="$FOSSOLOGY_DB_USER"
+fi
+if [ "$FOSSOLOGY_DB_PASSWORD" ]; then
+	db_password="$FOSSOLOGY_DB_PASSWORD"
+fi
+
+# Write configuration
+cat <<EOM > /usr/local/etc/fossology/Db.conf
+dbname=$db_name;
+host=$db_host;
+user=$db_user;
+password=$db_password;
+EOM
+
+# Startup DB if needed
+if [ "$db_host" = 'localhost' ]; then
+  echo '*****************************************************'
+  echo 'WARNING: No database host was set and therefore the'
+  echo 'internal database without persistency will be used.'
+  echo 'THIS IS NOT RECOMENDED FOR PRODUCTIVE USE!'
+  echo '*****************************************************'
+  /etc/init.d/postgresql start
+fi
+
+# Setup environment
+/usr/local/lib/fossology/fo-postinstall
+
+# Start Fossology
+echo
+echo 'Fossology initialisation complete; Starting up...'
+echo
+/etc/init.d/fossology start
+/usr/sbin/apache2ctl -D FOREGROUND

--- a/install/db/dbcreate.in
+++ b/install/db/dbcreate.in
@@ -5,6 +5,11 @@
 # This script checks to see if the the fossology db exists and if not
 # then creates it.
 
+if [ "$FOSSOLOGY_DB_HOST" ]; then
+  echo "NOTE: using external DB on host $FOSSOLOGY_DB_HOST"
+  exit 0
+fi
+
 echo "*** Setting up the FOSSology database ***"
 
 # At some point this is where we could dynamically set the db password

--- a/install/docker-compose.yml
+++ b/install/docker-compose.yml
@@ -1,0 +1,29 @@
+# FOSSology Docker Compose file
+# Copyright Siemens AG 2016, fabio.huser@siemens.com
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Description: Recipe for setting up a multi container FOSSology
+#              Docker setup with separate Database instance
+
+web:
+  build: ..
+  environment:
+    - FOSSOLOGY_DB_HOST=db
+    - FOSSOLOGY_DB_NAME=fossology
+    - FOSSOLOGY_DB_USER=fossy
+    - FOSSOLOGY_DB_PASSWORD=fossy
+  ports:
+    - 8081:80
+  links:
+    - db
+db:
+  image: postgres
+  environment:
+    - POSTGRES_DB=fossology
+    - POSTGRES_USER=fossy
+    - POSTGRES_PASSWORD=fossy
+    - POSTGRES_INITDB_ARGS='-E SQL_ASCII'

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -52,7 +52,7 @@ while true; do
       -b|--buildtime) BUILDTIME=1; shift;;
       -e|--everything) EVERYTHING=1; shift;;
       -o|--offline) OFFLINE=1; shift;;
-      -y) 
+      -y)
          YesOpt=" -y "; shift;;
       -h|--help)
          echo "Usage: fo-installdeps [options]";
@@ -123,13 +123,13 @@ if [ $BUILDTIME ]; then
          # F8=Werwolf F9=Sulphur F10=Cambridge F11=Leonidas F12=Constantine dev=Rawhide
          if [ $YesOpt ]; then
            YesOpt='-y'
-         fi                 
+         fi
          yum $YesOpt groupinstall "Development Tools"
          yum $YesOpt install \
             perl-Text-Template subversion \
             postgresql-devel file-devel \
             libxml2 \
-            boost-devel 
+            boost-devel
          ;;
       Mandriva)
          # 2008.1 tested
@@ -142,7 +142,7 @@ if [ $BUILDTIME ]; then
          # 4=Nahant* 5=Tikanga*
          if [ $YesOpt ]; then
            YesOpt='-y'
-         fi                     
+         fi
          yum $YesOpt install \
             postgresql-devel \
             gcc make file libxml2 \
@@ -166,7 +166,12 @@ if [ $RUNTIME ]; then
          apt-get $YesOpt install apache2 libapache2-mod-php5
          apt-get $YesOpt install php5 php5-pgsql php-pear php5-cli \
             libxml2 \
-            binutils php-gettext
+            binutils php-gettext \
+            cabextract cpio sleuthkit genisoimage \
+            poppler-utils upx-ucl \
+            unrar-free unzip p7zip-full p7zip wget \
+            subversion git \
+            dpkg-dev
          POSTGRE=`dpkg --get-selections|grep postgresql-8.4`
          if [ -z "$POSTGRE" ]; then  ## if postgresql-server-dev is installed
            case "$CODENAME" in
@@ -200,14 +205,14 @@ if [ $RUNTIME ]; then
       Fedora)
          if [ $YesOpt ]; then
            YesOpt='-y'
-         fi                  
+         fi
          yum $YesOpt install postgresql-server httpd
          yum $YesOpt install \
             postgresql \
             php php-pear php-pgsql php-process php-xml php-mbstring\
             smtpdaemon \
             libxml2 \
-            binutils 
+            binutils
 
          # enable, possible init, and start postgresql
          /sbin/chkconfig postgresql on
@@ -237,19 +242,19 @@ if [ $RUNTIME ]; then
          # 4=Nahant* 5=Tikanga*
          if [ $YesOpt ]; then
            YesOpt='-y'
-         fi                           
+         fi
          yum $YesOpt install postgresql-server httpd
          yum $YesOpt install \
             postgresql \
             php php-pear php-pgsql php-process\
             smtpdaemon \
             file libxml2 \
-            binutils 
+            binutils
          echo "NOTE: cabextract, sleuthkit, upx, and unrar are not"
          echo "    available in RHEL please install from upstream sources.";;
       *) echo "ERROR: distro not recognised, please fix and send a patch"; exit 1;;
    esac
-   
+
    which composer
     if [ $? -eq 0  ]; then
         if [ $OFFLINE -eq 0 ]; then
@@ -294,8 +299,8 @@ fi
 if [ ! -z "$YesOpt" ]; then
   options="$options -y"
 fi
-BASEDIR=$(dirname $0) 
+BASEDIR=$(dirname $0)
 mods_dir=$BASEDIR"/../src/" ## get the directory where fo-installdeps resides
-install_mod_deps $mods_dir 
- 
+install_mod_deps $mods_dir
+
 ########################################################################


### PR DESCRIPTION
This change adds the posibilitiy to build a Docker Image out of Fossology.
It allows the execution as standalone container (combined database) or
connection against an external database instance as used by the Docker compose setup.

Signed-off-by: Roger Meier <r.meier@siemens.com>
Signed-off-by: Fabio Huser <fabio.huser@siemens.com>
Tested-by: Maximilian Huber <maximilian.huber@tngtech.com>
Tested-by: Pascal Bach <pascal.bach@siemens.com>