### PR TITLE
fix(agent): Reschedule failed agents

### DIFF
--- a/src/www/ui/async/ScheduleAgent.php
+++ b/src/www/ui/async/ScheduleAgent.php
@@ -59,10 +59,13 @@ class ScheduleAgent extends DefaultPlugin
     {
       $upload = $this->uploadDao->getUpload($uploadId);
       $uploadName = $upload->getFilename();
-      $jobId = JobAddJob($userId, $groupId, $uploadName, $uploadId);
-
       $ourPlugin = plugin_find($agentName);
-      $jobqueueId = $ourPlugin->AgentAdd($jobId, $uploadId, $errorMessage, array());
+
+      $jobqueueId = isAlreadyRunning($ourPlugin->AgentName, $uploadId);
+      if($jobqueueId == 0) {
+        $jobId = JobAddJob($userId, $groupId, $uploadName, $uploadId);
+        $jobqueueId = $ourPlugin->AgentAdd($jobId, $uploadId, $errorMessage, array());
+      }
     } else
     {
       $errorMessage = "bad request";
@@ -82,5 +85,3 @@ class ScheduleAgent extends DefaultPlugin
 }
 
 register_plugin(new ScheduleAgent());
-
-


### PR DESCRIPTION
## Description

Earlier, failed agents were not shown under "**Schedule an Analysis**" for a given upload until the agent version changes.

### Changes

Added new parameter to function `LatestAgentpk` to get only successful results.

## How to test

On latest master:
1. Upload a package and kill/cancel some running agents to mark them as failed.
1. Go to Jobs » Schedule Agents.
1. The killed agents are not shown for re-scheduling.

Install the branch:
1. Upload a package and kill/cancel some running agents to mark them as failed.
1. Go to Jobs » Schedule Agents.
1. The killed agents will be shown for re-scheduling.