### PR TITLE
fix(deps): Add boost runtime dependency

### DIFF
--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -159,15 +159,15 @@ if [[ $RUNTIME ]]; then
             dpkg-dev
          case "$CODENAME" in
             trusty)
-               apt-get $YesOpt install postgresql-9.3 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl heirloom-mailx;;
+               apt-get $YesOpt install postgresql-9.3 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl heirloom-mailx libboost-program-options1.54.0 libboost-regex1.54.0;;
             jessie)
-               apt-get $YesOpt install postgresql-9.4 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl heirloom-mailx;;
+               apt-get $YesOpt install postgresql-9.4 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl heirloom-mailx libboost-program-options1.55.0 libboost-regex1.55.0;;
             xenial)
-               apt-get $YesOpt install postgresql-9.5 php7.0 libapache2-mod-php7.0 php7.0-pgsql php7.0-cli php7.0-curl php7.0-mbstring php7.0-zip s-nail;;
+               apt-get $YesOpt install postgresql-9.5 php7.0 libapache2-mod-php7.0 php7.0-pgsql php7.0-cli php7.0-curl php7.0-mbstring php7.0-zip s-nail libboost-program-options1.58.0 libboost-regex1.58.0;;
             stretch|buster|sid)
-               apt-get $YesOpt install postgresql-9.6 php7.0 php7.0-pgsql php7.0-cli php7.0-curl php7.0-xml php7.0-zip s-nail;;
+               apt-get $YesOpt install postgresql-9.6 php7.0 php7.0-pgsql php7.0-cli php7.0-curl php7.0-xml php7.0-zip s-nail libboost-program-options1.62.0 libboost-regex1.62.0;;
             bionic)
-               apt-get "$YesOpt" install postgresql-10 php7.2 php7.2-pgsql php7.2-cli php7.2-curl php7.2-xml php7.2-zip s-nail libboost-program-options1.65.1 libboost-regex1.65.1;;
+               apt-get $YesOpt install postgresql-10 php7.2 php7.2-pgsql php7.2-cli php7.2-curl php7.2-xml php7.2-zip s-nail libboost-program-options1.65.1 libboost-regex1.65.1;;
             *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
          esac
          ;;
@@ -179,7 +179,7 @@ if [[ $RUNTIME ]]; then
             smtpdaemon \
             libxml2 \
             binutils mailx \
-            sleuthkit
+            sleuthkit boost
 
          # enable, possible init, and start postgresql
          /sbin/chkconfig postgresql on
@@ -198,7 +198,7 @@ if [[ $RUNTIME ]]; then
             php php-pear php-pgsql php-process \
             smtpdaemon \
             file libxml2 \
-            binutils mailx
+            binutils mailx boost
          echo "NOTE: cabextract, sleuthkit, upx, and unrar are not"
          echo "    available in RHEL please install from upstream sources."
          ;;


### PR DESCRIPTION
## Description

Add the missing runtime dependency of boost.

### Changes

Add the missing boost regex and program options runtime dependencies.

## How to test

- Install compiled FOSSology on a fresh instance.
- Run `./utils/fo-installdeps -r -y`.

On master, copyright (and sub-agents) fails due to missing boost packages.

Install the fix and run the script again, the issue should be fixed.

Fix #1175