### PR TITLE
fix(php): resolve pass-by-reference errors

### DIFF
--- a/src/lib/php/Test/TestLiteDb.php
+++ b/src/lib/php/Test/TestLiteDb.php
@@ -63,7 +63,8 @@ class TestLiteDb extends TestAbstractDb
     
     $sqlite3Connection = new SQLite3($this->dbFileName, SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE);
 
-    $container->get('db.manager')->setDriver(new SqliteE($sqlite3Connection));
+    $sqliteDriver = new SqliteE($sqlite3Connection);
+    $container->get('db.manager')->setDriver($sqliteDriver);
     $this->dbManager = $container->get('db.manager');
   }
   

--- a/src/lib/php/Test/TestPgDb.php
+++ b/src/lib/php/Test/TestPgDb.php
@@ -59,7 +59,8 @@ class TestPgDb extends TestAbstractDb
     $this->logFileName = dirname(dirname(dirname(dirname(dirname(__FILE__))))) . 'db.pg.log';
     $logger->pushHandler(new StreamHandler($this->logFileName, Logger::DEBUG));
 
-    $container->get('db.manager')->setDriver(new Postgres($this->connection));
+    $postgresDriver = new Postgres($this->connection);
+    $container->get('db.manager')->setDriver($postgresDriver);
     $this->dbManager = $container->get('db.manager');
     $this->dbManager->queryOnce("DEALLOCATE ALL");
     $this->dropAllTables();


### PR DESCRIPTION
Seeing these in the Travis build logs (job 16):

```
Only variables should be passed by reference
/home/travis/build/fossology/fossology/src/lib/php/Test/TestPgDb.php:62
/home/travis/build/fossology/fossology/src/lib/php/Test/TestLiteDb.php:66
```

This causes 181 errors to occur in this job. This fix resolves all errors so that the job succeeds again.

EDIT: this is for the PHP7 build job. Only test files are changed so no production functionality is affected.