### PR TITLE
fix(monkbulk): check the job status when scheduling multiple monkbulks

### DIFF
--- a/src/decider/agent/BulkReuser.php
+++ b/src/decider/agent/BulkReuser.php
@@ -1,6 +1,6 @@
 <?php
 /*
- Copyright (C) 2015, Siemens AG
+ Copyright (C) 2015-2017, Siemens AG
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -34,31 +34,9 @@ class BulkReuser extends Object
   {
     $this->dbManager = $GLOBALS['container']->get('db.manager');
   }
-
-  protected function getBulkIds($uploadId, $groupId, $userId)
-  {
-    $sql = "SELECT jq_args FROM upload_reuse, jobqueue, job 
-           WHERE upload_fk=$1 AND group_fk=$2
-             AND EXISTS(SELECT * FROM group_user_member gum WHERE gum.group_fk=upload_reuse.group_fk AND gum.user_fk=$3)
-             AND jq_type=$4 AND jq_job_fk=job_pk
-             AND job_upload_fk=reused_upload_fk AND job_group_fk=reused_group_fk";
-    $stmt = __METHOD__;
-    $this->dbManager->prepare($stmt, $sql);
-    $res = $this->dbManager->execute($stmt,array($uploadId, $groupId, $userId,'monkbulk'));
-    $bulkIds = array();
-    while($row=  $this->dbManager->fetchArray($res))
-    {
-      $bulkIds = array_merge($bulkIds,explode("\n", $row['jq_args']));      
-    }
-    $this->dbManager->freeResult($res);
-    return array_unique($bulkIds);
-  }
   
-  public function rerunBulkAndDeciderOnUpload($uploadId, $groupId, $userId, $jobId) {
-    $bulkIds = $this->getBulkIds($uploadId, $groupId, $userId);
-    if (count($bulkIds) == 0) {
-      return 0;
-    }
+  public function rerunBulkAndDeciderOnUpload($uploadId, $groupId, $userId, $bulkId, $dependency)
+  {
     /* @var $uploadDao UploadDao */
     $uploadDao = $GLOBALS['container']->get('dao.upload');
     $topItem = $uploadDao->getUploadParent($uploadId);
@@ -72,21 +50,24 @@ class BulkReuser extends Object
             ."SELECT $1 as lrb_fk,rf_fk,removing FROM license_set_bulk WHERE lrb_fk=$2";
     $this->dbManager->prepare($stmt=__METHOD__.'cloneBulk', $sql);
     $this->dbManager->prepare($stmtLic=__METHOD__.'cloneBulkLic', $sqlLic);
-    foreach($bulkIds as $bulkId) {
-      $res = $this->dbManager->execute($stmt,array($userId,$groupId,$uploadId,$topItem, $bulkId));
-      $row = $this->dbManager->fetchArray($res);
-      $this->dbManager->freeResult($res);
-      $resLic = $this->dbManager->execute($stmtLic,array($row['lrb_pk'],$row['lrb_origin']));
-      $this->dbManager->freeResult($resLic);  
-      $dependecies[] = array('name' => 'agent_monk_bulk', 'args' => $row['lrb_pk'], AgentPlugin::PRE_JOB_QUEUE=>array('agent_decider'));
-    }
+    $res = $this->dbManager->execute($stmt,array($userId,$groupId,$uploadId,$topItem, $bulkId));
+    $row = $this->dbManager->fetchArray($res);
+    $this->dbManager->freeResult($res);
+    $resLic = $this->dbManager->execute($stmtLic,array($row['lrb_pk'],$row['lrb_origin']));
+    $this->dbManager->freeResult($resLic);
+    $upload = $uploadDao->getUpload($uploadId);
+    $uploadName = $upload->getFilename();
+    $job_pk = \JobAddJob($userId, $groupId, $uploadName, $uploadId);
+    /** @var DeciderJobAgentPlugin $deciderPlugin */
+    $deciderPlugin = plugin_find("agent_deciderjob");
+    $dependecies = array(array('name' => 'agent_monk_bulk', 'args' => $row['lrb_pk']));
     $errorMsg = '';
