### PR TITLE
feat(reuse): search all folders

### DIFF
--- a/src/lib/php/Dao/FolderDao.php
+++ b/src/lib/php/Dao/FolderDao.php
@@ -202,8 +202,24 @@ GROUP BY group_fk
     $this->dbManager->freeResult($res);
     return $results;
   }
-  
-  
+
+  public function getAllFolderIds()
+  {
+    $statementName = __METHOD__;
+    $this->dbManager->prepare($statementName, "SELECT DISTINCT folder_pk FROM folder");
+    $res = $this->dbManager->execute($statementName);
+    $results = $this->dbManager->fetchAll($res);
+    $this->dbManager->freeResult($res);
+
+    $allIds = array();
+    for($i=0; $i < sizeof($results); $i++)
+    {
+      array_push($allIds, intval($results[$i]['folder_pk']));
+    }
+
+    return $allIds;
+  }
+
   public function getFolderChildUploads($parentId, $trustGroupId)
   {
     $statementName = __METHOD__;

--- a/src/lib/php/Dao/test/FolderDaoTest.php
+++ b/src/lib/php/Dao/test/FolderDaoTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Copyright (C) 2014-2015, Siemens AG
+Copyright (C) 2014-2017, Siemens AG
 Author: Steffen Weber
 
 This program is free software; you can redistribute it and/or
@@ -55,6 +55,11 @@ class FolderDaoTest extends \PHPUnit_Framework_TestCase
     $this->dbManager = null;
   }
 
+  public function testGetAllFolderIds()
+  {
+    $this->testDb->insertData(array('folder'));
+    assertThat(sizeof($this->folderDao->getAllFolderIds())>0);
+  }
 
   public function testHasTopLevelFolder_yes()
   {

--- a/src/reuser/ui/reuser-plugin.php
+++ b/src/reuser/ui/reuser-plugin.php
@@ -46,7 +46,21 @@ class ReuserPlugin extends DefaultPlugin
     
     $this->folderDao = $this->getObject('dao.folder');
   }
