### PR TITLE
Fix EPEL dependency

### DIFF
--- a/pbconf/fossology.pb
+++ b/pbconf/fossology.pb
@@ -52,7 +52,7 @@ testver fossology = true
 # Additional repository to add at build time
 # addrepo centos-5-x86_64 = http://packages.sw.be/rpmforge-release/rpmforge-release-0.3.6-1.el5.rf.x86_64.rpm,ftp://ftp.project-builder.org/test/centos/5/pb.repo
 # addrepo centos-4-x86_64 = http://packages.sw.be/rpmforge-release/rpmforge-release-0.3.6-1.el4.rf.x86_64.rpm,ftp://ftp.project-builder.org/test/centos/4/pb.repo
-addrepo centos-7-x86_64 = ftp://ftp.project-builder.org/centos/7/x86_64/pb.repo,https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+addrepo centos-7-x86_64 = http://ftp.project-builder.org/centos/7/x86_64/pb.repo,http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
 
 # Adapt to your needs:
 # Optional if you need to overwrite the global values above


### PR DESCRIPTION
Use a specific package name corresponding to the real package name for EPEL
instead of a generic one whose verification was then failing.