### PR TITLE
feat(ui): Colour mapping for risk level in the ui.

### DIFF
--- a/src/www/ui/admin-license-file.php
+++ b/src/www/ui/admin-license-file.php
@@ -19,6 +19,7 @@
 
 use Fossology\Lib\BusinessRules\LicenseMap;
 use Fossology\Lib\Db\DbManager;
+use Symfony\Component\HttpFoundation\Response;
 
 define("TITLE_admin_license_file", _("License Administration"));
 
@@ -33,6 +34,7 @@ class admin_license_file extends FO_Plugin
     $this->Title      = TITLE_admin_license_file;
     $this->MenuList   = "Admin::License Admin";
     $this->DBaccess   = PLUGIN_DB_ADMIN;
+    $this->vars       = array();
     parent::__construct();
     
     $this->dbManager = $GLOBALS['container']->get('db.manager');
@@ -63,42 +65,40 @@ class admin_license_file extends FO_Plugin
     if (@$_POST["updateit"])
     {
       $resultstr = $this->Updatedb($_POST);
-      $V .= $resultstr;
       if (strstr($resultstr, $errorstr)) {
-        $V .= $this->Updatefm(0);
+        return $this->Updatefm(0);
       }
       else {
+        $V .= $resultstr;
         $V .= $this->Inputfm();
+        return $V;
       }
-      return $V;
     }
 
     if (@$_REQUEST['add'] == 'y')
     {
-      $V .= $this->Updatefm(0);
-      return $V;
+      return $this->Updatefm(0);
     }
 
     // Add new rec to db
     if (@$_POST["addit"])
     {
       $resultstr = $this->Adddb($_POST);
-      $V .= $resultstr;
       if (strstr($resultstr, $errorstr)) {
-        $V .= $this->Updatefm(0);
+        return $this->Updatefm(0);
       }
       else {
+        $V .= $resultstr;
         $V .= $this->Inputfm();
+        return $V;
       }
-      return $V;
     }
 
     // bring up the update form
     $rf_pk = @$_REQUEST['rf_pk'];
     if ($rf_pk)
     {
-      $V .= $this->Updatefm($rf_pk);
-      return $V;
+      return $this->Updatefm($rf_pk);
     }
 
     $V .= $this->Inputfm();
@@ -260,12 +260,18 @@ class admin_license_file extends FO_Plugin
   }
 
 
+  function Updatefm($rf_pk)
+  {
+    $this->vars += $this->getUpdatefmData($rf_pk);
+    return $this->render('admin_license-upload_form.html.twig');
+  }
+
   /**
    * @brief Update forms
    * @param int $rf_pk - for the license to update, empty to add
    * @return string The input form
    */
-  function Updatefm($rf_pk)
+  function getUpdatefmData($rf_pk)
   {
     $vars = array();
 
@@ -322,7 +328,7 @@ class admin_license_file extends FO_Plugin
         $row[$key] = $_POST[$key];
       }
     }
-    
+
     $vars['boolYesNoMap'] = array("true"=>"Yes", "false"=>"No");
     $row['rf_active'] = $this->dbManager->booleanFromDb($row['rf_active'])?'true':'false';
     $row['marydone'] = $this->dbManager->booleanFromDb($row['marydone'])?'true':'false';
@@ -334,8 +340,7 @@ class admin_license_file extends FO_Plugin
 
     $vars['rfId'] = $rf_pk?:$rf_pk_update;
 
-    $allVars = array_merge($vars,$row);
-    return $this->renderString('admin_license-upload_form.html.twig', $allVars);
+    return array_merge($vars,$row);
   }
 
 

--- a/src/www/ui/css/fossology.css
+++ b/src/www/ui/css/fossology.css
@@ -320,8 +320,46 @@ div.infoTable {
 #databaseTable {
   width: 100%;
 }
+
 .candidateFileList{
   height: 200px;
   overflow-x: hidden;
   overflow-y: auto;
+}
+
+.riskLevelBox {
+  height: 25px;
+  width: 25px;
+  padding: 0 4px;
+  font-weight: bold;
+  line-height: 25px;
+  text-align: center;
+  border-bottom-left-radius: 5px;
+  border-top-left-radius: 5px;
+  border-bottom-right-radius: 5px;
+  border-top-right-radius: 5px;
+}
+
+.riskLevelBackgroud0 {
+  background: #ffffff;
+}
+
+.riskLevelBackgroud1 {
+  background: #87cfff;
+}
+
+.riskLevelBackgroud2 {
+  background: #00d10d;
+}
+
+.riskLevelBackgroud3 {
+  background: #f2e600;
+}
+
+.riskLevelBackgroud4 {
+  background: #f17d00
+}
+
+.riskLevelBackgroud5 {
+  background: #e95850;
 }

