### PR TITLE
fix(delagent): Extra drop statements in test

### DIFF
--- a/src/delagent/agent/util.c
+++ b/src/delagent/agent/util.c
@@ -483,14 +483,11 @@ int deleteUpload (long UploadId, int user_id, int user_perm)
 
   if (Test)
   {
-    PQexecCheckClear(NULL, "ROLLBACK", __FILE__, __LINE__);
-
-    snprintf(SQL,MAXSQL,"DROP TABLE %s;",TempTable);
-    PQexecCheckClear(NULL, SQL, __FILE__, __LINE__);
+    PQexecCheckClear(NULL, "ROLLBACK;", __FILE__, __LINE__);
   }
   else
   {
-    PQexecCheckClear(NULL, "COMMIT", __FILE__, __LINE__);
+    PQexecCheckClear(NULL, "COMMIT;", __FILE__, __LINE__);
   }
 
   printfInCaseOfVerbosity("Deleted upload %ld\n",UploadId);


### PR DESCRIPTION
Removed extra drop statements as the temp table is already dropped 4 statements before.

Closes #368

! Merge after #1097