### PR TITLE
fix(licenseUpdate): update the license parameters with same shortname

### DIFF
--- a/src/www/ui/admin-license-file.php
+++ b/src/www/ui/admin-license-file.php
@@ -352,7 +352,21 @@ class admin_license_file extends FO_Plugin
     $check_count = $this->dbManager->getSingleRow($sql,array($rfId,$shortname,$text),__METHOD__.'.countLicensesByNomos');
     return (0 < $check_count['count']);
   }
-  
+
+
+  /** @brief check if shortname is changed */
+  private function isShortNameExists($rfId, $shortname)
+  {
+    $sql = "SELECT LOWER(rf_shortname) AS rf_shortname FROM license_ref WHERE rf_pk=$1";
+    $row = $this->dbManager->getSingleRow($sql,array($rfId),__METHOD__.'.DoNotChnageShortName');
+    if ($row['rf_shortname'] === strtolower($shortname)) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+
   /**
    * \brief Update the database
    *
@@ -375,9 +389,8 @@ class admin_license_file extends FO_Plugin
       return "<b>$text</b><p>";
     }
 
-    if ($this->isShortnameBlocked($rfId,$shortname,$text))
-    {
-      $text = _("ERROR: The shortname or license text already exist in the license list.  License not added.");
+    if (!$this->isShortNameExists($rfId,$shortname)) {
+      $text = _("ERROR: The shortname can not be changed. License not added.");
       return "<b>$text</b><p>";
     }
     

--- a/src/www/ui/template/admin_license-upload_form.html.twig
+++ b/src/www/ui/template/admin_license-upload_form.html.twig
@@ -29,7 +29,11 @@
     </tr>
     <tr>
       <td align="right">{{ "Short name"|trans }}</td>
-      <td><input type="text" name="rf_shortname" value="{{ rf_shortname|e }}" size="30"> ({{ 'must be unique'|trans }})</td>
+      {% if rfId %}
+        <td><input type="text" name="rf_shortname" value="{{ rf_shortname|e }}" size="30" readonly> ({{ 'must be unique'|trans }})</td>
+      {% else %}
+        <td><input type="text" name="rf_shortname" value="{{ rf_shortname|e }}" size="30"> ({{ 'must be unique'|trans }})</td>
+      {% endif %}
     </tr>
     <tr>
       <td align="right">{{ "Full name"|trans }}</td>


### PR DESCRIPTION
Steps to test.

User unable to update the license fields from License Administration.
Eg : Updating Risk, is giving error.

This PR fixes the above issue, and user should be able to update the require fields except the license shortname(unique). 