### PR TITLE
(Work in progress) Refactor Makefiles to seperate the composer call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ $(CLEANDIRS):
 phpvendors:
 	$(MAKE) -C $(FOSRCDIR) phpvendors
 
+phpvendors-no-dev:
+	$(MAKE) -C $(FOSRCDIR) phpvendors-no-dev
+
 # release stuff
 tar: dist-testing
 dist-testing:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,7 @@ fi
 PROXYSCRIPT
 
 $build_and_test = <<SCRIPT
+set -ex
 export DEBIAN_FRONTEND=noninteractive
 
 echo "Provisioning system to compile, test and develop."
@@ -29,9 +30,6 @@ sudo dpkg-reconfigure locales
 sudo apt-get update -qq -y
 
 sudo apt-get install -qq curl php5 git libspreadsheet-writeexcel-perl libdbd-sqlite3-perl
-
-curl -sS https://getcomposer.org/installer | php
-sudo mv composer.phar /usr/bin/composer
 
 # install spdx-tools
 /vagrant/install/scripts/install-spdx-tools.sh
@@ -45,6 +43,9 @@ echo "lets go!"
 cd /vagrant
 
 ./utils/fo-installdeps -e -y
+curl -sS https://getcomposer.org/installer | php
+sudo mv composer.phar /usr/bin/composer
+make phpvendors
 make CFLAGS=-I/usr/include/glib-2.0
 sudo make install
 sudo /usr/local/lib/fossology/fo-postinstall

--- a/src/Makefile
+++ b/src/Makefile
@@ -77,10 +77,11 @@ $(CLEANDIRS):
 phpvendors:
 	composer install -q
 
+phpvendors-no-dev:
+	composer install -q --no-dev
+
 composer_install:
-	@echo "current dir: '$${PWD}'"
-	$(INSTALL_DATA) composer.json composer.lock $(DESTDIR)$(MODDIR)
-	(cd $(DESTDIR)$(MODDIR); composer install -q --no-dev)
+	cp -r vendor $(DESTDIR)$(MODDIR)
 
 .PHONY: subdirs $(BUILDDIRS)
 .PHONY: subdirs $(DIRS)

--- a/utils/fo-mktar
+++ b/utils/fo-mktar
@@ -1,39 +1,48 @@
-#!/bin/sh
+#!/bin/bash
 # This script packages the directory into a tar file.
 # Copyright (C) 2014 Hewlett-Packard Development Company, L.P.
-# 
+#
 #  This program is free software; you can redistribute it and/or
 #  modify it under the terms of the GNU General Public License
 #  version 2 as published by the Free Software Foundation.
-#  
+#
 #  This program is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
-#  
+#
 #  You should have received a copy of the GNU General Public License along
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+set -e
+
 # make sure we're in a checked out git copy
 if [ ! -d .git ]; then
-   echo "ERROR: No Git information found. This script requires an git tree."
-   exit 0
+    echo "ERROR: No Git information found. This script requires an git tree."
+    exit 1
 fi
 
 # Check if SVN is available.  If not, then abort.
 which git >/dev/null 2>&1
 if [ $? != 0 ]; then
-   echo "ERROR: git command missing."
-   exit 1
+    echo "ERROR: git command missing."
+    exit 2
 fi
 
 ######################################################################
 # Package things up
 
+# Envirnomental variable $PACKAGE_WORKDIR defaults to ".."
+PACKAGE_WORKDIR=${PACKAGE_WORKDIR:-..}
+if [ ! -d "${PACKAGE_WORKDIR}" ]; then
+    echo "ERROR: ${PACKAGE_WORKDIR} is not a folder, exiting."
+    exit 3
+fi
+
 if [ ! -f "Makefile.conf" ]; then
    echo "ERROR: This utility must be run from the top of the fossology source tree."
-   exit 1
+   exit 4
 fi
 
 VERSION="`git describe --tags > /dev/null 2>&1 && git describe --tags | head -1`"
@@ -42,40 +51,44 @@ VERSION="`git describe --tags > /dev/null 2>&1 && git describe --tags | head -1`
 COMMIT_HASH="`git show | head -1 | awk '{print substr($2,1,6)}'`"
 
 TARBASE="fossology-$VERSION"
