### PR TITLE
This PR fixes a list of SPDX compatibility bugs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,10 @@ echo "lets go!"
 cd /vagrant
 
 ./utils/fo-installdeps -e -y
+
 make CFLAGS=-I/usr/include/glib-2.0
+sudo make composer_download
+sudo make composer_install
 sudo make install
 sudo /usr/local/lib/fossology/fo-postinstall
 sudo /etc/init.d/fossology start

--- a/src/lib/php/Dao/AgentDao.php
+++ b/src/lib/php/Dao/AgentDao.php
@@ -308,4 +308,14 @@ class AgentDao extends Object
     $row = $this->dbManager->getSingleRow("SELECT agent_name FROM agent WHERE agent_enabled AND agent_pk=$1", array($agentId));
     return ($row===false)?false:$row['agent_name'];
   }
-} 
+
+  /**
+   * @param int $agentId
+   * @return string
+   */
+  public function getAgentRev($agentId)
+  {
+    $row = $this->dbManager->getSingleRow("SELECT agent_rev FROM agent WHERE agent_enabled AND agent_pk=$1", array($agentId));
+    return ($row===false)?false:$row['agent_rev'];
+  }
+}

--- a/src/lib/php/Dao/TreeDao.php
+++ b/src/lib/php/Dao/TreeDao.php
@@ -1,7 +1,8 @@
 <?php
 /*
 Copyright (C) 2014-2015, Siemens AG
-Authors: Andreas Würl, Steffen Weber
+Copyright (C) 2017 TNG Technology Consulting GmbH
+Authors: Andreas Würl, Steffen Weber, Maximilian Huber
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/src/lib/php/Dao/UserDao.php
+++ b/src/lib/php/Dao/UserDao.php
@@ -373,4 +373,19 @@ class UserDao extends Object
     }
     return $userRow['user_name'];
   }
+
+
+  /**
+   * @param int $userId
+   * @return string
+   */
+  public function getUserEmail($userId)
+  {
+    $userRow = $this->dbManager->getSingleRow("SELECT user_email FROM users WHERE user_pk=$1",array($userId),__METHOD__);
+    if(!$userRow)
+    {
+      throw new \Exception('unknown user with id='.$userId);
+    }
+    return $userRow['user_email'];
+  }
 }

--- a/src/lib/php/Dao/test/TreeDaoTest.php
+++ b/src/lib/php/Dao/test/TreeDaoTest.php
@@ -73,6 +73,19 @@ class TreeDaoTest extends \PHPUnit_Framework_TestCase
     $this->prepareModularTable(array(array(6,5,1,0,0,5,6,$fName="file",5)));
     $cover = $this->treeDao->getMinimalCoveringItem(1, "uploadtree");
     assertThat($cover,equalTo(5));
+
+    $path = $this->treeDao->getFullPath(6, "uploadtree", $cover);
+    assertThat($path,equalTo($fName));
+
+    $path = $this->treeDao->getFullPath(6, "uploadtree", $cover, true);
+    assertThat($path,equalTo($fName));
+  }
+
+  public function testGetFullPathFromSingleFolderUploadWithDropArtifact()
+  {
+    $this->prepareModularTable(array(array(6,5,1,0,0,5,6,$fName="file",5)));
+    $cover = $this->treeDao->getMinimalCoveringItem(1, "uploadtree", true);
+    assertThat($cover,equalTo(5));
     $path = $this->treeDao->getFullPath(6, "uploadtree", $cover);
     assertThat($path,equalTo($fName));
   }
@@ -89,7 +102,13 @@ class TreeDaoTest extends \PHPUnit_Framework_TestCase
     $pathInsideArchive = $this->treeDao->getFullPath(6, "uploadtree", $cover);
     assertThat($pathInsideArchive,equalTo("archive/file"));
 
+    $pathInsideArchive = $this->treeDao->getFullPath(6, "uploadtree", $cover, true);
+    assertThat($pathInsideArchive,equalTo("archive/file"));
+
     $pathOutsideArchive = $this->treeDao->getFullPath(11, "uploadtree", $cover);
+    assertThat($pathOutsideArchive,equalTo("file2"));
+
+    $pathOutsideArchive = $this->treeDao->getFullPath(11, "uploadtree", $cover, true);
     assertThat($pathOutsideArchive,equalTo("file2"));
   }
 
