### PR TITLE
docs(README): Show only master build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FOSSology
 
-[![Travis-CI Build Status](https://travis-ci.org/fossology/fossology.png)](https://travis-ci.org/fossology/fossology/)
+[![Travis-CI Build Status](https://travis-ci.org/fossology/fossology.svg?branch=master)](https://travis-ci.org/fossology/fossology)
 [![Stories in Ready](https://badge.waffle.io/fossology/fossology.svg?label=ready&title=Ready)](http://waffle.io/fossology/fossology)
 [![Coverage Status](https://coveralls.io/repos/github/fossology/fossology/badge.svg?branch=master)](https://coveralls.io/github/fossology/fossology?branch=master)
 


### PR DESCRIPTION
Changed the Travis build status image to show build status of **master** branch only avoiding status of pull requests in README.md.