-    $jqId = $deciderPlugin->AgentAdd($jobId, $uploadId, $errorMsg, $dependecies);
+    $jqId = $deciderPlugin->AgentAdd($job_pk, $uploadId, $errorMsg, $dependecies);
+
     if (!empty($errorMsg))
     {
-      throw new Exception($errorMsg);
+      throw new Exception(str_replace('<br>', "\n", $errorMsg));
     }
     return $jqId;
   }
-
 }

--- a/src/decider/agent/DeciderAgent.php
+++ b/src/decider/agent/DeciderAgent.php
@@ -1,7 +1,7 @@
 <?php
 /*
  Author: Daniele Fognini
- Copyright (C) 2014-2015, Siemens AG
+ Copyright (C) 2014-2017, Siemens AG
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -30,6 +30,7 @@ use Fossology\Lib\Data\DecisionTypes;
 use Fossology\Lib\Data\LicenseMatch;
 use Fossology\Lib\Data\Tree\Item;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
+use Fossology\Lib\Dao\ShowJobsDao;
 
 include_once(__DIR__ . "/version.php");
 
@@ -53,6 +54,8 @@ class DeciderAgent extends Agent
   private $clearingDao;
   /** @var HighlightDao */
   private $highlightDao;
+  /** @var ShowJobsDao */
+  private $showJobsDao;
   /** @var DecisionTypes */
   private $decisionTypes;
   /** @var LicenseMap */
@@ -67,6 +70,7 @@ class DeciderAgent extends Agent
     $this->uploadDao = $this->container->get('dao.upload');
     $this->clearingDao = $this->container->get('dao.clearing');
     $this->highlightDao = $this->container->get('dao.highlight');
+    $this->showJobsDao = $this->container->get('dao.show_jobs');
     $this->decisionTypes = $this->container->get('decision.types');
     $this->clearingDecisionProcessor = $this->container->get('businessrules.clearing_decision_processor');
     $this->agentLicenseEventProcessor = $this->container->get('businessrules.agent_license_event_processor');
@@ -80,20 +84,43 @@ class DeciderAgent extends Agent
     $args = $this->args;
     $this->activeRules = array_key_exists('r', $args) ? intval($args['r']) : self::RULES_ALL;
     $this->licenseMap = new LicenseMap($this->dbManager, $this->groupId, $this->licenseMapUsage);
-    
+
+    if (($this->activeRules&self::RULES_BULK_REUSE)== self::RULES_BULK_REUSE)
+    {
+      $bulkReuser = new BulkReuser();
+      $bulkIds = $this->clearingDao->getPreviousBulkIds($uploadId, $this->groupId, $this->userId);
+      if (count($bulkIds) == 0) {
+        return true;
+      }
+      $jqId=0;
+      $minTime="4";
+      $maxTime="60";
+      foreach($bulkIds as $bulkId) {
+        $jqId = $bulkReuser->rerunBulkAndDeciderOnUpload($uploadId, $this->groupId, $this->userId, $bulkId, $jqId);
+        $this->heartbeat(1);
+        if(!empty($jqId)){
+          $jqIdRow = $this->showJobsDao->getDataForASingleJob($jqId);
+          while($this->showJobsDao->getJobStatus($jqId)){
+            $this->heartbeat(0);
+            $timeInSec = $this->showJobsDao->getEstimatedTime($jqIdRow['jq_job_fk'],'',0,0,1);
+            if($timeInSec > $maxTime){
+              sleep($maxTime);
+            }else if($timeInSec < $minTime){
+              sleep($minTime);
+            }else{
+              sleep($timeInSec);
+            }
+          }
+        }
+      }
+    }
+
     $parentBounds = $this->uploadDao->getParentItemBounds($uploadId);
     foreach ($this->uploadDao->getContainedItems($parentBounds) as $item)
     {
       $process = $this->processItem($item);
       $this->heartbeat($process);
     }
-
-    if (($this->activeRules&self::RULES_BULK_REUSE)== self::RULES_BULK_REUSE)
-    {
-      $bulkReuser = new BulkReuser();
-      $bulkReuser->rerunBulkAndDeciderOnUpload($uploadId, $this->groupId, $this->userId, $this->jobId);
-    }
-    
     return true;
   }
 

--- a/src/decider/agent_tests/Functional/SchedulerTestRunnerMock.php
+++ b/src/decider/agent_tests/Functional/SchedulerTestRunnerMock.php
@@ -26,6 +26,7 @@ use Fossology\Lib\Dao\AgentDao;
 use Fossology\Lib\Dao\ClearingDao;
 use Fossology\Lib\Dao\UploadDao;
 use Fossology\Lib\Dao\HighlightDao;
