### PR TITLE
feat(phpunit): Migrated to namespaced phpunit.

### DIFF
--- a/src/cli/tests/test_cp2foss.php
+++ b/src/cli/tests/test_cp2foss.php
@@ -25,7 +25,7 @@ require_once("./test_common.php");
 /**
  * @outputBuffering enabled
  */
-class test_cp2foss extends PHPUnit_Framework_TestCase {
+class test_cp2foss extends \PHPUnit\Framework\TestCase {
 
   public $SYSCONF_DIR = "/usr/local/etc/fossology/";
   public $DB_NAME;

--- a/src/cli/tests/test_fo_copyright_list.php
+++ b/src/cli/tests/test_fo_copyright_list.php
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 use Fossology\Lib\Test\TestInstaller;
 use Fossology\Lib\Test\TestPgDb;
 
-class test_fo_copyright_list extends PHPUnit_Framework_TestCase {
+class test_fo_copyright_list extends \PHPUnit\Framework\TestCase {
   /** @var string scheduler_path is the absolute path to the scheduler binary */
   public $fo_copyright_list_path;
   /** @var TestPgDb */

--- a/src/cli/tests/test_fo_nomos_license_list.php
+++ b/src/cli/tests/test_fo_nomos_license_list.php
@@ -25,7 +25,7 @@ require_once("./test_common.php");
 /**
  * @outputBuffering enabled
  */
-class test_fo_nomos_license_list extends PHPUnit_Framework_TestCase {
+class test_fo_nomos_license_list extends \PHPUnit\Framework\TestCase {
 
   public $SYSCONF_DIR = "/usr/local/etc/fossology/";
   public $DB_NAME;

--- a/src/cli/tests/test_fossjobs.php
+++ b/src/cli/tests/test_fossjobs.php
@@ -25,7 +25,7 @@ require_once("./test_common.php");
 /**
  * @outputBuffering enabled
  */
-class test_fossjobs extends PHPUnit_Framework_TestCase {
+class test_fossjobs extends \PHPUnit\Framework\TestCase {
 
   // fossology_testconfig is the temporary system configuration directory
   // created by the src/testing/db/create_test_database.php script.

--- a/src/cli/tests/test_oneshot.php
+++ b/src/cli/tests/test_oneshot.php
@@ -20,7 +20,7 @@
    * \brief test for one-shot nomos/copyright
    */
 
-  class test_oneshot extends PHPUnit_Framework_TestCase {
+  class test_oneshot extends \PHPUnit\Framework\TestCase {
 
 
     /**

--- a/src/copyright/agent_tests/Functional/schedulerTest.php
+++ b/src/copyright/agent_tests/Functional/schedulerTest.php
@@ -31,7 +31,7 @@ if (!function_exists('Traceback_uri'))
   }
 }
 
-class CopyrightScheduledTest extends \PHPUnit_Framework_TestCase
+class CopyrightScheduledTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestPgDb */
   private $testDb;

--- a/src/decider/agent_tests/Functional/schedulerTest.php
+++ b/src/decider/agent_tests/Functional/schedulerTest.php
@@ -41,7 +41,7 @@ include_once(__DIR__.'/../../../lib/php/Test/Agent/AgentTestMockHelper.php');
 include_once(__DIR__.'/SchedulerTestRunnerCli.php');
 include_once(__DIR__.'/SchedulerTestRunnerMock.php');
 
-class SchedulerTest extends \PHPUnit_Framework_TestCase
+class SchedulerTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestPgDb */
   private $testDb;

--- a/src/decider/agent_tests/Unit/DeciderAgentTest.php
+++ b/src/decider/agent_tests/Unit/DeciderAgentTest.php
@@ -37,7 +37,7 @@ require_once(__DIR__ . '/../../../lib/php/Test/Agent/AgentTestMockHelper.php');
 require_once(__DIR__ . '/../../agent/DeciderAgent.php');
 
 
-class DeciderAgentTest extends \PHPUnit_Framework_TestCase
+class DeciderAgentTest extends \PHPUnit\Framework\TestCase
 {
   /** @var DbManager */
   private $dbManager;

--- a/src/deciderjob/agent_tests/Functional/schedulerTest.php
+++ b/src/deciderjob/agent_tests/Functional/schedulerTest.php
@@ -40,7 +40,7 @@ include_once(__DIR__.'/../../../lib/php/Plugin/FO_Plugin.php');
 include_once(__DIR__.'/SchedulerTestRunnerCli.php');
 include_once(__DIR__.'/SchedulerTestRunnerMock.php');
 
-class SchedulerTest extends \PHPUnit_Framework_TestCase
+class SchedulerTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestPgDb */
   private $testDb;

--- a/src/delagent/agent_tests/Functional/ft_DelagentTest.php
+++ b/src/delagent/agent_tests/Functional/ft_DelagentTest.php
@@ -23,7 +23,7 @@ require_once (__DIR__ . "/../../../testing/db/createEmptyTestEnvironment.php");
  * \brief test delagent cli
  */
 
-class ft_DelagentTest extends PHPUnit_Framework_TestCase {
+class ft_DelagentTest extends \PHPUnit\Framework\TestCase {
 
   public $SYSCONF_DIR;
   public $DB_NAME;

--- a/src/delagent/agent_tests/Functional/ft_cliDelagentTest.php
+++ b/src/delagent/agent_tests/Functional/ft_cliDelagentTest.php
@@ -26,7 +26,7 @@ require_once (__DIR__ . "/../../../testing/db/createEmptyTestEnvironment.php");
 /**
  * \class ft_cliDelagentTest - functioin test delagent agent from cli
  */
-class ft_cliDelagentTest extends PHPUnit_Framework_TestCase {
+class ft_cliDelagentTest extends \PHPUnit\Framework\TestCase {
 
   public $EXE_PATH = "";
   public $PG_CONN;

--- a/src/lib/c/tests/testClib.php
+++ b/src/lib/c/tests/testClib.php
@@ -30,7 +30,7 @@ if (!function_exists('Traceback_uri'))
   }
 }
 
-class TestCLib extends \PHPUnit_Framework_TestCase
+class TestCLib extends \PHPUnit\Framework\TestCase
 {
   /** @var TestPgDb */
   private $testDb;

--- a/src/lib/php/Application/test/LicenseCsvExportTest.php
+++ b/src/lib/php/Application/test/LicenseCsvExportTest.php
@@ -23,7 +23,7 @@ use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Test\TestLiteDb;
 use Mockery as M;
 
-class LicenseCsvExportTest extends \PHPUnit_Framework_TestCase
+class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
 {
   protected function setUp()
   {
@@ -145,4 +145,3 @@ class LicenseCsvExportTest extends \PHPUnit_Framework_TestCase
   }
 
 }
- 

--- a/src/lib/php/Application/test/LicenseCsvImportTest.php
+++ b/src/lib/php/Application/test/LicenseCsvImportTest.php
@@ -25,7 +25,7 @@ use Fossology\Lib\Test\Reflectory;
 use Fossology\Lib\Test\TestLiteDb;
 use Mockery as M;
 
-class LicenseCsvImportTest extends \PHPUnit_Framework_TestCase
+class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
 {
   protected function setUp()
   {

--- a/src/lib/php/Application/test/RepositoryApiTest.php
+++ b/src/lib/php/Application/test/RepositoryApiTest.php
@@ -16,7 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 namespace Fossology\Lib\Application;
 
-class RepositoryApiTest extends \PHPUnit_Framework_TestCase {
+class RepositoryApiTest extends \PHPUnit\Framework\TestCase {
   /** @var RepositoryApi */
   private $repositoryApi;
 

--- a/src/lib/php/Application/test/UserInfoTest.php
+++ b/src/lib/php/Application/test/UserInfoTest.php
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 namespace Fossology\Lib\Application;
 
 
-class UserInfoTest extends \PHPUnit_Framework_TestCase {
+class UserInfoTest extends \PHPUnit\Framework\TestCase {
 
   /** @var UserInfo */
   private $userInfo;
@@ -44,4 +44,3 @@ class UserInfoTest extends \PHPUnit_Framework_TestCase {
     assertThat($this->userInfo->getGroupId(), is($groupId));
   }
 }
- 

--- a/src/lib/php/BusinessRules/test/AgentLicenseEventProcessorTest.php
+++ b/src/lib/php/BusinessRules/test/AgentLicenseEventProcessorTest.php
@@ -26,7 +26,7 @@ use Fossology\Lib\Data\Tree\ItemTreeBounds;
 use Fossology\Lib\Db\DbManager;
 use Mockery as M;
 
-class AgentLicenseEventProcessorTest extends \PHPUnit_Framework_TestCase
+class AgentLicenseEventProcessorTest extends \PHPUnit\Framework\TestCase
 {
   /** @var LicenseDao|M\MockInterface */
   private $licenseDao;
@@ -240,4 +240,3 @@ class AgentLicenseEventProcessorTest extends \PHPUnit_Framework_TestCase
   }
 
 }
- 

--- a/src/lib/php/BusinessRules/test/ClearingDecisionFilterTest.php
+++ b/src/lib/php/BusinessRules/test/ClearingDecisionFilterTest.php
@@ -23,7 +23,7 @@ use Fossology\Lib\Data\DecisionScopes;
 use Fossology\Lib\Data\DecisionTypes;
 use Mockery as M;
 
-class ClearingDecisionFilterTest extends \PHPUnit_Framework_TestCase {
+class ClearingDecisionFilterTest extends \PHPUnit\Framework\TestCase {
 
   /** @var ClearingDecisionFilter */
   private $clearingDecisionFilter;
@@ -91,4 +91,3 @@ class ClearingDecisionFilterTest extends \PHPUnit_Framework_TestCase {
     assertThat($filteredClearingDecisions, containsInAnyOrder($expecedArray));
   }
 }
- 

--- a/src/lib/php/BusinessRules/test/ClearingDecisionProcessorTest.php
+++ b/src/lib/php/BusinessRules/test/ClearingDecisionProcessorTest.php
@@ -38,7 +38,7 @@ function ReportCachePurgeAll()
 
 }
 
-class ClearingDecisionProcessorTest extends \PHPUnit_Framework_TestCase
+class ClearingDecisionProcessorTest extends \PHPUnit\Framework\TestCase
 {
   const MATCH_ID = 231;
   const PERCENTAGE = 315;

--- a/src/lib/php/BusinessRules/test/ClearingEventProcessorTest.php
+++ b/src/lib/php/BusinessRules/test/ClearingEventProcessorTest.php
@@ -25,7 +25,7 @@ use Fossology\Lib\Data\LicenseRef;
 use Mockery as M;
 
 
-class ClearingEventProcessorTest extends \PHPUnit_Framework_TestCase
+class ClearingEventProcessorTest extends \PHPUnit\Framework\TestCase
 {
   private $itemId = 12;
   private $userId = 5;
@@ -184,4 +184,3 @@ class ClearingEventProcessorTest extends \PHPUnit_Framework_TestCase
   }
 
 }
- 

--- a/src/lib/php/BusinessRules/test/LicenseMapTest.php
+++ b/src/lib/php/BusinessRules/test/LicenseMapTest.php
@@ -21,7 +21,7 @@ namespace Fossology\Lib\BusinessRules;
 use Fossology\Lib\Data\LicenseRef;
 use Fossology\Lib\Test\TestPgDb;
 
-class LicenseMapTest extends \PHPUnit_Framework_TestCase
+class LicenseMapTest extends \PHPUnit\Framework\TestCase
 {
   /** @var DbManager */
   private $dbManager;

--- a/src/lib/php/Dao/test/AgentDaoTest.php
+++ b/src/lib/php/Dao/test/AgentDaoTest.php
@@ -24,7 +24,7 @@ use Fossology\Lib\Test\TestPgDb;
 use Mockery as M;
 use Monolog\Logger;
 
-class AgentDaoTest extends \PHPUnit_Framework_TestCase {
+class AgentDaoTest extends \PHPUnit\Framework\TestCase {
 
   private $uploadId = 25;
   private $olderAgentId = 3;
@@ -192,4 +192,3 @@ class AgentDaoTest extends \PHPUnit_Framework_TestCase {
   }
 
 }
- 

--- a/src/lib/php/Dao/test/ClearingDaoTest.php
+++ b/src/lib/php/Dao/test/ClearingDaoTest.php
@@ -31,7 +31,7 @@ use Mockery\MockInterface;
 use Monolog\Handler\ErrorLogHandler;
 use Monolog\Logger;
 
-class ClearingDaoTest extends \PHPUnit_Framework_TestCase
+class ClearingDaoTest extends \PHPUnit\Framework\TestCase
 {
   /** @var  TestPgDb */
   private $testDb;

--- a/src/lib/php/Dao/test/CopyrightDaoTest.php
+++ b/src/lib/php/Dao/test/CopyrightDaoTest.php
@@ -33,7 +33,7 @@ if (!function_exists('Traceback_uri'))
   }
 }
 
-class CopyrightDaoTest extends \PHPUnit_Framework_TestCase
+class CopyrightDaoTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestPgDb */
   private $testDb;

--- a/src/lib/php/Dao/test/FolderDaoTest.php
+++ b/src/lib/php/Dao/test/FolderDaoTest.php
@@ -23,7 +23,7 @@ use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Test\TestPgDb;
 use Mockery as M;
 
-class FolderDaoTest extends \PHPUnit_Framework_TestCase
+class FolderDaoTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestPgDb */
   private $testDb;

--- a/src/lib/php/Dao/test/LicenseDaoTest.php
+++ b/src/lib/php/Dao/test/LicenseDaoTest.php
@@ -27,7 +27,7 @@ use Fossology\Lib\Data\Tree\ItemTreeBounds;
 use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Test\TestPgDb;
 
-class LicenseDaoTest extends \PHPUnit_Framework_TestCase
+class LicenseDaoTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestLiteDb */
   private $testDb;

--- a/src/lib/php/Dao/test/ShowJobsDaoTest.php
+++ b/src/lib/php/Dao/test/ShowJobsDaoTest.php
@@ -24,7 +24,7 @@ use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Test\TestPgDb;
 use Mockery as M;
 
-class ShowJobsDaoTest extends \PHPUnit_Framework_TestCase
+class ShowJobsDaoTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestPgDb */
   private $testDb;

--- a/src/lib/php/Dao/test/TreeDaoTest.php
+++ b/src/lib/php/Dao/test/TreeDaoTest.php
@@ -23,7 +23,7 @@ namespace Fossology\Lib\Dao;
 use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Test\TestPgDb;
 
-class TreeDaoTest extends \PHPUnit_Framework_TestCase
+class TreeDaoTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestPgDb */
   private $testDb;

--- a/src/lib/php/Dao/test/UploadDaoTest.php
+++ b/src/lib/php/Dao/test/UploadDaoTest.php
@@ -25,7 +25,7 @@ use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Test\TestPgDb;
 use Mockery as M;
 
-class UploadDaoTest extends \PHPUnit_Framework_TestCase
+class UploadDaoTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestPgDb */
   private $testDb;

--- a/src/lib/php/Dao/test/UploadPermissionDaoTest.php
+++ b/src/lib/php/Dao/test/UploadPermissionDaoTest.php
@@ -25,7 +25,7 @@ use Mockery as M;
 
 require_once __DIR__.'/../../Plugin/FO_Plugin.php';
 
-class UploadPermissionDaoTest extends \PHPUnit_Framework_TestCase
+class UploadPermissionDaoTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestPgDb */
   private $testDb;

--- a/src/lib/php/Dao/test/UserDaoTest.php
+++ b/src/lib/php/Dao/test/UserDaoTest.php
@@ -23,7 +23,7 @@ use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Test\TestLiteDb;
 use Monolog\Logger;
 
-class UserDaoTest extends \PHPUnit_Framework_TestCase
+class UserDaoTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestLiteDb */
   private $testDb;

--- a/src/lib/php/Data/Clearing/test/AgentClearingEventTest.php
+++ b/src/lib/php/Data/Clearing/test/AgentClearingEventTest.php
@@ -22,7 +22,7 @@ use Fossology\Lib\Data\AgentRef;
 use Fossology\Lib\Data\LicenseRef;
 use Mockery as M;
 
-class AgentClearingEventTest extends \PHPUnit_Framework_TestCase {
+class AgentClearingEventTest extends \PHPUnit\Framework\TestCase {
   /** @var LicenseRef|M\MockInterface */
   private $licenseRef;
 
@@ -120,4 +120,3 @@ class AgentClearingEventTest extends \PHPUnit_Framework_TestCase {
     assertThat($this->agentClearingEvent->getPercentage(), is($this->percentage));
   }
 }
- 

--- a/src/lib/php/Data/Clearing/test/ClearingEventTest.php
+++ b/src/lib/php/Data/Clearing/test/ClearingEventTest.php
@@ -20,7 +20,7 @@ namespace Fossology\Lib\Data\Clearing;
 
 use Mockery as M;
 
-class ClearingEventTest extends \PHPUnit_Framework_TestCase
+class ClearingEventTest extends \PHPUnit\Framework\TestCase
 {
   /** @var int */
   private $eventId = 12;
@@ -102,4 +102,3 @@ class ClearingEventTest extends \PHPUnit_Framework_TestCase
     assertThat($this->licenseDecisionEvent->getGroupId(), is($this->groupId));
   }
 }
- 

--- a/src/lib/php/Data/Clearing/test/ClearingResultTest.php
+++ b/src/lib/php/Data/Clearing/test/ClearingResultTest.php
@@ -22,7 +22,7 @@ use Fossology\Lib\Data\LicenseRef;
 use Fossology\Lib\Exception;
 use Mockery as M;
 
-class ClearingResultTest extends \PHPUnit_Framework_TestCase
+class ClearingResultTest extends \PHPUnit\Framework\TestCase
 {
 
   /** @var LicenseRef|M\MockInterface */
@@ -239,4 +239,3 @@ class ClearingResultTest extends \PHPUnit_Framework_TestCase
     new ClearingResult(null);
   }
 }
- 

--- a/src/lib/php/Data/Folder/test/FolderTest.php
+++ b/src/lib/php/Data/Folder/test/FolderTest.php
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 namespace Fossology\Lib\Data\Folder;
 
 
-class FolderTest extends \PHPUnit_Framework_TestCase {
+class FolderTest extends \PHPUnit\Framework\TestCase {
 
   /** @var int */
   private $folderId = 32;
@@ -56,4 +56,3 @@ class FolderTest extends \PHPUnit_Framework_TestCase {
     assertThat($this->folder->getPermissions(), is($this->folderPermissions));
   }
 }
- 

--- a/src/lib/php/Data/Package/test/PackageTest.php
+++ b/src/lib/php/Data/Package/test/PackageTest.php
@@ -22,7 +22,7 @@ use Fossology\Lib\Data\Upload\Upload;
 use Mockery as M;
 
 
-class PackageTest extends \PHPUnit_Framework_TestCase {
+class PackageTest extends \PHPUnit\Framework\TestCase {
 
   private $id = 123;
 
@@ -54,4 +54,3 @@ class PackageTest extends \PHPUnit_Framework_TestCase {
     assertThat($this->package->getUploads(), is($this->uploads));
   }
 }
- 

--- a/src/lib/php/Data/Tree/test/ItemTest.php
+++ b/src/lib/php/Data/Tree/test/ItemTest.php
@@ -23,7 +23,7 @@ use Mockery as M;
 
 require_once(__DIR__ . '/../../../common-dir.php');
 
-class ItemTest extends \PHPUnit_Framework_TestCase
+class ItemTest extends \PHPUnit\Framework\TestCase
 {
   private $id = 234;
   private $parentId = 432;
@@ -111,4 +111,3 @@ class ItemTest extends \PHPUnit_Framework_TestCase
   }
 
 }
- 

--- a/src/lib/php/Data/Tree/test/ItemTreeBoundsTest.php
+++ b/src/lib/php/Data/Tree/test/ItemTreeBoundsTest.php
@@ -20,7 +20,7 @@ namespace Fossology\Lib\Dao\Data;
 
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
 
-class ItemTreeBoundsTest extends \PHPUnit_Framework_TestCase
+class ItemTreeBoundsTest extends \PHPUnit\Framework\TestCase
 {
 
   /**
@@ -81,4 +81,3 @@ class ItemTreeBoundsTest extends \PHPUnit_Framework_TestCase
     assertThat($this->itemTreeBounds->containsFiles(), is(false));
   }
 }
- 

--- a/src/lib/php/Data/Upload/test/UploadTest.php
+++ b/src/lib/php/Data/Upload/test/UploadTest.php
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 namespace Fossology\Lib\Data\Upload;
 
 
-class UploadTest extends \PHPUnit_Framework_TestCase
+class UploadTest extends \PHPUnit\Framework\TestCase
 {
   /** @var int */
   private $id = 132;
@@ -90,4 +90,3 @@ class UploadTest extends \PHPUnit_Framework_TestCase
     assertThat($upload->getTimestamp(), is($this->timestamp));
   }
 }
- 

--- a/src/lib/php/Data/test/AgentRefTest.php
+++ b/src/lib/php/Data/test/AgentRefTest.php
@@ -18,7 +18,7 @@
 
 namespace Fossology\Lib\Data;
 
-class AgentRefTest extends \PHPUnit_Framework_TestCase
+class AgentRefTest extends \PHPUnit\Framework\TestCase
 {
   private $agentId = 1243;
   private $agentName = "<agentName>";

--- a/src/lib/php/Data/test/ClearingDecisionBuilderTest.php
+++ b/src/lib/php/Data/test/ClearingDecisionBuilderTest.php
@@ -25,7 +25,7 @@ use Fossology\Lib\Data\Clearing\ClearingEvent;
 use Fossology\Lib\Data\Clearing\ClearingLicense;
 use Mockery as M;
 
-class ClearingDecisionBuilderTest extends \PHPUnit_Framework_TestCase
+class ClearingDecisionBuilderTest extends \PHPUnit\Framework\TestCase
 {
   /** @var bool */
   private $sameUpload = true;
@@ -181,4 +181,3 @@ class ClearingDecisionBuilderTest extends \PHPUnit_Framework_TestCase
   }
 
 }
- 

--- a/src/lib/php/Data/test/HighlightTest.php
+++ b/src/lib/php/Data/test/HighlightTest.php
@@ -22,7 +22,7 @@ namespace Fossology\Lib\Data;
 use Fossology\Lib\Html\HtmlElement;
 use Mockery as M;
 
-class HighlightTest extends \PHPUnit_Framework_TestCase
+class HighlightTest extends \PHPUnit\Framework\TestCase
 {
   private $start = 10;
   private $end = 12;
@@ -100,4 +100,3 @@ class HighlightTest extends \PHPUnit_Framework_TestCase
     assertThat($this->highlight->getHtmlElement(), is($this->htmlElement));
   }
 }
- 

--- a/src/lib/php/Data/test/LicenseMatchTest.php
+++ b/src/lib/php/Data/test/LicenseMatchTest.php
@@ -19,7 +19,7 @@
 
 namespace Fossology\Lib\Data;
 
-class LicenseMatchTest extends \PHPUnit_Framework_TestCase
+class LicenseMatchTest extends \PHPUnit\Framework\TestCase
 {
   /** @var LicenseRef */
   private $licenseRef;

--- a/src/lib/php/Data/test/LicenseRefTest.php
+++ b/src/lib/php/Data/test/LicenseRefTest.php
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 namespace Fossology\Lib\Data;
 
-class LicenseRefTest extends \PHPUnit_Framework_TestCase
+class LicenseRefTest extends \PHPUnit\Framework\TestCase
 {
   private $id = 321;
   private $shortName = "<shortName>";
@@ -51,4 +51,3 @@ class LicenseRefTest extends \PHPUnit_Framework_TestCase
   }
 
 }
- 

--- a/src/lib/php/Data/test/LicenseTest.php
+++ b/src/lib/php/Data/test/LicenseTest.php
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 namespace Fossology\Lib\Data;
 
 
-class LicenseTest extends \PHPUnit_Framework_TestCase {
+class LicenseTest extends \PHPUnit\Framework\TestCase {
   /** @var string */
   private $text;
   /** @var string */
@@ -46,4 +46,3 @@ class LicenseTest extends \PHPUnit_Framework_TestCase {
     assertThat($this->license->getUrl(), is($this->url));
   }
 }
- 

--- a/src/lib/php/Data/test/TextFragmentTest.php
+++ b/src/lib/php/Data/test/TextFragmentTest.php
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 namespace Fossology\Lib\Data;
 
 
-class TextFragmentTest extends \PHPUnit_Framework_TestCase
+class TextFragmentTest extends \PHPUnit\Framework\TestCase
 {
   const START_OFFSET = 10;
 
@@ -67,4 +67,3 @@ class TextFragmentTest extends \PHPUnit_Framework_TestCase
     assertThat($this->fragment->getSlice(self::START_OFFSET + 9, self::START_OFFSET + 9 + 3), is("az"));
   }
 }
- 

--- a/src/lib/php/Db/test/DbManagerTest.php
+++ b/src/lib/php/Db/test/DbManagerTest.php
@@ -21,7 +21,7 @@ namespace Fossology\Lib\Db;
 use Mockery as M;
 use Mockery\MockInterface;
 
-abstract class DbManagerTest extends \PHPUnit_Framework_TestCase
+abstract class DbManagerTest extends \PHPUnit\Framework\TestCase
 {
   /** @var Driver|MockInterface */
   protected $driver;

--- a/src/lib/php/Html/test/LinkElementTest.php
+++ b/src/lib/php/Html/test/LinkElementTest.php
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 namespace Fossology\Lib\Html;
 
 
-class LinkElementTest extends \PHPUnit_Framework_TestCase {
+class LinkElementTest extends \PHPUnit\Framework\TestCase {
 
   public function testLinkElement()
   {
@@ -31,4 +31,3 @@ class LinkElementTest extends \PHPUnit_Framework_TestCase {
   }
 
 }
- 

--- a/src/lib/php/Html/test/SimpleElementTest.php
+++ b/src/lib/php/Html/test/SimpleElementTest.php
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 namespace Fossology\Lib\Html;
 
 
-class SimpleHtmlElementTest extends \PHPUnit_Framework_TestCase
+class SimpleHtmlElementTest extends \PHPUnit\Framework\TestCase
 {
 
   public function testElementWithoutAttributes()
@@ -56,4 +56,3 @@ class SimpleHtmlElementTest extends \PHPUnit_Framework_TestCase
     assertThat($element->getClosingText(), is("</p>"));
   }
 }
- 

--- a/src/lib/php/Plugin/test/DefaultPluginTest.php
+++ b/src/lib/php/Plugin/test/DefaultPluginTest.php
@@ -75,7 +75,7 @@ class TestPlugin extends DefaultPlugin
   }
 }
 
-class DefaultPluginTest extends \PHPUnit_Framework_TestCase
+class DefaultPluginTest extends \PHPUnit\Framework\TestCase
 {
   private $name = "<name>";
 

--- a/src/lib/php/Proxy/test/DbViewProxyTest.php
+++ b/src/lib/php/Proxy/test/DbViewProxyTest.php
@@ -21,7 +21,7 @@ namespace Fossology\Lib\Proxy;
 use Mockery as M;
 use Fossology\Lib\Db\DbManager;
 
-class DbViewProxyTest extends \PHPUnit_Framework_TestCase
+class DbViewProxyTest extends \PHPUnit\Framework\TestCase
 {
   private $dbViewName = "foo";
   private $dbViewQuery = "select 3.14";

--- a/src/lib/php/Proxy/test/LatestScannerProxyTest.php
+++ b/src/lib/php/Proxy/test/LatestScannerProxyTest.php
@@ -22,7 +22,7 @@ use Fossology\Lib\Test\TestLiteDb;
 use Mockery as M;
 
 
-class LatestScannerProxyTest extends \PHPUnit_Framework_TestCase
+class LatestScannerProxyTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestLiteDb */
   private $testDb;

--- a/src/lib/php/Proxy/test/LicenseViewProxyTest.php
+++ b/src/lib/php/Proxy/test/LicenseViewProxyTest.php
@@ -22,7 +22,7 @@ use Mockery as M;
 use Fossology\Lib\Db\DbManager;
 
 
-class LicenseViewProxyTest extends \PHPUnit_Framework_TestCase
+class LicenseViewProxyTest extends \PHPUnit\Framework\TestCase
 {
   private $dbManagerMock;
 

--- a/src/lib/php/Proxy/test/ScanJobProxyTest.php
+++ b/src/lib/php/Proxy/test/ScanJobProxyTest.php
@@ -23,7 +23,7 @@ use Fossology\Lib\Data\AgentRef;
 use Mockery as M;
 
 
-class ScanJobProxyTest extends \PHPUnit_Framework_TestCase
+class ScanJobProxyTest extends \PHPUnit\Framework\TestCase
 {
   private $agentDaoMock;
   private $uploadId = 23;

--- a/src/lib/php/Proxy/test/UploadBrowseProxyTest.php
+++ b/src/lib/php/Proxy/test/UploadBrowseProxyTest.php
@@ -23,7 +23,7 @@ use Fossology\Lib\Dao\UserDao;
 use Fossology\Lib\Data\UploadStatus;
 use Fossology\Lib\Test\TestPgDb;
 
-class UploadBrowseProxyTest extends \PHPUnit_Framework_TestCase
+class UploadBrowseProxyTest extends \PHPUnit\Framework\TestCase
 {
   private $testDb;
   private $groupId = 401;
@@ -247,4 +247,3 @@ class UploadBrowseProxyTest extends \PHPUnit_Framework_TestCase
     $uploadBrowseProxy->getStatus(-1);
   }
 }
- 

--- a/src/lib/php/Proxy/test/UploadTreeProxyTest.php
+++ b/src/lib/php/Proxy/test/UploadTreeProxyTest.php
@@ -22,7 +22,7 @@ use Fossology\Lib\Data\DecisionTypes;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
 use Fossology\Lib\Test\TestPgDb;
 
-class UploadTreeProxyTest extends \PHPUnit_Framework_TestCase
+class UploadTreeProxyTest extends \PHPUnit\Framework\TestCase
 {
   private $testDb;
 

--- a/src/lib/php/Proxy/test/UploadTreeViewProxyTest.php
+++ b/src/lib/php/Proxy/test/UploadTreeViewProxyTest.php
@@ -21,7 +21,7 @@ namespace Fossology\Lib\Proxy;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
 use Mockery as M;
 
-class UploadTreeViewProxyTest extends \PHPUnit_Framework_TestCase
+class UploadTreeViewProxyTest extends \PHPUnit\Framework\TestCase
 {
   private $viewSuffix = "<suffix>";
 
@@ -143,4 +143,3 @@ class UploadTreeViewProxyTest extends \PHPUnit_Framework_TestCase
     new UploadTreeViewProxy($this->itemTreeBounds, array('bar'));
   }
 }
- 

--- a/src/lib/php/Report/tests/ClearedGetterCommonTest.php
+++ b/src/lib/php/Report/tests/ClearedGetterCommonTest.php
@@ -59,7 +59,7 @@ class WeirdCharClearedGetter extends ClearedGetterCommon
   }
 }
 
-class ClearedComonReportTest extends \PHPUnit_Framework_TestCase
+class ClearedComonReportTest extends \PHPUnit\Framework\TestCase
 {
   /** @var UploadDao|MockInterface */
   private $uploadDao;

--- a/src/lib/php/Test/EnumMapTestBase.php
+++ b/src/lib/php/Test/EnumMapTestBase.php
@@ -20,7 +20,7 @@ namespace Fossology\Lib\Test;
 
 use Fossology\Lib\Data\Types;
 
-class EnumMapTestBase extends \PHPUnit_Framework_TestCase {
+class EnumMapTestBase extends \PHPUnit\Framework\TestCase {
 
   /** @var Types */
   private $types;

--- a/src/lib/php/Test/test/ReflectoryTest.php
+++ b/src/lib/php/Test/test/ReflectoryTest.php
@@ -32,7 +32,7 @@ class ClassWithPrivateMethod
   }
 }
 
-class ReflectoryTest extends \PHPUnit_Framework_TestCase
+class ReflectoryTest extends \PHPUnit\Framework\TestCase
 {
   protected function setUp()
   {

--- a/src/lib/php/Test/test/TestLiteDbTest.php
+++ b/src/lib/php/Test/test/TestLiteDbTest.php
@@ -18,7 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 namespace Fossology\Lib\Test;
 
-class TestLiteDbTest extends \PHPUnit_Framework_TestCase
+class TestLiteDbTest extends \PHPUnit\Framework\TestCase
 {
 
   public function testGetDbManager(){

--- a/src/lib/php/Test/test/TestPgDbTest.php
+++ b/src/lib/php/Test/test/TestPgDbTest.php
@@ -18,7 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 namespace Fossology\Lib\Test;
 
-class TestPgDbTest extends \PHPUnit_Framework_TestCase
+class TestPgDbTest extends \PHPUnit\Framework\TestCase
 {
   
   public function testIfTestDbIsCreated()

--- a/src/lib/php/Text/tests/EncodingConverterTest.php
+++ b/src/lib/php/Text/tests/EncodingConverterTest.php
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 namespace Fossology\Lib\Text;
 
 
-class EncodingConverterTest extends \PHPUnit_Framework_TestCase
+class EncodingConverterTest extends \PHPUnit\Framework\TestCase
 {
 
   private $testString = "äöüßÄÖÜ";
@@ -64,4 +64,3 @@ class EncodingConverterTest extends \PHPUnit_Framework_TestCase
   }
 
 }
- 

--- a/src/lib/php/UI/test/FolderNavTest.php
+++ b/src/lib/php/UI/test/FolderNavTest.php
@@ -29,7 +29,7 @@ function Traceback_uri()
   return 'uri';
 }
 
-class FolderNavTest extends \PHPUnit_Framework_TestCase
+class FolderNavTest extends \PHPUnit\Framework\TestCase
 {
   /** @var M */
   private $dbManager;

--- a/src/lib/php/Util/test/ArrayOperationTest.php
+++ b/src/lib/php/Util/test/ArrayOperationTest.php
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 namespace Fossology\Lib\Util;
 
 
-class ArrayOperationTest extends \PHPUnit_Framework_TestCase
+class ArrayOperationTest extends \PHPUnit\Framework\TestCase
 {
   
   protected function setUp()
@@ -93,4 +93,3 @@ class ArrayOperationTest extends \PHPUnit_Framework_TestCase
   }
   
 }
- 

--- a/src/lib/php/Util/test/StringOperationTest.php
+++ b/src/lib/php/Util/test/StringOperationTest.php
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 namespace Fossology\Lib\Util;
 
 
-class StringOperationTest extends \PHPUnit_Framework_TestCase
+class StringOperationTest extends \PHPUnit\Framework\TestCase
 {
   
   protected function setUp()
@@ -44,4 +44,3 @@ class StringOperationTest extends \PHPUnit_Framework_TestCase
    }
   
 }
- 

--- a/src/lib/php/Util/test/TimingLoggerTest.php
+++ b/src/lib/php/Util/test/TimingLoggerTest.php
@@ -29,7 +29,7 @@ class HackedTimingLogger extends TimingLogger
   }
 }
 
-class TimingLoggerTest extends \PHPUnit_Framework_TestCase
+class TimingLoggerTest extends \PHPUnit\Framework\TestCase
 {
   private $logger;
   
@@ -77,4 +77,3 @@ class TimingLoggerTest extends \PHPUnit_Framework_TestCase
   }
   
 }
- 

--- a/src/lib/php/View/test/HighlightProcessorTest.php
+++ b/src/lib/php/View/test/HighlightProcessorTest.php
@@ -25,7 +25,7 @@ use Fossology\Lib\Data\License;
 use Fossology\Lib\Data\SplitPosition;
 use Mockery as M;
 
-class HighlightProcessorTest extends \PHPUnit_Framework_TestCase
+class HighlightProcessorTest extends \PHPUnit\Framework\TestCase
 {
   /** @var License */
   private $license1;

--- a/src/lib/php/View/test/HighlightRendererTest.php
+++ b/src/lib/php/View/test/HighlightRendererTest.php
@@ -26,7 +26,7 @@ use Fossology\Lib\Html\SimpleHtmlElement;
 use Mockery\MockInterface;
 use Mockery as M;
 
-class HighlightRendererTest extends \PHPUnit_Framework_TestCase
+class HighlightRendererTest extends \PHPUnit\Framework\TestCase
 {
   /** @var int */
   private $level = 5;

--- a/src/lib/php/View/test/HighlightStateTest.php
+++ b/src/lib/php/View/test/HighlightStateTest.php
@@ -20,11 +20,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 namespace Fossology\Lib\View;
 
 
-class HighlightStateTest extends \PHPUnit_Framework_TestCase {
+class HighlightStateTest extends \PHPUnit\Framework\TestCase {
 
   public function testBla() {
     $highlightState = new HighlightState(new HighlightRenderer());
   }
 
 }
- 

--- a/src/lib/php/View/test/PagedHexResultTest.php
+++ b/src/lib/php/View/test/PagedHexResultTest.php
@@ -22,7 +22,7 @@ namespace Fossology\Lib\View;
 
 use Mockery as M;
 
-class PagedHexResultTest extends \PHPUnit_Framework_TestCase
+class PagedHexResultTest extends \PHPUnit\Framework\TestCase
 {
 
   const START_OFFSET = 5;
@@ -86,4 +86,3 @@ class PagedHexResultTest extends \PHPUnit_Framework_TestCase
         is("0x00000005 |66 6f 6f 20 <b>62 61 72 </b>62 61 7a 20 64 6f 6e 65 __| |foo&nbsp;<b>bar</b>baz&nbsp;done&nbsp;|"));
   }
 }
- 

--- a/src/lib/php/View/test/PagedResultTest.php
+++ b/src/lib/php/View/test/PagedResultTest.php
@@ -31,7 +31,7 @@ class TestPagedResult extends PagedResult {
   }
 }
 
-class PagedResultTest extends \PHPUnit_Framework_TestCase {
+class PagedResultTest extends \PHPUnit\Framework\TestCase {
 
   const START_OFFSET = 12;
   const META_TEXT = "<meta>";
@@ -98,4 +98,3 @@ class PagedResultTest extends \PHPUnit_Framework_TestCase {
   }
 
 }
- 

--- a/src/lib/php/View/test/PagedTextResultTest.php
+++ b/src/lib/php/View/test/PagedTextResultTest.php
@@ -24,7 +24,7 @@ if(!function_exists('') )
   require_once(__DIR__."/../../common-string.php");
 }
 
-class PagedTextResultTest extends \PHPUnit_Framework_TestCase {
+class PagedTextResultTest extends \PHPUnit\Framework\TestCase {
 
   const START_OFFSET = 15;
 
@@ -53,4 +53,3 @@ class PagedTextResultTest extends \PHPUnit_Framework_TestCase {
   }
 
 }
- 

--- a/src/lib/php/View/test/TextRendererTest.php
+++ b/src/lib/php/View/test/TextRendererTest.php
@@ -25,7 +25,7 @@ use Mockery as M;
 
 require_once __DIR__.'/../../common-string.php';
 
-class TextRendererTest extends \PHPUnit_Framework_TestCase
+class TextRendererTest extends \PHPUnit\Framework\TestCase
 {
   const START_OFFSET = 10;
   const FRAGMENT_TEXT = "foo bar baz quux";

--- a/src/lib/php/View/test/UrlBuilderTest.php
+++ b/src/lib/php/View/test/UrlBuilderTest.php
@@ -26,7 +26,7 @@ function Traceback_uri()
   return "http://localhost/repo";
 }
 
-class UrlBuilderTest extends \PHPUnit_Framework_TestCase
+class UrlBuilderTest extends \PHPUnit\Framework\TestCase
 {
   /** @var UrlBuilder */
   private $urlBuilder;
@@ -54,4 +54,3 @@ class UrlBuilderTest extends \PHPUnit_Framework_TestCase
         "'License text','width=600,height=400,toolbar=no,scrollbars=yes,resizable=yes');\">$shortName</a>"));
   }
 }
- 

--- a/src/lib/php/tests/test_common_active.php
+++ b/src/lib/php/tests/test_common_active.php
@@ -26,7 +26,7 @@ require_once(dirname(__FILE__) .'/../common-active.php');
 /**
  * \class test_common_active
  */
-class test_common_active extends PHPUnit_Framework_TestCase
+class test_common_active extends \PHPUnit\Framework\TestCase
 {
   /**
    * \brief initialization

--- a/src/lib/php/tests/test_common_auth.php
+++ b/src/lib/php/tests/test_common_auth.php
@@ -26,7 +26,7 @@ require_once(dirname(__FILE__) . '/../common-auth.php');
 /**
  * \class test_common_auth
  */
-class test_common_auth extends PHPUnit_Framework_TestCase
+class test_common_auth extends \PHPUnit\Framework\TestCase
 {
   /* initialization */
   protected function setUp()

--- a/src/lib/php/tests/test_common_cache.php
+++ b/src/lib/php/tests/test_common_cache.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/../common-db.php');
 /**
  * \class test_common_cache
  */
-class test_common_cached extends PHPUnit_Framework_TestCase
+class test_common_cached extends \PHPUnit\Framework\TestCase
 {
   public $PG_CONN;
   public $upload_pk = 0;

--- a/src/lib/php/tests/test_common_cli.php
+++ b/src/lib/php/tests/test_common_cli.php
@@ -26,7 +26,7 @@ require_once(dirname(__FILE__) . '/../common-cli.php');
 /**
  * \class test_common_cli
  */
-class test_common_cli extends PHPUnit_Framework_TestCase
+class test_common_cli extends \PHPUnit\Framework\TestCase
 {
   /**
    * \brief initialization

--- a/src/lib/php/tests/test_common_dir.php
+++ b/src/lib/php/tests/test_common_dir.php
@@ -26,7 +26,7 @@ require_once(dirname(__FILE__) . '/../common-dir.php');
 /**
  * \class test_common_dir
  */
-class test_common_dir extends PHPUnit_Framework_TestCase
+class test_common_dir extends \PHPUnit\Framework\TestCase
 {
   /* initialization */
   protected function setUp()

--- a/src/lib/php/tests/test_common_license_file.php
+++ b/src/lib/php/tests/test_common_license_file.php
@@ -32,7 +32,7 @@ require_once(dirname(__FILE__) . '/../common-ui.php');
 /**
  * \class test_common_license_file
  */
-class test_common_license_file extends PHPUnit_Framework_TestCase
+class test_common_license_file extends \PHPUnit\Framework\TestCase
 {
   public $upload_pk = 0;
   public $uploadtree_pk_parent = 0;

--- a/src/lib/php/tests/test_common_menu.php
+++ b/src/lib/php/tests/test_common_menu.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/../common-parm.php');
 /**
  * \class test_common_menu
  */
-class test_common_menu extends PHPUnit_Framework_TestCase
+class test_common_menu extends \PHPUnit\Framework\TestCase
 {
   /* initialization */
   protected function setUp()

--- a/src/lib/php/tests/test_common_parm.php
+++ b/src/lib/php/tests/test_common_parm.php
@@ -26,7 +26,7 @@ require_once(dirname(__FILE__) . '/../common-parm.php');
 /**
  * \class test_common_parm
  */
-class test_common_parm extends PHPUnit_Framework_TestCase
+class test_common_parm extends \PHPUnit\Framework\TestCase
 {
   /* initialization */
   protected function setUp()

--- a/src/lib/php/tests/test_common_pkg.php
+++ b/src/lib/php/tests/test_common_pkg.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/../common-db.php');
 /**
  * \class test_common_pkg
  */
-class test_common_pkg extends PHPUnit_Framework_TestCase
+class test_common_pkg extends \PHPUnit\Framework\TestCase
 {
   public $PG_CONN;
   public $DB_COMMAND =  "";

--- a/src/lib/php/tests/test_common_sysconfig.php
+++ b/src/lib/php/tests/test_common_sysconfig.php
@@ -28,7 +28,7 @@ require_once(dirname(dirname(__FILE__)) . '/common-sysconfig.php');
 /**
  * \class test_common_sysconfig
  */
-class test_common_sysconfig extends PHPUnit_Framework_TestCase
+class test_common_sysconfig extends \PHPUnit\Framework\TestCase
 {
   public $PG_CONN;
   public $DB_COMMAND =  "";

--- a/src/lib/php/tests/test_common_ui.php
+++ b/src/lib/php/tests/test_common_ui.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/../common-ui.php');
 /**
  * \class test_common_dir
  */
-class test_common_ui extends \PHPUnit_Framework_TestCase
+class test_common_ui extends \PHPUnit\Framework\TestCase
 {
   /* initialization */
   protected function setUp()

--- a/src/mimetype/agent_tests/Functional/cliParamsTest4Mimetype.php
+++ b/src/mimetype/agent_tests/Functional/cliParamsTest4Mimetype.php
@@ -29,7 +29,7 @@ require_once (__DIR__ . "/../../../testing/db/createEmptyTestEnvironment.php");
 /**
  * \class cliParamsTest4Mimetype - test mimetype agent from cli
  */
-class cliParamsTest4Mimetype extends PHPUnit_Framework_TestCase {
+class cliParamsTest4Mimetype extends \PHPUnit\Framework\TestCase {
 
   public $EXE_PATH = "";
   public $PG_CONN;

--- a/src/monk/agent_tests/Functional/bulkTest.php
+++ b/src/monk/agent_tests/Functional/bulkTest.php
@@ -29,7 +29,7 @@ use Fossology\Lib\Test\TestPgDb;
 use Monolog\Logger;
 
 
-class MonkBulkTest extends \PHPUnit_Framework_TestCase
+class MonkBulkTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestPgDb */
   private $testDb;

--- a/src/monk/agent_tests/Functional/cliTest.php
+++ b/src/monk/agent_tests/Functional/cliTest.php
@@ -20,7 +20,7 @@ use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Test\TestPgDb;
 
 
-class MonkCliTest extends \PHPUnit_Framework_TestCase
+class MonkCliTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestPgDb */
   private $testDb;

--- a/src/monk/agent_tests/Functional/schedulerTest.php
+++ b/src/monk/agent_tests/Functional/schedulerTest.php
@@ -31,7 +31,7 @@ use Fossology\Lib\Test\TestPgDb;
 use Monolog\Logger;
 
 
-class MonkScheduledTest extends PHPUnit_Framework_TestCase
+class MonkScheduledTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestPgDb */
   private $testDb;

--- a/src/ninka/agent_tests/Functional/schedulerTest.php
+++ b/src/ninka/agent_tests/Functional/schedulerTest.php
@@ -32,7 +32,7 @@ if (!function_exists('Traceback_uri'))
   }
 }
 
-class NinkaScheduledTest extends \PHPUnit_Framework_TestCase
+class NinkaScheduledTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestPgDb */
   private $testDb;

--- a/src/nomos/agent_tests/Functional/CommonCliTest.php
+++ b/src/nomos/agent_tests/Functional/CommonCliTest.php
@@ -19,7 +19,7 @@
 use Fossology\Lib\Test\TestInstaller;
 use Fossology\Lib\Test\TestPgDb;
 
-class CommonCliTest extends PHPUnit_Framework_TestCase
+class CommonCliTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestPgDb */
   protected $testDb;

--- a/src/pkgagent/agent_tests/Functional/ft_cliPkgagentTest.php
+++ b/src/pkgagent/agent_tests/Functional/ft_cliPkgagentTest.php
@@ -26,7 +26,7 @@
 
 require_once (__DIR__ . "/../../../testing/db/createEmptyTestEnvironment.php");
 
-class ft_cliPkgagentTest extends PHPUnit_Framework_TestCase {
+class ft_cliPkgagentTest extends \PHPUnit\Framework\TestCase {
 
   public $agentDir;
   public $pkgagent;

--- a/src/reuser/agent_tests/Functional/schedulerTest.php
+++ b/src/reuser/agent_tests/Functional/schedulerTest.php
@@ -41,7 +41,7 @@ include_once(__DIR__.'/../../../lib/php/Test/Agent/AgentTestMockHelper.php');
 include_once(__DIR__.'/SchedulerTestRunnerCli.php');
 include_once(__DIR__.'/SchedulerTestRunnerMock.php');
 
-class SchedulerTest extends \PHPUnit_Framework_TestCase
+class SchedulerTest extends \PHPUnit\Framework\TestCase
 {
   private $groupId = 3;
   private $userId = 2;

--- a/src/spdx2/agent_tests/Functional/schedulerTest.php
+++ b/src/spdx2/agent_tests/Functional/schedulerTest.php
@@ -26,7 +26,7 @@ use Fossology\Lib\Test\TestPgDb;
 include_once(__DIR__.'/../../../lib/php/Test/Agent/AgentTestMockHelper.php');
 include_once(__DIR__.'/SchedulerTestRunnerCli.php');
 
-class SchedulerTest extends \PHPUnit_Framework_TestCase
+class SchedulerTest extends \PHPUnit\Framework\TestCase
 {
   /** @var int */
   private $userId = 2;

--- a/src/spdx2/agent_tests/Unit/spdx2utilTest.php
+++ b/src/spdx2/agent_tests/Unit/spdx2utilTest.php
@@ -21,7 +21,7 @@ namespace Fossology\SpdxTwo;
 
 require_once(__DIR__ . '/../../agent/spdx2utils.php');
 
-class spdx2Test extends \PHPUnit_Framework_TestCase
+class spdx2Test extends \PHPUnit\Framework\TestCase
 {
   private $assertCountBefore;
 

--- a/src/testing/install/test4migrationinstall/test_cp2foss.php
+++ b/src/testing/install/test4migrationinstall/test_cp2foss.php
@@ -25,7 +25,7 @@ require_once("./test_common.php");
 /**
  * @outputBuffering enabled
  */
-class test_cp2foss extends PHPUnit_Framework_TestCase {
+class test_cp2foss extends \PHPUnit\Framework\TestCase {
 
   public $DB_NAME;
   public $PG_CONN;

--- a/src/testing/install/test4packageinstall/test_cp2foss.php
+++ b/src/testing/install/test4packageinstall/test_cp2foss.php
@@ -25,7 +25,7 @@ require_once("./test_common.php");
 /**
  * @outputBuffering enabled
  */
-class test_cp2foss extends PHPUnit_Framework_TestCase {
+class test_cp2foss extends \PHPUnit\Framework\TestCase {
 
   public $DB_NAME;
   public $PG_CONN;

--- a/src/testing/templates/PHPUnit/templatePHPUnit.php
+++ b/src/testing/templates/PHPUnit/templatePHPUnit.php
@@ -37,7 +37,7 @@ require_once '/usr/share/php/PHPUnit/Framework.php';
 global $GlobalReady;
 $GlobalReady=TRUE;
 
-class cli1Test extends PHPUnit_Framework_TestCase
+class cli1Test extends \PHPUnit\Framework\TestCase
 {
 	public function testHelp()
 	{

--- a/src/unifiedreport/agent_tests/Functional/schedulerTest.php
+++ b/src/unifiedreport/agent_tests/Functional/schedulerTest.php
@@ -25,7 +25,7 @@ use Fossology\Lib\Test\TestPgDb;
 include_once(__DIR__.'/../../../lib/php/Test/Agent/AgentTestMockHelper.php');
 include_once(__DIR__.'/SchedulerTestRunnerCli.php');
 
-class SchedulerTest extends \PHPUnit_Framework_TestCase
+class SchedulerTest extends \PHPUnit\Framework\TestCase
 {
   /** @var int */
   private $userId = 2;

--- a/src/ununpack/agent_tests/Functional/cliParamsTest4UnunpackException.php
+++ b/src/ununpack/agent_tests/Functional/cliParamsTest4UnunpackException.php
@@ -28,7 +28,7 @@ require_once './utility.php';
 use Fossology\Lib\Test\TestPgDb;
 use Fossology\Lib\Test\TestInstaller;
 
-class cliParamsTest4UnunpackExcption extends PHPUnit_Framework_TestCase
+class cliParamsTest4UnunpackExcption extends \PHPUnit\Framework\TestCase
 {
   private $agentDir;
 

--- a/src/ununpack/agent_tests/Functional/cliParamsTest4UnunpackNormal.php
+++ b/src/ununpack/agent_tests/Functional/cliParamsTest4UnunpackNormal.php
@@ -28,7 +28,7 @@ require_once './utility.php';
 use Fossology\Lib\Test\TestPgDb;
 use Fossology\Lib\Test\TestInstaller;
 
-class cliParamsTest4Ununpack extends PHPUnit_Framework_TestCase
+class cliParamsTest4Ununpack extends \PHPUnit\Framework\TestCase
 {
   private $agentDir;
   private $ununpack;

--- a/src/ununpack/agent_tests/Functional/unpackTest.php
+++ b/src/ununpack/agent_tests/Functional/unpackTest.php
@@ -35,7 +35,7 @@ require_once '/usr/share/php/PHPUnit/Framework.php';
 global $GlobalReady;
 $GlobalReady = TRUE;
 
-class cliParamsTest extends PHPUnit_Framework_TestCase {
+class cliParamsTest extends \PHPUnit\Framework\TestCase {
 
 	public $agentDir;
 	public $copyright;

--- a/src/wget_agent/agent_tests/Functional/cliParamsTest4WgetAgent.php
+++ b/src/wget_agent/agent_tests/Functional/cliParamsTest4WgetAgent.php
@@ -31,7 +31,7 @@ $TEST_RESULT_PATH = "./test_result";
 /**
  * \class cliParamsTest4Wget - test wget agent from cli
  */
-class cliParamsTest4Wget extends PHPUnit_Framework_TestCase {
+class cliParamsTest4Wget extends \PHPUnit\Framework\TestCase {
 
   public $WGET_PATH = "";
   public $DB_COMMAND = "";

--- a/src/www/ui_tests/Unit/test-showjobs.php
+++ b/src/www/ui_tests/Unit/test-showjobs.php
@@ -28,7 +28,7 @@ require_once(dirname(dirname(dirname(__FILE__)))."/ui/showjobs.php");
 /**
  * \class test_showjobs
  */
-class test_showjobs extends PHPUnit_Framework_TestCase {
+class test_showjobs extends \PHPUnit\Framework\TestCase {
   /**
    * \brief initialization
    */

--- a/src/www/ui_tests/Unit/ui-picker-Test.php
+++ b/src/www/ui_tests/Unit/ui-picker-Test.php
@@ -28,7 +28,7 @@ if(!function_exists('register_plugin')){ function register_plugin(){}}
 require_once ($wwwPath.'/ui/ui-picker.php');
 
 
-class ui_picker_Test extends \PHPUnit_Framework_TestCase
+class ui_picker_Test extends \PHPUnit\Framework\TestCase
 {
   /**
    * \brief test for Uploadtree2PathStr

--- a/src/www/ui_tests/startUpTest.php
+++ b/src/www/ui_tests/startUpTest.php
@@ -14,7 +14,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-class StartUpTest extends \PHPUnit_Framework_TestCase
+class StartUpTest extends \PHPUnit\Framework\TestCase
 {
   /** @var string */
   private $pageContent;


### PR DESCRIPTION
## Description

Add forward compatibility for the following change in PHPUnit 6
> PHPUnit's units of code are now namespaced. For instance, `PHPUnit_Framework_TestCase` is now `PHPUnit\Framework\TestCase

by implementing

> Added phpunit\framework\TestCase as an alias for PHPUnit_Framework_TestCase for forward compatibility

See: https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-6.0.0
See: https://github.com/sebastianbergmann/phpunit/blob/5.4/ChangeLog-5.4.md

## How to test

Run all tests or check the logs on travis-ci.

Thanks to @GMishx for pointing out this backwards compatibility issue in #1116