### PR TITLE
fix(folder-deletion): don't delete duplicate files in other folder, when folder is deleted

### DIFF
--- a/src/delagent/agent/util.c
+++ b/src/delagent/agent/util.c
@@ -559,9 +559,9 @@ int listFoldersRecurse (long Parent, int Depth, long Row, int DelFlag, int user_
     return 1;
   }
 
-  /* Find all folders with this parent and recurse */
+  /* Find all folders with this parent and recurse, but don't show uploads, if they also exist in other directories */
   snprintf(SQL,MAXSQL,"SELECT folder_pk,foldercontents_mode,name,description,upload_pk FROM folderlist "
-          "WHERE parent=%ld "
+          "WHERE parent=%ld AND upload_pk NOT IN (SELECT upload_pk FROM folderlist WHERE parent!=%ld GROUP BY upload_pk HAVING COUNT(*) > 0) "
           "ORDER BY name,parent,folder_pk",Parent);
   result = PQexec(db_conn, SQL);
   if (fo_checkPQresult(db_conn, result, SQL, __FILE__, __LINE__))


### PR DESCRIPTION
To reproduce issue:
1. Create a new Folder with Name "TestFolder"
2. Upload file (in this example test.zip)
3. Copy test.zip into TestFolder -> test.zip should now exist in the Software Repository and in the folder TestFolder
4. Delete TestFolder
Expected Behavior: test.zip still exists in the Software Repository, because it was only copied from there in TestFolder before
Actual Behavior: test.zip is gone from the Software Repository
This commit should fix this issue. Testing from more contributors is still necessary

This issue was found using the E2E Tests in PR #787