### PR TITLE
fix(copyright): match copyright statements in full

### DIFF
--- a/src/copyright/agent/copyright.conf
+++ b/src/copyright/agent/copyright.conf
@@ -27,7 +27,7 @@ author=(?:__author__)[:]?
 author=__author____SPACESALL____NAMESLIST__\.?
 #
 COPYSYM=(?:\(c\)|&copy;|\xA9|\xC2\xA9|\$\xB8|\xE2\x92\xB8|\$\xD2|\xE2\x93\x92|\$\x9E|\xE2\x92\x9E)
-REG_COPYRIGHT=\bcopyright(?:ed|s)?[[:space:]:]|__COPYSYM__[ \t]+([[:alnum:] ][^\0]{0,2}){5,}
+REG_COPYRIGHT=copyright(?:ed|s)?[[:space:]:]*|__COPYSYM__[ \t]+([[:alnum:] ][^\0]{0,2}){5,}
 REG_EXCEPTION=\bcopyrights?(?:[ \t/\\\*\+#"\.-]+)(?:licen[cs]es?|notices?|holders?|and|statements?|owners?)[ \t\.,][^\0]*
 REG_NON_BLANK=.*(?:[[:alpha:]][[:alpha:]]|[[:digit:]][[:digit:]]).*
 REG_SIMPLE_COPYRIGHT=\bcopyright\b|__COPYSYM__


### PR DESCRIPTION
## Description

Also Weird copyright statements should be matched in full

### Changes

Changed regex in copyright.conf

## How to test

If a copyright statement is there like

Copyright(c) 2018 Michael C. Jaeger

then it is matched by FOSSology like

(c) 2018 Michael C. Jaeger

because a space is missing before the bracket. users apparently find this confusing. it should be the copyright statement in full.



closes #1133 