### PR TITLE
perf(Docker): Use Debian Jessie slim variant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 #
 # Description: Docker container image recipe
 
-FROM debian:jessie as builder
+FROM debian:jessie-slim as builder
 
 LABEL maintainer="Fossology <fossology@fossology.org>"
 
@@ -46,7 +46,7 @@ RUN /fossology/utils/install_composer.sh
 RUN make install clean
 
 
-FROM debian:jessie
+FROM debian:jessie-slim
 
 LABEL maintainer="Fossology <fossology@fossology.org>"
 
@@ -55,7 +55,9 @@ COPY --from=builder /fossology/dependencies-for-runtime /fossology
 
 WORKDIR /fossology
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+# Fix for Postgres and other packages in slim variant
+RUN mkdir /usr/share/man/man1 /usr/share/man/man7 \
+ && DEBIAN_FRONTEND=noninteractive apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       curl \
       lsb-release \


### PR DESCRIPTION
## Description
Using slim variant of Debian Jessie to reduce the Docker image size

| [Current size](https://hub.docker.com/r/fossology/fossology/tags/) | [Slim size](https://hub.docker.com/r/gmishx/fossology/tags/) |
| --- | --- |
| ![normal](https://user-images.githubusercontent.com/18077542/43075645-fb49c146-8e9e-11e8-89c3-45c8f9e2f113.png) | ![slim](https://user-images.githubusercontent.com/18077542/43075646-fb74c74c-8e9e-11e8-8006-6514d838afc0.png) |


### Changes
-  Changed the image label from `debian:8.8` to `debian:jessie-slim` to use the slim variant.
-  The slim variant don't have the man pages, so creating
    -  /usr/share/man/man1
    -  /usr/share/man/man7

## How to test
1.  Pull latest docker image, check the image size
```bash
docker pull fossology/fossology:latest
docker image ls
```
2.  Build the new image, check the image size
```bash
docker build -t fossology/fossology:slim-variant .
docker image ls
```
3.  Run new image and test it (see [README.md](https://github.com/fossology/fossology/blob/master/README.md))