### PR TITLE
Provides a working build infrastructure

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -87,6 +87,12 @@ install-arch:
 	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-common \
            PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
            -C src composer_install
+	mkdir -p ~/composer/
+	utils/install_composer.sh ~/composer/
+	COMPOSER_PHAR=~/composer/composer
+	# emulating writing composer file, TODO see if that is really needed now
+	cp src/composer.json $(CURDIR)/debian/fossology-common
+	cp src/composer.lock $(CURDIR)/debian/fossology-common
 	mkdir -p $(CURDIR)/debian/fossology-common/usr/share/fossology/setup
 	cp $(CURDIR)/install/scripts/* $(CURDIR)/debian/fossology-common/usr/share/fossology/setup
 

--- a/install/scripts/php-conf-fix.sh
+++ b/install/scripts/php-conf-fix.sh
@@ -12,7 +12,7 @@ echo 'Automated php.ini configuration adjustments'
 echo
 if [ -f /etc/redhat-release ]; then
     phpIni=/etc/php.ini
-    TIMEZONE=`readlink /etc/localtime | sed 's%/usr/share/zoneinfo/%%'`
+    TIMEZONE=`readlink -f /etc/localtime | sed 's%/usr/share/zoneinfo/%%'`
 elif [ -f ${PHP5_PATH} ]; then
     phpIni=${PHP5_PATH}
     TIMEZONE=`cat /etc/timezone`

--- a/install/scripts/php-conf-fix.sh
+++ b/install/scripts/php-conf-fix.sh
@@ -18,6 +18,8 @@ elif [ -f ${PHP5_PATH} ]; then
     TIMEZONE=`cat /etc/timezone`
 elif [ -f ${PHP7_PATH} ]; then
     phpIni=${PHP7_PATH}
+else
+    phpIni=/etc/php5/apache2/php.ini
     TIMEZONE=`cat /etc/timezone`
 fi
 

--- a/pbconf/Vagrantfile
+++ b/pbconf/Vagrantfile
@@ -36,8 +36,8 @@ set -ex
 yum install -y wget git
 
 # install EPEL
-wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-rpm -Uvh epel-release-latest-7.noarch.rpm
+wget https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-11.noarch.rpm
+rpm -Uvh epel-release-7-11.noarch.rpm
 
 # install projectbuilder
 wget http://ftp.project-builder.org/test/centos/7/x86_64/pb-test.repo
@@ -140,8 +140,8 @@ PBRC
 # docker based generation here
 
 # maybe not all of the distros are relevant
-# DISTRO_LIST="ubuntu-14.10-x86_64 ubuntu-16.04-x86_64 ubuntu-16.10-x86_64 ubuntu-17.04-x86_64 debian-7-x86_64 debian-8-x86_64 debian-9-x86_64 fedora-21-x86_64 fedora-22-x86_64 fedora-23-x86_64 fedora-24-x86_64 fedora-25-x86_64 fedora-26-x86_64 centos-6-x86_64 centos-7-x86_64 mageia-5-x86_64 mageia-6-x86_64 opensuse-42.1-x86_64 opensuse-42.2-x86_64 opensuse-42.3-x86_64 gentoo-nover-x86_64"
-DISTRO_LIST="centos-7-x86_64 fedora-25-x86_64"
+# DISTRO_LIST="ubuntu-16.04-x86_64 ubuntu-16.10-x86_64 ubuntu-17.04-x86_64 debian-8-x86_64 debian-9-x86_64 fedora-25-x86_64 fedora-26-x86_64 centos-6-x86_64 centos-7-x86_64 mageia-6-x86_64 opensuse-42.2-x86_64 opensuse-42.3-x86_64"
+DISTRO_LIST="centos-7-x86_64"
 
 # some logic for command line ops here
 #DISTRO=$1

--- a/pbconf/Vagrantfile
+++ b/pbconf/Vagrantfile
@@ -40,8 +40,8 @@ wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 rpm -Uvh epel-release-latest-7.noarch.rpm
 
 # install projectbuilder
-wget http://ftp.project-builder.org/centos/7/x86_64/pb.repo
-cp pb.repo /etc/yum.repos.d/
+wget http://ftp.project-builder.org/test/centos/7/x86_64/pb-test.repo
+cp pb-test.repo /etc/yum.repos.d/
 
 # not using gpg checking is not recommended
 # yum update -y --nogpgcheck
@@ -49,10 +49,7 @@ cp pb.repo /etc/yum.repos.d/
 yum update -y
 
 # installs for projectbuilder
-yum install -y project-builder
-yum install -y subversion
-yum install -y perl-ExtUtils-MakeMaker
-yum install -y createrepo
+yum install -y project-builder subversion perl-ExtUtils-MakeMaker createrepo 
 
 # Fix a Fedora-26 issue
 cat >> /etc/pb/pb.conf << EOF
@@ -83,7 +80,7 @@ systemctl start docker
 # cd /home/vagrant/prj/fossology
 mkdir -p /home/vagrant/composer/
 /home/vagrant/prj/fossology/utils/install_composer.sh /home/vagrant/composer/
-mkdir /home/vagrant/prj/fossology/src/vendor
+mkdir -p /home/vagrant/prj/fossology/src/vendor
 chown vagrant:vagrant /home/vagrant/prj/fossology/src/vendor
 
 # preparing the transfer of the packages by ssh

--- a/pbconf/Vagrantfile
+++ b/pbconf/Vagrantfile
@@ -3,7 +3,7 @@
 
 #
 # original script by maximilian.huber@tngtech.com
-# additions by michael.c.jaeger@siemens.com
+# additions by bruno.cornec@hpe.com michael.c.jaeger@siemens.com
 #
 # SPDX-License-Identifier: GPL-2.0
 #
@@ -23,7 +23,8 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.synced_folder "..", "/home/vagrant/prj/fossology", type: "rsync"
-  config.vm.network "forwarded_port", guest: 80, host: 8081
+  config.vm.synced_folder "../target", "/home/vagrant/repo", type: "rsync", create: true
+  config.vm.network "forwarded_port", guest: 80, host: 8082
 
 #
 # part to prepare dependencies
@@ -46,7 +47,17 @@ cp pb.repo /etc/yum.repos.d/
 # yum update -y --nogpgcheck
 # yum install -y project-builder --nogpgcheck
 yum update -y
+
+# installs for projectbuilder
 yum install -y project-builder
+yum install -y subversion
+yum install -y perl-ExtUtils-MakeMaker
+yum install -y createrepo
+
+# Fix a Fedora-26 issue
+cat >> /etc/pb/pb.conf << EOF
+osupd fedora-26 = sudo /usr/bin/dnf makecache; sudo /usr/bin/dnf -y update
+EOF
 
 # adding docker install info for prepping the project builder installation runs
 cat > /etc/yum.repos.d/docker.repo << EOF
@@ -61,8 +72,28 @@ EOF
 # ... then installing docker
 yum install -y docker-engine
 
+# some modification of docker settings to run under user vagrant
+sed -i 's/dockerd$/dockerd -G vagrant/' /usr/lib/systemd/system/docker.service
+systemctl daemon-reload
+
 # ... starting docker
 systemctl start docker
+
+# ... installing composer things
+# cd /home/vagrant/prj/fossology
+mkdir -p /home/vagrant/composer/
+/home/vagrant/prj/fossology/utils/install_composer.sh /home/vagrant/composer/
+mkdir /home/vagrant/prj/fossology/src/vendor
+chown vagrant:vagrant /home/vagrant/prj/fossology/src/vendor
+
+# preparing the transfer of the packages by ssh
+ssh-keygen -t rsa -N "" -q -f /home/vagrant/.ssh/id_rsa
+chown vagrant:vagrant /home/vagrant/.ssh/id_rsa
+chown vagrant:vagrant /home/vagrant/.ssh/id_rsa.pub
+cat /home/vagrant/.ssh/id_rsa.pub >> /home/vagrant/.ssh/authorized_keys 
+chmod 600 /home/vagrant/.ssh/authorized_keys
+mkdir -p /home/vagrant/repo
+chown vagrant:vagrant /home/vagrant/repo
 
 SCRIPT
   end
@@ -87,32 +118,101 @@ cat<<PBRC > $HOME/.pbrc
 pbdefdir default = \\\$ENV{HOME}/cache-project-builder
 pbstoponerr default = true
 
-pburl fossology = git+https://github.com/fossology/fossology.git
-pbdefdir fossology =  \\\$ENV{'HOME'}/prj
-pbconfurl fossology = git+https://github.com/fossology/fossology.git
+# you need to swith depending on how you checked out fossology.git
+pburl fossology = git+ssh://git@github.com:fossology/fossology.git
+#pburl fossology = git+https://github.com/fossology/fossology.git
+pbconfurl fossology = git+ssh://git@github.com:fossology/fossology.git
+#pbconfurl fossology = git+https://github.com/fossology/fossology.git
+
+pbdefdir fossology = \\\$ENV{'HOME'}/prj
 pbconfdir fossology = \\\$ENV{'HOME'}/prj/fossology/pbconf
+
+pburl pb = svn://svn.project-builder.org/pb
+pbdefdir pb = \\\$ENV{'HOME'}
+pbconfurl pb = svn://svn.project-builder.org/pb/pbconf
+pbconfdir pb = \\\$ENV{'HOME'}/pb/pbconf
+
+sshhost fossology = localhost
+sshlogin fossology = vagrant
+sshdir fossology = /home/vagrant/repo
+sshport fossology = 22
 
 PBRC
 
 ################################################################################
-# sbx = sandbox
-pb -t -p fossology sbx2build   fossology
-pb    -p fossology build2prep  fossology
-# pb -t -p fossology sbx2pkg     fossology # actually, sbx2pkg is included in sbx2pkg2ins
-pb -t -p fossology sbx2pkg2ins fossology
+# docker based generation here
+
+# maybe not all of the distros are relevant
+# DISTRO_LIST="ubuntu-14.10-x86_64 ubuntu-16.04-x86_64 ubuntu-16.10-x86_64 ubuntu-17.04-x86_64 debian-7-x86_64 debian-8-x86_64 debian-9-x86_64 fedora-21-x86_64 fedora-22-x86_64 fedora-23-x86_64 fedora-24-x86_64 fedora-25-x86_64 fedora-26-x86_64 centos-6-x86_64 centos-7-x86_64 mageia-5-x86_64 mageia-6-x86_64 opensuse-42.1-x86_64 opensuse-42.2-x86_64 opensuse-42.3-x86_64 gentoo-nover-x86_64"
+DISTRO_LIST="centos-7-x86_64 fedora-25-x86_64"
+
+# some logic for command line ops here
+#DISTRO=$1
+#DISTROVER=$2
+#if [ "_$DISTRO" != "_" ]; then
+#DISTRO_LIST=$DISTRO-$DISTROVER-x86_64
+#fi
+
+VELIST=`echo $DISTRO_LIST | sed 's/ /,/g'`
+
+# note that velist and vepath should be set to default , not only project builder ('pb')
+cat >> $HOME/.pbrc << EOF
+velist default = $VELIST
+velogin default = pb
+vepath default = /tmp
+vetype default = docker
+dockerrepository default = pb
+EOF
+
+# Setup repos
+pb -p pb -r 0.14.6 sbx2pkg2ins
+# useless, instead use sbx2prepve
+pb -p fossology sbx2build
+
+# the grand for loop for the different distros
+for DISTRO in $DISTRO_LIST; do
+NAME=`pbdistrocheck $DISTRO | grep -E '^Name:' | awk '{print $2}'`
+VER=`pbdistrocheck $DISTRO | grep -E '^Ver:' | awk '{print $2}'`
+ARCH=`pbdistrocheck $DISTRO | grep -E '^Arch:' | awk '{print $2}'`
+pb -p pb -m $DISTRO newve -i ${NAME}:$VER
+pb -p pb -m $DISTRO sbx2setupve
+pb -p fossology -m $DISTRO prepve
+pb -p fossology -m $DISTRO build2ve
+done
+
+################################################################################
+#sbx = sandbox
+
+# git checkout could be done here if need for overwrite is needed ...
+
+# Give the ref to where composer is on the VM
+# adding componser binary to path
+
+export PATH=/home/vagrant/composer/:$PATH
+
+# and provide the variable to the make file
+#export COMPOSER_PHAR=/home/vagrant/composer/composer
+
+# commands for single distro generation 
+#pb -t -p fossology sbx2build   fossology
+#pb    -p fossology build2prep  fossology
+
+# actually, sbx2pkg is included in sbx2pkg2ins
+#pb -t -p fossology sbx2pkg     fossology 
+#pb -t -p fossology sbx2pkg2ins fossology
 
 SCRIPT
   end
 
 #
-# applying some work around
+# applying some work around for selinux
 #
   config.vm.provision "shell" do |s|
     s.privileged = false
     s.inline = <<SCRIPT
-# uahhh: disabling SELinux
+# todo disabling SELinux only at first start is needed but should be put in policies
 # remove if the https://github.com/fossology/fossology/issues/727
-setenforce 0
+sudo setenforce 0
 
 SCRIPT
   end

--- a/pbconf/fossology.pb
+++ b/pbconf/fossology.pb
@@ -61,7 +61,9 @@ testver fossology = true
 #
 #addrepo centos-5-x86_64 = http://packages.sw.be/rpmforge-release/rpmforge-release-0.3.6-1.el5.rf.x86_64.rpm,ftp://ftp.project-builder.org/test/centos/5/pb.repo
 #addrepo centos-4-x86_64 = http://packages.sw.be/rpmforge-release/rpmforge-release-0.3.6-1.el4.rf.x86_64.rpm,ftp://ftp.project-builder.org/test/centos/4/pb.repo
-addrepo centos-7-x86_64 = http://ftp.project-builder.org/centos/7/x86_64/pb.repo,https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+# Pending resolution of https://bugzilla.redhat.com/show_bug.cgi?id=1509190
+#addrepo centos-7-x86_64 = http://ftp.project-builder.org/centos/7/x86_64/pb.repo,https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+addrepo centos-7-x86_64 = http://ftp.project-builder.org/centos/7/x86_64/pb.repo,https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-11.noarch.rpm
 
 #
 # Adapt to your needs:

--- a/pbconf/fossology.pb
+++ b/pbconf/fossology.pb
@@ -61,7 +61,7 @@ testver fossology = true
 #
 #addrepo centos-5-x86_64 = http://packages.sw.be/rpmforge-release/rpmforge-release-0.3.6-1.el5.rf.x86_64.rpm,ftp://ftp.project-builder.org/test/centos/5/pb.repo
 #addrepo centos-4-x86_64 = http://packages.sw.be/rpmforge-release/rpmforge-release-0.3.6-1.el4.rf.x86_64.rpm,ftp://ftp.project-builder.org/test/centos/4/pb.repo
-addrepo centos-7-x86_64 = http://ftp.project-builder.org/centos/7/x86_64/pb.repo,https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
+addrepo centos-7-x86_64 = http://ftp.project-builder.org/centos/7/x86_64/pb.repo,https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 #
 # Adapt to your needs:

--- a/pbconf/fossology.pb
+++ b/pbconf/fossology.pb
@@ -1,8 +1,9 @@
 #
 # Project Builder configuration file
 # For project fossology
+# at least modifications by bruno.cerne@hpe.com michael.c.jaeger@siemens.com
 #
-# "$Id: $"
+# SPDX-License-Identifier: GPL-2.0
 #
 
 #
@@ -16,7 +17,9 @@ pburl fossology = git+https://github.com/fossology/fossology.git
 #pburl fossology = file:///src/fossology-devel.tar.gz
 #pburl fossology = dir:///src/fossology-devel
 
+#
 # Repository
+#
 pbrepo fossology = http://www.fossology.org/releases
 #pbml fossology = fossology-announce@lists.fossology.org
 #pbsmtp fossology = localhost
@@ -29,9 +32,11 @@ pbrepo fossology = http://www.fossology.org/releases
 #
 # Packager label
 #
-pbpackager fossology = Dong Ma <vincent@fossology.org>
+
+pbpackager fossology = Bruno Cornec <bruno.cornec@hpe.com>
 #
 
+#
 # For delivery to a machine by SSH (potentially the FTP server)
 # Needs hostname, account and directory
 #
@@ -46,14 +51,19 @@ sshport fossology = 22
 projver fossology = 3.1.0
 projtag fossology = 1
 
+#
 # Is it a test version or a production version
+#
 testver fossology = true
 
+#
 # Additional repository to add at build time
-# addrepo centos-5-x86_64 = http://packages.sw.be/rpmforge-release/rpmforge-release-0.3.6-1.el5.rf.x86_64.rpm,ftp://ftp.project-builder.org/test/centos/5/pb.repo
-# addrepo centos-4-x86_64 = http://packages.sw.be/rpmforge-release/rpmforge-release-0.3.6-1.el4.rf.x86_64.rpm,ftp://ftp.project-builder.org/test/centos/4/pb.repo
-addrepo centos-7-x86_64 = http://ftp.project-builder.org/centos/7/x86_64/pb.repo,http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
+#
+#addrepo centos-5-x86_64 = http://packages.sw.be/rpmforge-release/rpmforge-release-0.3.6-1.el5.rf.x86_64.rpm,ftp://ftp.project-builder.org/test/centos/5/pb.repo
+#addrepo centos-4-x86_64 = http://packages.sw.be/rpmforge-release/rpmforge-release-0.3.6-1.el4.rf.x86_64.rpm,ftp://ftp.project-builder.org/test/centos/4/pb.repo
+addrepo centos-7-x86_64 = http://ftp.project-builder.org/centos/7/x86_64/pb.repo,https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
 
+#
 # Adapt to your needs:
 # Optional if you need to overwrite the global values above
 #
@@ -64,14 +74,18 @@ defpkgdir fossology =
 # Hash of additional package/package directory
 #extpkgdir minor-pkg = dir-minor-pkg
 
+#
 # List of files per pkg on which to apply filters
 # Files are mentioned relatively to pbroot/defpkgdir
+#
 #filteredfiles fossology = Makefile.PL,configure.in,install.sh,fossology.8
 #supfiles fossology = fossology.init
 
+#
 # For perl modules, names are different depending on distro
 # Here perl-xxx for RPMs, libxxx-perl for debs, ...
 # So the package name is indeed virtual
+#
 #namingtype fossology = perl
 
 #addrepo rhel-5-i386 = http://packages.sw.be/rpmforge-release/rpmforge-release-0.3.6-1.el5.rf.i386.rpm,ftp://ftp.project-builder.org/test/centos/5/pb.repo

--- a/pbconf/fossology/deb/changelog
+++ b/pbconf/fossology/deb/changelog
@@ -1,167 +1,71 @@
-fossology (3.0.0~rc1-1) unstable; urgency=low
+fossology (3.1.0~rc2-1) unstable; urgency=low
 
-  * unofficial build version
+  * New upstream release
+  * see https://github.com/fossology/fossology/releases/tag/3.1.0rc2 for details
 
- -- bcornec <bruno.cornec@hpe.com>  Fri, 26 Aug 2016 16:35:55 +0800
+ -- maximilian.huber <maximilian.huber@tngtech.com>  Sat, 21 May 2016 15:35:55 +0800
 
-fossology (3.0.0) unstable; urgency=low
+fossology (3.1.0~rc1-1) unstable; urgency=low
 
-  * New Features
-    *New folder navigation** : Jquery based table UI for downloads including sorting and filtering with more handling attributes per upload.
-    *New license UI for editing concluded licenses** : Instead of providing a separate UI for license conclusion, now a single file view license UI allows for efficient license situation review: highlighted texts and selected licenses are moving together to one view now.
-    *Re-use of license decisions** : At uploading a new file, a user can select existing uploads for reusing already applied license decisions, if the file hash is the same.
-    *Bulk assignment of license decisions based on text phrases** : When identifying a phrase hinting to particular license (e.g. "license info can be found in readme"), the user can define this text as search string and assign a license decision to every matching file.
-    *Auto-decision of the Monk and Nomos scanner find the same license in the same text area** : If both scanners find the same license by short name, then a license decision can be applied automatically.
-    *Adding Ninka as optional scanner** : At upload or at scheduling jobs, the user can run Ninka scanner with FOSSology as third license scanner.
-    *New UI for editing copyrights** : Separate display for URL, E-Mails, copyright statements and authorship notes.
-    *Adding the concept of candidate licenses, to let users add licenses as candidates for the system** : New licenses must be added carefully to the server database. However, in order not to stop a user a reviewing an upload, candidate licenses can be registered for addition to the server by the server admin later.
-    *License import and export using a CSV interface** : Using CSV formatted files, licenses with the reference texts can be imported and exported to the FOSSology server.
-    *Adding readme / copying file generation** : Concluded licenses and copyright statements are written into a text file that is information for the distribution.
-    *SPDX 2.0 file generation** : Based on the scan results and concluded licenses, SPDX 2.0 XML format is generated (passes verification tool).
-  * Issues: Corrections
-    * #508 : Copyright agent fails to show copyrights without license information : Corrected filter value
-    * #492 : Correcting SPDX-non compliant LicenseRefs : FOSSology license refs contained so characters like single quotes which are not SPDX compliant
-    * #490 : Missing (report) cache for license overview : Fixed performance issue with separate new view in PHP
-    * #479 : Correcting Nomos Segmentation fault : That was an issue also shown in testing, corrected
-    * #472 : Adding escaping to license texts in SPDX output : If a license contains non-std chars, the generated extracted texts could contains also these non-UTF-8 characters. As such, the SPDX was invalid.
-    * #469 : Adding tooltip to the priority of the browse menu : In order to explain the user what the green and blue arrows in the priority column mean
-    * #467 : Adding header content of main table in the browse view : In order to tell the user which the current folder is that is displayed
-    * #465 : using wget_agent can modify files : Fixed an incompatibility with the wget call
-    * #404 : Error when load the license browse page : Fixed error in migration script
-    * #401 : At fo_nomos_license_list.php using --user instead of --username : Fixed by corrected commit
-    * #400 : Upload from File page cannot select folder : Corrected the according FolderDAO (data access object)
-    * #392 : Error when run cli cp2foss script : Corrected wrong function call
-    * #384 : Dashboard failure in 2.6.2 : Was a compatibility issue between different postgresql versions, solved for 9.2 and 9.3 now
-    * #366 : Incomplete scheduler error message  : Loggin missing columns
-    * #364 : At large number of jobs - performance problem : Correcting the SQL query to be a dimension faster
-    * #362 : Allow install to skip version (to skip versions at updates) : Changed the fossinit.php accordingly
-    * #360 : MIT and University of Illinois Open Source licenses not detected : Added licenses
-    * #359 : Remove hardcoded path in wget_agent : Fixed / removed hardcoced path
-    * #355 : Password in DBConnection string is printed to Fossology log when connection attempt fails : Password is removed from connection info map before printed to log
-    * #352 : Copyright agent using uploadtree: is it better now? : Ran analyses on copyright agent which confirmed copyright performance / precision
-    * #350 : License not found : Not really licenses, but some license references where not found, but they are found now with correction to the Nomos
-    * #349 : cp2foss fails to upload a directory using '*' option  : Corrected the use of wild cards
-    * #347 : Copyright agent 2.5.0: support copyright symbol  : Copyright symbol in UTF-8 is supported
-    * #345 : copyright agent 2.5.0: non-ASCII symbols : Changed copyright agent does cover also non-ASCII symbols
-    * #339 : A read only user can find none public files : Corrected access rights
-    * #335 : Scanner dependency: Monk agent rescan link not shown (needed for new licenses) : Adding manual setting to allow for enabling monk rescans
-    * #323 : Completely remove BSAM : Removed BSAM sub-project and UI references from codebase
-    * #282 : Need License Admin Documentation : Added documentation to the fossology.org wiki
-    * #264 : Nomos missing unidentified license ("Tapjoy") : Corrected and Nomos finds it now
-    * #259 : Documentation fix for copyright agent : Corrected documentation of the copyright agent
-    * #251 : On Maintenance page, be able to check all checkboxes one time : Corrected issue
-    * #218 : Edit users forgets users agent selections : Corrected issue
-    * #213 : Copyright - missed after long year string, for example ten years in a row : Corrected issue
-    * #212 : Moving an upload folder fails (circle protection) : Corrected issue
-    * #24 : Migration issue with table license_file_audit  : Corrected issue
-  * Issues: Enhancements
-    * #342 : Show Jobs - add estimated completion date/time : New completion time column was added (ETA)
-    * #319 : Tooltips for UI elements : Added tooltips mechanism and text for many UI elements
-    * #224 : At listing of copyrights - add text filter : Added a filter field - comes with the new jquery UI
-    * #214 : Create survey & solicit fossology users to respond to questions about fossology usage : yeay: http://www.fossology.org/projects/fossology/wiki/WhoUsesFOSSology
-  * Issues: Closed w/o Particular Commit
-    * #474 : copyright browser file path misplaced : Indeed, but UI needs major correction anyways, unchanged
-    * #388 : Major Nomos Regression with AGPL : Checked that license finding is acceptable
-    * #387 : Both Monk and Nomos appear to miss PostgreSQL License : Checked that license are found with reference file
-    * #338 : License browser regression - schedule link : Checked that link is there
-    * #318 : Scaling performance issues : Checked that large files seem to work with tables (also referring to #490)
-    * #216 : ‘(c)' is recognized as a copyright signature wrongly : Retested with current version and does not seem to be a serious problem since false positives have been reduced
-    * #247 : The maintagent - add feature to remove failed uploads  : Closed because user can remove uploads also with the menu item for organising uploads
-    * #238 : Browser tab interference when using FOSSology : Changes in the PHP UI do not show this issue anymore
-    * #225 : Folder selection fails in Edit Uploaded File Properties : Retested and current version does not show issue anymore
-    * #219 : New regex scanner module : There is on new module in the form of the all-new copyright agent (in c++) which is also generalised and thus extensible for new applications
-    * #215 : Flag license as possibly proprietary : Closed without modification because it needs to be solved with commercial license options
-    * #180 : Push continuous integration information to fossology.org : Is going to be moved to TLF
-    * #26 : View License Audit Link confusing with Edit concluded license  : Covered with changes in the UI anyways
-    * #25 : Pull SPDX module into master branch : Closed, because SPDX module was there
+  * New upstream release
+  * see https://github.com/fossology/fossology/releases/tag/3.1.0rc1 for details
 
- -- Steffen Weber <steffen.weber@tngtech.com>  Thu, 23 Jul 2015 16:34:24 +0200
+ -- maximilian.huber <maximilian.huber@tngtech.com>  Fri, 15 Apr 2016 15:35:55 +0800
 
-fossology (2.6.0) unstable; urgency=low
+fossology (3.0.0-1) unstable; urgency=low
 
-    * monk.  This is a new license scanner contributed by our friends at Siemens and TNGTech.  Monk looks for complete licenses (as defined in the database) and reports the percentage match (see also License highlighting below).
-    * License highlighting.  Now when you view a license you can see exactly what was added or removed from a license.  This works especially well with monk since monk scans for complete licenses (stored in the fossology database).  But it also works to show you what snippet nomos matched to identify a license.
-    * New license browser
-    * fo_copyright_list can now list files that contain a copyright, or list files that do not contain a copyright.
-    * fo_license_list has new options to exclude licenses (or directories)
-    * Many new licenses added
-    * Old bugs fixed, new ones added. see our "issue tracker": (link outdated)
+  * New upstream release
+  * see https://github.com/fossology/fossology/releases/tag/3.0.0 for details
 
- -- Steffen Weber <steffen.weber@tngtech.com>  Thu, 25 Jun 2015 18:48:38 +0200
+ -- maximilian.huber <maximilian.huber@tngtech.com>  Thu, 05 Nov 2015 15:35:55 +0800
 
-fossology (2.5.0) unstable; urgency=low
+fossology (2.6.2-1) unstable; urgency=low
 
-  * Note
-    * Be aware that the only supported upgrade path is a sequential one 2.0 > 2.1 > 2.2 > 2.3 > 2.4 > 2.5.
-    * If you run into any upgrade errors, for example with the copyright table, please let us know.
-    * Many thanks to all of you who submitted bugs, patches and suggestions.  FOSSology is for everyone, please help make it better.
-  * What Changed
-    * Switched source code repository to GIT (but still on SourceForge)
-    * Fixed unpack failure when archive asks for password
-    * Make nightly builds publicly accessible
-    * Fix Ubuntu 12.04 packaging error
-    * Improve FOSSology upgrade speed
-    * New command line program to list buckets (fo_bucket_list)
-    * Several user interface bugs fixed.
-  * License scanner updates:
-    * Fixed issue detecting Apache 2.0 reference
-    * Fix for GPL-v3 being labeled GPL-v3+ in certain cases
-    * Fixed several special cases where GPL was labelled LGPL or missed completely
-    * Fix problem of embedded quote in license names
-    * Fix case of GPL-2.0+ being identified as GPL-2.0
-    * Fix EPL labeled as CPL
-    * Fix special case of missed Boost software license
-    * Multiple fixes for special cases where GPL was missed
-    * Fix missed Sun Legal Notice
-    * Fix case where upload was failing on directories that contain spaces
-    * Fix special case where Freetype license was missed
-    * Fix MIT that should have been MIT-style
-    * Fix special case of missed CPL-1.0
-    * Fix cases of missed file references 
-    * Add LIBGCJ license
-    * Add WordNet (was being detected as MIT/Princeton license
-    * Add Interbase-1.0 license
-    * Add KnowledgeTree-1.1
-    * Add Open Cascade Technology Public License
-    * Add identifing licenses referenced in .spec files
-    * Add ACE license
-    * Add FACE license
-    * Add Tapjoy license
-    * Add ClearSilver license
-    * Add LGPL-2.1+-KDE-exception
+  * New upstream release
 
- -- Steffen Weber <steffen.weber.ext@siemens.com>  Tue, 12 May 2015 10:25:45 +0100
+ -- larainema <larainema@localhost.localdomain>  Mon, 12 Jan 2015 15:35:55 +0800
 
-fossology (2.4.1) unstable; urgency=low
+fossology (2.6.1-1) unstable; urgency=low
 
-  * bugfix
+  * New upstream release
 
- -- Steffen Weber <steffen.weber.ext@siemens.com>  Thu, 9 Mar 2015 11:31:45 +0100
+ -- larainema <larainema@localhost.localdomain>  Wed, 01 Oct 2014 15:35:55 +0800
 
-fossology (2.4.0) unstable; urgency=low
+fossology (2.6.0-1) unstable; urgency=low
 
-  * bugfixes
+  * New upstream release
 
- -- Steffen Weber <steffen.weber.ext@siemens.com>  Thu, 5 Mar 2015 14:30:00 +0100
+ -- larainema <larainema@localhost.localdomain>  Fri, 19 Sep 2014 15:35:55 +0800
 
-fossology (2.3.0) unstable; urgency=low
+fossology (2.5.0-1) unstable; urgency=low
 
-  * bugfixes
+  * New upstream release
 
- -- Steffen Weber <steffen.weber.ext@siemens.com>  Mon, 1 Jan 2015 12:00:00 +0100
+ -- larainema <larainema@localhost.localdomain>  Tue, 08 Apr 2014 15:35:55 +0800
+ 
+fossology (2.4.0-1) unstable; urgency=low
 
-fossology (2.2.0) unstable; urgency=low
+  * New upstream release
 
-  * bugfixes
+ -- larainema <larainema@localhost.localdomain>  Tue, 14 Jan 2014 15:35:55 +0800
 
- -- Andreas Wuerl <andreas.wuerl.ext@siemens.com>  Fri, 19 Dec 2014 08:00:00 +0100
+fossology (2.3.0-1) unstable; urgency=low
 
-fossology (2.1.0) unstable; urgency=low
+  * New upstream release
 
-  * bugfixes
+ -- larainema <larainema@localhost.localdomain>  Web, 25 Sep 2013 15:35:55 +0800
 
+fossology (2.2.0-1) unstable; urgency=low
 
- -- Andreas Wuerl <andreas.wuerl.ext@siemens.com>  Fri, 21 Nov 2014 08:00:00 +0100
+  * New upstream release
+
+ -- larainema <larainema@localhost.localdomain>  Fri, 28 Jun 2013 15:35:55 +0800
+ 
+fossology (2.1.0-1) unstable; urgency=low
+
+  * New upstream release
+
+ -- madong <madong@bl480c1>  Thu, 01 Nov 2012 15:35:55 +0800
 
 fossology (2.0.0-1) unstable; urgency=low
 
@@ -305,4 +209,5 @@ fossology (1.0.0~rc1-1) unstable; urgency=low
   * Upstream 1.0.0 release candidate 1
 
  -- Matt Taggart <taggart@debian.org>  Wed, 12 Nov 2008 03:01:48 -0800
+
 

--- a/pbconf/fossology/deb/control
+++ b/pbconf/fossology/deb/control
@@ -2,7 +2,7 @@ Source: fossology
 Section: utils
 Priority: extra
 Maintainer: Michael Jaeger <michael.c.jaeger@siemens.com>
-Build-Depends: debhelper, libglib2.0-dev, libmagic-dev, libxml2-dev, libmxml-dev, libtext-template-perl, librpm-dev, subversion, rpm, libpcre3-dev, libssl-dev, postgresql-server-dev-all, libboost-regex-dev, libboost-program-options-dev, php-mbstring, php-xml, PBPHPCLI, curl, PBBUILDDEP
+Build-Depends: debhelper, libglib2.0-dev, libmagic-dev, libxml2-dev, libmxml-dev, libtext-template-perl, librpm-dev, subversion, rpm, libpcre3-dev, libssl-dev, postgresql-server-dev-all, libboost-regex-dev, libboost-program-options-dev, PBPHPCLI, curl, PBBUILDDEP
 Standards-Version: PBDEBSTD
 Homepage: http://fossology.org
 

--- a/pbconf/fossology/deb/control
+++ b/pbconf/fossology/deb/control
@@ -2,7 +2,7 @@ Source: fossology
 Section: utils
 Priority: extra
 Maintainer: Michael Jaeger <michael.c.jaeger@siemens.com>
-Build-Depends: debhelper, libglib2.0-dev, libmagic-dev, libxml2-dev, libmxml-dev, libtext-template-perl, librpm-dev, subversion, rpm, libpcre3-dev, libssl-dev, postgresql-server-dev-all, libboost-regex-dev, libboost-program-options-dev, PBPHPCLI, curl, PBBUILDDEP
+Build-Depends: debhelper, libglib2.0-dev, libmagic-dev, libxml2-dev, libmxml-dev, libtext-template-perl, librpm-dev, subversion, rpm, libpcre3-dev, libssl-dev, postgresql-server-dev-all, libboost-regex-dev, libboost-program-options-dev, php-mbstring, php-xml, PBPHPCLI, curl, PBBUILDDEP
 Standards-Version: PBDEBSTD
 Homepage: http://fossology.org
 

--- a/pbconf/fossology/deb/control
+++ b/pbconf/fossology/deb/control
@@ -2,14 +2,26 @@ Source: fossology
 Section: utils
 Priority: extra
 Maintainer: Michael Jaeger <michael.c.jaeger@siemens.com>
-Build-Depends: debhelper, libglib2.0-dev, libmagic-dev, libxml2-dev, libtext-template-perl, librpm-dev, subversion, rpm, libpcre3-dev, libssl-dev, libboost-regex-dev, libboost-program-options-dev, php5, curl, PBBUILDDEP
+Build-Depends: debhelper, libglib2.0-dev, libmagic-dev, libxml2-dev, libmxml-dev, libtext-template-perl, librpm-dev, subversion, rpm, libpcre3-dev, libssl-dev, postgresql-server-dev-all, libboost-regex-dev, libboost-program-options-dev, PBPHPCLI, curl, PBBUILDDEP
 Standards-Version: PBDEBSTD
 Homepage: http://fossology.org
+
+Package: fossology-dev
+Architecture: any
+Depends: PBPHPCLI
+Description: architecture for analyzing software, development utils
+ The FOSSology project is a web based framework that allows you to
+ upload software to be picked apart and then analyzed by software agents
+ which produce results that are then browsable via the web interface.
+ Existing agents include license analysis, metadata extraction, and MIME
+ type identification.
+ .
+ This package contains software to ease development behind a firewall.
 
 Package: fossology
 Architecture: any
 Depends: fossology-web, fossology-scheduler, fossology-ununpack, fossology-copyright, fossology-buckets, fossology-mimetype, fossology-delagent, fossology-wgetagent, ${misc:Depends}
-Recommends: fossology-monk, fossology-monkbulk, fossology-decider, fossology-spdx2, fossology-reuser, fossology-ninka
+Recommends: fossology-monk, fossology-monkbulk, fossology-decider, fossology-readmeoss, fossology-spdx2, fossology-reuser, fossology-ninka
 Conflicts: fossology-db (<= 1.4.1), fossology-common (<= 1.4.1)
 Description: open and modular architecture for analyzing software
  The FOSSology project is a web based framework that allows you to
@@ -25,7 +37,7 @@ Description: open and modular architecture for analyzing software
 
 Package: fossology-common
 Architecture: any
-Depends: php5-pgsql, php-pear, php5-cli, php5-json, ${shlibs:Depends}, ${misc:Depends}
+Depends: php-pgsql, php-pear, PBPHPCLI, php-json, ${shlibs:Depends}, ${misc:Depends}
 Description: architecture for analyzing software, common files
  The FOSSology project is a web based framework that allows you to
  upload software to be picked apart and then analyzed by software agents
@@ -38,7 +50,7 @@ Description: architecture for analyzing software, common files
 
 Package: fossology-web
 Architecture: any
-Depends: fossology-common, fossology-db, fossology-decider, apache2, libapache2-mod-php5, ${misc:Depends}
+Depends: fossology-common, fossology-db, fossology-decider, apache2, libapache2-mod-php, ${misc:Depends}
 Description: architecture for analyzing software, web interface
  The FOSSology project is a web based framework that allows you to
  upload software to be picked apart and then analyzed by software agents
@@ -259,6 +271,19 @@ Description: architecture for analyzing software, Microsoft Word report generato
  type identification.
  .
  This package contains the unifiedreport agent programs and their resources.
+
+Package: fossology-readmeoss
+Architecture: any
+Depends: fossology-common, fossology-copyright ${misc:Depends}
+Description: architecture for analyzing software, OSS readme generator
+ The FOSSology project is a web based framework that allows you to
+ upload software to be picked apart and then analyzed by software agents
+ which produce results that are then browsable via the web interface.
+ Existing agents include license analysis, metadata extraction, and MIME
+ type identification.
+ .
+ This package contains the readmeoss agent programs and their resources.
+
 Package: fossology-reuser
 Architecture: any
 Depends: fossology-common, ${misc:Depends}

--- a/pbconf/fossology/deb/copyright
+++ b/pbconf/fossology/deb/copyright
@@ -1,7 +1,13 @@
 This package was debianized by Matt Taggart <taggart@debian.org> on
 Fri, 17 Oct 2008 01:24:09 -0700.
 
-It was downloaded from http://fossology.org
+Home Page:
+
+    https://www.fossology.org
+
+Project Page:
+
+    https://github.com/fossology/fossology
 
 Upstream Authors:
 
@@ -64,7 +70,10 @@ the GNU Lesser General Public License version 2.1
 On Debian systems, the complete text of the GNU Lesser General
 Public License can be found in `/usr/share/common-licenses/LGPL-2.1'.
 
-
 The original Debian packaging is (C) 2008, Matt Taggart <taggart@debian.org> and
 is licensed under the GPL, see above.
+
 Additional Debian packaging changes (C) 2008-2012 HP Development Company
+
+Additional Debian packaging changes (C) 2017 Michael C. Jaeger, mcj@mcj.de
+

--- a/pbconf/fossology/deb/fossology-common.README.Debian
+++ b/pbconf/fossology/deb/fossology-common.README.Debian
@@ -1,5 +1,8 @@
 FOSSology for Debian
 --------------------
+
+(to be updated, text is from 2008)
+
 FOSSology is a web based application. In addition to installing the
 fossology packages you need to configure some other services on your
 system like a webserver and database. Then you access FOSSology with

--- a/pbconf/fossology/deb/fossology-web.postinst
+++ b/pbconf/fossology/deb/fossology-web.postinst
@@ -24,7 +24,7 @@ case "$1" in
     if [ -f "/etc/apache2/sites-enabled/fossology.conf" ]; then
     rm -rf  /etc/apache2/sites-enabled/fossology.conf
     fi
-    sed -r -i.bak 's/;? ?upload_max_filesize ?= ?[0-9]+[kmgKMG]*/upload_max_filesize = 750M/' /etc/php5/apache2/php.ini
+    sed -r -i.bak 's/;? ?upload_max_filesize ?= ?[0-9]+[kmgKMG]*/upload_max_filesize = 750M/' /etc/php*/apache2/php.ini
     ln -s /etc/fossology/conf/fo-apache.conf /etc/apache2/sites-enabled/fossology.conf
     # need to run fo-postinstall web and agent stuff
     /usr/lib/fossology/fo-postinstall --web-only

