### PR TITLE
fix(email): Prevent scheduler crashes

### DIFF
--- a/src/scheduler/agent/database.c
+++ b/src/scheduler/agent/database.c
@@ -126,7 +126,7 @@ static gboolean email_replace(const GMatchInfo* match, GString* ret,
       g_string_append(ret, PQgetvalue(db_result, 0, 0));
     }
 
-    PQclear(db_result);
+    SafePQclear(db_result);
     g_free(sql);
   }
 
@@ -161,7 +161,7 @@ static gboolean email_replace(const GMatchInfo* match, GString* ret,
           fossy_url, PQgetvalue(db_result, 0, 0), PQgetvalue(db_result, 0, 1));
     }
 
-    PQclear(db_result);
+    SafePQclear(db_result);
     g_free(sql);
   }
 
@@ -185,7 +185,7 @@ static gboolean email_replace(const GMatchInfo* match, GString* ret,
           fossy_url, PQgetvalue(db_result, 0, 0));
     }
 
-    PQclear(db_result);
+    SafePQclear(db_result);
     g_free(sql);
   }
 
@@ -219,7 +219,7 @@ static gboolean email_replace(const GMatchInfo* match, GString* ret,
       GString *foldername = g_string_new(PQgetvalue(db_result, 0, 0));
       guint folder_pk = atoi(PQget(db_result, 0, "folder_pk"));
       g_ptr_array_add(rows, foldername);
-      PQclear(db_result);
+      SafePQclear(db_result);
       g_free(sql);
       sql = g_strdup_printf(parent_folder_name, folder_pk);
       db_result = database_exec(args->scheduler, sql);
@@ -228,7 +228,7 @@ static gboolean email_replace(const GMatchInfo* match, GString* ret,
         GString *foldername = g_string_new(PQgetvalue(db_result, 0, 0));
         guint folder_pk = atoi(PQget(db_result, 0, "folder_pk"));
         g_ptr_array_add(rows, foldername);
-        PQclear(db_result);
+        SafePQclear(db_result);
         g_free(sql);
         sql = g_strdup_printf(parent_folder_name, folder_pk);
         db_result = database_exec(args->scheduler, sql);
@@ -244,7 +244,7 @@ static gboolean email_replace(const GMatchInfo* match, GString* ret,
       g_ptr_array_free(rows, TRUE);
     }
 
-    PQclear(db_result);
+    SafePQclear(db_result);
     g_free(sql);
   }
 
@@ -301,7 +301,7 @@ static gboolean email_replace(const GMatchInfo* match, GString* ret,
       g_string_append(ret, email_format_text(rows, fossy_url));
       g_ptr_array_free(rows, TRUE);
     }
-    PQclear(db_result);
+    SafePQclear(db_result);
     g_free(sql);
   }
 
@@ -334,7 +334,7 @@ static gboolean email_replace(const GMatchInfo* match, GString* ret,
       g_string_append(ret, "]");
     }
 
-    PQclear(db_result);
+    SafePQclear(db_result);
     g_free(sql);
     g_free(table);
     g_free(column);*/
@@ -365,7 +365,7 @@ static gint email_checkjobstatus(scheduler_t* scheduler, job_t* job)
   {
     PQ_ERROR(db_result, "unable to check job status for jq_pk %d", job->id);
     g_free(sql);
-    PQclear(db_result);
+    SafePQclear(db_result);
     return 0;
   }
 
@@ -376,7 +376,7 @@ static gint email_checkjobstatus(scheduler_t* scheduler, job_t* job)
   }
 
   g_free(sql);
-  PQclear(db_result);
+  SafePQclear(db_result);
 
   sql = g_strdup_printf(jobsql_jobendbits, job->id);
   db_result = database_exec(scheduler, sql);
@@ -403,7 +403,7 @@ static gint email_checkjobstatus(scheduler_t* scheduler, job_t* job)
   }
 
   g_free(sql);
-  PQclear(db_result);
+  SafePQclear(db_result);
   return ret;
 }
 
