### PR TITLE
perf(copyright): Use prepared statements to fetch pfiles

### DIFF
--- a/src/copyright/agent/database.cc
+++ b/src/copyright/agent/database.cc
@@ -265,34 +265,28 @@ std::vector<unsigned long> CopyrightDatabaseHandler::queryFileIdsForUpload(int a
 {
   std::string uploadTreeTableName = queryUploadTreeTableName(uploadId);
 
-  QueryResult queryResult = dbManager.queryPrintf(
-      "SELECT pfile_pk"
+  fo_dbManager_PreparedStatement* preparedStatement =
+      fo_dbManager_PrepareStamement(dbManager.getStruct_dbManager(),
+          ("queryFileIdsForUpload:" IDENTITY "Agent" + uploadTreeTableName).c_str(),
+          ("SELECT pfile_pk"
             " FROM ("
             "  SELECT distinct(pfile_fk) AS PF"
-            "  FROM %s"
-            "  WHERE upload_fk = %d and (ufile_mode&x'3C000000'::int)=0"
+            "  FROM " + uploadTreeTableName +
+            "  WHERE upload_fk = $1 and (ufile_mode&x'3C000000'::int)=0"
             " ) AS SS "
-            "LEFT OUTER JOIN %s on (PF = pfile_fk AND agent_fk = %d) "
+          "LEFT OUTER JOIN " IDENTITY " ON (PF = pfile_fk AND agent_fk = $2) "
 #ifdef IDENTITY_COPYRIGHT
-            "LEFT OUTER JOIN author AS au ON (PF = au.pfile_fk AND au.agent_fk = %d) "
+          "LEFT OUTER JOIN author AS au ON (PF = au.pfile_fk AND au.agent_fk = $2) "
 #endif
-            "INNER JOIN pfile on (PF = pfile_pk) "
+          "INNER JOIN pfile ON (PF = pfile_pk) "
 #ifdef IDENTITY_COPYRIGHT
-            "WHERE copyright.copyright_pk IS NULL AND au.author_pk IS NULL",
+          "WHERE copyright.copyright_pk IS NULL AND au.author_pk IS NULL;").c_str(),
 #else
-            "WHERE %s_pk IS NULL OR agent_fk <> %d",
+          "WHERE " IDENTITY "_pk IS NULL OR agent_fk <> $2;").c_str(),
 #endif
-    uploadTreeTableName.c_str(),
-    uploadId,
-    IDENTITY,
-    agentId
-#ifdef IDENTITY_COPYRIGHT
-    , agentId
-#else
-    , IDENTITY
-    , agentId
-#endif
-  );
+          int, int);
+  QueryResult queryResult = dbManager.execPrepared(preparedStatement,
+      uploadId, agentId);
 
   return queryResult.getSimpleResults<unsigned long>(0, fo::stringToUnsignedLong);
 }


### PR DESCRIPTION
## Description

The query to fetch pfiles for scanning was taking longer than usual in huge (>40 GB) databases resulting in agent kill due to no heart beat (>10 minutes).

This PR uses prepared statements to fetch the pfiles for scanning.

This result in execution time reduction from 18.691 ms to 5.969 ms (on developer DB of size 29 MB).

### Changes

Use prepared statements to fetch the pfiles for scanning.

## How to test

Test on existing FOSSology instances with database > 30 GB. There should be performance improvement in Copyright, ECC and Keyword agents.