### PR TITLE
fix(nomos): Detect EPL in XMLs

### DIFF
--- a/src/nomos/agent/STRINGS.in
+++ b/src/nomos/agent/STRINGS.in
@@ -1836,6 +1836,10 @@
 %KEY% "licen[cs]"
 %STR% "license(:?|d under) eclipse public licen[cs]e =FEW= 1\.?0"
 #
+%ENTRY% _LT_EPL
+%KEY% "licen[cs]"
+%STR% "licen[cs]e =SOME= eclipse public licen[cs]e"
+#
 #####
 # DELETED: permission is ... this software and its documentation without
 # restriction including without limitation the rights to use copy modify
@@ -8067,9 +8071,17 @@ k
 %KEY% "licen[cs]"
 %STR% "eclipse public licen[cs]e =FEW= (1\.?0|(v|version )1\.?0)"
 #
+%ENTRY% _TITLE_EPL10ref_1
+%KEY% "\<(eclipse|epl)\>"
+%STR% "epl[ _-]?v?1\.?0"
+#
 %ENTRY% _TITLE_EPL20
 %KEY% "licen[cs]"
 %STR% "eclipse public licen[cs]e =FEW= (2\.?0|(v|version )2\.?0)"
+#
+%ENTRY% _TITLE_EPL20ref_1
+%KEY% "\<(eclipse|epl)\>"
+%STR% "epl[ _-]?v?2\.?0"
 #
 %ENTRY% _TITLE_EIFFEL2
 %KEY% "licen[cs]"

