### PR TITLE
feat(email): Added support for agent status in email

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -62,7 +62,7 @@ Description: architecture for analyzing software, web interface
 
 Package: fossology-scheduler
 Architecture: any
-Depends: fossology-common, ${shlibs:Depends}, ${misc:Depends}
+Depends: fossology-common, ${shlibs:Depends}, ${misc:Depends}, heirloom-mailx
 Conflicts: fossology-scheduler-single
 Description: architecture for analyzing software, scheduler
  The FOSSology project is a web based framework that allows you to

--- a/install/defconf/fossology.conf.in
+++ b/install/defconf/fossology.conf.in
@@ -89,7 +89,6 @@ LOGDIR=/var/log/$PROJECT
 header  = sampleheader.txt
 footer  = samplefooter.txt
 subject = FOSSology scan complete
-client  = /usr/bin/mailx
-
+client  = "/usr/bin/mailx -S smtp='smtp.gmail.com:587' -S smtp-use-starttls -S smtp-auth=login -S smtp-auth-user='user@gmail.com' -S smtp-auth-password='password' -S ssl-verify=ignore"
 
 

--- a/install/defconf/fossology.conf.in
+++ b/install/defconf/fossology.conf.in
@@ -89,6 +89,6 @@ LOGDIR=/var/log/$PROJECT
 header  = sampleheader.txt
 footer  = samplefooter.txt
 subject = FOSSology scan complete
-client  = "/usr/bin/mailx -S smtp='smtp.gmail.com:587' -S smtp-use-starttls -S smtp-auth=login -S smtp-auth-user='user@gmail.com' -S smtp-auth-password='password' -S ssl-verify=ignore"
+client  = /usr/bin/mailx
 
 

--- a/install/defconf/samplefooter.txt
+++ b/install/defconf/samplefooter.txt
@@ -1,2 +1,4 @@
 
+This is an automated email, do not respond to this.
+
 FOSSology

--- a/install/defconf/sampleheader.txt
+++ b/install/defconf/sampleheader.txt
@@ -1,8 +1,13 @@
-FOSSology scan has completed.
+Hello,
 
-$UPLOADNAME
-$BROWSELINK
-$JOBQUEUELINK
-$SCHEDULERLOG
-$UPLOADFOLDERNAME
-$DB.upload.upload_pk
+Your FOSSology scan has completed.
+
+Upload info
+
+Upload Name     => $UPLOADNAME
+Browse Upload   => $BROWSELINK
+Job Queue       => $JOBQUEUELINK
+Uploaded Folder => $UPLOADFOLDERNAME
+
+Agents => 
+$AGENTSTATUS

--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -26,11 +26,13 @@
 define("CONFIG_TYPE_INT", 1);
 define("CONFIG_TYPE_TEXT", 2);
 define("CONFIG_TYPE_TEXTAREA", 3);
+define("CONFIG_TYPE_PASSWORD", 4);
+define("CONFIG_TYPE_DROP", 5);
 //}@
 
 
 /**
- * \brief Initialize the fossology system after bootstrap().  
+ * \brief Initialize the fossology system after bootstrap().
  * This function also opens a database connection (global PG_CONN).
  *
  * System configuration variables are in four places:
@@ -40,7 +42,7 @@ define("CONFIG_TYPE_TEXTAREA", 3);
  *  - Database sysconfig table
  *
  * VERSION and fossology.conf variables are organized by group.  For example,
- * [DIRECTORIES] 
+ * [DIRECTORIES]
  *   REPODIR=/srv/mydir
  *
  * but the sysconfig table and Db.conf are not.  So all the table values will be put in
@@ -49,7 +51,7 @@ define("CONFIG_TYPE_TEXTAREA", 3);
  *
  * \param $sysconfdir - path to SYSCONFDIR
  * \param $SysConf - configuration variable array (updated by this function)
- * 
+ *
  * If the sysconfig table doesn't exist then create it.
  * Write records for the core variables into sysconfig table.
  *
@@ -60,7 +62,7 @@ define("CONFIG_TYPE_TEXTAREA", 3);
  *  -  $SysConf[VERSION][COMMIT_HASH] => "4467M"
  *
  * \Note Since so many files expect directory paths that used to be in pathinclude.php
- * to be global, this function will define the same globals (everything in the 
+ * to be global, this function will define the same globals (everything in the
  * DIRECTORIES section of fossology.conf).
  */
 function ConfigInit($sysconfdir, &$SysConf)
