### PR TITLE
fix(xenial): Added the missing runtime dependency php7.0-mbstring.

### DIFF
--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -161,7 +161,7 @@ if [[ $RUNTIME ]]; then
             jessie)
                apt-get $YesOpt install postgresql-9.4 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl;;
             xenial)
-               apt-get $YesOpt install postgresql-9.5 php7.0 libapache2-mod-php7.0 php7.0-pgsql php7.0-cli php7.0-curl php7.0-zip;;
+               apt-get $YesOpt install postgresql-9.5 php7.0 libapache2-mod-php7.0 php7.0-pgsql php7.0-cli php7.0-curl php7.0-mbstring php7.0-zip;;
             stretch|buster|sid)
                apt-get $YesOpt install postgresql-9.6 php7.0 php7.0-pgsql php7.0-cli php7.0-curl php7.0-xml php7.0-zip;;
             *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;


### PR DESCRIPTION
## Description

* On Trusty and Jessie mbstring is compiled into PHP.
* On Stretch mbstring is a dependency of php-gettext.

But on Xenial it is not compiled into PHP and it is not a dependency of any installed package.

## How to test

Run the following commands on a fresh Xenial and check that no error occurs:
```
# ./utils/fo-installdeps -e -y
$ cd src
$ composer install
```
Resolves #1186.