### PR TITLE
fix(lib): container.php access from cache

### DIFF
--- a/src/lib/php/common-container.php
+++ b/src/lib/php/common-container.php
@@ -50,6 +50,7 @@ else {
   if ($cacheDir && is_dir($cacheDir))
   {
     $dumper = new PhpDumper($container);
+    umask(0027);
     file_put_contents(
         $cacheFile,
         $dumper->dump(array('class' => $containerClassName))


### PR DESCRIPTION
saw the error from the log that the container.php was not accessible and found out that is some installation modes the assigned rights were not sufficient.

Unfortunately the conditions are unclear, because it happened at some time on "some instance". 

It seems to be connected with the generation of the SPDX. 