### PR TITLE
feat(wget_agent): Mask password in log

### DIFF
--- a/src/wget_agent/agent/wget_agent.h
+++ b/src/wget_agent/agent/wget_agent.h
@@ -121,5 +121,9 @@ void GetProxy();
 
 void replace_url_with_auth();
 
+void MaskPassword();
+
+char* GetVersionControlCommand(int withPassword);
+
 #endif /* _WGET_AGENT_H */
 


### PR DESCRIPTION
If the agent fail, generate new parameters with masked password before adding to log.

## Changes
1.  New function to mask password in parameters.
2.  Generate command in new function `GetVersionControlCommand()`.

## How to test
1.  Upload a package from version control.
    1.  With wrong URL/password.
    2.  With wrong URL (no username and password).
2.  Check the log of failed agent.
3.  Log should not contain password.

Closes #540