### PR TITLE
fix(delagent): delete child folder by parent id

### DIFF
--- a/src/delagent/agent/delagent.c
+++ b/src/delagent/agent/delagent.c
@@ -2,7 +2,7 @@
  delagent: Remove an upload from the DB and repository
 
  Copyright (C) 2007-2013 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2015-2016 Siemens AG
+ Copyright (C) 2015-2017 Siemens AG
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -54,6 +54,7 @@ void usage (char *Name)
   fprintf(stderr,"  -F # :: Delete folder ID and all uploads under this folder.\n");
   fprintf(stderr,"          Folder '1' is the default folder.  '-F 1' will delete\n");
   fprintf(stderr,"          every upload and folder in the navigation tree.\n");
+  fprintf(stderr,"          use -P to indicate parent of the copied folder.\n");
   fprintf(stderr,"  -s   :: Run from the scheduler.\n");
   fprintf(stderr,"  -T   :: TEST -- do not update the DB or delete any files (just pretend)\n");
   fprintf(stderr,"  -v   :: Verbose (-vv for more verbose)\n");
@@ -118,7 +119,7 @@ int main (int argc, char *argv[])
 {
   int c;
   int listProj=0, listFolder=0;
-  long delUpload=0, delFolder=0, delLicense=0;
+  long delUpload=0, delFolder=0, delLicense=0, delFolderParent=0;
   int scheduler=0; /* should it run from the scheduler? */
   int gotArg=0;
   char *agent_desc = "Deletes upload.  Other list/delete options available from the command line.";
@@ -141,7 +142,7 @@ int main (int argc, char *argv[])
     {0, 0, 0, 0}
   };
 
