### PR TITLE
fix(make): do not place composer at `/tmp/composer/composer`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,13 +27,13 @@ RUN set -x \
 
 ADD utils/fo-installdeps utils/fo-installdeps
 ADD install/scripts/php-conf-fix.sh install/scripts/php-conf-fix.sh
+ADD utils/install_composer.sh utils/install_composer.sh
 RUN set -x \
  && $_update \
- && /fossology/install/scripts/php-conf-fix.sh --overwrite \
  && /fossology/utils/fo-installdeps -e -y \
- && $_cleanup
-RUN curl -sS https://getcomposer.org/installer | php && \
-    mv composer.phar /usr/local/bin/composer
+ && $_cleanup \
+ && /fossology/install/scripts/php-conf-fix.sh --overwrite \
+ && /fossology/utils/install_composer.sh
 
 ADD . .
 RUN chmod +x /fossology/docker-entrypoint.sh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,8 +30,7 @@ sudo apt-get update -qq -y
 
 sudo apt-get install -qq curl php5 git libspreadsheet-writeexcel-perl libdbd-sqlite3-perl
 
-curl -sS https://getcomposer.org/installer | php
-sudo mv composer.phar /usr/bin/composer
+# sudo /vagrant/install/install_composer.sh
 
 # install spdx-tools
 /vagrant/install/scripts/install-spdx-tools.sh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,8 +47,6 @@ cd /vagrant
 ./utils/fo-installdeps -e -y
 
 make CFLAGS=-I/usr/include/glib-2.0
-sudo make composer_download
-sudo make composer_install
 sudo make install
 sudo /usr/local/lib/fossology/fo-postinstall
 sudo /etc/init.d/fossology start

--- a/pbconf/Vagrantfile
+++ b/pbconf/Vagrantfile
@@ -38,7 +38,7 @@ yum install -y wget git
 wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 rpm -Uvh epel-release-latest-7.noarch.rpm
 
-# install composer
+# install projectbuilder
 wget http://ftp.project-builder.org/centos/7/x86_64/pb.repo
 cp pb.repo /etc/yum.repos.d/
 
@@ -47,10 +47,6 @@ cp pb.repo /etc/yum.repos.d/
 # yum install -y project-builder --nogpgcheck
 yum update -y
 yum install -y project-builder
-
-# install build dependencies
-yum install -y redhat-lsb
-/home/vagrant/prj/fossology/utils/fo-installdeps -e -y
 
 # adding docker install info for prepping the project builder installation runs
 cat > /etc/yum.repos.d/docker.repo << EOF
@@ -70,7 +66,7 @@ systemctl start docker
 
 SCRIPT
   end
-  
+
 #
 # checking out and preparing project builder
 # note that triple backslashes are because of cat and vagrant escaping
@@ -100,24 +96,20 @@ PBRC
 
 ################################################################################
 # sbx = sandbox
-# actually, sbx2pkg is included in sbx2pkg2ins
-for pkg in "fossology-composer" "fossology"; do
-    pb -t -p fossology sbx2build   $pkg
-    pb -p    fossology build2prep  $pkg
-#   pb -t -p fossology sbx2pkg     $pkg
-    pb -t -p fossology sbx2pkg2ins $pkg
-done
+pb -t -p fossology sbx2build   fossology
+pb    -p fossology build2prep  fossology
+# pb -t -p fossology sbx2pkg     fossology # actually, sbx2pkg is included in sbx2pkg2ins
+pb -t -p fossology sbx2pkg2ins fossology
 
 SCRIPT
   end
-  
+
 #
 # applying some work around
 #
   config.vm.provision "shell" do |s|
     s.privileged = false
     s.inline = <<SCRIPT
-    
 # uahhh: disabling SELinux
 # remove if the https://github.com/fossology/fossology/issues/727
 setenforce 0

--- a/pbconf/fossology/deb/rules
+++ b/pbconf/fossology/deb/rules
@@ -31,9 +31,8 @@ build-arch: build-arch-stamp
 build-arch-stamp: configure-stamp  
 
 	# Add here commands to compile the arch part of the package.
