### PR TITLE
Improved PHP 7.2 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,9 @@ sudo: false
 jobs:
   include:
     - name: Syntax Check
-      script: src/testing/syntax/syntaxtest.sh
+      script:
+        - src/testing/syntax/syntaxtest.sh
+        - composer validate --no-check-all --working-dir=src --strict
     - name: Static Code Analysis
       addons:
         apt:
@@ -120,9 +122,9 @@ jobs:
       php: 7.0
     - <<: *phpunit-tests
       php: 7.1
+      install: composer update --ignore-platform-reqs --with-dependencies --prefer-dist --working-dir=src phpunit/phpunit
     - <<: *phpunit-tests
       php: 7.2
+      install: composer update --ignore-platform-reqs --with-dependencies --prefer-dist --working-dir=src phpunit/phpunit
   allow_failures:
     - name: Copy/Paste Detector
-    - php: 7.1
-    - php: 7.2

--- a/src/cli/tests/test_fo_copyright_list.php
+++ b/src/cli/tests/test_fo_copyright_list.php
@@ -56,51 +56,53 @@ class test_fo_copyright_list extends \PHPUnit\Framework\TestCase {
   {
     $upload_id = 2;
     $auth = "--user fossy --password fossy";
-    $out = "";
     $uploadtree_id = 13;
     $command = "$this->fo_copyright_list_path $auth -u $upload_id -t $uploadtree_id --container 1";
-    exec("$command 2>&1", $out, $rtn);
-    $this->assertEquals(27, count($out));
-    $this->assertEquals("B.zip/B/1b/AAL_B: copyright (c) 2002 by author", $out[22]);
+    exec("$command 2>&1", $output, $return_value);
+
+    $this->assertEquals(0, $return_value, "Non-zero exit status code with\n" . join('\n', $output));
+    $this->assertEquals(27, count($output));
+    $this->assertEquals("B.zip/B/1b/AAL_B: copyright (c) 2002 by author", $output[22]);
   }
 
   function test_get_copryright_list_email()
   {
     $upload_id = 2;
     $auth = "--user fossy --password fossy";
-    $out = "";
     $uploadtree_id = 13;
     $command = "$this->fo_copyright_list_path $auth -u $upload_id -t $uploadtree_id --type email --container 1";
-    exec("$command 2>&1", $out, $rtn);
-    /** check one line of the report */
-    $this->assertEquals("B.zip/B/1b/3DFX_B: info@3dfx.com", $out[7]);
+    exec("$command 2>&1", $output, $return_value);
+
+    $this->assertEquals(0, $return_value, "Non-zero exit status code with\n" . join('\n', $output));
+    $this->assertEquals("B.zip/B/1b/3DFX_B: info@3dfx.com", $output[7]);
   }
   
   function test_get_copryright_list_withoutContainer()
   {
     $upload_id = 2;
     $auth = "--user fossy --password fossy";
-    $out = "";
-    $uploadtree_id = 13;    $command = "$this->fo_copyright_list_path $auth -u $upload_id -t $uploadtree_id --type email --container 0";
-     exec("$command 2>&1", $out, $rtn);
-    /** check one line of the report */
-    $this->assertEquals("B.zip/B/1b/3DFX_B: info@3dfx.com", $out[4]);
+    $uploadtree_id = 13;
+    $command = "$this->fo_copyright_list_path $auth -u $upload_id -t $uploadtree_id --type email --container 0";
+    exec("$command 2>&1", $output, $return_value);
+
+    $this->assertEquals(0, $return_value, "Non-zero exit status code with\n" . join('\n', $output));
+    $this->assertEquals("B.zip/B/1b/3DFX_B: info@3dfx.com", $output[4]);
   }
 
   public function test_help() {
     $auth = "--user fossy --password fossy";
-
     $command = "$this->fo_copyright_list_path $auth -h";
-    exec("$command 2>&1", $out, $rtn);
-    $output_msg_count = count($out);
-    $this->assertEquals(11, $output_msg_count, "Test that the number of output lines from '$command' is $output_msg_count");
+    exec("$command 2>&1", $output, $return_value);
+
+    $this->assertEquals(0, $return_value, "Non-zero exit status code with\n" . join('\n', $output));
+    $this->assertEquals(11, count($output));
   }
   
   public function test_help_noAuthentication() {
-    $out = "";
     $command = "$this->fo_copyright_list_path -h";
-    exec("$command 2>&1", $out, $rtn);
-    $output_msg_count = count($out);
-    $this->assertEquals(11, $output_msg_count, "Test that the number of output lines from '$command' is $output_msg_count");
+    exec("$command 2>&1", $output, $return_value);
+
+    $this->assertEquals(0, $return_value, "Non-zero exit status code with\n" . join('\n', $output));
+    $this->assertEquals(11, count($output));
   }
 }

