### PR TITLE
fix(resequence): Check the column name from DB

### DIFF
--- a/install/db/dbmigrate_3.3-3.4.php
+++ b/install/db/dbmigrate_3.3-3.4.php
@@ -146,9 +146,6 @@ function Migrate_33_34($dbManager, $dryRun)
       ["bucket_container", "bucket_fk", "bucket_def", "bucket_pk"],
       ["bucket_file", "bucket_fk", "bucket_def", "bucket_pk"],
       ["bucket_file", "pfile_fk", "pfile", "pfile_pk"],
-      ["clearing_decision_event", "clearing_event_fk", "clearing_event", "clearing_event_pk"],
-      ["clearing_decision_event", "clearing_decision_fk", "clearing_decision", "clearing_decision_pk"],
-      ["clearing_event", "job_fk", "job", "job_pk"],
       ["copyright_decision", "pfile_fk", "pfile", "pfile_pk"],
       ["ecc", "agent_fk", "agent", "agent_pk"],
       ["ecc", "pfile_fk", "pfile", "pfile_pk"],
@@ -164,10 +161,8 @@ function Migrate_33_34($dbManager, $dryRun)
       ["report_cache", "report_cache_uploadfk", "upload", "upload_pk"],
       ["report_info", "upload_fk", "upload", "upload_pk"],
       ["reportgen", "upload_fk", "upload", "upload_pk"],
-      ["reportgen", "job_fk", "job", "job_pk"],
       ["upload", "pfile_fk", "pfile", "pfile_pk"],
-      ["upload_clearing_license", "upload_fk", "upload", "upload_pk"],
-      ["upload_clearing_license", "rf_fk", "license_ref", "rf_pk"]
+      ["upload_clearing_license", "upload_fk", "upload", "upload_pk"]
     ];
     $dbManager->queryOnce("BEGIN;");
 

--- a/install/db/dbmigrate_3.3-3.4.php
+++ b/install/db/dbmigrate_3.3-3.4.php
@@ -40,6 +40,11 @@ function cleanTableForeign($dbManager, $tableToClean, $foreignKey, $referenceTab
     echo "No connection object passed!\n";
     return false;
   }
