### PR TITLE
fix(wget_agent): Ignore test_proxy_ftp, because it is flaky on travis.

### DIFF
--- a/src/wget_agent/agent_tests/Functional/cliParamsTest4WgetAgent.php
+++ b/src/wget_agent/agent_tests/Functional/cliParamsTest4WgetAgent.php
@@ -224,6 +224,7 @@ class cliParamsTest4Wget extends PHPUnit_Framework_TestCase {
     global $db_conf;
     global $TEST_RESULT_PATH;
     global $WGET_PATH;
+    return; // TODO ignore this test case, because it is flaky on travis
     // ftp_proxy
     //$this->change_proxy("ftp_proxy", "web-proxy.cce.hp.com:8088");
     $command = "$WGET_PATH ftp://ftp.gnu.org/gnu/wget/wget-1.10.1.tar.gz  -d $TEST_RESULT_PATH";
@@ -278,7 +279,9 @@ class cliParamsTest4Wget extends PHPUnit_Framework_TestCase {
     // delete the directory ./test_result
     exec("/bin/rm -rf $TEST_RESULT_PATH $SYSCONF_DIR");
     // remove the sysconf/db/repo
-    exec("$DB_COMMAND -d $DB_NAME");
+    if (!empty($DB_COMMAND) && !empty($DB_NAME)) {
+      exec("$DB_COMMAND -d $DB_NAME");
+    }
   }
 }
 


### PR DESCRIPTION
## Description

The test test_proxy_ftp is flaky, because there are some issues with ftp and required sudo on travis. Since the essential part of the test is already commented out, we should ignore it until there exists a solution for travis.

### Changes

fix(wget_agent): Ignore test_proxy_ftp, because it is flaky on travis.
fix(wget_agent): Clean up the database only if it is necessary.
