### PR TITLE
faet(spdx2): bump output version from 2.0 to 2.1

### DIFF
--- a/src/spdx2/agent/template/spdx2-document.xml.twig
+++ b/src/spdx2/agent/template/spdx2-document.xml.twig
@@ -8,11 +8,11 @@
     xmlns:spdx="http://spdx.org/rdf/terms#"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
 <spdx:SpdxDocument rdf:about="{{ uri }}#SPDXRef-DOCUMENT">
-  <spdx:specVersion>SPDX-2.0</spdx:specVersion>
+  <spdx:specVersion>SPDX-2.1</spdx:specVersion>
   <spdx:dataLicense rdf:resource="http://spdx.org/licenses/CC0-1.0" />
   <spdx:creationInfo>
     <spdx:CreationInfo>
-      <spdx:licenseListVersion>2.6</spdx:licenseListVersion> 
+      <spdx:licenseListVersion>2.6</spdx:licenseListVersion>
       <spdx:creator>Person: {{ userName|e }}</spdx:creator>
       <spdx:creator>Organization: {{ organisation|e }}</spdx:creator>
       <spdx:creator>Tool: spdx2</spdx:creator>
@@ -20,7 +20,7 @@
     </spdx:CreationInfo>
   </spdx:creationInfo>
   <spdx:name>{{ documentName|e }}</spdx:name>
-  <rdfs:comment> 
+  <rdfs:comment>
     This document was created using license information and a generator from Fossology.
   </rdfs:comment>
 {% for licenseId,extractedText in licenseTexts %}{% if licenseId starts with 'LicenseRef-' %}

--- a/src/spdx2/agent/template/spdx2tv-document.twig
+++ b/src/spdx2/agent/template/spdx2tv-document.twig
@@ -4,7 +4,7 @@
    are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
    This file is offered as-is, without any warranty.
 #}
-SPDXVersion: SPDX-2.0
+SPDXVersion: SPDX-2.1
 DataLicense: CC0-1.0
 
 ##-------------------------


### PR DESCRIPTION
This PR just changes the versions in the templates. The templates are currently SPDX2.1 compatible.