### PR TITLE
Refactor docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # FOSSology Dockerfile
 # Copyright Siemens AG 2016, fabio.huser@siemens.com
+# Copyright TNG Technology Consulting GmbH 2016, maximilian.huber@tngtech.com
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -9,32 +10,78 @@
 # Description: Docker container image recipe
 
 FROM debian:stable
-
 MAINTAINER Fossology <fossology@fossology.org>
-
 WORKDIR /fossology
-ADD . .
 
-RUN apt-get update && \
-    apt-get install -y lsb-release sudo postgresql php5-curl libpq-dev libdbd-sqlite3-perl libspreadsheet-writeexcel-perl && \
-    /fossology/utils/fo-installdeps -e -y && \
-    rm -rf /var/lib/apt/lists/*
+ENV _update="apt-get update"
+ENV _install="apt-get install -y --no-install-recommends"
+ENV _cleanup="eval apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*"
 
+RUN set -x \
+ && $_update && $_install \
+       lsb-release curl php5 libpq-dev libdbd-sqlite3-perl libspreadsheet-writeexcel-perl postgresql-client \
+       sudo \
+       # for standalone mode:
+       postgresql \
+ && $_cleanup
+
+ADD utils/fo-installdeps utils/fo-installdeps
+ADD install/scripts/php-conf-fix.sh install/scripts/php-conf-fix.sh
+RUN set -x \
+ && $_update \
+ && /fossology/install/scripts/php-conf-fix.sh --overwrite \
+ && /fossology/utils/fo-installdeps -e -y \
+ && $_cleanup
 RUN curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer
 
-RUN /fossology/install/scripts/install-spdx-tools.sh
-
-RUN /fossology/install/scripts/install-ninka.sh
-
-RUN make install
-
-RUN cp /fossology/install/src-install-apache-example.conf /etc/apache2/conf-available/fossology.conf && \
-    ln -s /etc/apache2/conf-available/fossology.conf /etc/apache2/conf-enabled/fossology.conf
-
-RUN /fossology/install/scripts/php-conf-fix.sh --overwrite
-
-EXPOSE 80
-
+ADD . .
 RUN chmod +x /fossology/docker-entrypoint.sh
+RUN set -x \
+ && make install \
+ && make clean
+
+RUN set -x \
+ && /usr/local/lib/fossology/fo-postinstall --common \
+ && mkdir -p /srv/fossology/repository/
+
+################################################################################
+# scheduler related
+RUN /usr/local/lib/fossology/fo-postinstall \
+        --agent \
+        --scheduler-only
+
+RUN set -x \
+ && mkdir -p /var/log/fossology \
+ && chown -R fossy:fossy /var/log/fossology \
+ && chgrp -R fossy /usr/local/etc/fossology/ \
+ && chmod -R g+wr /usr/local/etc/fossology/ \
+ && chown fossy:fossy /usr/local/etc/fossology/Db.conf
+
+################################################################################
+# web related
+RUN /usr/local/lib/fossology/fo-postinstall \
+        --web-only \
+ && systemctl disable apache2
+
+RUN set -x \
+ && cp /fossology/install/src-install-apache-example.conf \
+        /etc/apache2/conf-available/fossology.conf \
+ && ln -s /etc/apache2/conf-available/fossology.conf \
+        /etc/apache2/conf-enabled/fossology.conf \
+ && echo Listen 8081 >/etc/apache2/ports.conf
+
+RUN set -x \
+ && chmod -R o+r /etc/apache2 \
+ && mkdir -p /var/log/apache2/ \
+ && chown -R fossy:fossy /var/log/apache2/ \
+ && chown -R fossy:fossy /var/run/apache2/ \
+ && chown -R fossy:fossy /var/lock/apache2/
+
+EXPOSE 8081
+
+################################################################################
+VOLUME /srv/fossology/repository/
+USER fossy
+
 ENTRYPOINT ["/fossology/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ use, since the the standalone image does not take care of data persistency.
 
 A pre-built Docker image is available from [Docker Hub](https://hub.docker.com/r/fossology/fossology/) and can be run using following command:
 ``` sh
-docker run -p 8081:80 fossology/fossology
+docker run -p 8081:8081 fossology/fossology
 ```
 
 Execution with external database container can be done using Docker Compose.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # FOSSology docker-entrypoint script
 # Copyright Siemens AG 2016, fabio.huser@siemens.com
+# Copyright TNG Technology Consulting GmbH 2016, maximilian.huber@tngtech.com
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -9,22 +10,24 @@
 #
 # Description: startup helper script for the FOSSology Docker container
 
+set -e
+
 db_host="localhost"
 db_name="fossology"
 db_user="fossy"
 db_password="fossy"
 
 if [ "$FOSSOLOGY_DB_HOST" ]; then
-	db_host="$FOSSOLOGY_DB_HOST"
+  db_host="$FOSSOLOGY_DB_HOST"
 fi
 if [ "$FOSSOLOGY_DB_NAME" ]; then
-	db_name="$FOSSOLOGY_DB_NAME"
+  db_name="$FOSSOLOGY_DB_NAME"
 fi
 if [ "$FOSSOLOGY_DB_USER" ]; then
-	db_user="$FOSSOLOGY_DB_USER"
+  db_user="$FOSSOLOGY_DB_USER"
 fi
 if [ "$FOSSOLOGY_DB_PASSWORD" ]; then
-	db_password="$FOSSOLOGY_DB_PASSWORD"
+  db_password="$FOSSOLOGY_DB_PASSWORD"
 fi
 
 # Write configuration
@@ -35,6 +38,9 @@ user=$db_user;
 password=$db_password;
 EOM
 
+sed -i 's/address = .*/address = '"${FOSSOLOGY_SCHEDULER_HOST:-localhost}"'/' \
+    /usr/local/etc/fossology/fossology.conf
+
 # Startup DB if needed or wait for external DB
 if [ "$db_host" = 'localhost' ]; then
   echo '*****************************************************'
