### PR TITLE
fix(copyright): invalid pointer to regex

### DIFF
--- a/src/copyright/agent/regexConfProvider.cc
+++ b/src/copyright/agent/regexConfProvider.cc
@@ -119,10 +119,9 @@ const char* RegexConfProvider::getRegexValue(const string& identity,
                                              const string& key)
 {
   const string* rv;
-  map<string,RegexMap> rmm = RegexConfProvider::_regexMapMap;
 #pragma omp critical(rmm)
   {
-    rv = &(rmm[identity][key]);
+    rv = &(RegexConfProvider::_regexMapMap[identity][key]);
   }
   return (*rv).c_str();
 }


### PR DESCRIPTION
Fixes issue where a pointer to a local variable is being returned from the `getRegexValue` function, causing an invalid regex to be passed to the copyright agent, triggering an infinite loop and agent crash after memory exhaustion.

Fixes #717 