### PR TITLE
fix(spdx): typo 'spxd2' in document templates

### DIFF
--- a/src/spdx2/agent/template/spdx2-document.xml.twig
+++ b/src/spdx2/agent/template/spdx2-document.xml.twig
@@ -15,7 +15,7 @@
       <spdx:licenseListVersion>2.0</spdx:licenseListVersion> 
       <spdx:creator>Person: {{ userName|e }}</spdx:creator>
       <spdx:creator>Organization: {{ organisation|e }}</spdx:creator>
-      <spdx:creator>Tool: spxd2</spdx:creator>
+      <spdx:creator>Tool: spdx2</spdx:creator>
       <spdx:created>{{ 'now'|date('Y-m-d\\TH:i:s\\Z')}}{# date('c') for ISO 8601 is not parsed by spdxTool #}</spdx:created>
     </spdx:CreationInfo>
   </spdx:creationInfo>

--- a/src/spdx2/agent/template/spdx2tv-document.twig
+++ b/src/spdx2/agent/template/spdx2tv-document.twig
@@ -19,7 +19,7 @@ SPDXID: SPDXRef-DOCUMENT
 ## Creation Information
 ##-------------------------
 
-Creator: Tool: spxd2
+Creator: Tool: spdx2
 {% if userName is not empty %}
 Creator: Person: {{ userName }}
 {% endif %}


### PR DESCRIPTION
I can't find any reference to spxd anywhere in the repository, so I'm assuming this is a typo.