--- a/pbconf/fossology/deb/notes
+++ b/pbconf/fossology/deb/notes
@@ -1,5 +1,6 @@
-Notes on the Debian packaging of FOSSology v2.0
 ==========================================
+(note: to be modified according to moving to git)
+
 1.) The debian/ directory is kept in upstream SVN, but it is excluded
 from upstream release tarballs in order to prevent the messy
 situation of having to patch and merge this directory.
@@ -54,5 +55,9 @@ So that that results in the following packages and relationships:
   * fossology-ninka Depends on fossology-common
   * fossology-decider Depends on fossology-common
   * fossology-deciderjob Depends on fossology-common
+  * fossology-readmeoss Depends on fossology-common and fossology-copyright
   * fossology-reuser Depends on fossology-common
+  
+4.) FOSSology v3.X brought a number of additions to the code base including the
+the SPDX2 generation agent.
   * fossology-spdx2 Depends on fossology-common

--- a/pbconf/fossology/deb/rules
+++ b/pbconf/fossology/deb/rules
@@ -158,6 +158,11 @@ install-arch:
 	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-unifiedreport \
            PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
            -C src/unifiedreport install
+
+	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-readmeoss \
+           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
+           -C src/readmeoss install
+	
 	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-reuser \
            PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
            -C src/reuser install
