### PR TITLE
add user findings of copyright and ecc from files with non-agent finding

### DIFF
--- a/src/lib/php/Report/XpClearedGetter.php
+++ b/src/lib/php/Report/XpClearedGetter.php
@@ -60,7 +60,7 @@ class XpClearedGetter extends ClearedGetterCommon
     }
     $this->extrawhere .= ' agent_fk='.$latestXpAgentId;
 
-    return $this->copyrightDao->getAllEntries($this->tableName, $uploadId, $uploadTreeTableName, $this->type, $this->getOnlyCleared, DecisionTypes::IDENTIFIED, $this->extrawhere);
+    return $this->copyrightDao->getAllEntriesReport($this->tableName, $uploadId, $uploadTreeTableName, $this->type, $this->getOnlyCleared, DecisionTypes::IDENTIFIED, $this->extrawhere);
   }
 }
 

--- a/src/readmeoss/agent/readmeoss.php
+++ b/src/readmeoss/agent/readmeoss.php
@@ -46,7 +46,7 @@ class ReadmeOssAgent extends Agent
 
   function __construct()
   {
-    $this->cpClearedGetter = new XpClearedGetter("copyright", "statement", false);
+    $this->cpClearedGetter = new XpClearedGetter("copyright", "statement");
     $this->licenseClearedGetter = new LicenseClearedGetter();
     $this->licenseMainGetter = new LicenseMainGetter();
 
@@ -81,7 +81,7 @@ class ReadmeOssAgent extends Agent
       $moreLicenses = $this->licenseClearedGetter->getCleared($addUploadId, $groupId);
       $licenseStmts = array_merge($licenseStmts, $moreLicenses['statements']);
       $this->heartbeat(count($moreLicenses['statements']));
-      $moreCopyrights = $this->cpClearedGetter->getCleared($addUploadId, $groupId);
+      $moreCopyrights = $this->cpClearedGetter->getCleared($addUploadId, $groupId, true, "copyright");
       $copyrightStmts = array_merge($copyrightStmts, $moreCopyrights['statements']);
       $this->heartbeat(count($moreCopyrights['statements']));
       $moreMainLicenses = $this->licenseMainGetter->getCleared($addUploadId, $groupId);

--- a/src/unifiedreport/agent/unifiedreport.php
+++ b/src/unifiedreport/agent/unifiedreport.php
@@ -107,7 +107,7 @@ class UnifiedReport extends Agent
   function __construct()
   {
     $this->cpClearedGetter = new XpClearedGetter("copyright", "statement");
-    $this->eccClearedGetter = new XpClearedGetter("ecc", "skipcontent", true);
+    $this->eccClearedGetter = new XpClearedGetter("ecc", "ecc");
     $this->licenseClearedGetter = new LicenseClearedGetter();
     $this->licenseMainGetter = new LicenseMainGetter();
     $this->bulkMatchesGetter = new BulkMatchesGetter();
@@ -153,7 +153,7 @@ class UnifiedReport extends Agent
     $copyrights = $this->cpClearedGetter->getCleared($uploadId, $groupId, true, "copyright");
     $this->heartbeat(count($copyrights["statements"]));
 
-    $ecc = $this->eccClearedGetter->getCleared($uploadId, $groupId);
+    $ecc = $this->eccClearedGetter->getCleared($uploadId, $groupId, true, "ecc");
     $this->heartbeat(count($ecc["statements"]));
 
     $otherStatement = $this->otherGetter->getReportData($uploadId);
@@ -424,16 +424,18 @@ class UnifiedReport extends Agent
     $table = $section->addTable($this->tablestyle);
     if(!empty($statementsCEI)){
       foreach($statementsCEI as $statements){
-        $table->addRow($smallRowHeight);
-        $cell1 = $table->addCell($firstColLen); 
-        $text = html_entity_decode($statements['content']);	
-        $cell1->addText(htmlspecialchars($text, ENT_DISALLOWED), $this->licenseTextColumn, "pStyle");
-        $cell2 = $table->addCell($secondColLen);
-        $cell2->addText(htmlspecialchars($statements['comments'], ENT_DISALLOWED), $this->licenseTextColumn, "pStyle");
-        $cell3 = $table->addCell($thirdColLen);
-        asort($statements["files"]);
-        foreach($statements['files'] as $fileName){ 
-          $cell3->addText(htmlspecialchars($fileName), $this->filePathColumn, "pStyle");
+        if(!empty($statements['content'])){
+          $table->addRow($smallRowHeight);
+          $cell1 = $table->addCell($firstColLen);
+          $text = html_entity_decode($statements['content']);
+          $cell1->addText(htmlspecialchars($text, ENT_DISALLOWED), $this->licenseTextColumn, "pStyle");
+          $cell2 = $table->addCell($secondColLen);
+          $cell2->addText(htmlspecialchars($statements['comments'], ENT_DISALLOWED), $this->licenseTextColumn, "pStyle");
+          $cell3 = $table->addCell($thirdColLen);
+          asort($statements["files"]);
+          foreach($statements['files'] as $fileName){
+            $cell3->addText(htmlspecialchars($fileName), $this->filePathColumn, "pStyle");
+          }
         }
       }
     }else{


### PR DESCRIPTION
 Point is that when manually adding a finding by the user in the single file view Web UI on a file where the agent did not find anything ("text finding"), then this finding is not put into the reporting.

These are rare cases, as the usual way is to just correct scanner findings. However, manually added things should be there too.