### PR TITLE
First implementation of obligations and risks management

### DIFF
--- a/src/lib/php/Application/ObligationCsvExport.php
+++ b/src/lib/php/Application/ObligationCsvExport.php
@@ -1,0 +1,98 @@
+<?php
+/*
+Copyright (C) 2015, Siemens AG
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+namespace Fossology\Lib\Application;
+
+use Fossology\Lib\BusinessRules\LicenseMap;
+use Fossology\Lib\Db\DbManager;
+
+class ObligationCsvExport {
+  /** @var DbManager */
+  protected $dbManager;
+  /** @var string */
+  protected $delimiter = ',';
+  /** @var string */
+  protected $enclosure = '"';
+
+  public function __construct(DbManager $dbManager)
+  {
+    $this->dbManager = $dbManager;
+    $this->obligationMap = $GLOBALS['container']->get('businessrules.obligationmap');
+  }
+
+  public function setDelimiter($delimiter=',')
+  {
+    $this->delimiter = substr($delimiter,0,1);
+  }
+
+  public function setEnclosure($enclosure='"')
+  {
+    $this->enclosure = substr($enclosure,0,1);
+  }
+
+  /**
+   * @param int $rf
+   * @return string csv
+   */
+  public function createCsv($ob=0)
+  {
+    $csvarray = array();
+    $sql = "SELECT ob_pk, ob_topic,ob_text
+            FROM obligation_ref;";
+    if ($ob>0)
+    {
+      $stmt = __METHOD__.'.ob';
+      $sql .= ' WHERE ob_pk=$'.$ob;
+      $row = $this->dbManager->getSingleRow($sql,$stmt);
+      $vars = $row ? array( $row ) : array();
+      $liclist = $this->obligationMap->getLicenseList($ob);
+      array_shift($vars);
+      array_push($vars,$liclist);
+      $csvarray = $vars;
+    }
+    else
+    {
+      $stmt = __METHOD__;
+      $this->dbManager->prepare($stmt,$sql);
+      $res = $this->dbManager->execute($stmt);
+      $vars = $this->dbManager->fetchAll($res);
+      $this->dbManager->freeResult($res);
+
+      foreach ($vars as $row)
+      {
+        $liclist = $this->obligationMap->getLicenseList($row['ob_pk']);
+        array_shift($row);
+        array_push($row,$liclist);
+        array_push($csvarray,$row);
+      }
+    }
+
+    $out = fopen('php://output', 'w');
+    ob_start();
+    $head = array('Obligation or Risk topic','Full Text','Associated Licenses');
+    fputcsv($out, $head, $this->delimiter, $this->enclosure);
+    foreach($csvarray as $row)
+    {
+      fputcsv($out, $row, $this->delimiter, $this->enclosure);
+    }
+    $content = ob_get_contents();
+    ob_end_clean();
+    return $content;
+  }
+
+}

--- a/src/lib/php/Application/ObligationCsvImport.php
+++ b/src/lib/php/Application/ObligationCsvImport.php
@@ -1,0 +1,184 @@
+<?php
+/*
+Copyright (C) 2014-2015, Siemens AG
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+namespace Fossology\Lib\Application;
+
+use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\Util\ArrayOperation;
+
+class ObligationCsvImport {
+  /** @var DbManager */
+  protected $dbManager;
+  /** @var string */
+  protected $delimiter = ',';
+  /** @var string */
+  protected $enclosure = '"';
+  /** @var null|array */
+  protected $headrow = null;
+  /** @var array */
+  protected $alias = array(
+      'topic'=>array('topic','Obligation or Risk topic'),
+      'text'=>array('text','Full Text'),
+      'licnames'=>array('licnames','Associated Licenses')
+    );
+
+  public function __construct(DbManager $dbManager)
+  {
+    $this->dbManager = $dbManager;
+    $this->obligationMap = $GLOBALS['container']->get('businessrules.obligationmap');
+  }
+
+  public function setDelimiter($delimiter=',')
+  {
+    $this->delimiter = substr($delimiter,0,1);
+  }
+
+  public function setEnclosure($enclosure='"')
+  {
+    $this->enclosure = substr($enclosure,0,1);
+  }
+
+  /**
+   * @param string $filename
+   * @return string message
+   */
+  public function handleFile($filename)
+  {
+    if (!is_file($filename) || ($handle = fopen($filename, 'r')) === FALSE) {
+      return _('Internal error');
+    }
+    $cnt = -1;
+    $msg = '';
+    try
+    {
+      while(($row = fgetcsv($handle,0,$this->delimiter,$this->enclosure)) !== FALSE) {
+        $log = $this->handleCsv($row);
+        if (!empty($log))
+        {
+          $msg .= "$log\n";
+        }
+        $cnt++;
+      }
+      $msg .= _('Read csv').(": $cnt ")._('obligations');
+    }
+    catch(\Exception $e)
+    {
+      fclose($handle);
+      return $msg .= _('Error while parsing file').': '.$e->getMessage();
+    }
+    fclose($handle);
+    return $msg;
+  }
+
+  /**
+   * @param array $row
+   * @return string $log
+   */
+  private function handleCsv($row)
+  {
+    if($this->headrow===null)
+    {
+      $this->headrow = $this->handleHeadCsv($row);
+      return 'head okay';
+    }
+
+    $mRow = array();
+    foreach( array('topic','text','licnames') as $needle){
+      $mRow[$needle] = $row[$this->headrow[$needle]];
+    }
+
+    return $this->handleCsvObligation($mRow);
+  }
+
+  private function handleHeadCsv($row)
+  {
+    $headrow = array();
+    foreach( array('topic','text','licnames') as $needle){
+      $col = ArrayOperation::multiSearch($this->alias[$needle], $row);
+      if (false === $col)
+      {
+        throw new \Exception("Undetermined position of $needle");
+      }
+      $headrow[$needle] = $col;
+    }
+    return $headrow;
+  }
+
+  private function getKeyFromTopicAndText($row)
+  {
+    $req = array($row['topic'], $row['text']);
+    $row = $this->dbManager->getSingleRow('SELECT ob_pk FROM obligation_ref WHERE ob_topic=$1 AND ob_md5=md5($2)',$req);
+    return ($row === false) ? false : $row['ob_pk'];
+  }
+
+
+  /**
+   * @param array $row
+   * @return string
+   */
+  private function handleCsvObligation($row)
+  {
+    /* @var $dbManager DbManager */
+    $dbManager = $this->dbManager;
+    $exists = $this->getKeyFromTopicAndText($row);
+    if ($exists !== false)
+    {
+      return "Obligation topic '$row[topic]' with text '$row[text]' already exists in DB (id=".$exists.")";
+    }
+
+    $stmtInsert = __METHOD__.'.insert';
+    $dbManager->prepare($stmtInsert,'INSERT INTO obligation_ref (ob_topic,ob_text,ob_md5)'
+            . ' VALUES ($1,$2,md5($2)) RETURNING ob_pk');
+    $resi = $dbManager->execute($stmtInsert,
+            array($row['topic'],$row['text']));
+    $new = $dbManager->fetchArray($resi);
+    $dbManager->freeResult($resi);
+
+    $associatedLicenses = "";
+    $licenses = explode(";",$row['licnames']);
+    foreach ($licenses as $license)
+    {
+      $licId = $this->obligationMap->getIdFromShortname($license);
+      if ($licId == '0')
+      {
+        $message = _("ERROR: License with shortname '$license' not found in the DB. Obligation not updated.");
+        return "<b>$message</b><p>";
+      }
+
+      if ($this->obligationMap->isLicenseAssociated($new['ob_pk'],$licId))
+      {
+        continue;
+      }
+
+      $this->obligationMap->associateLicenseWithObligation($new['ob_pk'],$licId);
+      if ($associatedLicenses == "")
+      {
+        $associatedLicenses = "$license";
+      }
+      else
+      {
+        $associatedLicenses .= ";$license";
+      }
+    }
+
+    $return = "Obligation topic '$row[topic]' was added and associated with licenses '$associatedLicenses' in DB";
+
+    return $return;
+  }
+
+}

