### PR TITLE
fix(test): phpunit-bootstrap doesn't find Hamcrest

### DIFF
--- a/src/phpunit-bootstrap.php
+++ b/src/phpunit-bootstrap.php
@@ -17,5 +17,14 @@ namespace TestSupport;
 $classLoader = require __DIR__ . '/vendor/autoload.php';
 
 $hamcrestUtilPath = $classLoader->findFile('\Hamcrest\Util');
-require dirname($hamcrestUtilPath) . '/../Hamcrest.php';
-
+if($hamcrestUtilPath != null && $hamcrestUtilPath != "") {
+    $hamcrestPath = dirname($hamcrestUtilPath) . '/..';
+}else{
+    // failed to find folder with classLoader, try fallback
+    $hamcrestPath = __DIR__ . "/vendor/hamcrest/hamcrest-php/hamcrest";
+    if(! is_dir($hamcrestPath) || ! is_file($hamcrestPath . '/Hamcrest.php')){
+        // fallback folder or file does not exist
+        exit(1);
+    }
+}
+require $hamcrestPath . '/Hamcrest.php';


### PR DESCRIPTION
Currently all Travis-builds fail,.

As a quickfix, this adds a fallback in `phpunit-bootstrap.php` which might work in all cases.