### PR TITLE
fix(fo-installdeps): Allow running without the option '-y'.

### DIFF
--- a/src/delagent/mod_deps
+++ b/src/delagent/mod_deps
@@ -38,8 +38,8 @@ fi
 
 eval set -- "$OPTS"
 
-# if no options then do everything
-if [[ $OPTS == ' --' ]]; then
+# if no options or just -y then do everything
+if [[ $OPTS == ' --' || $OPTS == ' -y --' ]]; then
   EVERYTHING=true
 fi
 
@@ -75,11 +75,11 @@ if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
     Debian|Ubuntu|LinuxMint)
-      apt-get "$YesOpt" install \
+      apt-get $YesOpt install \
         libssl-dev
       ;;
     RedHatEnterprise*|CentOS|Fedora)
-      yum "$YesOpt" install \
+      yum $YesOpt install \
         openssl-devel
       ;;
   esac

--- a/src/mimetype/mod_deps
+++ b/src/mimetype/mod_deps
@@ -38,8 +38,8 @@ fi
 
 eval set -- "$OPTS"
 
-# if no options then do everything
-if [[ $OPTS == ' --' ]]; then
+# if no options or just -y then do everything
+if [[ $OPTS == ' --' || $OPTS == ' -y --' ]]; then
   EVERYTHING=true
 fi
 
@@ -75,11 +75,11 @@ if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
     Debian|Ubuntu|LinuxMint)
-      apt-get "$YesOpt" install \
+      apt-get $YesOpt install \
         libmagic-dev
       ;;
     RedHatEnterprise*|CentOS|Fedora)
-      yum "$YesOpt" install \
+      yum $YesOpt install \
         file-devel
       ;;
   esac
@@ -89,11 +89,11 @@ if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
     Debian|Ubuntu|LinuxMint)
-      apt-get "$YesOpt" install \
+      apt-get $YesOpt install \
         libmagic1
       ;;
     RedHatEnterprise*|CentOS|Fedora)
-      yum "$YesOpt" install \
+      yum $YesOpt install \
         file-libs
       ;;
   esac

--- a/src/pkgagent/mod_deps
+++ b/src/pkgagent/mod_deps
@@ -38,8 +38,8 @@ fi
 
 eval set -- "$OPTS"
 
-# if no options then do everything
-if [[ $OPTS == ' --' ]]; then
+# if no options or just -y then do everything
+if [[ $OPTS == ' --' || $OPTS == ' -y --' ]]; then
   EVERYTHING=true
 fi
 
@@ -75,11 +75,11 @@ if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
     Debian|Ubuntu|LinuxMint)
-      apt-get "$YesOpt" install \
+      apt-get $YesOpt install \
         librpm-dev
       ;;
     RedHatEnterprise*|CentOS|Fedora)
-      yum "$YesOpt" install \
+      yum $YesOpt install \
         rpm-devel
       ;;
   esac
@@ -89,11 +89,11 @@ if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
     Debian|Ubuntu|LinuxMint)
-      apt-get "$YesOpt" install \
+      apt-get $YesOpt install \
         rpm
       ;;
     RedHatEnterprise*|CentOS|Fedora)
-      yum "$YesOpt" install \
+      yum $YesOpt install \
         rpm
       ;;
   esac

--- a/src/scheduler/mod_deps
+++ b/src/scheduler/mod_deps
@@ -38,8 +38,8 @@ fi
 
 eval set -- "$OPTS"
 
-# if no options then do everything
-if [[ $OPTS == ' --' ]]; then
+# if no options or just -y then do everything
+if [[ $OPTS == ' --' || $OPTS == ' -y --' ]]; then
   EVERYTHING=true
 fi
 
@@ -75,11 +75,11 @@ if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
     Debian|Ubuntu|LinuxMint)
-      apt-get "$YesOpt" install \
+      apt-get $YesOpt install \
         libglib2.0-dev
       ;;
     RedHatEnterprise*|CentOS|Fedora)
-      yum "$YesOpt" install \
+      yum $YesOpt install \
         glib2-devel
       ;;
     *) echo "ERROR: distro not recognised, please fix and send a patch"; exit 1;;