--- a/src/lib/php/BusinessRules/ObligationMap.php
+++ b/src/lib/php/BusinessRules/ObligationMap.php
@@ -1,0 +1,111 @@
+<?php
+/*
+Copyright (C) 2017, Siemens AG
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+namespace Fossology\Lib\BusinessRules;
+
+use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\Util\Object;
+
+class ObligationMap extends Object
+{
+
+  /** @var DbManager */
+  private $dbManager;
+
+  public function __construct(DbManager $dbManager)
+  {
+    $this->dbManager = $dbManager;
+  }
+
+  /** @brief get the license id from the shortname */
+  public function getIdFromShortname($shortname)
+  {
+    $sql = "SELECT * from license_ref where rf_shortname = $1;";
+    $result = $this->dbManager->getSingleRow($sql,array($shortname));
+    return $result['rf_pk'];
+  }
+
+  /** @brief get the shortname of the license by Id */
+  public function getShortnameFromId($rfId)
+  {
+    $sql = "SELECT * FROM license_ref WHERE rf_pk = $1;";
+    $result = $this->dbManager->getSingleRow($sql,array($rfId));
+    return $result['rf_shortname'];
+  }
+
+  /** @brief get the list of licenses associated with the obligation */
+  public function getLicenseList($obId)
+  {
+    $liclist = "";
+    $sql = "SELECT rf_fk FROM obligation_map WHERE ob_fk=$obId;";
+    $stmt = __METHOD__.".om_$obId";
+    $this->dbManager->prepare($stmt,$sql);
+    $res = $this->dbManager->execute($stmt);
+    $vars = $this->dbManager->fetchAll($res);
+    $this->dbManager->freeResult($res);
+    foreach ($vars as $map_entry)
+    {
+      $licname = $this->getShortnameFromId($map_entry['rf_fk']);
+      if ($liclist == "")
+      {
+        $liclist = "$licname";
+      }
+      else
+      {
+        $liclist .= ";$licname";
+      }
+    }
+
+    return $liclist;
+  }
+
+  /** @brief check if the obligation is already associated with the license */
+  public function isLicenseAssociated($obId,$licId)
+  {
+    $sql = "SELECT * from obligation_map where ob_fk = $1 and rf_fk = $2;";
+    $result = $this->dbManager->getSingleRow($sql,array($obId,$licId));
+    if ($result)
+    {
+      return True;
+    }
+
+    return False;
+  }
+
+  /** @brief check if the text of this obligation is existing */
+  public function associateLicenseWithObligation($obId,$licId)
+  {
+    $sql = "INSERT INTO obligation_map (ob_fk, rf_fk) VALUES ($1, $2)";
+    $this->dbManager->prepare($stmt,$sql);
+    $res = $this->dbManager->execute($stmt,array($obId,$licId));
+    $this->dbManager->fetchArray($res);
+    $this->dbManager->freeResult($res);
+  }
+
+  /** @brief check if the text of this obligation is existing */
+  public function unassociateLicenseFromObligation($obId,$licId)
+  {
+    $sql = "DELETE FROM obligation_map WHERE ob_fk=$1 AND rf_fk=$2";
+    $stmt = __METHOD__.".omdel_$licId";
+    $this->dbManager->prepare($stmt,$sql);
+    $res = $this->dbManager->execute($stmt,array($obId,$licId));
+    $this->dbManager->fetchArray($res);
+    $this->dbManager->freeResult($res);
+  }
+
+}

--- a/src/lib/php/Plugin/FO_Plugin.php
+++ b/src/lib/php/Plugin/FO_Plugin.php
@@ -341,6 +341,7 @@ class FO_Plugin implements Plugin
 
     $styles = "<link rel='stylesheet' href='css/fossology.css'>\n";
     $styles .= "<link rel='stylesheet' href='css/jquery-ui.css'>\n";
+    $styles .= "<link rel='stylesheet' href='css/select2.min.css'>\n";
     $styles .= "<link rel='stylesheet' href='css/jquery.dataTables.css'>\n";
     $styles .= "<link rel='icon' type='image/x-icon' href='favicon.ico'>\n";
     $styles .= "<link rel='shortcut icon' type='image/x-icon' href='favicon.ico'>\n";
@@ -406,7 +407,7 @@ class FO_Plugin implements Plugin
       $response = $this->render($this->getTemplateName());
     }
     ob_end_clean();
-    
+
     return $response;
   }
 
