### PR TITLE
feat(serverUpload): Check for wildchar during upload

### DIFF
--- a/src/www/ui/page/UploadSrvPage.php
+++ b/src/www/ui/page/UploadSrvPage.php
@@ -1,7 +1,7 @@
 <?php
 /***********************************************************
  Copyright (C) 2008-2014 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2015 Siemens AG
+ Copyright (C) 2018 Siemens AG
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -190,12 +190,19 @@ class UploadSrvPage extends UploadPageBase
     }
 
     $name = $request->get(self::NAME_PARAM);
-    if (empty($name)) 
+
+    if((preg_match('/[*?%$]+/', $sourceFiles)) && empty($name))
+    {
+      $text = _("The file path contains a wildchar, you must provide a name for the upload.");
+      return array(false, $text, $description);
+    }
+
+    if (empty($name))
     {
       $name = basename($sourceFiles);
     }
-    $shortName = basename($name);
-    if (empty($shortName)) 
+    $shortName = $this->basicShEscaping(basename($name));
+    if (empty($shortName))
     {
       $shortName = $name;
     }
@@ -292,4 +299,3 @@ class UploadSrvPage extends UploadPageBase
   }
 }
 register_plugin(new UploadSrvPage());
-

--- a/src/www/ui/template/upload_srv.html.twig
+++ b/src/www/ui/template/upload_srv.html.twig
@@ -1,4 +1,4 @@
-{# Copyright 2014-2015 Siemens AG
+{# Copyright 2014-2018 Siemens AG
 
    Copying and distribution of this file, with or without modification,
    are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
@@ -24,7 +24,7 @@
 </li>
 <li>
   <label for="{{ nameField }}">
-    {{ '(Optional) Enter a viewable name for this file or directory'| trans }}:
+    ({{ 'Optional'|trans }}) {{ 'Enter a viewable name for this file or directory'| trans }}:
   </label>
   <br/>
   <input name="{{ nameField }}" type="text" size="120"/><br/>
@@ -40,4 +40,9 @@
   </select>
 </li>
 {% endif %}
+{% endblock %}
+{% block foot %}
+  {{ parent() }}
+  <script type="text/javascript"> {% include "upload_srv.js.twig" %} </script>
+  {{ injectedFoot }}
 {% endblock %}

--- a/src/www/ui/template/upload_srv.js.twig
+++ b/src/www/ui/template/upload_srv.js.twig
@@ -1,0 +1,70 @@
+{#
+Copyright (C) 2018 Siemens AG
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#}
+
+function checkWildCard() {
+  var sourceField = $('input[name={{ sourceFilesField }}]').val();
+  if(sourceField.match(/[*?%$]+/)) {
+    var note = $('label[for={{ nameField }}]');
+    var newNote = note.html().replace("({{ 'Optional'|trans }}) ","");
+    note.html(newNote);
+    $('input[name={{ nameField }}]')
+      .prop('required',true)
+      .prop('title',"{{ 'Since the file path contains a wildchar, it is necessary to provide a name'|trans }}")
+      .tooltip({
+        position: {
+          my: "left top",
+          at: "right+5 top-5",
+          collision: "none",
+          using: function( position, feedback ) {
+            $( this ).css( position );
+            $( this ).addClass( "ui-state-error" );
+            $( this ).children().addClass( "ui-state-error-text" );
+          }
+        }
+      });
+    return true;
+  }
+  else {
+    var note = $('label[for={{ nameField }}]');
+    if ( note.html().indexOf("({{ 'Optional'|trans }}) ") === -1) {
+      var newNote = "({{ 'Optional'|trans }}) " + note.html();
+      note.html(newNote);
+    }
+    $('input[name={{ nameField }}]')
+      .prop('required',false)
+      .prop('title',"")
+      .tooltip({});
+    return false;
+  }
+}
+
+$('input[name={{ sourceFilesField }}]').on('input propertychange paste', function() {
+  checkWildCard();
+});
+
+$("form").submit(function( event ) {
+  if( checkWildCard() ) {
+    var nameField = $( "input[name={{ nameField }}]" );
+    if( nameField.val() !== "" ) {
+      return;
+    } else {
+      event.preventDefault();
+      nameField.tooltip("open");
+      nameField.focus();
+    }
+  }
+});


### PR DESCRIPTION
>  Enhancement over #1048

### Features
1.  Check if the upload path contains a wild-char and warn the user right-away.
2.  Check for the wild-char at server-side as well.
3.  Prevent unlikely names in uploads and escape special characters.

### How to test
1.  Goto Upload -> From Server
2.  Enter an file path with the wildchar.
3.  Do not fill the name field for the upload.
4.  The optional name field should become required and user should not be able submit the form.
5.  Repeat the steps above with JavaScript disabled in the browser.
6.  The form can now be submitted but the user must see the server side error if the name is not provided for the upload.