### PR TITLE
fix(web.postinst): Reflect changes from php-conf-fix

### DIFF
--- a/debian/fossology-web.postinst
+++ b/debian/fossology-web.postinst
@@ -26,7 +26,11 @@ case "$1" in
     fi
     PHP_PATH=$(php --ini | awk '/\/etc\/php.*\/cli$/{print $5}')
     phpIni="${PHP_PATH}/../apache2/php.ini"
-    sed -r -i.bak 's/;? ?upload_max_filesize ?= ?[0-9]+[kmgKMG]*/upload_max_filesize = 750M/' ${phpIni}
+    cp ${phpIni} ${phpIni}.bak
+    sed -i 's/^\(max_execution_time\s*=\s*\).*$/\1300/' ${phpIni}
+    sed -i 's/^\(memory_limit\s*=\s*\).*$/\1702M/' ${phpIni}
+    sed -i 's/^\(post_max_size\s*=\s*\).*$/\1701M/' ${phpIni}
+    sed -i 's/^\(upload_max_filesize\s*=\s*\).*$/\1700M/' ${phpIni}
     ln -s /etc/fossology/conf/fo-apache.conf /etc/apache2/sites-enabled/fossology.conf
     # need to run fo-postinstall web and agent stuff
     /usr/lib/fossology/fo-postinstall --web-only


### PR DESCRIPTION
## Description

PHP conf was not updated with all the required changes while installing the Debian packages.

### Changes

Get the changes done by [php-conf-fix.sh](/fossology/fossology/blob/master/install/scripts/php-conf-fix.sh) and perform the same in [fossology-web.postinst](/fossology/fossology/blob/master/debian/fossology-web.postinst)

## How to test

1.  Create Debian packages.
2.  Install them on clean machine.
3.  Check if the `php.ini` is updated with the changes.