### PR TITLE
fix(browse): ajax browse required login

### DIFF
--- a/src/www/ui/async/AjaxBrowse.php
+++ b/src/www/ui/async/AjaxBrowse.php
@@ -54,9 +54,9 @@ class AjaxBrowse extends DefaultPlugin
   function __construct()
   {
     parent::__construct(self::NAME, array(
-        self::PERMISSION => Auth::PERM_READ
-      ));
-        
+      self::REQUIRES_LOGIN => false,
+      self::PERMISSION => Auth::PERM_READ
+    ));
     global $container;
     $this->uploadDao = $container->get('dao.upload');
     $this->userDao = $container->get('dao.user');


### PR DESCRIPTION
The browse plugin `ui-browse.php` does not require login to be used, but the
ajax backend `AjaxBrowse.php` required it.

The problem was caused due to the migration of the parent class `FO_Plugin` to
`DefaultPlugin` in the `AjaxBrowse.php`. In `FO_Plugin` is by default no login
required, this logic is flipped in the newer implementation `DefaultPlugin`.

closes #994