@@ -90,11 +90,11 @@ if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
     Debian|Ubuntu|LinuxMint)
-      apt-get "$YesOpt" install \
+      apt-get $YesOpt install \
         libglib2.0-0
       ;;
     RedHatEnterprise*|CentOS|Fedora)
-      yum "$YesOpt" install \
+      yum $YesOpt install \
         glib2
       ;;
   esac

--- a/src/ununpack/mod_deps
+++ b/src/ununpack/mod_deps
@@ -38,8 +38,8 @@ fi
 
 eval set -- "$OPTS"
 
-# if no options then do everything
-if [[ $OPTS == ' --' ]]; then
+# if no options or just -y then do everything
+if [[ $OPTS == ' --' || $OPTS == ' -y --' ]]; then
   EVERYTHING=true
 fi
 
@@ -79,15 +79,15 @@ if [ $RUNTIME ]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
     Debian|Ubuntu|LinuxMint)
-      apt-get "$YesOpt" install \
+      apt-get $YesOpt install \
         bzip2 cabextract cpio genisoimage p7zip poppler-utils rpm tar upx-ucl unzip gzip sleuthkit p7zip-full unrar-free
       ;;
     RedHatEnterprise*|CentOS)
-      yum "$YesOpt" install \
+      yum $YesOpt install \
         bzip2 cpio mkisofs p7zip poppler-utils rpm tar unzip gzip p7zip-plugins sleuthkit unrar
       ;;
     Fedora)
-      yum "$YesOpt" install \
+      yum $YesOpt install \
         bzip2 cabextract cpio genisoimage p7zip p7zip-plugins poppler-utils rpm tar upx unzip gzip sleuthkit unrar
       ;;
   esac

--- a/src/wget_agent/mod_deps
+++ b/src/wget_agent/mod_deps
@@ -38,8 +38,8 @@ fi
 
 eval set -- "$OPTS"
 
-# if no options then do everything
-if [[ $OPTS == ' --' ]]; then
+# if no options or just -y then do everything
+if [[ $OPTS == ' --' || $OPTS == ' -y --' ]]; then
   EVERYTHING=true
 fi
 
@@ -79,11 +79,11 @@ if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
     Debian|Ubuntu|LinuxMint)
-      apt-get "$YesOpt" install \
+      apt-get $YesOpt install \
         subversion git wget
       ;;
     RedHatEnterprise*|CentOS|Fedora)
-      yum "$YesOpt" install \
+      yum $YesOpt install \
         subversion git wget
       ;;
   esac

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -58,8 +58,8 @@ fi
 
 eval set -- "$OPTS"
 
-# if no options then do everything
-if [[ $OPTS == ' --' ]]; then
+# if no options or just -y then do everything
+if [[ $OPTS == ' --' || $OPTS == ' -y --' ]]; then
   EVERYTHING=true
 fi
 
@@ -100,33 +100,33 @@ if [[ $BUILDTIME ]]; then
    case "$DISTRO" in
       Debian|Ubuntu|LinuxMint)
          echo "DB: Installing build essential....."
-         apt-get "$YesOpt" install \
+         apt-get $YesOpt install \
             libmxml-dev curl libxml2-dev libcunit1-dev \
             build-essential libtext-template-perl subversion rpm librpm-dev libmagic-dev libglib2.0 libboost-regex-dev libboost-program-options-dev
          if ! dpkg --get-selections | grep -q postgresql-server-dev; then  ## if postgresql-server-dev is not installed
            case "$CODENAME" in
               trusty)
-                apt-get "$YesOpt" install postgresql-server-dev-9.3;;
+                apt-get $YesOpt install postgresql-server-dev-9.3;;
               jessie)
-                apt-get "$YesOpt" install postgresql-server-dev-9.4;;
+                apt-get $YesOpt install postgresql-server-dev-9.4;;
               xenial)
-                apt-get "$YesOpt" install postgresql-server-dev-9.5;;
+                apt-get $YesOpt install postgresql-server-dev-9.5;;
               stretch|buster|sid)
-                apt-get "$YesOpt" install postgresql-server-dev-9.6;;
+                apt-get $YesOpt install postgresql-server-dev-9.6;;
               *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
            esac
          fi
          ;;
       Fedora)