@@ -209,7 +228,8 @@ class TreeDaoTest extends \PHPUnit_Framework_TestCase
     $this->prepareUploadTree($this->getTestFileStructure());
     $cover = $this->treeDao->getMinimalCoveringItem(32, "uploadtree");
     assertThat($cover,equalTo(3652));
-    assertThat($this->treeDao->getFullPath(3666, "uploadtree", $cover),equalTo("L/L1"));
+    assertThat($this->treeDao->getFullPath(3666, "uploadtree", $cover),      equalTo("L/L1"));
+    assertThat($this->treeDao->getFullPath(3666, "uploadtree", $cover,true), equalTo("L/L1"));
   }
 
   public function testGetFullPathWithComlpexStructureFromFile()
@@ -217,8 +237,12 @@ class TreeDaoTest extends \PHPUnit_Framework_TestCase
     $this->prepareUploadTree($this->getTestFileStructure());
     $cover = $this->treeDao->getMinimalCoveringItem(32, "uploadtree");
     assertThat($cover,equalTo(3652));
-    assertThat($this->treeDao->getFullPath(3665, "uploadtree", $cover),equalTo("L/L2/L2a"));
-    assertThat($this->treeDao->getFullPath(3665, "uploadtree"),equalTo("uploadDaoTest.tar/uploadDaoTest/L/L2/L2a"));
+
+    assertThat($this->treeDao->getFullPath(3665, "uploadtree", $cover),       equalTo("L/L2/L2a"));
+    assertThat($this->treeDao->getFullPath(3665, "uploadtree", $cover, true), equalTo("L/L2/L2a"));
+
+    assertThat($this->treeDao->getFullPath(3665, "uploadtree"),        equalTo("uploadDaoTest.tar/uploadDaoTest/L/L2/L2a"));
+    assertThat($this->treeDao->getFullPath(3665, "uploadtree",0,true), equalTo(                  "uploadDaoTest/L/L2/L2a"));
   }
 
   public function testGetFullPathWithComlpexStructureFromFileAndOtherUpload()
@@ -227,8 +251,10 @@ class TreeDaoTest extends \PHPUnit_Framework_TestCase
     $this->prepareModularTable(array(array(6,5,1,0,0,5,6,"file",6)));
     $cover = $this->treeDao->getMinimalCoveringItem(32, "uploadtree");
     assertThat($cover,equalTo(3652));
-    assertThat($this->treeDao->getFullPath(3665, "uploadtree", $cover),equalTo("L/L2/L2a"));
-    assertThat($this->treeDao->getFullPath(3665, "uploadtree"),equalTo("uploadDaoTest.tar/uploadDaoTest/L/L2/L2a"));
+    assertThat($this->treeDao->getFullPath(3665, "uploadtree", $cover),      equalTo("L/L2/L2a"));
+    assertThat($this->treeDao->getFullPath(3665, "uploadtree", $cover,true), equalTo("L/L2/L2a"));
+    assertThat($this->treeDao->getFullPath(3665, "uploadtree"),        equalTo("uploadDaoTest.tar/uploadDaoTest/L/L2/L2a"));
+    assertThat($this->treeDao->getFullPath(3665, "uploadtree",0,true), equalTo(                  "uploadDaoTest/L/L2/L2a"));
   }
   
   public function testGetUploadHashes()
@@ -240,4 +266,56 @@ class TreeDaoTest extends \PHPUnit_Framework_TestCase
     $hashes = $this->treeDao->getItemHashes(7,'uploadtree_a');
     assertThat($hashes,equalTo(array('md5'=>'59CACDFCE5051CD8A1D8A1F2DCCE40A5','sha1'=>'04621571BCBABCE75C4DD1C6445B87DEC0995734')));
   }
