### PR TITLE
fix(search.php): Fix the number of files matching the search criteria

### DIFF
--- a/src/www/ui/search.php
+++ b/src/www/ui/search.php
@@ -22,7 +22,7 @@ use Fossology\Lib\Dao\UploadDao;
 
 class search extends FO_Plugin
 {
-  protected $MaxPerPage  = 10;  /* maximum number of result items per page */
+  protected $MaxPerPage  = 100;  /* maximum number of result items per page */
   /** @var UploadDao */
   private $uploadDao;
   
@@ -82,8 +82,8 @@ class search extends FO_Plugin
   {
     global $PG_CONN;
     $UploadtreeRecs = array();  // uploadtree record array to return
-    $totalUploadtreeRecs = array();  // total uploadtree record array to return
-    $totalUploadtreeRecsCount = 0;
+    $totalUploadtreeRecs = array();  // total uploadtree record array
+    $totalUploadtreeRecsCount = 0; // total uploadtree records count to return
     $NeedTagfileTable = true;
     $NeedTaguploadtreeTable = true;
 


### PR DESCRIPTION
This fix issue #985 

<img width="1142" alt="screen shot 2018-03-15 at 12 40 52 pm" src="https://user-images.githubusercontent.com/11582770/37449068-eea19894-284e-11e8-968b-54744b8c809c.png">

It displays the total number of files that match the search criteria 
Also, the message about the UI so that users are not confused why indentation is there in the search results.