### PR TITLE
fix(nonzipUpload): Fixed the query to select every upload

### DIFF
--- a/src/lib/php/Dao/FolderDao.php
+++ b/src/lib/php/Dao/FolderDao.php
@@ -229,8 +229,8 @@ GROUP BY group_fk
 SELECT u.*,uc.*,fc.foldercontents_pk FROM foldercontents fc
   INNER JOIN upload u ON u.upload_pk = fc.child_id
   INNER JOIN upload_clearing uc ON u.upload_pk=uc.upload_fk AND uc.group_fk=$2
-WHERE fc.parent_fk = $1 AND fc.foldercontents_mode = " .self::MODE_UPLOAD. " AND u.upload_mode = 104
-");
+WHERE fc.parent_fk = $1 AND fc.foldercontents_mode = " .self::MODE_UPLOAD. " AND ((u.upload_mode & 96) = 96);");
+    //upload_mode&96 => unpack and adj2nest completed successfully
     $res = $this->dbManager->execute($statementName, $parameters);
     $results = $this->dbManager->fetchAll($res);
     $this->dbManager->freeResult($res);

--- a/src/lib/php/Dao/FolderDao.php
+++ b/src/lib/php/Dao/FolderDao.php
@@ -189,7 +189,7 @@ class FolderDao extends Object
 SELECT group_fk group_id,count(*) FROM foldercontents fc
   INNER JOIN upload u ON u.upload_pk = fc.child_id
   INNER JOIN upload_clearing uc ON u.upload_pk=uc.upload_fk AND uc.group_fk=ANY($2)
-WHERE fc.parent_fk = $1 AND fc.foldercontents_mode = ". self::MODE_UPLOAD ." AND u.upload_mode = 104
+WHERE fc.parent_fk = $1 AND fc.foldercontents_mode = ". self::MODE_UPLOAD ." AND (u.upload_mode = 100 OR u.upload_mode = 104)
 GROUP BY group_fk
 ");
     $res = $this->dbManager->execute($statementName, $parameters);
@@ -229,8 +229,7 @@ GROUP BY group_fk
 SELECT u.*,uc.*,fc.foldercontents_pk FROM foldercontents fc
   INNER JOIN upload u ON u.upload_pk = fc.child_id
   INNER JOIN upload_clearing uc ON u.upload_pk=uc.upload_fk AND uc.group_fk=$2
-WHERE fc.parent_fk = $1 AND fc.foldercontents_mode = " .self::MODE_UPLOAD. " AND ((u.upload_mode & 96) = 96);");
-    //upload_mode&96 => unpack and adj2nest completed successfully
+WHERE fc.parent_fk = $1 AND fc.foldercontents_mode = " .self::MODE_UPLOAD. " AND (u.upload_mode = 100 OR u.upload_mode = 104);");
     $res = $this->dbManager->execute($statementName, $parameters);
     $results = $this->dbManager->fetchAll($res);
     $this->dbManager->freeResult($res);

--- a/src/www/ui/async/AjaxFolderContents.php
+++ b/src/www/ui/async/AjaxFolderContents.php
@@ -66,6 +66,10 @@ class AjaxFolderContents extends DefaultPlugin
     {
       $filterResults[$content] = $results[$content];
     }
+    if(empty($filterResults))
+    {
+      $filterResults["-1"] = "No removable content found";
+    }
     return new JsonResponse($filterResults);
   }
   

--- a/src/www/ui/template/admin_content_delete.html.twig
+++ b/src/www/ui/template/admin_content_delete.html.twig
@@ -28,7 +28,7 @@
         </label>
         <br/>
 
-        <input type="submit" name="move" value="{{ 'Delete'|trans }}"/>
+        <input type="submit" name="move" id="movebutton" value="{{ 'Delete'|trans }}"/>
       </form>
     </td>
   </tr>

--- a/src/www/ui/template/admin_content_move.js.twig
+++ b/src/www/ui/template/admin_content_move.js.twig
@@ -37,3 +37,4 @@ $(document).ready(function() {
 
   $('.clickable-folder').first().trigger('click');
 });
+

--- a/src/www/ui/template/admin_content_move.js.twig
+++ b/src/www/ui/template/admin_content_move.js.twig
@@ -26,6 +26,14 @@ $(document).ready(function() {
         .fail(failed);
     return false;
   });
+  $('#foldercontent').click(function(event){
+    if (this.value == -1) {
+      $('#movebutton').attr('disabled',true);
+    }
+    else {
+      $('#movebutton').attr('disabled',false);
+    }
+  });
 
   $('.clickable-folder').first().trigger('click');
 });


### PR DESCRIPTION
Made a change in query to select every upload on which ununpack agent and adj2nest has finished (which includes zip and non-zip uploads).

**How to test:**

Check #993 

**Additional features:**

1.  Print a message while browsing empty folder in Organize->Uploads->Delete Uploaded File.
2.  Disable the Delete button if a folder is empty.

**How to test:**

1.  Create a new directory.
2.  Goto Organize->Uploads->Delete Uploaded File.
3.  Browse to newly created directory.
4.  A message _"No removable content found"_ should appear instead of empty list.
5.  The Delete button should get disabled.

Closes #993 