+use Fossology\Lib\Dao\ShowJobsDao;
 use Fossology\Lib\Data\DecisionTypes;
 use Fossology\Lib\Db\DbManager;
 use Mockery as M;
@@ -53,14 +54,16 @@ class SchedulerTestRunnerMock implements SchedulerTestRunner
   private $decisionTypes;
   /** @var HighlightDao */
   private $highlightDao;
+  /** @var ShowJobsDao */
+  private $showJobsDao;
 
-  public function __construct(DbManager $dbManager, AgentDao $agentDao, ClearingDao $clearingDao, UploadDao $uploadDao, HighlightDao $highlightDao,
-    ClearingDecisionProcessor $clearingDecisionProcessor, AgentLicenseEventProcessor $agentLicenseEventProcessor)
+  public function __construct(DbManager $dbManager, AgentDao $agentDao, ClearingDao $clearingDao, UploadDao $uploadDao, HighlightDao $highlightDao, ShowJobsDao $showJobsDao, ClearingDecisionProcessor $clearingDecisionProcessor, AgentLicenseEventProcessor $agentLicenseEventProcessor)
   {
     $this->clearingDao = $clearingDao;
     $this->agentDao = $agentDao;
     $this->uploadDao = $uploadDao;
     $this->highlightDao = $highlightDao;
+    $this->showJobsDao = $showJobsDao;
     $this->dbManager = $dbManager;
     $this->decisionTypes = new DecisionTypes();
     $this->clearingDecisionProcessor = $clearingDecisionProcessor;
@@ -89,6 +92,7 @@ class SchedulerTestRunnerMock implements SchedulerTestRunner
     $container->shouldReceive('get')->with('dao.clearing')->andReturn($this->clearingDao);
     $container->shouldReceive('get')->with('dao.upload')->andReturn($this->uploadDao);
     $container->shouldReceive('get')->with('dao.highlight')->andReturn($this->highlightDao);
+    $container->shouldReceive('get')->with('dao.show_jobs')->andReturn($this->showJobsDao);
     $container->shouldReceive('get')->with('decision.types')->andReturn($this->decisionTypes);
     $container->shouldReceive('get')->with('businessrules.clearing_decision_processor')->andReturn($this->clearingDecisionProcessor);
     $container->shouldReceive('get')->with('businessrules.agent_license_event_processor')->andReturn($this->agentLicenseEventProcessor);

--- a/src/decider/agent_tests/Functional/schedulerTest.php
+++ b/src/decider/agent_tests/Functional/schedulerTest.php
@@ -28,6 +28,7 @@ use Fossology\Lib\Dao\HighlightDao;
 use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Dao\UploadDao;
 use Fossology\Lib\Dao\UploadPermissionDao;
+use Fossology\Lib\Dao\ShowJobsDao;
 use Fossology\Lib\Data\DecisionScopes;
 use Fossology\Lib\Data\DecisionTypes;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
@@ -63,6 +64,8 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
   private $uploadPermDao;
   /** @var HighlightDao */
   private $highlightDao;
+  /** @var ShowJobsDao */
+  private $showJobsDao;
   /** @var SchedulerTestRunnerCli */
   private $runnerCli;
   /** @var SchedulerTestRunnerMock */
@@ -82,13 +85,14 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
     $this->agentLicenseEventProcessor = new AgentLicenseEventProcessor($this->licenseDao, $agentDao);
     $clearingEventProcessor = new ClearingEventProcessor();
     $this->clearingDao = new ClearingDao($this->dbManager, $this->uploadDao);
+    $this->showJobsDao = new ShowJobsDao($this->dbManager, $this->uploadDao);
     $this->clearingDecisionProcessor = new ClearingDecisionProcessor($this->clearingDao, $this->agentLicenseEventProcessor, $clearingEventProcessor, $this->dbManager);
 
     global $container;
     $container = M::mock('ContainerBuilder');
     $container->shouldReceive('get')->withArgs(array('db.manager'))->andReturn($this->dbManager);
 
-    $this->runnerMock = new SchedulerTestRunnerMock($this->dbManager, $agentDao, $this->clearingDao, $this->uploadDao, $this->highlightDao, $this->clearingDecisionProcessor, $this->agentLicenseEventProcessor);
+    $this->runnerMock = new SchedulerTestRunnerMock($this->dbManager, $agentDao, $this->clearingDao, $this->uploadDao, $this->highlightDao, $this->showJobsDao, $this->clearingDecisionProcessor, $this->agentLicenseEventProcessor);
     $this->runnerCli = new SchedulerTestRunnerCli($this->testDb);
   }
 
