### PR TITLE
fix(chore): fix debian linker error

### DIFF
--- a/src/buckets/agent/Makefile
+++ b/src/buckets/agent/Makefile
@@ -20,7 +20,7 @@ VARS = $(TOP)/Makefile.conf
 include $(VARS)
 
 DEF = -DPROJECTSTATEDIR='"$(PROJECTSTATEDIR)"' -DDATADIR='"$(DATADIR)"'
-CFLAGS_LOCAL = $(DEF) $(FO_CFLAGS) $(DEFS)
+CFLAGS_LOCAL = $(DEF) $(FO_CFLAGS) $(DEFS) -fPIC
 
 EXE = buckets
 OBJS = validate.o inits.o liccache.o walk.o leaf.o match.o container.o child.o write.c


### PR DESCRIPTION
building from source fails on debian 9 with GCC - this PR allows the linking to complete
```
$ make
....
make -s -C buckets
make[2]: Entering directory '/mnt/data/code/fossology/src/buckets'
writing VERSION file for buckets
make[3]: Entering directory '/mnt/data/code/fossology/src/buckets/agent'
make[4]: Entering directory '/mnt/data/code/fossology/src/lib/c'
make[4]: Leaving directory '/mnt/data/code/fossology/src/lib/c'
/usr/bin/ld: validate.o: relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: inits.o: relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: liccache.o: relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: walk.o: relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: leaf.o: relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: container.o: relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: child.o: relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Nonrepresentable section on output
collect2: error: ld returned 1 exit status
Makefile:32: recipe for target 'buckets' failed
make[3]: *** [buckets] Error 1
....
```
