### PR TITLE
chore(editorconfig): add editorconfig to project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = tab


### PR DESCRIPTION
This helps the code style of the project. Some text editors automatically set settings based on this file, can be used for linting later

Fixes #794