@@ -418,19 +418,15 @@ static gint email_checkjobstatus(scheduler_t* scheduler, job_t* job)
 static void email_notification(scheduler_t* scheduler, job_t* job)
 {
   PGresult* db_result;
-  PGresult* db_result_smtp;
   int j_id = job->id;
   int upload_id;
   int status;
-  int i;
+  int retcode;
   char* val;
-  char* final_cmd;
-  char* temp_smtpvariable = NULL;
+  char* final_cmd = NULL;
   char sql[1024];
-  GHashTable* smtpvariables;
   FILE* mail_io;
   GString* email_txt;
-  GString* client_cmd;
   job_status curr_status = job->status;
   email_replace_args args;
 
@@ -447,7 +443,7 @@ static void email_notification(scheduler_t* scheduler, job_t* job)
   }
 
   upload_id = atoi(PQgetvalue(db_result, 0, 0));
-  PQclear(db_result);
+  SafePQclear(db_result);
 
   sprintf(sql, upload_common, upload_id);
   db_result = database_exec(scheduler, sql);
@@ -456,6 +452,7 @@ static void email_notification(scheduler_t* scheduler, job_t* job)
     PQ_ERROR(db_result, "unable to check common uploads to job %d", j_id);
     return;
   }
+  SafePQclear(db_result);
 
   sprintf(sql, jobsql_email, upload_id);
   db_result = database_exec(scheduler, sql);
@@ -468,6 +465,7 @@ static void email_notification(scheduler_t* scheduler, job_t* job)
   /* special for delagent, upload records have been deleted, so can't get the user info from upload table, so get the user info from job table */
   if(PQntuples(db_result) == 0)
   {
+    SafePQclear(db_result);
     sprintf(sql, jobsql_email_job, j_id);
     db_result = database_exec(scheduler, sql);
     if(PQresultStatus(db_result) != PGRES_TUPLES_OK || PQntuples(db_result) == 0)
@@ -494,113 +492,43 @@ static void email_notification(scheduler_t* scheduler, job_t* job)
       args.job        = job;
       args.scheduler  = scheduler;
       val = g_regex_replace_eval(scheduler->parse_db_email, email_txt->str,
-          email_txt->len, 0, 0, (GRegexEvalCallback)email_replace, &args, NULL);
+            email_txt->len, 0, 0, (GRegexEvalCallback)email_replace, &args, NULL);
     }
     else
     {
       val = email_txt->str;
     }
 
-    sprintf(sql, "%s", smtp_values);
-    db_result_smtp = database_exec(scheduler, sql);
-    if(PQresultStatus(db_result_smtp) != PGRES_TUPLES_OK || PQntuples(db_result_smtp) == 0)
+    final_cmd = get_email_command(scheduler, PQget(db_result, 0, "user_email"));
+    if(final_cmd == NULL)
     {
-      PQ_ERROR(db_result_smtp, "unable to get conf variables for SMTP from sysconfig");
       if(scheduler->parse_db_email != NULL)
         g_free(val);
       g_string_free(email_txt, TRUE);
       return;
     }
