### PR TITLE
fix(pkgagent): Added support for RPM >= 4.14

### DIFF
--- a/src/pkgagent/agent/Makefile
+++ b/src/pkgagent/agent/Makefile
@@ -26,8 +26,6 @@ LDFLAGS_LOCAL = $(FO_LDFLAGS) -lpq -lrpm -lrpmio
 
 EXE = pkgagent
 HDRS = pkgagent.h
-CFLAGS_LOCAL_RPM_4_4 = $(CFLAGS_LOCAL) -D_RPM_4_4
-CFLAGS_LOCAL_RPM = $(CFLAGS_LOCAL) -D_RPM_4_4_COMPAT
 
 all: $(EXE)
 
@@ -35,26 +33,10 @@ $(EXE): main.c $(FOLIB) pkgagent.o $(VARS) $(HDRS)
 	$(CC) main.c pkgagent.o $(LDFLAGS_LOCAL) $(CFLAGS_LOCAL) $(DEFS) -o $@
 
 pkgagent.o: pkgagent.c pkgagent.h
-	if expr `rpm --version|awk '{print $$3}'|awk -F. '{print $$1"."$$2}'` \>= 4.5 >/dev/null; then \
-		$(CC) -c $< $(CFLAGS_LOCAL_RPM); \
-	else \
-		if expr `rpm --version|awk '{print $$3}'|awk -F. '{print $$1"."$$2}'` \>= 4.10 >/dev/null; then \
-			$(CC) -c $< $(CFLAGS_LOCAL_RPM); \
-		else \
-			$(CC) -c $< $(CFLAGS_LOCAL_RPM_4_4); \
-		fi \
-	fi
+	$(CC) -c $< $(CFLAGS_LOCAL)
 
 pkgagent_cov.o: pkgagent.c pkgagent.h
-	if expr `rpm --version|awk '{print $$3}'|awk -F. '{print $$1"."$$2}'` \>= 4.5 >/dev/null; then \
-		$(CC) -c $< $(FLAG_COV) $(CFLAGS_LOCAL_RPM) -o $@; \
-	else \
-		if expr `rpm --version|awk '{print $$3}'|awk -F. '{print $$1"."$$2}'` \>= 4.10 >/dev/null; then \
-			$(CC) -c $< $(FLAG_COV) $(CFLAGS_LOCAL_RPM) -o $@; \
-		else \
-			$(CC) -c $< $(FLAG_COV) $(CFLAGS_LOCAL_RPM_4_4) -o $@; \
-		fi \
-	fi
+	$(CC) -c $< $(FLAG_COV) $(CFLAGS_LOCAL) -o $@
 
 install: all
 	$(INSTALL_PROGRAM) $(EXE) $(DESTDIR)$(MODDIR)/$(EXE)/agent/$(EXE)

--- a/src/pkgagent/agent/main.c
+++ b/src/pkgagent/agent/main.c
@@ -190,12 +190,10 @@ int	main	(int argc, char *argv[])
         printf("OK\n");
       else
         printf("Fail\n");
-#ifdef _RPM_4_4_COMPAT
       rpmFreeCrypto();
       int i;
       for(i=0; i< rpmpi->req_size;i++)
         free(rpmpi->requires[i]);
-#endif /* After RPM4.4 version*/
       free(rpmpi->requires);
       free(rpmpi);
       rpmFreeMacros(NULL);

--- a/src/pkgagent/agent/pkgagent.c
+++ b/src/pkgagent/agent/pkgagent.c
@@ -361,11 +361,9 @@ int ProcessUpload (long upload_pk)
         RecordMetadataRPM(pi);
       }
       /* free memory */
-#ifdef _RPM_4_4_COMPAT
       int i;
       for(i=0; i< pi->req_size;i++)
         free(pi->requires[i]);
-#endif /* After RPM4.4 version*/
       free(pi->requires);
     }
     else if (!strcasecmp(mimetype, "application/x-debian-package")){
@@ -403,9 +401,7 @@ int ProcessUpload (long upload_pk)
     fo_scheduler_heart(1);
   }
   PQclear(result);
-#ifdef _RPM_4_4_COMPAT
   rpmFreeCrypto();
-#endif /* After RPM4.4 version*/
   rpmFreeMacros(NULL);
   free(pi);
   free(dpi);
@@ -429,28 +425,12 @@ void ReadHeaderInfo(Header header, struct rpmpkginfo *pi)
   long *tp,t;
   int header_status;
 
