### PR TITLE
fix(reuser): copy events for reuse

### DIFF
--- a/src/reuser/agent/ReuserAgent.php
+++ b/src/reuser/agent/ReuserAgent.php
@@ -30,6 +30,7 @@ use Fossology\Lib\Data\ClearingDecision;
 use Fossology\Lib\Data\DecisionTypes;
 use Fossology\Lib\Data\Tree\Item;
 use Fossology\Lib\Util\ArrayOperation;
+use Fossology\Lib\Data\Clearing\ClearingEventTypes;
 
 include_once(__DIR__ . "/version.php");
 
@@ -226,7 +227,15 @@ class ReuserAgent extends Agent
     /** @var ClearingEvent $clearingEvent */
     foreach ($clearingDecisionToCopy->getClearingEvents() as $clearingEvent)
     {
-      $clearingEventIdsToCopy[] = $clearingEvent->getEventId();
+      $licenseId = $clearingEvent->getLicenseId();
+      $uploadTreeId = $itemId;
+      $isRemoved = $clearingEvent->isRemoved();
+      $type = ClearingEventTypes::USER;
+      $reportInfo = $clearingEvent->getReportinfo();
+      $comment = $clearingEvent->getComment();
+      $acknowledgement = $clearingEvent->getAcknowledgement();
+      $jobId = $this->jobId;
+      $clearingEventIdsToCopy[] = $this->clearingDao->insertClearingEvent($uploadTreeId, $userId, $groupId, $licenseId, $isRemoved, $type, $reportInfo, $comment, $acknowledgement, $jobId);
     }
 
     $this->clearingDao->createDecisionFromEvents(


### PR DESCRIPTION
copying the missing events to be consistent on the license identifier state in the reused package.
Issue :
1. upload a package upload-A, 
2. cleared the component upload-A(with bulk),
3. reuse the component for upload-B.
4. In upload-B file decided with Bulk,(after reuse) 
clicking "submit" on those the file, will change the license identifier state. 