### PR TITLE
fix(www): Undefined index in admin-license-file.php

### DIFF
--- a/src/www/ui/admin-license-file.php
+++ b/src/www/ui/admin-license-file.php
@@ -312,7 +312,7 @@ class admin_license_file extends FO_Plugin
     }
     else
     {
-      $row = array('rf_active' =>'t', 'marydone'=>'f', 'rf_text_updatable'=>'t', 'rf_parent'=>0, 'rf_report'=>0, 'rf_risk', 'rf_spdx_compatible'=>'f');
+      $row = array('rf_active' =>'t', 'marydone'=>'f', 'rf_text_updatable'=>'t', 'rf_parent'=>0, 'rf_report'=>0, 'rf_risk'=>0, 'rf_spdx_compatible'=>'f');
     }
     
     foreach(array_keys($row) as $key)


### PR DESCRIPTION
`rf_risk` was being added to the `$row` array as a value, not as an index. This causes an `undefined index` error. This PR does not change any behaviour, as the combo box using this value was defaulting to zero.

Fixes #885.