@@ -166,6 +171,7 @@ install-arch:
            PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
            -C src/spdx2 install
 
+	mkdir -p $(CURDIR)/debian/fossology-dev/usr/bin
 	mkdir -p $(CURDIR)/debian/fossology-dev/usr/share/fossology/
 	tar czf $(CURDIR)/debian/fossology-dev/usr/share/fossology/php-vendor.tar.gz -C $(CURDIR)/debian/fossology-common/usr/share/fossology vendor
 

--- a/pbconf/fossology/rpm/fossology.spec
+++ b/pbconf/fossology/rpm/fossology.spec
@@ -273,7 +273,7 @@ cp utils/fo-cleanold $RPM_BUILD_ROOT/%{_usr}/lib/PBPROJ/
 cp install/scripts/php-conf-fix.sh $RPM_BUILD_ROOT/%{_usr}/lib/PBPROJ/
 
 # manually add the version file
-cp $RPM_BUILD_ROOT%{_usr}/share/PBPROJ/VERSION $RPM_BUILD_ROOT%{_sysconfdir}/PBPROJ/
+cp VERSION $RPM_BUILD_ROOT%{_sysconfdir}/PBPROJ/
 
 #rm -f $RPM_BUILD_ROOT/%{_sysconfdir}/default/PBPROJ
 