@@ -71,7 +73,7 @@ function ConfigInit($sysconfdir, &$SysConf)
   $VersionFile = "{$sysconfdir}/VERSION";
   $VersionConf = parse_ini_file($VersionFile, true);
 
-  /* Add this file contents to $SysConf, then destroy $VersionConf 
+  /* Add this file contents to $SysConf, then destroy $VersionConf
    * This file can define its own groups and is eval'd.
    */
   foreach($VersionConf as $GroupName=>$GroupArray)
@@ -88,7 +90,7 @@ function ConfigInit($sysconfdir, &$SysConf)
   $dbPath = "{$sysconfdir}/Db.conf";
   $dbConf = parse_ini_file($dbPath, true);
 
-  /* Add this file contents to $SysConf, then destroy $dbConf 
+  /* Add this file contents to $SysConf, then destroy $dbConf
    * This file can define its own groups and is eval'd.
    */
   foreach($dbConf as $var=>$val) $SysConf['DBCONF'][$var] = $val;
@@ -106,7 +108,8 @@ function ConfigInit($sysconfdir, &$SysConf)
 
   /**************** read/create/populate the sysconfig table *********/
   /* create if sysconfig table if it doesn't exist */
-  $NewTable = Create_sysconfig();
+  $NewTable  = Create_sysconfig();
+  $NewColumn = Create_option_value();
 
   /* populate it with core variables */
   Populate_sysconfig();
@@ -155,7 +158,8 @@ CREATE TABLE sysconfig (
     group_name character varying(20) NOT NULL,
     group_order int,
     description text NOT NULL,
-    validation_function character varying(40) DEFAULT NULL
+    validation_function character varying(40) DEFAULT NULL,
+    option_value character varying(40) DEFAULT NULL
 );
 ";
 
@@ -173,7 +177,8 @@ COMMENT ON COLUMN sysconfig.group_name IS 'Name of this variables group in the u
 COMMENT ON COLUMN sysconfig.group_order IS 'The order this variable appears in the user interface group';
 COMMENT ON COLUMN sysconfig.description IS 'Description of variable to document how/where the variable value is used.';
 COMMENT ON COLUMN sysconfig.validation_function IS 'Name of function to validate input. Not currently implemented.';
-COMMENT ON COLUMN sysconfig.vartype IS 'variable type.  1=int, 2=text, 3=textarea';
+COMMENT ON COLUMN sysconfig.vartype IS 'variable type.  1=int, 2=text, 3=textarea, 4=password, 5=dropdown';
+COMMENT ON COLUMN sysconfig.option_value IS 'If vartype is 5, provide options in format op1{val1}|op2{val2}|...';
     ";
   /* this is a non critical update */
   $result = pg_query($PG_CONN, $sql);
