### PR TITLE
fix(monkbulk): check the job status when scheduling multiple monkbulks

### DIFF
--- a/src/decider/agent_tests/Functional/SchedulerTestRunnerMock.php
+++ b/src/decider/agent_tests/Functional/SchedulerTestRunnerMock.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Copyright (C) 2014, Siemens AG
+Copyright (C) 2014-2018, Siemens AG
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -26,6 +26,7 @@ use Fossology\Lib\Dao\AgentDao;
 use Fossology\Lib\Dao\ClearingDao;
 use Fossology\Lib\Dao\UploadDao;
 use Fossology\Lib\Dao\HighlightDao;
+use Fossology\Lib\Dao\ShowJobsDao;
 use Fossology\Lib\Data\DecisionTypes;
 use Fossology\Lib\Db\DbManager;
 use Mockery as M;
@@ -53,14 +54,16 @@ class SchedulerTestRunnerMock implements SchedulerTestRunner
   private $decisionTypes;
   /** @var HighlightDao */
   private $highlightDao;
+  /** @var ShowJobsDao */
+  private $showJobsDao;
 
-  public function __construct(DbManager $dbManager, AgentDao $agentDao, ClearingDao $clearingDao, UploadDao $uploadDao, HighlightDao $highlightDao,
-    ClearingDecisionProcessor $clearingDecisionProcessor, AgentLicenseEventProcessor $agentLicenseEventProcessor)
+  public function __construct(DbManager $dbManager, AgentDao $agentDao, ClearingDao $clearingDao, UploadDao $uploadDao, HighlightDao $highlightDao, ShowJobsDao $showJobsDao, ClearingDecisionProcessor $clearingDecisionProcessor, AgentLicenseEventProcessor $agentLicenseEventProcessor)
   {
     $this->clearingDao = $clearingDao;
     $this->agentDao = $agentDao;
     $this->uploadDao = $uploadDao;
     $this->highlightDao = $highlightDao;
+    $this->showJobsDao = $showJobsDao;
     $this->dbManager = $dbManager;
     $this->decisionTypes = new DecisionTypes();
     $this->clearingDecisionProcessor = $clearingDecisionProcessor;
@@ -89,6 +92,7 @@ class SchedulerTestRunnerMock implements SchedulerTestRunner
     $container->shouldReceive('get')->with('dao.clearing')->andReturn($this->clearingDao);
     $container->shouldReceive('get')->with('dao.upload')->andReturn($this->uploadDao);
     $container->shouldReceive('get')->with('dao.highlight')->andReturn($this->highlightDao);
+    $container->shouldReceive('get')->with('dao.show_jobs')->andReturn($this->showJobsDao);
     $container->shouldReceive('get')->with('decision.types')->andReturn($this->decisionTypes);
     $container->shouldReceive('get')->with('businessrules.clearing_decision_processor')->andReturn($this->clearingDecisionProcessor);
     $container->shouldReceive('get')->with('businessrules.agent_license_event_processor')->andReturn($this->agentLicenseEventProcessor);

--- a/src/decider/agent_tests/Functional/schedulerTest.php
+++ b/src/decider/agent_tests/Functional/schedulerTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Copyright (C) 2014-2015, Siemens AG
+Copyright (C) 2014-2018, Siemens AG
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -28,6 +28,7 @@ use Fossology\Lib\Dao\HighlightDao;
 use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Dao\UploadDao;
 use Fossology\Lib\Dao\UploadPermissionDao;
+use Fossology\Lib\Dao\ShowJobsDao;
 use Fossology\Lib\Data\DecisionScopes;
 use Fossology\Lib\Data\DecisionTypes;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
@@ -63,6 +64,8 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
   private $uploadPermDao;
   /** @var HighlightDao */
   private $highlightDao;
+  /** @var ShowJobsDao */
+  private $showJobsDao;
   /** @var SchedulerTestRunnerCli */
   private $runnerCli;
   /** @var SchedulerTestRunnerMock */
@@ -82,13 +85,14 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
     $this->agentLicenseEventProcessor = new AgentLicenseEventProcessor($this->licenseDao, $agentDao);
     $clearingEventProcessor = new ClearingEventProcessor();
     $this->clearingDao = new ClearingDao($this->dbManager, $this->uploadDao);
+    $this->showJobsDao = new ShowJobsDao($this->dbManager, $this->uploadDao);
     $this->clearingDecisionProcessor = new ClearingDecisionProcessor($this->clearingDao, $this->agentLicenseEventProcessor, $clearingEventProcessor, $this->dbManager);
 
     global $container;
     $container = M::mock('ContainerBuilder');
     $container->shouldReceive('get')->withArgs(array('db.manager'))->andReturn($this->dbManager);
 
-    $this->runnerMock = new SchedulerTestRunnerMock($this->dbManager, $agentDao, $this->clearingDao, $this->uploadDao, $this->highlightDao, $this->clearingDecisionProcessor, $this->agentLicenseEventProcessor);
+    $this->runnerMock = new SchedulerTestRunnerMock($this->dbManager, $agentDao, $this->clearingDao, $this->uploadDao, $this->highlightDao, $this->showJobsDao, $this->clearingDecisionProcessor, $this->agentLicenseEventProcessor);
     $this->runnerCli = new SchedulerTestRunnerCli($this->testDb);
   }
 