@@ -99,6 +103,7 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
     $this->dbManager = null;
     $this->licenseDao = null;
     $this->highlightDao = null;
+    $this->showJobsDao = null;
     $this->clearingDao = null;
     M::close();
   }

--- a/src/decider/ui/DeciderAgentPlugin.php
+++ b/src/decider/ui/DeciderAgentPlugin.php
@@ -87,7 +87,8 @@ class DeciderAgentPlugin extends AgentPlugin
           $rulebits |= 0x2;
           break;
         case 'reuseBulk':
-          $dependencies[] = 'agent_reuser';
+          $dependencies[] = 'agent_nomos';
+          $dependencies[] = 'agent_monk';
           $rulebits |= 0x4;
           break;
         case 'wipScannerUpdates':

--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -850,4 +850,32 @@ INSERT INTO clearing_decision (
     $this->dbManager->freeResult($res);
     return $irrelevantFiles;
   }
+
+  /**
+   * @param int $uploadId
+   * @param int $groupId
+   * @param int $userId
+   */
+  public function getPreviousBulkIds($uploadId, $groupId, $userId, $onlyCount=0)
+  {
+    $stmt = __METHOD__;
+    $bulkIds = array();
+    $sql = "SELECT jq_args FROM upload_reuse, jobqueue, job
+            WHERE upload_fk=$1 AND group_fk=$2
+             AND EXISTS(SELECT * FROM group_user_member gum WHERE gum.group_fk=upload_reuse.group_fk AND gum.user_fk=$3)
+             AND jq_type=$4 AND jq_job_fk=job_pk
+             AND job_upload_fk=reused_upload_fk AND job_group_fk=reused_group_fk";
+    $this->dbManager->prepare($stmt, $sql);
+    $res = $this->dbManager->execute($stmt,array($uploadId, $groupId, $userId,'monkbulk'));
+    while($row=  $this->dbManager->fetchArray($res))
+    {
+      $bulkIds = array_merge($bulkIds,explode("\n", $row['jq_args']));
+    }
+    $this->dbManager->freeResult($res);
+    if(empty($onlyCount)) {
+      return array_unique($bulkIds);
+    } else {
+      return count(array_unique($bulkIds));
+    }
+  }
 }

--- a/src/lib/php/Dao/ShowJobsDao.php
+++ b/src/lib/php/Dao/ShowJobsDao.php
@@ -1,6 +1,6 @@
 <?php
 /*
- Copyright (C) 2015, Siemens AG
+ Copyright (C) 2015-2017, Siemens AG
  Author: Shaheem Azmal<shaheem.azmal@siemens.com>, 
          Anupam Ghosh <anupam.ghosh@siemens.com>
 
@@ -244,10 +244,10 @@ class ShowJobsDao extends Object
    * @param int $job_pk
    * @param string $jq_Type
    * @param float $filesPerSec
-   * @param int $uploadId 
-   * @return Returns empty if estimated time is 0 else returns time. 
+   * @param int $uploadId
+   * @return Returns empty if estimated time is 0 else returns time.
    **/