@@ -190,7 +195,7 @@ function Populate_sysconfig()
 {
   global $PG_CONN;
 
-  $Columns = "variablename, conf_value, ui_label, vartype, group_name, group_order, description, validation_function";
+  $Columns = "variablename, conf_value, ui_label, vartype, group_name, group_order, description, validation_function, option_value";
   $ValueArray = array();
 
   /*  Email */
@@ -199,7 +204,7 @@ function Populate_sysconfig()
   $SupportEmailLabelDesc = _('e.g. "Support"<br>Text that the user clicks on to create a new support email. This new email will be preaddressed to this support email address and subject.  HTML is ok.');
   $ValueArray[$Variable] = "'$Variable', 'Support', '$SupportEmailLabelPrompt',"
   . CONFIG_TYPE_TEXT .
-                    ",'Support', 1, '$SupportEmailLabelDesc', ''";
+                    ",'Support', 1, '$SupportEmailLabelDesc', '', null";
 
   $Variable = "SupportEmailAddr";
   $SupportEmailAddrPrompt = _('Support Email Address');
@@ -207,14 +212,14 @@ function Populate_sysconfig()
   $SupportEmailAddrDesc = _('e.g. "support@mycompany.com"<br>Individual or group email address to those providing FOSSology support.');
   $ValueArray[$Variable] = "'$Variable', null, '$SupportEmailAddrPrompt', "
   . CONFIG_TYPE_TEXT .
-                    ",'Support', 2, '$SupportEmailAddrDesc', '$SupportEmailAddrValid'";
+                    ",'Support', 2, '$SupportEmailAddrDesc', '$SupportEmailAddrValid', null";
 
   $Variable = "SupportEmailSubject";
   $SupportEmailSubjectPrompt = _('Support Email Subject line');
   $SupportEmailSubjectDesc = _('e.g. "fossology support"<br>Subject line to use on support email.');
   $ValueArray[$Variable] = "'$Variable', 'FOSSology Support', '$SupportEmailSubjectPrompt',"
   . CONFIG_TYPE_TEXT .
-                    ",'Support', 3, '$SupportEmailSubjectDesc', ''";
+                    ",'Support', 3, '$SupportEmailSubjectDesc', '', null";
 
   /*  Banner Message */
   $Variable = "BannerMsg";
@@ -222,7 +227,7 @@ function Populate_sysconfig()
   $BannerMsgDesc = _('This is message will be displayed on every page with a banner.  HTML is ok.');
   $ValueArray[$Variable] = "'$Variable', null, '$BannerMsgPrompt', "
   . CONFIG_TYPE_TEXTAREA .
-                    ",'Banner', 1, '$BannerMsgDesc', ''";
+                    ",'Banner', 1, '$BannerMsgDesc', '', null";
 
   /*  Logo  */
   $Variable = "LogoImage";
@@ -231,7 +236,7 @@ function Populate_sysconfig()
   $LogoImageDesc = _('e.g. "http://mycompany.com/images/companylogo.png" or "images/mylogo.png"<br>This image replaces the fossology project logo. Image is constrained to 150px wide.  80-100px high is a good target.  If you change this URL, you MUST also enter a logo URL.');
   $ValueArray[$Variable] = "'$Variable', null, '$LogoImagePrompt', "
   . CONFIG_TYPE_TEXT .
-                    ",'Logo', 1, '$LogoImageDesc', '$LogoImageValid'";
+                    ",'Logo', 1, '$LogoImageDesc', '$LogoImageValid', null";
 
   $Variable = "LogoLink";
   $LogoLinkPrompt = _('Logo URL');
@@ -239,8 +244,8 @@ function Populate_sysconfig()
   $LogoLinkValid = "check_logo_url";
   $ValueArray[$Variable] = "'$Variable', null, '$LogoLinkPrompt', "
   . CONFIG_TYPE_TEXT .
-                    ",'Logo', 2, '$LogoLinkDesc', '$LogoLinkValid'" ;
-   
+                    ",'Logo', 2, '$LogoLinkDesc', '$LogoLinkValid', null";
+
   $Variable = "FOSSologyURL";
   $URLPrompt = _("FOSSology URL");
   $hostname = exec("hostname -f");
@@ -250,7 +255,7 @@ function Populate_sysconfig()
   $URLValid = "check_fossology_url";
   $ValueArray[$Variable] = "'$Variable', '$FOSSologyURL', '$URLPrompt', "
   . CONFIG_TYPE_TEXT .
-                    ",'URL', 1, '$URLDesc', '$URLValid'";
+                    ",'URL', 1, '$URLDesc', '$URLValid', null";
 
   $Variable = "NomostListNum";
   $NomosNumPrompt = _("Maximum licenses to List");
@@ -258,7 +263,7 @@ function Populate_sysconfig()
   $NomosNumDesc = _("For License List and License List Download, you can set the maximum number of lines to list/download. Default 2200.");
   $ValueArray[$Variable] = "'$Variable', '$NomostListNum', '$NomosNumPrompt', "
   . CONFIG_TYPE_TEXT .
-                    ",'Number', 4, '$NomosNumDesc', null";
+                    ",'Number', 4, '$NomosNumDesc', null, null";
 
   $Variable = "ShowJobsAutoRefresh";
   $contextNamePrompt = _("ShowJobs Auto Refresh Time");
@@ -266,7 +271,7 @@ function Populate_sysconfig()
   $contextDesc = _("No of seconds to refresh ShowJobs");
   $ValueArray[$Variable] = "'$Variable', '$contextValue', '$contextNamePrompt', "
   . CONFIG_TYPE_TEXT .
-                    ",'Number', null, '$contextDesc', null";
+                    ",'Number', null, '$contextDesc', null, null";
 
   /* Report Header Text */
   $Variable = "ReportHeaderText";
@@ -275,38 +280,38 @@ function Populate_sysconfig()
   $contextDesc = _("Report Header Text at right side corner");
   $ValueArray[$Variable] = "'$Variable', '$contextValue', '$contextNamePrompt', "
   . CONFIG_TYPE_TEXT .
-                    ",'ReportText', null, '$contextDesc', null";
+                    ",'ReportText', null, '$contextDesc', null, null";
   $Variable = "CommonObligation";
   $contextNamePrompt = _("Common Obligation");
   $contextValue = "";
   $contextDesc = _("Common Obligation Text, add line break at the end of the line");
   $ValueArray[$Variable] = "'$Variable', '$contextValue', '$contextNamePrompt', "
   . CONFIG_TYPE_TEXTAREA .
-                    ",'ReportText', null, '$contextDesc', null";
+                    ",'ReportText', null, '$contextDesc', null, null";
   $Variable = "AdditionalObligation";
   $contextNamePrompt = _("Additional Obligation");
   $contextValue = "";
   $contextDesc = _("Additional Obligation Text, add line break at the end of the line");
   $ValueArray[$Variable] = "'$Variable', '$contextValue', '$contextNamePrompt', "
   . CONFIG_TYPE_TEXTAREA .
-                    ",'ReportText', null, '$contextDesc', null";
+                    ",'ReportText', null, '$contextDesc', null, null";
   $Variable = "ObligationAndRisk";
   $contextNamePrompt = _("Obligation And Risk Assessment");
   $contextValue = "";
   $contextDesc = _("Obligations and risk assessment, add line break at the end of the line");
   $ValueArray[$Variable] = "'$Variable', '$contextValue', '$contextNamePrompt', "
   . CONFIG_TYPE_TEXTAREA .
-                    ",'ReportText', null, '$contextDesc', null";
+                    ",'ReportText', null, '$contextDesc', null, null";
 
   $Variable = "BlockSizeHex";
   $hexPrompt = _("Chars per page in hex view");
   $hexDesc = _("Number of characters per page in hex view");
-  $ValueArray[$Variable] = "'$Variable', '8192', '$hexPrompt', ". CONFIG_TYPE_TEXT . ",'Number', 5, '$hexDesc', null";
+  $ValueArray[$Variable] = "'$Variable', '8192', '$hexPrompt', ". CONFIG_TYPE_TEXT . ",'Number', 5, '$hexDesc', null, null";
 
   $Variable = "BlockSizeText";
   $textPrompt = _("Chars per page in text view");
   $textDesc = _("Number of characters per page in text view");
-  $ValueArray[$Variable] = "'$Variable', '81920', '$textPrompt', " . CONFIG_TYPE_TEXT . ",'Number', 5, '$textDesc', null";
+  $ValueArray[$Variable] = "'$Variable', '81920', '$textPrompt', " . CONFIG_TYPE_TEXT . ",'Number', 5, '$textDesc', null, null";
 
   /*  "Upload from server"-configuration  */
   $Variable = "UploadFromServerWhitelist";
@@ -315,16 +320,66 @@ function Populate_sysconfig()
   $contextDesc = _("List of allowed prefixes for upload, separated by \":\" (colon)");
   $ValueArray[$Variable] = "'$Variable', '$contextValue', '$contextNamePrompt', "
   . CONFIG_TYPE_TEXT .
-                    ",'UploadFromServer', 5, '$contextDesc', null";
+                    ",'UploadFromServer', 5, '$contextDesc', null, null";
   $Variable = "UploadFromServerAllowedHosts";
   $contextNamePrompt = _("List of allowed hosts for serverupload");
   $contextValue = "localhost";
   $contextDesc = _("List of allowed hosts for upload, separated by \":\" (colon)");
   $ValueArray[$Variable] = "'$Variable', '$contextValue', '$contextNamePrompt', "
   . CONFIG_TYPE_TEXT .
-                    ",'UploadFromServer', 5, '$contextDesc', null";
+                    ",'UploadFromServer', 5, '$contextDesc', null, null";
 
-  
+  /*  SMTP config */
+  $Variable = "SMTPHostName";
+  $SMTPHostPrompt = _('SMTP Host Name');
+  $SMTPHostDesc = _('e.g.: "smtp.domain.com"<br>The domain to be used to send emails.');
+  $ValueArray[$Variable] = "'$Variable', null, '$SMTPHostPrompt',"
+  . CONFIG_TYPE_TEXT .
+                    ",'SMTP', 1, '$SMTPHostDesc', null, null";
+
+  $Variable = "SMTPPort";
+  $SMTPPortPrompt = _('SMTP Port');
+  $SMTPPortDesc = _('e.g.: "25"<br>SMTP port to be used.');
+  $ValueArray[$Variable] = "'$Variable', 25, '$SMTPPortPrompt', "
+  . CONFIG_TYPE_INT .
+                    ",'SMTP', 2, '$SMTPPortDesc', null, null";
+
+  $Variable = "SMTPAuth";
+  $SMTPAuthPrompt = _('SMTP Auth Type');
+  $SMTPAuthDesc = _('Algorithm to use for login.<br>Login => Encrypted<br>None => No authentication<br>Plain => Send as plain text');
+  $ValueArray[$Variable] = "'$Variable', 'L', '$SMTPAuthPrompt',"
+  . CONFIG_TYPE_DROP .
+                    ",'SMTP', 3, '$SMTPAuthDesc', null, 'Login{L}|None{N}|Plain{P}'";
+
+  $Variable = "SMTPAuthUser";
+  $SMTPAuthUserPrompt = _('SMTP User');
+  $SMTPAuthUserDesc = _('e.g.: "user@domain.com"<br>Email to be used for login in SMTP and for from address.');
+  $ValueArray[$Variable] = "'$Variable', null, '$SMTPAuthUserPrompt',"
+  . CONFIG_TYPE_TEXT .
+                    ",'SMTP', 4, '$SMTPAuthUserDesc', 'check_email_address', null";
+
+  $Variable = "SMTPAuthPasswd";
+  $SMTPAuthPasswdPrompt = _('SMTP Login Password');
+  $SMTPAuthPasswdDesc = _('Password used for SMTP login.');
+  $ValueArray[$Variable] = "'$Variable', null, '$SMTPAuthPasswdPrompt',"
+  . CONFIG_TYPE_PASSWORD .
+                    ",'SMTP', 5, '$SMTPAuthPasswdDesc', null, null";
+
+  $Variable = "SMTPSslVerify";
+  $SMTPSslPrompt = _('SMTP SSL Verify');
+  $SMTPSslDesc = _('The SSL verification for connection is required?');
+  $ValueArray[$Variable] = "'$Variable', 'S', '$SMTPSslPrompt',"
+  . CONFIG_TYPE_DROP .
+                    ",'SMTP', 6, '$SMTPSslDesc', null, 'Ignore{I}|Strict{S}|Warn{W}'";
+
+  $Variable = "SMTPStartTls";
+  $SMTPTlsPrompt = _('Start TLS');
+  $SMTPTlsDesc = _('Use TLS connection for SMTP?');
+  $ValueArray[$Variable] = "'$Variable', '1', '$SMTPTlsPrompt',"
+  . CONFIG_TYPE_DROP .
+                    ",'SMTP', 7, '$SMTPTlsDesc', null, 'Yes{1}|No{2}'";
+
+
   /* Doing all the rows as a single insert will fail if any row is a dupe.
    So insert each one individually so that new variables get added.
   */
@@ -347,11 +402,47 @@ function Populate_sysconfig()
 }
 
 /**
+ * \brief Create the option_value column in sysconfig table.
+ *
+ * \return 0 if column already exists.
+ * 1 if it was created
+ */
+function Create_option_value()
+{
+  global $PG_CONN;
+
+  /* If sysconfig exists, then we are done */
+  $sql = "SELECT column_name FROM information_schema.columns WHERE table_name='sysconfig' and column_name='option_value' limit 1;";
+  $result = pg_query($PG_CONN, $sql);
+  DBCheckResult($result, $sql, __FILE__, __LINE__);
+  $numrows = pg_num_rows($result);
+  pg_free_result($result);
+  if ($numrows > 0) return 0;
+
+  /* Create the option_value column */
+  $sql = "ALTER TABLE sysconfig ADD COLUMN option_value character varying(40) DEFAULT NULL;";
+
+  $result = pg_query($PG_CONN, $sql);
+  DBCheckResult($result, $sql, __FILE__, __LINE__);
+  pg_free_result($result);
+
+  /* Document columns */
+  $sql = "
+COMMENT ON COLUMN sysconfig.option_value IS 'If vartype is 5, provide options in format op1{val1}|op2{val2}|...';
+    ";
+  /* this is a non critical update */
+  $result = pg_query($PG_CONN, $sql);
+  DBCheckResult($result, $sql, __FILE__, __LINE__);
+  pg_free_result($result);
+  return 1;
+}
+
+/**
  * \brief validation function check_boolean().
  * check if the value format is valid,
  * only true/false is valid
  *
- * \param $value - the value which will be checked 
+ * \param $value - the value which will be checked
  *
  * \return 1, if the value is valid, or 0
  */