--- a/pbconf/fossology/rpm/fossology.spec
+++ b/pbconf/fossology/rpm/fossology.spec
@@ -236,7 +236,6 @@ utils/install_composer.sh $RPM_BUILD_DIR/composer/
 #
 
 %build
-COMPOSER_PHAR=/home/vagrant/composer/composer 
 make SYSCONFDIR=%{_sysconfdir}/fossology PREFIX=%{_usr} LOCALSTATEDIR=%{_var}
 #make %{?_smp_mflags} SYSCONFDIR=%{_sysconfdir}
 make SYSCONFDIR=%{_sysconfdir}/fossology PREFIX=%{_usr} LOCALSTATEDIR=%{_var} -C src/nomos/agent/ -f Makefile.sa

--- a/pbconf/fossology/rpm/fossology.spec
+++ b/pbconf/fossology/rpm/fossology.spec
@@ -20,7 +20,7 @@ Url:            PBURL
 Source:         PBSRC
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(id -u -n)
 Requires:       fossology-web fossology-scheduler fossology-ununpack fossology-copyright fossology-buckets fossology-mimetype fossology-delagent fossology-wgetagent fossology-decider fossology-spdx2 fossology-reuser
-#Recommends:		fossology-decider, fossology-spdx2, fossology-reuse,fossology-ninka
+#Recommends:		fossology-decider, fossology-spdx2, fossology-reuser, fossology-ninka
 BuildRequires:  postgresql-devel >= 8.1.11,glib2-devel,libxml2,gcc,make,perl,rpm-devel,pcre-devel,openssl-devel,gcc-c++,php,boost-devel,php-phar,php-mbstring,php-xml,curl,PBBUILDDEP
 Summary:        FOSSology is a license compliance analysis  tool
 