--- a/src/composer.json
+++ b/src/composer.json
@@ -1,7 +1,7 @@
 {
     "name" : "fossology/fossology",
     "description" : "FOSSology is a open source license compliance software system and toolkit.",
-    "_readme" : [
+    "_comment" : [
         "Copyright Siemens AG 2014-2016",
         "",
         "Copying and distribution of this file, with or without modification,",
@@ -10,20 +10,28 @@
         "without any warranty."
     ],
     "require" : {
-        "monolog/monolog" : "1.10.*",
-        "symfony/config" : "2.6.*",
-        "symfony/http-foundation" : "2.6.*",
-        "symfony/dependency-injection" : "2.6.*",
-        "twig/twig" : "1.*",
-        "twig/extensions" : "1.*",
         "easyrdf/easyrdf" : "0.9.*",
-        "phpoffice/phpword" : "v0.13.*"
+        "ext-gettext": "*",
+        "ext-mbstring": "*",
+        "ext-json" : "*",
+        "ext-xml" : "*",
+        "monolog/monolog" : "1.10.*",
+        "phpoffice/phpword" : "v0.13.*",
+        "symfony/config" : "~2.7.36",
+        "symfony/http-foundation" : "~2.7.36",
+        "symfony/dependency-injection" : "~2.7.36",
+        "twig/twig" : "1.*",
+        "twig/extensions" : "1.*"
     },
     "require-dev" : {
+        "doctrine/instantiator" : "1.0.5",
+        "ext-posix" : "*",
+        "ext-sqlite3" : "*",
         "hamcrest/hamcrest-php" : "^2",
         "mockery/mockery" : "^1",
+        "myclabs/deep-copy" : "1.7.0",
         "php-coveralls/php-coveralls" : "^2",
-        "phpunit/phpunit" : "^5.7",
+        "phpunit/phpunit" : "^5.7 || ^6",
         "sebastian/phpcpd" : "^3",
         "squizlabs/php_codesniffer" : "^3"
     },

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c4cfb459b3ba1854c52bf2f2c88e4ea7",
+    "content-hash": "566a2ed7743d91db22563584d256d062",
     "packages": [
         {
             "name": "easyrdf/easyrdf",
@@ -377,36 +377,42 @@
         },
         {
             "name": "symfony/config",
-            "version": "v2.6.13",
-            "target-dir": "Symfony/Component/Config",
+            "version": "v2.7.49",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "0ca496cbe208fc37c4cf3415ebb3056e0963115b"
+                "reference": "2f7d39c15d0ed93b7f1c63a4dfa71a004c36b0b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/0ca496cbe208fc37c4cf3415ebb3056e0963115b",
-                "reference": "0ca496cbe208fc37c4cf3415ebb3056e0963115b",
+                "url": "https://api.github.com/repos/symfony/config/zipball/2f7d39c15d0ed93b7f1c63a4dfa71a004c36b0b7",
+                "reference": "2f7d39c15d0ed93b7f1c63a4dfa71a004c36b0b7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "symfony/filesystem": "~2.3"
+                "php": ">=5.3.9",
+                "symfony/filesystem": "~2.3",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
+                "symfony/yaml": "~2.7"
+            },
+            "suggest": {
+                "symfony/yaml": "To use the yaml reference dumper"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Config\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -424,25 +430,24 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-08T05:59:48+00:00"
+            "time": "2018-05-01T22:30:49+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.6.13",
-            "target-dir": "Symfony/Component/DependencyInjection",
+            "version": "v2.7.49",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "d9fe6837d74aed11e5ee741cd6b6dfe45e0af78e"
+                "reference": "ae8effd3cdafad8e2652fccc5e5bcf991dbd6af1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/d9fe6837d74aed11e5ee741cd6b6dfe45e0af78e",
-                "reference": "d9fe6837d74aed11e5ee741cd6b6dfe45e0af78e",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/ae8effd3cdafad8e2652fccc5e5bcf991dbd6af1",
+                "reference": "ae8effd3cdafad8e2652fccc5e5bcf991dbd6af1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.3.9"
             },
             "conflict": {
                 "symfony/expression-language": "<2.6"
@@ -450,24 +455,27 @@
             "require-dev": {
                 "symfony/config": "~2.2",
                 "symfony/expression-language": "~2.6",
-                "symfony/phpunit-bridge": "~2.7",
-                "symfony/yaml": "~2.1"
+                "symfony/yaml": "~2.3.42|~2.7.14|^2.8.7"
             },
             "suggest": {
                 "symfony/config": "",
+                "symfony/expression-language": "For using expressions in service container configuration",
                 "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
                 "symfony/yaml": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\DependencyInjection\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -485,7 +493,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-22T10:08:40+00:00"
+            "time": "2018-02-15T07:59:01+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -539,38 +547,40 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v2.6.13",
-            "target-dir": "Symfony/Component/HttpFoundation",
+            "version": "v2.7.49",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "e8fd1b73ac1c3de1f76c73801ddf1a8ecb1c1c9c"
+                "reference": "b0450941536afecc0142fda28db37dd3b67931b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/e8fd1b73ac1c3de1f76c73801ddf1a8ecb1c1c9c",
-                "reference": "e8fd1b73ac1c3de1f76c73801ddf1a8ecb1c1c9c",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/b0450941536afecc0142fda28db37dd3b67931b4",
+                "reference": "b0450941536afecc0142fda28db37dd3b67931b4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.3.9",
+                "symfony/polyfill-mbstring": "~1.1"
             },
             "require-dev": {
-                "symfony/expression-language": "~2.4",
-                "symfony/phpunit-bridge": "~2.7"
+                "symfony/expression-language": "~2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\HttpFoundation\\": ""
                 },
                 "classmap": [
-                    "Symfony/Component/HttpFoundation/Resources/stubs"
+                    "Resources/stubs"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -589,7 +599,7 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-22T10:08:40+00:00"
+            "time": "2018-07-31T19:55:31+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -646,6 +656,65 @@
                 "ctype",
                 "polyfill",
                 "portable"
+            ],
+            "time": "2018-08-06T14:22:27+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
             ],
             "time": "2018-08-06T14:22:27+00:00"
         },
@@ -2667,16 +2736,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.3.1",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec"
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/628a481780561150481a9ec74709092b9759b3ec",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6ad28354c04b364c3c71a34e4a18b629cc3b231e",
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e",
                 "shasum": ""
             },
             "require": {
@@ -2714,7 +2783,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-07-26T23:47:18+00:00"
+            "time": "2018-09-23T23:08:17+00:00"
         },
         {
             "name": "symfony/console",
@@ -2883,65 +2952,6 @@
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
             "time": "2018-07-26T11:19:56+00:00"
-        },
-        {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
-                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "time": "2018-08-06T14:22:27+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -3143,8 +3153,16 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {
+        "ext-gettext": "*",
+        "ext-mbstring": "*",
+        "ext-json": "*",
+        "ext-xml": "*"
+    },
+    "platform-dev": {
+        "ext-posix": "*",
+        "ext-sqlite3": "*"
+    },
     "platform-overrides": {
         "php": "5.6"
     }

--- a/src/nomos/agent_tests/Functional/tests.xml
+++ b/src/nomos/agent_tests/Functional/tests.xml
@@ -1,4 +1,4 @@
-<phpunit>
+<phpunit backupGlobals="true">
   <testsuites>
     <testsuite name="nomos/agent_tests/Functional Tests">
       <file>CommonCliTest.php</file>

--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <phpunit
   bootstrap="./phpunit-bootstrap.php" colors="true"
+  backupGlobals="true"
+  beStrictAboutTestsThatDoNotTestAnything="false"
   convertErrorsToExceptions="true"
   convertNoticesToExceptions="false"
   stopOnFailure="false">


### PR DESCRIPTION
## Description

The PHP 7.2 tests on travis-ci pass.

## Changes

* Added support for PHPUnit 6.
* Switched to PHPUnit 6 for PHP 7.1 and PHP 7.2.
* PHP 7.1 and 7.2 tests have to pass.
* Added necessary php extensions to composer.json.
* Added validation step for composer.json in travis-ci.
* Locked some development dependencies for backward compatibility.
* Updated symfony for PHP 7.2 compatibility.

## How to test

Please check that fossology is working properly because symfony was upgraded.

Fixed #1182.