--- a/src/www/ui/popup-license.php
+++ b/src/www/ui/popup-license.php
@@ -81,7 +81,7 @@ class PopupLicense extends FO_Plugin
     }
     $this->vars['url'] = $licenseUrl;
     $this->vars['text'] = $license->getText();
-    $this->vars['risk'] = $license->getRisk();
+    $this->vars['risk'] = $license->getRisk() ?: 0;
     return $this->render('popup_license.html.twig');
   }  
 }

--- a/src/www/ui/template/admin_license-upload_form.html.twig
+++ b/src/www/ui/template/admin_license-upload_form.html.twig
@@ -4,6 +4,10 @@
    are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
    This file is offered as-is, without any warranty.
 #}
+{% extends "include/base.html.twig" %}
+
+{% block content %}
+
 <form name="Updatefm" action="{{ actionUri }}" method="post">
   <input type="hidden" name="req_marydone" value="{{ req_marydone }}"/>
   <input type="hidden" name="req_shortname" value="{{ req_shortname }}"/>
@@ -72,3 +76,10 @@
   {% endif %}
   <input type="submit" value="{% if rfId %}{{ 'Update'|trans }}{% else %}{{ 'Add license'|trans }}{% endif %}"/>
 </form>
+{% endblock %}
+
+{% block foot %}
+  {{ parent() }}
+  {% set riskSelectId = 'risk_level' %}
+  <script>{% include "riskLevel_select.js.twig" %}</script>
+{% endblock %}

--- a/src/www/ui/template/advice_license-edit.html.twig
+++ b/src/www/ui/template/advice_license-edit.html.twig
@@ -48,3 +48,10 @@
 </form>  
   
 {% endblock %}
+
+
+{% block foot %}
+  {{ parent() }}
+  {% set riskSelectId = 'risk' %}
+  <script>{% include "riskLevel_select.js.twig" %}</script>
+{% endblock %}

--- a/src/www/ui/template/popup_license.html.twig
+++ b/src/www/ui/template/popup_license.html.twig
@@ -31,9 +31,9 @@
           <h2>{{ 'Reference URL'|trans }}:</h2>
           <a href="{{ url }}" target="_blank">{{ url|e }}</a>
         {% endif %}
-        {% if risk %}
+        {% if risk is defined %}
           <h2>{{ 'Risk level'|trans }}:</h2>
-          {{ risk }}
+            <div class="riskLevelBox riskLevelBackgroud{{ risk }}"> {{ risk }} </div>
         {% endif %}
         {% if text %}
           <h2>{{ 'License Text'|trans }}</h2>

--- a/src/www/ui/template/riskLevel_select.js.twig
+++ b/src/www/ui/template/riskLevel_select.js.twig
@@ -1,0 +1,17 @@
+{# Copyright 2017 Siemens AG
+
+   Copying and distribution of this file, with or without modification,
+   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
+   This file is offered as-is, without any warranty.
+#}
+
+$('#{{ riskSelectId }}').on('change', function() {
+    $(this).attr('class', 'riskLevelBackgroud'+$(this).val());
+});
+$('#{{ riskSelectId }} option').each( function() {
+    $(this).attr("class", 'riskLevelBackgroud'+$(this).val());
+});
+
+$(document).ready(function() {
+    $('#{{ riskSelectId }}').trigger('change');
+});


### PR DESCRIPTION
This feature adds a colour mapping for the risk level of a license in the UI. (See issue https://github.com/fossology/fossology/issues/878)

* When adding or updating a license, the dropdown for the risk level is colour encoded:
![risk1](https://user-images.githubusercontent.com/10673021/32177826-83e44ec6-bd8b-11e7-9138-42cddd34a294.png)

* In the license detail view of the license browser the risk level is shown by coloured rectangles:
![risk2](https://user-images.githubusercontent.com/10673021/32178040-0c4e0e78-bd8c-11e7-8be2-a411f0d74ad4.png)

* The colours can be specified globally in `fossology.css`.