### PR TITLE
CSV import from obligations: improve checks while associating Licenses

### DIFF
--- a/src/lib/php/Application/ObligationCsvImport.php
+++ b/src/lib/php/Application/ObligationCsvImport.php
@@ -131,7 +131,7 @@ class ObligationCsvImport {
     return ($row === false) ? false : $row['ob_pk'];
   }
 
-  private function compareLicList ($exists, $listFromCsv, $candidate, $row)
+  private function compareLicList($exists, $listFromCsv, $candidate, $row)
   {
     $getList = $this->obligationMap->getLicenseList($exists, $candidate);
     $listFromDb = $this->reArrangeString($getList);
@@ -164,6 +164,9 @@ class ObligationCsvImport {
     /* @var $dbManager DbManager */
     $dbManager = $this->dbManager;
     $exists = $this->getKeyFromTopicAndText($row);
+    $associatedLicenses = "";
+    $candidateLicenses = "";
+    $listFromCsv = "";
     $msg = "";
     if ($exists !== false)
     {
@@ -182,7 +185,7 @@ class ObligationCsvImport {
         $msg .=" No Changes in CandidateLicense";
       }
       else {
-        $this->clearListFromDb($exists, $listFromCsv, true);
+        $this->clearListFromDb($exists, $listFromCsv);
         if(!empty($row['candidatenames'])) {
           $associatedLicenses = $this->AssociateWithLicenses($row['candidatenames'], $exists, True);
         }
@@ -199,13 +202,9 @@ class ObligationCsvImport {
     $new = $dbManager->fetchArray($resi);
     $dbManager->freeResult($resi);
 
-    $associatedLicenses = "";
-    $candidateLicenses = "";
     if (!empty($row['licnames'])) {
       $associatedLicenses = $this->AssociateWithLicenses($row['licnames'], $new['ob_pk']);
-    } else {
-      $associatedLicenses = "";
-    }
+    } 
     if (!empty($row['candidatenames'])) {
       $candidateLicenses = $this->AssociateWithLicenses($row['candidatenames'], $new['ob_pk'], True);
     }
@@ -249,34 +248,17 @@ class ObligationCsvImport {
           $associatedLicenses .= ";$license";
         }
       } else {
-        if ($message == "")
-        {
-          $message = "License $license could not be found in the DB.\n";
-        } else {
-          $message .= "License $license could not be found in the DB.\n";
-        }
+        $message .= "License $license could not be found in the DB.\n";
       }
     }
 
     if (!empty($associatedLicenses))
     {
-      if ($message == "")
-      {
-        $message = "$associatedLicenses were associated.\n";
-      } else {
-        $message .= "$associatedLicenses were associated.\n";
-      }
+      $message .= "$associatedLicenses were associated.\n";
     } else {
-      if ($message == "")
-      {
-        $message = "No ";
-        $message .= $candidate ? "candidate": "";
-        $message .= "licenses were associated.\n";
-      } else {
-        $message .= "No ";
-        $message .= $candidate ? "candidate": "";
-        $message .= "licenses were associated.\n";
-      }
+      $message .= "No ";
+      $message .= $candidate ? "candidate": "";
+      $message .= "licenses were associated.\n";
     }
     return $message;
   }
@@ -287,5 +269,4 @@ class ObligationCsvImport {
       array($exists, $row['classification'], $row['modifications'], $row['comment']),
       __METHOD__ . '.updateOtherOb');
   }
-
 }

--- a/src/www/ui/admin-obligation-file.php
+++ b/src/www/ui/admin-obligation-file.php
@@ -433,6 +433,7 @@ class admin_obligation_file extends FO_Plugin
     $candidatenames = $_POST['candidateSelector'];
     $text = trim($_POST['ob_text']);
     $comment = trim($_POST['ob_comment']);
+    $message = "";
 
     if (empty($topic)) {
       $text = _("ERROR: The obligation topic is empty.");


### PR DESCRIPTION
Importing obligations from a CSV file with licenses not available
in the DB leads to a `not-null constrains` Postgres error.
With those changes, the license association first checks for the
availability of the license's shortname before associating the
license with the obligation.