### PR TITLE
Set Postgres driver using variable reference

### DIFF
--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -101,7 +101,8 @@ function ConfigInit($sysconfdir, &$SysConf)
   $PG_CONN = DBconnect($sysconfdir);
 
   global $container;
-  $container->get('db.manager')->setDriver(new \Fossology\Lib\Db\Driver\Postgres($PG_CONN));
+  $postgresDriver = new \Fossology\Lib\Db\Driver\Postgres($PG_CONN);
+  $container->get('db.manager')->setDriver($postgresDriver);
 
   /**************** read/create/populate the sysconfig table *********/
   /* create if sysconfig table if it doesn't exist */


### PR DESCRIPTION
Creating the Postgres driver inline causes warnings to be logged in PHP7. Storing the object in a variable and passing a reference to that variable fixes this.
Closes #715.