-         yum "$YesOpt" groupinstall "Development Tools"
-         yum "$YesOpt" install \
+         yum $YesOpt groupinstall "Development Tools"
+         yum $YesOpt install \
             perl-Text-Template subversion \
             postgresql-devel file-devel \
             libxml2 \
             boost-devel
          ;;
       RedHatEnterprise*|CentOS)
-         yum "$YesOpt" install \
+         yum $YesOpt install \
             postgresql-devel \
             gcc make file libxml2 \
             perl-Text-Template subversion \
@@ -146,8 +146,8 @@ if [[ $RUNTIME ]]; then
    case "$DISTRO" in
       Debian|Ubuntu|LinuxMint)
         echo "doing runtime"
-         apt-get "$YesOpt" install apache2
-         apt-get "$YesOpt" install php-pear \
+         apt-get $YesOpt install apache2
+         apt-get $YesOpt install php-pear \
             libxml2 \
             binutils php-gettext \
             cabextract cpio sleuthkit genisoimage \
@@ -157,19 +157,19 @@ if [[ $RUNTIME ]]; then
             dpkg-dev heirloom-mailx
          case "$CODENAME" in
             trusty)
-               apt-get "$YesOpt" install postgresql-9.3 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl;;
+               apt-get $YesOpt install postgresql-9.3 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl;;
             jessie)
-               apt-get "$YesOpt" install postgresql-9.4 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl;;
+               apt-get $YesOpt install postgresql-9.4 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl;;
             xenial)
-               apt-get "$YesOpt" install postgresql-9.5 php7.0 libapache2-mod-php7.0 php7.0-pgsql php7.0-cli php7.0-curl php7.0-zip;;
+               apt-get $YesOpt install postgresql-9.5 php7.0 libapache2-mod-php7.0 php7.0-pgsql php7.0-cli php7.0-curl php7.0-zip;;
             stretch|buster|sid)
-               apt-get "$YesOpt" install postgresql-9.6 php7.0 php7.0-pgsql php7.0-cli php7.0-curl php7.0-xml php7.0-zip;;
+               apt-get $YesOpt install postgresql-9.6 php7.0 php7.0-pgsql php7.0-cli php7.0-curl php7.0-xml php7.0-zip;;
             *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
          esac
          ;;
       Fedora)
-         yum "$YesOpt" install postgresql-server httpd
-         yum "$YesOpt" install \
+         yum $YesOpt install postgresql-server httpd
+         yum $YesOpt install \
             postgresql \
             php php-pear php-pgsql php-process php-xml php-mbstring\
             smtpdaemon \
@@ -188,8 +188,8 @@ if [[ $RUNTIME ]]; then
          echo "   please install from upstream sources."
          ;;
       RedHatEnterprise*|CentOS)
-         yum "$YesOpt" install postgresql-server httpd
-         yum "$YesOpt" install \
+         yum $YesOpt install postgresql-server httpd
+         yum $YesOpt install \
             postgresql \
             php php-pear php-pgsql php-process \
             smtpdaemon \

--- a/utils/prepare-test
+++ b/utils/prepare-test
@@ -110,8 +110,8 @@ if echo ${WarnAccept} | grep -q -e "^[yY]$" ; then
   fi
   case "${DISTRO}" in
     Debian|Ubuntu|LinuxMint)
-      sudo apt-get install -q "${YesOpt}" cppcheck ;;
+      sudo apt-get install -q $YesOpt cppcheck ;;
     Fedora|RedHatEnterprise*|CentOS)
-      yum "${YesOpt}" install cppcheck ;;
+      yum $YesOpt install cppcheck ;;
   esac
 fi


### PR DESCRIPTION
## Changes

fix(fo-installdeps): Allow running without the option '-y'.
fix(fo-installdeps): Install everything on '-y'.

## How to test

* Run `./utils/fo-installdeps` and check that build and runtime dependencies are installed.
* Run `./utils/fo-installdeps -y` and check that build and runtime dependencies are installed.

Thanks to @GMishx for pointing out this issue.

edit: It resolves #1188.