### PR TITLE
fix(obligations): reintegrate lost changes

### DIFF
--- a/src/lib/php/Application/ObligationCsvExport.php
+++ b/src/lib/php/Application/ObligationCsvExport.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Copyright (C) 2015, Siemens AG
+Copyright (C) 2017, Siemens AG
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/src/lib/php/Application/ObligationCsvImport.php
+++ b/src/lib/php/Application/ObligationCsvImport.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Copyright (C) 2014-2015, Siemens AG
+Copyright (C) 2014-2017, Siemens AG
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -150,33 +150,40 @@ class ObligationCsvImport {
     $dbManager->freeResult($resi);
 
     $associatedLicenses = "";
-    $licenses = explode(";",$row['licnames']);
-    foreach ($licenses as $license)
+    if (empty($row['licnames']))
     {
-      $licId = $this->obligationMap->getIdFromShortname($license);
-      if ($licId == '0')
-      {
-        $message = _("ERROR: License with shortname '$license' not found in the DB. Obligation not updated.");
-        return "<b>$message</b><p>";
-      }
-
-      if ($this->obligationMap->isLicenseAssociated($new['ob_pk'],$licId))
-      {
-        continue;
-      }
-
-      $this->obligationMap->associateLicenseWithObligation($new['ob_pk'],$licId);
-      if ($associatedLicenses == "")
-      {
-        $associatedLicenses = "$license";
-      }
-      else
-      {
-        $associatedLicenses .= ";$license";
-      }
+      $return = "Obligation topic '$row[topic]' was added without being associated with any license.";
     }
+    else
+    {
+      $licenses = explode(";",$row['licnames']);
+      foreach ($licenses as $license)
+      {
+        $licId = $this->obligationMap->getIdFromShortname($license);
+        if ($licId == '0')
+        {
+          $message = _("ERROR: License with shortname '$license' not found in the DB. Obligation not updated.");
+          return "<b>$message</b><p>";
+        }
 
-    $return = "Obligation topic '$row[topic]' was added and associated with licenses '$associatedLicenses' in DB";
+        if ($this->obligationMap->isLicenseAssociated($new['ob_pk'],$licId))
+        {
+          continue;
+        }
+
+        $this->obligationMap->associateLicenseWithObligation($new['ob_pk'],$licId);
+        if ($associatedLicenses == "")
+        {
+          $associatedLicenses = "$license";
+        }
+        else
+        {
+          $associatedLicenses .= ";$license";
+        }
+      }
+
+      $return = "Obligation topic '$row[topic]' was added and associated with licenses '$associatedLicenses' in DB";
+    }
 
     return $return;
   }

--- a/src/lib/php/Plugin/FO_Plugin.php
+++ b/src/lib/php/Plugin/FO_Plugin.php
@@ -1,7 +1,7 @@
 <?php
 /***********************************************************
  * Copyright (C) 2008-2013 Hewlett-Packard Development Company, L.P.
- * Copyright (C) 2014-2015 Siemens AG
+ * Copyright (C) 2014-2017 Siemens AG
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/lib/php/common-db.php
+++ b/src/lib/php/common-db.php
@@ -1,6 +1,7 @@
 <?php
 /***********************************************************
  Copyright (C) 2011-2012 Hewlett-Packard Development Company, L.P.
+ Copyright (C) 2017, Siemens AG
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/src/lib/php/common-ui.php
+++ b/src/lib/php/common-ui.php
@@ -1,6 +1,7 @@
 <?php
 /***********************************************************
  Copyright (C) 2009-2014 Hewlett-Packard Development Company, L.P.
+ Copyright (C) 2017, Siemens AG
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/src/www/ui/page/AdminObligationFromCSV.php
+++ b/src/www/ui/page/AdminObligationFromCSV.php
@@ -1,7 +1,7 @@
 <?php
 /***********************************************************
  * Copyright (C) 2008-2013 Hewlett-Packard Development Company, L.P.
- * Copyright (C) 2014 Siemens AG
+ * Copyright (C) 2014-2017 Siemens AG
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/www/ui/page/AdminObligationToCSV.php
+++ b/src/www/ui/page/AdminObligationToCSV.php
@@ -1,6 +1,6 @@
 <?php
 /***********************************************************
- * Copyright (C) 2014 Siemens AG
+ * Copyright (C) 2014-2017 Siemens AG
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -45,9 +45,10 @@ class AdminObligationToCSV extends DefaultPlugin
   {
     $obligationCsvExport = new \Fossology\Lib\Application\ObligationCsvExport($this->getObject('db.manager'));
     $content = $obligationCsvExport->createCsv(intval($request->get('rf')));
-
+    $fileName = "fossology-obligations-export-".date("YMj-Gis");
     $headers = array(
-        'Content-type' => 'text/csv',
+        'Content-type' => 'text/csv, charset=UTF-8',
+        'Content-Disposition' => 'attachment; filename='.$fileName.'.csv',
         'Pragma' => 'no-cache',
         'Cache-Control' => 'no-cache, must-revalidate, maxage=1, post-check=0, pre-check=0',
         'Expires' => 'Expires: Thu, 19 Nov 1981 08:52:00 GMT');

--- a/src/www/ui/template/include/macros.html.twig
+++ b/src/www/ui/template/include/macros.html.twig
@@ -1,4 +1,4 @@
-{# Copyright 2014-2015 Siemens AG
+{# Copyright 2014-2017 Siemens AG
 
    Copying and distribution of this file, with or without modification,
    are permitted in any medium without royalty provided the copyright notice and this notice are preserved.


### PR DESCRIPTION
Use correct copyright year for last changes.
Set filename while exporting the obligations CSV.
Allow obligations with no licenses associated.