### PR TITLE
feat(packaging): vagrant test file and config for httpd 2.4

### DIFF
--- a/install/fo-apache.conf
+++ b/install/fo-apache.conf
@@ -5,8 +5,15 @@ Alias /repo /usr/share/fossology/www/ui
 <Directory "/usr/share/fossology/www/ui">
 	AllowOverride None
 	Options FollowSymLinks MultiViews
-	Order allow,deny
-	Allow from all
+	
+    <IfVersion < 2.3>
+        order allow,deny
+        allow from all
+    </IfVersion>
+    <IfVersion >= 2.3>
+        Require all granted
+    </IfVersion>
+	
 	# uncomment to turn on php error reporting
 	#php_flag display_errors on
 	#php_value error_reporting 2039

--- a/install/src-install-apache-example.conf
+++ b/install/src-install-apache-example.conf
@@ -1,8 +1,8 @@
 # FOSSology example apache config
 
-Alias /repo/ /usr/local/share/fossology/www/ui/
+Alias /repo /usr/local/share/fossology/www/ui
 
-<Directory "/usr/local/share/fossology/www/ui/">
+<Directory "/usr/local/share/fossology/www/ui">
 	AllowOverride None
 	Options FollowSymLinks MultiViews
 

--- a/pbconf/Vagrantfile
+++ b/pbconf/Vagrantfile
@@ -1,5 +1,19 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+
+#
+# original script by maximilian.huber@tngtech.com
+# additions by michael.c.jaeger@siemens.com
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# this script starts a VM in order to run project builder inside
+# for development and debugging
+#
+
+#
+# std vagrant setup
+#
 Vagrant.configure("2") do |config|
   config.vm.box = "centos/7"
 
@@ -9,7 +23,11 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.synced_folder "..", "/home/vagrant/prj/fossology", type: "rsync"
+  config.vm.network "forwarded_port", guest: 80, host: 8081
 
+#
+# part to prepare dependencies
+#
   config.vm.provision "shell" do |s|
     s.inline = <<SCRIPT
 set -ex
@@ -52,7 +70,11 @@ systemctl start docker
 
 SCRIPT
   end
-
+  
+#
+# checking out and preparing project builder
+# note that triple backslashes are because of cat and vagrant escaping
+#
   config.vm.provision "shell" do |s|
     s.privileged = false
     s.inline = <<SCRIPT
@@ -79,13 +101,28 @@ PBRC
 ################################################################################
 # sbx = sandbox
 # actually, sbx2pkg is included in sbx2pkg2ins
-pb -t -p fossology sbx2build   fossology
-pb -p    fossology build2prep  fossology
-#   pb -t -p fossology sbx2pkg  fossology
-pb -t -p fossology sbx2pkg2ins fossology
+for pkg in "fossology-composer" "fossology"; do
+    pb -t -p fossology sbx2build   $pkg
+    pb -p    fossology build2prep  $pkg
+#   pb -t -p fossology sbx2pkg     $pkg
+    pb -t -p fossology sbx2pkg2ins $pkg
+done
+
+SCRIPT
+  end
+  
+#
+# applying some work around
+#
+  config.vm.provision "shell" do |s|
+    s.privileged = false
+    s.inline = <<SCRIPT
+    
+# uahhh: disabling SELinux
+# remove if the https://github.com/fossology/fossology/issues/727
+setenforce 0
 
 SCRIPT
   end
 
-  config.vm.network "forwarded_port", guest: 80, host: 8081
 end


### PR DESCRIPTION
Cleaning up the final version of the vagrant test file in pbconf for
testing and developing package builds after it worked for centos7. In
addition fixing configuration for Apache httpd 2.4 and leaving config for 2.2 as comment

for this PR 734 there is now an updated vagrant file which creates a centos7 machine and creates the packages for the same. Currently there are the following open issues with the created packages:

* apache 2.4 config must be adapated [1], which is also covered by this PR 734 
* SELinux setting for the file in /var/cache is wrong
* It would require ninka, otherwise fossology-ninka (and other parts of fossology) will not work. Work around with uninstalling or not installing fossology-ninka
* The time zone must be set for PHP. This is an issue which I have not seen for my deb trials [2].

[1] https://httpd.apache.org/docs/2.4/upgrading.html
[2] http://stackoverflow.com/questions/16765158/date-it-is-not-safe-to-rely-on-the-systems-timezone-settings