@@ -371,7 +462,7 @@ function check_boolean($value)
  * \brief validation function check_fossology_url().
  * check if the url is valid,
  *
- * \param $url - the url which will be checked 
+ * \param $url - the url which will be checked
  *
  * \return  1: valid, 0: invalid
  */
@@ -404,7 +495,7 @@ function check_fossology_url($url)
  * \brief validation function check_logo_url().
  * check if the url is available,
  *
- * \param $url - the url which will be checked 
+ * \param $url - the url which will be checked
  *
  * \return 1: available, 0: unavailable
  */
@@ -425,7 +516,7 @@ function check_logo_url($url)
  * \brief validation function check_logo_image_url().
  * check if the url is available,
  *
- * \param $url - the url which will be checked 
+ * \param $url - the url which will be checked
  *
  * \return 1: the url is available, 0: unavailable
  */
@@ -450,7 +541,7 @@ function check_logo_image_url($url)
  * implement this function if needed in the future
  * check if the email address is valid
  *
- * \param $email_address - the email address which will be checked 
+ * \param $email_address - the email address which will be checked
  *
  * \return 1: valid, 0: invalid
  */
@@ -488,7 +579,7 @@ function is_available($url, $timeout = 2, $tries = 2)
 
 /**
  * \brief check if the url is valid
- * \param $url - the url which will be checked 
+ * \param $url - the url which will be checked
  * \return 1: the url is valid, 0: invalid
  */
 function check_url($url)