@@ -236,6 +236,7 @@ utils/install_composer.sh $RPM_BUILD_DIR/composer/
 #
 
 %build
+COMPOSER_PHAR=/home/vagrant/composer/composer 
 make SYSCONFDIR=%{_sysconfdir}/fossology PREFIX=%{_usr} LOCALSTATEDIR=%{_var}
 #make %{?_smp_mflags} SYSCONFDIR=%{_sysconfdir}
 make SYSCONFDIR=%{_sysconfdir}/fossology PREFIX=%{_usr} LOCALSTATEDIR=%{_var} -C src/nomos/agent/ -f Makefile.sa
@@ -274,6 +275,7 @@ cp install/scripts/php-conf-fix.sh $RPM_BUILD_ROOT/%{_usr}/lib/PBPROJ/
 
 # manually add the version file
 cp VERSION $RPM_BUILD_ROOT%{_sysconfdir}/PBPROJ/
+#cp $RPM_BUILD_ROOT%{_usr}/share/PBPROJ/VERSION $RPM_BUILD_ROOT%{_sysconfdir}/PBPROJ/
 
 #rm -f $RPM_BUILD_ROOT/%{_sysconfdir}/default/PBPROJ
 

--- a/pbconf/fossology/rpm/fossology.spec
+++ b/pbconf/fossology/rpm/fossology.spec
@@ -273,8 +273,7 @@ cp utils/fo-cleanold $RPM_BUILD_ROOT/%{_usr}/lib/PBPROJ/
 cp install/scripts/php-conf-fix.sh $RPM_BUILD_ROOT/%{_usr}/lib/PBPROJ/
 
 # manually add the version file
