### PR TITLE
fix(debian): Add php7.2 dependencies for Ubuntu Bionic

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: fossology
 Section: utils
 Priority: extra
 Maintainer: Michael Jaeger <michael.c.jaeger@siemens.com>
-Build-Depends: debhelper, libglib2.0-dev, libmagic-dev, libxml2-dev, libmxml-dev, libtext-template-perl, librpm-dev, subversion, rpm, libpcre3-dev, libssl-dev, postgresql-server-dev-all, libboost-regex-dev, libboost-program-options-dev, libjson0-dev|libjson-c-dev, php5-cli|php7.0-cli|php7.2-cli
+Build-Depends: debhelper, libglib2.0-dev, libmagic-dev, libxml2-dev, libmxml-dev, libtext-template-perl, librpm-dev, subversion, rpm, libpcre3-dev, libssl-dev, postgresql-server-dev-all, libboost-regex-dev, libboost-program-options-dev, libjsoncpp-dev, php5-cli|php7.0-cli|php7.2-cli
 Standards-Version: 3.9.1
 Homepage: http://fossology.org
 
@@ -262,7 +262,7 @@ Description: architecture for analyzing software, deciderjob
 
 Package: fossology-readmeoss
 Architecture: any
-Depends: fossology-common, fossology-copyright ${misc:Depends}
+Depends: fossology-common, fossology-copyright, ${misc:Depends}
 Description: architecture for analyzing software, OSS readme generator
  The FOSSology project is a web based framework that allows you to
  upload software to be picked apart and then analyzed by software agents

--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: fossology
 Section: utils
 Priority: extra
 Maintainer: Michael Jaeger <michael.c.jaeger@siemens.com>
-Build-Depends: debhelper, libglib2.0-dev, libmagic-dev, libxml2-dev, libmxml-dev, libtext-template-perl, librpm-dev, subversion, rpm, libpcre3-dev, libssl-dev, postgresql-server-dev-all, libboost-regex-dev, libboost-program-options-dev, libjson0-dev|libjson-c-dev, php5-cli|php7.0-cli
+Build-Depends: debhelper, libglib2.0-dev, libmagic-dev, libxml2-dev, libmxml-dev, libtext-template-perl, librpm-dev, subversion, rpm, libpcre3-dev, libssl-dev, postgresql-server-dev-all, libboost-regex-dev, libboost-program-options-dev, libjson0-dev|libjson-c-dev, php5-cli|php7.0-cli|php7.2-cli
 Standards-Version: 3.9.1
 Homepage: http://fossology.org
 
 Package: fossology-dev
 Architecture: any
-Depends: php5-cli|php7.0-cli
+Depends: php5-cli|php7.0-cli|php7.2-cli
 Description: architecture for analyzing software, development utils
  The FOSSology project is a web based framework that allows you to
  upload software to be picked apart and then analyzed by software agents
@@ -37,7 +37,7 @@ Description: open and modular architecture for analyzing software
 
 Package: fossology-common
 Architecture: any
-Depends: php5-pgsql|php7.0-pgsql, php-pear, php5-cli|php7.0-cli, php5-json|php7.0-json, ${shlibs:Depends}, ${misc:Depends}
+Depends: php5-pgsql|php7.0-pgsql|php7.2-pgsql, php-pear, php5-cli|php7.0-cli|php7.2-cli, php5-json|php7.0-json|php7.2-json, ${shlibs:Depends}, ${misc:Depends}
 Description: architecture for analyzing software, common files
  The FOSSology project is a web based framework that allows you to
  upload software to be picked apart and then analyzed by software agents
@@ -50,7 +50,7 @@ Description: architecture for analyzing software, common files
 
 Package: fossology-web
 Architecture: any
-Depends: fossology-common, fossology-db, fossology-decider, apache2, libapache2-mod-php5|libapache2-mod-php7.0, ${misc:Depends}
+Depends: fossology-common, fossology-db, fossology-decider, apache2, libapache2-mod-php5|libapache2-mod-php7.0|libapache2-mod-php7.2, ${misc:Depends}
 Description: architecture for analyzing software, web interface
  The FOSSology project is a web based framework that allows you to
  upload software to be picked apart and then analyzed by software agents

--- a/debian/fossology-web.postinst
+++ b/debian/fossology-web.postinst
@@ -22,15 +22,12 @@ case "$1" in
     configure)
     # link the apache config for fossology
     if [ -f "/etc/apache2/sites-enabled/fossology.conf" ]; then
-    rm -rf  /etc/apache2/sites-enabled/fossology.conf
+        rm -rf  /etc/apache2/sites-enabled/fossology.conf
     fi
