### PR TITLE
fix(reuser): remove warnings and errors with testcases for reuse

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -35,7 +35,6 @@
             "Fossology\\Agent\\Copyright\\UI\\": "copyright/ui",
             "Fossology\\DeciderJob\\UI\\": "deciderjob/ui",
             "Fossology\\Decider\\UI\\": "decider/ui",
-            "Fossology\\Reuser\\Ui\\": "reuser/ui",
             "Fossology\\DelAgent\\UI\\": "delagent/ui",
             "Fossology\\UI\\Page\\": "www/ui/page"
         }

--- a/src/lib/php/Dao/UploadDao.php
+++ b/src/lib/php/Dao/UploadDao.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Copyright (C) 2014-2015, Siemens AG
+Copyright (C) 2014-2018, Siemens AG
 Authors: Andreas Würl, Steffen Weber
 
 This program is free software; you can redistribute it and/or
@@ -34,6 +34,12 @@ require_once(dirname(dirname(__FILE__)) . "/common-dir.php");
 
 class UploadDao extends Object
 {
+
+  const REUSE_NONE = 0;
+  const REUSE_ENHANCED = 2;
+  const REUSE_MAIN = 4;
+  const REUSE_ENH_MAIN = 8;
+
   /** @var DbManager */
   private $dbManager;
   /** @var Logger */

--- a/src/reuser/agent/ReuserAgent.php
+++ b/src/reuser/agent/ReuserAgent.php
@@ -1,6 +1,6 @@
 <?php
 /*
- Copyright (C) 2014-2015, Siemens AG
+ Copyright (C) 2014-2018, Siemens AG
  Author: Daniele Fognini, Andreas Würl
 
 This program is free software; you can redistribute it and/or
@@ -17,7 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-namespace Fossology\Reuser\Agent;
+namespace Fossology\Reuser;
 
 use Fossology\Lib\Agent\Agent;
 use Fossology\Lib\BusinessRules\AgentLicenseEventProcessor;
@@ -30,7 +30,6 @@ use Fossology\Lib\Data\ClearingDecision;
 use Fossology\Lib\Data\DecisionTypes;
 use Fossology\Lib\Data\Tree\Item;
 use Fossology\Lib\Util\ArrayOperation;
-use Fossology\Reuser\Ui\ReuserAgentPlugin;
 
 include_once(__DIR__ . "/version.php");
 
@@ -76,14 +75,14 @@ class ReuserAgent extends Agent
       {
         continue;
       }
-      if($reuseMode & ReuserAgentPlugin::REUSE_ENHANCED){
+      if($reuseMode & UploadDao::REUSE_ENHANCED){
         $this->processEnhancedUploadReuse($itemTreeBounds, $itemTreeBoundsReused, $reusedGroupId);
       }
-      elseif($reuseMode & ReuserAgentPlugin::REUSE_MAIN){
+      elseif($reuseMode & UploadDao::REUSE_MAIN){
         $this->reuseMainLicense($uploadId, $this->groupId, $reusedUploadId, $reusedGroupId);
         $this->processUploadReuse($itemTreeBounds, $itemTreeBoundsReused, $reusedGroupId);
       }
-      elseif($reuseMode & ReuserAgentPlugin::REUSE_ENH_MAIN){
+      elseif($reuseMode & UploadDao::REUSE_ENH_MAIN){
         $this->reuseMainLicense($uploadId, $this->groupId, $reusedUploadId, $reusedGroupId);
         $this->processEnhancedUploadReuse($itemTreeBounds, $itemTreeBoundsReused, $reusedGroupId);
       }

--- a/src/reuser/agent/reuser.php
+++ b/src/reuser/agent/reuser.php
@@ -1,6 +1,6 @@
 <?php
 /*
- Copyright (C) 2014, Siemens AG
+ Copyright (C) 2014-2018, Siemens AG
  Author: Daniele Fognini, Andreas Würl
 
  This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
@@ -10,7 +10,7 @@
  You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-namespace Fossology\Reuser\Agent;
+namespace Fossology\Reuser;
 
 include_once(__DIR__."/ReuserAgent.php");
 

--- a/src/reuser/agent_tests/Functional/schedulerTest.php
+++ b/src/reuser/agent_tests/Functional/schedulerTest.php
@@ -243,16 +243,16 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
   /** @group Functional */
   public function testReuserMockedScanWithALocalClearing()
   {
-    $this->runnerReuserScanWithALocalClearing($this->runnerMock);
+    $this->runnerReuserScanWithALocalClearing($this->runnerMock,1);
   }
 
   /** @group Functional */
   public function testReuserRealScanWithALocalClearing()
   {
-    $this->runnerReuserScanWithALocalClearing($this->runnerCli);
+    $this->runnerReuserScanWithALocalClearing($this->runnerCli,1);
   }
 
-  private function runnerReuserScanWithALocalClearing($runner)
+  private function runnerReuserScanWithALocalClearing($runner, $heartBeat=0)
   {
     $this->setUpTables();
     $this->setUpRepo();
@@ -269,8 +269,7 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
 
     $this->assertTrue($success, 'cannot run runner');
     $this->assertEquals($retCode, 0, 'reuser failed: '.$output);
-
-    assertThat($this->getHeartCount($output), equalTo(1));
+    assertThat($this->getHeartCount($output), equalTo($heartBeat));
 
     $newUploadClearings = $this->getFilteredClearings($uploadId, $this->groupId);
     $potentiallyReusableClearings = $this->getFilteredClearings($reusedUpload, $this->groupId);
@@ -443,10 +442,11 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
     /*reuse main license*/
     $this->clearingDao->makeMainLicense($uploadId=2, $this->groupId, $mainLicenseId=402);
     $mainLicenseIdForReuse = $this->clearingDao->getMainLicenseIds($reusedUploadId=2, $this->groupId);
-    $this->clearingDao->makeMainLicense($uploadId=3, $this->groupId, $mainLicenseIdForReuse);
+    $mainLicenseIdForReuseSingle = array_values($mainLicenseIdForReuse);
+    $this->clearingDao->makeMainLicense($uploadId=3, $this->groupId, $mainLicenseIdForReuseSingle[0]);
     $mainLicense=$this->clearingDao->getMainLicenseIds($uploadId=3, $this->groupId);
-    assertEquals(array_values($mainLicenseIdForReuse), array_values($mainLicense));
-
+    $mainLicenseSingle = array_values($mainLicense);
+    $this->assertEquals($mainLicenseIdForReuseSingle, $mainLicenseSingle);
     $this->rmRepo();
   }
   

--- a/src/reuser/ui/agent-reuser.php
+++ b/src/reuser/ui/agent-reuser.php
@@ -1,6 +1,6 @@
 <?php
 /***********************************************************
- * Copyright (C) 2014-2015, Siemens AG
+ * Copyright (C) 2014-2018, Siemens AG
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  ***********************************************************/
 
-namespace Fossology\Reuser\Ui;
+namespace Fossology\Reuser;
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\PackageDao;
@@ -28,10 +28,6 @@ use Symfony\Component\HttpFoundation\Request;
 class ReuserAgentPlugin extends AgentPlugin
 {
   const UPLOAD_TO_REUSE_SELECTOR_NAME = 'uploadToReuse';
-  const REUSE_NONE = 0;
-  const REUSE_ENHANCED = 2;
-  const REUSE_MAIN = 4;
-  const REUSE_ENH_MAIN = 8;
 
   /** @var UploadDao */
   private $uploadDao;
@@ -96,19 +92,19 @@ class ReuserAgentPlugin extends AgentPlugin
     
     $getReuseValue = $request->get('reuseMode');
 
-    $reuseMode=self::REUSE_NONE;
+    $reuseMode = UploadDao::REUSE_NONE;
 
     if(!empty($getReuseValue)){
       if(count($getReuseValue)<2){
         if(in_array('reuseMain', $getReuseValue)){
-          $reuseMode=self::REUSE_MAIN;
+          $reuseMode = UploadDao::REUSE_MAIN;
         }
         else{
-          $reuseMode=self::REUSE_ENHANCED;
+          $reuseMode = UploadDao::REUSE_ENHANCED;
         }
       }
       else{
-        $reuseMode=self::REUSE_ENH_MAIN;
+        $reuseMode = UploadDao::REUSE_ENH_MAIN;
       }
     }
 

--- a/src/reuser/ui/reuser-plugin.php
+++ b/src/reuser/ui/reuser-plugin.php
@@ -1,6 +1,6 @@
 <?php
 /***********************************************************
- * Copyright (C) 2014-2015, Siemens AG
+ * Copyright (C) 2014-2018, Siemens AG
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  ***********************************************************/
 
-namespace Fossology\Reuser\Ui;
+namespace Fossology\Reuser;
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\FolderDao;


### PR DESCRIPTION
Fixed failing testcases and warnings(phpunit) in reuser for debian OS. 

**ERRORS**
`PHP Notice:  Array to string conversion in /builds/fossology/fossologyng/src/lib/php/Db/Driver/Postgres.php on line 72
dropdb: database removal failed: ERROR:  database "reusersched" is being accessed by other users
DETAIL:  There is 1 other session using the database.

1) Fossology\Reuser\Test\SchedulerTest::testReuserRealScanWithARepoClearingEnhanced
pg_execute(): Query failed: ERROR:  invalid input syntax for integer: "Array"
`