-    client_cmd = g_string_new("");
-    smtpvariables = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
-    for(i = 0; i < PQntuples(db_result_smtp); i++)
-    {
-      if(PQget(db_result_smtp, i, "conf_value")[0])  //Not empty
-      {
-        g_hash_table_insert(smtpvariables, g_strdup(PQget(db_result_smtp, i, "variablename")),
-                            g_strdup(PQget(db_result_smtp, i, "conf_value")));
-      }
-    }
-    PQclear(db_result_smtp);
-    if(g_hash_table_contains(smtpvariables, "SMTPHostName") && g_hash_table_contains(smtpvariables, "SMTPPort"))
-    {
-      g_string_append_printf(client_cmd, " -S smtp='%s:%s'", (char *)g_hash_table_lookup(smtpvariables, "SMTPHostName"),
-          (char *)g_hash_table_lookup(smtpvariables, "SMTPPort"));
-    }
-    if(g_hash_table_contains(smtpvariables, "SMTPStartTls"))
-    {
-      temp_smtpvariable = (char *)g_hash_table_lookup(smtpvariables, "SMTPStartTls");
-      if(g_strcmp0(temp_smtpvariable, "1") == 0)
-      {
-        g_string_append_printf(client_cmd, " -S smtp-use-starttls");
-      }
-    }
-    if(g_hash_table_contains(smtpvariables, "SMTPAuth"))
-    {
-      temp_smtpvariable = (char *)g_hash_table_lookup(smtpvariables, "SMTPAuth");
-      if(g_strcmp0(temp_smtpvariable, "L") == 0)
-      {
-        g_string_append_printf(client_cmd, " -S smtp-auth=login");
-      }
-      else if(g_strcmp0(temp_smtpvariable, "P") == 0)
-      {
-        g_string_append_printf(client_cmd, " -S smtp-auth=plain");
-      }
-    }
-    if(g_hash_table_contains(smtpvariables, "SMTPAuthUser"))
-    {
-      g_string_append_printf(client_cmd, " -S smtp-auth-user='%s' -S from='%s'",
-          (char *)g_hash_table_lookup(smtpvariables, "SMTPAuthUser"),
-          (char *)g_hash_table_lookup(smtpvariables, "SMTPAuthUser"));
-    }
-    if(g_hash_table_contains(smtpvariables, "SMTPAuthPasswd"))
-    {
-      g_string_append_printf(client_cmd, " -S smtp-auth-password='%s'",
-         (char *)g_hash_table_lookup(smtpvariables, "SMTPAuthPasswd"));
-    }
-    if(g_hash_table_contains(smtpvariables, "SMTPSslVerify"))
-    {
-      temp_smtpvariable = (char *)g_hash_table_lookup(smtpvariables, "SMTPSslVerify");
-      g_string_append(client_cmd, " -S ssl-verify=");
-      if(g_strcmp0(temp_smtpvariable, "I") == 0)
-      {
-        g_string_append(client_cmd, "ignore");
-      }
-      else if(g_strcmp0(temp_smtpvariable, "S") == 0)
-      {
-        g_string_append(client_cmd, "strict");
-      }
-      else if(g_strcmp0(temp_smtpvariable, "W") == 0)
-      {
-        g_string_append(client_cmd, "warn");
-      }
-    }
-    g_hash_table_destroy(smtpvariables);
-
-    final_cmd = g_strdup_printf(EMAIL_BUILD_CMD, scheduler->email_command,
-                client_cmd->str, scheduler->email_subject, PQget(db_result, 0, "user_email"));
-
     if((mail_io = popen(final_cmd, "w")) != NULL)
     {
       fprintf(mail_io, "%s", val);
-      pclose(mail_io);
+      fflush(mail_io);
+      retcode = WEXITSTATUS(pclose(mail_io));
+      if(retcode != 0)
+      {
+        ERROR("Received error code %d from '%s'", retcode, scheduler->email_command);
+      }
     }
     else
     {
       WARNING("Unable to spawn email notification process: '%s'.\n",
-          scheduler->email_command);
+              scheduler->email_command);
     }
-
     job->status = curr_status;
     if(scheduler->parse_db_email != NULL)
       g_free(val);
     g_free(final_cmd);
     g_string_free(email_txt, TRUE);
-    g_string_free(client_cmd, TRUE);
-    g_free(temp_smtpvariable);
   }
-
-  PQclear(db_result);
+  SafePQclear(db_result);
 }
 
 /**
@@ -783,7 +711,7 @@ static void check_tables(scheduler_t* scheduler)
       }
     }
 
-    PQclear(db_result);
+    SafePQclear(db_result);
     g_string_free(sql, TRUE);
   }
 
@@ -833,7 +761,7 @@ void database_init(scheduler_t* scheduler)
   db_result = database_exec(scheduler, url_checkout);
   if(PQresultStatus(db_result) == PGRES_TUPLES_OK && PQntuples(db_result) != 0)
     scheduler->host_url = g_strdup(PQgetvalue(db_result, 0, 0));
-  PQclear(db_result);
+  SafePQclear(db_result);
 
   /* check that relevant database fields exist */
   check_tables(scheduler);
