### PR TITLE
feat(copyright): also show deactivated copyrights/urls/authors/... in the UI

### DIFF
--- a/src/copyright/ui/CopyrightView.php
+++ b/src/copyright/ui/CopyrightView.php
@@ -68,7 +68,7 @@ class CopyrightView extends Xpview
 
     $vars = array('statement'=>$tableVars,
         'content' => "$output\n",
-        'script' => '<script>$(document).ready(function() { tableCopyright = createTablestatement(); } );</script>');
+        'script' => '<script>$(document).ready(function() { createTablestatement(); } );</script>');
     return $vars;
   }
   

--- a/src/copyright/ui/HistogramBase.php
+++ b/src/copyright/ui/HistogramBase.php
@@ -60,11 +60,20 @@ abstract class HistogramBase extends FO_Plugin {
         "uploadTreeId" => $uploadTreeId, "agentId" => $agentId, "filter" => $filter, "description" => $description);
 
     //TODO template this! For now I just template the js
-    $output = "<div><table border=1 width='100%' id='copyright".$type."'></table></div><br/><br/>
+    $typeDescriptor = "";
+    if($type !== "statement")
+    {
+      $typeDescriptor = $type;
+    }
+    $output = "<h4>Activated $typeDescriptor statements:</h4>
+               <div><table border=1 width='100%' id='copyright".$type."'></table></div>
+               <br/><br/>
                <div>
                 <a style='cursor: pointer; margin-left:10px;'id='deleteSelected".$type."' class='buttonLink'>Mark selected rows for deletion</a>
-               </div>  
-              <br/>";
+               <br/><br/>
+               <h4>Deactivated $typeDescriptor statements:</h4>
+               </div>
+               <div><table border=1 width='100%' id='copyright".$type."deactivated'></table></div>";
 
     return array($output, $out);
   }

--- a/src/copyright/ui/email-hist.php
+++ b/src/copyright/ui/email-hist.php
@@ -106,7 +106,8 @@ class EmailHistogram extends HistogramBase {
       tableEmail = createTableemail();
       tableUrl = createTableurl();
       tableAuthor = createTableauthor();
-    } );
+      $(\"#EmailUrlAuthorTabs\").tabs();
+    });
     ";
   }
 

--- a/src/copyright/ui/template/emailhist_tables.html.twig
+++ b/src/copyright/ui/template/emailhist_tables.html.twig
@@ -7,25 +7,22 @@
 <table border="0" width="100%">
 <tr>
   <td valign="top">
-    <a name="emails"></a>{{'Jump to'|trans}}:
-    <a href="#urls">{{'URLs'|trans}}</a> | 
-    <a href="#authors">{{'Authors or Maintainers'|trans}}</a>
-    <br/>
-    {{ contEmail }}
-    <br/>
-    
-    <a name="urls"></a>{{'Jump to'|trans}}:
-    <a href="#emails">{{'Emails'|trans}}</a> | 
-    <a href="#authors">{{'Authors or Maintainers'|trans}}</a>
-    <br/>
-    {{ contUrl }}
-    <br/>
-
-    <a name="authors"></a>{{'Jump to'|trans}}:
-    <a href="#emails">{{'Emails'|trans}}</a> | 
-    <a href="#urls">{{'URLs'|trans}}</a>
-    <br/>
-    {{ contAuthor }}
+    <div id="EmailUrlAuthorTabs">
+      <ul>
+        <li><a href="#EmailTab">Email</a></li>
+        <li><a href="#UrlTab">URL</a></li>
+        <li><a href="#AuthorTab">Author</a></li>
+      </ul>
+      <div id="EmailTab">
+        {{ contEmail }}
+      </div>
+      <div id="UrlTab">
+        {{ contUrl }}
+      </div>
+      <div id="AuthorTab">
+        {{ contAuthor }}
+      </div>
+    </div>
   </td>
   <td valign="top">{{ fileList }}</td>
 </tr>

--- a/src/copyright/ui/template/histTable.js.twig
+++ b/src/copyright/ui/template/histTable.js.twig
@@ -4,10 +4,33 @@
    are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
    This file is offered as-is, without any warranty.
 #}
