### PR TITLE
update packages deps for latest debian and ubuntus

### DIFF
--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -110,13 +110,13 @@ if [ $BUILDTIME ]; then
               lenny|hardy) apt-get $YesOpt install $YesOpt postgresql-server-dev-8.3;;
               squeeze) apt-get $YesOpt install $YesOpt postgresql-server-dev-8.4;;
               wheezy) apt-get $YesOpt install $YesOpt postgresql-server-dev-9.1;;
-              sid) apt-get  $YesOpt install $YesOpt postgresql-server-dev-8.4;;
               lucid|natty) apt-get $YesOpt install postgresql-server-dev-8.4;;
               isadora) apt-get $YesOpt install postgresql-server-dev-8.4;;
               precise|oneiric|quantal|raring|saucy) apt-get $YesOpt install postgresql-server-dev-9.1;;
               trusty) apt-get $YesOpt install postgresql-server-dev-9.3;;
               jessie) apt-get $YesOpt install postgresql-server-dev-9.4;;
-              xenial) apt-get $YesOpt install postgresql-server-dev-9.5;;
+              xenial|yakkety) apt-get $YesOpt install postgresql-server-dev-9.5;;
+              stretch|buster|sid|zesty|artful) apt-get $YesOpt install postgresql-server-dev-9.6;;
               *) echo "ERROR: Unknown or Unsupported $DISTRO release, please report to the mailing list"; exit 1;;
            esac
          fi
@@ -165,10 +165,10 @@ if [ $RUNTIME ]; then
    case "$DISTRO" in
       Debian|Ubuntu|LinuxMint)
         echo "doing runtime"
-         apt-get $YesOpt install apache2 libapache2-mod-php5
-         apt-get $YesOpt install php5 php5-pgsql php-pear php5-cli \
+         apt-get $YesOpt install apache2
+         apt-get $YesOpt install php-pear \
             libxml2 \
-            binutils php-gettext php5-curl \
+            binutils php-gettext \
             cabextract cpio sleuthkit genisoimage \
             poppler-utils upx-ucl \
             unrar-free unzip p7zip-full p7zip wget \
@@ -178,23 +178,23 @@ if [ $RUNTIME ]; then
          if [ -z "$POSTGRE" ]; then  ## if postgresql-server-dev is installed
            case "$CODENAME" in
               squeeze)
-                 apt-get $YesOpt install postgresql-8.4;;
+                 apt-get $YesOpt install postgresql-8.4 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl;;
               wheezy)
-                 apt-get $YesOpt install postgresql-9.1;;
-              sid)
-                 apt-get $YesOpt install postgresql-8.4;;
+                 apt-get $YesOpt install postgresql-9.1 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl;;
               lucid|natty)
-                 apt-get $YesOpt install postgresql-8.4;;
+                 apt-get $YesOpt install postgresql-8.4 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl;;
               isadora)
-                 apt-get $YesOpt install postgresql-8.4;;
+                 apt-get $YesOpt install postgresql-8.4 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl;;
               precise|oneiric|quantal|raring|saucy)
-                 apt-get $YesOpt install postgresql-9.1;;
+                 apt-get $YesOpt install postgresql-9.1 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl;;
               trusty)
-                 apt-get $YesOpt install postgresql-9.3;;
+                 apt-get $YesOpt install postgresql-9.3 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl;;
               jessie)
-                 apt-get $YesOpt install postgresql-9.4;;
-              xenial)
-                 apt-get $YesOpt install postgresql-9.5;;
+                 apt-get $YesOpt install postgresql-9.4 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl;;
+              xenial|yakkety)
+                 apt-get $YesOpt install postgresql-9.5 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl;;
+              stretch|buster|sid|zesty|artful)
+                 apt-get $YesOpt install postgresql-9.6 php7.0 php7.0-pgsql php7.0-cli php7.0-curl php7.0-xml;;
               *) echo "ERROR: Unknown or Unsupported $DISTRO release, please report to the mailing list"; exit 1;;
            esac
          fi


### PR DESCRIPTION
the explicit requirement of PHP5 cause build to fail on debian 9 which has PHP7
```
$ sudo utils/fo-installdeps 
...
Package libapache2-mod-php5 is not available, but is referred to by another package.
E: Package 'libapache2-mod-php5' has no installation candidate
Package php5 is not available, but is referred to by another package.
Package php5-pgsql is not available, but is referred to by another package.
Package php5-cli is not available, but is referred to by another package.
Package php5-curl is not available, but is referred to by another package.
E: Package 'php5' has no installation candidate
E: Package 'php5-pgsql' has no installation candidate
E: Package 'php5-cli' has no installation candidate
E: Package 'php5-curl' has no installation candidate
...
```

this PR addis the appropriate package for debian 'stretch' and ubuntu 'yakkety','zesty', and 'artful' - although this was not tested on ubuntu the package names were gathered from the following URLs:
* https://packages.debian.org/search?keywords=postgresql-9.6&searchon=names&exact=1&suite=all&section=all
* https://packages.debian.org/search?keywords=postgresql-server-dev-9.6&searchon=names&exact=1&suite=all&section=all
* https://packages.ubuntu.com/search?keywords=postgresql-9&searchon=names&suite=all&section=all
* https://packages.ubuntu.com/search?keywords=postgresql-server-dev&searchon=names&suite=all&section=all

the additional  'php-xml' package was needed when bulding on debian 9 
```
$ sudo  /usr/local/lib/fossology/fo-postinstall
....
PHP Fatal error:  Uncaught Error: Class 'DOMDocument' not found in /usr/local/share/fossology/vendor/symfony/config/Symfony/Component/Config/Util/XmlUtils.php:52
Stack trace:
#0 /usr/local/share/fossology/vendor/symfony/dependency-injection/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php(232): Symfony\Component\Config\Util\XmlUtils::loadFile('/usr/local/shar...', Array)
....
```

it should be noted that, instead of this PR, the entire debian/ubuntu sections could probably be greatly simplified to resemble the other distro sections by requiring only these meta packages - i.e. these would probably work for any release:
```
postgresql-server-dev-all
instead of
postgresql-server-dev-9.5
or
postgresql-server-dev-9.6

postgresql php php-pgsql php-cli php-curl php-xml
instead of
postgresql-9.5 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl
or
postgresql-9.6 libapache2-mod-php7.0 php7.0 php7.0-pgsql php7.0-cli php7.0-curl php7.0-xml;;
```
note that 'libapache2-mod-php7.0' is be omitted in this PR because it is required by 'php7.0'
```
$ apt depends php php-pgsql php-cli php-curl php-xml 
php
  Depends: php7.0
php-pgsql
  Depends: php-common
  Depends: php7.0-pgsql
php-cli
  Depends: php7.0-cli
php-curl
  Depends: php-common
  Depends: php7.0-curl
php-xml
  Depends: php-common
  Depends: php7.0-xml

$ apt depends php7.0
php7.0
 |Depends: libapache2-mod-php7.0
 |Depends: php7.0-fpm
  Depends: php7.0-cgi
  Depends: php7.0-common
```