+
+  protected function getNestedTestFileStructure()
+  {
+    /*
+     * example.zip
+     *   |
+     *   \- file
+     *   \~ subExample.tar.gz
+     *        |
+     *        \- subEample.tar
+     *             |
+     *             \- innerFile
+     *             \~ someFolder
+     *                  |
+     *                  \- someFileInFolder
+     */
+    return array(
+        array(14, 13,   2, 8, 32768,     5,  6,  'someFileInFolder',  13,   ),
+        array(13, 5,    2, 0, 536888320, 4,  7,  'someFolder',        5,    ),
+        array(12, 11,   2, 7, 33188,     13, 14, 'innerFile',         11,   ),
+        array(11, 10,   2, 0, 536888320, 12, 15, 'subExample',        9,    ),
+        array(10, 9,    2, 0, 805323776, 11, 16, 'artifact.dir',      9,    ),
+        array(9,  8,    2, 6, 536903680, 10, 17, 'subExample.tar',    7,    ),
+        array(8,  7,    2, 0, 805323776, 9,  18, 'artifact.dir',      7,    ),
+        array(7,  5,    2, 5, 536903680, 8,  19, 'subExample.tar.gz', 5,    ),
+        array(6,  5,    2, 4, 32768,     20, 21, 'file',              5,    ),
+        array(5,  4,    2, 0, 536888320, 3,  22, 'example',           2,    ),
+        array(4,  2,    2, 0, 805323776, 2,  23, 'artifact.dir',      2,    ),
+        array(3,  2,    2, 3, 268469248, 24, 25, 'artifact.meta',     2,    ),
+        array(2,  NULL, 2, 2, 536904704, 1,  26, 'example.zip',       NULL, ),
+    );
+  }
+
+  public function testGetFullPathWithNestedStructure()
+  {
+    $this->prepareUploadTree($this->getNestedTestFileStructure());
+    assertThat($this->treeDao->getFullPath(2, "uploadtree", 0),      equalTo('example.zip'));
+    assertThat($this->treeDao->getFullPath(2, "uploadtree", 0,true), equalTo('example.zip'));
+
+    assertThat($this->treeDao->getFullPath(6, "uploadtree", 0),      equalTo('example.zip/example/file'));
+    assertThat($this->treeDao->getFullPath(6, "uploadtree", 0,true), equalTo(            'example/file'));
+
+    assertThat($this->treeDao->getFullPath(12, "uploadtree", 0),      equalTo('example.zip/example/subExample.tar.gz/subExample.tar/subExample/innerFile'));
+    assertThat($this->treeDao->getFullPath(12, "uploadtree", 0,true), equalTo(            'example/subExample.tar.gz/subExample.tar/subExample/innerFile'));
+
+    assertThat($this->treeDao->getFullPath(12, "uploadtree", 5),      equalTo('subExample.tar.gz/subExample.tar/subExample/innerFile'));
+    assertThat($this->treeDao->getFullPath(12, "uploadtree", 5,true), equalTo(                                 'subExample/innerFile'));
+
+    assertThat($this->treeDao->getFullPath(12, "uploadtree", 7),      equalTo('subExample.tar/subExample/innerFile'));
+    assertThat($this->treeDao->getFullPath(12, "uploadtree", 7,true), equalTo(               'subExample/innerFile'));
+  }
+
 }

--- a/src/lib/php/Dao/test/TreeDaoTest.php
+++ b/src/lib/php/Dao/test/TreeDaoTest.php
@@ -1,7 +1,8 @@
 <?php
 /*
 Copyright (C) 2014-2015, Siemens AG
-Author: Steffen Weber, Johannes Najjar
+Copyright (C) 2017 TNG Technology Consulting GmbH
+Author: Steffen Weber, Johannes Najjar, Maximilian Huber
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/src/spdx2/Makefile
+++ b/src/spdx2/Makefile
@@ -22,7 +22,7 @@ all: VERSIONFILE
 	$(call DIR_LOOP, )
 
 test: all
-	$(MAKE) -C $(TESTDIR) test
+	$(call DIR_LOOP,test)
 
 coverage: all
 	@echo "nothing to do"

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -208,7 +208,6 @@ class SpdxTwoAgent extends Agent
   }
 
   /**
-   * @param string $fileBase
    * @param string $packageName
    * @return string
    */