--- a/src/scheduler/agent/Makefile
+++ b/src/scheduler/agent/Makefile
@@ -1,6 +1,6 @@
 ######################################################################
 # Copyright (C) 2010-2012 Hewlett-Packard Development Company, L.P.
-# Copyright (C) 2015 Siemens AG
+# Copyright (C) 2018 Siemens AG
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -52,7 +52,8 @@ OBJS = scheduler.o \
        host.o \
        interface.o \
        job.o \
-       logging.o
+       logging.o \
+       emailformatter.o
 
 COVERAGE = $(OBJS:%.o=%_cov.o)
 
@@ -63,7 +64,8 @@ HEAD = agent.h \
        job.h \
        logging.h \
        interface.h \
-       sqlstatements.h
+       sqlstatements.h \
+       emailformatter.h
 
 ##########################
 # executable build rules #
@@ -116,6 +118,9 @@ job.o: %.o: %.c %.h agent.h database.h $(DEPEN)
 	$(CC) -c $(CFLAGS_LOCAL) $(DEF) $<
 
 logging.o: %.o: %.c $(DEPEN)
+	$(CC) -c $(CFLAGS_LOCAL) $(DEF) $<
+
+emailformatter.o: %.o: %.c agent.h $(DEPEN)
 	$(CC) -c $(CFLAGS_LOCAL) $(DEF) $<
 
 $(COVERAGE): %_cov.o: %.c $(HEAD) $(DEPEN)