-cp VERSION $RPM_BUILD_ROOT%{_sysconfdir}/PBPROJ/
-#cp $RPM_BUILD_ROOT%{_usr}/share/PBPROJ/VERSION $RPM_BUILD_ROOT%{_sysconfdir}/PBPROJ/
+cp $RPM_BUILD_ROOT%{_usr}/share/PBPROJ/VERSION $RPM_BUILD_ROOT%{_sysconfdir}/PBPROJ/
 
 #rm -f $RPM_BUILD_ROOT/%{_sysconfdir}/default/PBPROJ
 

--- a/pbconf/fossology/rpm/fossology.spec
+++ b/pbconf/fossology/rpm/fossology.spec
@@ -1,6 +1,14 @@
 #
-# $Id$
+# Spec file for fossology for building rpm packages
 #
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+
 %define srcname PBPKG
 
 Name:           PBPKG
@@ -11,10 +19,14 @@ Group:          PBGRP
 Url:            PBURL
 Source:         PBSRC
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(id -u -n)
-Requires:       fossology-web fossology-scheduler fossology-ununpack fossology-copyright fossology-buckets fossology-mimetype fossology-delagent fossology-wgetagent
-#Recommends:		fossology-decider, fossology-spdx2, fossology-reuser, fossology-ninka
+Requires:       fossology-web fossology-scheduler fossology-ununpack fossology-copyright fossology-buckets fossology-mimetype fossology-delagent fossology-wgetagent fossology-decider fossology-spdx2 fossology-reuser
+#Recommends:		fossology-decider, fossology-spdx2, fossology-reuse,fossology-ninka
 BuildRequires:  postgresql-devel >= 8.1.11,glib2-devel,libxml2,gcc,make,perl,rpm-devel,pcre-devel,openssl-devel,gcc-c++,php,boost-devel,php-phar,curl,PBBUILDDEP
-Summary:        FOSSology is a licenses exploration tool
+Summary:        FOSSology is a license compliance analysis  tool
+
+#
+# package
+#
 
 %package common
 Requires:       php >= 5.1.6,php-pear >= 5.16,php-pgsql >= 5.1.6,php-process,php-mbstring,PBDEP
@@ -118,6 +130,10 @@ Requires:       fossology-common
 Summary:        Architecture for reusing clearing result of other uploads, monkbulk
 Group:          PBGRP
 
+#
+# description
+#
+
 %description
 PBDESC
 
@@ -187,24 +203,43 @@ This package contains the monk agent programs and their resources.
 %description monkbulk
 This package contains the monkbulk agent programs and their resources.
 
+#
+# prep
+#
+
 %prep
 %setup -q -n %{name}-%{version}PBEXTDIR
 #PBPATCHCMD
 
-mkdir -p /tmp/composer/
-utils/install_composer.sh /tmp/composer/
-COMPOSER_PHAR=/tmp/composer/composer
+mkdir -p $RPM_BUILD_DIR/composer/
+utils/install_composer.sh $RPM_BUILD_DIR/composer/
+# make DESTDIR=$RPM_BUILD_ROOT PREFIX=%{_usr} SYSCONFDIR=%{_sysconfdir}/fossology LOCALSTATEDIR=%{_var} LIBDIR=%{_libdir} composer_install
 