@@ -437,6 +436,7 @@ class SpdxTwoAgent extends Agent
       $reportedLicenseId = $this->licenseMap->getProjectedId($row['rf_fk']);
       $shortName = $this->licenseMap->getProjectedShortname($reportedLicenseId);
       if ($shortName != 'No_license_found' && $shortName != 'Void') {
+        $filesWithLicenses[$row['uploadtree_pk']]['scanner'][] = $shortName;
         $this->includedLicenseIds[$reportedLicenseId] = true;
       }
     }

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -519,7 +519,7 @@ class SpdxTwoAgent extends Agent
     $message = $this->renderString($this->getTemplateFile('document'),array(
         'documentName'=>$fileBase,
         'uri'=>$this->uri,
-        'userName'=>$this->container->get('dao.user')->getUserName($this->userId),
+        'userName'=>$this->container->get('dao.user')->getUserName($this->userId) . " (" . $this->container->get('dao.user')->getUserEmail($this->userId) . ")",
         'organisation'=>'',
         'packageNodes'=>$packageNodes,
         'packageIds'=>$packageIds,

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -1,6 +1,7 @@
 <?php
 /*
  * Copyright (C) 2015-2016, Siemens AG
+ * Copyright (C) 2017 TNG Technology Consulting GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -264,7 +264,7 @@ class SpdxTwoAgent extends Agent
 
     $hashes = $this->uploadDao->getUploadHashes($uploadId);
     return $this->renderString($this->getTemplateFile('package'),array(
-        'uploadId'=>$uploadId,
+        'packageId'=>$uploadId,
         'uri'=>$this->uri,
         'packageName'=>$upload->getFilename(),
         'uploadName'=>$upload->getFilename(),

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -367,7 +367,7 @@ class SpdxTwoAgent extends Agent
       {
         $this->heartbeat(0);
       }
-      $fullPath = $treeDao->getFullPath($fileId,$treeTableName);
+      $fullPath = $treeDao->getFullPath($fileId,$treeTableName,0,true);
       if(!empty($licenses['concluded']) && count($licenses['concluded'])>0)
       {
         $this->toLicensesWithFilesAdder($licensesWithFiles,$licenses['concluded'],$licenses['copyrights'],$fileId,$fullPath);
@@ -594,7 +594,7 @@ class SpdxTwoAgent extends Agent
         $lastValue = $filesProceeded;
       }
       $hashes = $treeDao->getItemHashes($fileId);
-      $fileName = $treeDao->getFullPath($fileId,$treeTableName);
+      $fileName = $treeDao->getFullPath($fileId,$treeTableName,0,true);
       if(!is_array($licenses['concluded']))
       {
         $licenses['concluded'] = array();

--- a/src/spdx2/agent/spdx2utils.php
+++ b/src/spdx2/agent/spdx2utils.php
@@ -80,12 +80,10 @@ class SpdxTwoUtils
 
   static public function addPrefixOnDemandList($licenses, $spdxValidityChecker = null)
   {
-    $ret = array();
-    foreach($licenses as $license)
+    return array_map(function ($license) use ($spdxValidityChecker)
     {
-      $ret[] = self::addPrefixOnDemand($license, $spdxValidityChecker);
-    }
-    return $ret;
+      return SpdxTwoUtils::addPrefixOnDemand($license, $spdxValidityChecker);
+    },$licenses);
   }
 
   /**
@@ -101,10 +99,7 @@ class SpdxTwoUtils
       return "";
     }
 
-    $licenses = array_map(function ($license) use ($spdxValidityChecker)
-    {
-      return SpdxTwoUtils::addPrefixOnDemand($license, $spdxValidityChecker);
-    },$licenses);
+    $licenses = self::addPrefixOnDemandList($licenses, $spdxValidityChecker);
     sort($licenses, SORT_NATURAL | SORT_FLAG_CASE);
 
     if(count($licenses) == 3 &&

--- a/src/spdx2/agent/template/spdx2-document.xml.twig
+++ b/src/spdx2/agent/template/spdx2-document.xml.twig
@@ -23,13 +23,10 @@
   <rdfs:comment> 
     This document was created using license informations and a generator from Fossology.
   </rdfs:comment>
-{% for licenseId,extractedText in licenseTexts %}
+{% for licenseId,extractedText in licenseTexts %}{% if licenseId starts with 'LicenseRef-' %}
   <spdx:hasExtractedLicensingInfo>
-{% if licenseId starts with 'LicenseRef-' %}
     <spdx:ExtractedLicensingInfo rdf:about="{{ uri }}#{{ licenseId|replace(' ','-')|url_encode }}">
-{% else %}
     <spdx:ExtractedLicensingInfo rdf:about="http://spdx.org/licenses/{{ licenseId|replace(' ','-')|url_encode }}">
-{% endif %}
       <spdx:licenseId>{{ licenseId|replace(' ','-')|e }}</spdx:licenseId>
       <spdx:extractedText><![CDATA[
 {{ extractedText|replace({'\f':''})
@@ -37,7 +34,7 @@
       ]]></spdx:extractedText>
     </spdx:ExtractedLicensingInfo>
   </spdx:hasExtractedLicensingInfo>
-{% endfor %}
+{% endif %}{% endfor %}
   {{ packageNodes|replace({'\n':'\n  '}) }}
 </spdx:SpdxDocument>
 </rdf:RDF>

--- a/src/spdx2/agent/template/spdx2-document.xml.twig
+++ b/src/spdx2/agent/template/spdx2-document.xml.twig
@@ -25,8 +25,11 @@
   </rdfs:comment>
 {% for licenseId,extractedText in licenseTexts %}{% if licenseId starts with 'LicenseRef-' %}
   <spdx:hasExtractedLicensingInfo>
+{% if licenseId starts with 'LicenseRef-' %}
     <spdx:ExtractedLicensingInfo rdf:about="{{ uri }}#{{ licenseId|replace(' ','-')|url_encode }}">
+{% else %}
     <spdx:ExtractedLicensingInfo rdf:about="http://spdx.org/licenses/{{ licenseId|replace(' ','-')|url_encode }}">
+{% endif %}
       <spdx:licenseId>{{ licenseId|replace(' ','-')|e }}</spdx:licenseId>
       <spdx:extractedText><![CDATA[
 {{ extractedText|replace({'\f':''})

--- a/src/spdx2/agent/template/spdx2-file.xml.twig
+++ b/src/spdx2/agent/template/spdx2-file.xml.twig
@@ -10,13 +10,13 @@
     <spdx:checksum>
       <spdx:Checksum>
         <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1" />
-        <spdx:checksumValue>{{ sha1 }}</spdx:checksumValue>
+        <spdx:checksumValue>{{ sha1 | lower }}</spdx:checksumValue>
       </spdx:Checksum>
     </spdx:checksum>
     <spdx:checksum> 
       <spdx:Checksum>
         <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_md5" />
-        <spdx:checksumValue>{{ md5 }}</spdx:checksumValue>
+        <spdx:checksumValue>{{ md5 | lower }}</spdx:checksumValue>
       </spdx:Checksum>
     </spdx:checksum>
 {% if isCleared %}

--- a/src/spdx2/agent/template/spdx2-package.xml.twig
+++ b/src/spdx2/agent/template/spdx2-package.xml.twig
@@ -20,13 +20,13 @@
         <spdx:checksum>
           <spdx:Checksum>
             <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1" />
-            <spdx:checksumValue>{{ sha1 }}</spdx:checksumValue>
+            <spdx:checksumValue>{{ sha1 | lower }}</spdx:checksumValue>
           </spdx:Checksum>
         </spdx:checksum>
         <spdx:checksum> 
           <spdx:Checksum>
             <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_md5" />
-            <spdx:checksumValue>{{ md5 }}</spdx:checksumValue>
+            <spdx:checksumValue>{{ md5 | lower }}</spdx:checksumValue>
           </spdx:Checksum>
         </spdx:checksum>
         <spdx:licenseConcluded>

--- a/src/spdx2/agent/template/spdx2-package.xml.twig
+++ b/src/spdx2/agent/template/spdx2-package.xml.twig
@@ -8,7 +8,7 @@
   <spdx:Relationship>
     <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes" />
     <spdx:relatedSpdxElement>
-      <spdx:Package rdf:about="{{ uri }}#SPDXRef-upload{{ uploadId|url_encode }}">
+      <spdx:Package rdf:about="{{ uri }}#SPDXRef-upload{{ packageId|url_encode }}">
         <spdx:name>{{ packageName }}</spdx:name>
         <spdx:packageFileName>{{ uploadName }}</spdx:packageFileName>
         <spdx:downloadLocation rdf:resource="http://spdx.org/rdf/terms#noassertion" />

--- a/src/spdx2/agent/template/spdx2tv-document.twig
+++ b/src/spdx2/agent/template/spdx2tv-document.twig
@@ -36,10 +36,6 @@ LicenseListVersion: 2.0
 ## Package Information
 ##-------------------------
 
-{% for packageId in packageIds %}
-Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-upload{{ packageId }}
-{% endfor %}
-
 {{ packageNodes }}
 
 ##-------------------------

--- a/src/spdx2/agent/template/spdx2tv-document.twig
+++ b/src/spdx2/agent/template/spdx2tv-document.twig
@@ -42,10 +42,10 @@ Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-upload{{ packageId }}
 ## License Information
 ##-------------------------
 
-{% for licenseId,extractedText in licenseTexts %}
+{% for licenseId,extractedText in licenseTexts %}{% if licenseId starts with 'LicenseRef-' %}
 LicenseID: {{ licenseId|replace(' ','-') }}
 LicenseName: {{ licenseId|replace(' ','-') }}
 ExtractedText: <text> {{ extractedText|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
                                       |replace({'\f':''}) }} </text>
 
-{% endfor %}
+{% endif %}{% endfor %}

--- a/src/spdx2/agent/template/spdx2tv-document.twig
+++ b/src/spdx2/agent/template/spdx2tv-document.twig
@@ -20,8 +20,12 @@ SPDXID: SPDXRef-DOCUMENT
 ##-------------------------
 
 Creator: Tool: spxd2
+{% if userName is not empty %}
 Creator: Person: {{ userName }}
+{% endif %}
+{% if organization is not empty %}
 Creator: Organization: {{ organisation }}
+{% endif %}
 CreatorComment: <text>
 This document was created using license informations and a generator from Fossology.
 </text>

--- a/src/spdx2/agent/template/spdx2tv-file.twig
+++ b/src/spdx2/agent/template/spdx2tv-file.twig
@@ -10,8 +10,8 @@
 FileName: {{ fileName }}
 SPDXID: SPDXRef-item{{ fileId }}
 {# FileType: OTHER #}
-FileChecksum: SHA1: {{ sha1 }}
-FileChecksum: MD5: {{ md5 }}
+FileChecksum: SHA1: {{ sha1 | lower }}
+FileChecksum: MD5: {{ md5 | lower }}
 {% if isCleared %}
 {% if concludedLicenses|default is empty %}
 LicenseConcluded: NONE

--- a/src/spdx2/agent/template/spdx2tv-package.twig
+++ b/src/spdx2/agent/template/spdx2tv-package.twig
@@ -11,9 +11,9 @@ PackageFileName: {{ uploadName }}
 SPDXID: SPDXRef-upload{{ uploadId }}
 PackageDownloadLocation: NOASSERTION
 PackageVerificationCode: {{ verificationCode }}
-PackageChecksum: SHA1: {{ sha1 }}
+PackageChecksum: SHA1: {{ sha1 | lower }}
 {# PackageChecksum: SHA256: #}
-PackageChecksum: MD5: {{ md5  }}
+PackageChecksum: MD5: {{ md5 | lower }}
 {# PackageChecksum: SSDEEP: #}
 {% if mainLicenses|default is empty %}
 PackageLicenseConcluded: NOASSERTION

--- a/src/spdx2/agent/template/spdx2tv-package.twig
+++ b/src/spdx2/agent/template/spdx2tv-package.twig
@@ -5,10 +5,9 @@
    This file is offered as-is, without any warranty.
 #}
 
-{# RelationshipComment: #}
 PackageName: {{ packageName }}
 PackageFileName: {{ uploadName }}
-SPDXID: SPDXRef-upload{{ uploadId }}
+SPDXID: SPDXRef-upload{{ packageId }}
 PackageDownloadLocation: NOASSERTION
 PackageVerificationCode: {{ verificationCode }}
 PackageChecksum: SHA1: {{ sha1 | lower }}
@@ -26,6 +25,9 @@ PackageLicenseDeclared: {{ mainLicense }}
 {% endif %}
 PackageLicenseInfoFromFiles: NOASSERTION
 PackageCopyrightText: NOASSERTION
+
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-upload{{ packageId }}
+{# RelationshipComment: #}
 
 ##--------------------------
 ## File Information

--- a/src/spdx2/agent_tests/Functional/schedulerTest.php
+++ b/src/spdx2/agent_tests/Functional/schedulerTest.php
@@ -1,6 +1,7 @@
 <?php
 /*
 Copyright (C) 2015, Siemens AG
+Copyright (C) 2017 TNG Technology Consulting GmbH
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/src/spdx2/agent_tests/Functional/schedulerTest.php
+++ b/src/spdx2/agent_tests/Functional/schedulerTest.php
@@ -100,15 +100,15 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
   }
 
   /** @group Functional */
-  public function testReportForNormalUploadtreeTable()
+  public function testSpdxForNormalUploadtreeTable()
   {
     $this->setUpTables();
     $this->setUpRepo();
-    $this->runAndTestReport();
+    $this->runAndTestReportRDF();
   }
 
   /** @group Functional */
-  public function testReportForSpecialUploadtreeTable()
+  public function testSpdxForSpecialUploadtreeTable()
   {
     $this->setUpTables();
     $this->setUpRepo();
@@ -118,23 +118,34 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
     $this->dbManager->getSingleRow("UPDATE upload SET uploadtree_tablename=$1 WHERE upload_pk=$2",
             array("uploadtree_$uploadId",$uploadId),__METHOD__.'.alterUpload');
 
-    $this->runAndTestReport($uploadId);
+    $this->runAndTestReportRDF($uploadId);
   }
 
-  public function runAndTestReport($uploadId=1)
-  {
-    list($success,$output,$retCode) = $this->runnerCli->run($uploadId, $this->userId, $this->groupId, $jobId=7);
+  public function runJobFromJobque($uploadId, $jobId){
+    list($success,$output,$retCode) = $this->runnerCli->run($uploadId, $this->userId, $this->groupId, $jobId);
 
     assertThat('cannot run runner', $success, equalTo(true));
     assertThat('report failed: "'.$output.'"', $retCode, equalTo(0));
     assertThat($this->getHeartCount($output), greaterThan(0));
+  }
 
+  public function getReportFilepathFromJob($uploadId, $jobId){
     $row = $this->dbManager->getSingleRow("SELECT upload_fk,job_fk,filepath FROM reportgen WHERE job_fk = $1", array($jobId), "reportFileName");
     assertThat($row, hasKeyValuePair('upload_fk', $uploadId));
     assertThat($row, hasKeyValuePair('job_fk', $jobId));
     $filepath = $row['filepath'];
     assertThat($filepath, endsWith('.rdf'));
     assertThat(file_exists($filepath),equalTo(true));
+
+    return $filepath;
+  }
+
+  public function runAndTestReportRDF($uploadId=1)
+  {
+    $jobId=7;
+
+    $this->runJobFromJobque($uploadId, $jobId);
+    $filepath = $this->getReportFilepathFromJob($uploadId, $jobId);
 
     $copyrightStatement = 'Copyright (C) 1991-2, RSA Data Security, Inc. Created 1991. All rights reserved';
     assertThat(file_get_contents($filepath), stringContainsInOrder($copyrightStatement));
@@ -145,25 +156,22 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
     $this->addToAssertionCount(\Hamcrest\MatcherAssert::getCount()-$this->assertCountBefore);
 
     $this->verifyRdf($filepath);
-    unlink($filepath);
     $this->rmRepo();
   }
-
+  
   protected function verifyRdf($filepath)
   {
-    $lines = '';
-    $returnVar = 0;
-    exec('which java', $lines, $returnVar);
-    $this->assertEquals(0,$returnVar,'java required for this test');
-
     $toolJarFile = $this->pullSpdxTools();
 
     $verification = exec("java -jar $toolJarFile Verify $filepath");
     assertThat($verification,equalTo('This SPDX Document is valid.'));
+    unlink($filepath);
   }
 
   protected function pullSpdxTools()
   {
+    $this-> verifyJavaIsInstalled();
+
     $version='2.1.0';
     $tag='v'.$version;
 
@@ -185,5 +193,12 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
     }
     $this->assertFileExists($jarFile, 'could not extract SPDXTools');
     return $jarFile;
+  }
+
+  protected function verifyJavaIsInstalled(){
+    $lines = '';
+    $returnVar = 0;
+    exec('which java', $lines, $returnVar);
+    $this->assertEquals(0,$returnVar,'java required for this test');
   }
 }

--- a/src/spdx2/agent_tests/Unit/spdx2utilTest.php
+++ b/src/spdx2/agent_tests/Unit/spdx2utilTest.php
@@ -54,7 +54,63 @@ class spdx2Test extends \PHPUnit_Framework_TestCase
     assertThat($result["key2"], equalTo("anotherValue"));
   }
 