-    
+
+  function getAllUploads()
+  {
+    $allFolder = $this->folderDao->getAllFolderIds();
+    $result = array();
+    for($i=0; $i < sizeof($allFolder); $i++)
+    {
+      $listObject = $this->prepareFolderUploads($allFolder[$i]);
+      foreach ($listObject as $key => $value)
+      {
+        $result[explode(",",$key)[0]] = $value;
+      }
+    }
+    return $result;
+  }
 
   /**
    * @param Request $request
@@ -60,14 +74,21 @@ class ReuserPlugin extends DefaultPlugin
 
     if ($ajaxMethodName == "getUploads")
     {
-      $uploadsById = $this->prepareFolderUploads($folderId, $trustGroupId);
+      $uploadsById = "";
+      if(empty($folderId) || empty($trustGroupId))
+      {
+        $uploadsById = $this->getAllUploads();
+      }
+      else
+      {
+        $uploadsById = $this->prepareFolderUploads($folderId, $trustGroupId);
+      }
       return new JsonResponse($uploadsById, JsonResponse::HTTP_OK);
     }
     
     return new Response('called without valid method', Response::HTTP_METHOD_NOT_ALLOWED);
   }
-  
-  
+
   public function getFolderIdAndTrustGroup($folderGroup)
   {
     $folderGroupPair = explode(',', $folderGroup,2);

--- a/src/reuser/ui/template/agent_reuser.html.twig
+++ b/src/reuser/ui/template/agent_reuser.html.twig
@@ -2,10 +2,9 @@
 
 <li>
   ({{ 'Optional'|trans }}) {{ 'Reuse'|trans }}<img src="images/info_16.png" title="{{ 'copy clearing decisions if there is the same file hash between two files'|trans }}" alt="" class="info-bullet"/><br/>
-  {{ 'Select an already uploaded package for reuse in folder ' | trans }}
+  <input type="checkbox" id="searchInFolder"/> {{ 'Select an already uploaded package for reuse in specific folder ' | trans }}
   {% include 'reuse-folder.html.twig' with {'name': reuseFolderSelectorName, 'id': reuseFolderSelectorName} %}
   <br/>
+  {{ macro.select(uploadToReuseSelectorName, folderUploads, uploadToReuseSelectorName, reuseUploadId, 'style="min-width:420px;"', 5) }} <br />
   <input type="checkbox" name="reuseMode"/> {{ 'enhanced reuse (slower)'|trans }}<img src="images/info_16.png" title="{{'will copy a clearing decision if the two files differ by one line determined by a diff tool'|trans}}" alt="" class="info-bullet"/><br/>
-  {{ 'Upload to reuse'|trans }}:<br/>
-  {{ macro.select(uploadToReuseSelectorName, folderUploads, uploadToReuseSelectorName, reuseUploadId, 'style="min-width:420px;"', 5) }}
 </li>

--- a/src/reuser/ui/template/agent_reuser.js.twig
+++ b/src/reuser/ui/template/agent_reuser.js.twig
@@ -2,22 +2,41 @@ $.getScript( "scripts/tools.js", function( data, textStatus, jqxhr ) {console.lo
 
 $('#{{ reuseFolderSelectorName }}').change(function () {
   var folderGroupPair = this.selectedOptions[0].value;
-
-  $.getJSON("?mod=plugin_reuser&do=getUploads&{{ folderParameterName }}=" + folderGroupPair)
-      .done(function (data) {
-        var packageForReuse = $('#{{ uploadToReuseSelectorName }}');
-        packageForReuse.empty();
-        $.each(data, function (key, value) {
-          var option = document.createElement("option");
-          option.innerHTML = value;
-          option.value = key;
-          packageForReuse.append(option);
-        });
-        sortList('#{{ uploadToReuseSelectorName }} option');
-      })
-      .fail(failed);
+  //noinspection JSAnnotator
+  reloadUploads('&{{ folderParameterName }}=' + folderGroupPair);
 });
 
+function reloadUploads(parameter) {
+  $.getJSON("?mod=plugin_reuser&do=getUploads" + parameter)
+    .done(function (data) {
+      var packageForReuse = $('#{{ uploadToReuseSelectorName }}');
+      packageForReuse.empty();
+      $.each(data, function (key, value) {
+        var option = document.createElement("option");
+        option.innerHTML = value;
+        option.value = key;
+        packageForReuse.append(option);
+      });
+      sortList('#{{ uploadToReuseSelectorName }} option');
+    })
+    .fail(failed);
+}
+
+function toggleDisabled() {
+  $('#searchInFolder').click(function () {
+    $('#{{ reuseFolderSelectorName }}').prop('disabled', !$(this).prop('checked'));
+    $('#{{ uploadToReuseSelectorName }}').empty();
+    if($(this).prop('checked')) {
+      $('#{{ reuseFolderSelectorName }}').change();
+    }
+    else {
+      reloadUploads("");
+    }
+  });
+  reloadUploads("");
+
+}
+
 $(document).ready( function(){
-  $('#{{ reuseFolderSelectorName }}').trigger("change");
+  toggleDisabled();
 });

--- a/src/reuser/ui/template/reuse-folder.html.twig
+++ b/src/reuser/ui/template/reuse-folder.html.twig
@@ -7,7 +7,7 @@
 {% if selected is not defined %}
   {% set selected = -1 %}
 {% endif %}
-<select name="{{ name }}"{% if id is defined %} id="{{ id }}"{% endif %}>
+<select disabled name="{{ name }}"{% if id is defined %} id="{{ id }}"{% endif %}>
   {% for entry in folderStructure %}
     {% for entryReuse in entry.reuse %}
       <option value="{{ entry.folder.id }},{{ entryReuse.group_id }}"{% if selected == entry.folder.id %} selected="selected"{% endif %}>


### PR DESCRIPTION
This PR enabled the search of all uploads to reuse. No need to specify a specific folder anymore, but it's still possible to do so.

#### Please check the performance implications of this pull request with a larger amount of folders and uploads

![image](https://cloud.githubusercontent.com/assets/6639323/26586912/02eb0218-4551-11e7-8936-e1ff76c0689f.png)
<hr />

![image](https://cloud.githubusercontent.com/assets/6639323/26586959/31b3c864-4551-11e7-8190-4231ea088107.png)
