### PR TITLE
fix(copyright): replace ct_pk with table_pk for all copyright sub-agents

### DIFF
--- a/install/db/dbmigrate_copyright-author.php
+++ b/install/db/dbmigrate_copyright-author.php
@@ -32,7 +32,7 @@
                            SELECT agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled 
                            FROM copyright WHERE type <> 'statement' AND content IS NOT NULL;");
     $countInsertedAuthorColumns = $dbManager->getSingleRow("SELECT count(*) FROM author au INNER JOIN copyright co 
-                           ON au.pfile_fk = co.pfile_fk WHERE au.ct_pk = co.ct_pk AND au.content = co.content;",array(),'getCountInsertedAuthorColumns');      
+                           ON au.pfile_fk = co.pfile_fk WHERE au.author_pk = co.copyright_pk AND au.content = co.content;",array(),'getCountInsertedAuthorColumns');      
     if($countAuthorColumns['count'] == $countInsertedAuthorColumns['count']){
       echo "Deleting the email/url/author data from copyright table...\n";
       $dbManager->queryOnce("DELETE FROM copyright WHERE type <> 'statement' AND content IS NOT NULL;");

--- a/install/db/resequence_author_table.php
+++ b/install/db/resequence_author_table.php
@@ -30,7 +30,7 @@ function ResequenceAuthorTablePKey($dbManager)
 
   $sql = "
 BEGIN;
-DROP SEQUENCE IF EXISTS public.author_ct_pk_seq CASCADE;
+DROP SEQUENCE IF EXISTS public.author_pk_seq CASCADE;
 
 ALTER TABLE ONLY public.author
     DROP CONSTRAINT IF EXISTS author_agent_fk_fkey CASCADE;
@@ -41,20 +41,20 @@ ALTER TABLE ONLY public.author
 ";
   $dbManager->queryOnce($sql);
   $sql = "
-CREATE SEQUENCE public.author_ct_pk_seq;
-SELECT setval('public.author_ct_pk_seq',(SELECT greatest(1,max(ct_pk)) val FROM author));
-ALTER TABLE public.author ALTER COLUMN ct_pk SET DEFAULT nextval('author_ct_pk_seq'::regclass);
+CREATE SEQUENCE public.author_pk_seq;
+SELECT setval('public.author_pk_seq',(SELECT greatest(1,max(author_pk)) val FROM author));
+ALTER TABLE public.author ALTER COLUMN author_pk SET DEFAULT nextval('author_pk_seq'::regclass);
 
 DROP INDEX IF EXISTS author_agent_fk_idx;
 DROP INDEX IF EXISTS author_pfile_fk_index;
 DROP INDEX IF EXISTS author_pfile_hash_idx;
 DROP INDEX IF EXISTS author_pkey;
 
-ALTER SEQUENCE public.author_ct_pk_seq RESTART WITH 1;
-UPDATE public.author SET ct_pk=nextval('public.author_ct_pk_seq');
+ALTER SEQUENCE public.author_pk_seq RESTART WITH 1;
+UPDATE public.author SET author_pk=nextval('public.author_pk_seq');
 
 ALTER TABLE ONLY public.author
-    ADD CONSTRAINT author_pkey PRIMARY KEY (ct_pk);
+    ADD CONSTRAINT author_pkey PRIMARY KEY (author_pk);
 
 CREATE INDEX author_agent_fk_idx ON public.author USING btree (agent_fk);
 CREATE INDEX author_pfile_fk_index ON public.author USING btree (pfile_fk);
@@ -90,11 +90,11 @@ DROP INDEX IF EXISTS copyright_pkey;
 ";
   $dbManager->queryOnce($sql);
   $sql = "
-ALTER SEQUENCE public.copyright_ct_pk_seq RESTART WITH 1;
-UPDATE public.copyright SET ct_pk=nextval('public.copyright_ct_pk_seq');
+ALTER SEQUENCE public.copyright_pk_seq RESTART WITH 1;
+UPDATE public.copyright SET copyright_pk=nextval('public.copyright_pk_seq');
 
 ALTER TABLE ONLY public.copyright
-    ADD CONSTRAINT copyright_pkey PRIMARY KEY (ct_pk);
+    ADD CONSTRAINT copyright_pkey PRIMARY KEY (copyright_pk);
 ALTER TABLE ONLY public.copyright
     ADD CONSTRAINT copyright_agent_fk_fkey FOREIGN KEY (agent_fk) REFERENCES public.agent(agent_pk) ON DELETE CASCADE;
 
@@ -119,17 +119,17 @@ function CleanAuthorTable($dbManager)
 BEGIN;
 DELETE FROM public.author
 USING public.author AS a LEFT OUTER JOIN public.pfile AS p ON p.pfile_pk = a.pfile_fk
-WHERE public.author.ct_pk = a.ct_pk AND p.pfile_pk IS NULL;
+WHERE public.author.author_pk = a.author_pk AND p.pfile_pk IS NULL;
 
 DELETE FROM public.author
 USING public.author AS au LEFT OUTER JOIN public.agent AS ag ON au.agent_fk = ag.agent_pk
-WHERE public.author.ct_pk = au.ct_pk AND ag.agent_pk IS NULL;
+WHERE public.author.author_pk = au.author_pk AND ag.agent_pk IS NULL;
 
 DELETE FROM public.author
-WHERE ct_pk IN (SELECT ct_pk
-FROM (SELECT ct_pk,
+WHERE author_pk IN (SELECT author_pk
+FROM (SELECT author_pk,
       ROW_NUMBER() OVER (PARTITION BY hash, pfile_fk, agent_fk, copy_startbyte, copy_endbyte, type
-                         ORDER BY ct_pk) AS rnum
+                         ORDER BY author_pk) AS rnum
       FROM public.author) a
       WHERE a.rnum > 1);
 COMMIT;
@@ -153,7 +153,7 @@ BEGIN;
 
 DELETE FROM public.copyright
 USING public.copyright AS cp LEFT OUTER JOIN public.agent AS ag ON cp.agent_fk = ag.agent_pk
-WHERE public.copyright.ct_pk = cp.ct_pk AND ag.agent_pk IS NULL;
+WHERE public.copyright.copyright_pk = cp.copyright_pk AND ag.agent_pk IS NULL;
 
 COMMIT;
 ";
@@ -161,7 +161,7 @@ COMMIT;
 }
 
 
-$result = $dbManager->getSingleRow("SELECT count(*) FROM pg_class WHERE relname = 'author_ct_pk_seq';",
+$result = $dbManager->getSingleRow("SELECT count(*) FROM pg_class WHERE relname = 'author_pk_seq';",
   array(), 'checkAuthorCtPkSequence');
 if($result['count'] == 0)
 {

--- a/src/copyright/agent/database.cc
+++ b/src/copyright/agent/database.cc
@@ -113,8 +113,9 @@ bool CopyrightDatabaseHandler::createTables() const
 
 const CopyrightDatabaseHandler::ColumnDef CopyrightDatabaseHandler::columns[] =
   {
-#define SEQUENCE_NAME IDENTITY"_ct_pk_seq"
-    {"ct_pk", "bigint", "PRIMARY KEY DEFAULT nextval('" SEQUENCE_NAME "'::regclass)"},
+#define SEQUENCE_NAME IDENTITY"_pk_seq"
+#define COLUMN_NAME_PK IDENTITY"_pk"
+    { COLUMN_NAME_PK, "bigint", "PRIMARY KEY DEFAULT nextval('" SEQUENCE_NAME "'::regclass)"},
     {"agent_fk", "bigint", "NOT NULL"},
     {"pfile_fk", "bigint", "NOT NULL"},
     {"content", "text", ""},
@@ -277,18 +278,20 @@ std::vector<unsigned long> CopyrightDatabaseHandler::queryFileIdsForUpload(int a
 #endif
             "INNER JOIN pfile on (PF = pfile_pk) "
 #ifdef IDENTITY_COPYRIGHT
-            "WHERE copyright.ct_pk IS NULL AND au.ct_pk IS NULL",
+            "WHERE copyright.copyright_pk IS NULL AND au.author_pk IS NULL",
 #else
-            "WHERE ct_pk IS NULL OR agent_fk <> %d",
+            "WHERE %s_pk IS NULL OR agent_fk <> %d",
 #endif
     uploadTreeTableName.c_str(),
     uploadId,
     IDENTITY,
     agentId
 #ifdef IDENTITY_COPYRIGHT
-    , agentId, agentId
-#endif
     , agentId
+#else
+    , IDENTITY
+    , agentId
+#endif
   );
 
   return queryResult.getSimpleResults<unsigned long>(0, fo::stringToUnsignedLong);

--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -375,10 +375,11 @@ class CopyrightDao
       $params[] = $content;
     }
 
+    $cpTablePk = $cpTable."_pk";
     $sql = "UPDATE $cpTable AS cpr SET $setSql
             FROM $cpTable as cp
             INNER JOIN $itemTable AS ut ON cp.pfile_fk = ut.pfile_fk
-            WHERE cpr.ct_pk = cp.ct_pk
+            WHERE cpr.$cpTablePk = cp.$cpTablePk
               AND cp.hash = $1
               AND ( ut.lft BETWEEN $2 AND $3 )";
     if ('uploadtree_a' == $item->getUploadTreeTableName())

--- a/src/lib/php/Dao/test/CopyrightDaoTest.php
+++ b/src/lib/php/Dao/test/CopyrightDaoTest.php
@@ -106,7 +106,7 @@ class CopyrightDaoTest extends \PHPUnit\Framework\TestCase
     $this->testDb->createInheritedTables(array('uploadtree_a'));
     $this->testDb->insertData(array('copyright','uploadtree_a'));
 
-    $this->testDb->createSequences(array('copyright_ct_pk_seq','copyright_decision_pk_seq'));
+    $this->testDb->createSequences(array('copyright_pk_seq','copyright_decision_pk_seq'));
     $this->testDb->alterTables(array('copyright','copyright_decision'));
   }
 
@@ -300,7 +300,7 @@ class CopyrightDaoTest extends \PHPUnit\Framework\TestCase
     $copyrightDao = new CopyrightDao($this->dbManager,$uploadDao);
     $copyrightDao->updateTable($item, $hash2, $content='foo', $userId=55);
 
-    $updatedCp = $this->dbManager->getSingleRow('SELECT * FROM copyright WHERE ct_pk=$1',array($ctPk),__METHOD__.'.cp');
+    $updatedCp = $this->dbManager->getSingleRow('SELECT * FROM copyright WHERE copyright_pk=$1',array($ctPk),__METHOD__.'.cp');
     assertThat($updatedCp['content'],is(equalTo($content)));
   }
   

--- a/src/lib/php/Proxy/UploadTreeProxy.php
+++ b/src/lib/php/Proxy/UploadTreeProxy.php
@@ -315,9 +315,9 @@ class UploadTreeProxy extends DbViewProxy
         return " $conditionQueryHasLicense
               AND NOT EXISTS (SELECT * FROM ($decisionQuery) as latest_decision WHERE latest_decision.decision_type IN (".DecisionTypes::IRRELEVANT.",".DecisionTypes::IDENTIFIED.") )";
       case "noCopyright":
-        return "EXISTS (SELECT ct_pk FROM copyright cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null )";
+        return "EXISTS (SELECT copyright_pk FROM copyright cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null )";
       case "noEcc":
-        return "EXISTS (SELECT ct_pk FROM ecc cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null )";
+        return "EXISTS (SELECT ecc_pk FROM ecc cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null )";
     }
   }
 

