### PR TITLE
fix(docker): `.git` should not be excluded via dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 install/docker-compose*
 !install/docker-compose.docker-entrypoint.sh
 fossology310-source.spdx


### PR DESCRIPTION
The problem is that FOSSology looks into `.git` in the make step to get the current version. Without the git folder the agent table looks like:
![2017-09-08_10 58 38](https://user-images.githubusercontent.com/1187050/30204345-6ac010b2-9485-11e7-8dc0-a5ce1efffe2d.png)
and FOSSology can not handle agent-changes correctly.

Note: adding the git folder to the docker container **increases the container size dramatically (see https://github.com/fossology/fossology/pull/888)** and the `.git` folder might contain unpublished or confidential information (e.g. the fetched content of a private repository). It would be good to switch to some other way of building the container, e.g.
- use a multistep buildscript, which includes git only in the first run but ecludes it for the second run which does `make install`
- use a more complicated script which
  1) builds a base image
  2) runs that base image and bind-mounts the source folder. It then should call `make` and `make install`
  3) export the new state as the fossology image