@@ -99,6 +103,7 @@ class SchedulerTest extends \PHPUnit_Framework_TestCase
     $this->dbManager = null;
     $this->licenseDao = null;
     $this->highlightDao = null;
+    $this->showJobsDao = null;
     $this->clearingDao = null;
     M::close();
   }

--- a/src/decider/ui/DeciderAgentPlugin.php
+++ b/src/decider/ui/DeciderAgentPlugin.php
@@ -1,6 +1,6 @@
 <?php
 /***********************************************************
- * Copyright (C) 2014-2015, Siemens AG
+ * Copyright (C) 2014-2018, Siemens AG
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -87,7 +87,8 @@ class DeciderAgentPlugin extends AgentPlugin
           $rulebits |= 0x2;
           break;
         case 'reuseBulk':
-          $dependencies[] = 'agent_reuser';
+          $dependencies[] = 'agent_nomos';
+          $dependencies[] = 'agent_monk';
           $rulebits |= 0x4;
           break;
         case 'wipScannerUpdates':

--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -917,4 +917,32 @@ INSERT INTO clearing_decision (
     $this->dbManager->freeResult($res);
     return $irrelevantFiles;
   }
+
+  /**
+   * @param int $uploadId
+   * @param int $groupId
+   * @param int $userId
+   */
+  public function getPreviousBulkIds($uploadId, $groupId, $userId, $onlyCount=0)
+  {
+    $stmt = __METHOD__;
+    $bulkIds = array();
+    $sql = "SELECT jq_args FROM upload_reuse, jobqueue, job
+            WHERE upload_fk=$1 AND group_fk=$2
+             AND EXISTS(SELECT * FROM group_user_member gum WHERE gum.group_fk=upload_reuse.group_fk AND gum.user_fk=$3)
+             AND jq_type=$4 AND jq_job_fk=job_pk
+             AND job_upload_fk=reused_upload_fk AND job_group_fk=reused_group_fk";
+    $this->dbManager->prepare($stmt, $sql);
+    $res = $this->dbManager->execute($stmt,array($uploadId, $groupId, $userId,'monkbulk'));
+    while($row=  $this->dbManager->fetchArray($res))
+    {
+      $bulkIds = array_merge($bulkIds,explode("\n", $row['jq_args']));
+    }
+    $this->dbManager->freeResult($res);
+    if(empty($onlyCount)) {
+      return array_unique($bulkIds);
+    } else {
+      return count(array_unique($bulkIds));
+    }
+  }
 }

--- a/src/www/ui/ajax-showjobs.php
+++ b/src/www/ui/ajax-showjobs.php
@@ -21,6 +21,7 @@
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\ShowJobsDao;
 use Fossology\Lib\Dao\UserDao;
