### PR TITLE
fix(nomos): Use space as separator

### DIFF
--- a/src/nomos/agent/CHECKSTR
+++ b/src/nomos/agent/CHECKSTR
@@ -1,7 +1,7 @@
 #!/bin/sh
 #**************************************************************
 # Copyright (C) 2006-2009 Hewlett-Packard Development Company, L.P.
-# 
+#
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # version 2 as published by the Free Software Foundation.
@@ -25,9 +25,13 @@ ERRS=0
 # echo "$PROG: validating phrase seeds in license strings..."
 for i in $(seq 1 $WC) ; do
 	LINE=$(head -n $i $DATA | tail -n 1)
+	if echo "${LINE}" | egrep -iq "^\[=NULL=\]" ; then
+		continue
+	fi
 	KEY=$(echo "$LINE" | awk -F\" '{print $2}')
-	REST=$(echo "$LINE" | awk -F: '{print $2}')
-	TAG=$(expr "$LINE" : '\[.*\] \(.*\):')
+# License string can contain `:`
+	REST=$(expr "$LINE" : '\[.*\] _.*: \(.*\)$')
+	TAG=$(expr "$LINE" : '\[.*\] \(.*\): ')
 #	echo LINE $i: key $KEY tag $TAG rest $REST
 	if [ -f checkstr.OK ]; then
 #		grep -qx "$TAG" $PASS && echo "$TAG: OK" && continue
@@ -44,7 +48,7 @@ for i in $(seq 1 $WC) ; do
 		KLUDGE="${CH1})${OTH}"
 		if echo "$LINE" | fgrep -iq "$KLUDGE" ; then
 			X=1	# echo "OK (kludge \"$KLUDGE\")"
-		else 
+		else
 			echo "$PROG: Key \"$KEY\" NOT FOUND in entry below:"
 			echo "$LINE"
 			ERRS=$((ERRS+1))

--- a/src/nomos/agent/GENSEARCHDATA
+++ b/src/nomos/agent/GENSEARCHDATA
@@ -274,7 +274,7 @@ END {
 # the auto-generated source file with a syntax error so we don't build.
 # The build _should_ fail until the error is repaired.
 #####
-grep "%KEY%" $INFILE | grep -v '^#' | sed -e 's/%KEY%	/ /g' | sort |
+grep "%KEY%" $INFILE | grep -v '^#' | sed -e 's/%KEY% / /g' | sort |
     uniq -c | sort -nr > $STR_HIST
 # [ -f ${NEW_H}_TAIL ] && cat ${NEW_H}_TAIL >> $NEW_H		# no remove!
 #####

--- a/src/nomos/agent/PRECHECK
+++ b/src/nomos/agent/PRECHECK
@@ -90,10 +90,10 @@ BEGIN {
 	NAME=$NF;
 }
 /^%STR%/ {
-	BUF=$NF;
+	BUF=substr($0, index($0,$2));
 	if (f) {
 		printf("%s: ", NAME);
-		if ($NF ~ "[(]") {
+		if (BUF ~ "[(]") {
 			max = length(BUF);
 			for (i = 1; i <= max; i++) {
 				ch = substr(BUF, i, 1);
@@ -115,7 +115,7 @@ BEGIN {
 			printf("\n");
 		}
 		else {
-			printf("%s\n", $NF);
+			printf("%s\n", BUF);
 		}
 		f=0;
 	}
@@ -177,7 +177,7 @@ void preloadResults(char *filetext, char *ltsr)
 		FNAME=$(printf "$DIR/split_%02d.%s" $I "$WORD")
 		for i in $(seq 1 $WC) ; do
 			LINE=$(head -n $i $TEMP | tail -1)
-			TAG=$(expr "$LINE" : '\(.*\):')
+			TAG=$(expr "$LINE" : '\(.*\): ')
 ##			echo "$LINE" | sed -e 's/.*: //' | grep -iq "$WORD"
 ##			if [ $? -ne 0 ]; then
 ##				echo "\"$WORD\" is NOT in this line:" 

--- a/src/nomos/agent/PRECHECK
+++ b/src/nomos/agent/PRECHECK
@@ -41,50 +41,51 @@ esac
 TRIES=$#
 rm -f $PASS
 #set -x
-awk -F\	 -v PASS="$PASS" 'BEGIN { f=0; c=1 }
-    /^%ENTRY%	_LT/ { f=1; NAME=$NF }
-    /^%KEY%/ { KEY=$NF }
+awk -v PASS="$PASS" 'BEGIN { f=0; c=1 }
+    /^%ENTRY% _LT/ { f=1; NAME=$NF }
+# Keys can have space in between, so select every field after first field.
+    /^%KEY%/ { KEY=substr($0, index($0,$2)) }
     /^%NOCHECK%/ { c=1 }
     /^%STR%/ {
-        if (f) {
-    	    printf("[%s] %s: ", KEY, NAME);
-	    if ($0 !~ "\\(") {
-	        printf("%s", $0);
-	    }
-	    else {
-     	        N=length($0); x=0;
-	        for (i=1; i<=N; i++) {
-		    X=substr($0, i, 1);
-		    if (X == "(") {
-			    x++;
-		    }
-		    else if (X == ")") {
-			    X = "_";
-			    x--;
-		    }
-		    Y[i] = !x ? X : "_";
-	        }
-	        for (i=1; i<=N; i++) {
-		    printf("%c", Y[i]);
-	        }
-            }
-	    printf("\n");
-            f=0;
-	    if (c) {
-	        cmd = sprintf("echo %s >> %s", NAME, PASS);
-		system(cmd);
-	    }
-	    c=0;
-        }
-    }
+		if (f) {
+			printf("[%s] %s: ", KEY, NAME);
+			if ($0 !~ "\\(") {
+				printf("%s", $0);
+			}
+			else {
+				N=length($0); x=0;
+				for (i=1; i<=N; i++) {
+					X=substr($0, i, 1);
+					if (X == "(") {
+						x++;
+					}
+					else if (X == ")") {
+						X = "_";
+						x--;
+					}
+					Y[i] = !x ? X : "_";
+				}
+				for (i=1; i<=N; i++) {
+					printf("%c", Y[i]);
+				}
+			}
+			printf("\n");
+			f=0;
+			if (c) {
+				cmd = sprintf("echo %s >> %s", NAME, PASS);
+				system(cmd);
+			}
+			c=0;
+		}
+	}
 ' $IN | sed -e 's/%STR%//g' |
     tee $TEMP > $DATA
 # cp $TEMP file_1	# for debugging...
-awk -F\	 '
+awk '
 BEGIN {
 	f=0;
 }
-/^%ENTRY%	_LT/ {
+/^%ENTRY% _LT/ {
 	f=1;
 	NAME=$NF;
 }
@@ -181,7 +182,7 @@ void preloadResults(char *filetext, char *ltsr)
 ##			if [ $? -ne 0 ]; then
 ##				echo "\"$WORD\" is NOT in this line:" 
 ##				echo "$LINE"
-##				sed -e "s/$TAG
+##				sed -e "s/$TAG"
 ##				grep -v $TAG $FNAME > X
 ##				mv -f X $FNAME
 ##				continue

--- a/src/nomos/agent/STRINGS.in
+++ b/src/nomos/agent/STRINGS.in
@@ -2408,7 +2408,7 @@
 %STR% "you may do anything with this at your own risk"
 #
 %ENTRY% _LT_FREE_103
-%KEY% "(©|\(c\)|copyright|\<c\>[^+:]|&copy)"
+%KEY% "(©|\(c\)|copyright|\<c\>[^+:]|copy)"
 %STR% "you make absolutely no changes to your copy =FEW= if you do make changes you name it something other"
 #
 %ENTRY% _LT_FREE_104

--- a/src/nomos/agent/STRINGS.in
+++ b/src/nomos/agent/STRINGS.in
@@ -734,24 +734,24 @@
 #####
 #
 %ENTRY% _LT_Autoconf_exception_1
-%KEY%	"(condit|vers)ion"
-%STR%	"versions? of (the )?autoconf"
+%KEY% "(condit|vers)ion"
+%STR% "versions? of (the )?autoconf"
 #
 %ENTRY% _LT_Autoconf_exception_2
 %KEY% "configur"
 %STR% "configur(e|ation) scripts? =FEW= Autoconf"
 #
 %ENTRY% _LT_Autoconf_exception_3
-%KEY%	"distribut"
+%KEY% "distribut"
 %STR% "unlimited permission to copy distribute and modify the configure scripts that are the output of autoconf"
 #
 %ENTRY% _LT_Autoconf_exception_20
-%KEY%	"distribut"
-%STR%	"as a special exception the free software foundation gives unlimited permission to copy distribute and modify the configure scripts that are the output of autoconf"
+%KEY% "distribut"
+%STR% "as a special exception the free software foundation gives unlimited permission to copy distribute and modify the configure scripts that are the output of autoconf"
 #
 %ENTRY% _LT_Autoconf_exception_30
-%KEY%	"distribut"
-%STR%	"purpose of this exception is to allow distribution of autoconf.s typical output under terms of the recipient.s choice"
+%KEY% "distribut"
+%STR% "purpose of this exception is to allow distribution of autoconf.s typical output under terms of the recipient.s choice"
 #
 %ENTRY% _LT_AVM_1
 %KEY% "so(ftware|urce)"
@@ -832,8 +832,8 @@
 %STR% "bison =FEW= distribute =FEW= under terms of your choice"
 #
 %ENTRY% _LT_Bison_exception_22
-%KEY%	"bison"
-%STR%	"special exception was added by the Free Software Foundation in version 2\.?2 of Bison"
+%KEY% "bison"
+%STR% "special exception was added by the Free Software Foundation in version 2\.?2 of Bison"
 #
 %ENTRY% _LT_BISONref
 %KEY% "licen[cs]"
@@ -912,12 +912,12 @@
 %STR% "(free|distribu|develop|offere?d?|covered|released?|licen[cs]ed?|available|protected|provided|subject|comes|used|software|\<is\>|code) =SOME= boost software licen[cs]e"
 #
 %ENTRY% _LT_Bootloader_exception
-%KEY%	"restrict"
-%STR%	"link =FEW= bootloader =FEW= into combinations with other programs =SOME= without any restriction"
+%KEY% "restrict"
+%STR% "link =FEW= bootloader =FEW= into combinations with other programs =SOME= without any restriction"
 #
 %ENTRY% _LT_BRAINSTORM_EULA
-%KEY%	"licen[cs]"
-%STR%	"this agreement the agreement is made between BrainStorm Inc BSI and the recipient party Licen[cs]ee"
+%KEY% "licen[cs]"
+%STR% "this agreement the agreement is made between BrainStorm Inc BSI and the recipient party Licen[cs]ee"
 #
 %ENTRY% _LT_BROADCOM_EULA
 %KEY% "licen[cs]"
@@ -1141,7 +1141,7 @@
 %STR% "no express or implied licenses to any =FEW= patent rights are granted by this license"
 #
 %ENTRY% _LT_FREE_BSD
-%KEY% "software"	
+%KEY% "software"
 %STR% "this software is provided by =FEW= freebsd project"
 #
 %ENTRY% _LT_BSD_AND_MIT
@@ -1161,7 +1161,7 @@
 %STR% "bzip2 =FEW= libbzip2 =FEW= version 1.0.6"
 #
 %ENTRY% _LT_UC
-%KEY% "copyright"	
+%KEY% "copyright"
 %STR% "copyright =SOME= (university of california|UC)"
 #####
 # DELETED: ... and recipients of the program to use the program including
@@ -2668,12 +2668,12 @@
 %STR% "you should have received a copy of the =SOME= licen[cs]e along"
 #
 %ENTRY% _LT_GNU_GETTEXT
-%KEY%	=NULL=
-%STR%	"please note that the actual code of the GNU gettext library is covered"
+%KEY% =NULL=
+%STR% "please note that the actual code of the GNU gettext library is covered"
 #
 %ENTRY% _LT_GNU_PROJECTS
-%KEY%	"distribut"
-%STR%	"may only be used modified and r?e?-?distributed under the terms of the (emacs|gphoto) project licen[cs]e"
+%KEY% "distribut"
+%STR% "may only be used modified and r?e?-?distributed under the terms of the (emacs|gphoto) project licen[cs]e"
 #
 %ENTRY% _LT_GNUPLOT_1
 %KEY% "distribut"
@@ -2729,12 +2729,12 @@
 %STR% "in addition to the permissions in the GNU (general p|p)ublic licen[cs]e =FEW= gives you unlimited permission to link the compiled version"
 #
 %ENTRY% _LT_GPL_EXCEPT_5
-%KEY%	"permi[st]"
-%STR%	"this exception is an additional permission under section 7 of the gnu general public license version 3"
+%KEY% "permi[st]"
+%STR% "this exception is an additional permission under section 7 of the gnu general public license version 3"
 #
 %ENTRY% _LT_GPL_EXCEPT_6
-%KEY%	"permi[st]"
-%STR%	"special exception =SOME= permission to link this (library|software) with =SOME= to produce an executable"
+%KEY% "permi[st]"
+%STR% "special exception =SOME= permission to link this (library|software) with =SOME= to produce an executable"
 #
 %ENTRY% _LT_GPL_EXCEPT_7
 %KEY% "licen[cs]"
@@ -2753,12 +2753,12 @@
 %STR% "class\ ?path"
 #
 %ENTRY% _LT_Libtool_exception
-%KEY%	=NULL=
-%STR%	"is built using GNU Libtool"
+%KEY% =NULL=
+%STR% "is built using GNU Libtool"
 #
 %ENTRY% _LT_GPL_EXCEPT_Trolltech
-%KEY%	=NULL=
-%STR%	"(as a special exception =SOME= trolltech|trolltech =FEW= gplexception)"
+%KEY% =NULL=
+%STR% "(as a special exception =SOME= trolltech|trolltech =FEW= gplexception)"
 #
 %ENTRY% _LT_GPL_SWI_PROLOG_EXCEPT
 %KEY% "exception"
@@ -2832,7 +2832,7 @@
 %STR% "licen[cs]e is compatible with =FEW= (\<gpl\>|gnu general public license)"
 #
 %ENTRY% _LT_GPL_NAMED_COMPATIBLE_1
-%KEY%  =NULL=
+%KEY% =NULL=
 %STR% "(\<gpl\>|gnu general public license) compatib(le|ility)"
 #
 %ENTRY% _LT_AGPL_NAMED
@@ -2956,8 +2956,8 @@
 %STR% "see the GNU general public licen[cs](e|e the licen[cs]e) for full details of the terms of using copying modifying and r?e?-?distributing"
 #
 %ENTRY% _LT_GPLref21
-%KEY%	"licen[cs]"
-%STR%	"under the (terms of the )?(gnu )?general public licen[cs]e"
+%KEY% "licen[cs]"
+%STR% "under the (terms of the )?(gnu )?general public licen[cs]e"
 #
 %ENTRY% _LT_GPLref22
 %KEY% "\<under\>"
@@ -3051,15 +3051,15 @@
 %KEY% "(\<gnu|free\>|l?gpl)"
 %STR% "\<(either|or|alternately)\> =FEW= ([^al]gpl|GNU (general p|p)ublic licen[cs]e)"
 #
-%ENTRY%  _LT_i2p_gpl_java_exception
+%ENTRY% _LT_i2p_gpl_java_exception
 %KEY% "distribut"
 %STR% "as a special exception =FEW= permission to link the code of this program with the proprietary Java implementation =SOME= and distribute linked combinations including the two"
 #
-%ENTRY%  _LT_IGNORE_CLAUSE_2
+%ENTRY% _LT_IGNORE_CLAUSE_2
 %KEY% "licen[cs]"
 %STR% "can be used in projects which are not available under (the )?gnu general public license"
 #
-%ENTRY%  _LT_IGNORE_CLAUSE
+%ENTRY% _LT_IGNORE_CLAUSE
 %KEY% =NULL=
 %STR% "to apply these terms =ANY= to (the|your) (program|library)"
 #####
@@ -4069,6 +4069,7 @@
 %STR% "(no|not|don't be) evil"
 #
 %ENTRY% _LT_JSON
+%NOCHECK%
 %KEY% "json"
 %STR% "."
 #
@@ -5042,12 +5043,12 @@
 %STR% "cnri(.s)? python 1\.?6 license"
 #
 %ENTRY% _LT_CNRI_PYTHON_GPL
-%KEY%	"licen[cs]"
-%STR%	"cnri open source gpl-compatible license agreement"
+%KEY% "licen[cs]"
+%STR% "cnri open source gpl-compatible license agreement"
 #
-%ENTRY%	_LT_CNRI_PYTHON_GPL_2
-%KEY%	=NULL=
-%STR%	"Python 1\.6\.1 that incorporate non-separable material"
+%ENTRY% _LT_CNRI_PYTHON_GPL_2
+%KEY% =NULL=
+%STR% "Python 1\.6\.1 that incorporate non-separable material"
 #####
 # DELETED: distributing party must clearly and ... is produced by the
 # party that modified the software and is not a qualcomm product
@@ -5672,12 +5673,12 @@
 # notice appears in all copies
 #####
 %ENTRY% _LT_u_boot_exception_20
-%KEY%	=NULL=
-%STR%	"this does \*?not\*? cover the so.called \"?standalone\"? applications that use U.Boot services by means of the jump table"
+%KEY% =NULL=
+%STR% "this does \*?not\*? cover the so.called \"?standalone\"? applications that use U.Boot services by means of the jump table"
 #
-%ENTRY%	_LT_UBUNTU_FONT
-%KEY%	"licen[cs]"
-%STR%	"each copy of the font software must contain the above copyright notice and this licen[cs]e"
+%ENTRY% _LT_UBUNTU_FONT
+%KEY% "licen[cs]"
+%STR% "each copy of the font software must contain the above copyright notice and this licen[cs]e"
 #
 %ENTRY% _LT_UCAR_1
 %KEY% "distribut"
@@ -6404,6 +6405,7 @@ k
 #
 %ENTRY% _LT_SEE_OTHER_14
 %KEY% "copyright"
+%NOCHECK%
 %STR% "see =FEW= for more details on licensing"
 #
 %ENTRY% _LT_SEE_OTHER_15
@@ -6644,13 +6646,13 @@ k
 %KEY% "so(ftware|urce)"
 %STR% "you can modify and change the source of face"
 #
-%ENTRY%  _LT_Sendmail_title
-%KEY%  "licen[cs]e"
-%STR%  "unless a different license is obtained (directly )?from Sendmail"
+%ENTRY% _LT_Sendmail_title
+%KEY% "licen[cs]e"
+%STR% "unless a different license is obtained (directly )?from Sendmail"
 #
-%ENTRY%  _LT_Sendmail_823_title
-%KEY%  "licen[cs]e"
-%STR%  "unless a redistribution agreement or other license is obtained from Proofpoint"
+%ENTRY% _LT_Sendmail_823_title
+%KEY% "licen[cs]e"
+%STR% "unless a redistribution agreement or other license is obtained from Proofpoint"
 #
 %ENTRY% _LT_TAPJOY
 %KEY% "licen[cs]e"
@@ -6662,7 +6664,7 @@ k
 #
 %ENTRY% _LT_GENERIC_UNCLASSIFIED
 %KEY% "licen[cs]e"
-%STR% "licen[cs](e|ed) under the term"
+%STR% "licen[cs]ed? under the term"
 #
 ##%ENTRY% _LT_SEEK_1
 ##%KEY% "(©|\(c\)|copyright|\<c\>[^+:]|&copy)"
@@ -8194,8 +8196,8 @@ k
 %STR% "licen[cs]e(:?) gplv3\.?0?(\+| or (later|newer))"
 #
 %ENTRY% _TITLE_GPL3_ref4_later
-%KEY%  "licen[cs]"
-%STR%  "license =SOME= ([^l]gplv3\.?0?\+|gnu gpl version 3 or later)"
+%KEY% "licen[cs]"
+%STR% "license =SOME= ([^l]gplv3\.?0?\+|gnu gpl version 3 or later)"
 #
 %ENTRY% _TITLE_GPL2_ref1
 %KEY% "gpl"
@@ -8407,9 +8409,9 @@ k
 %KEY% "licen[cs]"
 %STR% "exhibit [abc] =ANY= \<MIT\> licen[cs]e"
 #
-%ENTRY%	_TITLE_MOTOROLA_MOBILE
-%KEY%	"licen[cs]"
-%STR%	"MOTOROLA MOBILE Software License Agreement"
+%ENTRY% _TITLE_MOTOROLA_MOBILE
+%KEY% "licen[cs]"
+%STR% "MOTOROLA MOBILE Software License Agreement"
 #
 %ENTRY% _TITLE_MOTOSOTO091
 %KEY% "licen[cs]"
@@ -9047,9 +9049,9 @@ k
 %KEY% "licen[cs]"
 %STR% "wu-ftpd software licen[cs]e"
 #
-%ENTRY%	_TITLE_UBUNTU_FONT
-%KEY%	"licen[cs]"
-%STR%	"ubuntu font licen[cs]e version 1\.?0"
+%ENTRY% _TITLE_UBUNTU_FONT
+%KEY% "licen[cs]"
+%STR% "ubuntu font licen[cs]e version 1\.?0"
 #
 %ENTRY% _TITLE_UL_EULA
 %KEY% "\<(end[ -]user|eula)\>"
@@ -9113,27 +9115,27 @@ k
 %STR% "netizen open source licen[cs]e"
 #
 %ENTRY% _TITLE_NBPL_V10
-%KEY% "licen[cs]"	
+%KEY% "licen[cs]"
 %STR% "the net boolean public licen[cs]e (v|version )?1"
 #
 %ENTRY% _TITLE_Flora_V10
-%KEY% "licen[cs]"	
+%KEY% "licen[cs]"
 %STR% "Flora Licen[cs]e (version |v)1\.?0"
 #
 %ENTRY% _TITLE_Flora_V11
-%KEY% "licen[cs]"	
+%KEY% "licen[cs]"
 %STR% "Flora Licen[cs]e (version |v)1\.?1"
 #
 %ENTRY% _TITLE_SMLNJ
-%KEY% "licen[cs]"	
+%KEY% "licen[cs]"
 %STR% "standard ml of new jersey copyright notice\,? licen[cs]e and disclaimer"
 #
 %ENTRY% _TITLE_CITRIX
-%KEY% "licen[cs]"	
+%KEY% "licen[cs]"
 %STR% "citrix =FEW= license agreement"
 #
 %ENTRY% _TITLE_MPL_style
-%KEY% "licen[cs]"	
+%KEY% "licen[cs]"
 %STR% "the openi public licen[cs]e"
 #
 %ENTRY% _TITLE_X11
@@ -9284,16 +9286,16 @@ k
 %STR% "licensed under the Clear BSD"
 #
 %ENTRY% _PHR_BSD_3_CLAUSE_LBNL
-%KEY%	"licen[cs]"
-%STR%	"you are agreeing to =FEW= BSD-LBNL.license"
+%KEY% "licen[cs]"
+%STR% "you are agreeing to =FEW= BSD-LBNL.license"
 #
 %ENTRY% _PHR_CC0_1
 %KEY% "licen[cs]"
 %STR% "licen[cs]e =FEW= CC0-1\.?0"
 #
 %ENTRY% _PHR_CC0_2
-%KEY%	"licen[cs]"
-%STR%	"under the terms of a creative commons cc0 1\.?0 license"
+%KEY% "licen[cs]"
+%STR% "under the terms of a creative commons cc0 1\.?0 license"
 #
 %ENTRY% _PHR_CDDL
 %KEY% "distribut"
@@ -9463,7 +9465,7 @@ k
 #
 %ENTRY% _PHR_GPL3_OR_LATER
 %KEY% "(\<gnu|free\>|l?gpl)"
-%STR%  "(([^l-]gp(l|l licen[cs]e)|gnu (general p|p)ublic licen[cs]e) =SOME= (\<v3\.?0?\>|[^_-]versions? (three|\<3\>))|[^l]gpl(_|-|v| )?3) =SOME= \<or\> =SOME= (later|newer|subsequent|more recent)"
+%STR% "(([^l-]gp(l|l licen[cs]e)|gnu (general p|p)ublic licen[cs]e) =SOME= (\<v3\.?0?\>|[^_-]versions? (three|\<3\>))|[^l]gpl(_|-|v| )?3) =SOME= \<or\> =SOME= (later|newer|subsequent|more recent)"
 #
 %ENTRY% _PHR_GPL3_OR_LATER_ref1
 %KEY% "licen[cs]"
@@ -9475,7 +9477,7 @@ k
 #
 %ENTRY% _PHR_GPL3_OR_LATER_ref3
 %KEY% "(\<gnu|free\>|l?gpl)"
-%STR%  "([^l-]gp(l|l licen[cs]e)|gnu (general p|p)ublic licen[cs]e) =SOME= versions? (three|\<3\>) =SOME= or =SOME= (later|newer|subsequent|more recent)"
+%STR% "([^l-]gp(l|l licen[cs]e)|gnu (general p|p)ublic licen[cs]e) =SOME= versions? (three|\<3\>) =SOME= or =SOME= (later|newer|subsequent|more recent)"
 #
 %ENTRY% _PHR_GPLISH_SAMPLE
 %KEY% "(©|\(c\)|copyright|\<c\>[^+:]|&copy)"
@@ -9662,16 +9664,16 @@ k
 %STR% "(lgp(l|l licen[cs]e)|gnu (lesser|library) (general p|p)ublic licen[cs]e) =SOME= (v|[^_-]version )2 =SOME= or =SOME= (later|newer|subsequent|more recent)"
 #
 %ENTRY% _PHR_LGPL2_OR_LATER_2
-%KEY%  "(\<gnu|free\>|l?gpl)"
-%STR%  "lgpl( |-|v)2\.?0?\+"
+%KEY% "(\<gnu|free\>|l?gpl)"
+%STR% "lgpl( |-|v)2\.?0?\+"
 #
 %ENTRY% _PHR_LGPL2_OR_LATER_3
-%KEY%  "(\<gnu|free\>|l?gpl)"
-%STR%  "lgpl(-|v)?2\.?0?-or-later"
+%KEY% "(\<gnu|free\>|l?gpl)"
+%STR% "lgpl(-|v)?2\.?0?-or-later"
 #
 %ENTRY% _PHR_LGPL21_ONLY
 %KEY% "(\<gnu|free\>|l?gpl)"
-%STR%  "(lgp(l|l licen[cs]e)|gnu (lesser|library) (general p|p)ublic licen[cs]e) =FEW= (v|[^_-]version )2\.?1"
+%STR% "(lgp(l|l licen[cs]e)|gnu (lesser|library) (general p|p)ublic licen[cs]e) =FEW= (v|[^_-]version )2\.?1"
 #
 %ENTRY% _PHR_LGPL21_ONLY_ref
 %KEY% "licen[cs]"
@@ -9687,7 +9689,7 @@ k
 #
 %ENTRY% _PHR_LGPL21_ONLY_ref4
 %KEY% "(\<gnu|free\>|l?gpl)"
-%STR%  "gnu (lesser|library) (general p|p)ublic licen[cs]e 2\.?1"
+%STR% "gnu (lesser|library) (general p|p)ublic licen[cs]e 2\.?1"
 #
 %ENTRY% _PHR_LGPL21_OR_LATER_1
 %KEY% "(\<gnu|free\>|l?gpl)"
@@ -9851,9 +9853,9 @@ k
 %KEY% "licen[cs]"
 %STR% "cannot simply be copied and put under another distribution licen[cs]e"
 #
-%ENTRY%	_PHR_NOT_UNDER_GPL
-%KEY%	"(\<gnu|free\>|l?gpl)"
-%STR%	"\<not\> (free|distribu|develop|offere?d?|covered|released?|licen[cs]ed?|available|protected|provided|subject|\<(and|or|by)\>) =SOME= ([^l]gpl|(general p|p)ublic licen[cs]e)"
+%ENTRY% _PHR_NOT_UNDER_GPL
+%KEY% "(\<gnu|free\>|l?gpl)"
+%STR% "\<not\> (free|distribu|develop|offere?d?|covered|released?|licen[cs]ed?|available|protected|provided|subject|\<(and|or|by)\>) =SOME= ([^l]gpl|(general p|p)ublic licen[cs]e)"
 #
 %ENTRY% _PHR_NOT_UNDER_LGPL
 %KEY% "(\<gnu|free\>|l?gpl)"
@@ -11591,8 +11593,8 @@ k
 ##%STR% "fedora"
 #
 %ENTRY% _TEXT_FONT
-%KEY%	=NULL=
-%STR%	"as a special exception =FEW= which uses this font"
+%KEY% =NULL=
+%STR% "as a special exception =FEW= which uses this font"
 #
 %ENTRY% _TEXT_GCC
 %KEY% =NULL=
@@ -12285,15 +12287,15 @@ k
 %STR% "w?w?w?\.?(zlib|gzip)\.?org/zlib/zlib_licen[cs]e"
 #
 %ENTRY% _URL_Flora
-%KEY% "licen[cs]"	
+%KEY% "licen[cs]"
 %STR% "floralicense\.?org/license"
 #
 %ENTRY% _URL_EUDatagrid
-%KEY% "licen[cs]"	
+%KEY% "licen[cs]"
 %STR% "w?w?w?\.?eu-datagrid\.?org/license\.?html"
 #
 %ENTRY% _URL_OPEN_PL_V10
-%KEY% "open"	
+%KEY% "open"
 %STR% "opencontent\.?org/openpub"
 #
 %ENTRY% _MIN_AFFERO_V3

--- a/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan
+++ b/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan
@@ -670,7 +670,7 @@ File NomosTestfiles/Dual-license/GPL-2.0_or_X11.txt contains license(s) Dual-lic
 File NomosTestfiles/Dual-license/ClearBSD_or_GPL-2.0+.txt contains license(s) BSD-3-Clause-Clear,Dual-license,GPL-2.0+
 File NomosTestfiles/Dual-license/BSD-2-Clause_or_GPL-2.0.txt contains license(s) BSD-2-Clause,Dual-license,GPL-2.0
 File NomosTestfiles/Dual-license/Sleepycat_or_Commercial.txt contains license(s) COMMERCIAL,Dual-license,Sleepycat
-File NomosTestfiles/Dual-license/LGPL_or_GPL.txt contains license(s) GPL,Dual-license,LGPL
+File NomosTestfiles/Dual-license/LGPL_or_GPL.txt contains license(s) Dual-license,GPL,LGPL
 File NomosTestfiles/Dual-license/AFL-2.1_or_GPL-2.0.txt contains license(s) AFL-2.1,Dual-license,GPL-2.0
 File NomosTestfiles/Dual-license/CDDL_or_GPL-2.0-with-classpath-exception.txt contains license(s) CDDL,Classpath-exception-2.0,Dual-license,GPL-2.0
 File NomosTestfiles/Dual-license/Base64Code.java contains license(s) Apache-2.0,BSD,Dual-license,EPL-1.0,GPL-2.0+,LGPL-2.1+
@@ -686,7 +686,7 @@ File NomosTestfiles/Dual-license/mscc.c contains license(s) Dual-license,GPL,MIT
 File NomosTestfiles/Dual-license/MIT_or_Python.txt contains license(s) Dual-license,MIT
 File NomosTestfiles/Dual-license/BSD-3-Clause_or_GPL-2.0+.txt contains license(s) BSD-style,Dual-license,GPL-2.0+
 File NomosTestfiles/Dual-license/GPL-2.0+_or_MIT.txt contains license(s) Dual-license,GPL-2.0+,MIT
-File NomosTestfiles/Dual-license/GPL-2.0+_or_LGPL-2.0+.txt contains license(s) Dual-license,GPL-2.0,LGPL-2.0+
+File NomosTestfiles/Dual-license/GPL-2.0+_or_LGPL-2.0+.txt contains license(s) Dual-license,LGPL-2.0+
 File NomosTestfiles/Dual-license/Apache-2.0_or_CC0-1.0.txt contains license(s) Apache-2.0,CC0-1.0,Dual-license
 File NomosTestfiles/Dual-license/Apache-2.0_or_BSD-3-Clause.txt contains license(s) Apache-2.0,BSD-3-Clause,Dual-license
 File NomosTestfiles/OFL/OFL-1.0.txt contains license(s) OFL-1.0

--- a/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan
+++ b/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan
@@ -670,7 +670,7 @@ File NomosTestfiles/Dual-license/GPL-2.0_or_X11.txt contains license(s) Dual-lic
 File NomosTestfiles/Dual-license/ClearBSD_or_GPL-2.0+.txt contains license(s) BSD-3-Clause-Clear,Dual-license,GPL-2.0+
 File NomosTestfiles/Dual-license/BSD-2-Clause_or_GPL-2.0.txt contains license(s) BSD-2-Clause,Dual-license,GPL-2.0
 File NomosTestfiles/Dual-license/Sleepycat_or_Commercial.txt contains license(s) COMMERCIAL,Dual-license,Sleepycat
-File NomosTestfiles/Dual-license/LGPL_or_GPL.txt contains license(s) Dual-license,GPL,LGPL
+File NomosTestfiles/Dual-license/LGPL_or_GPL.txt contains license(s) GPL,Dual-license,LGPL
 File NomosTestfiles/Dual-license/AFL-2.1_or_GPL-2.0.txt contains license(s) AFL-2.1,Dual-license,GPL-2.0
 File NomosTestfiles/Dual-license/CDDL_or_GPL-2.0-with-classpath-exception.txt contains license(s) CDDL,Classpath-exception-2.0,Dual-license,GPL-2.0
 File NomosTestfiles/Dual-license/Base64Code.java contains license(s) Apache-2.0,BSD,Dual-license,EPL-1.0,GPL-2.0+,LGPL-2.1+
@@ -686,7 +686,7 @@ File NomosTestfiles/Dual-license/mscc.c contains license(s) Dual-license,GPL,MIT
 File NomosTestfiles/Dual-license/MIT_or_Python.txt contains license(s) Dual-license,MIT
 File NomosTestfiles/Dual-license/BSD-3-Clause_or_GPL-2.0+.txt contains license(s) BSD-style,Dual-license,GPL-2.0+
 File NomosTestfiles/Dual-license/GPL-2.0+_or_MIT.txt contains license(s) Dual-license,GPL-2.0+,MIT
-File NomosTestfiles/Dual-license/GPL-2.0+_or_LGPL-2.0+.txt contains license(s) Dual-license,LGPL-2.0+
+File NomosTestfiles/Dual-license/GPL-2.0+_or_LGPL-2.0+.txt contains license(s) Dual-license,GPL-2.0,LGPL-2.0+
 File NomosTestfiles/Dual-license/Apache-2.0_or_CC0-1.0.txt contains license(s) Apache-2.0,CC0-1.0,Dual-license
 File NomosTestfiles/Dual-license/Apache-2.0_or_BSD-3-Clause.txt contains license(s) Apache-2.0,BSD-3-Clause,Dual-license
 File NomosTestfiles/OFL/OFL-1.0.txt contains license(s) OFL-1.0


### PR DESCRIPTION
## Description

After merging #1118, separators in `STRINGS.in` were changed from tab to space.

This resulted in missing checks from `PRECHECK` and `CHECKSTR`.

([Old log](https://travis-ci.org/fossology/fossology/jobs/404417533#L1624) => [Latest master log](https://travis-ci.org/fossology/fossology/jobs/459532025#L1313))


### Changes

1. Use space as a separator in `PRECHECK` and `GENSEARCHDATA` instead of a tab.
1. Also replace remaining tabs with space in `STRINGS.in`.

## How to test

Check the new travis log for `PRECHECK`s. (https://travis-ci.org/fossology/fossology/jobs/477241832#L1327)

Maybe [the wiki](https://github.com/fossology/fossology/wiki/Nomos#step-1-add-the-new-signature---stringsin) can also be updated.