### PR TITLE
fix(cunit-version): Change script with new syntax

### DIFF
--- a/utils/cunit-version
+++ b/utils/cunit-version
@@ -3,26 +3,26 @@
 # Copyright 2018 Siemens AG
 # Author: Gaurav Mishra <mishra.gaurav@siemens.com>
 
-DISTRO=`lsb_release -is`
+DISTRO=$(lsb_release -is)
 
 CUNIT=""
 
 case "$DISTRO" in
-	Debian|Ubuntu|LinuxMint)
-		CUNIT=`dpkg-query -W -f='${Version}' libcunit1-dev`
-	;;
-	RedHatEnterprise*|CentOS|Fedora|Mandriva)
-		CUNIT=`rpm -qi CUnit | grep -i "Version"`
-	;;
-	*)
-		CUNIT="2.1.2"
-	;;
+  Debian|Ubuntu|LinuxMint)
+    CUNIT=$(dpkg-query -W -f='${Version}' libcunit1-dev)
+  ;;
+  RedHatEnterprise*|CentOS|Fedora|Mandriva)
+    CUNIT=$(rpm -qi CUnit | grep -i "Version")
+  ;;
+  *)
+    CUNIT="2.1.2"
+  ;;
 esac
 
-if [ ! -z `echo $CUNIT | grep "2.1-3"` ]; then
-	echo "213"
-elif [ ! -z `echo $CUNIT | grep "2.1.3"` ]; then
-	echo "213"
+if echo $CUNIT | grep -q "2.1-3"; then
+  echo "213"
+elif echo $CUNIT | grep -q "2.1.3"; then
+  echo "213"
 else
-	echo "212"
+  echo "212"
 fi


### PR DESCRIPTION
## Description

Updated the script to get the CUnit version installed to new syntax understandable by bash.

### Changes

1.  Removed the `[ ... ]` in if statements.
2.  Use `$(...)` instead of using back quote.
3.  Use `grep -q` instead of `! -z`.

## How to test

1.  Run the old script on non-Debian based machines (tested on Fedora) which will fail.
2.  Run new script on any machine.