### PR TITLE
fix(fo-postinstall): PHP warnings

### DIFF
--- a/install/fossinit.php
+++ b/install/fossinit.php
@@ -132,7 +132,8 @@ if (!file_exists($SchemaFilePath))
 }
 
 require_once("$MODDIR/lib/php/libschema.php");
-$libschema->setDriver(new Postgres($PG_CONN));
+$pgDriver = new Postgres($PG_CONN);
+$libschema->setDriver($pgDriver);
 $previousSchema = $libschema->getCurrSchema();
 $isUpdating = array_key_exists('TABLE', $previousSchema) && array_key_exists('users', $previousSchema['TABLE']);
 /* @var $dbManager DbManager */

--- a/src/lib/php/libschema.php
+++ b/src/lib/php/libschema.php
@@ -1077,7 +1077,8 @@ if (empty($dbManager) || !($dbManager instanceof DbManager))
   $logger = new Logger(__FILE__);
   $logger->pushHandler(new ErrorLogHandler(ErrorLogHandler::OPERATING_SYSTEM, $logLevel));
   $dbManager = new ModernDbManager($logger);
-  $dbManager->setDriver(new Postgres($PG_CONN));
+  $pgDriver = new Postgres($PG_CONN);
+  $dbManager->setDriver($pgDriver);
 }
 /* simulate the old functions*/
 $libschema = new fo_libschema($dbManager);


### PR DESCRIPTION
The following warnings are printed during fo-postinstall:

```
PHP Notice:  Only variables should be passed by reference in /usr/local/share/fossology/lib/php/libschema.php on line 1080
PHP Notice:  Only variables should be passed by reference in /usr/local/lib/fossology/fossinit.php on line 135
```

This PR fixes those warnings. Tested on latest commit 37eb354d9d45114700c3801bdaa8348c40aea0f7