### PR TITLE
fix(docker): use debian 8.8 for images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #
 # Description: Docker container image recipe
 
-FROM debian:stable
+FROM debian:8.8
 
 MAINTAINER Fossology <fossology@fossology.org>
 

--- a/install/docker-compose.Dockerfile
+++ b/install/docker-compose.Dockerfile
@@ -9,7 +9,7 @@
 #
 # Description: Docker container image recipe
 
-FROM debian:stable
+FROM debian:8.8
 MAINTAINER Fossology <fossology@fossology.org>
 WORKDIR /fossology
 


### PR DESCRIPTION
PHP 7 is not yet supported in Fossology
Debian 9 comes with PHP 7.0.14-2 as default