### PR TITLE
feat(monk): allow monk to run standalone

### DIFF
--- a/src/monk/agent/Makefile
+++ b/src/monk/agent/Makefile
@@ -22,7 +22,7 @@ endif
 EXE = monk monkbulk
 OBJECTS = string_operations.o file_operations.o database.o encoding.o \
           license.o highlight.o match.o hash.o diff.o common.o \
-          cli.o scheduler.o \
+          cli.o scheduler.o serialize.o \
           _squareVisitor.o
 COVERAGE = string_operations_cov.o file_operations_cov.o encoding_cov.o \
            database_cov.o license_cov.o highlight_cov.o match_cov.o \

--- a/src/monk/agent/cli.c
+++ b/src/monk/agent/cli.c
@@ -19,7 +19,6 @@ Copyright (C) 2013-2014, Siemens AG
 #include "file_operations.h"
 #include "database.h"
 #include "match.h"
-#include <getopt.h>
 
 MatchCallbacks cliCallbacks =
   { .onNo = cli_onNoMatch,
@@ -44,51 +43,7 @@ int matchCliFileWithLicenses(MonkState* state, const Licenses* licenses, int arg
   return result;
 }
 
-int parseArguments(MonkState* state, int argc, char** argv, int* fileOptInd)
-{
-  int c;
-  state->verbosity = 0;
-  state->json = 0;
-  while ((c = getopt(argc, argv, "VvJhB:")) != -1) {
-    switch (c) {
-      case 'v':
-        state->verbosity++;
-        break;
-       case 'V':
-#ifdef COMMIT_HASH_S
-        printf(AGENT_NAME " version " VERSION_S " r(" COMMIT_HASH_S ")\n");
-#else
-        printf(AGENT_NAME " (no version available)\n");
-#endif
-        return 0;
-      case 'J':
-        state->json = 1;
-        break;
-      case 'h':
-      default:
-        printf("Usage: %s [options] -- [file [file [...]]\n", argv[0]);
-        printf("  -h   :: help (print this message), then exit.\n"
-               "  -c   :: specify the directory for the system configuration.\n"
-               "  -v   :: verbose output.\n"
-               "  -J   :: JSON output.\n"
-               "  file :: scan file and print licenses detected within it.\n"
-               "  no file :: process data from the scheduler.\n"
-               "  -V   :: print the version info, then exit.\n");
-        return 0;
-    }
-  }
-  *fileOptInd = optind;
-  return 1;
-}
-
-int handleCliMode(MonkState* state, const Licenses* licenses, int argc, char** argv) {
-  int fileOptInd;
-  if (!parseArguments(state, argc, argv, &fileOptInd))
-    return 0;
-
-  state->scanMode = MODE_CLI;
-
-  int threadError = 0;
+int handleCliMode(MonkState* state, const Licenses* licenses, int argc, char** argv, int fileOptInd) {
 #ifdef MONK_MULTI_THREAD
   #pragma omp parallel
 #endif
@@ -96,21 +51,15 @@ int handleCliMode(MonkState* state, const Licenses* licenses, int argc, char** a
     MonkState threadLocalStateStore = *state;
     MonkState* threadLocalState = &threadLocalStateStore;
 
-    threadLocalState->dbManager = fo_dbManager_fork(state->dbManager);
-    if (threadLocalState->dbManager) {
 #ifdef MONK_MULTI_THREAD
-      #pragma omp for schedule(dynamic)
+    #pragma omp for schedule(dynamic)
 #endif
-      for (int fileId = fileOptInd; fileId < argc; fileId++) {
-        matchCliFileWithLicenses(threadLocalState, licenses, fileId, argv);
-      }
-      fo_dbManager_finish(threadLocalState->dbManager);
-    } else {
-      threadError = 1;
+    for (int fileId = fileOptInd; fileId < argc; fileId++) {
+      matchCliFileWithLicenses(threadLocalState, licenses, fileId, argv);
     }
   }
 
-  return !threadError;
+  return 1;
 }
 
 int cli_onNoMatch(MonkState* state, const File* file) {
@@ -124,9 +73,6 @@ int cli_onNoMatch(MonkState* state, const File* file) {
 }
 
 int cli_onFullMatch(MonkState* state, const File* file, const License* license, const DiffMatchInfo* matchInfo) {
-  if (state->scanMode != MODE_CLI)
-    return 0;
-
   if (state->json) {
     printf("{\"type\":\"full\",\"license\":\"%s\",\"ref-pk\":%ld,\"matched\":\"%zu+%zu\"}",
            license->shortname, license->refId,
@@ -140,9 +86,6 @@ int cli_onFullMatch(MonkState* state, const File* file, const License* license, 
 }
 
 int cli_onDiff(MonkState* state, const File* file, const License* license, const DiffResult* diffResult) {
-  if (state->scanMode != MODE_CLI)
-    return 0;
-
   unsigned short rank = diffResult->percentual;
 
   char * formattedMatchArray = formatMatchArray(diffResult->matchedInfo);

--- a/src/monk/agent/cli.h
+++ b/src/monk/agent/cli.h
@@ -22,7 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "monk.h"
 #include "diff.h"
 
-int handleCliMode(MonkState* state, const Licenses* licenses, int argc, char** argv);
+int handleCliMode(MonkState* state, const Licenses* licenses, int argc, char** argv, int fileOptInd);
 int cli_onNoMatch(MonkState* state, const File* file);
 int cli_onFullMatch(MonkState* state, const File* file, const License* license, const DiffMatchInfo* matchInfo);
 int cli_onDiff(MonkState* state, const File* file, const License* license, const DiffResult* diffResult);

--- a/src/monk/agent/common.c
+++ b/src/monk/agent/common.c
@@ -27,7 +27,9 @@ void scheduler_disconnect(MonkState* state, int exitval) {
 }
 
 void bail(MonkState* state, int exitval) {
-  scheduler_disconnect(state, exitval);
+  if(state->dbManager != NULL) {
+    scheduler_disconnect(state, exitval);
+  }
   exit(exitval);
 }
 

--- a/src/monk/agent/monk.c
+++ b/src/monk/agent/monk.c
@@ -22,112 +22,109 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "scheduler.h"
 #include "cli.h"
 #include "common.h"
+#include <getopt.h>
 
-MatchCallbacks schedulerCallbacks =
-  { .onNo = sched_onNoMatch,
-    .onFull = sched_onFullMatch,
-    .onDiff = sched_onDiffMatch,
-    .onBeginOutput = sched_noop,
-    .onBetweenIndividualOutputs = sched_noop,
-    .onEndOutput = sched_noop,
-    .ignore = sched_ignore
-  };
-
-int processUploadId(MonkState* state, int uploadId, Licenses* licenses) {
-  PGresult* fileIdResult = queryFileIdsForUpload(state->dbManager, uploadId);
-
-  if (!fileIdResult)
-    return 0;
-
-  if (PQntuples(fileIdResult) == 0) {
-    PQclear(fileIdResult);
-    fo_scheduler_heart(0);
-    return 1;
-  }
-
-  int threadError = 0;
-#ifdef MONK_MULTI_THREAD
-  #pragma omp parallel
+void parseArguments(MonkState* state, int argc, char** argv, int* fileOptInd) {
+  int c;
+  static struct option long_options[] = {{"config", required_argument, 0, 'c'},
+                                         {"userID", required_argument, 0, 'u'},
+                                         {"groupID", required_argument, 0, 'g'},
+                                         {"scheduler_start", no_argument, 0, 'S'},
+                                         {"jobId", required_argument, 0, 'j'},
+                                         {NULL, 0, NULL, 0}};
+  int option_index = 0;
+  while ((c = getopt_long(argc, argv, "VvJhs:k:c:", long_options, &option_index)) != -1) {
+    switch (c) {
+      case 'c':
+        break;
+      case 'u':
+      case 'g':
+      case 'S':
+      case 'j':
+        /* these options are handled by the fo_scheduler_connect_dbMan call later in detail */
+        state->scanMode = MODE_SCHEDULER;
+        break;
+      case 'v':
+        state->verbosity++;
+        break;
+       case 'V':
+#ifdef COMMIT_HASH_S
+        printf(AGENT_NAME " version " VERSION_S " r(" COMMIT_HASH_S ")\n");
+#else
+        printf(AGENT_NAME " (no version available)\n");
 #endif
-  {
-    MonkState threadLocalStateStore = *state;
-    MonkState* threadLocalState = &threadLocalStateStore;
-
-    threadLocalState->dbManager = fo_dbManager_fork(state->dbManager);
-    if (threadLocalState->dbManager) {
-      int count = PQntuples(fileIdResult);
-#ifdef MONK_MULTI_THREAD
-      #pragma omp for schedule(dynamic)
-#endif
-      for (int i = 0; i < count; i++) {
-        if (threadError)
-          continue;
-
-        long pFileId = atol(PQgetvalue(fileIdResult, i, 0));
-
-        if ((pFileId <= 0) || hasAlreadyResultsFor(threadLocalState->dbManager, threadLocalState->agentId, pFileId))
-        {
-          fo_scheduler_heart(0);
-          continue;
-        }
-
-        if (matchPFileWithLicenses(threadLocalState, pFileId, licenses, &schedulerCallbacks)) {
-          fo_scheduler_heart(1);
-        } else {
-          fo_scheduler_heart(0);
-          threadError = 1;
-        }
-      }
-      fo_dbManager_finish(threadLocalState->dbManager);
-    } else {
-      threadError = 1;
+        state->scanMode = 0;
+        return;
+      case 'J':
+        state->json = 1;
+        break;
+      case 'h':
+      case '?':
+        printf("Usage:\n"
+               "\nAs CLI tool using the licenses from the FOSSology database:\n");
+        printf("       %s [options] file [file [...]]\n", argv[0]);
+        printf("               options:\n"
+               "                  -h          :: help (print this message), then exit.\n"
+               "                  -c config   :: specify the directory for the system configuration.\n"
+               "                  -v          :: verbose output.\n"
+               "                  -J          :: JSON output.\n"
+               "                  file        :: scan file and print licenses detected within it.\n"
+               "                  -V          :: print the version info, then exit.\n"
+               "\nThe following should only be called by the FOSSology scheduler:\n");
+        printf("       %s --scheduler_start [options]\n", argv[0]);
+        printf("               options:\n"
+               "                  -c config   :: specify the directory for the system configuration.\n"
+               "                  --userID i  :: the id of the user that created the job\n"
+               "                  --groupID i :: the id of the group of the user that created the job\n"
+               "                  --jobID i   :: the id of the job\n");
+        state->scanMode = 0;
+        return;
     }
   }
-  PQclear(fileIdResult);
-
-  return !threadError;
+  *fileOptInd = optind;
+  if (optind < argc) {
+    state->scanMode = MODE_CLI;
+  }
 }
 
 int main(int argc, char** argv) {
-  MonkState stateStore;
+  int fileOptInd;
+  MonkState stateStore = { .dbManager = NULL,
+                           .agentId = 0,
+                           .scanMode = 0,
+                           .verbosity = 0,
+                           .json = 0,
+                           .ptr = NULL };
   MonkState* state = &stateStore;
+  parseArguments(state, argc, argv, &fileOptInd);
+  int wasSuccessful = 1;
 
+  if (state->scanMode == 0) {
+    return 0;
+  }
+
+  int oldArgc = argc;
   fo_scheduler_connect_dbMan(&argc, argv, &(state->dbManager));
+  fileOptInd = fileOptInd - oldArgc + argc;
 
   PGresult* licensesResult = queryAllLicenses(state->dbManager);
   Licenses* licenses = extractLicenses(state->dbManager, licensesResult, MIN_ADJACENT_MATCHES, MAX_LEADING_DIFF);
   PQclear(licensesResult);
 
-  if (argc > 1) {
-    if (!handleCliMode(state, licenses, argc, argv))
-      bail(state, 3);
-  } else {
-    /* scheduler mode */
-    state->scanMode = MODE_SCHEDULER;
-    queryAgentId(state, AGENT_NAME, AGENT_DESC);
-
-    while (fo_scheduler_next() != NULL) {
-      int uploadId = atoi(fo_scheduler_current());
-
-      if (uploadId == 0) continue;
-
-      int arsId = fo_WriteARS(fo_dbManager_getWrappedConnection(state->dbManager),
-                              0, uploadId, state->agentId, AGENT_ARS, NULL, 0);
-
-      if (arsId<=0)
-        bail(state, 1);
-
-      if (!processUploadId(state, uploadId, licenses))
-        bail(state, 2);
-
-      fo_WriteARS(fo_dbManager_getWrappedConnection(state->dbManager),
-                  arsId, uploadId, state->agentId, AGENT_ARS, NULL, 1);
+  if (state->scanMode == MODE_SCHEDULER) {
+    wasSuccessful = handleSchedulerMode(state, licenses);
+    scheduler_disconnect(state, ! wasSuccessful);
+  } else if (state->scanMode == MODE_CLI) {
+    /* we no longer need a database connection */
+    if (state->dbManager != NULL) {
+      scheduler_disconnect(state, 0);
     }
-    fo_scheduler_heart(0);
+    state->dbManager = NULL;
+
+    wasSuccessful = handleCliMode(state, licenses, argc, argv, fileOptInd);
   }
 
   licenses_free(licenses);
 
-  scheduler_disconnect(state, 0);
-  return 0;
+  return ! wasSuccessful;
 }

--- a/src/monk/agent/monk.h
+++ b/src/monk/agent/monk.h
@@ -26,6 +26,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MODE_SCHEDULER 1
 #define MODE_CLI 2
 #define MODE_BULK 3
+#define MODE_EXPORT_KOWLEDGEBASE 4
+#define MODE_CLI_OFFLINE 5
 
 #define FULL_MATCH "M"
 #define DIFF_TYPE_MATCH "M0"
@@ -54,6 +56,7 @@ typedef struct {
   int agentId;
   int scanMode;
   int verbosity;
+  char* knowledgebaseFile;
   int json;
   void* ptr;
 } MonkState;

--- a/src/monk/agent/monk.h
+++ b/src/monk/agent/monk.h
@@ -21,7 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define AGENT_NAME "monk" ///< the name of the agent, used to get agent key
 #define AGENT_DESC "monk agent" ///< what program this is
-#define AGENT_ARS  "monk_ars" 
+#define AGENT_ARS  "monk_ars"
 
 #define MODE_SCHEDULER 1
 #define MODE_CLI 2

--- a/src/monk/agent/scheduler.h
+++ b/src/monk/agent/scheduler.h
@@ -21,6 +21,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "match.h"
 
+int handleSchedulerMode(MonkState* state, const Licenses* licenses);
+
 int sched_onNoMatch(MonkState* state, const File* file);
 int sched_onFullMatch(MonkState* state, const File* file, const License* license, const DiffMatchInfo* matchInfo);
 int sched_onDiffMatch(MonkState* state, const File* file, const License* license, const DiffResult* diffResult);

--- a/src/monk/agent/serialize.c
+++ b/src/monk/agent/serialize.c
@@ -1,0 +1,130 @@
+/*
+Author: Maximilian Huber
+Copyright (C) 2018, TNG Technology Consulting GmbH
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "serialize.h"
+
+#include "monk.h"
+#include "license.h"
+#include "string_operations.h"
+#include <stdio.h>
+#include <errno.h>
+
+/*
+ * serialization
+ */
+
+int serializeToFile(Licenses* licenses, char* filename) {
+  FILE* fp = fopen(filename, "w+");
+  if (fp == NULL) {
+    return 0;
+  }
+  int retCode = serialize(licenses, fp);
+  fclose(fp);
+  return retCode;
+}
+
+int serialize(Licenses* licenses, FILE* fp) {
+  return serializeGArray(licenses->licenses, fp);
+}
+
+int serializeGArray(GArray* licenses, FILE* fp) {
+  int retCode;
+  for (guint i = 0; i < licenses->len; i++) {
+    retCode = serializeOne(license_index(licenses, i), fp);
+    if (retCode == 0) {
+      return retCode;
+    }
+  }
+  return 1;
+}
+
+int serializeOne(License* license, FILE* fp) {
+  return serializeOneMeta(license, fp) &&
+    serializeOneShortname(license, fp) &&
+    serializeOneTokens(license->tokens, fp);
+}
+
+int serializeOneMeta(License* license, FILE* fp) {
+  SerializingMeta meta = { .refId = license->refId,
+                           .shortnameLen = strlen(license->shortname),
+                           .tokensLen = license->tokens->len };
+
+  return fwrite(&meta, sizeof(SerializingMeta), 1, fp) == 1;
+}
+
+int serializeOneShortname(License* license, FILE* fp) {
+  return fprintf(fp, "%s", license->shortname) > 0;
+}
+
+int serializeOneTokens(GArray* tokens, FILE* fp) {
+  for (guint i = 0; i < tokens->len; i++) {
+    if (fwrite(tokens_index(tokens,i), sizeof(Token), 1, fp) != 1) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+/*
+ * deserialization
+ */
+
+Licenses* deserializeFromFile(char* filename, unsigned minAdjacentMatches, unsigned maxLeadingDiff) {
+  FILE* fp = fopen(filename, "r");
+  if(fp == NULL) {
+    exit(3);
+  }
+  Licenses* result = deserialize(fp, minAdjacentMatches, maxLeadingDiff);
+  fclose(fp);
+  return result;
+}
+
+Licenses* deserialize(FILE* fp, unsigned minAdjacentMatches, unsigned maxLeadingDiff) {
+  GArray* licenses = g_array_new(TRUE, FALSE, sizeof(License));
+
+  SerializingMeta meta;
+  while (fread(&meta, sizeof(SerializingMeta), 1, fp) == 1) {
+    License license = { .refId = meta.refId };
+
+    license.shortname = calloc(1,(size_t) meta.shortnameLen + 1);
+    if(fread(license.shortname, sizeof(char), meta.shortnameLen, fp) != meta.shortnameLen){
+      strerror(errno);
+    }
+
+    license.tokens = deserializeTokens(fp, meta.tokensLen);
+
+    g_array_append_vals(licenses, &license, 1);
+  }
+
+  return buildLicenseIndexes(licenses, minAdjacentMatches, maxLeadingDiff);
+}
+
+GArray* deserializeTokens(FILE* fp, guint tokensLen) {
+  Token* freadResult = malloc(sizeof(Token) * tokensLen);
+  if(fread(freadResult, sizeof(Token), tokensLen, fp) != tokensLen){
+    strerror(errno);
+  }
+
+  GArray* tokens = g_array_new(FALSE, FALSE, sizeof(Token));
+  g_array_append_vals(tokens,
+                      freadResult,
+                      tokensLen);
+  free(freadResult);
+
+  return tokens;
+}

--- a/src/monk/agent/serialize.h
+++ b/src/monk/agent/serialize.h
@@ -1,0 +1,42 @@
+/*
+Author: Maximilian Huber
+Copyright (C) 2018, TNG Technology Consulting GmbH
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef MONK_AGENT_SERIALIZE_H
+#define MONK_AGENT_SERIALIZE_H
+
+#include "monk.h"
+
+typedef struct {
+  long refId;
+  size_t shortnameLen;
+  guint tokensLen;
+} SerializingMeta;
+
+int serializeToFile(Licenses* licenses, char* filename);
+int serialize(Licenses* licenses, FILE* fp);
+int serializeGArray(GArray* licenses, FILE* fp);
+int serializeOne(License* license, FILE* fp);
+int serializeOneMeta(License* license, FILE* fp);
+int serializeOneShortname(License* license, FILE* fp);
+int serializeOneTokens(GArray* tokens, FILE* fp);
+
+Licenses* deserializeFromFile(char* filename, unsigned minAdjacentMatches, unsigned maxLeadingDiff);
+Licenses* deserialize(FILE* fp, unsigned minAdjacentMatches, unsigned maxLeadingDiff);
+GArray* deserializeTokens(FILE* fp, guint tokensLen);
+
+#endif // MONK_AGENT_SERIALIZE_H

--- a/src/monk/agent_tests/Unit/Makefile
+++ b/src/monk/agent_tests/Unit/Makefile
@@ -39,7 +39,8 @@ OBJECTS = test_string_operations.o \
           test_match.o \
           test_diff.o \
           test_database.o \
-          test_encoding.o
+          test_encoding.o \
+          test_serialize.o
 
 all: $(EXE)
 

--- a/src/monk/agent_tests/Unit/run_tests.c
+++ b/src/monk/agent_tests/Unit/run_tests.c
@@ -39,6 +39,7 @@ extern CU_TestInfo diff_testcases[];
 extern CU_TestInfo match_testcases[];
 extern CU_TestInfo database_testcases[];
 extern CU_TestInfo encoding_testcases[];
+extern CU_TestInfo serialize_testcases[];
 
 extern int license_setUpFunc();
 extern int license_tearDownFunc();
@@ -61,6 +62,7 @@ CU_SuiteInfo suites[] = {
     {"Testing match:", NULL, NULL, NULL, NULL, match_testcases},
     {"Testing database:", NULL, NULL, (CU_SetUpFunc)database_setUpFunc, (CU_TearDownFunc)database_tearDownFunc, database_testcases},
     {"Testing encoding:", NULL, NULL, NULL, NULL, encoding_testcases},
+    {"Testing serialize:", NULL, NULL, NULL, NULL, serialize_testcases},
     CU_SUITE_INFO_NULL
 };
 #else
@@ -74,6 +76,7 @@ CU_SuiteInfo suites[] = {
     {"Testing match:", NULL, NULL, match_testcases},
     {"Testing database:", database_setUpFunc, database_tearDownFunc, database_testcases},
     {"Testing encoding:", NULL, NULL, encoding_testcases},
+    {"Testing serialize:", NULL, NULL, serialize_testcases},
     CU_SUITE_INFO_NULL
 };
 #endif

--- a/src/monk/agent_tests/Unit/test_serialize.c
+++ b/src/monk/agent_tests/Unit/test_serialize.c
@@ -1,0 +1,116 @@
+/*
+Author: Maximilian Huber
+Copyright (C) 2018, TNG Technology Consulting GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <stdio.h>
+#include <libfocunit.h>
+
+#include "serialize.h"
+#include "monk.h"
+#include "match.h"
+#include "license.h"
+#include "libfocunit.h"
+
+Licenses* getNLicensesWithText2(int count, ...) {
+  GArray* licenseArray = g_array_new(TRUE, FALSE, sizeof(License));
+  va_list texts;
+  va_start(texts, count);
+  for (int i = 0; i < count; i++) {
+    char* text = g_strdup(va_arg(texts, char*));
+    License license;
+    license.refId = i;
+    license.shortname = g_strdup_printf("%d-testLic", i);
+    license.tokens = tokenize(text, "^" );
+
+    g_array_append_val(licenseArray, license);
+    g_free(text);
+  }
+  va_end(texts);
+
+  return buildLicenseIndexes(licenseArray, 1, 0);
+}
+
+Licenses* roundtrip(Licenses* licenses) {
+  FILE *out, *in;
+  size_t size;
+  char *ptr;
+  out = open_memstream(&ptr, &size);
+  if (out == NULL){
+    return NULL;
+  }
+
+  serialize(licenses, out);
+  fclose(out);
+
+  in = fmemopen(ptr, size, "r");
+  Licenses* lics = deserialize(in, MIN_ADJACENT_MATCHES, MAX_LEADING_DIFF);
+
+  free(ptr);
+
+  return lics;
+}
+
+void assert_Token(Token* token1, Token* token2) {
+  CU_ASSERT_EQUAL(token1->length, token2->length);
+  CU_ASSERT_EQUAL(token1->removedBefore, token2->removedBefore);
+  CU_ASSERT_EQUAL(token1->hashedContent, token2->hashedContent);
+}
+
+void assert_License(License* lic1, License* lic2) {
+  CU_ASSERT_EQUAL(lic1->refId, lic2->refId);
+  CU_ASSERT_STRING_EQUAL(lic1->shortname, lic2->shortname);
+  CU_ASSERT_EQUAL(lic1->tokens->len, lic2->tokens->len);
+
+  for (guint i = 0; i < lic1->tokens->len; i++) {
+    Token* tokenFrom1 = tokens_index(lic1->tokens, i);
+    Token* tokenFrom2 = tokens_index(lic2->tokens, i);
+
+    assert_Token(tokenFrom1, tokenFrom2);
+  }
+}
+
+void assert_Licenses(Licenses* lics1, Licenses* lics2) {
+  CU_ASSERT_EQUAL(lics1->licenses->len, lics2->licenses->len);
+
+  for (guint i = 0; i < lics1->licenses->len; i++) {
+    License* licFrom1 = license_index(lics1->licenses, i);
+    License* licFrom2 = license_index(lics2->licenses, i);
+
+    assert_License(licFrom1, licFrom2);
+  }
+}
+
+void test_roundtrip_one() {
+  Licenses* licenses = getNLicensesWithText2(1,"a b cde f");
+  Licenses* returnedLicenses = roundtrip(licenses);
+
+  assert_Licenses(licenses, returnedLicenses);
+}
+
+void test_roundtrip() {
+  Licenses* licenses = getNLicensesWithText2(6, "a^b", "a^b^c^d", "d", "e", "f", "e^f^g");
+  Licenses* returnedLicenses = roundtrip(licenses);
+
+  assert_Licenses(licenses, returnedLicenses);
+}
+
+CU_TestInfo serialize_testcases[] = {
+  {"Test roundtrip with empty:", test_roundtrip_one},
+  {"Test roundtrip with some licenses with tokens:", test_roundtrip},
+  CU_TEST_INFO_NULL
+};


### PR DESCRIPTION
For the command line usage of monk, one has to provide the license knowledgebase in some way. Usually this is done by connecting the monk application directly to the fossology database and pulling the licenses from there.

For a lightweight setup this is problematic, since one wants to have as little overhead and dependencies as possible.

For that this PR creates the possibility to serialize the knowledgebase using the monk cli tool. The created file can be used to run monk standalone.

## standalone usage example / how to test:
(e.g. in the vagrant vm)
```
$ ./src/monk/agent/monk -s /tmp/monk.knowledgebase
Write knowledgebase to /tmp/monk.knowledgebase
$ sudo /etc/init.d/postgresql stop
 * Stopping PostgreSQL 9.3 database server
$ ./src/monk/agent/monk -k /tmp/monk.knowledgebase LICENSE
found diff match between "LICENSE" and "GPL-2.0" (rf_pk=317); rank 88; diffs: {t[484+18] M0 s[0+18], t[503+139] MR s[19+132], t[643+22] M0 s[152+22], t[666+193] MR s[175+35], t[860+22] M0 s[211+22], t[883+154] MR s[234+661], t[1038+15] M0 s[896+15], t[1054] M- s[912+629], t[1054+1836] M0 s[1542+1831], t[2912+26] M+ s[3377], t[2942+12833] M0 s[3377+12652], t[15781+4] MR s[16033+3], t[15786+35] M0 s[16037+35], t[15822+7] MR s[16073+2], t[15830+15] M0 s[16076+15], t[15846+49] MR s[16092+41], t[15901+703] M0 s[16137+675], t[16605+10] MR s[16814+11], t[16616+1072] M0 s[16826+1068], t[17692+23] MR s[17898+21], t[17716+375] M0 s[17920+372]}
found diff match between "LICENSE" and "LGPL-2.1+" (rf_pk=8); rank 99; diffs: {t[18111+5992] M0 s[0+5923], t[24123+33] M+ s[5927], t[24160+19078] M0 s[5927+18791], t[43244+4] MR s[24722+3], t[43249+35] M0 s[24726+35], t[43285+7] MR s[24762+2], t[43293+15] M0 s[24765+15], t[43309+49] MR s[24781+40], t[43364+1157] M0 s[24825+1122], t[44525+23] MR s[25951+21], t[44549+69] M0 s[25973+68]}
```

## the updated help message:
```
$ ./src/monk/agent/monk -h
Usage:

As CLI tool using the licenses from the FOSSology database:
       ./src/monk/agent/monk [options] file [file [...]]
               options:
                  -h          :: help (print this message), then exit.
                  -c config   :: specify the directory for the system configuration.
                  -v          :: verbose output.
                  -J          :: JSON output.
                  file        :: scan file and print licenses detected within it.
                  -V          :: print the version info, then exit.

Save knowledgebase to knowledgebaseFile for offline usage without db:
       ./src/monk/agent/monk [options] -s knowledgebaseFile
               options:
                  -c config   :: specify the directory for the system configuration.

Use previously saved knowledgebaseFile for offline usage without db.
       ./src/monk/agent/monk -k knowledgebaseFile [options] file [file [...]]
               options:
                  -J          :: JSON output.
                  file        :: scan file and print licenses detected within it.

The following should only be called by the FOSSology scheduler:
       ./src/monk/agent/monk --scheduler_start [options]
               options:
                  -c config   :: specify the directory for the system configuration.
                  --userID i  :: the id of the user that created the job
                  --groupID i :: the id of the group of the user that created the job
                  --jobID i   :: the id of the job
```

##

At a later point one could add support for build time generation of the knowledgebase from the information conained in the source tree.