### PR TITLE
fix(treeView): removed license through edit, still exists

### DIFF
--- a/src/lib/php/BusinessRules/ClearingDecisionProcessor.php
+++ b/src/lib/php/BusinessRules/ClearingDecisionProcessor.php
@@ -144,7 +144,7 @@ class ClearingDecisionProcessor extends Object
 
     $itemId = $itemBounds->getItemId();
 
-    $previousEvents = $this->clearingDao->getRelevantClearingEvents($itemBounds, $groupId);
+    $previousEvents = $this->clearingDao->getRelevantClearingEvents($itemBounds, $groupId, $includeSubFolders=false);
     if ($type === self::NO_LICENSE_KNOWN_DECISION_TYPE)
     {
       $type = DecisionTypes::IDENTIFIED;

--- a/src/lib/php/BusinessRules/test/ClearingDecisionProcessorTest.php
+++ b/src/lib/php/BusinessRules/test/ClearingDecisionProcessorTest.php
@@ -62,6 +62,8 @@ class ClearingDecisionProcessorTest extends \PHPUnit_Framework_TestCase
   private $clearingEventProcessor;
   /** @var int */
   private $timestamp;
+  /** @var boolean */
+  private $includeSubFolders;
 
   protected function setUp()
   {
@@ -70,6 +72,7 @@ class ClearingDecisionProcessorTest extends \PHPUnit_Framework_TestCase
     $this->userId = 12;
     $this->groupId = 5;
     $this->timestamp = time();
+    $this->includeSubFolders = false;
 
     $this->clearingDao = M::mock(ClearingDao::classname());
     $this->agentLicenseEventProcessor = M::mock(AgentLicenseEventProcessor::classname());
@@ -101,7 +104,7 @@ class ClearingDecisionProcessorTest extends \PHPUnit_Framework_TestCase
     $addedEvent = $this->createClearingEvent(123, $this->timestamp, 13, "licA", "License A");
 
     $this->clearingDao->shouldReceive("getRelevantClearingEvents")
-        ->with($this->itemTreeBounds, $this->groupId)
+        ->with($this->itemTreeBounds, $this->groupId, $this->includeSubFolders)
         ->andReturn(array($addedEvent));
     $this->agentLicenseEventProcessor->shouldReceive("getScannerEvents")
             ->with($this->itemTreeBounds)
@@ -128,7 +131,7 @@ class ClearingDecisionProcessorTest extends \PHPUnit_Framework_TestCase
     $addedEvent = $this->createClearingEvent(123, $this->timestamp, 13, "licA", "License A");
 
     $this->clearingDao->shouldReceive("getRelevantClearingEvents")
-        ->with($this->itemTreeBounds, $this->groupId)
+        ->with($this->itemTreeBounds, $this->groupId, $this->includeSubFolders)
         ->andReturn(array($addedEvent));
     $this->agentLicenseEventProcessor->shouldReceive("getScannerEvents")
             ->with($this->itemTreeBounds)->andReturn(array());
@@ -157,7 +160,7 @@ class ClearingDecisionProcessorTest extends \PHPUnit_Framework_TestCase
     $addedEvent = $this->createClearingEvent(123, $this->timestamp, 13, "licA", "License A");
 
     $this->clearingDao->shouldReceive("getRelevantClearingEvents")
-        ->with($this->itemTreeBounds, $this->groupId)
+        ->with($this->itemTreeBounds, $this->groupId, $this->includeSubFolders)
         ->andReturn(array($addedEvent));
     $this->agentLicenseEventProcessor->shouldReceive("getScannerEvents")
             ->with($this->itemTreeBounds)->andReturn(array());
@@ -188,7 +191,7 @@ class ClearingDecisionProcessorTest extends \PHPUnit_Framework_TestCase
             ->with($this->itemTreeBounds)->andReturn(array());
 
     $this->clearingDao->shouldReceive("getRelevantClearingEvents")
-        ->with($this->itemTreeBounds, $this->groupId)
+        ->with($this->itemTreeBounds, $this->groupId, $this->includeSubFolders)
         ->andReturn(array());
 
     $clearingDecision = M::mock(ClearingDecision::classname());
@@ -218,7 +221,7 @@ class ClearingDecisionProcessorTest extends \PHPUnit_Framework_TestCase
         ->with($this->itemTreeBounds)->andReturn(array());
 
     $this->clearingDao->shouldReceive("getRelevantClearingEvents")
-        ->with($this->itemTreeBounds, $this->groupId)
+        ->with($this->itemTreeBounds, $this->groupId, $this->includeSubFolders)
         ->andReturn(array($licenseRef->getId() => $addedEvent));
 
     $clearingDecision = M::mock(ClearingDecision::classname());
@@ -250,7 +253,7 @@ class ClearingDecisionProcessorTest extends \PHPUnit_Framework_TestCase
         ->with($this->itemTreeBounds)->andReturn(array());
 
     $this->clearingDao->shouldReceive("getRelevantClearingEvents")
-        ->with($this->itemTreeBounds, $this->groupId)
+        ->with($this->itemTreeBounds, $this->groupId, $this->includeSubFolders)
         ->andReturn(array($licenseRef->getId() => $removedEvent));
 
     $clearingDecision = M::mock(ClearingDecision::classname());
@@ -279,7 +282,7 @@ class ClearingDecisionProcessorTest extends \PHPUnit_Framework_TestCase
     $removedEvent = $this->createClearingEvent(123, $this->timestamp, $licenseRef->getId(), $licenseRef->getShortName(), $licenseRef->getFullName(), ClearingEventTypes::USER, $isRemoved = true);
 
     $this->clearingDao->shouldReceive("getRelevantClearingEvents")
-        ->with($this->itemTreeBounds, $this->groupId)
+        ->with($this->itemTreeBounds, $this->groupId, $this->includeSubFolders)
         ->andReturn(array($licenseRef->getId() => $removedEvent));
 
     $this->agentLicenseEventProcessor->shouldReceive("getScannerEvents")

--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -382,9 +382,9 @@ INSERT INTO clearing_decision (
    * @param int $groupId
    * @return ClearingEvent[] sorted by ts_added
    */
-  public function getRelevantClearingEvents($itemTreeBounds, $groupId)
+  public function getRelevantClearingEvents($itemTreeBounds, $groupId, $includeSubFolders=true)
   {
-    $decision = $this->getFileClearingsFolder($itemTreeBounds, $groupId, $onlyCurrent=true);
+    $decision = $this->getFileClearingsFolder($itemTreeBounds, $groupId, $includeSubFolders, $onlyCurrent=true);
     $events = array();
     $date = 0;
 


### PR DESCRIPTION
**To Reproduce Issue:**

-> Install **Master** and upload a package.
-> From file tree view of uploaded component, Click on edit and add a license from any folder.
-> Now remove the added license from the same folder.
-> Removed license still exist in edited license column.

Now repeat the same steps in **contrib/fixRemoveEditLicenseTreeView**