-#ifdef _RPM_4_4
-  void* pointer;
-  int_32 type, data_size;
-#endif /* RPM4.4 version*/
-
-#ifdef _RPM_4_4_COMPAT
   struct rpmtd_s req;
   rpm_count_t data_size;
-#endif /* After RPM4.4 version*/
 
   for (i = 0; i < 14; i++) {
     memset(fmt, 0, sizeof(fmt));
     strcat( fmt, "%{");
-#ifdef _RPM_4_4
-    strcat( fmt, tagName(tag[i]));
-    strcat( fmt, "}\n");
-
-    msgstr = headerSprintf(header, fmt, rpmTagTable, rpmHeaderFormats, &errstr);
-    if (msgstr != NULL){
-      trim(msgstr);
-      printf("%s:%s\n",tagName(tag[i]),msgstr);
-#else /* RPM4.4 version*/
     strcat( fmt, rpmTagGetName(tag[i]));
     strcat( fmt, "}\n");
 
@@ -458,7 +438,6 @@ void ReadHeaderInfo(Header header, struct rpmpkginfo *pi)
     if (msgstr != NULL){
       trim(msgstr);
       printf("%s:%s\n",rpmTagGetName(tag[i]),msgstr);
-#endif /* After RPM4.4 version*/
       switch (tag[i]) {
         case RPMTAG_NAME:
           EscapeString(msgstr, pi->pkgName, sizeof(pi->pkgName));
@@ -511,16 +490,6 @@ void ReadHeaderInfo(Header header, struct rpmpkginfo *pi)
     free((void *)msgstr);
   }
   if (Verbose > 1) { printf("Name:%s\n",pi->pkgName);}
-#ifdef _RPM_4_4
-  header_status = headerGetEntry(header,tag[14],&type,&pointer,&data_size);
-  if (header_status) {
-    if (type == RPM_STRING_ARRAY_TYPE) {
-      pi->requires = (char **) pointer;
-      pi->req_size = data_size;
-    }
-  }
-#endif/* RPM4.4 version*/
-#ifdef _RPM_4_4_COMPAT
   header_status = headerGet(header, tag[14], &req, HEADERGET_DEFAULT);
   if (header_status) {
     data_size = rpmtdCount(&req);
@@ -533,7 +502,6 @@ void ReadHeaderInfo(Header header, struct rpmpkginfo *pi)
     pi->req_size = data_size;
     rpmtdFreeData(&req);
   }
-#endif/* After RPM4.4 version*/
 
   if (Verbose > 1) {
     printf("Size:%d\n",pi->req_size);

--- a/src/pkgagent/agent/pkgagent.c
+++ b/src/pkgagent/agent/pkgagent.c
@@ -442,6 +442,7 @@ void ReadHeaderInfo(Header header, struct rpmpkginfo *pi)
   for (i = 0; i < 14; i++) {
     memset(fmt, 0, sizeof(fmt));
     strcat( fmt, "%{");
+#ifdef _RPM_4_4
     strcat( fmt, tagName(tag[i]));
     strcat( fmt, "}\n");
 
@@ -449,6 +450,15 @@ void ReadHeaderInfo(Header header, struct rpmpkginfo *pi)
     if (msgstr != NULL){
       trim(msgstr);
       printf("%s:%s\n",tagName(tag[i]),msgstr);
+#else /* RPM4.4 version*/
+    strcat( fmt, rpmTagGetName(tag[i]));
+    strcat( fmt, "}\n");
+
+    msgstr = headerFormat(header, fmt, &errstr);
+    if (msgstr != NULL){
+      trim(msgstr);
+      printf("%s:%s\n",rpmTagGetName(tag[i]),msgstr);
+#endif /* After RPM4.4 version*/
       switch (tag[i]) {
         case RPMTAG_NAME:
           EscapeString(msgstr, pi->pkgName, sizeof(pi->pkgName));

--- a/src/pkgagent/agent_tests/Unit/Makefile
+++ b/src/pkgagent/agent_tests/Unit/Makefile
@@ -14,8 +14,6 @@ TEST_LIB = -L $(TEST_LIB_DIR) -l fodbreposysconf
 CFLAGS_LOCAL = -I/usr/include/rpm $(FO_CFLAGS) -I$(LOCALAGENTDIR) -I $(TEST_LIB_DIR) -I $(CUNIT_LIB_DIR) -DCU_VERSION_P=$(CUNIT_VERSION)
 LDFLAGS_LOCAL = -lrpm $(FO_LDFLAGS) -lcunit $(CUNIT_LIB) $(TEST_LIB) -lrpmio
 EXE = test_pkgagent
-CFLAGS_LOCAL_RPM_4_4 = $(CFLAGS_LOCAL) -D_RPM_4_4
-CFLAGS_LOCAL_RPM = $(CFLAGS_LOCAL) -D_RPM_4_4_COMPAT
 TEST_OBJ = testRun.o testGetFieldValue.o testRecordMetadataRPM.o testRecordMetadataDEB.o testGetMetadataDebSource.o testGetMetadataDebBinary.o
 
 all: $(EXE)
@@ -36,15 +34,7 @@ $(TEST_OBJ): %.o: %.c
 	$(CC) -c $(CFLAGS_LOCAL) $<
 
 testGetMetadata.o: testGetMetadata.c
-	if expr `rpm --version|awk '{print $$3}'|awk -F. '{print $$1"."$$2}'` \>= 4.5 >/dev/null; then \
-		$(CC) -c $< $(CFLAGS_LOCAL_RPM); \
-	else \
-		if expr `rpm --version|awk '{print $$3}'|awk -F. '{print $$1"."$$2}'` \>= 4.10 >/dev/null; then \
-			$(CC) -c $< $(CFLAGS_LOCAL_RPM); \
-		else \
-			$(CC) -c $< $(CFLAGS_LOCAL_RPM_4_4); \
-		fi \
-	fi
+	$(CC) -c $< $(CFLAGS_LOCAL)
 
 cunit_lib:
 	$(MAKE) -C $(CUNIT_LIB_DIR)

--- a/src/pkgagent/agent_tests/Unit/testGetMetadata.c
+++ b/src/pkgagent/agent_tests/Unit/testGetMetadata.c
@@ -54,13 +54,11 @@ void test_GetMetadata_normal()
   CU_ASSERT_STRING_EQUAL(pi->sourceRPM, "fossology-1.2.0-1.el5.src.rpm");
   CU_ASSERT_EQUAL(pi->req_size, 44);
   PQfinish(db_conn);
-#ifdef _RPM_4_4_COMPAT
   rpmFreeCrypto();
   /* free memroy */
   int i;
   for(i=0; i< pi->req_size;i++)
     free(pi->requires[i]);
-#endif /* After RPM4.4 version*/
   rpmFreeMacros(NULL);
   free(pi->requires);
   free(pi);
@@ -85,9 +83,7 @@ void test_GetMetadata_wrong_testfile()
   int Result = GetMetadata(pkg, pi);
   //printf("test_GetMetadata Result is:%d\n", Result);
   PQfinish(db_conn);
-#ifdef _RPM_4_4_COMPAT
   rpmFreeCrypto();
-#endif /* After RPM4.4 version*/
   rpmFreeMacros(NULL);
   memset(pi, 0, sizeof(struct rpmpkginfo));
   free(pi);
@@ -112,13 +108,11 @@ void test_GetMetadata_no_testfile()
   int Result = GetMetadata(pkg, pi);
   //printf("test_GetMetadata Result is:%d\n", Result);
   PQfinish(db_conn);
-#ifdef _RPM_4_4_COMPAT
   rpmFreeCrypto();
   /* free memroy */
   int i;
   for(i=0; i< pi->req_size;i++)
     free(pi->requires[i]);
-#endif /* After RPM4.4 version*/
   rpmFreeMacros(NULL);
   free(pi->requires);
   free(pi);


### PR DESCRIPTION
Fix for #1007 . Building fails on Fedora 27 because RPM >= 4.14 has removed the RPM 4.4.x API compatibility.

## Changes

Used the following defines from the removed rpmlegacy.h:
```
#define headerSprintf(_h, _fmt, _tbltags, _exts, _emsg) \
	headerFormat((_h), (_fmt), (_emsg))
#define	tagName		rpmTagGetName
```
edit: Dropped support for RPM 4.4.x and RHEL/CentOS 5.

## How to test

Compile on Fedora 27.

## Question

Should we remove the legacy RPM 4.4.x stuff? RHEL/CentOS 5 are the remaining users of RPM 4.4.x but RHEL is in the Extended Life-cycle Support and CentOS 5 is now EOL.