-function createTable{{ table.type }}() {
-  var otable = $('#copyright{{ table.type }}').dataTable({
+
+function createTableBase{{ table.type }}(activated) {
+  var aoColumns = [
+      { "sTitle": "{{ 'Count'| trans }}", "sClass": "right read_only", "sWidth": "5%" },
+      { "sTitle": "{{ table.description }}", "sClass": "left"}
+    ]
+  if (activated)
+  {
+    var id = '#copyright{{ table.type }}';
+    var action = 'getData'
+    aoColumns = aoColumns.concat([
+      { "sTitle": "", "sClass": "center read_only", "sWidth": "10%", "bSortable": false },
+      { "sTitle": "<input type='checkbox' name='selectDelete{{ table.type }}' id='selectDelete{{ table.type }}' style='margin-left:11px'>", "sClass": "center read_only", "sWidth": "5%", "bSortable": false }
+    ]);
+  }
+  else
+  {
+    var id = '#copyright{{ table.type }}deactivated';
+    var action = 'getDeactivatedData'
+    aoColumns = aoColumns.concat([
+      { "sTitle": "", "sClass": "center read_only", "sWidth": "10%", "bSortable": false }
+    ]);
+  }
+
+  return $(id).dataTable({
     "bServerSide": true,
-    "sAjaxSource": "?mod=ajax-copyright-hist&action=getData",
+    "sAjaxSource": "?mod=ajax-copyright-hist&action=" + action,
     "fnServerData": function (sSource, aoData, fnCallback) {
       aoData.push({ "name":"upload", "value": "{{ table.uploadId }}" });
       aoData.push({ "name":"item", "value": "{{ table.uploadTreeId }}" });
@@ -19,19 +42,18 @@ function createTable{{ table.type }}() {
           window.location.href = "?mod=auth";
       });
     },
-    "aoColumns": [
-      { "sTitle": "{{ 'Count'| trans }}", "sClass": "right read_only", "sWidth": "5%" },
-      { "sTitle": "{{ table.description }}", "sClass": "left"},
-      { "sTitle": "", "sClass": "center read_only", "sWidth": "10%", "bSortable": false },
-      { "sTitle": "<input type='checkbox' name='selectDelete{{ table.type }}' id='selectDelete{{ table.type }}' style='margin-left:11px'>", "sClass": "center read_only", "sWidth": "5%", "bSortable": false }
-    ],
+    "aoColumns": aoColumns,
     "aaSorting": {{ table.sorting }},
     "iDisplayLength": 50,
     "bProcessing": true,
     "bStateSave": true,
     "sCookiePrefix": "fossology_",
     "bRetrieve": true
-  }).makeEditable({
+  });
+}
+
+function createTable{{ table.type }}() {
+  var enabledTable = createTableBase{{ table.type }}(true).makeEditable({
     "sReadOnlyCellClass": "read_only",
     "sSelectedRowClass": "selectedRow",
     "sUpdateURL": "?mod=ajax-copyright-hist&action=update&type={{ table.type }}",
@@ -51,6 +73,8 @@ function createTable{{ table.type }}() {
     "sSuccessResponse": "success"
   });
 
+  createTableBase{{ table.type }}(false);
+
   $('#selectDelete{{ table.type }}').change(function () {
     $('.deleteBySelect{{ table.type }}').prop('checked', $(this).prop("checked"));
   });
@@ -63,7 +87,7 @@ function createTable{{ table.type }}() {
     });
   });
 
-  return otable;
+  return enabledTable;
 }
 
 function delete{{ table.type }}(upload, item, hash, kind) {
@@ -74,9 +98,7 @@ function delete{{ table.type }}(upload, item, hash, kind) {
     data: { id : upload + ',' + item + ',' + hash + ',' + kind },
       success: function(data) {
         $("#delete{{ table.type }}" + hash).hide();
-        var updateElement = $("#update{{ table.type }}" + hash);
-        updateElement.html('deleted [<a href="#" onclick="event.preventDefault();undo{{ table.type }}(' +upload + ',' + item + ',\'' + hash + '\',\'' + kind + '\');return false;">Undo</a>]');
-        updateElement.show();
+        $("#update{{ table.type }}" + hash).show();
       },
       error: function() { alert('error'); }
   });
@@ -90,7 +112,7 @@ function undo{{ table.type }}(upload, item, hash, kind) {
     data: { id : upload + ',' + item + ',' + hash + ',' + kind },
       success: function(data) { 
         $("#delete{{ table.type }}" + hash).show();
-        $("#update{{ table.type }}" + hash).html('').show();
+        $("#update{{ table.type }}" + hash).hide();
         $("#deleteBySelect{{ table.type }}" + hash).prop('checked', false);
       },
       error: function() { alert('error'); }

--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -222,24 +222,24 @@ class CopyrightDao extends Object
   {
     $itemTable = $item->getUploadTreeTableName();
     $stmt = __METHOD__.".$cpTable.$itemTable";
-    $params = array();
+    $params = array($hash,$item->getLeft(),$item->getRight());
 
     if($action == "delete") {
-      $cpBoolValue = "is_enabled='false'";
-      $params = array($hash,$item->getLeft(),$item->getRight());
+      $setSql = "is_enabled='false'";
+      $stmt .= '.delete';
     } else if($action == "rollback") {
-      $cpBoolValue = "is_enabled='true'";
-      $params = array($hash,$item->getLeft(),$item->getRight());
+      $setSql = "is_enabled='true'";
+      $stmt .= '.rollback';
     } else {
-      $cpBoolValue = "content = $4, hash = md5($4), is_enabled='true'";
-      $params = array($hash,$item->getLeft(),$item->getRight(),$content);
+      $setSql = "content = $4, hash = md5($4), is_enabled='true'";
+      $params[] = $content;
     }
 
-    $sql = "UPDATE $cpTable AS cpr SET $cpBoolValue
+    $sql = "UPDATE $cpTable AS cpr SET $setSql
             FROM $cpTable as cp
             INNER JOIN $itemTable AS ut ON cp.pfile_fk = ut.pfile_fk
             WHERE cpr.ct_pk = cp.ct_pk
-              AND cp.hash =$1
+              AND cp.hash = $1
               AND ( ut.lft BETWEEN $2 AND $3 )";
     if ('uploadtree_a' == $item->getUploadTreeTableName())
     {


### PR DESCRIPTION
This PR adds a new table with deactivated statements to all views of Copyright, the result looks like:

![2017-09-12_07 53 59](https://user-images.githubusercontent.com/1187050/30310203-90bc157e-978f-11e7-9ab8-4887ed8f363b.png)
and
![2017-09-12_07 53 50](https://user-images.githubusercontent.com/1187050/30310211-97569454-978f-11e7-8dd6-80267184591d.png)

To make the `Email/URL/Author` more readable this adds tabs which look like:
![2017-09-12_07 53 43](https://user-images.githubusercontent.com/1187050/30310212-9bb09298-978f-11e7-845b-40498523a575.png)
(there is a slight css problem, i.e. the `Undo` is black and not blue. That will be fixed by https://github.com/fossology/fossology/pull/904)