### PR TITLE
fix(uploadSrvPage): Added feature so that users can update the name of upload manually

### DIFF
--- a/src/www/ui/page/UploadSrvPage.php
+++ b/src/www/ui/page/UploadSrvPage.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpFoundation\Request;
 class UploadSrvPage extends UploadPageBase
 {
   const NAME = 'upload_srv_files';
+  const NAME_PARAM = 'name';
   const SOURCE_FILES_FIELD = 'sourceFiles';
 
   public function __construct()
@@ -138,6 +139,7 @@ class UploadSrvPage extends UploadPageBase
   protected function handleView(Request $request, $vars)
   {
     $vars['sourceFilesField'] = self::SOURCE_FILES_FIELD;
+    $vars['nameField'] = self::NAME_PARAM;
     $vars['hostlist'] = HostListOption();
     return $this->render("upload_srv.html.twig", $this->mergeWithDefault($vars));
   }
@@ -187,10 +189,15 @@ class UploadSrvPage extends UploadPageBase
       return array(false, $text, $description);
     }
 
-    $shortName = basename($sourceFiles);
-    if (empty($shortName))
+    $name = $request->get(self::NAME_PARAM);
+    if (empty($name)) 
     {
-      $shortName = $sourceFiles;
+      $name = basename($sourceFiles);
+    }
+    $shortName = basename($name);
+    if (empty($shortName)) 
+    {
+      $shortName = $name;
     }
     if(strcmp($host,"localhost"))
     {

--- a/src/www/ui/template/upload_srv.html.twig
+++ b/src/www/ui/template/upload_srv.html.twig
@@ -22,6 +22,14 @@
   NOTE: <strong>Contents under a directory will be recursively included.</strong>
   '*' is supported to select multiple files (e.g. *.txt).
 </li>
+<li>
+  <label for="{{ nameField }}">
+    {{ '(Optional) Enter a viewable name for this file or directory'| trans }}:
+  </label>
+  <br/>
+  <input name="{{ nameField }}" type="text" size="120"/><br/>
+  {{ 'Note: If no name is provided, then the uploaded file (directory) name will be used.' |trans }}
+</li>
 {% if hostlist|length > 0 %}
 <li>
   <label for="host">


### PR DESCRIPTION
This fix issue #959 
Now the users can change the name of upload manually(optional).

![image](https://user-images.githubusercontent.com/11582770/37948884-cdaaac56-31af-11e8-9cda-5803c43076cc.png)
