### PR TITLE
fix(dataTables): Update datatable objects to 1.10

### DIFF
--- a/src/copyright/ui/template/histTable.js.twig
+++ b/src/copyright/ui/template/histTable.js.twig
@@ -47,7 +47,6 @@ function createTableBase{{ table.type }}(activated) {
     "iDisplayLength": 50,
     "bProcessing": true,
     "bStateSave": true,
-    "sCookiePrefix": "fossology_",
     "bRetrieve": true
   });
 }

--- a/src/www/ui/scripts/browse.js
+++ b/src/www/ui/scripts/browse.js
@@ -36,7 +36,7 @@ $(document).ready(function () {
     initPrioClick();
     initPrioDraw();
     $('.cc').dblclick( function (){
-        var source=table.fnGetData(this);
+        var source=table.cell(this).data();
         openCommentModal(source[0],source[1],source[2]); 
       } );
     $('select.goto-active-option').change(function() {
@@ -51,7 +51,7 @@ $(document).ready(function () {
 function initPrioClick() {
   $("td.priobucket").click(function () {
     table = createBrowseTable();
-    elementData = table.fnGetData(this);
+    elementData = table.cell(this).data();
     yourKey = elementData[0];
     if (myKey > 0 && myKey !== yourKey) {
       changePriority(myKey, yourKey);
@@ -75,7 +75,7 @@ function initPrioDraw() {
   $("td.priobucket").each(function () {
     $('.ui-tooltip').remove();
     $(this).html(function () {
-      return prioColumn(table.fnGetData(this), 'display');
+      return prioColumn(table.cell(this).data(), 'display');
     });
   });
   
@@ -116,20 +116,20 @@ function closeCommentModal() {
 
 function mysuccess() {
   var oTable = createBrowseTable();
-  oTable.fnDraw(false);
+  oTable.draw(false);
 }
 
 function mysuccess3() {
   closeCommentModal();
   var oTable = createBrowseTable();
-  oTable.fnDraw(false);
+  oTable.draw(false);
 }
 
 function mysuccess4() {
   myKey = 0;
   initPrioDraw();
   var oTable = createBrowseTable();
-  oTable.fnDraw(false);
+  oTable.draw(false);
 }
 
 function changeTableEntry(sel, uploadId, columnName) {
@@ -155,13 +155,13 @@ function changeTableEntry(sel, uploadId, columnName) {
 function filterAssignee() {
   assigneeSelected = $('#assigneeSelector').val();
   var oTable = createBrowseTable();
-  oTable.fnDraw(false);
+  oTable.draw(false);
 }
 
 function filterStatus() {
   statusSelected = $('#statusSelector').val();
   var oTable = createBrowseTable();
-  oTable.fnDraw(false);
+  oTable.draw(false);
 }
 
 function changePriority(move, beyond) {

--- a/src/www/ui/template/browse_file.js.twig
+++ b/src/www/ui/template/browse_file.js.twig
@@ -45,7 +45,6 @@ function createDirlistTable() {
         {"sTitle":"Actions <input type='checkbox' id='selectMarkIrrelevant'>","sClass":"left","bSortable":false,"bSearchable":false,"sWidth":"13.6%"}],
     "bProcessing": true,
     "bStateSave": true,
-    "sCookiePrefix" : "fossology_",
     "bRetrieve": true,
     "bPaginate": true,
     "bFilter": true,

--- a/src/www/ui/template/file-browse.js.twig
+++ b/src/www/ui/template/file-browse.js.twig
@@ -30,7 +30,6 @@ function createDirlistTable() {
     "iDisplayLength": 25,
     "bProcessing": true,
     "bStateSave": true,
-    "sCookiePrefix" : "fossology_",
     "bRetrieve": true,
     "bPaginate": true,
     "bFilter": true,

--- a/src/www/ui/template/ui-browse.js.twig
+++ b/src/www/ui/template/ui-browse.js.twig
@@ -49,12 +49,11 @@ dataTableConfig =
       "iDisplayLength": 50,
       "bProcessing": true,
       "bStateSave": true,
-      "sCookiePrefix": "fossology_",
       "bRetrieve": true
     };
 
 function createBrowseTable() {
-  var otable = $('#browsetbl').dataTable(dataTableConfig);
+  var otable = $('#browsetbl').DataTable(dataTableConfig);
   return otable;
 }
 

--- a/src/www/ui/template/ui-clearing-view.js.twig
+++ b/src/www/ui/template/ui-clearing-view.js.twig
@@ -34,7 +34,6 @@ selectedLicensesTableConfig = {
   "iDisplayLength": 25,
   "bProcessing": true,
   "bStateSave": true,
-  "sCookiePrefix" : "fossology_",
   "bRetrieve": true,
   "bPaginate": false,
   "bFilter": false,
@@ -72,7 +71,6 @@ addLicenseTableConfig = {
   "iDisplayLength": 25,
   "bProcessing": true,
   "bStateSave": true,
-  "sCookiePrefix" : "fossology_",
   "bRetrieve": true,
   "bPaginate": false,
   "bFilter": true
@@ -98,7 +96,6 @@ addClearingHistoryTableConfig = {
   "iDisplayLength": 25,
   "bProcessing": true,
   "bStateSave": true,
-  "sCookiePrefix" : "fossology_",
   "bRetrieve": false,
   "bPaginate": false,
   "bFilter": false,

--- a/src/www/ui/template/ui-job-show.js.twig
+++ b/src/www/ui/template/ui-job-show.js.twig
@@ -29,7 +29,6 @@
   "iDisplayLength": 25,
   "bProcessing": true,
   "bStateSave": true,
-  "sCookiePrefix" : "fossology_",
   "bRetrieve": true,
   "bPaginate": false,
   "bFilter": false,


### PR DESCRIPTION
## Description

Made changes in data table objects after changing datatables from V1.9 to V1.10 in #832

### Changes

As per [data tables upgrade guide](https://datatables.net/upgrade/1.10-convert)
1.  Removed `sCookiePrefix` parameter as data tables use local cache.
2.  Updated `fnGetData(this)` to `cell(this).data()`.
3.  Updated `fnDraw()` to `draw()`.
4.  Use new object from `DataTable` instead of `dataTable`.

## How to test

1.  Install current master
    1.  Drop-downs in ui-browse does not work
    1.  You can not change priorities
1.  Install the fix
    *  They should work.

## Note

It is recommended to use `DataTable` instead of `dataTable` to use new API. But this new API is not usable by [jquery.dataTables.editable.js](https://github.com/fossology/fossology/blob/master/src/www/ui/scripts/jquery.dataTables.editable.js).