-  public function provideLicenseSet()
+  public function testAddPrefixOnDemandNoChecker()
+  {
+    assertThat(SpdxTwoUtils::addPrefixOnDemand("LIC1"), equalTo("LIC1"));
+  }
+
+  public function provideLicenseSetAddPrefixOnDemand()
+  {
+    $constTrue = function ($licId) { return true; };
+    $constFalse = function ($licId) { return false; };
+
+    return array(
+        'null' => array("LIC1", null, "LIC1"),
+        'const false' => array("LIC1", $constFalse, SpdxTwoUtils::$prefix . "LIC1"),
+        'const true' => array("LIC1", $constTrue, "LIC1")
+    );
+  }
+
+  /**
+   * @dataProvider provideLicenseSetAddPrefixOnDemand
+   * @param string $licenseId
+   * @param closure $checker
+   * @param string $expected
+   */
+  public function testAddPrefixOnDemand($licenseId, $checker, $expected)
+  {
+    assertThat(SpdxTwoUtils::addPrefixOnDemand($licenseId, $checker), equalTo($expected));
+  }
+
+  public function provideLicenseSetAddPrefixOnDemandList()
+  {
+    $constTrue = function ($licId) { return true; };
+    $constFalse = function ($licId) { return false; };
+
+    return array(
+        'single with null' => array(array("LIC1"), null, array("LIC1")),
+        'single with const false' => array(array("LIC1"), $constFalse, array(SpdxTwoUtils::$prefix . "LIC1")),
+        'single with const true' => array(array("LIC1"), $constTrue, array("LIC1")),
+        'multiple with null' => array(array("LIC1","LIC2","LIC3"), null, array("LIC1", "LIC2", "LIC3")),
+        'multiple with const false' => array(array("LIC1","LIC2","LIC3"), $constFalse, array(SpdxTwoUtils::$prefix . "LIC1", SpdxTwoUtils::$prefix . "LIC2", SpdxTwoUtils::$prefix . "LIC3")),
+        'multiple with const true' => array(array("LIC1","LIC2","LIC3"), $constTrue, array("LIC1","LIC2","LIC3")),
+        'two licenses with one prefix (A)' => array(array("LIC1","LIC2"), function ($licId) { return $licId === 'LIC2';}, array(SpdxTwoUtils::$prefix.'LIC1', 'LIC2')),
+        'two licenses with one prefix (2)' => array(array("LIC1","LIC2"), function ($licId) { return $licId === 'LIC1';}, array('LIC1', SpdxTwoUtils::$prefix.'LIC2'))
+    );
+  }
+
+  /**
+   * @dataProvider provideLicenseSetAddPrefixOnDemandList
+   * @param array $licenseIds
+   * @param closure $checker
+   * @param string $expected
+   */
+  public function testAddPrefixOnDemandList($licenseIds, $checker, $expected)
+  {
+    assertThat(SpdxTwoUtils::addPrefixOnDemandList($licenseIds, $checker), equalTo($expected));
+  }
+
+  public function provideLicenseSetImplodeLicenses()
   {
     $constTrue = function ($licId) { return true; };
     $constFalse = function ($licId) { return false; };
@@ -79,7 +135,7 @@ class spdx2Test extends \PHPUnit_Framework_TestCase
   }
 
   /**
-   * @dataProvider provideLicenseSet
+   * @dataProvider provideLicenseSetImplodeLicenses
    * @param array $lics
    * @param string $prefix
    * @param string $expected

--- a/src/spdx2/agent_tests/Unit/spdx2utilTest.php
+++ b/src/spdx2/agent_tests/Unit/spdx2utilTest.php
@@ -1,6 +1,7 @@
 <?php
 /*
 Copyright (C) 2016, Siemens AG
+Copyright (C) 2017 TNG Technology Consulting GmbH
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License


### PR DESCRIPTION
This PR fixes the following bugs in spdx2 (in order):
- **only print extracted texts of `LicenseRef-` licenses**
  other license texts are given by the SPDX license list
- **in spdx all hashes should be lowercase**
- **only show organization key if not empty**
- **show clearnames of scanners with versions in spdx result**
- **move tag `Releationship` below the package information**
  only in tag-value applicable
- **spdx file did not contain scanner findings**
  this was a major bug introduced by myself
- **fix bug in template caused by missing if statement**
- **path names should not contain prefix**
  in fossology our paths of files look like `example.zip/example/LICENSE` but in the SPDX file one has to strip of the prefix, i.e. only have `example/LICENSE`
 
  there is still the advanced problem of nested archives open. It might be necessary to represent them by creating separate packages in the SPDX document. 