### PR TITLE
fix(jquery): remove old version of jquery from copyright-hist

### DIFF
--- a/src/copyright/ui/template/copyrighthist.html.twig
+++ b/src/copyright/ui/template/copyrighthist.html.twig
@@ -8,8 +8,6 @@
 
 {% block foot %}
   {{ parent() }}
-
-  <script src="scripts/jquery-1.11.1.min.js" type="text/javascript"></script>
   <script src="scripts/jquery.dataTables.min.js" type="text/javascript"></script>
   <script src="scripts/jquery.dataTables.editable.js" type="text/javascript"></script>
   <script src="scripts/jquery.jeditable.js" type="text/javascript"></script>


### PR DESCRIPTION
jquery 3.2.0 is already included in the compiled html file