### PR TITLE
fix(postgresql): Fixed postgresql version to 9.6 and use a volume for its data.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,13 +57,16 @@ services:
     volumes:
       - repository:/srv/fossology/repository/
   db:
-    image: postgres
+    image: postgres:9.6
     restart: unless-stopped
     environment:
       - POSTGRES_DB=fossology
       - POSTGRES_USER=fossy
       - POSTGRES_PASSWORD=fossy
       - POSTGRES_INITDB_ARGS='-E SQL_ASCII'
+    volumes:
+      - database:/var/lib/postgresql/data
 
 volumes:
+  database:
   repository:


### PR DESCRIPTION
### Changes

There are issues with postgresql versions >= 10.

## How to test

Inspect the logs of `$ docker-compose up` and open the dashboard.

Fixes #1229 