### PR TITLE
fix(docker): use a simpler Dockerfile for standalone build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # FOSSology Dockerfile
 # Copyright Siemens AG 2016, fabio.huser@siemens.com
-# Copyright TNG Technology Consulting GmbH 2016, maximilian.huber@tngtech.com
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -10,77 +9,32 @@
 # Description: Docker container image recipe
 
 FROM debian:stable
+
 MAINTAINER Fossology <fossology@fossology.org>
+
 WORKDIR /fossology
+COPY . .
 
-ENV _update="apt-get update"
-ENV _install="apt-get install -y --no-install-recommends"
-ENV _cleanup="eval apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*"
+RUN apt-get update && \
+    apt-get install -y lsb-release sudo postgresql php5-curl libpq-dev libdbd-sqlite3-perl libspreadsheet-writeexcel-perl && \
+    /fossology/utils/fo-installdeps -e -y && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN set -x \
- && $_update && $_install \
-       lsb-release curl php5 libpq-dev libdbd-sqlite3-perl libspreadsheet-writeexcel-perl postgresql-client \
-       sudo \
-       # for standalone mode:
-       postgresql \
- && $_cleanup
+RUN curl -sS https://getcomposer.org/installer | php && \
+    mv composer.phar /usr/local/bin/composer
 
-ADD utils/fo-installdeps utils/fo-installdeps
-ADD install/scripts/php-conf-fix.sh install/scripts/php-conf-fix.sh
-ADD utils/install_composer.sh utils/install_composer.sh
-RUN set -x \
- && $_update \
- && /fossology/utils/fo-installdeps -e -y \
- && $_cleanup \
- && /fossology/install/scripts/php-conf-fix.sh --overwrite \
- && /fossology/utils/install_composer.sh
+RUN /fossology/install/scripts/install-spdx-tools.sh
 
-ADD . .
-RUN chmod +x /fossology/docker-entrypoint.sh
-RUN set -x \
- && make install \
- && make clean
+RUN /fossology/install/scripts/install-ninka.sh
 
-RUN set -x \
- && /usr/local/lib/fossology/fo-postinstall --common \
- && mkdir -p /srv/fossology/repository/
+RUN make install
 
-################################################################################
-# scheduler related
-RUN /usr/local/lib/fossology/fo-postinstall \
-        --agent \
-        --scheduler-only
+RUN cp /fossology/install/src-install-apache-example.conf /etc/apache2/conf-available/fossology.conf && \
+    ln -s /etc/apache2/conf-available/fossology.conf /etc/apache2/conf-enabled/fossology.conf
 
-RUN set -x \
- && mkdir -p /var/log/fossology \
- && chown -R fossy:fossy /var/log/fossology \
- && chgrp -R fossy /usr/local/etc/fossology/ \
- && chmod -R g+wr /usr/local/etc/fossology/ \
- && chown fossy:fossy /usr/local/etc/fossology/Db.conf
-
-################################################################################
-# web related
-RUN /usr/local/lib/fossology/fo-postinstall \
-        --web-only \
- && systemctl disable apache2
-
-RUN set -x \
- && cp /fossology/install/src-install-apache-example.conf \
-        /etc/apache2/conf-available/fossology.conf \
- && ln -s /etc/apache2/conf-available/fossology.conf \
-        /etc/apache2/conf-enabled/fossology.conf \
- && echo Listen 8081 >/etc/apache2/ports.conf
-
-RUN set -x \
- && chmod -R o+r /etc/apache2 \
- && mkdir -p /var/log/apache2/ \
- && chown -R fossy:fossy /var/log/apache2/ \
- && chown -R fossy:fossy /var/run/apache2/ \
- && chown -R fossy:fossy /var/lock/apache2/
+RUN /fossology/install/scripts/php-conf-fix.sh --overwrite
 
 EXPOSE 8081
 
-################################################################################
-VOLUME /srv/fossology/repository/
-
+RUN chmod +x /fossology/docker-entrypoint.sh
 ENTRYPOINT ["/fossology/docker-entrypoint.sh"]

