### PR TITLE
Improve json hpp install

### DIFF
--- a/install/scripts/install-json-hpp.sh
+++ b/install/scripts/install-json-hpp.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# Source fossology config file, for Proxy settings
-conf_file=/etc/fossology.conf
-[ -r $conf_file ] && . $conf_file
-
 cd "$(dirname "$0")/../.."
 FINAL_FILE=./src/copyright/agent/json.hpp
 FILE_SHASUM="fbdfec4b4cf63b3b565d09f87e6c3c183bdd45c5be1864d3fcb338f6f02c1733"

--- a/install/scripts/install-json-hpp.sh
+++ b/install/scripts/install-json-hpp.sh
@@ -19,6 +19,10 @@ _check_file() {
 # Check if file is already available
 _check_file "$SHASUM" "$FINAL_FILE" && exit 0
 
+# Proxy Setup: If needed, configure the proxy variables in the appropriate config file
+proxy_file=/etc/fossology/fossology-proxy.conf
+[ -r $proxy_file ] && . $proxy_file
+
 TMP=$(mktemp)
 curl -s $CURL_OPION -o "$TMP" -L $FILe_URL
 SUCCESS=$?

--- a/install/scripts/install-json-hpp.sh
+++ b/install/scripts/install-json-hpp.sh
@@ -2,7 +2,7 @@
 
 cd "$(dirname "$0")/../.."
 FINAL_FILE=./src/copyright/agent/json.hpp
-FILE_SHASUM="faa2321beb1aa7416d035e7417fcfa59692ac3d8c202728f9bcc302e2d558f57"
+FILE_SHASUM="fbdfec4b4cf63b3b565d09f87e6c3c183bdd45c5be1864d3fcb338f6f02c1733"
 FILE_URL="https://github.com/nlohmann/json/releases/download/v2.1.1/json.hpp"
 CURL_OPTIONS="--max-time 10 --retry 4"
 

--- a/install/scripts/install-json-hpp.sh
+++ b/install/scripts/install-json-hpp.sh
@@ -7,7 +7,7 @@ conf_file=/etc/fossology.conf
 cd "$(dirname "$0")/../.."
 FINAL_FILE=./src/copyright/agent/json.hpp
 FILE_SHASUM="fbdfec4b4cf63b3b565d09f87e6c3c183bdd45c5be1864d3fcb338f6f02c1733"
-FILE_URL="https://github.com/nlohmann/json/releases/download/v2.1.1/json.hpp"
+FILE_URL="https://github.com/nlohmann/json/releases/download/v3.1.2/json.hpp"
 CURL_OPTIONS="--max-time 10 --retry 4"
 
 _check_file() {

--- a/install/scripts/install-json-hpp.sh
+++ b/install/scripts/install-json-hpp.sh
@@ -24,7 +24,7 @@ proxy_file=/etc/fossology/fossology-proxy.conf
 [ -r $proxy_file ] && . $proxy_file
 
 TMP=$(mktemp)
-curl -s $CURL_OPION -o "$TMP" -L $FILe_URL
+curl -s $CURL_OPION -o "$TMP" -L $FILE_URL
 SUCCESS=$?
 
 if [[ $SUCCESS -ne 0 ]]

--- a/install/scripts/install-json-hpp.sh
+++ b/install/scripts/install-json-hpp.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Source fossology config file, for Proxy settings
+conf_file=/etc/fossology.conf
+[ -r $conf_file ] && . $conf_file
+
 cd "$(dirname "$0")/../.."
 FINAL_FILE=./src/copyright/agent/json.hpp
 FILE_SHASUM="fbdfec4b4cf63b3b565d09f87e6c3c183bdd45c5be1864d3fcb338f6f02c1733"
@@ -18,10 +22,6 @@ _check_file() {
 
 # Check if file is already available
 _check_file "$SHASUM" "$FINAL_FILE" && exit 0
-
-# Proxy Setup: If needed, configure the proxy variables in the appropriate config file
-proxy_file=/etc/fossology/fossology-proxy.conf
-[ -r $proxy_file ] && . $proxy_file
 
 TMP=$(mktemp)
 curl -s $CURL_OPION -o "$TMP" -L $FILE_URL

--- a/install/scripts/install-json-hpp.sh
+++ b/install/scripts/install-json-hpp.sh
@@ -2,20 +2,38 @@
 
 cd "$(dirname "$0")/../.."
 FINAL_FILE=./src/copyright/agent/json.hpp
-SHASUM=fbdfec4b4cf63b3b565d09f87e6c3c183bdd45c5be1864d3fcb338f6f02c1733
-TMP=$(mktemp)
-CHECKSUMFILE=$(mktemp)
+FILE_SHASUM="faa2321beb1aa7416d035e7417fcfa59692ac3d8c202728f9bcc302e2d558f57"
+FILE_URL="https://github.com/nlohmann/json/releases/download/v2.1.1/json.hpp"
+CURL_OPTIONS="--max-time 10 --retry 4"
 
-curl -s -o "$TMP" -L https://github.com/nlohmann/json/releases/download/v3.1.2/json.hpp
-echo "$SHASUM $TMP" > "$CHECKSUMFILE"
-sha256sum --quiet -c "$CHECKSUMFILE"
+_check_file() {
+  [[ -r "$2" ]] || return 1
+  local checksum_file=$(mktemp)
+  echo "$1 $2" > "$checksum_file"
+  sha256sum --quiet -c "$checksum_file"
+  local res=$?
+  rm "$checksum_file"
+  return $res
+}
+
+# Check if file is already available
+_check_file "$SHASUM" "$FINAL_FILE" && exit 0
+
+TMP=$(mktemp)
+curl -s $CURL_OPION -o "$TMP" -L $FILe_URL
 SUCCESS=$?
+
+if [[ $SUCCESS -ne 0 ]]
+then
+  echo "Failed to download file $FINAL_FILE"
+else
+  _check_file "$SHASUM" "$TMP"
+  SUCCESS=$?
+fi
 
 if [[ $SUCCESS -eq 0 ]]
 then
   mv "$TMP" "$FINAL_FILE"
 fi
-
-rm "$CHECKSUMFILE"
 
 exit $SUCCESS


### PR DESCRIPTION
## Description

I have several difficulties when installing Fossology from sources:
- sometimes my network is unstable, and the whole install process fails because the download of the json.hpp file fails
- Quite often, the machines I install Fossology on require a proxy to access the internet.

### Changes

- Check first that file final file is not already available (sith correct checksum)
- Added the Retry and Timeout options to curl, to make the installation process more robust
- Let the user configure a proxy by sourcing a new configuration file: `/etc/fossology/fossology-proxy.conf`

## How to test

Install Fossology from source, through a proxy
