### PR TITLE
fix(licenseView): display clearing history for all clearings done on …

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Copyright (C) 2014-2015, Siemens AG
+Copyright (C) 2014-2017, Siemens AG
 Author: Johannes Najjar
 
 This program is free software; you can redistribute it and/or
@@ -150,7 +150,7 @@ class ClearingDao extends Object
    * @param bool $onlyCurrent
    * @return ClearingDecision[]
    */
-  function getFileClearings(ItemTreeBounds $itemTreeBounds, $groupId, $onlyCurrent=true)
+  function getFileClearings(ItemTreeBounds $itemTreeBounds, $groupId, $onlyCurrent=true, $forClearingHistory=false)
   {
     $this->dbManager->begin();
 
@@ -161,7 +161,7 @@ class ClearingDao extends Object
 
     $decisionsCte = $this->getRelevantDecisionsCte($itemTreeBounds, $groupId, $onlyCurrent, $statementName, $params, $condition);
 
-    $clearingsWithLicensesArray = $this->getDecisionsFromCte($decisionsCte, $statementName, $params);
+    $clearingsWithLicensesArray = $this->getDecisionsFromCte($decisionsCte, $statementName, $params, $forClearingHistory);
 
     $this->dbManager->commit();
     return $clearingsWithLicensesArray;
@@ -204,7 +204,7 @@ class ClearingDao extends Object
    * @param array $params
    * @return ClearingDecision[]
    */
-  private function getDecisionsFromCte($decisionsCte, $statementName, $params) {
+  private function getDecisionsFromCte($decisionsCte, $statementName, $params, $forClearingHistory=false) {
     $sql = "$decisionsCte
             SELECT
               decision.*,
@@ -220,7 +220,7 @@ class ClearingDao extends Object
               ce.reportinfo AS reportinfo,
               ce.comment AS comment
             FROM decision
-              LEFT JOIN users ON decision.user_id = users.user_pk
+            LEFT JOIN users ON decision.user_id = users.user_pk
             LEFT JOIN clearing_decision_event cde ON cde.clearing_decision_fk = decision.id
             LEFT JOIN clearing_event ce ON ce.clearing_event_pk = cde.clearing_event_fk
             LEFT JOIN license_ref lr ON lr.rf_pk = ce.rf_fk
@@ -264,7 +264,9 @@ class ClearingDao extends Object
         $firstMatch = false;
         //prepare the new one
         $previousClearingId = $clearingId;
-        $previousItemId = $itemId;
+        if(!$forClearingHistory){
+          $previousItemId = $itemId;
+        }
         $clearingEvents = array();
         $clearingDecisionBuilder = ClearingDecisionBuilder::create()
             ->setClearingId($row['id'])

--- a/src/www/ui/ui-clearing-view.php
+++ b/src/www/ui/ui-clearing-view.php
@@ -1,6 +1,6 @@
 <?php
 /*
- Copyright (C) 2014-2015, Siemens AG
+ Copyright (C) 2014-2017, Siemens AG
  Author: Daniele Fognini, Johannes Najjar
 
  This program is free software; you can redistribute it and/or
@@ -270,7 +270,7 @@ class ClearingView extends FO_Plugin
     $clearingDecisions = null;
     if ($isSingleFile || $hasWritePermission)
     {
-      $clearingDecisions = $this->clearingDao->getFileClearings($itemTreeBounds, $groupId, false);
+      $clearingDecisions = $this->clearingDao->getFileClearings($itemTreeBounds, $groupId, false, true);
     }
 
     if ($isSingleFile && $hasWritePermission)


### PR DESCRIPTION
Currently in master for single file view clearing history is broken and shows only recent one.

-> Clearing History Before Changes
 
![historybcapture](https://cloud.githubusercontent.com/assets/10155976/26356207/edc26182-3fe8-11e7-9f43-f64a79b61f59.PNG)

-> Clearing History After Changes

![historyacapture](https://cloud.githubusercontent.com/assets/10155976/26356252/18e7a3f4-3fe9-11e7-900d-19fc577eee00.PNG)