@@ -42,6 +48,7 @@ if [ "$db_host" = 'localhost' ]; then
   echo 'internal database without persistency will be used.'
   echo 'THIS IS NOT RECOMENDED FOR PRODUCTIVE USE!'
   echo '*****************************************************'
+  sleep 5
   /etc/init.d/postgresql start
 else
   testForPostgres(){
@@ -55,11 +62,28 @@ else
 fi
 
 # Setup environment
-/usr/local/lib/fossology/fo-postinstall
+if [[ $# = 0 || ( $# = 1 && "$1" == "scheduler" ) ]]; then
+  /usr/local/lib/fossology/fo-postinstall --database --licenseref
+fi
 
 # Start Fossology
 echo
 echo 'Fossology initialisation complete; Starting up...'
 echo
-/etc/init.d/fossology start
-/usr/sbin/apache2ctl -D FOREGROUND
+if [ $# -eq 0 ]; then
+  /etc/init.d/fossology start
+  /usr/local/share/fossology/scheduler/agent/fo_scheduler \
+    --log /dev/stdout \
+    --verbose=3 \
+    --reset &
+  /usr/sbin/apache2ctl -D FOREGROUND
+elif [[ $# = 1 && "$1" == "scheduler" ]]; then
+  exec /usr/local/share/fossology/scheduler/agent/fo_scheduler \
+    --log /dev/stdout \
+    --verbose=3 \
+    --reset
+elif [[ $# = 1 && "$1" == "web" ]]; then
+  exec /usr/sbin/apache2ctl -D FOREGROUND
+else
+  exec "$@"
+fi

--- a/install/docker-compose.base.yml
+++ b/install/docker-compose.base.yml
@@ -1,0 +1,26 @@
+# FOSSology Docker Compose file
+# Copyright TNG Technology Consulting GmbH 2016, maximilian.huber@tngtech.com
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Description: Base recipe for setting up a multi container FOSSology
+#              Docker setup with separate Database instance
+
+version: '2'
+services:
+  fossology:
+    build:
+      context: ..
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: fossology
+    restart: unless-stopped
+    environment:
+      - FOSSOLOGY_DB_HOST=fossology-db
+      - FOSSOLOGY_DB_NAME=fossology
+      - FOSSOLOGY_DB_USER=fossy

--- a/install/docker-compose.yml
+++ b/install/docker-compose.yml
@@ -1,5 +1,6 @@
 # FOSSology Docker Compose file
 # Copyright Siemens AG 2016, fabio.huser@siemens.com
+# Copyright TNG Technology Consulting GmbH 2016, maximilian.huber@tngtech.com
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -8,22 +9,39 @@
 #
 # Description: Recipe for setting up a multi container FOSSology
 #              Docker setup with separate Database instance
-
-web:
-  build: ..
-  environment:
-    - FOSSOLOGY_DB_HOST=db
-    - FOSSOLOGY_DB_NAME=fossology
-    - FOSSOLOGY_DB_USER=fossy
-    - FOSSOLOGY_DB_PASSWORD=fossy
-  ports:
-    - 8081:80
-  links:
-    - db
-db:
-  image: postgres
-  environment:
-    - POSTGRES_DB=fossology
-    - POSTGRES_USER=fossy
-    - POSTGRES_PASSWORD=fossy
-    - POSTGRES_INITDB_ARGS='-E SQL_ASCII'
+version: '2'
+services:
+  fossology-scheduler:
+    extends:
+      file: docker-compose.base.yml
+      service: fossology
+    environment:
+      - FOSSOLOGY_DB_PASSWORD=fossy
+    command: scheduler
+    links:
+      - fossology-db
+    # volumes:
+    #   - ./_repository:/srv/fossology/repository/
+  fossology-web:
+    extends:
+      file: docker-compose.base.yml
+      service: fossology
+    environment:
+      - FOSSOLOGY_DB_PASSWORD=fossy
+      - FOSSOLOGY_SCHEDULER_HOST=fossology-scheduler
+    command: web
+    ports:
+      - 8081:8081
+    links:
+      - fossology-db
+      - fossology-scheduler
+    volumes_from:
+      - fossology-scheduler
+  fossology-db:
+    image: postgres
+    restart: unless-stopped
+    environment:
+      - POSTGRES_DB=fossology
+      - POSTGRES_USER=fossy
+      - POSTGRES_PASSWORD=fossy
+      - POSTGRES_INITDB_ARGS='-E SQL_ASCII'

--- a/install/fo-postinstall.in
+++ b/install/fo-postinstall.in
@@ -10,6 +10,8 @@
 
 ## Options parsing and setup
 # parse options
+# set -x
+
 OPTS=`getopt -o adwseolch --long agent,database,web-only,scheduler-only,everything,overwrite,licenseref,common,help -n 'fo-postinstall' -- "$@"`
 
 if [ $? != 0 ]; then
@@ -70,12 +72,14 @@ if [ $EVERYTHING ]; then
    LICENSEREF=1
 fi
 
-# This must run as root.
-if [ `id -u` != "0" ] ; then
-   echo "ERROR: fo-postinstall must run as root."
-   echo "Aborting."
-   exit 1
-fi
+onlyAllowedAsRoot() \{
+   # This must run as root.
+   if [ `id -u` != "0" ] ; then
+      echo "ERROR: fo-postinstall must run as root."
+      echo "Aborting."
+      exit 1
+   fi
+\}
 
 
 readConfigVal() \{
@@ -106,6 +110,7 @@ else
 fi
 
 if [ $COMMON ]; then
+   onlyAllowedAsRoot
    echo "*** Running postinstall for common actions***"
 
    ## check path to repo
@@ -235,7 +240,6 @@ fi
 
 if [ $DATABASE ]; then
    {$LIBEXECDIR}/dbcreate
-
 fi # end of DATABASE
 
 if [ $LICENSEREF ]; then
@@ -246,6 +250,7 @@ fi # end of license reference
 ########################################################################
 
 if [ $AGENT ]; then
+   onlyAllowedAsRoot
    # change all files ownership to {$PROJECTUSER}:$PROJECTGROUP
    chown -R {$PROJECTUSER}:$PROJECTGROUP {$MODDIR}
    #chmod u+s {$MODDIR}/scheduler/agent/fo_scheduler
@@ -274,6 +279,7 @@ fi # end of AGENT
 ########################################################################
 
 if [ $SCHEDULERONLY ]; then
+   onlyAllowedAsRoot
    echo "*** Setting up scheduler ***"
 
    # Create the scheduler log directory.
@@ -291,6 +297,7 @@ fi # end of SCHEDULERONLY
 
 ########################################################################
 if [ $WEBONLY ]; then
+   onlyAllowedAsRoot
    if [ $LICENSEREF == 0 ] ; then
      echo "*** Initializing database tables ***"
      {$LIBEXECDIR}/fossinit.php -c {$SYSCONFDIR}


### PR DESCRIPTION
This PR was already announced in a comment on #695.

It is not yet ready and needs further improvements and intense testing.

This PR
- splits the container into multiple ones:
  - one for the scheduler
  - one for the apache
    - which runs as user fossy (as suggested in https://github.com/fossology/fossology/issues/695#issuecomment-246330229)
  - one for the SW360 connection (not implemented yet) 
- moves calls like `/usr/local/lib/fossology/fo-postinstall --common` from entrypoint to Dockerfile
- reorders Dockerfile to prevent rebuilding all dependencies on every changes of the source code
- (currently) breaks the support for running docker without compose.
