### PR TITLE
fix(scheduler): make init script wait for postgresql on startup

### DIFF
--- a/src/scheduler/agent/defconf/init.d/fossology.in
+++ b/src/scheduler/agent/defconf/init.d/fossology.in
@@ -8,8 +8,8 @@
 #
 ### BEGIN INIT INFO
 # Provides:          {$PROJECT}
-# Required-Start:    $network $local_fs $remote_fs $syslog $named
-# Required-Stop:     $network $local_fs $remote_fs $syslog $named
+# Required-Start:    $network $local_fs $remote_fs $syslog $named postgresql
+# Required-Stop:     $network $local_fs $remote_fs $syslog $named postgresql
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: FOSSology scheduler daemon


### PR DESCRIPTION
Signed-off-by: Steve Winslow <swinslow@gmail.com>

## Description

Fixes #1171 

This makes the init script for the scheduler agent wait for PostgreSQL to start up.

### Changes

In the init script, 'postgresql' was added to the Required-Start: and Required-Stop: header lines.

## How to test

Please note that I have tested this in production, when using the Debian packages for 3.3.0, by manually making this change to `/etc/init.d/fossology`. I've confirmed that this appears to fix the recurring problem in #1171 where the scheduler would fail to start, due to the unavailability of the PostgreSQL database during boot-up.

I have not rebuilt the packages with the change made in this PR, so someone who is familiar with the packages may of course want to do so.