-	# This is not clean again
-	make SYSCONFDIR=%{_sysconfdir}/fossology PREFIX=%{_usr} LOCALSTATEDIR=%{_var} composer_download
-	#
+	mkdir -p /tmp/composer
+	(cd /tmp/composer && (curl -sS https://getcomposer.org/installer | php))
 	@dpkg-parsechangelog | sed -n -e 's/^Version: //p' > VERSIONSTRING
 	$(MAKE) PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var
 	$(MAKE) PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var -C src/nomos/agent/ -f Makefile.sa
@@ -87,6 +86,7 @@ install-arch:
            -C src/maintagent install
 	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-common \
            PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
+           COMPOSER_PHAR=/tmp/composer/composer.phar \
            -C src composer_install
 	mkdir -p $(CURDIR)/debian/fossology-common/usr/share/fossology/setup
 	cp $(CURDIR)/install/scripts/* $(CURDIR)/debian/fossology-common/usr/share/fossology/setup

--- a/pbconf/fossology/rpm/fossology.spec
+++ b/pbconf/fossology/rpm/fossology.spec
@@ -190,8 +190,6 @@ This package contains the monkbulk agent programs and their resources.
 %prep
 %setup -q -n %{name}-%{version}PBEXTDIR
 #PBPATCHCMD
-# This is not clean, but should allow to work menawhild a better solution is found
-make SYSCONFDIR=%{_sysconfdir}/fossology PREFIX=%{_usr} LOCALSTATEDIR=%{_var} composer_download
 
 %build
 make SYSCONFDIR=%{_sysconfdir}/fossology PREFIX=%{_usr} LOCALSTATEDIR=%{_var}

--- a/pbconf/fossology/rpm/fossology.spec
+++ b/pbconf/fossology/rpm/fossology.spec
@@ -191,13 +191,19 @@ This package contains the monkbulk agent programs and their resources.
 %setup -q -n %{name}-%{version}PBEXTDIR
 #PBPATCHCMD
 
+mkdir -p /tmp/composer/
+utils/install_composer.sh /tmp/composer/
+COMPOSER_PHAR=/tmp/composer/composer
+
+make DESTDIR=$RPM_BUILD_ROOT PREFIX=%{_usr} SYSCONFDIR=%{_sysconfdir}/fossology LOCALSTATEDIR=%{_var} LIBDIR=%{_libdir} composer_install
+
 %build
 make SYSCONFDIR=%{_sysconfdir}/fossology PREFIX=%{_usr} LOCALSTATEDIR=%{_var}
 #make %{?_smp_mflags} SYSCONFDIR=%{_sysconfdir}
 make SYSCONFDIR=%{_sysconfdir}/fossology PREFIX=%{_usr} LOCALSTATEDIR=%{_var} -C src/nomos/agent/ -f Makefile.sa
 
 %install
-make DESTDIR=$RPM_BUILD_ROOT PREFIX=%{_usr} SYSCONFDIR=%{_sysconfdir}/fossology LOCALSTATEDIR=%{_var} LIBDIR=%{_libdir} install
+make DESTDIR=$RPM_BUILD_ROOT PREFIX=%{_usr} SYSCONFDIR=%{_sysconfdir}/fossology LOCALSTATEDIR=%{_var} LIBDIR=%{_libdir} install_offline
 make DESTDIR=$RPM_BUILD_ROOT PREFIX=%{_usr} SYSCONFDIR=%{_sysconfdir}/fossology LOCALSTATEDIR=%{_var} LIBDIR=%{_libdir} -C src/nomos/agent/ -f Makefile.sa install
 #mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}/httpd/conf.d
 #cat > $RPM_BUILD_ROOT/%{_sysconfdir}/httpd/conf.d/PBPROJ.conf << EOF

--- a/src/Makefile
+++ b/src/Makefile
@@ -49,7 +49,8 @@ $(BUILDDIRS):
 	$(MAKE) -s -C $(@:build-%=%)
 
 # install depends on everything being built first
-install: all $(INSTALLDIRS) composer_install
+install: install_offline composer_install
+install_offline: all $(INSTALLDIRS)
 $(INSTALLDIRS):
 	$(MAKE) -s -C $(@:install-%=%) install
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@
 
 TOP = ..
 VARS = $(TOP)/Makefile.conf
-COMPOSERTMP = /tmp/composer
+COMPOSER_PHAR ?= composer
 include $(VARS)
 
 # the directories we do things in by default
@@ -76,17 +76,12 @@ $(CLEANDIRS):
 	$(MAKE) -s -C $(@:clean-%=%) clean
 
 phpvendors:
-	$(COMPOSERTMP)/composer install -q
-
-composer_download:
-	curl -sS https://getcomposer.org/installer | php
-	mkdir -p $(COMPOSERTMP)
-	mv composer.phar $(COMPOSERTMP)/composer
+	$(COMPOSER_PHAR) install -q
 
 composer_install:
 	@echo "current dir: '$${PWD}'"
 	$(INSTALL_DATA) composer.json composer.lock $(DESTDIR)$(MODDIR)
-	(cd $(DESTDIR)$(MODDIR); $(COMPOSERTMP)/composer install -q --no-dev)
+	(cd $(DESTDIR)$(MODDIR); export COMPOSER_HOME=/dev/null; $(COMPOSER_PHAR) install -q --no-dev)
 
 .PHONY: subdirs $(BUILDDIRS)
 .PHONY: subdirs $(DIRS)

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -1,4 +1,4 @@
-
+#!/usr/bin/env bash
 # FOSSology fo-installdeps script
 # Copyright (C) 2008-2014 Hewlett-Packard Development Company, L.P.
 # This program is free software; you can redistribute it and/or
@@ -114,7 +114,8 @@ if [ $BUILDTIME ]; then
               lucid|natty) apt-get $YesOpt install postgresql-server-dev-8.4;;
               isadora) apt-get $YesOpt install postgresql-server-dev-8.4;;
               precise|oneiric|quantal|raring|saucy) apt-get $YesOpt install postgresql-server-dev-9.1;;
-              trusty|jessie) apt-get $YesOpt install postgresql-server-dev-9.3;;
+              trusty) apt-get $YesOpt install postgresql-server-dev-9.3;;
+              jessie) apt-get $YesOpt install postgresql-server-dev-9.4;;
               xenial) apt-get $YesOpt install postgresql-server-dev-9.5;;
               *) echo "ERROR: Unknown or Unsupported $DISTRO release, please report to the mailing list"; exit 1;;
            esac
@@ -188,8 +189,10 @@ if [ $RUNTIME ]; then
                  apt-get $YesOpt install postgresql-8.4;;
               precise|oneiric|quantal|raring|saucy)
                  apt-get $YesOpt install postgresql-9.1;;
-              trusty|jessie)
+              trusty)
                  apt-get $YesOpt install postgresql-9.3;;
+              jessie)
+                 apt-get $YesOpt install postgresql-9.4;;
               xenial)
                  apt-get $YesOpt install postgresql-9.5;;
               *) echo "ERROR: Unknown or Unsupported $DISTRO release, please report to the mailing list"; exit 1;;
@@ -258,21 +261,12 @@ if [ $RUNTIME ]; then
       *) echo "ERROR: distro not recognised, please fix and send a patch"; exit 1;;
    esac
    
-   which composer
-    if [ $? -eq 0  ]; then
-        if [ $OFFLINE -eq 0 ]; then
-            composer selfupdate
-        else
-           echo "WARNING: composer is not updated due to the offline switch"
-        fi
-    else
-        if [ $OFFLINE -eq 0 ]; then
-            curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
-        else
-            echo "WARNING: composer is not installed, and the installer does not install it due to the offline switch"
-            echo "Please run the equivalent of 'curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer'"
-        fi
-    fi
+   if [ $OFFLINE -eq 0 ]; then
+       "$( dirname "$0" )/install_composer.sh"
+   else
+       echo "WARNING: composer is not installed, and the installer does not install it due to the offline switch"
+       echo "Please run the equivalent of 'sudo ./utils/install_composer.sh'"
+   fi
 fi
 
 ########################################################################

--- a/utils/install_composer.sh
+++ b/utils/install_composer.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Copyright (C) 2017 Maximilian Huber
+# based on documentation found at https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
+
+################################################################################
+## Configuration:
+# commit hash of https://github.com/composer/getcomposer.org
+
+current_github_hash="5fd32f776359b8714e2647ab4cd8a7bed5f3714d"
+# version of composer (must be present in https://github.com/composer/getcomposer.org/tree/${current_github_hash}/web/download)
+version="1.3.2"
+
+##
+################################################################################
+
+################################################################################
+# prepare
+
+set -e
+cd "$( dirname "${BASH_SOURCE[0]}" )/.."
+
+if [[ "$1" == "-h" ]]; then
+    cat <<EOF
+This script is used to install composer in version=${version}.
+The composer artifact is downloaded from https://github.com/composer/getcomposer.org with commit_hash=${current_github_hash}.
+(These values are hardcoded in the script)
+
+It should be called like
+   \$ ${BASH_SOURCE[0]} [-h] [/target/install/path] [-f]
+where the optionional path argument is internally called \`install_dir\`
+
+Note: If one passes an relative path (e.g. install_dir=./utils) this gets resolved relative to the project root
+
+The \`install_dir\` defaults to
+  - /usr/local/bin  - if the script is called by root or via sudo
+  - ./utils   - otherwise
+EOF
+    exit 0
+fi
+
+# if run as root, install by default to /usr/bin, otherwise install to ./utils
+if [ "$EUID" -ne 0 ]; then
+    install_dir="${1:-utils}"
+else
+    install_dir="${1:-/usr/local/bin}"
+fi
+
+if [ ! -d "$install_dir" ]; then
+    echo "install_dir=\"${install_dir}\" is not present (currently at \"$(pwd)\")"
+    exit 1
+fi
+
+filename="composer"
+target="$install_dir/$filename"
+
+################################################################################
+# do the install
+
+echo "composer $version will be installed to: $target (this will override any old executable)"
+wget -q \
+     -O "$target" \
+     "https://github.com/composer/getcomposer.org/raw/$current_github_hash/web/download/$version/composer.phar"
+chmod +x "$target"


### PR DESCRIPTION
this pull request
- undos the changes to the composer placement introduced in #701
- adds the option to pass the environmental variable `COMPOSER_PHAR` to
  `src/Makefile` to allow placing the composer.phar at arbitrary places
- this fixes the source installation, i.e. the documentation was not up
  to date
- this fixes the problems with `vagrant up` (see #732)
- this fixes the problems with `docker-compose build`

as discussed in #731

closes #732