--- a/src/nomos/agent/parse.c
+++ b/src/nomos/agent/parse.c
@@ -5017,19 +5017,27 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
   /* More EPL cases */
   if (!_epl) {
     if (INFILE(_LT_EPLref)) {
-	  if (INFILE(_TITLE_EPL10)) {
-	    INTERESTING(lDebug ? "Eclipse(v.0#2)" : "EPL-1.0");
-	  }
-	  else if (INFILE(_TITLE_EPL20)) {
-	    INTERESTING(lDebug ? "Eclipse(v.2#2)" : "EPL-2.0");
-	  }
-	  else {
-	    INTERESTING(lDebug ? "Eclipse(#2)" : "EPL");
-	  }
-	}
-	else if (INFILE(_LT_EPL10ref_1)) {
-	  INTERESTING(lDebug ? "Eclipse(ref#2)" : "EPL-1.0");
-	}
+      if (INFILE(_TITLE_EPL10)) {
+        INTERESTING(lDebug ? "Eclipse(v.0#2)" : "EPL-1.0");
+      }
+      else if (INFILE(_TITLE_EPL20)) {
+        INTERESTING(lDebug ? "Eclipse(v.2#2)" : "EPL-2.0");
+      }
+      else {
+        INTERESTING(lDebug ? "Eclipse(#2)" : "EPL");
+      }
+    }
+    else if (INFILE(_LT_EPL10ref_1)) {
+      INTERESTING(lDebug ? "Eclipse(ref#2)" : "EPL-1.0");
+    }
+    else if (INFILE(_LT_EPL) && NOT_INFILE(_TITLE_EPL_IGNORE)) {
+      if (INFILE(_TITLE_EPL10ref_1)) {
+        INTERESTING(lDebug ? "Eclipse(v1.0#2)" : "EPL-1.0");
+      }
+      if (INFILE(_TITLE_EPL20ref_1)) {
+        INTERESTING(lDebug ? "Eclipse(v1.0#2)" : "EPL-2.0");
+      }
+    }
   }
   cleanLicenceBuffer();
   /*

--- a/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan
+++ b/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan
@@ -39,6 +39,7 @@ File NomosTestfiles/EPL/filterscallbacks.h contains license(s) EPL-1.0
 File NomosTestfiles/EPL/egPrerequisites.h contains license(s) EPL-1.0
 File NomosTestfiles/EPL/SampleGatherer.java contains license(s) EPL-1.0
 File NomosTestfiles/EPL/DEPENDENCIES.txt contains license(s) Apache-2.0,CPL-1.0,EPL-1.0
+File NomosTestfiles/EPL/epl1-pom.xml contains license(s) EPL-1.0,EPL-2.0
 File NomosTestfiles/DPTC/dpt_osdutil.h contains license(s) DPTC
 File NomosTestfiles/OPL/OPL.tex contains license(s) GPL,OPL-style,Open-PL-0.4
 File NomosTestfiles/OPL/opl-1.0 contains license(s) OPL-1.0

--- a/src/nomos/agent_tests/testdata/NomosTestfiles/EPL/epl1-pom.xml
+++ b/src/nomos/agent_tests/testdata/NomosTestfiles/EPL/epl1-pom.xml
@@ -1,0 +1,392 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>ch.qos.logback</groupId>
+  <artifactId>logback-parent</artifactId>
+  <version>1.1.7</version>
+  <packaging>pom</packaging>
+  <name>Logback-Parent</name>
+  <description>logback project pom.xml file</description>
+
+  <url>http://logback.qos.ch</url>
+
+  <organization>
+    <name>QOS.ch</name>
+    <url>http://www.qos.ch</url>
+  </organization>
+  <inceptionYear>2005</inceptionYear>
+
+  <licenses>
+    <license>
+      <name>Eclipse Public License - v 1.0</name>
+      <url>http://www.eclipse.org/legal/epl-v10.html</url>
+    </license>
+    <license>
+      <name>Eclipse Public License - v 2.0</name>
+      <url>https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.html</url>
+    </license>
+  </licenses>
+
+  <scm>
+    <url>https://github.com/ceki/logback</url>
+    <connection>git@github.com:ceki/logback.git</connection>
+  </scm>
+
+  <modules>
+    <module>logback-core</module>
+    <module>logback-classic</module>
+    <module>logback-access</module>
+    <module>logback-site</module>
+    <module>logback-examples</module>
+  </modules>
+
+  <properties>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <!-- slf4j.version property is used below, in
+         logback-classic/pom.xml and in setClasspath.cmd -->
+    <slf4j.version>1.7.20</slf4j.version>
+    <junit.version>4.10</junit.version>
+    <javax.mail.version>1.4</javax.mail.version>
+    <janino.version>2.7.8</janino.version>
+    <groovy.version>2.4.0</groovy.version>
+
+    <consolePlugin.version>1.1.0</consolePlugin.version>
+    <tomcat.version>7.0.59</tomcat.version>
+    <jetty.version>7.5.1.v20110908</jetty.version>
+    <jansi.version>1.9</jansi.version>
+    <javadoc.plugin.version>2.9.1</javadoc.plugin.version>
+    <cobertura.maven.plugin.version>2.6</cobertura.maven.plugin.version>
+    <maven-license-plugin.version>1.9.0</maven-license-plugin.version>
+  </properties>
+
+  <developers>
+    <developer>
+      <id>ceki</id>
+      <name>Ceki Gulcu</name>
+      <email>ceki@qos.ch</email>
+    </developer>
+
+    <developer>
+      <id>hixi</id>
+      <name>Joern Huxhorn</name>
+      <email>huxi@undisclosed.org</email>
+    </developer>
+  </developers>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>1.7.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Project modules -->
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>servlet-api</artifactId>
+        <version>2.5</version>
+      </dependency>
+      <dependency>
+        <groupId>joda-time</groupId>
+        <artifactId>joda-time</artifactId>
+        <version>2.9.2</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.wagon</groupId>
+        <artifactId>wagon-ssh</artifactId>
+        <version>2.8</version>
+      </extension>
+    </extensions>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>2.6.1</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>animal-sniffer-maven-plugin</artifactId>
+          <version>1.14</version>
+          <configuration>
+            <ignores>
+              <ignore>sun.reflect.Reflection</ignore>
+            </ignores>
+            <signature>
+              <groupId>org.codehaus.mojo.signature</groupId>
+              <artifactId>java16</artifactId>
+              <version>1.0</version>
+            </signature>
+          </configuration>
+        </plugin>
+
+      </plugins>
+
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.5.3</version>
+        <configuration>
+          <descriptors>
+            <descriptor>src/main/assembly/dist.xml</descriptor>
+          </descriptors>
+          <finalName>logback-${project.version}</finalName>
+          <appendAssemblyId>false</appendAssemblyId>
+          <outputDirectory>target/site/dist/</outputDirectory>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <configuration>
+          <threshold>High</threshold>
+          <!--<trace>true</trace>-->
+          <excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
+
+ 
+
+
+      <!-- ================ site plugin ==================== -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <configuration>
+          <reportPlugins>
+
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-jxr-plugin</artifactId>
+              <version>2.5</version>
+              <configuration>
+                <aggregate>true</aggregate>
+                <javadocDir>target/site/apidocs/</javadocDir>
+                <linkJavadoc>true</linkJavadoc>
+              </configuration>
+            </plugin>
+            
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>2.10.1</version>
+              <configuration>
+                <aggregate>true</aggregate>
+                <links>
+                  <link>
+                    http://docs.oracle.com/javase/6/docs/api/
+                  </link>
+                </links>
+                <groups>
+                  <group>
+                    <title>Logback Core</title>
+                    <packages>ch.qos.logback.core:ch.qos.logback.core.*
+                    </packages>
+                  </group>
+                  <group>
+                    <title>Logback Classic</title>
+                    <packages>
+                      ch.qos.logback:ch.qos.logback.classic:ch.qos.logback.classic.*
+                    </packages>
+                  </group>
+                  <group>
+                    <title>Logback Access</title>
+                    <packages>ch.qos.logback.access:ch.qos.logback.access.*
+                    </packages>
+                  </group>
+                  <group>
+                    <title>SLF4J</title>
+                    <packages>org.slf4j:org.slf4j.*</packages>
+                  </group>
+                  <group>
+                    <title>Examples</title>
+                    <packages>chapter*:joran*</packages>
+                  </group>
+                </groups>
+              </configuration>
+            </plugin>
+
+          </reportPlugins>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <distributionManagement>
+
+    <site>
+      <id>tao</id>
+      <url>scp://tao.qos.ch/var/www/logback.qos.ch/htdocs/</url>
+    </site>
+
+    <repository>
+      <id>sonatype-nexus-staging</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+
+      <!--<id>pixie</id>-->
+      <!--<url>scp://pixie.qos.ch/var/mvnrepo/</url>-->
+    </repository>
+
+  </distributionManagement>
+
+  <profiles>
+    <profile>
+      <id>testSkip</id>
+      <properties>
+        <maven.test.skip>true</maven.test.skip>
+      </properties>
+    </profile>
+    <profile>
+      <id>license</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.mycila.maven-license-plugin</groupId>
+            <artifactId>maven-license-plugin</artifactId>
+            <version>1.9.0</version>
+            <configuration>
+              <header>src/main/licenseHeader.txt</header>
+              <quiet>false</quiet>
+              <failIfMissing>true</failIfMissing>
+              <aggregate>true</aggregate>
+              <includes>
+                <include>src/**/*.java</include>
+                <include>src/**/*.groovy</include>
+              </includes>
+              <useDefaultExcludes>true</useDefaultExcludes>
+              <useDefaultMapping>true</useDefaultMapping>
+              <properties>
+                <year>1999</year>
+              </properties>
+              <headerDefinitions>
+                <headerDefinition>src/main/javadocHeaders.xml</headerDefinition>
+              </headerDefinitions>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>javadocjar</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${javadoc.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                  <goal>test-jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>sign-artifacts</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>cobertura</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-site-plugin</artifactId>
+            <configuration>
+              <reportPlugins>
+                
+                
+            
+                <plugin>
+                  <groupId>org.codehaus.mojo</groupId>
+                  <artifactId>cobertura-maven-plugin</artifactId>
+                  <version>${cobertura.maven.plugin.version}</version>
+                  <configuration>
+                    <formats>
+                      <format>html</format>
+                    </formats>
+                    <aggregate>true</aggregate>
+                  </configuration>
+                </plugin>
+              </reportPlugins>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+
+  </profiles>
+
+</project>


### PR DESCRIPTION
## Description

Eclipse Public License - v 1.0 was not detected in some cases.

### Changes

1. Added new entry `_LT_EPL`, `_TITLE_EPL10ref_1` and `_TITLE_EPL20ref_1`.
1. `_LT_EPL` will look for EPL string.
    1. `_TITLE_EPL10ref_1` and `_TITLE_EPL20ref_1` will distinguish between versions.

## How to test

Put the following text in a file and scan using nomos:
```
  <licenses>
    <license>
      <name>Eclipse Public License - v 1.0</name>
      <url>http://www.eclipse.org/legal/epl-v10.html</url>
    </license>

    <license>
      <name>GNU Lesser General Public License</name>
      <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html</url>
    </license>
  </licenses>
```