### PR TITLE
fix(bulk): separate td for each image and add width for select

### DIFF
--- a/src/www/ui/template/ui-clearing-view_bulk.html.twig
+++ b/src/www/ui/template/ui-clearing-view_bulk.html.twig
@@ -14,18 +14,23 @@
 
     <table>
       <tr>
-        <td style="padding-right:20px">
-          <span id="bulkExistingLicense">
-            <select id="bulkLicense" style="min-width:200px" >
+        <td id="bulkExistingLicense">
+            <select id="bulkLicense" style="width:100%" >
               {% for license in licenseArray %}
                 <option value="{{ license.id }}" title="{{ license.fullname|e }}">{{ license.shortname|e }}</option>
               {% endfor %}
-            </select><img src="images/info_16.png" style="vertical-align:middle !important;" title="{{ 'The user can select an according license'|trans }}" alt="" class="info-bullet"/>
-          </span>
+            </select>
         </td>
-        <td style="padding-right:20px">
+        <td>
+          <img src="images/info_16.png" style="vertical-align:middle !important;" title="{{ 'The user can select an according license'|trans }}" alt="" class="info-bullet"/>
+        </td>
+        <td style="padding:0px 3px 0px 3px">
           <a href="#" id="bulkFormAddLicense" style="font-size:20px;"><img src="images/icons/add_16.png" title="append job to add selected license" alt="+"/></a>
+        </td>
+        <td style="padding:0px 3px 0px 3px">
           <a href="#" id="bulkFormRmLicense" style="font-size:20px;"><img src="images/icons/remove_16.png" title="append job to remove selected license" alt="-"/></a>
+        </td>
+        <td>
           <img src="images/info_16.png" style="vertical-align:middle !important;" title="{{ 'Adding or removing a license is possible. Removing a license will pull the scanner found license off from the potential clearing decisions. This can be used to correct a scanner finding'|trans }}" alt="" class="info-bullet"/>
         </td>
         <td>
@@ -48,7 +53,7 @@
 
     <br/>
     {{ 'Reference text'| trans }}:<br/>
-    <textarea name="bulkRefText" id="bulkRefText" type="text" cols="80" rows="12"></textarea><br>
+    <textarea name="bulkRefText" id="bulkRefText" type="text" rows="12" style="width:100%"></textarea><br>
     <select name="bulkScope" id="bulkScope">
       <option value="u">{{ 'scan whole Upload'| trans }}</option>
       <option value="f">{{ 'scan only current Folder'| trans }}</option>


### PR DESCRIPTION
**To Reproduce:**

-> Add a new license or candidate license to fossology database with min 50 characters for shortname.
-> Go to single file view click on bulk recognition.
-> Select license will be out of the box.

<img width="822" alt="screen shot 2017-12-20 at 11 47 41" src="https://user-images.githubusercontent.com/3418977/34203498-a52582ae-e57b-11e7-8605-79f70905ecd6.png">

