### PR TITLE
fix(ars_seq): Reset ars sequence to ars_master

### DIFF
--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -1777,7 +1777,7 @@
   $Schema["SEQUENCE"]["agent_runstatus_ars_pk_seq"]["UPDATE"] = "SELECT setval('agent_runstatus_ars_pk_seq',(SELECT greatest(1,max(ars_pk)) val FROM agent_runstatus))";
 
   $Schema["SEQUENCE"]["nomos_ars_ars_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"nomos_ars_ars_pk_seq\"";
-  $Schema["SEQUENCE"]["nomos_ars_ars_pk_seq"]["UPDATE"] = "SELECT setval('nomos_ars_ars_pk_seq',(SELECT greatest(1,max(ars_pk)) val FROM bucket_ars))";
+  $Schema["SEQUENCE"]["nomos_ars_ars_pk_seq"]["UPDATE"] = "SELECT setval('nomos_ars_ars_pk_seq',(SELECT greatest(1,max(ars_pk)) val FROM ars_master))";
 
   $Schema["SEQUENCE"]["attachments_attachment_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"attachments_attachment_pk_seq\"";
   $Schema["SEQUENCE"]["attachments_attachment_pk_seq"]["UPDATE"] = "SELECT setval('attachments_attachment_pk_seq',(SELECT greatest(1,max(attachment_pk)) val FROM attachments))";


### PR DESCRIPTION
## Description

The next value for `nomos_ars_ars_pk_seq` sequence resets at every install to `bucket_ars` instead of `ars_master`. This creates issue while inserting new values in ars child tables.

### Changes

Fixed the **UPDATE** query for `nomos_ars_ars_pk_seq` sequence.

## How to test

1.  Install on an existing server and upload a new package.
1.  The ars entries of new scans should be in sequence.
    1.  Also, no UNIQUE key conflicts should occur while writing to ARS tables.

Closes #1134 