### PR TITLE
feat(spdx2): strip invalid characters from non-spdx-compatible licenses

### DIFF
--- a/src/spdx2/agent/spdx2utils.php
+++ b/src/spdx2/agent/spdx2utils.php
@@ -53,23 +53,24 @@ class SpdxTwoUtils
     {
       return "NOASSERTION";
     }
+
     if(strpos($license, " OR ") !== false)
     {
       return "(" . $license . ")";
     }
-    else
+
+    if($spdxValidityChecker === null ||
+        (is_callable($spdxValidityChecker) &&
+            call_user_func($spdxValidityChecker, $license)))
     {
-      if($spdxValidityChecker === null ||
-          (is_callable($spdxValidityChecker) &&
-              call_user_func($spdxValidityChecker, $license)))
-      {
-        return $license;
-      }
-      else
-      {
-        return self::$prefix . $license;
-      }
+      return $license;
     }
+
+    // if we get here, we're using a non-standard SPDX license
+    // make sure our license text conforms to the SPDX specifications
+    $license = preg_replace('/[^a-zA-Z0-9\-\_\.\+]/','-',$license);
+    $license = preg_replace('/\+(?!$)/','-',$license);
+    return self::$prefix . $license;
   }
 
   static public function addPrefixOnDemandKeys($licenses, $spdxValidityChecker = null)

--- a/src/spdx2/agent_tests/Unit/spdx2utilTest.php
+++ b/src/spdx2/agent_tests/Unit/spdx2utilTest.php
@@ -68,7 +68,11 @@ class spdx2Test extends \PHPUnit_Framework_TestCase
     return array(
         'null' => array("LIC1", null, "LIC1"),
         'const false' => array("LIC1", $constFalse, SpdxTwoUtils::$prefix . "LIC1"),
-        'const true' => array("LIC1", $constTrue, "LIC1")
+        'const true' => array("LIC1", $constTrue, "LIC1"),
+        'invalid plus' => array("abc+123", $constFalse, SpdxTwoUtils::$prefix . "abc-123"),
+        'other invalid chars' => array("to do?", $constFalse, SpdxTwoUtils::$prefix . "to-do-"),
+        'valid plus' => array("this+that_more+", $constFalse, SpdxTwoUtils::$prefix . "this-that_more+"),
+        'valid periods' => array("name.with.dots.", $constFalse, SpdxTwoUtils::$prefix . "name.with.dots.")
     );
   }
 


### PR DESCRIPTION
When generating an SPDX file, make sure all non-standard licenses conform to the SPDX standard naming convention. This partially solves #855 by ensuring generated files are valid even if (future) checks fail when licenses are created.

This change also flattens the `addPrefixOnDemand` function, as there were a number of unnecessary if/else blocks.

Example sanitizing:
`abc+123` -> `LicenseRef-abc-123`
`to do?` -> `LicenseRef-to-do-`
`this+that_more+` -> `LicenseRef-this-that_more+`
`name.with.dots.` -> `LicenseRef-name.with.dots.`