### PR TITLE
fix(installdeps): Run child terminals interactively

### DIFF
--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -228,6 +228,6 @@ if [[ $YesOpt ]]; then
 fi
 mods_dir="$(dirname "$0")/../src/" ## get the directory where fo-installdeps resides
 
-find "$mods_dir" -type f -name mod_deps -print0 | xargs -0 -I{} bash -cv "{} $options"
+find "$mods_dir" -type f -name mod_deps -execdir bash -cv "{} $options" \;
 
 ########################################################################


### PR DESCRIPTION
## Description

Use find's `execdir` instead of `xargs` to run interactive child shell.

### Changes

Remove `xarg` from and replace with `execdir`.

## How to test

1. Run the `sudo utils/fo-installdeps` on fresh machine, the `mod_deps` in agent dirs will not wait for input for `apt-get`.
1. Pull the branch and run `sudo utils/fo-installdeps` on fresh machine, the `mod_deps` will wait for input for `apt-get`.

Fixes #1239