### PR TITLE
feat(copyright): New JSON hpp version

### DIFF
--- a/install/scripts/install-json-hpp.sh
+++ b/install/scripts/install-json-hpp.sh
@@ -2,11 +2,11 @@
 
 cd "$(dirname "$0")/../.."
 FINAL_FILE=./src/copyright/agent/json.hpp
-SHASUM=faa2321beb1aa7416d035e7417fcfa59692ac3d8c202728f9bcc302e2d558f57
+SHASUM=fbdfec4b4cf63b3b565d09f87e6c3c183bdd45c5be1864d3fcb338f6f02c1733
 TMP=$(mktemp)
 CHECKSUMFILE=$(mktemp)
 
-curl -s -o "$TMP" -L https://github.com/nlohmann/json/releases/download/v2.1.1/json.hpp
+curl -s -o "$TMP" -L https://github.com/nlohmann/json/releases/download/v3.1.2/json.hpp
 echo "$SHASUM $TMP" > "$CHECKSUMFILE"
 sha256sum --quiet -c "$CHECKSUMFILE"
 SUCCESS=$?


### PR DESCRIPTION
Referring to suggestion in #1002.

1.  Updated the version of nlohmann/json from 2.1.1 to 3.1.2 because of several fixes in the library.