+  if(!(DB_TableExists($tableToClean) == 1 && DB_TableExists($referenceTable) == 1)) {
+    // Table does not exists (migrating from old version)
+    echo "Table $tableToClean or $referenceTable does not exists, not cleaning!\n";
+    return 0;
+  }
 
   $sql = "";
   if($dryRun) {
@@ -81,6 +86,11 @@ function cleanWithUnique($dbManager, $tableName, $primaryKey, $columnNames, $dry
   if($dbManager == NULL){
     echo "No connection object passed!\n";
     return false;
+  }
+  if(DB_TableExists($tableName) != 1) {
+    // Table does not exists (migrating from old version)
+    echo "Table $tableName does not exists, not cleaning!\n";
+    return 0;
   }
 
   $sql = "";
@@ -125,7 +135,7 @@ WITH deleted AS (
  */
 function Migrate_33_34($dbManager, $dryRun)
 {
-  if(DB_ConstraintExists('group_user_member_user_group_ukey')) {
+  if(DB_ConstraintExists('group_user_member_user_group_ukey', $GLOBALS["SysConf"]["DBCONF"]["dbname"])) {
     // The last constraint also cleared, no need for re-run
     return;
   }
@@ -148,7 +158,6 @@ function Migrate_33_34($dbManager, $dryRun)
       ["keyword", "agent_fk", "agent", "agent_pk"],
       ["keyword", "pfile_fk", "pfile", "pfile_pk"],
       ["keyword_decision", "pfile_fk", "pfile", "pfile_pk"],
-      ["license_file", "rf_fk", "license_ref", "rf_pk"],
       ["license_ref_bulk", "upload_fk", "upload", "upload_pk"],
       ["pkg_deb_req", "pkg_fk", "pkg_deb", "pkg_pk"],
       ["pkg_rpm_req", "pkg_fk", "pkg_rpm", "pkg_pk"],
@@ -175,8 +184,8 @@ function Migrate_33_34($dbManager, $dryRun)
     $count += cleanWithUnique($dbManager, "obligation_ref", "ob_pk", ["ob_md5"], $dryRun);
     $count += cleanWithUnique($dbManager, "group_user_member", "group_user_member_pk",
       ["user_fk", "group_fk"], $dryRun);
-    echo "Removed $count rows from tables with new constraints\n";
     $dbManager->queryOnce("COMMIT;");
+    echo "Removed $count rows from tables with new constraints\n";
   } catch (Exception $e) {
     echo "Something went wrong. Try running postinstall again!\n";
     $dbManager->queryOnce("ROLLBACK;");

--- a/install/db/resequence_author_table.php
+++ b/install/db/resequence_author_table.php
@@ -24,10 +24,11 @@
 
 /**
  * \brief Drop all sequence and constrains and resequence the author table and build them again
- * \param DbManager $dbManager DB Manager to be used 
+ * \param DbManager $dbManager DB Manager to be used
+ * \param string $authorColumn Primary column name
  */
 
-function ResequenceAuthorTablePKey($dbManager)
+function ResequenceAuthorTablePKey($dbManager, $authorColumn)
 {
   if($dbManager == NULL){
     echo "No connection object passed!\n";
@@ -48,8 +49,8 @@ ALTER TABLE ONLY public.author
   $dbManager->queryOnce($sql);
   $sql = "
 CREATE SEQUENCE public.author_pk_seq;
-SELECT setval('public.author_pk_seq',(SELECT greatest(1,max(author_pk)) val FROM author));
-ALTER TABLE public.author ALTER COLUMN author_pk SET DEFAULT nextval('author_pk_seq'::regclass);
+SELECT setval('public.author_pk_seq',(SELECT greatest(1,max($authorColumn)) val FROM author));
+ALTER TABLE public.author ALTER COLUMN $authorColumn SET DEFAULT nextval('author_pk_seq'::regclass);
 
 DROP INDEX IF EXISTS author_agent_fk_idx;
 DROP INDEX IF EXISTS author_pfile_fk_index;
@@ -57,10 +58,10 @@ DROP INDEX IF EXISTS author_pfile_hash_idx;
 DROP INDEX IF EXISTS author_pkey;
 
 ALTER SEQUENCE public.author_pk_seq RESTART WITH 1;
-UPDATE public.author SET author_pk=nextval('public.author_pk_seq');
+UPDATE public.author SET $authorColumn=nextval('public.author_pk_seq');
 
 ALTER TABLE ONLY public.author
-    ADD CONSTRAINT author_pkey PRIMARY KEY (author_pk);
+    ADD CONSTRAINT author_pkey PRIMARY KEY ($authorColumn);
 
 CREATE INDEX author_agent_fk_idx ON public.author USING btree (agent_fk);
 CREATE INDEX author_pfile_fk_index ON public.author USING btree (pfile_fk);
@@ -78,9 +79,10 @@ COMMIT;
 /**
  * \brief Drop primary key constrains and resequence the copyright table and build them again
  * \param DbManager $dbManager DB Manager to be used
+ * \param string $copyrightColumn Primary column name
  */
 
-function ResequenceCopyrightTablePKey($dbManager)
+function ResequenceCopyrightTablePKey($dbManager, $copyrightColumn)
 {
   if($dbManager == NULL){
     echo "No connection object passed!\n";
@@ -94,14 +96,18 @@ ALTER TABLE ONLY public.copyright
 ALTER TABLE ONLY public.copyright
     DROP CONSTRAINT IF EXISTS copyright_agent_fk_fkey CASCADE;
 DROP INDEX IF EXISTS copyright_pkey;
+DROP SEQUENCE IF EXISTS public.copyright_pk_seq CASCADE;
 ";
   $dbManager->queryOnce($sql);
   $sql = "
+CREATE SEQUENCE public.copyright_pk_seq;
+SELECT setval('public.copyright_pk_seq',(SELECT greatest(1,max($copyrightColumn)) val FROM copyright));
+ALTER TABLE public.copyright ALTER COLUMN $copyrightColumn SET DEFAULT nextval('copyright_pk_seq'::regclass);
 ALTER SEQUENCE public.copyright_pk_seq RESTART WITH 1;
-UPDATE public.copyright SET copyright_pk=nextval('public.copyright_pk_seq');
+UPDATE public.copyright SET $copyrightColumn=nextval('public.copyright_pk_seq');
 
 ALTER TABLE ONLY public.copyright
-    ADD CONSTRAINT copyright_pkey PRIMARY KEY (copyright_pk);
+    ADD CONSTRAINT copyright_pkey PRIMARY KEY ($copyrightColumn);
 ALTER TABLE ONLY public.copyright
     ADD CONSTRAINT copyright_agent_fk_fkey FOREIGN KEY (agent_fk) REFERENCES public.agent(agent_pk) ON DELETE CASCADE;
 
@@ -112,11 +118,12 @@ COMMIT;
 
 
 /**
- * \brief Remove reduntant entries from author table
+ * \brief Remove redundant entries from author table
  * \param DbManager $dbManager DB Manager to be used
+ * \param string $authorColumn Primary column name
  */
 
-function CleanAuthorTable($dbManager)
+function CleanAuthorTable($dbManager, $authorColumn)
 {
   if($dbManager == NULL){
     echo "No connection object passed!\n";
@@ -127,17 +134,17 @@ function CleanAuthorTable($dbManager)
 BEGIN;
 DELETE FROM public.author
 USING public.author AS a LEFT OUTER JOIN public.pfile AS p ON p.pfile_pk = a.pfile_fk
-WHERE public.author.author_pk = a.author_pk AND p.pfile_pk IS NULL;
+WHERE public.author.$authorColumn = a.$authorColumn AND p.pfile_pk IS NULL;
 
 DELETE FROM public.author
 USING public.author AS au LEFT OUTER JOIN public.agent AS ag ON au.agent_fk = ag.agent_pk
-WHERE public.author.author_pk = au.author_pk AND ag.agent_pk IS NULL;
+WHERE public.author.$authorColumn = au.$authorColumn AND ag.agent_pk IS NULL;
 
 DELETE FROM public.author
-WHERE author_pk IN (SELECT author_pk
-FROM (SELECT author_pk,
+WHERE $authorColumn IN (SELECT $authorColumn
+FROM (SELECT $authorColumn,
       ROW_NUMBER() OVER (PARTITION BY hash, pfile_fk, agent_fk, copy_startbyte, copy_endbyte, type
-                         ORDER BY author_pk) AS rnum
+                         ORDER BY $authorColumn) AS rnum
       FROM public.author) a
       WHERE a.rnum > 1);
 COMMIT;
@@ -148,9 +155,10 @@ COMMIT;
 /**
  * \brief Remove invalid entries from copyright table
  * \param DbManager $dbManager DB Manager to be used
+ * \param string $copyrightColumn Primary column name
  */
 
-function CleanCopyrightTable($dbManager)
+function CleanCopyrightTable($dbManager, $copyrightColumn)
 {
   if($dbManager == NULL){
     echo "No connection object passed!\n";
@@ -162,27 +170,30 @@ BEGIN;
 
 DELETE FROM public.copyright
 USING public.copyright AS cp LEFT OUTER JOIN public.agent AS ag ON cp.agent_fk = ag.agent_pk
-WHERE public.copyright.copyright_pk = cp.copyright_pk AND ag.agent_pk IS NULL;
+WHERE public.copyright.$copyrightColumn = cp.$copyrightColumn AND ag.agent_pk IS NULL;
 
 COMMIT;
 ";
   $dbManager->queryOnce($sql);
 }
 
-
 $result = $dbManager->getSingleRow("SELECT count(*) FROM pg_class WHERE relname = 'author_pk_seq';",
   array(), 'checkAuthorCtPkSequence');
 if($result['count'] == 0)
 {
+  $DatabaseName = $GLOBALS["SysConf"]["DBCONF"]["dbname"];
+  $authorColumn = DB_ColExists("author", "ct_pk", $DatabaseName) == 1 ? "ct_pk" : "author_pk";
+  $copyrightColumn = DB_ColExists("copyright", "ct_pk", $DatabaseName) == 1 ? "ct_pk" : "copyright_pk";
+
   try {
     echo "*** Cleaning author table ***\n";
-    CleanAuthorTable($dbManager);
+    CleanAuthorTable($dbManager, $authorColumn);
     echo "*** Cleaning copyright table ***\n";
-    CleanCopyrightTable($dbManager);
+    CleanCopyrightTable($dbManager, $copyrightColumn);
     echo "*** Resequencing author table ***\n";
-    ResequenceAuthorTablePKey($dbManager);
+    ResequenceAuthorTablePKey($dbManager, $authorColumn);
     echo "*** Resequencing copyright table ***\n";
-    ResequenceCopyrightTablePKey($dbManager);
+    ResequenceCopyrightTablePKey($dbManager, $copyrightColumn);
   } catch (Exception $e) {
     echo "Something went wrong. Try running postinstall again!\n";
     $dbManager->queryOnce("ROLLBACK;");

--- a/install/fossinit.php
+++ b/install/fossinit.php
@@ -95,6 +95,8 @@ foreach($Options as $optKey => $optVal)
 
 /* Set SYSCONFDIR and set global (for backward compatibility) */
 $SysConf = bootstrap($sysconfdir);
+$SysConf["DBCONF"]["dbname"] = $DatabaseName;
+$GLOBALS["SysConf"] = array_merge($GLOBALS["SysConf"], $SysConf);
 $projectGroup = $SysConf['DIRECTORIES']['PROJECTGROUP'] ?: 'fossy';
 $gInfo = posix_getgrnam($projectGroup);
 posix_setgid($gInfo['gid']);

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -1883,10 +1883,7 @@
   $Schema["CONSTRAINT"]["clearing_decision_pkey"] = "ALTER TABLE \"clearing_decision\" ADD CONSTRAINT \"clearing_decision_pkey\" PRIMARY KEY (\"clearing_decision_pk\");";
   $Schema["CONSTRAINT"]["clearing_decision_pfile_fk_fkey"] = "ALTER TABLE \"clearing_decision\" ADD CONSTRAINT \"clearing_decision_pfile_fk_fkey\" FOREIGN KEY (\"pfile_fk\") REFERENCES \"pfile\" (\"pfile_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["clearing_decision_user_fk_fkey"] = "ALTER TABLE \"clearing_decision\" ADD CONSTRAINT \"clearing_decision_user_fk_fkey\" FOREIGN KEY (\"user_fk\") REFERENCES \"users\" (\"user_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
-  $Schema["CONSTRAINT"]["clearing_decision_event_event_fk_fkey"] = "ALTER TABLE \"clearing_decision_event\" ADD CONSTRAINT \"clearing_decision_event_event_fk_fkey\" FOREIGN KEY (\"clearing_event_fk\") REFERENCES \"clearing_event\" (\"clearing_event_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
-  $Schema["CONSTRAINT"]["clearing_decision_event_decision_fk_fkey"] = "ALTER TABLE \"clearing_decision_event\" ADD CONSTRAINT \"clearing_decision_event_decision_fk_fkey\" FOREIGN KEY (\"clearing_decision_fk\") REFERENCES \"clearing_decision\" (\"clearing_decision_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["clearing_event_pkey"] = "ALTER TABLE \"clearing_event\" ADD CONSTRAINT \"clearing_event_pkey\" PRIMARY KEY (\"clearing_event_pk\");";
-  $Schema["CONSTRAINT"]["clearing_event_job_fk_fkey"] = "ALTER TABLE \"clearing_event\" ADD CONSTRAINT \"clearing_event_job_fk_fkey\" FOREIGN KEY (\"job_fk\") REFERENCES \"job\" (\"job_pk\") ON UPDATE RESTRICT ON DELETE RESTRICT;";
   $Schema["CONSTRAINT"]["copyright_pkey"] = "ALTER TABLE \"copyright\" ADD CONSTRAINT \"copyright_pkey\" PRIMARY KEY (\"copyright_pk\");";
   $Schema["CONSTRAINT"]["copyright_agent_fk_fkey"] = "ALTER TABLE \"copyright\" ADD CONSTRAINT \"copyright_agent_fk_fkey\" FOREIGN KEY (\"agent_fk\") REFERENCES \"agent\" (\"agent_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["copyright_pfile_fk_fkey"] = "ALTER TABLE \"copyright\" ADD CONSTRAINT \"copyright_pfile_fk_fkey\" FOREIGN KEY (\"pfile_fk\") REFERENCES \"pfile\" (\"pfile_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
@@ -1959,7 +1956,6 @@
   $Schema["CONSTRAINT"]["report_info_pkey"] = "ALTER TABLE \"report_info\" ADD CONSTRAINT \"report_info_pkey\" PRIMARY KEY (\"ri_pk\");";
   $Schema["CONSTRAINT"]["report_info_upload_fk_fkey"] = "ALTER TABLE \"report_info\" ADD CONSTRAINT \"report_info_upload_fk_fkey\" FOREIGN KEY (\"upload_fk\") REFERENCES \"upload\" (\"upload_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["reportgen_upload_fk_fkey"] = "ALTER TABLE \"reportgen\" ADD CONSTRAINT \"reportgen_upload_fk_fkey\" FOREIGN KEY (\"upload_fk\") REFERENCES \"upload\" (\"upload_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
-  $Schema["CONSTRAINT"]["reportgen_job_fk_fkey"] = "ALTER TABLE \"reportgen\" ADD CONSTRAINT \"reportgen_job_fk_fkey\" FOREIGN KEY (\"job_fk\") REFERENCES \"job\" (\"job_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["sysconfig_pkey"] = "ALTER TABLE \"sysconfig\" ADD CONSTRAINT \"sysconfig_pkey\" PRIMARY KEY (\"sysconfig_pk\");";
   $Schema["CONSTRAINT"]["sysconfig_variablename_key"] = "ALTER TABLE \"sysconfig\" ADD CONSTRAINT \"sysconfig_variablename_key\" UNIQUE (\"variablename\");";
   $Schema["CONSTRAINT"]["tags_pkey"] = "ALTER TABLE \"tag\" ADD CONSTRAINT \"tags_pkey\" PRIMARY KEY (\"tag_pk\");";
@@ -1974,7 +1970,6 @@
   $Schema["CONSTRAINT"]["upload_pfile_fk_fkey"] = "ALTER TABLE \"upload\" ADD CONSTRAINT \"upload_pfile_fk_fkey\" FOREIGN KEY (\"pfile_fk\") REFERENCES \"pfile\" (\"pfile_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["upload_clearing_pkey"] = "ALTER TABLE \"upload_clearing\" ADD CONSTRAINT \"upload_clearing_pkey\" PRIMARY KEY (\"upload_fk\",\"group_fk\");";
   $Schema["CONSTRAINT"]["upload_clearing_license_upload_fk_fkey"] = "ALTER TABLE \"upload_clearing_license\" ADD CONSTRAINT \"upload_clearing_license_upload_fk_fkey\" FOREIGN KEY (\"upload_fk\") REFERENCES \"upload\" (\"upload_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
-  $Schema["CONSTRAINT"]["upload_clearing_license_rf_fk_fkey"] = "ALTER TABLE \"upload_clearing_license\" ADD CONSTRAINT \"upload_clearing_license_rf_fk_fkey\" FOREIGN KEY (\"rf_fk\") REFERENCES \"license_ref\" (\"rf_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["upload_packages_package_fk"] = "ALTER TABLE \"upload_packages\" ADD CONSTRAINT \"upload_packages_package_fk\" FOREIGN KEY (\"package_fk\") REFERENCES \"package\" (\"package_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["upload_packages_upload_fk"] = "ALTER TABLE \"upload_packages\" ADD CONSTRAINT \"upload_packages_upload_fk\" FOREIGN KEY (\"upload_fk\") REFERENCES \"upload\" (\"upload_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["upload_reuse_reused_upload_fk"] = "ALTER TABLE \"upload_reuse\" ADD CONSTRAINT \"upload_reuse_reused_upload_fk\" FOREIGN KEY (\"reused_upload_fk\") REFERENCES \"upload\" (\"upload_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";


### PR DESCRIPTION
## Description

After renaming the primary column names of `copyright`, `author`, `ecc` and `keyword` table, the migration script was failing.

### Changes

Check the copyright and author table column name from DB before resequencing the tables.
Also check for tables before applying new constraints (which does not exists in previous versions).

## How to test

Install fossology and run post install script on existing old setup.

```bash
$ sudo make install
$ sudo install/fo-postinstall
```

Closes #1227
Closes #1209