@@ -434,8 +435,18 @@ class FO_Plugin implements Plugin
   public function renderString($templateName, $vars = null)
   {
     return $this->renderer->loadTemplate($templateName)->render($vars ?: $this->vars);
-  }  
-  
+  }
+
+  /**
+   * @brief Render JavaScript in the template's footer
+   *
+   * @param string $scripts
+   */
+  public function renderScripts($scripts)
+  {
+    $this->vars['scripts'] = $scripts;
+  }
+
   /**
    * @param string $templateName
    * @param array $vars

--- a/src/lib/php/common-db.php
+++ b/src/lib/php/common-db.php
@@ -145,6 +145,48 @@ function DB2KeyValArray($Table, $KeyCol, $ValCol, $Where="")
   return $ResArray;
 }
 
+/**
+ * \brief Create an array by using table
+ *        rows to source the values.
+ *
+ * \param $Table   tablename
+ * \param $ValCol  Value column name in $Table
+ * \param $Uniq    Sort out duplicates
+ * \param $Where   SQL where clause (optional)
+ *                 This can really be any clause following the
+ *                 table name in the sql
+ *
+ * \return
+ *  Array[Key] = Val for each row in the table
+ *  May be empty if no table rows or Where results
+ *  in no rows.
+ **/
+function DB2ValArray($Table, $ValCol, $Uniq=false, $Where="")
+{
+  global $PG_CONN;
+
+  $ResArray = array();
+
+  if ($Uniq)
+  {
+    $sql = "SELECT DISTINCT $ValCol from $Table $Where";
+  }
+  else
+  {
+    $sql = "SELECT $ValCol from $Table $Where";
+  }
+  $result = pg_query($PG_CONN, $sql);
+  DBCheckResult($result, $sql, __FILE__, __LINE__);
+
+  $i = 0;
+  while ($row = pg_fetch_assoc($result))
+  {
+    $ResArray[$i] = $row[$ValCol];
+    ++$i;
+  }
+  return $ResArray;
+}
+
 
 /**
  * \brief Check the postgres result for unexpected errors.

--- a/src/lib/php/common-ui.php
+++ b/src/lib/php/common-ui.php
@@ -31,22 +31,26 @@ use Symfony\Component\HttpFoundation\Session\Session;
  * \param $SelElt - True (default) if $SelectedVal is a value False if $SelectedVal is a key
  * \param $Options - Optional.  Options to add to the select statment.
  * For example, "id=myid onclick= ..."
+ * \param $ReturnKey - True (default) return the Key as value, if False return the Value
  *
  * \return a string of select html 
  */