--- a/src/scheduler/agent/Makefile
+++ b/src/scheduler/agent/Makefile
@@ -1,6 +1,6 @@
 ######################################################################
 # Copyright (C) 2010-2012 Hewlett-Packard Development Company, L.P.
-# Copyright (C) 2018 Siemens AG
+# Copyright (C) 2015, 2018 Siemens AG
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/src/scheduler/agent/emailformatter.c
+++ b/src/scheduler/agent/emailformatter.c
@@ -1,0 +1,58 @@
+/*
+ **************************************************************
+ Copyright (C) 2018 Siemens AG
+ Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ **************************************************************
+ */
+
+#include <agent.h>
+#include <emailformatter.h>
+
+/**
+ * @brief Format rows as plain text
+ *
+ * @param rows      rows of type agent_info
+ * @param fossy_url host url of fossology
+ * @return rows in plain text format
+ */
+const gchar* email_format_text(GPtrArray *rows, gchar *fossy_url)
+{
+  guint i;
+  GString* ret = g_string_new("");
+  if(rows == NULL)
+  {
+    return "";
+  }
+  g_string_append(ret, "Agents run:\n");
+  g_string_append(ret, "    Job ID =>      Agent Name =>     Status => Link\n");
+  for (i = 0; i < rows->len; i++)
+  {
+    agent_info *data = (agent_info *)g_ptr_array_index(rows, i);
+    g_string_append_printf(ret, "%10d => %15s => ", data->id, data->agent->str);
+    if (data->status == TRUE)
+    {
+      g_string_append(ret, " COMPLETED\n");
+    }
+    else
+    {
+      g_string_append_printf(ret, "%10s => http://%s?mod=showjobs&job=%d\n",
+                             "FAILED", fossy_url, data->id);
+    }
+    g_string_free(data->agent, TRUE);
+  }
+  return ret->str;
+}
+

