### PR TITLE
fix(spdx2): set agent name for spdx2, spdx2tv, dep5

### DIFF
--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -78,7 +78,15 @@ class SpdxTwoAgent extends Agent
 
   function __construct()
   {
-    parent::__construct('spdx2', AGENT_VERSION, AGENT_REV);
+    // deduce the agent name from the command line arguments
+    $args = getopt("", array(self::OUTPUT_FORMAT_KEY.'::'));
+    $agentName = trim($args[self::OUTPUT_FORMAT_KEY]);
+    if (empty($agentName))
+    {
+        $agentName = self::DEFAULT_OUTPUT_FORMAT;
+    }
+
+    parent::__construct($agentName, AGENT_VERSION, AGENT_REV);
 
     $this->uploadDao = $this->container->get('dao.upload');
     $this->clearingDao = $this->container->get('dao.clearing');


### PR DESCRIPTION
All three of these agents use the same spdx2 PHP script. The output format is set as a command line argument. Use this argument to set the agent name. This fixes #785 and has the added bonus of showing all three agents in the enabled agents list (Admin -> Scheduler -> Agents).