### PR TITLE
fix(unifiedreport): Global license appears twice in Main license section

### DIFF
--- a/src/unifiedreport/agent/unifiedreport.php
+++ b/src/unifiedreport/agent/unifiedreport.php
@@ -244,16 +244,26 @@ class UnifiedReport extends Agent
     $lenTotalLics = count($contents["licenses"]["statements"]);
     // both of this variables have same value but used for different operations
     $lenMainLics = $lenLicsMain = count($contents["licensesMain"]["statements"]);
-    for($j=0; $j<$lenLicsMain; $j++){
-      for($i=0; $i<$lenTotalLics; $i++){
-        if(!strcmp($contents["licenses"]["statements"][$i]["content"], $contents["licensesMain"]["statements"][$j]["content"])){
-          if(!strcmp($contents["licenses"]["statements"][$i]["text"], $contents["licensesMain"]["statements"][$j]["text"])){
-            $contents["licensesMain"]["statements"][$j]["files"] = $contents["licenses"]["statements"][$i]["files"];
-          } else {
-            $lenMainLics++;
-            $contents["licensesMain"]["statements"][$lenMainLics] = $contents["licenses"]["statements"][$i];
+    if($lenLicsMain > 0 ) {
+      for($j=0; $j<$lenLicsMain; $j++) {
+        if($lenTotalLics > 0) {
+          $found = 0;
+          for($i=0; $i<$lenTotalLics; $i++) {
+            if(!strcmp($contents["licenses"]["statements"][$i]["content"], $contents["licensesMain"]["statements"][$j]["content"])) {
+              $found += 1;
+              $lenMainLics += 1;
+              $contents["licensesMain"]["statements"][$lenMainLics] = $contents["licenses"]["statements"][$i];
+              unset($contents["licenses"]["statements"][$i]);
+            }
           }
-          unset($contents["licenses"]["statements"][$i]);          
+          if ($found == 0 ) {
+            $lenMainLics += 1;
+            $contents["licensesMain"]["statements"][$lenMainLics] = $contents["licensesMain"]["statements"][$j];
+            unset($contents["licensesMain"]["statements"][$j]);
+          }
+          else {
+            unset($contents["licensesMain"]["statements"][$j]);
+          }
         }
       }
     }
@@ -544,7 +554,7 @@ class UnifiedReport extends Agent
     $timestamp = $jobInfo['ts'];
     $packageUri = "";
     if(!empty($jobInfo['jq_cmd_args'])){
-     $packageUri = trim($jobInfo['jq_cmd_args'])."?mod=showjobs&upload=".$uploadId;
+      $packageUri = trim($jobInfo['jq_cmd_args'])."?mod=showjobs&upload=".$uploadId;
     }
 
     /* Applying document properties and styling */


### PR DESCRIPTION
In report sometime main license is appearing twice, and one without any file name in file column.
steps to reproduce : 
1. scan a package, 
2. package should have one file with one license-identifier
3. Select that license-identifier as global license.
4. add a new text for the license identifier.

result : (2 entries in main-license section) 
License text without file name
License text with file name.