--- a/src/scheduler/agent/emailformatter.h
+++ b/src/scheduler/agent/emailformatter.h
@@ -1,0 +1,35 @@
+/* **************************************************************
+ Copyright (C) 2018 Siemens AG
+ Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ************************************************************** */
+
+#ifndef EMAILFORMATTER_H_INCLUDE
+#define EMAILFORMATTER_H_INCLUDE
+
+#include <agent.h>
+
+typedef struct
+{
+  guint id;
+  GString* agent;
+  gboolean status;
+} agent_info;
+
+/* Format rows as plain text */
+const gchar* email_format_text(GPtrArray *rows, gchar *fossy_url);
+
+#endif /* EMAILFORMATTER_H_INCLUDE */
+

--- a/src/scheduler/agent/sqlstatements.h
+++ b/src/scheduler/agent/sqlstatements.h
@@ -1,6 +1,6 @@
 /* **************************************************************
 Copyright (C) 2012 Hewlett-Packard Development Company, L.P.
-Copyright (C) 2015 Siemens AG
+Copyright (C) 2018 Siemens AG
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -48,11 +48,16 @@ const char* upload_common =
     "   WHERE job.job_upload_fk = %d;";
 
 const char* folder_name =
-    " SELECT folder_name FROM folder "
+    " SELECT folder_name, folder_pk FROM folder "
     "   LEFT JOIN foldercontents ON folder_pk = foldercontents.parent_fk "
     "   LEFT JOIN job ON child_id = job_upload_fk "
     "   LEFT JOIN jobqueue ON jq_job_fk = job_pk "
     "   WHERE jq_pk = %d;";
+
+const char* parent_folder_name =
+    " SELECT folder_name, folder_pk FROM folder "
+    "   INNER JOIN foldercontents ON folder_pk=foldercontents.parent_fk "
+    "   WHERE child_id = %d AND foldercontents_mode = 1;";
 
 const char* upload_name =
     " SELECT upload_filename FROM upload "
@@ -175,6 +180,13 @@ const char* jobsql_resetqueue =
     "      jq_endtext=null, "
     "      jq_schedinfo=null "
     "  WHERE jq_endtime is NULL;";
+
+const char* jobsql_jobinfo =
+    " SELECT * FROM jobqueue "
+    "   WHERE jq_job_fk = ( "
+    "     SELECT jq_job_fk FROM jobqueue "
+    "       WHERE jq_pk = %d "
+    "   );";
 
 #endif /* SQLSTATEMENTS_H */
 

--- a/src/scheduler/agent/sqlstatements.h
+++ b/src/scheduler/agent/sqlstatements.h
@@ -1,6 +1,6 @@
 /* **************************************************************
 Copyright (C) 2012 Hewlett-Packard Development Company, L.P.
-Copyright (C) 2018 Siemens AG
+Copyright (C) 2015, 2018 Siemens AG
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -187,6 +187,10 @@ const char* jobsql_jobinfo =
     "     SELECT jq_job_fk FROM jobqueue "
     "       WHERE jq_pk = %d "
     "   );";
+
+const char* smtp_values =
+    " SELECT conf_value, variablename FROM sysconfig "
+    "   WHERE variablename LIKE 'SMTP%';";
 
 #endif /* SQLSTATEMENTS_H */
 

--- a/src/www/ui/admin-config.php
+++ b/src/www/ui/admin-config.php
@@ -80,6 +80,31 @@ class foconfig extends FO_Plugin
           $OutBuf .= "<br><textarea name='new[$row[variablename]]' rows=3 cols=80 title='$row[description]' $InputStyle>$ConfVal</textarea>";
           $OutBuf .= "<br>$row[description]";
           break;
+        case CONFIG_TYPE_PASSWORD:
+          $ConfVal = htmlentities($row['conf_value']);
+          $OutBuf .= "<INPUT type='password' name='new[$row[variablename]]' size='70' value='$ConfVal' title='$row[description]' $InputStyle>";
+          $OutBuf .= "<br>$row[description]";
+          break;
+        case CONFIG_TYPE_DROP:
+          $ConfVal = htmlentities($row['conf_value']);
+          $Options = explode("|",$row['option_value']);
+          $OutBuf .= "<select name='new[$row[variablename]]' title='$row[description]' $InputStyle>";
+          foreach($Options as $Option)
+          {
+            $matches = array();
+            preg_match('/(\\w+)[{](.*)[}]/', $Option, $matches);
+            $Option_display = $matches[1];
+            $Option_value   = $matches[2];
+            $OutBuf .= "<option $InputStyle value='$Option_value' ";
+            if($ConfVal == $Option_value)
+            {
+              $OutBuf .= "selected";
+            }
+            $OutBuf .= ">$Option_display</option>";
+          }
+          $OutBuf .= "</select>";
+          $OutBuf .= "<br>$row[description]";
+          break;
         default:
           $OutBuf .= "Invalid configuration variable.  Unknown type.";
       }

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -1314,7 +1314,7 @@
   $Schema["TABLE"]["sysconfig"]["ui_label"]["ADD"] = "ALTER TABLE \"sysconfig\" ADD COLUMN \"ui_label\" varchar(60)";
   $Schema["TABLE"]["sysconfig"]["ui_label"]["ALTER"] = "ALTER TABLE \"sysconfig\" ALTER COLUMN \"ui_label\" SET NOT NULL";
 
