### PR TITLE
Missing quotes around string literal

### DIFF
--- a/src/www/ui/admin-dashboard.php
+++ b/src/www/ui/admin-dashboard.php
@@ -150,7 +150,7 @@ function GetLastAnalyzeTime($TableName)
     /**** Version ****/
     $text = _("Postgresql version");
     $V .= "<tr><td>$text</td>";
-    $V .= "<td align='right'> {$this->pgVersion[server]} </td></tr>\n";
+    $V .= "<td align='right'> {$this->pgVersion['server']} </td></tr>\n";
 
     /**** Query stats ****/
     // count current queries


### PR DESCRIPTION
These missing quotes cause this warning to be printed to apache2/error.log whenever the Dashboard page is loaded:
```
==> /var/log/apache2/error.log <==
[Sat Dec 03 05:16:30.994315 2016] [:error] [pid 176] [client 192.168.99.1:51693] PHP Notice:  Use of undefined constant server - assumed 'server' in /usr/local/share/fossology/www/ui/admin-dashboard.php on line 153, referer: https://docker.localhost/?mod=showjobs&allusers=1
```