-make DESTDIR=$RPM_BUILD_ROOT PREFIX=%{_usr} SYSCONFDIR=%{_sysconfdir}/fossology LOCALSTATEDIR=%{_var} LIBDIR=%{_libdir} composer_install
+#
+# build
+#
 
 %build
 make SYSCONFDIR=%{_sysconfdir}/fossology PREFIX=%{_usr} LOCALSTATEDIR=%{_var}
 #make %{?_smp_mflags} SYSCONFDIR=%{_sysconfdir}
 make SYSCONFDIR=%{_sysconfdir}/fossology PREFIX=%{_usr} LOCALSTATEDIR=%{_var} -C src/nomos/agent/ -f Makefile.sa
 
+#
+# install
+#
+
 %install
+export COMPOSER_PHAR=$RPM_BUILD_DIR/composer/composer
 make DESTDIR=$RPM_BUILD_ROOT PREFIX=%{_usr} SYSCONFDIR=%{_sysconfdir}/fossology LOCALSTATEDIR=%{_var} LIBDIR=%{_libdir} install_offline
+make DESTDIR=$RPM_BUILD_ROOT PREFIX=%{_usr} SYSCONFDIR=%{_sysconfdir}/fossology LOCALSTATEDIR=%{_var} LIBDIR=%{_libdir} -C install/ -f Makefile install
 make DESTDIR=$RPM_BUILD_ROOT PREFIX=%{_usr} SYSCONFDIR=%{_sysconfdir}/fossology LOCALSTATEDIR=%{_var} LIBDIR=%{_libdir} -C src/nomos/agent/ -f Makefile.sa install
+make DESTDIR=$RPM_BUILD_ROOT PREFIX=%{_usr} SYSCONFDIR=%{_sysconfdir}/fossology LOCALSTATEDIR=%{_var} LIBDIR=%{_libdir} composer_install
+
+# emulating writing composer file, TODO see if that is really needed now
+cp src/composer.json $RPM_BUILD_ROOT%{_usr}/share/PBPROJ
+cp src/composer.lock $RPM_BUILD_ROOT%{_usr}/share/PBPROJ
+#cp $RPM_BUILD_ROOT%fossology/src/vendor $RPM_BUILD_ROOT%{_usr}/share/PBPROJ
+
 #mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}/httpd/conf.d
 #cat > $RPM_BUILD_ROOT/%{_sysconfdir}/httpd/conf.d/PBPROJ.conf << EOF
 #Alias /repo/ /usr/share/PBPROJ/www/
@@ -219,16 +254,28 @@ make DESTDIR=$RPM_BUILD_ROOT PREFIX=%{_usr} SYSCONFDIR=%{_sysconfdir}/fossology 
 #</Directory>
 #EOF
 cp utils/fo-cleanold $RPM_BUILD_ROOT/%{_usr}/lib/PBPROJ/
+cp install/scripts/php-conf-fix.sh $RPM_BUILD_ROOT/%{_usr}/lib/PBPROJ/
+
+# manually add the version file
+cp VERSION $RPM_BUILD_ROOT%{_sysconfdir}/PBPROJ/
 
 #rm -f $RPM_BUILD_ROOT/%{_sysconfdir}/default/PBPROJ
+
+#
+# clean
+#
 
 %clean
 %{__rm} -rf $RPM_BUILD_ROOT
 
+#
+# files
+#
+
 %files
 %defattr(-,root,root)
-%doc ChangeLog
-%doc COPYING COPYING.LGPL HACKING README.md install/INSTALL install/INSTALL.multi LICENSE
+# %doc ChangeLog # mcj todo not existing anymore, right?
+%doc COPYING COPYING.LGPL README.md install/INSTALL install/INSTALL.multi NOTICES CONTRIBUTING.md CHANGELOG.md
 
 %files common
 %defattr(-,root,root)