-  $Schema["TABLE"]["sysconfig"]["vartype"]["DESC"] = "COMMENT ON COLUMN \"sysconfig\".\"vartype\" IS 'variable type.  1=int, 2=text, 3=textarea'";
+  $Schema["TABLE"]["sysconfig"]["vartype"]["DESC"] = "COMMENT ON COLUMN \"sysconfig\".\"vartype\" IS 'variable type.  1=int, 2=text, 3=textarea, 4=password, 5=dropdown'";
   $Schema["TABLE"]["sysconfig"]["vartype"]["ADD"] = "ALTER TABLE \"sysconfig\" ADD COLUMN \"vartype\" int4";
   $Schema["TABLE"]["sysconfig"]["vartype"]["ALTER"] = "ALTER TABLE \"sysconfig\" ALTER COLUMN \"vartype\" SET NOT NULL";
 
@@ -1333,6 +1333,10 @@
   $Schema["TABLE"]["sysconfig"]["validation_function"]["DESC"] = "COMMENT ON COLUMN \"sysconfig\".\"validation_function\" IS 'Name of function to validate input. Not currently implemented.'";
   $Schema["TABLE"]["sysconfig"]["validation_function"]["ADD"] = "ALTER TABLE \"sysconfig\" ADD COLUMN \"validation_function\" varchar(40) DEFAULT NULL::character varying";
   $Schema["TABLE"]["sysconfig"]["validation_function"]["ALTER"] = "ALTER TABLE \"sysconfig\" ALTER COLUMN \"validation_function\" DROP NOT NULL, ALTER COLUMN \"validation_function\" SET DEFAULT NULL::character varying";
+  
+  $Schema["TABLE"]["sysconfig"]["option_value"]["DESC"] = "COMMENT ON COLUMN \"sysconfig\".\"option_value\" IS 'If vartype is 5, provide options in format op1{val1}|op2{val2}|...'";
+  $Schema["TABLE"]["sysconfig"]["option_value"]["ADD"] = "ALTER TABLE \"sysconfig\" ADD COLUMN \"option_value\" character varying(40) DEFAULT NULL";
+  $Schema["TABLE"]["sysconfig"]["option_value"]["ALTER"] = "ALTER TABLE \"sysconfig\" ALTER COLUMN \"option_value\" DROP NOT NULL, ALTER COLUMN \"option_value\" SET DEFAULT NULL";
 
 
   $Schema["TABLE"]["tag"]["tag_pk"]["DESC"] = "";

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -173,7 +173,7 @@ if [ $RUNTIME ]; then
             poppler-utils upx-ucl \
             unrar-free unzip p7zip-full p7zip wget \
             subversion git \
-            dpkg-dev
+            dpkg-dev heirloom-mailx
          POSTGRE=`dpkg --get-selections|grep postgresql-8.4`
          if [ -z "$POSTGRE" ]; then  ## if postgresql-server-dev is installed
            case "$CODENAME" in
@@ -218,7 +218,7 @@ if [ $RUNTIME ]; then
             php php-pear php-pgsql php-process php-xml php-mbstring\
             smtpdaemon \
             libxml2 \
-            binutils
+            binutils mailx
 
          # enable, possible init, and start postgresql
          /sbin/chkconfig postgresql on
@@ -255,7 +255,7 @@ if [ $RUNTIME ]; then
             php php-pear php-pgsql php-process \
             smtpdaemon \
             file libxml2 \
-            binutils 
+            binutils mailx
          echo "NOTE: cabextract, sleuthkit, upx, and unrar are not"
          echo "    available in RHEL please install from upstream sources.";;
       *) echo "ERROR: distro not recognised, please fix and send a patch"; exit 1;;


### PR DESCRIPTION
**Prerequisite:**

1.  Install heirloom-mailx (BSD mail client, formally known as "nail").

    `sudo apt-get install heirloom-mailx`

**Enhancement:**

1.  New AGENTSTATUS macro for list of passed or failed agents.
2.  Complete path of the folder where the package is uploaded.

pls see also: https://github.com/fossology/fossology/wiki/Email-notification-configuration