-function Array2SingleSelect($KeyValArray, $SLName="unnamed", $SelectedVal= "",
-$FirstEmpty=false, $SelElt=true, $Options="")
+function Array2SingleSelect($KeyValArray, $SLName="unnamed", $SelectedVal= "", 
+$FirstEmpty=false, $SelElt=true, $Options="", $ReturnKey=true)
 {
   $str ="\n<select name='$SLName' $Options>\n";
   if ($FirstEmpty == true) $str .= "<option value='' > </option>\n";
-
+  
   foreach ($KeyValArray as $key => $val)
   {
     if ($SelElt == true)
     $SELECTED = ($val == $SelectedVal) ? "SELECTED" : "";
     else
     $SELECTED = ($key == $SelectedVal) ? "SELECTED" : "";
+    if ($ReturnKey == true)
     $str .= "<option value='$key' $SELECTED>".htmlentities($val, ENT_QUOTES)."</option>\n";
+    else
+    $str .= "<option value='$val' $SELECTED>".htmlentities($val, ENT_QUOTES)."</option>\n";
   }
   $str .= "</select>";
   return $str;

--- a/src/lib/php/services.xml.in
+++ b/src/lib/php/services.xml.in
@@ -139,10 +139,21 @@ without any warranty.
             <argument type="service" id="db.manager"/>
         </service>
 
+        <service id="businessrules.obligationmap" class="Fossology\Lib\BusinessRules\ObligationMap">
+        </service>
+        <service id="businessrules.obligationmap"
+                 class="Fossology\Lib\BusinessRules\ObligationMap">
+            <argument type="service" id="db.manager"/>
+        </service>
+
         <service id="app.license_csv_import" class="Fossology\Lib\Application\LicenseCsvImport">
             <argument type="service" id="db.manager"/>
         </service>
-    
+
+        <service id="app.obligation_csv_import" class="Fossology\Lib\Application\ObligationCsvImport">
+            <argument type="service" id="db.manager"/>
+        </service>
+
         <service id="ui.component.menu" class="Fossology\Lib\UI\Component\Menu">
             <argument type="service" id="twig.environment"/>
         </service>

--- a/src/www/ui/admin-obligation-file.php
+++ b/src/www/ui/admin-obligation-file.php
@@ -1,0 +1,443 @@
+<?php
+/***********************************************************
+ Copyright (C) 2008-2014 Hewlett-Packard Development Company, L.P.
+ Copyright (C) 2015-2017, Siemens AG
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***********************************************************/
+
+use Fossology\Lib\BusinessRules\LicenseMap;
+use Fossology\Lib\BusinessRules\ObligationMap;
+use Fossology\Lib\Db\DbManager;
+
+define("TITLE_admin_obligation_file", _("Obligations and Risks Administration"));
+
+class admin_obligation_file extends FO_Plugin
+{
+  /** @var DbManager */
+  private $dbManager;
+
+  /** @var ObligationMap */
+  private $obligationMap;
+
+  function __construct()
+  {
+    $this->Name       = "admin_obligation";
+    $this->Title      = TITLE_admin_obligation_file;
+    $this->MenuList   = "Admin::Obligation Admin";
+    $this->DBaccess   = PLUGIN_DB_ADMIN;
+    parent::__construct();
+
+    $this->dbManager = $GLOBALS['container']->get('db.manager');
+    $this->obligationMap = $GLOBALS['container']->get('businessrules.obligationmap');
+  }
+
+  /** @brief return an array of all obligation topics from the DB */
+  private function ObligationTopics()
+  {
+    $topicarray = DB2ValArray("obligation_ref", "ob_topic", true, " order by ob_topic");
+    return ($topicarray);
+  }
+
+  /** @brief check if the text of this obligation is existing */
+  private function isObligationTopicAndTextBlocked($obId,$topic,$text)
+  {
+    $sql = "SELECT count(*) from obligation_ref where ob_pk <> $1 and (ob_topic <> '' and ob_topic = $2) and (ob_text <> '' and ob_text = $3)";
+    $check_count = $this->dbManager->getSingleRow($sql,array($obId,$topic,$text));
+    return (0 < $check_count['count']);
+  }
+
+  /**
+   * \brief Customize submenus.
+   */
+  function RegisterMenus()
+  {
+    if ($this->State != PLUGIN_STATE_READY) { return(0); }
+
+    $URL = $this->Name."&add=y";
+    $text = _("Add new obligation");
+    menu_insert("Main::".$this->MenuList."::Add Obligation",0, $URL, $text);
+    $URL = $this->Name;
+    $text = _("Select obligation");
+    menu_insert("Main::".$this->MenuList."::Select Obligation",0, $URL, $text);
+  }
+
+  public function Output()
+  {
+    $V = ""; // menu_to_1html(menu_find($this->Name, $MenuDepth),0);
+    $errorstr = "Obligation or risk not added";
+
+    // update the db
+    if (@$_POST["updateit"])
+    {
+      $resultstr = $this->Updatedb($_POST);
+      $V .= $resultstr;
+      if (strstr($resultstr, $errorstr)) {
+        $V .= $this->Updatefm(0);
+      }
+      else {
+        $V .= $this->Inputfm();
+      }
+      return $V;
+    }
+
+    if (@$_REQUEST['add'] == 'y')
+    {
+      $V .= $this->Updatefm(0);
+      return $V;
+    }
+
+    // Add new rec to db
+    if (@$_POST["addit"])
+    {
+      $resultstr = $this->Adddb($_POST);
+      $V .= $resultstr;
+      if (strstr($resultstr, $errorstr)) {
+        $V .= $this->Updatefm(0);
+      }
+      else {
+        $V .= $this->Inputfm();
+      }
+      return $V;
+    }
+
+    // bring up the update form
+    $ob_pk = @$_REQUEST['ob_pk'];
+    if ($ob_pk)
+    {
+      $V .= $this->Updatefm($ob_pk);
+      return $V;
+    }
+
+    $V .= $this->Inputfm();
+    if (@$_POST['req_topic'])
+      $V .= $this->ObligationTopic($_POST['req_topic']);
+    return $V;
+  }
+
+  /**
+   * \brief Build the input form
+   *
+   * \return The input form as a string
+   */
+  function Inputfm()
+  {
+    $V = "<FORM name='Inputfm' action='?mod=" . $this->Name . "' method='POST'>";
+    $V.= _("From which topic do you wish to view the obligations and risks:<br>");
+
+    // qualify by license name
+    // all are optional
+    $V.= "<p>";
+    $V.= _("From topic: ");
+    $Topicarray = $this->ObligationTopics();
+    $Topicarray = array("All"=>"All") + $Topicarray;
+    $Selected = @$_REQUEST['req_topic'];
+    $Pulldown = Array2SingleSelect($Topicarray, "req_topic", $Selected, false, false, "", false);
+    $V.= $Pulldown;
+    $V.= "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
+    $text = _("Find");
+    $V.= "<INPUT type='submit' value='$text'>\n";
+    $V .= "</FORM>\n";
+    $V.= "<hr>";
+
+    return $V;
+  }
+
+
+  /**
+   * \brief Build the input form
+   *
+   * \param $license - license name
+   *
+   * \return The input form as a string
+   */
+  function ObligationTopic($topic)
+  {
+    global $PG_CONN;
+
+    $ob = "";     // output buffer
+
+    // look at all
+    if ($topic == "All")
+      $where = "";
+    else
+      $where = "WHERE ob_topic='". pg_escape_string($topic) ."' ";
+
+    $sql = "SELECT * FROM ONLY obligation_ref $where ORDER BY ob_pk";
+    $result = pg_query($PG_CONN, $sql);
+    DBCheckResult($result, $sql, __FILE__, __LINE__);
+
+    // print simple message if we have no results
+    if (pg_num_rows($result) == 0)
+    {
+      $topic = addslashes($topic);
+      $text1 = _("No obligation matching the topic");
+      $text2 = _("were found");
+      $ob .= "<br>$text1 '$topic' $text2.<br>";
+      pg_free_result($result);
+      return $ob;
+    }
+
+    $plural = (pg_num_rows($result) == 1) ? "" : "s";
+    $ob .= pg_num_rows($result) . " obligation$plural found.";
+
+    $ob .= "<table style='border: thin dotted gray'>";
+    $ob .= "<table rules='rows' cellpadding='3'>";
+    $ob .= "<tr>";
+    $text = _("Edit");
+    $ob .= "<th>$text</th>";
+    $text = _("Topic");
+    $ob .= "<th>$text</th>";
+    $text = _("Text");
+    $ob .= "<th>$text</th>";
+    $text = _("Associated Licenses");
+    $ob .= "<th>$text</th>";
+    $ob .= "</tr>";
+    $lineno = 0;
+    while ($row = pg_fetch_assoc($result))
+    {
+      if ($lineno++ % 2)
+        $style = "style='background-color:lavender'";
+      else
+        $style = "";
+      $ob .= "<tr $style>";
+
+      $associatedLicenses = $this->obligationMap->getLicenseList($row['ob_pk']);
+
+      // Edit button brings up full screen edit of all license_ref fields
+      $ob .= "<td align=center><a href='";
+      $ob .= Traceback_uri();
+      $ob .= "?mod=" . $this->Name .
+           "&ob_pk=$row[ob_pk]' >'".
+           "<img border=0 src='" . Traceback_uri() . "images/button_edit.png'></a></td>";
+
+      $ob .= "<td align=left>$row[ob_topic]</td>";
+      $vetext = htmlspecialchars($row['ob_text']);
+      $ob .= "<td><textarea readonly=readonly rows=3 cols=40>$vetext</textarea></td> ";
+      $ob .= "<td align=center>$associatedLicenses</td>";
+      $ob .= "</tr>";
+    }
+    pg_free_result($result);
+    $ob .= "</table>";
+    return $ob;
+  }
+
+  /**
+   * @brief Update forms
+   * @param int $ob_pk - for the obligation to update, empty to add
+   * @return string The input form
+   */
+  function Updatefm($ob_pk)
+  {
+    $vars = array();
+
+    $ob_pk_update = "";
+
+    if (0 < count($_POST)) {
+      $ob_pk_update = $_POST['ob_pk'];
+      if (!empty($ob_pk)) $ob_pk_update = $ob_pk;
+      else if (empty($ob_pk_update)) $ob_pk_update = $_GET['ob_pk'];
+    }
+
+    $vars['actionUri'] = "?mod=" . $this->Name."&ob_pk=$ob_pk_update";
+
+    if ($ob_pk)  // true if this is an update
+    {
+      $row = $this->dbManager->getSingleRow("SELECT * FROM ONLY obligation_ref WHERE ob_pk=$1", array($ob_pk),__METHOD__.'.forUpdate');
+      if ($row === false)
+      {
+        $text = _("No obligation matching this key");
+        $text1 = _("was found");
+        return "$text ($ob_pk) $text1.";
+      }
+
+      $associatedLicenses = $this->obligationMap->getLicenseList($ob_pk);
+      $vars['licnames'] = explode(";",$associatedLicenses);
+    }
+    else
+    {
+      $row = array('ob_active' =>'t', 'ob_text_updatable'=>'t');
+    }
+
+    foreach(array_keys($row) as $key)
+    {
+      if (array_key_exists($key, $_POST))
+      {
+        $row[$key] = $_POST[$key];
+      }
+    }
+
+    $vars['boolYesNoMap'] = array("true"=>"Yes", "false"=>"No");
+    $row['ob_active'] = $this->dbManager->booleanFromDb($row['ob_active'])?'true':'false';
+    $row['ob_text_updatable'] = $this->dbManager->booleanFromDb($row['ob_text_updatable'])?'true':'false';
+    $vars['isReadOnly'] = !(empty($ob_pk) || $row['ob_text_updatable']=='true');
+
+    $vars['obId'] = $ob_pk?:$ob_pk_update;
+
+    // get list of known license shortnames
+    $licenseMap = new LicenseMap($this->dbManager, 0, LicenseMap::REPORT);
+    $reportLicenses = $licenseMap->getTopLevelLicenseRefs();
+    $vars['licenseShortnames'] = array();
+    foreach ($reportLicenses as $licRef)
+    {
+      $vars['licenseShortnames'][$licRef->getShortName()] = $licRef->getShortName();
+    }
+    natcasesort($vars['licenseShortnames']);
+
+    $vars['licenseSelectorName'] = 'licenseSelector[]';
+    $vars['licenseSelectorId'] = 'licenseSelectorId';
+    $scripts = "<script src='scripts/tools.js' type='text/javascript'></script>
+      <script src='scripts/select2.full.min.js'></script>
+      <script type='text/javascript'>
+        $('#licenseSelectorId').select2({'placeholder': 'Select license associated with this obligation'});
+      </script>";
+
+    $this->renderScripts($scripts);
+    $allVars = array_merge($vars,$row);
+    return $this->renderString('admin_obligation-upload_form.html.twig', $allVars);
+  }
+
+  /**
+   * \brief Update the database
+   *
+   * \return An update status string
+   */
+  function Updatedb()
+  {
+    $obId = intval($_POST['ob_pk']);
+    $topic = trim($_POST['ob_topic']);
+    $licnames = $_POST['licenseSelector'];
+    $text = trim($_POST['ob_text']);
+    if (empty($topic)) {
+      $text = _("ERROR: The obligation topic is empty.");
+      return "<b>$text</b><p>";
+    }
+
+    if ($this->isObligationTopicAndTextBlocked($obId,$topic,$text))
+    {
+      $text = _("ERROR: The obligation topic and text already exist in the obligation list. Obligation not updated.");
+      return "<b>$text</b><p>";
+    }
+
+    $md5term = empty($text) ? 'null' : 'md5($5)';
+    $sql = "UPDATE obligation_ref SET
+        ob_active=$2, ob_topic=$3, ob_text_updatable=$4, ob_text=$5,
+        ob_md5=$md5term WHERE ob_pk=$1";
+    $params = array($obId,
+        $_POST['ob_active'],$topic,$_POST['ob_text_updatable'],$text);
+    $this->dbManager->prepare($stmt=__METHOD__.".$md5term", $sql);
+    $this->dbManager->freeResult($this->dbManager->execute($stmt,$params));
+
+    # Add new licenses
+    $associatedLicenses = "";
+    foreach ($licnames as $license)
+    {
+      $licId = $this->obligationMap->getIdFromShortname($license);
+      if ($this->obligationMap->isLicenseAssociated($obId,$licId))
+        continue;
+
+      $this->obligationMap->associateLicenseWithObligation($obId,$licId);
+      if ($associatedLicenses == "")
+        $associatedLicenses = "$license";
+      else
+        $associatedLicenses .= ";$license";
+    }
+
+    # Remove licenses that shouldn't be associated with the obligation any more
+    $unassociatedLicenses = "";
+    $allAssociatedLicenses = $this->obligationMap->getLicenseList($obId);
+    $allLicenses = explode(";", $allAssociatedLicenses);
+    $obsoleteLicenses = array_diff($allLicenses, $licnames);
+    foreach ($obsoleteLicenses as $toBeRemoved)
+    {
+      $licId = $this->obligationMap->getIdFromShortname($toBeRemoved);
+      $this->obligationMap->unassociateLicenseFromObligation($obId,$licId);
+      if ($unassociatedLicenses == "")
+        $unassociatedLicenses = "$toBeRemoved";
+      else
+        $unassociatedLicenses .= ";$toBeRemoved";
+    }
+
+    $ob = "Obligation '$_POST[ob_topic]' associated with licenses ";
+    if ($associatedLicenses != '')
+      $ob .=  "(+) '$associatedLicenses' ";
+    if ($unassociatedLicenses != '')
+      $ob .=  "(-) '$unassociatedLicenses' ";
+    $ob .= "updated.<p>";
+    return $ob;
+  }
+
+
+  /**
+   * \brief Add a new obligation_ref to the database
+   *
+   * \return An add status string
+   */
+  function Adddb()
+  {
+    $ob_topic = trim($_POST['ob_topic']);
+    $licnames = $_POST['licenseSelector'];
+    $ob_text = trim($_POST['ob_text']);
+
+    if (empty($ob_topic)) {
+      $text = _("ERROR: The obligation topic is empty.");
+      return "<b>$text</b><p>";
+    }
+
+    if (empty($licnames)) {
+      $text = _("ERROR: There are no licenses associated with this topic.");
+      return "<b>$text</b><p>";
+    }
+
+    if ($this->isObligationTopicAndTextBlocked(0,$ob_topic,$ob_text))
+    {
+      $text = _("ERROR: The obligation topic and text already exist in the obligation list. Obligation not added.");
+      return "<b>$text</b><p>";
+    }
+
+    $md5term = empty($ob_text) ? 'null' : 'md5($3)';
+    $stmt = __METHOD__.'.ob';
+    $sql = "INSERT into obligation_ref (ob_active, ob_topic, ob_md5, ob_text, ob_text_updatable) VALUES ($1, $2, $md5term, $3, $4) RETURNING ob_pk";
+    $this->dbManager->prepare($stmt,$sql);
+    $res = $this->dbManager->execute($stmt,array($_POST['ob_active'],$ob_topic,$ob_text, $_POST['ob_text_updatable']));
+    $row = $this->dbManager->fetchArray($res);
+    $obId = $row['ob_pk'];
+
+    $associatedLicenses = "";
+    foreach ($licnames as $license)
+    {
+      $licId = $this->obligationMap->getIdFromShortname($license);
+      if ($licId == '0')
+      {
+        $message = _("ERROR: License with shortname '$license' not found in the DB. Obligation not updated.");
+        return "<b>$message</b><p>";
+      }
+
+      if ($this->obligationMap->isLicenseAssociated($obId,$licId))
+        continue;
+
+      $this->obligationMap->associateLicenseWithObligation($obId,$licId);
+      if ($associatedLicenses == "")
+        $associatedLicenses = "$license";
+      else
+        $associatedLicenses .= ";$license";
+    }
+
+    $ob = "Obligation '$_POST[ob_topic]' associated with licenses '$associatedLicenses' (id=$obId) added.<p>";
+    return $ob;
+  }
+
+}
+
+$NewPlugin = new admin_obligation_file;

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -883,7 +883,7 @@
   $Schema["TABLE"]["license_candidate"]["group_fk"]["ADD"] = "ALTER TABLE \"license_candidate\" ADD COLUMN \"group_fk\" int8";
   $Schema["TABLE"]["license_candidate"]["group_fk"]["ALTER"] = "ALTER TABLE \"license_candidate\" ALTER COLUMN \"group_fk\" DROP NOT NULL";
 
-  
+
   $Schema["TABLE"]["license_ref_bulk"]["lrb_pk"]["DESC"] = "COMMENT ON COLUMN \"license_ref_bulk\".\"lrb_pk\" IS 'Primary Key'";
   $Schema["TABLE"]["license_ref_bulk"]["lrb_pk"]["ADD"] = "ALTER TABLE \"license_ref_bulk\" ADD COLUMN \"lrb_pk\" int8 DEFAULT nextval('license_ref_bulk_lrb_pk_seq'::regclass)";
   $Schema["TABLE"]["license_ref_bulk"]["lrb_pk"]["ALTER"] = "ALTER TABLE \"license_ref_bulk\" ALTER COLUMN \"lrb_pk\" SET NOT NULL, ALTER COLUMN \"lrb_pk\" SET DEFAULT nextval('license_ref_bulk_lrb_pk_seq'::regclass)";
@@ -929,6 +929,42 @@
   $Schema["TABLE"]["mimetype"]["mimetype_name"]["DESC"] = "";
   $Schema["TABLE"]["mimetype"]["mimetype_name"]["ADD"] = "ALTER TABLE \"mimetype\" ADD COLUMN \"mimetype_name\" text";
   $Schema["TABLE"]["mimetype"]["mimetype_name"]["ALTER"] = "ALTER TABLE \"mimetype\" ALTER COLUMN \"mimetype_name\" SET NOT NULL";
+
+  $Schema["TABLE"]["obligation_map"]["om_pk"]["DESC"] = "COMMENT ON COLUMN \"obligation_map\".\"om_pk\" IS 'Primary Key'";
+  $Schema["TABLE"]["obligation_map"]["om_pk"]["ADD"] = "ALTER TABLE \"obligation_map\" ADD COLUMN \"om_pk\" int8 DEFAULT nextval('obligation_map_om_pk_seq'::regclass)";
+  $Schema["TABLE"]["obligation_map"]["om_pk"]["ALTER"] = "ALTER TABLE \"obligation_map\" ALTER COLUMN \"om_pk\" SET NOT NULL, ALTER COLUMN \"om_pk\" SET DEFAULT nextval('obligation_map_om_pk_seq'::regclass)";
+
+  $Schema["TABLE"]["obligation_map"]["ob_fk"]["DESC"] = "COMMENT ON COLUMN \"obligation_map\".\"ob_fk\" IS 'Obligation topic key as in obligation_ref'";
+  $Schema["TABLE"]["obligation_map"]["ob_fk"]["ADD"] = "ALTER TABLE \"obligation_map\" ADD COLUMN \"ob_fk\" int8";
+  $Schema["TABLE"]["obligation_map"]["ob_fk"]["ALTER"] = "ALTER TABLE \"obligation_map\" ALTER COLUMN \"ob_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["obligation_map"]["rf_fk"]["DESC"] = "COMMENT ON COLUMN \"obligation_map\".\"rf_fk\" IS 'Reference license key as in rf_license'";
+  $Schema["TABLE"]["obligation_map"]["rf_fk"]["ADD"] = "ALTER TABLE \"obligation_map\" ADD COLUMN \"rf_fk\" int8";
+  $Schema["TABLE"]["obligation_map"]["rf_fk"]["ALTER"] = "ALTER TABLE \"obligation_map\" ALTER COLUMN \"rf_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["obligation_ref"]["ob_pk"]["DESC"] = "COMMENT ON COLUMN \"obligation_ref\".\"ob_pk\" IS 'Primary Key'";
+  $Schema["TABLE"]["obligation_ref"]["ob_pk"]["ADD"] = "ALTER TABLE \"obligation_ref\" ADD COLUMN \"ob_pk\" int8 DEFAULT nextval('obligation_ref_ob_pk_seq'::regclass)";
+  $Schema["TABLE"]["obligation_ref"]["ob_pk"]["ALTER"] = "ALTER TABLE \"obligation_ref\" ALTER COLUMN \"ob_pk\" SET NOT NULL, ALTER COLUMN \"ob_pk\" SET DEFAULT nextval('obligation_ref_ob_pk_seq'::regclass)";
+
+  $Schema["TABLE"]["obligation_ref"]["ob_topic"]["DESC"] = "COMMENT ON COLUMN \"obligation_ref\".\"ob_topic\" IS 'Include notices, Copyleft effect, ...'";
+  $Schema["TABLE"]["obligation_ref"]["ob_topic"]["ADD"] = "ALTER TABLE \"obligation_ref\" ADD COLUMN \"ob_topic\" text";
+  $Schema["TABLE"]["obligation_ref"]["ob_topic"]["ALTER"] = "ALTER TABLE \"obligation_ref\" ALTER COLUMN \"ob_topic\" SET NOT NULL";
+
+  $Schema["TABLE"]["obligation_ref"]["ob_text"]["DESC"] = "COMMENT ON COLUMN \"obligation_ref\".\"ob_text\" IS 'Obligation text'";
+  $Schema["TABLE"]["obligation_ref"]["ob_text"]["ADD"] = "ALTER TABLE \"obligation_ref\" ADD COLUMN \"ob_text\" text";
+  $Schema["TABLE"]["obligation_ref"]["ob_text"]["ALTER"] = "ALTER TABLE \"obligation_ref\" ALTER COLUMN \"ob_text\" SET NOT NULL";
+
+  $Schema["TABLE"]["obligation_ref"]["ob_active"]["DESC"] = "COMMENT ON COLUMN \"obligation_ref\".\"ob_active\" IS 'change this to false if you don''t want this obligation to be used in new reports'";
+  $Schema["TABLE"]["obligation_ref"]["ob_active"]["ADD"] = "ALTER TABLE \"obligation_ref\" ADD COLUMN \"ob_active\" bool DEFAULT true";
+  $Schema["TABLE"]["obligation_ref"]["ob_active"]["ALTER"] = "ALTER TABLE \"obligation_ref\" ALTER COLUMN \"ob_active\" SET NOT NULL, ALTER COLUMN \"ob_active\" SET DEFAULT true";
+
+  $Schema["TABLE"]["obligation_ref"]["ob_text_updatable"]["DESC"] = "COMMENT ON COLUMN \"obligation_ref\".\"ob_text_updatable\" IS 'true if the obligation text can be updated'";
+  $Schema["TABLE"]["obligation_ref"]["ob_text_updatable"]["ADD"] = "ALTER TABLE \"obligation_ref\" ADD COLUMN \"ob_text_updatable\" bool DEFAULT false";
+  $Schema["TABLE"]["obligation_ref"]["ob_text_updatable"]["ALTER"] = "ALTER TABLE \"obligation_ref\" ALTER COLUMN \"ob_text_updatable\" SET NOT NULL, ALTER COLUMN \"ob_text_updatable\" SET DEFAULT false";
+
+  $Schema["TABLE"]["obligation_ref"]["ob_md5"]["DESC"] = "COMMENT ON COLUMN \"obligation_ref\".\"ob_md5\" IS 'md5 of the obligation text, used to keep duplicates out of the system'";
+  $Schema["TABLE"]["obligation_ref"]["ob_md5"]["ADD"] = "ALTER TABLE \"obligation_ref\" ADD COLUMN \"ob_md5\" char(32)";
+  $Schema["TABLE"]["obligation_ref"]["ob_md5"]["ALTER"] = "ALTER TABLE \"obligation_ref\" ALTER COLUMN \"ob_md5\" DROP NOT NULL";
 
 
   $Schema["TABLE"]["package"]["package_pk"]["DESC"] = "";
@@ -1586,6 +1622,12 @@
   $Schema["SEQUENCE"]["mimetype_mimetype_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"mimetype_mimetype_pk_seq\"";
   $Schema["SEQUENCE"]["mimetype_mimetype_pk_seq"]["UPDATE"] = "SELECT setval('mimetype_mimetype_pk_seq',(SELECT greatest(1,max(mimetype_pk)) val FROM mimetype))";
 
+  $Schema["SEQUENCE"]["obligation_map_om_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"obligation_map_om_pk_seq\"";
+  $Schema["SEQUENCE"]["obligation_map_om_pk_seq"]["UPDATE"] = "SELECT setval('obligation_map_om_pk_seq',(SELECT greatest(1,max(om_pk)) val FROM obligation_map))";
+
+  $Schema["SEQUENCE"]["obligation_ref_ob_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"obligation_ref_ob_pk_seq\"";
+  $Schema["SEQUENCE"]["obligation_ref_ob_pk_seq"]["UPDATE"] = "SELECT setval('obligation_ref_ob_pk_seq',(SELECT greatest(1,max(ob_pk)) val FROM obligation_ref))";
+
   $Schema["SEQUENCE"]["pfile_pfile_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"pfile_pfile_pk_seq\"";
   $Schema["SEQUENCE"]["pfile_pfile_pk_seq"]["UPDATE"] = "SELECT setval('pfile_pfile_pk_seq',(SELECT greatest(1,max(pfile_pk)) val FROM pfile))";
 
@@ -1822,4 +1864,3 @@
   $Schema["INHERITS"]["nomos_ars"] = "ars_master";
   $Schema["INHERITS"]["monk_ars"] = "ars_master";
   $Schema["INHERITS"]["license_candidate"] = "license_ref";
-

--- a/src/www/ui/page/AdminObligationFromCSV.php
+++ b/src/www/ui/page/AdminObligationFromCSV.php
@@ -1,0 +1,101 @@
+<?php
+/***********************************************************
+ * Copyright (C) 2008-2013 Hewlett-Packard Development Company, L.P.
+ * Copyright (C) 2014 Siemens AG
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***********************************************************/
+
+namespace Fossology\UI\Page;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Plugin\DefaultPlugin;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Fossology\Lib\Application\LicenseCsvImport;
+
+/**
+ * \brief Upload a file from the users computer using the UI.
+ */
+class AdminObligationFromCSV extends DefaultPlugin
+{
+  const NAME = "admin_obligation_from_csv";
+  const KEY_UPLOAD_MAX_FILESIZE = 'upload_max_filesize';
+
+  function __construct()
+  {
+    parent::__construct(self::NAME, array(
+        self::TITLE => "Admin Obligation CSV Import",
+        self::MENU_LIST => "Admin::Obligation Admin::CSV Import",
+        self::REQUIRES_LOGIN => true,
+        self::PERMISSION => Auth::PERM_ADMIN
+    ));
+  }
+
+  /**
+   * @param Request $request
+   * @return Response
+   */
+  protected function handle (Request $request)
+  {
+    $vars = array();
+
+    if ($request->isMethod('POST'))
+    {
+      $uploadFile = $request->files->get('file_input');
+      $delimiter = $request->get('delimiter')?:',';
+      $enclosure = $request->get('enclosure')?:'"';
+      $vars['message'] = $this->handleFileUpload($uploadFile,$delimiter,$enclosure);
+    }
+
+    $vars[self::KEY_UPLOAD_MAX_FILESIZE] = ini_get(self::KEY_UPLOAD_MAX_FILESIZE);
+    $vars['baseUrl'] = $request->getBaseUrl();
+
+    return $this->render("admin_license_from_csv.html.twig", $this->mergeWithDefault($vars));
+  }
+
+  /**
+   * @param UploadedFile $uploadedFile
+   * @return null|string
+   */
+  protected function handleFileUpload($uploadedFile,$delimiter=',',$enclosure='"')
+  {
+    $errMsg = '';
+    if ( !($uploadedFile instanceof UploadedFile) )
+    {
+      $errMsg = _("No file selected");
+    }
+    elseif ($uploadedFile->getSize() == 0 && $uploadedFile->getError() == 0)
+    {
+      $errMsg = _("Larger than upload_max_filesize ") . ini_get(self::KEY_UPLOAD_MAX_FILESIZE);
+    }
+    elseif($uploadedFile->getClientOriginalExtension()!='csv')
+    {
+      $errMsg = _('Invalid extension ').$uploadedFile->getClientOriginalExtension().' of file '.$uploadedFile->getClientOriginalName();
+    }
+    if (!empty($errMsg))
+    {
+      return $errMsg;
+    }
+    /** @var LicenseCsvImport */
+    $obligationCsvImport = $this->getObject('app.obligation_csv_import');
+    $obligationCsvImport->setDelimiter($delimiter);
+    $obligationCsvImport->setEnclosure($enclosure);
+    return $obligationCsvImport->handleFile($uploadedFile->getRealPath());
+  }
+
+}
+
+register_plugin(new AdminObligationFromCSV());

--- a/src/www/ui/page/AdminObligationToCSV.php
+++ b/src/www/ui/page/AdminObligationToCSV.php
@@ -1,0 +1,60 @@
+<?php
+/***********************************************************
+ * Copyright (C) 2014 Siemens AG
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***********************************************************/
+
+namespace Fossology\UI\Page;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Plugin\DefaultPlugin;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AdminObligationToCSV extends DefaultPlugin
+{
+  const NAME = "admin_obligation_to_csv";
+
+  function __construct()
+  {
+    parent::__construct(self::NAME, array(
+        self::TITLE => "Admin Obligation CSV Export",
+        self::MENU_LIST => "Admin::Obligation Admin::CSV Export",
+        self::REQUIRES_LOGIN => true,
+        self::PERMISSION => Auth::PERM_ADMIN
+    ));
+  }
+
+  /**
+   * @param Request $request
+   * @return Response
+   */
+  protected function handle(Request $request)
+  {
+    $obligationCsvExport = new \Fossology\Lib\Application\ObligationCsvExport($this->getObject('db.manager'));
+    $content = $obligationCsvExport->createCsv(intval($request->get('rf')));
+
+    $headers = array(
+        'Content-type' => 'text/csv',
+        'Pragma' => 'no-cache',
+        'Cache-Control' => 'no-cache, must-revalidate, maxage=1, post-check=0, pre-check=0',
+        'Expires' => 'Expires: Thu, 19 Nov 1981 08:52:00 GMT');
+
+    return new Response($content, Response::HTTP_OK, $headers);
+  }
+
+}
+
+register_plugin(new AdminObligationToCSV());

--- a/src/www/ui/template/admin_obligation-upload_form.html.twig
+++ b/src/www/ui/template/admin_obligation-upload_form.html.twig
@@ -1,0 +1,45 @@
+{# Copyright 2014-2017 Siemens AG
+
+   Copying and distribution of this file, with or without modification,
+   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
+   This file is offered as-is, without any warranty.
+#}
+<form name="Updatefm" action="{{ actionUri }}" method="post">
+  <input type="hidden" name="ob_pk" value="{{ ob_pk }}"/>
+  <input type="hidden" name="{% if ob_pk %}updateit{% else %}addit{% endif %}" value="true"/>
+  <table>
+    {% import 'include/macros.html.twig' as macro %}
+    <tr>
+      <td align="right">{{ 'Active'|trans }}</td>
+      <td align="left">{{ macro.select('ob_active',boolYesNoMap,'ob_active',ob_active) }}</td>
+    </tr>
+    <tr>
+      <td align="right">{{ 'Obligation Topic'|trans }}
+        {% if isReadOnly %}
+          ({{ 'read only'|trans }}){% endif %}
+      </td>
+      <td><input type="text" name="ob_topic" value="{{ ob_topic|e }}" size="30"></td>
+    </tr>
+    <tr>
+      <td align="right">{{ 'Obligation Text'|trans }}
+        {% if isReadOnly %}
+          ({{ 'read only'|trans }}){% endif %}
+      </td>
+      <td>
+        <textarea name="ob_text" rows="10" cols="80" {% if isReadOnly %} readonly="readonly" {% endif %}>{{ ob_text|e }}</textarea>
+      </td>
+    </tr>
+    <tr>
+      <td align="right">{{ "Associated Licenses"|trans }}</td>
+      <td align="left">{{ macro.selectwitharray(licenseSelectorName, licenseShortnames, licenseSelectorId, licnames, 'style="min-width:420px;"', 5) }}</td>
+    </tr>
+    <tr>
+      <td align="right">{{ 'Text Updatable'|trans }}</td>
+      <td align="left">{{ macro.select('ob_text_updatable',boolYesNoMap,'ob_text_updatable',ob_text_updatable) }}</td>
+    </tr>
+  </table>
+  {% if obId %}
+    <a href="?mod=admin_obligation_to_csv&amp;ob={{ obId }}" class="buttonLink">{{ 'Export as CSV'|trans }}</a>
+  {% endif %}
+  <input type="submit" value="{% if obId %}{{ 'Update'|trans }}{% else %}{{ 'Add obligation'|trans }}{% endif %}"/>
+</form>

--- a/src/www/ui/template/include/macros.html.twig
+++ b/src/www/ui/template/include/macros.html.twig
@@ -42,3 +42,23 @@
     {% endfor %}
   </select>
 {% endmacro %}
+
+{% macro selectwitharray(name, options, id, selected, action, size) %}
+  {% if size is not defined %}
+    {% set size = 0 %}
+  {% endif %}
+  <select name="{{ name }}"{% if id is defined %} id="{{ id }}"{% endif %}{% if size > 0  %} multiple="multiple" size="{{ size }}"{% endif %}{% if action is defined %}
+    {{ action}}{% endif %}>
+    {% for key, value in options %}
+      {% set selectedflag = false %}
+      {% for num, license in selected %}
+        {% if license == value %}
+          {% set selectedflag = true %}
+        {% endif %}
+      {% endfor %}
+      <option value="{{ key }}" {% if selectedflag %}selected="selected"{% endif %}>
+      {{ value|e }}
+      </option>
+    {% endfor %}
+  </select>
+{% endmacro %}


### PR DESCRIPTION
Create two new tables: **obligation_ref** and **obligation_map**.

The table **obligation_ref** contains the topic and text of the obligations.
The table **obligation_map** maps obligation references to licenses.

The combination of an obligation topic (`ob_topic`) and text (`ob_text`)
must be unique. One obligation can be mapped to several licenses.
The license shortnames are used in the UI, only licenses already
available in the **license_ref** table can be used. The UI uses javascript
code for the license selection, the implementation is based on "select2".

CSV export and import functions are available. The license list
is exported as a string with ";" as separator.