-# Check for command-line for subversion
+
 if [ "$1" = "-s" ]; then
    TARBASE="fossology-$VERSION-$COMMIT_HASH"
 fi
 
 echo "*** Packaging $VERSION (git $COMMIT_HASH) into $TARBASE ***"
 
-if [ -d "../$TARBASE" ]; then
-   echo "WARNING: ../$TARBASE exists, removing"
-   rm -rf "../$TARBASE"
-   if [ -d "../$TARBASE" ]; then
-      echo "ERROR: Unable to delete ../$TARBASE, exiting."
-      exit 2
+if [ -d "${PACKAGE_WORKDIR}/$TARBASE" ]; then
+   echo "WARNING: ${PACKAGE_WORKDIR}/$TARBASE exists, removing"
+   rm -rf "${PACKAGE_WORKDIR}/$TARBASE"
+   if [ -d "${PACKAGE_WORKDIR}/$TARBASE" ]; then
+      echo "ERROR: Unable to delete ${PACKAGE_WORKDIR}/$TARBASE, exiting."
+      exit 5
    fi
 fi
 
-echo "*** Exporting git version $COMMIT_HASH to ../$TARBASE ***"
-mkdir "../$TARBASE"
-cp -r . "../$TARBASE"
-find "../$TARBASE" | grep .git | xargs rm -rf
+echo "*** Exporting git version $COMMIT_HASH to ${PACKAGE_WORKDIR}/$TARBASE ***"
+git checkout-index -a -f --prefix="${PACKAGE_WORKDIR}/${TARBASE}/"
 if [ $? != 0 ]; then
    echo "ERROR: git export failed."
-   exit 3
+   exit 6
 fi
 
-# Create the tar
+echo "*** Download php dependencies ***"
 (
-cd ..
+cd "${PACKAGE_WORKDIR}/$TARBASE"
+make phpvendors-no-dev
+)
+
+echo "*** Create the tar ***"
+(
+cd ${PACKAGE_WORKDIR}
 if [ -f "$TARBASE.tar.gz" ]; then
-   echo "WARNING: ../$TARBASE.tar.gz exists, removing"
+   echo "WARNING: ${PACKAGE_WORKDIR}/$TARBASE.tar.gz exists, removing"
    rm -f "$TARBASE.tar.gz"
    if [ -f "$TARBASE.tar.gz" ]; then
-      echo "ERROR: unable to remove ../$TARBASE.tar.gz, exiting."
-      exit 4
+      echo "ERROR: unable to remove ${PACKAGE_WORKDIR}/$TARBASE.tar.gz, exiting."
+      exit 7
    fi
 fi
 
@@ -83,16 +96,16 @@ echo "*** Creating tar ***"
 tar --anchored --exclude=\*/debian -czf "$TARBASE.tar.gz" "$TARBASE"
 if [ $? != 0 ]; then
    echo "ERROR: unable to create ../$TARBASE.tar.gz, exiting."
-   exit 4
+   exit 8
 fi
 )
 
 # Clean up
 echo "*** Cleaning up ***"
-rm -rf "../$TARBASE"
-if [ -d "../$TARBASE" ]; then
-   echo "WARNING: Unable to clean up ../$TARBASE, exiting."
-   exit 5
+rm -rf "${PACKAGE_WORKDIR}/$TARBASE"
+if [ -d "${PACKAGE_WORKDIR}/$TARBASE" ]; then
+   echo "WARNING: Unable to clean up ${PACKAGE_WORKDIR}/$TARBASE, exiting."
+   exit 9
 fi
 
-echo "*** ../$TARBASE.tar.gz created successfully. ***"
+echo "*** ${PACKAGE_WORKDIR}/$TARBASE.tar.gz created successfully. ***"


### PR DESCRIPTION
**OUTDATED:**

> in `src/Makefile` the call to `install` is replaced by
> 
> ```
> install: composer_install deploy
> ```
> 
> this allows the user to do the composer related stuff, which wants to talk to
> the internet, before the other install related commands.
> 
> The two commands are:
> 
> ```
> cd src && make composer_install
> ```
> 
> and
> 
> ```
> make deploy
> ```
> 
> This might be useful for packaging.
