### PR TITLE
fix(upload-file): get distinct of groupid to insert in perm upload table

### DIFF
--- a/src/lib/php/Dao/UploadPermissionDao.php
+++ b/src/lib/php/Dao/UploadPermissionDao.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Copyright (C) 2015, Siemens AG
+Copyright (C) 2015-2018, Siemens AG
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -80,11 +80,15 @@ class UploadPermissionDao extends Object
     if (null === $perm) {
       $perm = Auth::PERM_ADMIN;
     }
-    $this->dbManager->getSingleRow("INSERT INTO perm_upload (perm, upload_fk, group_fk) "
-            . "SELECT $1 perm, $2 upload_fk, gum.group_fk"
-            . " FROM group_user_member gum LEFT JOIN perm_upload ON perm_upload.group_fk=gum.group_fk AND upload_fk=$2"
-            . " WHERE perm_upload IS NULL AND gum.user_fk=$3",
-               array($perm, $uploadId, $userId), __METHOD__.'.insert');
+
+    $this->dbManager->getSingleRow("INSERT INTO perm_upload (group_fk, perm, upload_fk)
+                                    SELECT DISTINCT(gum.group_fk), $perm perm, $uploadId upload_fk
+                                      FROM group_user_member gum
+                                      LEFT JOIN perm_upload ON perm_upload.group_fk=gum.group_fk
+                                       AND upload_fk=$uploadId
+                                     WHERE perm_upload IS NULL AND gum.user_fk=$userId",
+                                    array(), __METHOD__.'.insert');
+
   }
  
   public function updatePermissionId($permId, $permLevel)


### PR DESCRIPTION
Get Distinct of group id for "visible to all groups" via upload-file. Which was throwing the below error for duplicates.


`[Mon Mar 26 05:37:57.272706 2018] [:error] [pid 10860] [client 10.0.2.2:57156] PHP Fatal error:  Uncaught exception 'Fossology\Lib\Exception' with message 'error executing: Fossology\Lib\Dao\UploadPermissionDao::makeAccessibleToAllGroupsOf.insert: INSERT INTO perm_upload (perm, upload_fk, group_fk) SELECT $1 perm, $2 upload_fk, gum.group_fk FROM group_user_member gum LEFT JOIN perm_upload ON perm_upload.group_fk=gum.group_fk AND upload_fk=$2 WHERE perm_upload IS NULL AND gum.user_fk=$3 -- -- Array\n(\n    [0] => 10\n    [1] => 11875\n    [2] => 2\n)\n\n\nERROR:  duplicate key value violates unique constraint "perm_upload_upload_fk_group_fk_key"\nDETAIL:  Key (upload_fk, group_fk)=(11875, 69) already exists.' in /usr/share/fossology/lib/php/Db/DbManager.php:141\nStack trace:\n#0 /usr/share/fossology/lib/php/Db/ModernDbManager.php(71): Fossology\Lib\Db\DbManager->checkResult(false, 'Fossology\Lib\D...')\n#1 /usr/share/fossology/lib/php/Db/DbManager.php(162): Fossology\Lib\Db\ModernDbManager->execute('Fossology\Lib\D...', Array)\n#2 /usr/share/fossology/lib/php/Dao/UploadPermissionDao.php(87): Fossology\Lib\Db\DbManager in /usr/share/fossology/lib/php/Db/DbManager.php on line 141`