+use Fossology\Lib\Dao\ClearingDao;
 use Fossology\Lib\Db\DbManager;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -39,6 +40,9 @@ class AjaxShowJobs extends FO_Plugin
   /** @var UserDao */
   private $userDao;
 
+  /** @var ClearingDao */
+  private $clearingDao;
+
   /** @var int $maxUploadsPerPage max number of uploads to display on a page */
   private $maxUploadsPerPage = 10;
 
@@ -55,6 +59,7 @@ class AjaxShowJobs extends FO_Plugin
     global $container;
     $this->showJobsDao = $container->get('dao.show_jobs');
     $this->userDao = $container->get('dao.user');
+    $this->clearingDao = $container->get('dao.clearing');
     $this->dbManager = $container->get('db.manager');
 
     parent::__construct();
@@ -359,9 +364,18 @@ class AjaxShowJobs extends FO_Plugin
         }
         if (empty($jobqueueRec['jq_endtime'])) {
           $varJobQueueRow['eta'] = $this->showJobsDao->getEstimatedTime($jobqueueRec['jq_job_fk'], $jobqueueRec['jq_type'], $itemsPerSec, $job['job']['job_upload_fk']);
+          if($jobqueueRec['jq_type'] === 'monkbulk' || $jobqueueRec['jq_type'] === 'deciderjob'){
+            $noOfMonkBulk = $this->showJobsDao->getItemsProcessedForDecider('decider', $jobqueueRec['jq_job_fk']);
+            if(!empty($noOfMonkBulk)){
+              $totalCountOfMb = $this->clearingDao->getPreviousBulkIds($noOfMonkBulk[1], Auth::getGroupId(), Auth::getUserId(), $onlyCount=1);
+            }
+            if(!empty($totalCountOfMb)){
+              $varJobQueueRow['isNoOfMonkBulk'] = $noOfMonkBulk[0]."/".$totalCountOfMb;
+            }
+          }
         }
-        $varJobQueueRow['canDoActions'] = 
-                ($_SESSION[Auth::USER_LEVEL] == PLUGIN_DB_ADMIN) || (Auth::getUserId() == $job['job']['job_user_fk']);
+
+        $varJobQueueRow['canDoActions'] = ($_SESSION[Auth::USER_LEVEL] == PLUGIN_DB_ADMIN) || (Auth::getUserId() == $job['job']['job_user_fk']);
         $varJobQueueRow['isInProgress'] = ($jobqueueRec['jq_end_bits'] == 0);
         $varJobQueueRow['isReady'] = ($jobqueueRec['jq_end_bits'] == 1);
         

--- a/src/www/ui/template/ui-showjobs-jobqueue-row.html.twig
+++ b/src/www/ui/template/ui-showjobs-jobqueue-row.html.twig
@@ -49,5 +49,8 @@
     {% elseif download and isReady %}
       [<a href="?mod=download&report={{ jobId }}">Download {{ download }}</a>]
     {% endif %}
+    {% if isNoOfMonkBulk is defined %}
+    [{{ 'Count : '|trans }}<a href="#" title="isNoOfMonkBulk">{{ isNoOfMonkBulk }}</a>]
+    {% endif %}
   </td>
 </tr>


### PR DESCRIPTION
To reproduce:

**Install "Master" :** 
   - Upload a package (with at least 3 licenses as scanner findings in each file) and Goto single file view.
         **Note: I have used fckeditor** 
   - Using bulk recognition add license1 and remove license2 and license3.
   - Using bulk recognition add license2 and remove license1 and license3.
   - Using bulk recognition add license3 and remove license1 and license2.
   - Now upload some other version of the package you have uploaded previously.  
   - And reuse the bulk decisions. Check the decisions are improper, Because of timestamp.

**Install "contrib/fixBulkOrderingByETA" :**
   - Now upload the same package with improper decisions.
   - Reuse it with the first package. Now the results should be proper.