-  while ((c = getopt_long (argc, argv, "n:p:ifF:lL:sTuU:vVc:h",
+  while ((c = getopt_long (argc, argv, "n:p:ifF:lL:sTuU:P:vVc:h",
          long_options, &option_index)) != -1)
   {
     switch (c)
@@ -165,6 +166,10 @@ int main (int argc, char *argv[])
         break;
       case 'L':
         delLicense=atol(optarg);
+        gotArg=1;
+        break;
+      case 'P':
+        delFolderParent=atol(optarg);
         gotArg=1;
         break;
       case 's':
@@ -244,7 +249,7 @@ int main (int argc, char *argv[])
     }
     if (delFolder)
     {
-      returnedCode = deleteFolder(delFolder, user_id, user_perm);
+      returnedCode = deleteFolder(delFolder, delFolderParent, user_id, user_perm);
 
       writeMessageAfterDelete("folder", delFolder, user_name, returnedCode);
     }

--- a/src/delagent/agent/delagent.h
+++ b/src/delagent/agent/delagent.h
@@ -1,6 +1,6 @@
 /********************************************************
  Copyright (C) 2007-2012 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2015-2016 Siemens AG
+ Copyright (C) 2015-2017 Siemens AG
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -41,6 +41,7 @@ extern int Test;
 extern PGconn* db_conn;
 
 #define MAXSQL  1024
+#define MAXSQLFolder 1024
 #define MAXLINE 1024
 #define myBUFSIZ 2048
 
@@ -60,7 +61,7 @@ int listUploads(int user_id, int user_perm);
 /* function that delete actual things */
 int deleteLicense(long UploadId, int user_perm);
 int deleteUpload(long UploadId, int user_id, int user_perm);
-int deleteFolder(long FolderId, int user_id, int user_perm);
+int deleteFolder(long cFolder, long pFolder, int user_id, int user_perm);
 
 /* for usage from scheduler */
 void doSchedulerTasks();

--- a/src/delagent/agent/util.c
+++ b/src/delagent/agent/util.c
@@ -560,13 +560,10 @@ int listFoldersRecurse (long Parent, int Depth, long Row, int DelFlag, int user_
     return 1;
   }
 
-  snprintf(SQLFolder, MAXSQLFolder,"SELECT COUNT(*) FROM folderlist WHERE folder_pk=%ld",Parent);
-  resultFolder = PQexec(db_conn, SQLFolder);
-  count= atoi(PQgetvalue(resultFolder,0,0));
-  /* Find all folders with this parent and recurse */
+  /* Find all folders with this parent and recurse, but don't show uploads, if they also exist in other directories */
   snprintf(SQL,MAXSQL,"SELECT folder_pk,foldercontents_mode,name,description,upload_pk FROM folderlist "
-          "WHERE parent=%ld "
-          "ORDER BY name,parent,folder_pk",Parent);
+          "WHERE parent=%ld AND upload_pk NOT IN (SELECT upload_pk FROM folderlist WHERE parent!=%ld GROUP BY upload_pk HAVING COUNT(*) > 0) "
+          "ORDER BY name,parent,folder_pk",Parent,Parent);
   result = PQexec(db_conn, SQL);
   if (fo_checkPQresult(db_conn, result, SQL, __FILE__, __LINE__))
   {

--- a/src/delagent/ui/admin-folder-delete.php
+++ b/src/delagent/ui/admin-folder-delete.php
@@ -1,10 +1,7 @@
 <?php
-
-use Fossology\Lib\Auth\Auth;
-use Fossology\Lib\Db\DbManager;
 /***********************************************************
  Copyright (C) 2008-2013 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2015-2016 Siemens AG
+ Copyright (C) 2015-2017 Siemens AG
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -19,6 +16,9 @@ use Fossology\Lib\Db\DbManager;
  with this program; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  ***********************************************************/
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Db\DbManager;
 
 define("TITLE_admin_folder_delete", _("Delete Folder"));
 
@@ -47,13 +47,14 @@ class admin_folder_delete extends FO_Plugin {
    */
   function Delete($folderpk, $userId) 
   {
+    $splitFolder = explode(" ",$folderpk);
     /* Can't remove top folder */
-    if ($folderpk == FolderGetTop()) {
+    if ($splitFolder[1] == FolderGetTop()) {
       $text = _("Can Not Delete Root Folder");
       return ($text);
     }
     /* Get the folder's name */
-    $FolderName = FolderGetName($folderpk);
+    $FolderName = FolderGetName($splitFolder[1]);
     /* Prepare the job: job "Delete" */
     $groupId = Auth::getGroupId();
     $jobpk = JobAddJob($userId, $groupId, "Delete Folder: $FolderName");
@@ -81,11 +82,12 @@ class admin_folder_delete extends FO_Plugin {
    */
   public function Output() {
     /* If this is a POST, then process the request. */
-    $folder = GetParm('folder', PARM_INTEGER);
+    $folder = GetParm('folder', PARM_RAW);
+    $splitFolder = explode(" ",$folder);
     if (!empty($folder)) {
       $userId = Auth::getUserId();
       $sql = "SELECT folder_name FROM folder join users on (users.user_pk = folder.user_fk or users.user_perm = 10) where folder_pk = $1 and users.user_pk = $2;";
-      $Folder = $this->dbManager->getSingleRow($sql,array($folder,$userId),__METHOD__."GetRowWithFolderName");
+      $Folder = $this->dbManager->getSingleRow($sql,array($splitFolder[1],$userId),__METHOD__."GetRowWithFolderName");
       if(!empty($Folder['folder_name'])){
         $rc = $this->Delete($folder, $userId);
         if (empty($rc)) {
@@ -125,7 +127,7 @@ class admin_folder_delete extends FO_Plugin {
     $V.= "<select name='folder'>\n";
     $text = _("select folder");
     $V.= "<option value=''>[$text]</option>\n";
-    $V.= FolderListOption(-1, 0);
+    $V.= FolderListOption(-1, 0, 1, -1, true);
     $V.= "</select><P />\n";
     $text = _("Delete");
     $V.= "<input type='submit' value='$text'>\n";

--- a/src/lib/php/common-folders.php
+++ b/src/lib/php/common-folders.php
@@ -1,7 +1,7 @@
 <?php
 /***********************************************************
  Copyright (C) 2008-2015 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2014 Siemens AG
+ Copyright (C) 2014-2017 Siemens AG
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -170,7 +170,7 @@ function GetFolderFromItem($upload_pk="", $uploadtree_pk="")
  *
  * \return HTML of the folder tree
  */
-function FolderListOption($ParentFolder,$Depth, $IncludeTop=1, $SelectId=-1)
+function FolderListOption($ParentFolder,$Depth, $IncludeTop=1, $SelectId=-1, $linkParent=false, $OldParent=0)
 {
   if ($ParentFolder == "-1") { $ParentFolder = FolderGetTop(); }
   if (empty($ParentFolder)) { return; }
@@ -183,6 +183,11 @@ function FolderListOption($ParentFolder,$Depth, $IncludeTop=1, $SelectId=-1)
     if ($ParentFolder == $SelectId)
     {
       $V .= "<option value='$ParentFolder' SELECTED>";
+    }
+    elseif($linkParent)
+    {
+      if(empty($OldParent)) $OldParent=0;
+      $V .= "<option value='$OldParent $ParentFolder'>";      
     }
     else
     {
@@ -224,7 +229,7 @@ function FolderListOption($ParentFolder,$Depth, $IncludeTop=1, $SelectId=-1)
     if ($Depth > 0) { $Hide = "style='display:none;'"; }
     while($row = pg_fetch_assoc($result))
     {
-      $V .= FolderListOption($row['folder_pk'],$Depth+1,$IncludeTop,$SelectId);
+      $V .= FolderListOption($row['folder_pk'],$Depth+1,$IncludeTop,$SelectId,$linkParent,$row['parent']);
     }
   }
   pg_free_result($result);

--- a/src/www/ui/page/AdminContentDelete.php
+++ b/src/www/ui/page/AdminContentDelete.php
@@ -1,6 +1,6 @@
 <?php
 /***********************************************************
- Copyright (C) 2015 Siemens AG
+ Copyright (C) 2015-2017 Siemens AG
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -25,7 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class AdminContentDelete extends DefaultPlugin
 {
-  const NAME = 'content_delete';
+  const NAME = 'content_unlink';
   
   /** @var FolderDao */
   private $folderDao;


### PR DESCRIPTION
**Delete child folder from command line.** 

Deletion of child folder use to delete all the reference folders as there was no link to its parent.  now use "-p" to indicate the child folders parent.

Also included https://github.com/fossology/fossology/pull/788 after removing a run-time warning

To reproduce issue:

Create a new Folder with Name "TestFolder"
Upload file (in this example test.zip)
Copy test.zip into TestFolder -> test.zip should now exist in the Software Repository and in the folder TestFolder
Delete TestFolder
Expected Behavior: test.zip still exists in the Software Repository, because it was only copied from there in TestFolder before
Actual Behavior: test.zip is gone from the Software Repository
This commit should fix this issue. Testing from more contributors is still necessary 