@@ -960,7 +888,7 @@ void database_update_event(scheduler_t* scheduler, void* unused)
     if(PQntuples(pri_result)==0)
     {
       WARNING("can not find the user information of job_pk %s\n", parent);
-      PQclear(pri_result);
+      SafePQclear(pri_result);
       continue;
     }
     job = job_init(scheduler->job_list, scheduler->job_queue, type, host, j_id,
@@ -970,10 +898,10 @@ void database_update_event(scheduler_t* scheduler, void* unused)
         atoi(PQget(pri_result, 0, "job_priority")), jq_cmd_args);
     job_set_data(scheduler, job,  value, (pfile && pfile[0] != '\0'));
 
-    PQclear(pri_result);
+    SafePQclear(pri_result);
   }
 
-  PQclear(db_result);
+  SafePQclear(db_result);
 }
 
 /**
@@ -1081,4 +1009,103 @@ void database_job_priority(scheduler_t* scheduler, job_t* job, int priority)
     PQ_ERROR(db_result, "failed to change job queue entry priority");
 
   g_free(sql);
+}
+
+/**
+ * \brief Build command to run to send email
+ * \param scheduler  Current scheduler object
+ * \param user_email Email id to send mail to
+ * \return The command to run
+ */
+char* get_email_command(scheduler_t* scheduler, char* user_email)
+{
+  PGresult* db_result_smtp;
+  int i;
+  GString* client_cmd;
+  GHashTable* smtpvariables;
+  char* temp_smtpvariable;
+  char* final_command;
+
+  db_result_smtp = database_exec(scheduler, smtp_values);
+  if(PQresultStatus(db_result_smtp) != PGRES_TUPLES_OK || PQntuples(db_result_smtp) == 0)
+  {
+    PQ_ERROR(db_result_smtp, "unable to get conf variables for SMTP from sysconfig");
+    return NULL;
+  }
+  client_cmd = g_string_new("");
+  smtpvariables = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+  for(i = 0; i < PQntuples(db_result_smtp); i++)
+  {
+    if(PQget(db_result_smtp, i, "conf_value")[0])  //Not empty
+    {
+      g_hash_table_insert(smtpvariables, g_strdup(PQget(db_result_smtp, i, "variablename")),
+                          g_strdup(PQget(db_result_smtp, i, "conf_value")));
+    }
+  }
+  SafePQclear(db_result_smtp);
+  if(g_hash_table_contains(smtpvariables, "SMTPHostName") && g_hash_table_contains(smtpvariables, "SMTPPort"))
+  {
+    g_string_append_printf(client_cmd, " -S smtp=\"%s:%s\"", (char *)g_hash_table_lookup(smtpvariables, "SMTPHostName"),
+        (char *)g_hash_table_lookup(smtpvariables, "SMTPPort"));
+    if(g_hash_table_contains(smtpvariables, "SMTPStartTls"))
+    {
+      temp_smtpvariable = (char *)g_hash_table_lookup(smtpvariables, "SMTPStartTls");
+      if(g_strcmp0(temp_smtpvariable, "1") == 0)
+      {
+        g_string_append_printf(client_cmd, " -S smtp-use-starttls");
+      }
+    }
+    if(g_hash_table_contains(smtpvariables, "SMTPAuth"))
+    {
+      temp_smtpvariable = (char *)g_hash_table_lookup(smtpvariables, "SMTPAuth");
+      if(g_strcmp0(temp_smtpvariable, "L") == 0)
+      {
+        g_string_append_printf(client_cmd, " -S smtp-auth=login");
+      }
+      else if(g_strcmp0(temp_smtpvariable, "P") == 0)
+      {
+        g_string_append_printf(client_cmd, " -S smtp-auth=plain");
+      }
+    }
+    if(g_hash_table_contains(smtpvariables, "SMTPAuthUser"))
+    {
+      g_string_append_printf(client_cmd, " -S smtp-auth-user=\"%s\" -S from=\"%s\"",
+          (char *)g_hash_table_lookup(smtpvariables, "SMTPAuthUser"),
+          (char *)g_hash_table_lookup(smtpvariables, "SMTPAuthUser"));
+    }
+    if(g_hash_table_contains(smtpvariables, "SMTPAuthPasswd"))
+    {
+      g_string_append_printf(client_cmd, " -S smtp-auth-password=\"%s\"",
+         (char *)g_hash_table_lookup(smtpvariables, "SMTPAuthPasswd"));
+    }
+    if(g_hash_table_contains(smtpvariables, "SMTPSslVerify"))
+    {
+      temp_smtpvariable = (char *)g_hash_table_lookup(smtpvariables, "SMTPSslVerify");
+      g_string_append(client_cmd, " -S ssl-verify=");
+      if(g_strcmp0(temp_smtpvariable, "I") == 0)
+      {
+        g_string_append(client_cmd, "ignore");
+      }
+      else if(g_strcmp0(temp_smtpvariable, "S") == 0)
+      {
+        g_string_append(client_cmd, "strict");
+      }
+      else if(g_strcmp0(temp_smtpvariable, "W") == 0)
+      {
+        g_string_append(client_cmd, "warn");
+      }
+    }
+    temp_smtpvariable = NULL;
+    final_command = g_strdup_printf(EMAIL_BUILD_CMD, scheduler->email_command,
+                  client_cmd->str, scheduler->email_subject, user_email);
+  }
+  else
+  {
+    NOTIFY("Unable to send email. SMTP host or port not found in the configuration.\n"
+        "Please check Configuration Variables.");
+    final_command = NULL;
+  }
+  g_hash_table_destroy(smtpvariables);
+  g_string_free(client_cmd, TRUE);
+  return final_command;
 }

