### PR TITLE
feat(nomos): extend unclassified license detection

### DIFF
--- a/src/nomos/agent/STRINGS.in
+++ b/src/nomos/agent/STRINGS.in
@@ -6284,6 +6284,10 @@ k
 %KEY% "agreement"
 %STR% "the tapjoy =SOME= you agree that you have =SOME= agree to be bound by =FEW= and are authorized to bind the entity on whose behalf you are entering into this agreement"
 #
+%ENTRY% _LT_GENERIC_UNCLASSIFIED
+%KEY% "licen[cs]e"
+%STR% "licen[cs](e|ed) under the term"
+#
 ##%ENTRY%	_LT_SEEK_1
 ##%KEY%	"(©|\(c\)|copyright|\<c\>[^+:]|&copy)"
 ##%STR%	"&copy"

--- a/src/nomos/agent/parse.c
+++ b/src/nomos/agent/parse.c
@@ -9116,7 +9116,7 @@ int checkUnclassified(char *filetext, int size, int score,
    * one before trying the word-matching magic checks (below).
    */
   gl.flags |= FL_SAVEBASE; /* save match buffer (if any) */
-  m = INFILE(_LT_GEN_EULA) || INFILE(_LT_LG);
+  m = INFILE(_LT_GEN_EULA) || INFILE(_LT_LG) || INFILE(_LT_GENERIC_UNCLASSIFIED);
   /* gl.flags & ~FL_SAVEBASE;  CDB -- This makes no sense, given line above */
   if (m) {
     if (cur.licPara == NULL_STR  && cur.matchBase) {

--- a/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan
+++ b/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan
@@ -811,6 +811,7 @@ File NomosTestfiles/UnclassifiedLicense/LICENSE.fatfs contains license(s) Non-pr
 File NomosTestfiles/UnclassifiedLicense/eula.txt contains license(s) Citrix
 File NomosTestfiles/UnclassifiedLicense/net_phy_def.h contains license(s) UnclassifiedLicense
 File NomosTestfiles/UnclassifiedLicense/port.h contains license(s) Restricted-rights,UnclassifiedLicense
+File NomosTestfiles/UnclassifiedLicense/cygwinRef.txt contains license(s) UnclassifiedLicense
 File NomosTestfiles/MX4J/MX4J-1.0 contains license(s) MX4J-1.0
 File NomosTestfiles/Postfix/master_spawn.c contains license(s) Postfix
 File NomosTestfiles/Princeton/adj.dat contains license(s) Princeton

--- a/src/nomos/agent_tests/testdata/NomosTestfiles/UnclassifiedLicense/cygwinRef.txt
+++ b/src/nomos/agent_tests/testdata/NomosTestfiles/UnclassifiedLicense/cygwinRef.txt
@@ -1,0 +1,3 @@
+This software is a copyrighted work licensed under the terms of the
+Cygwin license.  Please consult the file "CYGWIN_LICENSE" for
+details.


### PR DESCRIPTION
Includes files having text "licensed under the term" as unclassified license(example below license text).

/* binmode.c

This file is part of Cygwin.

This software is a copyrighted work licensed under the terms of the
Cygwin license.  Please consult the file "CYGWIN_LICENSE" for
details. */

#include "winlean.h"
#include <sys/fcntl.h>
#include <sys/cygwin.h>

extern int _fmode;
