### PR TITLE
test(monk): Remove unwanted echo from test script

### DIFF
--- a/src/monk/agent_tests/Functional/cliTest.php
+++ b/src/monk/agent_tests/Functional/cliTest.php
@@ -78,7 +78,6 @@ class MonkCliTest extends \PHPUnit\Framework\TestCase
     }
 
     $cmd = "$execDir/$agentName -c $sysConf $args";
-    echo "run: $cmd\n";
     $pipeFd = popen($cmd, "r");
     $this->assertTrue($pipeFd !== false, 'running monk failed');
 


### PR DESCRIPTION
## Description

There were some unwanted print in PHP-unit test cases.

### Changes

Removed unwanted `echo` statement in Monk test cases.

## How to test

Run phpunit test cases for monk.

`cd src/monk/agent_tests/Functional/ && make test`

No extra print statements should occur.