-    if [ -f "/etc/php/7.0/apache2/php.ini" ]; then
-        sed -r -i.bak 's/;? ?upload_max_filesize ?= ?[0-9]+[kmgKMG]*/upload_max_filesize = 750M/' /etc/php/7.0/apache2/php.ini
-        ln -s /etc/fossology/conf/fo-apache.conf /etc/apache2/sites-enabled/fossology.conf
-    else
-        sed -r -i.bak 's/;? ?upload_max_filesize ?= ?[0-9]+[kmgKMG]*/upload_max_filesize = 750M/' /etc/php5/apache2/php.ini
-        ln -s /etc/fossology/conf/fo-apache.conf /etc/apache2/sites-enabled/fossology.conf
-    fi
+    PHP_PATH=$(php --ini | awk '/\/etc\/php.*\/cli$/{print $5}')
+    phpIni="${PHP_PATH}/../apache2/php.ini"
+    sed -r -i.bak 's/;? ?upload_max_filesize ?= ?[0-9]+[kmgKMG]*/upload_max_filesize = 750M/' ${phpIni}
+    ln -s /etc/fossology/conf/fo-apache.conf /etc/apache2/sites-enabled/fossology.conf
     # need to run fo-postinstall web and agent stuff
     /usr/lib/fossology/fo-postinstall --web-only
     invoke-rc.d apache2 restart

--- a/debian/rules
+++ b/debian/rules
@@ -18,6 +18,8 @@
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
 
+COMPOSER_PHAR := $(shell which composer)
+
 configure: configure-stamp
 configure-stamp:
 	dh_testdir
@@ -73,6 +75,12 @@ install-arch:
 	dh_clean -k -s 
 	dh_installdirs -s
 
+ifeq ($(COMPOSER_PHAR),)
+	mkdir -p ~/composer/
+	utils/install_composer.sh ~/composer/
+	$(eval COMPOSER_PHAR=~/composer/composer)
+endif
+
 	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-common \
            PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var install-install
 	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-common \
@@ -86,13 +94,8 @@ install-arch:
            -C src/maintagent install
 	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-common \
            PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
+           COMPOSER_PHAR=$(COMPOSER_PHAR) \
            -C src composer_install
-	mkdir -p ~/composer/
-	utils/install_composer.sh ~/composer/
-	COMPOSER_PHAR=~/composer/composer
-	# emulating writing composer file, TODO see if that is really needed now
-	cp src/composer.json $(CURDIR)/debian/fossology-common
-	cp src/composer.lock $(CURDIR)/debian/fossology-common
 	mkdir -p $(CURDIR)/debian/fossology-common/usr/share/fossology/setup
 	cp $(CURDIR)/install/scripts/* $(CURDIR)/debian/fossology-common/usr/share/fossology/setup
 
@@ -180,7 +183,7 @@ install-arch:
            -C src/reportImport install
 
 	mkdir -p $(CURDIR)/debian/fossology-dev/usr/bin
-	cp $(shell which composer) $(CURDIR)/debian/fossology-dev/usr/bin
+	cp $(COMPOSER_PHAR) $(CURDIR)/debian/fossology-dev/usr/bin
 	mkdir -p $(CURDIR)/debian/fossology-dev/usr/share/fossology/
 	tar czf $(CURDIR)/debian/fossology-dev/usr/share/fossology/php-vendor.tar.gz -C $(CURDIR)/debian/fossology-common/usr/share/fossology vendor
 

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -165,9 +165,9 @@ if [[ $RUNTIME ]]; then
             xenial)
                apt-get $YesOpt install postgresql-9.5 php7.0 libapache2-mod-php7.0 php7.0-pgsql php7.0-cli php7.0-curl php7.0-mbstring php7.0-zip s-nail libboost-program-options1.58.0 libboost-regex1.58.0;;
             stretch|buster|sid)
-               apt-get $YesOpt install postgresql-9.6 php7.0 php7.0-pgsql php7.0-cli php7.0-curl php7.0-xml php7.0-zip s-nail libboost-program-options1.62.0 libboost-regex1.62.0;;
+               apt-get $YesOpt install postgresql-9.6 php7.0 php7.0-pgsql php7.0-cli php7.0-curl php7.0-xml php7.0-zip php-mbstring s-nail libboost-program-options1.62.0 libboost-regex1.62.0;;
             bionic)
-               apt-get $YesOpt install postgresql-10 php7.2 php7.2-pgsql php7.2-cli php7.2-curl php7.2-xml php7.2-zip s-nail libboost-program-options1.65.1 libboost-regex1.65.1;;
+               apt-get $YesOpt install postgresql-10 php7.2 php7.2-pgsql php7.2-cli php7.2-curl php7.2-xml php7.2-zip php7.2-mbstring s-nail libboost-program-options1.65.1 libboost-regex1.65.1;;
             *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
          esac
          ;;


### PR DESCRIPTION
## Description

Added missing php7.2 dependencies for Ubuntu Bionic.

## How to test

Build debian packages in Ubuntu Bionic (18.04) and install them.

`dpkg-buildpackage -I`