### PR TITLE
Split composer download and install and use a temp directory to host it

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -75,12 +75,16 @@ $(CLEANDIRS):
 	$(MAKE) -s -C $(@:clean-%=%) clean
 
 phpvendors:
-	composer install -q
+	$(BUILDDIRS)/composer install -q
+
+composer_download:
+	curl -sS https://getcomposer.org/installer | php
+	mv composer.phar $(BUILDDIRS)/composer
 
 composer_install:
 	@echo "current dir: '$${PWD}'"
 	$(INSTALL_DATA) composer.json composer.lock $(DESTDIR)$(MODDIR)
-	(cd $(DESTDIR)$(MODDIR); composer install -q --no-dev)
+	(cd $(DESTDIR)$(MODDIR); $(BUILDDIRS)/composer install -q --no-dev)
 
 .PHONY: subdirs $(BUILDDIRS)
 .PHONY: subdirs $(DIRS)


### PR DESCRIPTION
(michael:) this is required for "making make" without moving composer to `/usr/bin` which keeps the make "sudoless".