--- a/src/lib/php/Test/testdata.sql
+++ b/src/lib/php/Test/testdata.sql
@@ -64,40 +64,40 @@ INSERT INTO upload (upload_pk, upload_desc, upload_filename, user_fk, upload_mod
 INSERT INTO bucketpool (bucketpool_pk, bucketpool_name, version, active, description) VALUES (1, 'GPL Demo bucket pool', 1, 'Y', 'Demonstration of a very simple GPL/non-gpl bucket pool');
 INSERT INTO bucket_def (bucket_pk, bucket_name, bucket_color, bucket_reportorder, bucket_evalorder, bucketpool_fk, bucket_type, bucket_regex, bucket_filename, stopon, applies_to) VALUES (1, 'GPL Licenses (Demo)', 'orange', 50, 50, 1, 3, '(affero|gpl)', NULL, 'N', 'f');
 INSERT INTO bucket_def (bucket_pk, bucket_name, bucket_color, bucket_reportorder, bucket_evalorder, bucketpool_fk, bucket_type, bucket_regex, bucket_filename, stopon, applies_to) VALUES (2, 'non-gpl (Demo)', 'yellow', 50, 1000, 1, 99, NULL, NULL, 'N', 'f');
-INSERT INTO copyright (ct_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (1, 8, 3, 'copyright (c) 1993-2009, all rights reserved. since doc software is open-source, freely available software, you are free to use, modify, copy, and distribute--perpetually and irrevocably--the doc softw', '0xc94dcc0ecf38ec1b', 'statement', 342, 543, 'true');
-INSERT INTO copyright (ct_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (2, 8, 3, 'modified versions of this software. you must, however, include this copyright statement along with any code built using doc software that you release. no copyright statement needs to be provided if you', '0x3a910990f114f12f', 'statement', 632, 833, 'true');
-INSERT INTO copyright (ct_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (3, 8, 3, 'maintained by the doc group at the institute for software integrated systems (isis) and the center for distributed object computing of washington university, st. louis for the development of open-sourc', '0x39f39190219b296f', 'statement', 1563, 1764, 'true');
-INSERT INTO copyright (ct_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (4, 8, 3, 'written permission from washington university, uc irvine, or vanderbilt university. this license grants no permission to call products or services derived from this source ace(tm), tao(tm), ciao(tm), d', '0xd9cce4755af8544e', 'statement', 4021, 4222, 'true');
-INSERT INTO copyright (ct_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (5, 8, 4, 'copyright 3dfx interactive, inc. 1999, all rights reserved this 
+INSERT INTO copyright (copyright_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (1, 8, 3, 'copyright (c) 1993-2009, all rights reserved. since doc software is open-source, freely available software, you are free to use, modify, copy, and distribute--perpetually and irrevocably--the doc softw', '0xc94dcc0ecf38ec1b', 'statement', 342, 543, 'true');
+INSERT INTO copyright (copyright_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (2, 8, 3, 'modified versions of this software. you must, however, include this copyright statement along with any code built using doc software that you release. no copyright statement needs to be provided if you', '0x3a910990f114f12f', 'statement', 632, 833, 'true');
+INSERT INTO copyright (copyright_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (3, 8, 3, 'maintained by the doc group at the institute for software integrated systems (isis) and the center for distributed object computing of washington university, st. louis for the development of open-sourc', '0x39f39190219b296f', 'statement', 1563, 1764, 'true');
+INSERT INTO copyright (copyright_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (4, 8, 3, 'written permission from washington university, uc irvine, or vanderbilt university. this license grants no permission to call products or services derived from this source ace(tm), tao(tm), ciao(tm), d', '0xd9cce4755af8544e', 'statement', 4021, 4222, 'true');
+INSERT INTO copyright (copyright_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (5, 8, 4, 'copyright 3dfx interactive, inc. 1999, all rights reserved this 
 ', '0xd5b4932ee22d9d53', 'statement', 5063, 5128, 'true');
-INSERT INTO copyright (ct_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (6, 8, 4, 'written permission of 3dfx interactive, 
+INSERT INTO copyright (copyright_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (6, 8, 4, 'written permission of 3dfx interactive, 
 inc. see the 3dfx glide general public license for a full text of the 
 ', '0x6efc9d9755ede08', 'statement', 5290, 5403, 'true');
-INSERT INTO copyright (ct_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (7, 8, 4, 'copyright laws of 
+INSERT INTO copyright (copyright_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (7, 8, 4, 'copyright laws of 
 the united states. 
 
 copyright 3dfx interactive, inc. 1999, all rights reserved" 
 ', '0x68a5892b51a5958b', 'statement', 6854, 6958, 'true');
-INSERT INTO copyright (ct_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (8, 8, 4, 'info@3dfx.com', '0x7214ac670cc0668', 'email', 5467, 5480, 'true');
-INSERT INTO copyright (ct_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (9, 8, 4, 'info@3dfx.com', '0x7214ac670cc0668', 'email', 6322, 6335, 'true');
-INSERT INTO copyright (ct_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (10, 8, 5, 'copyright (c) 2002 by author 
+INSERT INTO copyright (copyright_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (8, 8, 4, 'info@3dfx.com', '0x7214ac670cc0668', 'email', 5467, 5480, 'true');
+INSERT INTO copyright (copyright_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (9, 8, 4, 'info@3dfx.com', '0x7214ac670cc0668', 'email', 6322, 6335, 'true');
+INSERT INTO copyright (copyright_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (10, 8, 5, 'copyright (c) 2002 by author 
 professional identification * url 
 ', '0xcd38e0e5aeb1930f', 'statement', 31, 97, 'true');
-INSERT INTO copyright (ct_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (11, 8, 5, '(c) url ("url"). 
+INSERT INTO copyright (copyright_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (11, 8, 5, '(c) url ("url"). 
 3. neither the name nor any trademark of the author may be used to 
 ', '0x2e0e72503af8034', 'statement', 1252, 1339, 'true');
-INSERT INTO copyright (ct_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (12, 8, 6, 'copyright (c) 2002 lawrence e. rosen. all rights
+INSERT INTO copyright (copyright_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (12, 8, 6, 'copyright (c) 2002 lawrence e. rosen. all rights
 reserved. permission is hereby granted to copy and distribute this
 ', '0x746a69946ff2da41', 'statement', 4499, 4616, 'true');
-INSERT INTO copyright (ct_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (13, 8, 6, 'copyright grant to the software. the
+INSERT INTO copyright (copyright_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (13, 8, 6, 'copyright grant to the software. the
     bsd and apache licenses are vague and incomplete in that respect.
 ', '0xd4a26567ae3c6dde', 'statement', 5431, 5539, 'true');
-INSERT INTO copyright (ct_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (14, 8, 6, 'copyright to the license will control changes. the apache
+INSERT INTO copyright (copyright_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (14, 8, 6, 'copyright to the license will control changes. the apache
 ', '0x5c8f0370f2ab5d52', 'statement', 6363, 6421, 'true');
-INSERT INTO copyright (ct_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (15, 8, 8, 'written permission.
+INSERT INTO copyright (copyright_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (15, 8, 8, 'written permission.
 
 you agree to indemnify, hold harmless and defend adobe systems incorporated from and against any loss, damage, claims or lawsuits, including attorney''''s fees that arise or result ', '0x32c91329da4f38ae', 'statement', 100, 201, 'true');
-INSERT INTO copyright (ct_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (16, 8, 9, 'copyright (c) 2048', '0x5c8f0370f2ab5d53', 'statement', 0, 18, 'true');
+INSERT INTO copyright (copyright_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (16, 8, 9, 'copyright (c) 2048', '0x5c8f0370f2ab5d53', 'statement', 0, 18, 'true');
 INSERT INTO copyright_ars (ars_pk, agent_fk, upload_fk, ars_success, ars_status, ars_starttime, ars_endtime) VALUES (5, 8, 1, true, NULL, '2014-08-07 09:57:20.634464+00', '2014-08-07 09:57:20.642878+00');
 INSERT INTO copyright_ars (ars_pk, agent_fk, upload_fk, ars_success, ars_status, ars_starttime, ars_endtime) VALUES (11, 8, 2, true, NULL, '2014-08-07 09:57:27.86361+00', '2014-08-07 09:57:27.869927+00');
 INSERT INTO folder (folder_pk, folder_name, folder_desc, folder_perm) VALUES (1, 'Software Repository', 'Top Folder', NULL);

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -361,9 +361,9 @@
   $Schema["TABLE"]["clearing_event"]["date_added"]["ALTER"] = "ALTER TABLE \"clearing_event\" ALTER COLUMN \"date_added\" SET NOT NULL, ALTER COLUMN \"date_added\" SET DEFAULT now()";
 
 
-  $Schema["TABLE"]["copyright"]["ct_pk"]["DESC"] = "";
-  $Schema["TABLE"]["copyright"]["ct_pk"]["ADD"] = "ALTER TABLE \"copyright\" ADD COLUMN \"ct_pk\" int8 DEFAULT nextval('copyright_ct_pk_seq'::regclass)";
-  $Schema["TABLE"]["copyright"]["ct_pk"]["ALTER"] = "ALTER TABLE \"copyright\" ALTER COLUMN \"ct_pk\" SET NOT NULL, ALTER COLUMN \"ct_pk\" SET DEFAULT nextval('copyright_ct_pk_seq'::regclass)";
+  $Schema["TABLE"]["copyright"]["copyright_pk"]["DESC"] = "";
+  $Schema["TABLE"]["copyright"]["copyright_pk"]["ADD"] = "ALTER TABLE \"copyright\" ADD COLUMN \"copyright_pk\" int8 DEFAULT nextval('copyright_pk_seq'::regclass)";
+  $Schema["TABLE"]["copyright"]["copyright_pk"]["ALTER"] = "ALTER TABLE \"copyright\" ALTER COLUMN \"copyright_pk\" SET NOT NULL, ALTER COLUMN \"copyright_pk\" SET DEFAULT nextval('copyright_pk_seq'::regclass)";
 
   $Schema["TABLE"]["copyright"]["agent_fk"]["DESC"] = "";
   $Schema["TABLE"]["copyright"]["agent_fk"]["ADD"] = "ALTER TABLE \"copyright\" ADD COLUMN \"agent_fk\" int8";
@@ -431,9 +431,9 @@
   $Schema["TABLE"]["copyright_decision"]["is_enabled"]["ALTER"] = "ALTER TABLE \"copyright_decision\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT true";
 
 
-  $Schema["TABLE"]["author"]["ct_pk"]["DESC"] = "";
-  $Schema["TABLE"]["author"]["ct_pk"]["ADD"] = "ALTER TABLE \"author\" ADD COLUMN \"ct_pk\" int8 DEFAULT nextval('author_ct_pk_seq'::regclass)";
-  $Schema["TABLE"]["author"]["ct_pk"]["ALTER"] = "ALTER TABLE \"author\" ALTER COLUMN \"ct_pk\" SET NOT NULL, ALTER COLUMN \"ct_pk\" SET DEFAULT nextval('author_ct_pk_seq'::regclass)";
+  $Schema["TABLE"]["author"]["author_pk"]["DESC"] = "";
+  $Schema["TABLE"]["author"]["author_pk"]["ADD"] = "ALTER TABLE \"author\" ADD COLUMN \"author_pk\" int8 DEFAULT nextval('author_pk_seq'::regclass)";
+  $Schema["TABLE"]["author"]["author_pk"]["ALTER"] = "ALTER TABLE \"author\" ALTER COLUMN \"author_pk\" SET NOT NULL, ALTER COLUMN \"author_pk\" SET DEFAULT nextval('author_pk_seq'::regclass)";
 
   $Schema["TABLE"]["author"]["agent_fk"]["DESC"] = "";
   $Schema["TABLE"]["author"]["agent_fk"]["ADD"] = "ALTER TABLE \"author\" ADD COLUMN \"agent_fk\" int8";
@@ -468,9 +468,9 @@
   $Schema["TABLE"]["author"]["is_enabled"]["ALTER"] = "ALTER TABLE \"author\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT true";
 
 
-  $Schema["TABLE"]["ecc"]["ct_pk"]["DESC"] = "";
-  $Schema["TABLE"]["ecc"]["ct_pk"]["ADD"] = "ALTER TABLE \"ecc\" ADD COLUMN \"ct_pk\" int8 DEFAULT nextval('ecc_ct_pk_seq'::regclass)";
-  $Schema["TABLE"]["ecc"]["ct_pk"]["ALTER"] = "ALTER TABLE \"ecc\" ALTER COLUMN \"ct_pk\" SET NOT NULL, ALTER COLUMN \"ct_pk\" SET DEFAULT nextval('ecc_ct_pk_seq'::regclass)";
+  $Schema["TABLE"]["ecc"]["ecc_pk"]["DESC"] = "";
+  $Schema["TABLE"]["ecc"]["ecc_pk"]["ADD"] = "ALTER TABLE \"ecc\" ADD COLUMN \"ecc_pk\" int8 DEFAULT nextval('ecc_pk_seq'::regclass)";
+  $Schema["TABLE"]["ecc"]["ecc_pk"]["ALTER"] = "ALTER TABLE \"ecc\" ALTER COLUMN \"ecc_pk\" SET NOT NULL, ALTER COLUMN \"ecc_pk\" SET DEFAULT nextval('ecc_pk_seq'::regclass)";
 
   $Schema["TABLE"]["ecc"]["agent_fk"]["DESC"] = "";
   $Schema["TABLE"]["ecc"]["agent_fk"]["ADD"] = "ALTER TABLE \"ecc\" ADD COLUMN \"agent_fk\" int8";
@@ -538,9 +538,9 @@
   $Schema["TABLE"]["ecc_decision"]["is_enabled"]["ALTER"] = "ALTER TABLE \"ecc_decision\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT true";
 
 
-  $Schema["TABLE"]["keyword"]["ct_pk"]["DESC"] = "";
-  $Schema["TABLE"]["keyword"]["ct_pk"]["ADD"] = "ALTER TABLE \"keyword\" ADD COLUMN \"ct_pk\" int8 DEFAULT nextval('keyword_ct_pk_seq'::regclass)";
-  $Schema["TABLE"]["keyword"]["ct_pk"]["ALTER"] = "ALTER TABLE \"keyword\" ALTER COLUMN \"ct_pk\" SET NOT NULL, ALTER COLUMN \"ct_pk\" SET DEFAULT nextval('keyword_ct_pk_seq'::regclass)";
+  $Schema["TABLE"]["keyword"]["keyword_pk"]["DESC"] = "";
+  $Schema["TABLE"]["keyword"]["keyword_pk"]["ADD"] = "ALTER TABLE \"keyword\" ADD COLUMN \"keyword_pk\" int8 DEFAULT nextval('keyword_pk_seq'::regclass)";
+  $Schema["TABLE"]["keyword"]["keyword_pk"]["ALTER"] = "ALTER TABLE \"keyword\" ALTER COLUMN \"keyword_pk\" SET NOT NULL, ALTER COLUMN \"keyword_pk\" SET DEFAULT nextval('keyword_pk_seq'::regclass)";
 
   $Schema["TABLE"]["keyword"]["agent_fk"]["DESC"] = "";
   $Schema["TABLE"]["keyword"]["agent_fk"]["ADD"] = "ALTER TABLE \"keyword\" ADD COLUMN \"agent_fk\" int8";
@@ -1800,8 +1800,8 @@
   $Schema["SEQUENCE"]["perm_upload_perm_upload_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"perm_upload_perm_upload_pk_seq\"";
   $Schema["SEQUENCE"]["perm_upload_perm_upload_pk_seq"]["UPDATE"] = "SELECT setval('perm_upload_perm_upload_pk_seq',(SELECT greatest(1,max(perm_upload_pk)) val FROM perm_upload))";
 
-  $Schema["SEQUENCE"]["copyright_ct_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"copyright_ct_pk_seq\"";
-  $Schema["SEQUENCE"]["copyright_ct_pk_seq"]["UPDATE"] = "SELECT setval('copyright_ct_pk_seq',(SELECT greatest(1,max(ct_pk)) val FROM copyright))";
+  $Schema["SEQUENCE"]["copyright_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"copyright_pk_seq\"";
+  $Schema["SEQUENCE"]["copyright_pk_seq"]["UPDATE"] = "SELECT setval('copyright_pk_seq',(SELECT greatest(1,max(copyright_pk)) val FROM copyright))";
 
   $Schema["SEQUENCE"]["license_file_fl_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"license_file_fl_pk_seq\"";
   $Schema["SEQUENCE"]["license_file_fl_pk_seq"]["UPDATE"] = "SELECT setval('license_file_fl_pk_seq',(SELECT greatest(1,max(fl_pk)) val FROM license_file))";
@@ -1898,14 +1898,14 @@
   $Schema["SEQUENCE"]["copyright_decision_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"copyright_decision_pk_seq\"";
   $Schema["SEQUENCE"]["copyright_decision_pk_seq"]["UPDATE"] = "SELECT setval('copyright_decision_pk_seq',(SELECT greatest(1,max(copyright_decision_pk)) val FROM copyright_decision))";
 
-  $Schema["SEQUENCE"]["ecc_ct_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"ecc_ct_pk_seq\"";
-  $Schema["SEQUENCE"]["ecc_ct_pk_seq"]["UPDATE"] = "SELECT setval('ecc_ct_pk_seq',(SELECT greatest(1,max(ct_pk)) val FROM ecc))";
+  $Schema["SEQUENCE"]["ecc_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"ecc_pk_seq\"";
+  $Schema["SEQUENCE"]["ecc_pk_seq"]["UPDATE"] = "SELECT setval('ecc_pk_seq',(SELECT greatest(1,max(ecc_pk)) val FROM ecc))";
 
-  $Schema["SEQUENCE"]["author_ct_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"author_ct_pk_seq\"";
-  $Schema["SEQUENCE"]["author_ct_pk_seq"]["UPDATE"] = "SELECT setval('author_ct_pk_seq',(SELECT greatest(1,max(ct_pk)) val FROM author))";
+  $Schema["SEQUENCE"]["author_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"author_pk_seq\"";
+  $Schema["SEQUENCE"]["author_pk_seq"]["UPDATE"] = "SELECT setval('author_pk_seq',(SELECT greatest(1,max(author_pk)) val FROM author))";
 
-  $Schema["SEQUENCE"]["keyword_ct_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"keyword_ct_pk_seq\"";
-  $Schema["SEQUENCE"]["keyword_ct_pk_seq"]["UPDATE"] = "SELECT setval('keyword_ct_pk_seq',(SELECT greatest(1,max(ct_pk)) val FROM keyword))";
+  $Schema["SEQUENCE"]["keyword_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"keyword_pk_seq\"";
+  $Schema["SEQUENCE"]["keyword_pk_seq"]["UPDATE"] = "SELECT setval('keyword_pk_seq',(SELECT greatest(1,max(keyword_pk)) val FROM keyword))";
 
   $Schema["SEQUENCE"]["ecc_decision_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"ecc_decision_pk_seq\"";
   $Schema["SEQUENCE"]["ecc_decision_pk_seq"]["UPDATE"] = "SELECT setval('ecc_decision_pk_seq',(SELECT greatest(1,max(ecc_decision_pk)) val FROM ecc_decision))";
@@ -1925,14 +1925,14 @@
   $Schema["CONSTRAINT"]["clearing_decision_pkey"] = "ALTER TABLE \"clearing_decision\" ADD CONSTRAINT \"clearing_decision_pkey\" PRIMARY KEY (\"clearing_decision_pk\");";
   $Schema["CONSTRAINT"]["clearing_event_pkey"] = "ALTER TABLE \"clearing_event\" ADD CONSTRAINT \"clearing_event_pkey\" PRIMARY KEY (\"clearing_event_pk\");";
   $Schema["CONSTRAINT"]["copyright_decision_pkey"] = "ALTER TABLE \"copyright_decision\" ADD CONSTRAINT \"copyright_decision_pkey\" PRIMARY KEY (\"copyright_decision_pk\");";
-  $Schema["CONSTRAINT"]["copyright_pkey"] = "ALTER TABLE \"copyright\" ADD CONSTRAINT \"copyright_pkey\" PRIMARY KEY (\"ct_pk\");";
-  $Schema["CONSTRAINT"]["author_pkey"] = "ALTER TABLE \"author\" ADD CONSTRAINT \"author_pkey\" PRIMARY KEY (\"ct_pk\");";
+  $Schema["CONSTRAINT"]["copyright_pkey"] = "ALTER TABLE \"copyright\" ADD CONSTRAINT \"copyright_pkey\" PRIMARY KEY (\"copyright_pk\");";
+  $Schema["CONSTRAINT"]["author_pkey"] = "ALTER TABLE \"author\" ADD CONSTRAINT \"author_pkey\" PRIMARY KEY (\"author_pk\");";
   $Schema["CONSTRAINT"]["author_pfile_fk_fkey"] = "ALTER TABLE \"author\" ADD CONSTRAINT \"author_pfile_fk_fkey\" FOREIGN KEY (\"pfile_fk\") REFERENCES \"pfile\" (\"pfile_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["author_agent_fk_fkey"] = "ALTER TABLE \"author\" ADD CONSTRAINT \"author_agent_fk_fkey\" FOREIGN KEY (\"agent_fk\") REFERENCES \"agent\" (\"agent_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["ecc_decision_pkey"] = "ALTER TABLE \"ecc_decision\" ADD CONSTRAINT \"ecc_decision_pkey\" PRIMARY KEY (\"ecc_decision_pk\");";
-  $Schema["CONSTRAINT"]["ecc_pkey"] = "ALTER TABLE \"ecc\" ADD CONSTRAINT \"ecc_pkey\" PRIMARY KEY (\"ct_pk\");";
+  $Schema["CONSTRAINT"]["ecc_pkey"] = "ALTER TABLE \"ecc\" ADD CONSTRAINT \"ecc_pkey\" PRIMARY KEY (\"ecc_pk\");";
   $Schema["CONSTRAINT"]["keyword_decision_pkey"] = "ALTER TABLE \"keyword_decision\" ADD CONSTRAINT \"keyword_decision_pkey\" PRIMARY KEY (\"keyword_decision_pk\");";
-  $Schema["CONSTRAINT"]["keyword_pkey"] = "ALTER TABLE \"keyword\" ADD CONSTRAINT \"keyword_pkey\" PRIMARY KEY (\"ct_pk\");";
+  $Schema["CONSTRAINT"]["keyword_pkey"] = "ALTER TABLE \"keyword\" ADD CONSTRAINT \"keyword_pkey\" PRIMARY KEY (\"keyword_pk\");";
   $Schema["CONSTRAINT"]["file_picker_pkey"] = "ALTER TABLE \"file_picker\" ADD CONSTRAINT \"file_picker_pkey\" PRIMARY KEY (\"file_picker_pk\");";
   $Schema["CONSTRAINT"]["folder_pkey"] = "ALTER TABLE \"folder\" ADD CONSTRAINT \"folder_pkey\" PRIMARY KEY (\"folder_pk\");";
   $Schema["CONSTRAINT"]["foldercontents_pkey"] = "ALTER TABLE \"foldercontents\" ADD CONSTRAINT \"foldercontents_pkey\" PRIMARY KEY (\"foldercontents_pk\");";


### PR DESCRIPTION
## Description

Replace ct_pk with table_pk for all copyright sub-agents

### Changes

Change `ct_pk` to `tablename_pk`.

## How to test

edit , delete operations with existing and new uploads.
- [x] Copyright view single/file-tree
- [x] ECC view single/file-tree
- [x] Keyword view single/file-tree