### PR TITLE
feat(spdx2): add name field to extracted license info

### DIFF
--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -684,7 +684,7 @@ class SpdxTwoAgent extends Agent
    */
   protected function getLicenseTexts() {
     $licenseTexts = array();
-    $licenseViewProxy = new LicenseViewProxy($this->groupId,array(LicenseViewProxy::OPT_COLUMNS=>array('rf_pk','rf_shortname','rf_text')));
+    $licenseViewProxy = new LicenseViewProxy($this->groupId,array(LicenseViewProxy::OPT_COLUMNS=>array('rf_pk','rf_shortname','rf_fullname','rf_text')));
     $this->dbManager->prepare($stmt=__METHOD__, $licenseViewProxy->getDbViewQuery());
     $res = $this->dbManager->execute($stmt);
 
@@ -692,14 +692,18 @@ class SpdxTwoAgent extends Agent
     {
       if (array_key_exists($row['rf_pk'], $this->includedLicenseIds))
       {
-        $licenseTexts[$row['rf_shortname']] = $row['rf_text'];
+        $licenseTexts[$row['rf_shortname']] = array(
+          'text' => $row['rf_text'],
+          'name' => $row['rf_fullname'] ?: $row['rf_shortname']);
       }
     }
     foreach($this->includedLicenseIds as $license => $customText)
     {
       if (true !== $customText)
       {
-        $licenseTexts[$license] = $customText;
+        $licenseTexts[$license] = array(
+          'text' => $customText,
+          'name' => $license);
       }
     }
     $this->dbManager->freeResult($res);

--- a/src/spdx2/agent/template/dep5-copyright-document.twig
+++ b/src/spdx2/agent/template/dep5-copyright-document.twig
@@ -19,11 +19,11 @@ Comment: {% if licenseComments %}
 {# File Paragraphes: #}
 {{ packageNodes }}
 {# Stand-alone License Paragraphes: #}
-{% for licenseId,extractedText in licenseTexts %}
+{% for licenseId,licenseData in licenseTexts %}{% if licenseId starts with 'LicenseRef-' %}
 
 License: {{ licenseId }}
- {{ extractedText|replace({'\f':''})|replace({'\r\n':'\n'})
-                                    |replace({'\n\n':'\n.\n'})
-                                    |replace({'\n\n':'\n.\n'})
-                                    |replace({'\n':'\n '}) }}
+ {{ licenseData['text']|replace({'\f':''})|replace({'\r\n':'\n'})
+                                          |replace({'\n\n':'\n.\n'})
+                                          |replace({'\n\n':'\n.\n'})
+                                          |replace({'\n':'\n '}) }}
 {% endfor %}

--- a/src/spdx2/agent/template/spdx2-document.xml.twig
+++ b/src/spdx2/agent/template/spdx2-document.xml.twig
@@ -23,7 +23,7 @@
   <rdfs:comment> 
     This document was created using license information and a generator from Fossology.
   </rdfs:comment>
-{% for licenseId,extractedText in licenseTexts %}{% if licenseId starts with 'LicenseRef-' %}
+  {% for licenseId,licenseData in licenseTexts %}{% if licenseId starts with 'LicenseRef-' %}
   <spdx:hasExtractedLicensingInfo>
 {% if licenseId starts with 'LicenseRef-' %}
     <spdx:ExtractedLicensingInfo rdf:about="{{ uri }}#{{ licenseId|replace(' ','-')|url_encode }}">
@@ -31,9 +31,10 @@
     <spdx:ExtractedLicensingInfo rdf:about="http://spdx.org/licenses/{{ licenseId|replace(' ','-')|url_encode }}">
 {% endif %}
       <spdx:licenseId>{{ licenseId|replace(' ','-')|e }}</spdx:licenseId>
+      <spdx:name>{{ licenseData['name']|e }}</spdx:name>
       <spdx:extractedText><![CDATA[
-{{ extractedText|replace({'\f':''})
-                |replace({']]>':']]]]><![CDATA[>'}) }}
+{{ licenseData['text']|replace({'\f':''})
+                      |replace({']]>':']]]]><![CDATA[>'}) }}
       ]]></spdx:extractedText>
     </spdx:ExtractedLicensingInfo>
   </spdx:hasExtractedLicensingInfo>

--- a/src/spdx2/agent/template/spdx2tv-document.twig
+++ b/src/spdx2/agent/template/spdx2tv-document.twig
@@ -42,10 +42,10 @@ LicenseListVersion: 2.6
 ## License Information
 ##-------------------------
 
-{% for licenseId,extractedText in licenseTexts %}{% if licenseId starts with 'LicenseRef-' %}
+{% for licenseId,licenseData in licenseTexts %}{% if licenseId starts with 'LicenseRef-' %}
 LicenseID: {{ licenseId|replace(' ','-') }}
-LicenseName: {{ licenseId|replace(' ','-') }}
-ExtractedText: <text> {{ extractedText|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
-                                      |replace({'\f':''}) }} </text>
+LicenseName: {{ licenseData['name'] }}
+ExtractedText: <text> {{ licenseData['text']|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
+                                            |replace({'\f':''}) }} </text>
 
 {% endif %}{% endfor %}


### PR DESCRIPTION
The generated SPDX reported currently does not contain the optional field `name`, containing the clear name, for extracted license infos.