@@ -271,30 +318,36 @@ cp utils/fo-cleanold $RPM_BUILD_ROOT/%{_usr}/lib/PBPROJ/
 %{_datadir}/PBPROJ/readmeoss/*
 
 %files ninka
+%defattr(-,root,root)
 %{_sysconfdir}/PBPROJ/mods-enabled/ninka
 %{_datadir}/PBPROJ/ninka/*
 
 %files decider
+%defattr(-,root,root)
 %dir %{_datadir}/PBPROJ/decider
 %{_sysconfdir}/PBPROJ/mods-enabled/decider
 %{_datadir}/PBPROJ/decider/*
 
 %files deciderjob
+%defattr(-,root,root)
 %dir %{_datadir}/PBPROJ/deciderjob
 %{_sysconfdir}/PBPROJ/mods-enabled/deciderjob
 %{_datadir}/PBPROJ/deciderjob/*
 
 %files reuser
+%defattr(-,root,root)
 %dir %{_datadir}/PBPROJ/reuser
 %{_sysconfdir}/PBPROJ/mods-enabled/reuser
 %{_datadir}/PBPROJ/reuser/*
 
 %files monk
+%defattr(-,root,root)
 %dir %{_datadir}/PBPROJ/monk
 %{_sysconfdir}/PBPROJ/mods-enabled/monk
 %{_datadir}/PBPROJ/monk/*
 
 %files monkbulk
+%defattr(-,root,root)
 %dir %{_datadir}/PBPROJ/monkbulk
 %{_sysconfdir}/PBPROJ/mods-enabled/monkbulk
 %{_datadir}/PBPROJ/monkbulk/*
@@ -374,6 +427,10 @@ cp utils/fo-cleanold $RPM_BUILD_ROOT/%{_usr}/lib/PBPROJ/
 %{_datadir}/PBPROJ/dep5/*
 %{_datadir}/PBPROJ/spdx2tv/*
 
+#
+# post
+#
+
 %post common
 # Run the postinstall script
 /usr/lib/PBPROJ/fo-postinstall --common
@@ -415,6 +472,9 @@ ln -s %{_sysconfdir}/PBPROJ/conf/fo-apache.conf  %{_sysconfdir}/httpd/conf.d/PBP
 # Run the postinstall script
 /usr/lib/PBPROJ/fo-postinstall --web-only
 
+# fix php config for fixing the time zone, TODO does not work reliably with cent
+/usr/lib/PBPROJ/php-conf-fix.sh --overwrite
+
 # httpd is also assumed to run locally
 LANGUAGE=C service httpd status 2>&1 | grep -q PBSTOP
 if [ $? -eq 0 ]; then
@@ -432,8 +492,72 @@ fi
 # Run the postinstall script
 /usr/lib/PBPROJ/fo-postinstall --agent
 
+#
+# post: agent independency ops
+#
+
+%post ununpack
+# Run the postinstall script
+/usr/lib/PBPROJ/fo-postinstall --agent
+
+%post copyright
+# Run the postinstall script
+/usr/lib/PBPROJ/fo-postinstall --agent
+
+%post buckets
+# Run the postinstall script
+/usr/lib/PBPROJ/fo-postinstall --agent
+
+%post mimetype
+# Run the postinstall script
+/usr/lib/PBPROJ/fo-postinstall --agent
+
+%post nomos
+# Run the postinstall script
+/usr/lib/PBPROJ/fo-postinstall --agent
+
+%post pkgagent
+# Run the postinstall script
+/usr/lib/PBPROJ/fo-postinstall --agent
+
+%post delagent
+# Run the postinstall script
+/usr/lib/PBPROJ/fo-postinstall --agent
+
+%post wgetagent
+# Run the postinstall script
+/usr/lib/PBPROJ/fo-postinstall --agent
+
+%post spdx2
+# Run the postinstall script
+/usr/lib/PBPROJ/fo-postinstall --agent
+
+%post decider
+# Run the postinstall script
+/usr/lib/PBPROJ/fo-postinstall --agent
+
+%post deciderjob
+# Run the postinstall script
+/usr/lib/PBPROJ/fo-postinstall --agent
+
+%post reuser
+# Run the postinstall script
+/usr/lib/PBPROJ/fo-postinstall --agent
+
+%post monk
+# Run the postinstall script
+/usr/lib/PBPROJ/fo-postinstall --agent
+
+%post monkbulk
+# Run the postinstall script
+/usr/lib/PBPROJ/fo-postinstall --agent
+
 chkconfig --add PBPROJ
 /etc/init.d/PBPROJ start
+
+#
+# preun
+#
 
 %preun
 if [ $1 -eq 0 ]; then
@@ -445,6 +569,10 @@ if [ $1 -eq 0 ]; then
   /usr/lib/PBPROJ/fo-cleanold
 fi
 
+#
+# postun
+#
+
 %postun scheduler
 if [ $1 -eq 0 ]; then
   # cleanup logs
@@ -452,6 +580,7 @@ if [ $1 -eq 0 ]; then
     rm -rf /var/log/PBPROJ || echo "ERROR: could not remove /var/log/fossology"
   fi
 fi
+
 %postun common
 if [ $1 -eq 0 ]; then
   echo "removing FOSSology user..."
@@ -475,5 +604,13 @@ if [ $1 -eq 0 ]; then
   fi
 fi
 
+#
+# changelog
+#
+
 %changelog
 PBLOG
+
+#
+# end
+#

--- a/pbconf/fossology/rpm/fossology.spec
+++ b/pbconf/fossology/rpm/fossology.spec
@@ -21,7 +21,7 @@ Source:         PBSRC
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(id -u -n)
 Requires:       fossology-web fossology-scheduler fossology-ununpack fossology-copyright fossology-buckets fossology-mimetype fossology-delagent fossology-wgetagent fossology-decider fossology-spdx2 fossology-reuser
 #Recommends:		fossology-decider, fossology-spdx2, fossology-reuse,fossology-ninka
-BuildRequires:  postgresql-devel >= 8.1.11,glib2-devel,libxml2,gcc,make,perl,rpm-devel,pcre-devel,openssl-devel,gcc-c++,php,boost-devel,php-phar,curl,PBBUILDDEP
+BuildRequires:  postgresql-devel >= 8.1.11,glib2-devel,libxml2,gcc,make,perl,rpm-devel,pcre-devel,openssl-devel,gcc-c++,php,boost-devel,php-phar,php-mbstring,php-xml,curl,PBBUILDDEP
 Summary:        FOSSology is a license compliance analysis  tool
 
 #
@@ -130,6 +130,16 @@ Requires:       fossology-common
 Summary:        Architecture for reusing clearing result of other uploads, monkbulk
 Group:          PBGRP
 
+%package unifiedreport
+Requires:       fossology-common
+Summary:        Unified report Agent
+Group:          PBGRP
+
+%package reportimport
+Requires:       fossology-common
+Summary:        Report Import Agent
+Group:          PBGRP
+
 #
 # description
 #
@@ -202,6 +212,12 @@ This package contains the monk agent programs and their resources.
 
 %description monkbulk
 This package contains the monkbulk agent programs and their resources.
+
+%description unifiedreport
+This package contains the unified report agent programs and their resources.
+
+%description reportimport
+This package contains the report import agent programs and their resources.
 
 #
 # prep
@@ -301,6 +317,18 @@ cp VERSION $RPM_BUILD_ROOT%{_sysconfdir}/PBPROJ/
 %{_datadir}/PBPROJ/composer.json
 %{_datadir}/PBPROJ/composer.lock
 %{_datadir}/PBPROJ/vendor/*
+
+%files unifiedreport
+%{_sysconfdir}/PBPROJ/mods-enabled/unifiedreport
+%{_datadir}/PBPROJ/unifiedreport/*
+%{_datadir}/PBPROJ/unifiedreport/ui/*
+%{_datadir}/PBPROJ/unifiedreport/agent/*
+
+%files reportimport
+%{_sysconfdir}/PBPROJ/mods-enabled/reportImport
+%{_datadir}/PBPROJ/reportImport/*
+%{_datadir}/PBPROJ/reportImport/agent/*
+%{_datadir}/PBPROJ/reportImport/ui/*
 
 %files db
 %defattr(-,root,root)
@@ -551,6 +579,7 @@ fi
 %post monkbulk
 # Run the postinstall script
 /usr/lib/PBPROJ/fo-postinstall --agent
+
 
 chkconfig --add PBPROJ
 /etc/init.d/PBPROJ start

--- a/pbconf/pbfilter/debian-9.pbf
+++ b/pbconf/pbfilter/debian-9.pbf
@@ -11,4 +11,4 @@ filter PBDEBCOMP = 7
 
 filter PBBUILDDEP = postgresql-server-dev-9.6,libjson-c-dev
 filter PBDEP = postgresql (>= 8.1) | postgresql-9.6
-filter PBPHPCLI = php-cli
+filter PBPHPCLI = php-cli,php-mbstring,php-xml

--- a/pbconf/pbfilter/debian-9.pbf
+++ b/pbconf/pbfilter/debian-9.pbf
@@ -9,6 +9,6 @@ filter PBDEBSTD = 3.9.1
 # PBDEBCOMP is replaced by the Debian Compatibility value
 filter PBDEBCOMP = 7
 
-filter PBBUILDDEP = postgresql-server-dev-9.4,libjson0-dev
-filter PBDEP = postgresql (>= 8.1) | postgresql-9.4
-filter PBPHPCLI = php5-cli
+filter PBBUILDDEP = postgresql-server-dev-9.6,libjson-c-dev
+filter PBDEP = postgresql (>= 8.1) | postgresql-9.6
+filter PBPHPCLI = php-cli

--- a/pbconf/pbfilter/ubuntu-16.04.pbf
+++ b/pbconf/pbfilter/ubuntu-16.04.pbf
@@ -7,4 +7,4 @@
 # according to thread at http://postgresql.1045698.n5.nabble.com/Details-about-libpq-cross-version-compatibility-td5723830.html the API has not changed significantly since 7.4
 filter PBBUILDDEP = postgresql-server-dev-9.5
 filter PBDEP = postgresql (>= 8.1) | postgresql-9.5
-filter PBPHPCLI = php7.0-cli
+filter PBPHPCLI = php7.0-cli,php-mbstring,php-xml

--- a/pbconf/pbfilter/ubuntu-16.04.pbf
+++ b/pbconf/pbfilter/ubuntu-16.04.pbf
@@ -6,3 +6,5 @@
 # for Ubuntu 16.04 use the postgres 9.5 libpq headers
 # according to thread at http://postgresql.1045698.n5.nabble.com/Details-about-libpq-cross-version-compatibility-td5723830.html the API has not changed significantly since 7.4
 filter PBBUILDDEP = postgresql-server-dev-9.5
+filter PBDEP = postgresql (>= 8.1) | postgresql-9.5
+filter PBPHPCLI = php7.0-cli

--- a/pbconf/pbfilter/ubuntu-16.10.pbf
+++ b/pbconf/pbfilter/ubuntu-16.10.pbf
@@ -7,4 +7,4 @@
 # according to thread at http://postgresql.1045698.n5.nabble.com/Details-about-libpq-cross-version-compatibility-td5723830.html the API has not changed significantly since 7.4
 filter PBBUILDDEP = postgresql-server-dev-9.5
 filter PBDEP = postgresql (>= 8.1) | postgresql-9.5
-filter PBPHPCLI = php7.0-cli
+filter PBPHPCLI = php7.0-cli,php-mbstring,php-xml

--- a/pbconf/pbfilter/ubuntu-17.04.pbf
+++ b/pbconf/pbfilter/ubuntu-17.04.pbf
@@ -7,4 +7,4 @@
 # according to thread at http://postgresql.1045698.n5.nabble.com/Details-about-libpq-cross-version-compatibility-td5723830.html the API has not changed significantly since 7.4
 filter PBBUILDDEP = postgresql-server-dev-9.6
 filter PBDEP = postgresql (>= 8.1) | postgresql-9.6
-filter PBPHPCLI = php7.0-cli
+filter PBPHPCLI = php7.0-cli,php-mbstring,php-xml

--- a/pbconf/pbfilter/ubuntu-17.04.pbf
+++ b/pbconf/pbfilter/ubuntu-17.04.pbf
@@ -5,6 +5,6 @@
 
 # for Ubuntu 16.10 use the postgres 9.5 libpq headers
 # according to thread at http://postgresql.1045698.n5.nabble.com/Details-about-libpq-cross-version-compatibility-td5723830.html the API has not changed significantly since 7.4
-filter PBBUILDDEP = postgresql-server-dev-9.5
-filter PBDEP = postgresql (>= 8.1) | postgresql-9.5
+filter PBBUILDDEP = postgresql-server-dev-9.6
+filter PBDEP = postgresql (>= 8.1) | postgresql-9.6
 filter PBPHPCLI = php7.0-cli


### PR DESCRIPTION
- Make packages for the following distributions:
  debian 8/9, ubuntu 16.04/16.10/17.04, centos 7 and fedora 25
- Find a compromise around composer using COMPOSER_PHAR variable
- Copy the correct VERSION file in /etc/fossology for spec
- Fix TimeZone computation when links are used
- Adjusting file write attributes for rpm package installation
- Vagrant additions for docker based package building
- Remains to fix: Fedora 26 has a syntax change in dnf makecache (solved
  in project-builder.org 0.15.1)
- Fix PHP version usage in install procedure cf #920

Should allow to close #688 and #692 for now (while the composer aspect s far from being ideal)