--- a/install/docker-compose.Dockerfile
+++ b/install/docker-compose.Dockerfile
@@ -1,0 +1,86 @@
+# FOSSology Dockerfile
+# Copyright Siemens AG 2016, fabio.huser@siemens.com
+# Copyright TNG Technology Consulting GmbH 2016, maximilian.huber@tngtech.com
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Description: Docker container image recipe
+
+FROM debian:stable
+MAINTAINER Fossology <fossology@fossology.org>
+WORKDIR /fossology
+
+ENV _update="apt-get update"
+ENV _install="apt-get install -y --no-install-recommends"
+ENV _cleanup="eval apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*"
+
+RUN set -x \
+ && $_update && $_install \
+       lsb-release curl php5 libpq-dev libdbd-sqlite3-perl libspreadsheet-writeexcel-perl postgresql-client \
+       sudo \
+       # for standalone mode:
+       postgresql \
+ && $_cleanup
+
+ADD utils/fo-installdeps utils/fo-installdeps
+ADD install/scripts/php-conf-fix.sh install/scripts/php-conf-fix.sh
+ADD utils/install_composer.sh utils/install_composer.sh
+RUN set -x \
+ && $_update \
+ && /fossology/utils/fo-installdeps -e -y \
+ && $_cleanup \
+ && /fossology/install/scripts/php-conf-fix.sh --overwrite \
+ && /fossology/utils/install_composer.sh
+
+ADD . .
+RUN chmod +x /fossology/install/docker-compose.docker-entrypoint.sh
+RUN set -x \
+ && make install \
+ && make clean
+
+RUN set -x \
+ && /usr/local/lib/fossology/fo-postinstall --common \
+ && mkdir -p /srv/fossology/repository/
+
+################################################################################
+# scheduler related
+RUN /usr/local/lib/fossology/fo-postinstall \
+        --agent \
+        --scheduler-only
+
+RUN set -x \
+ && mkdir -p /var/log/fossology \
+ && chown -R fossy:fossy /var/log/fossology \
+ && chgrp -R fossy /usr/local/etc/fossology/ \
+ && chmod -R g+wr /usr/local/etc/fossology/ \
+ && chown fossy:fossy /usr/local/etc/fossology/Db.conf
+
+################################################################################
+# web related
+RUN /usr/local/lib/fossology/fo-postinstall \
+        --web-only \
+ && systemctl disable apache2
+
+RUN set -x \
+ && cp /fossology/install/src-install-apache-example.conf \
+        /etc/apache2/conf-available/fossology.conf \
+ && ln -s /etc/apache2/conf-available/fossology.conf \
+        /etc/apache2/conf-enabled/fossology.conf \
+ && echo Listen 8081 >/etc/apache2/ports.conf
+
+RUN set -x \
+ && chmod -R o+r /etc/apache2 \
+ && mkdir -p /var/log/apache2/ \
+ && chown -R fossy:fossy /var/log/apache2/ \
+ && chown -R fossy:fossy /var/run/apache2/ \
+ && chown -R fossy:fossy /var/lock/apache2/
+
+EXPOSE 8081
+
+################################################################################
+VOLUME /srv/fossology/repository/
+
+ENTRYPOINT ["/fossology/install/docker-compose.docker-entrypoint.sh"]

--- a/install/docker-compose.base.yml
+++ b/install/docker-compose.base.yml
@@ -14,6 +14,7 @@ services:
   fossology:
     build:
       context: ..
+      dockerfile: install/docker-compose.Dockerfile
       args:
         - http_proxy
         - https_proxy

--- a/install/docker-compose.docker-entrypoint.sh
+++ b/install/docker-compose.docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # FOSSology docker-entrypoint script
 # Copyright Siemens AG 2016, fabio.huser@siemens.com
+# Copyright TNG Technology Consulting GmbH 2016, maximilian.huber@tngtech.com
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -9,22 +10,24 @@
 #
 # Description: startup helper script for the FOSSology Docker container
 
+set -e
+
 db_host="localhost"
 db_name="fossology"
 db_user="fossy"
 db_password="fossy"
 
 if [ "$FOSSOLOGY_DB_HOST" ]; then
-	db_host="$FOSSOLOGY_DB_HOST"
+  db_host="$FOSSOLOGY_DB_HOST"
 fi
 if [ "$FOSSOLOGY_DB_NAME" ]; then
-	db_name="$FOSSOLOGY_DB_NAME"
+  db_name="$FOSSOLOGY_DB_NAME"
 fi
 if [ "$FOSSOLOGY_DB_USER" ]; then
-	db_user="$FOSSOLOGY_DB_USER"
+  db_user="$FOSSOLOGY_DB_USER"
 fi
 if [ "$FOSSOLOGY_DB_PASSWORD" ]; then
-	db_password="$FOSSOLOGY_DB_PASSWORD"
+  db_password="$FOSSOLOGY_DB_PASSWORD"
 fi
 
 # Write configuration
@@ -35,6 +38,9 @@ user=$db_user;
 password=$db_password;
 EOM
 
+sed -i 's/address = .*/address = '"${FOSSOLOGY_SCHEDULER_HOST:-localhost}"'/' \
+    /usr/local/etc/fossology/fossology.conf
+
 # Startup DB if needed or wait for external DB
 if [ "$db_host" = 'localhost' ]; then
   echo '*****************************************************'
@@ -42,6 +48,7 @@ if [ "$db_host" = 'localhost' ]; then
   echo 'internal database without persistency will be used.'
   echo 'THIS IS NOT RECOMENDED FOR PRODUCTIVE USE!'
   echo '*****************************************************'
+  sleep 5
   /etc/init.d/postgresql start
 else
   testForPostgres(){
@@ -55,11 +62,28 @@ else
 fi
 
 # Setup environment
-/usr/local/lib/fossology/fo-postinstall
+if [[ $# = 0 || ( $# = 1 && "$1" == "scheduler" ) ]]; then
+  /usr/local/lib/fossology/fo-postinstall --database --licenseref
+fi
 
 # Start Fossology
 echo
 echo 'Fossology initialisation complete; Starting up...'
 echo
-/etc/init.d/fossology start
-/usr/sbin/apache2ctl -D FOREGROUND
+if [ $# -eq 0 ]; then
+  /etc/init.d/fossology start
+  /usr/local/share/fossology/scheduler/agent/fo_scheduler \
+    --log /dev/stdout \
+    --verbose=3 \
+    --reset &
+  /usr/sbin/apache2ctl -D FOREGROUND
+elif [[ $# = 1 && "$1" == "scheduler" ]]; then
+  exec /usr/local/share/fossology/scheduler/agent/fo_scheduler \
+    --log /dev/stdout \
+    --verbose=3 \
+    --reset
+elif [[ $# = 1 && "$1" == "web" ]]; then
+  exec /usr/sbin/apache2ctl -D FOREGROUND
+else
+  exec "$@"
+fi


### PR DESCRIPTION
The modified Dockerfile did not work with the split-up docker-compose
setup. This moves the "complicated" dockerfile to
`install/docker-compose.Dockerfile` and places the old Dockerfile at the
root level.

TODO: merge these dockerfiles again