### PR TITLE
test(postgres): Run test cases in PostgreSQL 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,9 +75,9 @@ jobs:
       install:
         - composer install --prefer-dist --working-dir=src
         - ./install/scripts/install-spdx-tools.sh
-      before_script: ./utils/prepare-test -afty
+      before_script: &default-before-script
+        ./utils/prepare-test -afty
       script:
-        - make
         - make test
     - <<: *compiler-tests
       env: CC=gcc-5 CXX=g++-5 CFLAGS='-Wall'
@@ -108,6 +108,26 @@ jobs:
           packages:
             - *default_packages
             - clang-3.6
+    - <<: *compiler-tests
+      env: CC=gcc-6 CXX=g++-6 CFLAGS='-Wall' PGPORT=5432
+      addons:
+        postgresql: "10"
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - *default_packages
+            - gcc-6
+            - g++-6
+            - postgresql-10
+            - postgresql-client-10
+      before_script: &postgres-before-script
+        # Use default port
+        - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/10/main/postgresql.conf
+        # Use 9.6 auth config:
+        - sudo cp /etc/postgresql/{9.6,10}/main/pg_hba.conf
+        - sudo service postgresql restart
+        - *default-before-script
 #### PHPUnit tests ###########################
     - &phpunit-tests
       php: 5.6
@@ -125,6 +145,18 @@ jobs:
       install: composer update --ignore-platform-reqs --with-dependencies --prefer-dist --working-dir=src phpunit/phpunit
     - <<: *phpunit-tests
       php: 7.2
+      install: composer update --ignore-platform-reqs --with-dependencies --prefer-dist --working-dir=src phpunit/phpunit
+    - <<: *phpunit-tests
+      php: 7.2
+      env: PGPORT=5432
+      addons:
+        postgresql: "10"
+        apt:
+          packages:
+            - *default_packages
+            - postgresql-10
+            - postgresql-client-10
+      before_script: *postgres-before-script
       install: composer update --ignore-platform-reqs --with-dependencies --prefer-dist --working-dir=src phpunit/phpunit
   allow_failures:
     - name: Copy/Paste Detector

--- a/install/db/dbcreate.in
+++ b/install/db/dbcreate.in
@@ -26,12 +26,12 @@ su postgres -c "psql --tuples-only --command \"select * from pg_database where d
 if [ $? = 0 ]; then
    echo "NOTE: fossology database already exists, not creating"
    echo "*** Checking for plpgsql support ***"
-   su postgres -c 'createlang -l fossology' |grep -q plpgsql
+   su postgres -c 'echo "SELECT * FROM pg_language;" | psql -t fossology' |grep -q plpgsql
    if [ $? = 0 ]; then
       echo "NOTE: plpgsql already exists in fossology database, good"
    else
       echo "NOTE: plpgsql doesn't exist, adding"
-      su postgres -c 'createlang plpgsql fossology'
+      su postgres -c 'echo "CREATE LANGUAGE plpgsql;" | psql fossology'
       if [ $? != 0 ]; then
          echo "ERROR: failed to add plpgsql to fossology database"
       fi

--- a/src/testing/db/TestDbFactory.php
+++ b/src/testing/db/TestDbFactory.php
@@ -57,10 +57,10 @@ class TestDbFactory
     exec($cmd = "psql -Ufossy -h localhost -lqtA | cut -f 1 -d '|' | grep -q '^$dbName\$'", $cmdOut, $cmdRtn);
     if ($cmdRtn == 0)
     {
-      exec($cmd = "createlang -Ufossy -h localhost -l $dbName | grep -q plpgsql", $cmdOut, $cmdRtn);
+      exec($cmd = "echo 'SELECT * FROM pg_language;' | psql -Ufossy -h localhost -t $dbName | grep -q plpgsql", $cmdOut, $cmdRtn);
       if ($cmdRtn != 0)
       {
-        exec($cmd = "createlang -Ufossy -h localhost plpgsql $dbName", $cmdOut, $cmdRtn);
+        exec($cmd = "echo 'CREATE LANGUAGE plpgsql;' | psql -Ufossy -h localhost $dbName", $cmdOut, $cmdRtn);
         if ($cmdRtn != 0)
           throw new \Exception("ERROR: failed to add plpgsql to $dbName database");
       }

--- a/src/testing/db/ftdbcreate.sh
+++ b/src/testing/db/ftdbcreate.sh
@@ -32,12 +32,12 @@ su postgres -c 'psql -l' |grep -q $dbname
 if [ $? = 0 ]; then
    echo "NOTE: $dbname database already exists, not creating"
    echo "*** Checking for plpgsql support ***"
-   su postgres -c "createlang -l $dbname" |grep -q plpgsql
+   su postgres -c "echo 'SELECT * FROM pg_language;' | psql -t" | grep -q plpgsql
    if [ $? = 0 ]; then
       echo "NOTE: plpgsql already exists in $dbname database, good"
    else
       echo "NOTE: plpgsql doesn't exist, adding"
-      su postgres -c "createlang plpgsql $dbname"
+      su postgres -c "echo 'CREATE LANGUAGE plpgsql;' | psql $dbname"
       if [ $? != 0 ]; then
          echo "ERROR: failed to add plpgsql to $dbname database"
       fi

--- a/src/testing/utils/dbcreate
+++ b/src/testing/utils/dbcreate
@@ -21,12 +21,12 @@ su postgres -c 'psql -l' |grep -q fosstest
 if [ $? = 0 ]; then
    echo "NOTE: fosstest database already exists, not creating"
    echo "*** Checking for plpgsql support ***"
-   su postgres -c 'createlang -l fosstest' |grep -q plpgsql
+   su postgres -c 'echo "SELECT * FROM pg_language;" | psql -t fosstest' |grep -q plpgsql
    if [ $? = 0 ]; then
       echo "NOTE: plpgsql already exists in fosstest database, good"
    else
       echo "NOTE: plpgsql doesn't exist, adding"
-      su postgres -c 'createlang plpgsql fosstest'
+      su postgres -c 'echo "CREATE LANGUAGE plpgsql;" | psql fosstest'
       if [ $? != 0 ]; then
          echo "ERROR: failed to add plpgsql to fosstest database"
       fi


### PR DESCRIPTION
## Description

Included new test cases for PHP 7.0 and 7.2 with PostgreSQL 10.

### Changes

Replaced `createlang` with `CREATE LANGUAGE` query as `createlang` is deprecated in PostgreSQL 9.3 and removed in PostgreSQL 10.

## How to test

Check Travis and with PostgreSQL 10.