-  public function getEstimatedTime($job_pk, $jq_Type='', $filesPerSec=0, $uploadId=0)
+  public function getEstimatedTime($job_pk, $jq_Type='', $filesPerSec=0, $uploadId=0, $timeInSec=0)
   {
     if(!empty($uploadId)) {
       $itemCount = $this->dbManager->getSingleRow(
@@ -265,10 +265,10 @@ class ShowJobsDao extends Object
       );
     }
 
-    if(!empty($itemCount['jq_itemsprocessed'])){
+    if(!empty($itemCount['jq_itemsprocessed']) && $jq_Type !== 'decider'){
 
-      $selectCol = "jq_type, jq_endtime, jq_starttime, jq_itemsprocessed"; 
-      if(empty($jq_Type)){ 
+      $selectCol = "jq_type, jq_endtime, jq_starttime, jq_itemsprocessed";
+      if(empty($jq_Type)){
         $removeType = "jq_type NOT LIKE 'ununpack' AND jq_type NOT LIKE 'reportgen' AND jq_type NOT LIKE 'decider' AND";
         /* get starttime endtime and jobtype form jobqueue for a jobid except $removeType */
         $statementName = __METHOD__."$selectCol.$removeType";
@@ -285,13 +285,13 @@ class ShowJobsDao extends Object
 
       while($row = $this->dbManager->fetchArray($result)){
         $timeOfCompletion = 0;
-        if(empty($row['jq_endtime']) && !empty($row['jq_starttime'])) { // for agent started and not ended 
+        if(empty($row['jq_endtime']) && !empty($row['jq_starttime'])) { // for agent started and not ended
           if(empty($filesPerSec)) {
             $burnTime = time() - strtotime($row['jq_starttime']);
             $filesPerSec = $this->getNumItemsPerSec($row['jq_itemsprocessed'], $burnTime);
           }
 
-          if(!empty($filesPerSec)) {           
+          if(!empty($filesPerSec)) {
             $timeOfCompletion = ($itemCount['jq_itemsprocessed'] - $row['jq_itemsprocessed']) / $filesPerSec;
           }
           array_push($estimatedArray, $timeOfCompletion);
@@ -302,9 +302,12 @@ class ShowJobsDao extends Object
       }
       else {
         $estimatedTime = round(max($estimatedArray)); // collecting max agent time in seconds
-        return intval($estimatedTime/3600).gmdate(":i:s", $estimatedTime);  // convert seconds to time and return     
-      } 
-    } 
+        if(!empty($timeInSec)){
+          return intval(!empty($estimatedTime) ? $estimatedTime : 0);
+        }
+        return intval($estimatedTime/3600).gmdate(":i:s", $estimatedTime);  // convert seconds to time and return
+      }
+    }
   }/* getEstimatedTime() */
 
   /** 
@@ -312,14 +315,53 @@ class ShowJobsDao extends Object
    * @param $job_pk
    * @return $row
    */
-  public function getDataForASingleJob($job_pk)
+  public function getDataForASingleJob($jq_pk)
   {
     $statementName = __METHOD__."getDataForASingleJob";
     $this->dbManager->prepare($statementName,
     "SELECT *, jq_endtime-jq_starttime as elapsed FROM jobqueue LEFT JOIN job ON job.job_pk = jobqueue.jq_job_fk WHERE jobqueue.jq_pk =$1");
-    $result = $this->dbManager->execute($statementName, array($job_pk));
+    $result = $this->dbManager->execute($statementName, array($jq_pk));
     $row = $this->dbManager->fetchArray($result);
     $this->dbManager->freeResult($result);
     return $row;
   } /* getDataForASingleJob */
+
+  /** 
+   * @brief Return boolean
+   * @param $jq_pk
+   */
+  public function getJobStatus($jqPk)
+  {
+    $statementName = __METHOD__."forjq_pk";
+    $row = $this->dbManager->getSingleRow(
+           "SELECT jq_end_bits FROM jobqueue WHERE jq_pk = $1",
+           array($jqPk),
+           $statementName
+    );
+    if($row['jq_end_bits'] == 1 || $row['jq_end_bits'] == 2){
+      return false;
+    }else{
+      return true;
+    }
+  }
+
+  /**
+   * @brief Return array
+   * @param $jobId
+   * @param $jqType
+   */
+  public function getItemsProcessedForDecider($jqType, $jobId)
+  {
+    $statementName = __METHOD__."forjqTypeAndjobId";
+    $row = $this->dbManager->getSingleRow(
+           "SELECT jq_itemsprocessed, job.job_upload_fk FROM jobqueue JOIN job ON jobqueue.jq_job_fk = job.job_pk WHERE jq_type = $1 AND jq_end_bits = 0 AND jq_job_fk IN (SELECT job_pk FROM job WHERE job_upload_fk = (SELECT job_upload_fk FROM job WHERE job_pk = $2 LIMIT 1)) LIMIT 1",
+           array($jqType, $jobId),
+           $statementName
+    );
+    if(!empty($row['jq_itemsprocessed'])) {
+      return array($row['jq_itemsprocessed'], $row['job_upload_fk']);
+    } else {
+      return array();
+    }
+  }
 }

--- a/src/www/ui/ajax-showjobs.php
+++ b/src/www/ui/ajax-showjobs.php
@@ -21,6 +21,7 @@
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\ShowJobsDao;
 use Fossology\Lib\Dao\UserDao;
+use Fossology\Lib\Dao\ClearingDao;
 use Fossology\Lib\Db\DbManager;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -39,6 +40,9 @@ class AjaxShowJobs extends FO_Plugin
   /** @var UserDao */
   private $userDao;
 
+  /** @var ClearingDao */
+  private $clearingDao;
+
   /** @var int $maxUploadsPerPage max number of uploads to display on a page */
   private $maxUploadsPerPage = 10;
 
@@ -55,6 +59,7 @@ class AjaxShowJobs extends FO_Plugin
     global $container;
     $this->showJobsDao = $container->get('dao.show_jobs');
     $this->userDao = $container->get('dao.user');
+    $this->clearingDao = $container->get('dao.clearing');
     $this->dbManager = $container->get('db.manager');
 
     parent::__construct();
@@ -355,9 +360,18 @@ class AjaxShowJobs extends FO_Plugin
         }
         if (empty($jobqueueRec['jq_endtime'])) {
           $varJobQueueRow['eta'] = $this->showJobsDao->getEstimatedTime($jobqueueRec['jq_job_fk'], $jobqueueRec['jq_type'], $itemsPerSec, $job['job']['job_upload_fk']);
+          if($jobqueueRec['jq_type'] === 'monkbulk' || $jobqueueRec['jq_type'] === 'deciderjob'){
+            $noOfMonkBulk = $this->showJobsDao->getItemsProcessedForDecider('decider', $jobqueueRec['jq_job_fk']);
+            if(!empty($noOfMonkBulk)){
+              $totalCountOfMb = $this->clearingDao->getPreviousBulkIds($noOfMonkBulk[1], Auth::getGroupId(), Auth::getUserId(), $onlyCount=1);
+            }
+            if(!empty($totalCountOfMb)){
+              $varJobQueueRow['isNoOfMonkBulk'] = $noOfMonkBulk[0]."/".$totalCountOfMb;
+            }
+          }
         }
-        $varJobQueueRow['canDoActions'] = 
-                ($_SESSION[Auth::USER_LEVEL] == PLUGIN_DB_ADMIN) || (Auth::getUserId() == $job['job']['job_user_fk']);
+
+        $varJobQueueRow['canDoActions'] = ($_SESSION[Auth::USER_LEVEL] == PLUGIN_DB_ADMIN) || (Auth::getUserId() == $job['job']['job_user_fk']);
         $varJobQueueRow['isInProgress'] = ($jobqueueRec['jq_end_bits'] == 0);
         $varJobQueueRow['isReady'] = ($jobqueueRec['jq_end_bits'] == 1);
         

--- a/src/www/ui/template/ui-showjobs-jobqueue-row.html.twig
+++ b/src/www/ui/template/ui-showjobs-jobqueue-row.html.twig
@@ -49,5 +49,8 @@
     {% elseif download and isReady %}
       [<a href="?mod=download&report={{ jobId }}">Download {{ download }}</a>]
     {% endif %}
+    {% if isNoOfMonkBulk is defined %}
+    [{{ 'Count : '|trans }}<a href="#" title="isNoOfMonkBulk">{{ isNoOfMonkBulk }}</a>]
+    {% endif %}
   </td>
 </tr>


### PR DESCRIPTION
To reproduce:

**Install "Master" :** 
   - Upload a package (with at least 3 licenses as scanner findings in each file) and Goto single file view.
         **Note: I have used fckeditor** 
   - Using bulk recognition add license1 and remove license2 and license3.
   - Using bulk recognition add license2 and remove license1 and license3.
   - Using bulk recognition add license3 and remove license1 and license2.
   - Now upload some other version of the package you have uploaded previously.  
   - And reuse the bulk decisions. Check the decisions are improper, Because of timestamp.

**Install "contrib/fixBulkOrderingByETA" :**
   - Now upload the same package with improper decisions.
   - Reuse it with the first package. Now the results should be proper.