--- a/src/scheduler/agent/database.h
+++ b/src/scheduler/agent/database.h
@@ -51,5 +51,6 @@ void database_update_job(scheduler_t* db_conn, job_t* j, job_status status);
 void database_job_processed(int j_id, int number);
 void database_job_log(int j_id, char* log_name);
 void database_job_priority(scheduler_t* scheduler, job_t* job, int priority);
+char* get_email_command(scheduler_t* scheduler, char* user_email);
 
 #endif /* DATABASE_H_INCLUDE */

--- a/src/scheduler/agent/job.c
+++ b/src/scheduler/agent/job.c
@@ -203,7 +203,7 @@ void job_destroy(job_t* job)
 
   if(job->db_result != NULL)
   {
-    PQclear(job->db_result);
+    SafePQclear(job->db_result);
 
 #if GLIB_MAJOR_VERSION >= 2 && GLIB_MINOR_VERSION >= 32
     g_mutex_clear(job->lock);
@@ -574,7 +574,7 @@ int job_is_open(scheduler_t* scheduler, job_t* job)
   }
   else
   {
-    PQclear(job->db_result);
+    SafePQclear(job->db_result);
     job->db_result = database_exec(scheduler, job->data);
     job->idx = 0;
 

--- a/src/scheduler/agent/logging.h
+++ b/src/scheduler/agent/logging.h
@@ -91,7 +91,7 @@ extern log_t* main_log;
             lprintf(main_log, __VA_ARGS__); \
             lprintf(main_log, "\n"); \
             lprintf(main_log, "ERROR postgresql error: %s\n", PQresultErrorMessage(pg_r)); } \
-            PQclear(pg_r)
+            SafePQclear(pg_r)
 
 /** Macros that is called when a notification is generated */
 #define TEST_NOTIFY verbose > 0

--- a/src/scheduler/agent/scheduler.h
+++ b/src/scheduler/agent/scheduler.h
@@ -41,6 +41,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define AGENT_BINARY "%s/%s/%s/agent/%s"
 #define AGENT_CONF "mods-enabled"
 
+/**
+ * Check if PGresult is not NULL. Then call PQclear and set result as NULL
+ * to prevent multiple calls.
+ */
+#define SafePQclear(pgres)  if (pgres) {PQclear(pgres); pgres = NULL;}
+
 /* ************************************************************************** */
 /* *** Scheduler structure ************************************************** */
 /* ************************************************************************** */


### PR DESCRIPTION
## Fixes
1. Check if SMTP variable is set, then only send email otherwise print a notice in log.
2. Separate function to get command (readability, traceability).
3. Check email client's return code.
4. Safe clear for PQresult (SafePQclear) which checks
    1. Result is not NULL
    2. Clean it
    3. Set result to NULL to prevent double-clear