### PR TITLE
fix(fo-installdeps): Add php-mbstring to build deps

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: fossology
 Section: utils
 Priority: extra
 Maintainer: Michael Jaeger <michael.c.jaeger@siemens.com>
-Build-Depends: debhelper, libglib2.0-dev, libmagic-dev, libxml2-dev, libmxml-dev, libtext-template-perl, librpm-dev, subversion, rpm, libpcre3-dev, libssl-dev, postgresql-server-dev-all, libboost-regex-dev, libboost-program-options-dev, libjsoncpp-dev, php5-cli|php7.0-cli|php7.2-cli
+Build-Depends: debhelper, libglib2.0-dev, libmagic-dev, libxml2-dev, libmxml-dev, libtext-template-perl, librpm-dev, subversion, rpm, libpcre3-dev, libssl-dev, postgresql-server-dev-all, libboost-regex-dev, libboost-program-options-dev, libjsoncpp-dev, php5-cli|php7.0-cli|php7.2-cli, php-mbstring|php5, php-zip|php5, php-xml|php5
 Standards-Version: 3.9.1
 Homepage: http://fossology.org
 
@@ -37,7 +37,7 @@ Description: open and modular architecture for analyzing software
 
 Package: fossology-common
 Architecture: any
-Depends: php5-pgsql|php7.0-pgsql|php7.2-pgsql, php-pear, php5-cli|php7.0-cli|php7.2-cli, php5-json|php7.0-json|php7.2-json, ${shlibs:Depends}, ${misc:Depends}
+Depends: php5-pgsql|php7.0-pgsql|php7.2-pgsql, php-pear, php5-cli|php7.0-cli|php7.2-cli, php5-json|php7.0-json|php7.2-json, php-mbstring|php5, php-zip|php5, php-xml|php5, ${shlibs:Depends}, ${misc:Depends}
 Description: architecture for analyzing software, common files
  The FOSSology project is a web based framework that allows you to
  upload software to be picked apart and then analyzed by software agents
@@ -274,7 +274,7 @@ Description: architecture for analyzing software, OSS readme generator
 
 Package: fossology-unifiedreport
 Architecture: any
-Depends: fossology-common, ${misc:Depends}
+Depends: fossology-common, php-zip|php5, php-xml|php5, ${misc:Depends}
 Description: architecture for analyzing software, Microsoft Word report generator
  The FOSSology project is a web based framework that allows you to
  upload software to be picked apart and then analyzed by software agents
@@ -310,7 +310,7 @@ Description: architecture for analyzing software, SPDX v2.0 generator
 
 Package: fossology-reportimport
 Architecture: any
-Depends: fossology-common, ${misc:Depends}
+Depends: fossology-common, php-mbstring|php5, ${misc:Depends}
 Description: architecture for analyzing software, report importer
  The FOSSology project is a web based framework that allows you to
  upload software to be picked apart and then analyzed by software agents

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -103,6 +103,10 @@ if [[ $BUILDTIME ]]; then
          apt-get $YesOpt install \
             libmxml-dev curl libxml2-dev libcunit1-dev \
             build-essential libtext-template-perl subversion rpm librpm-dev libmagic-dev libglib2.0 libboost-regex-dev libboost-program-options-dev
+         case "$CODENAME" in
+           xenial|stretch|buster|sid|bionic)
+             apt-get $YesOpt install php-mbstring;;
+         esac
          if ! dpkg --get-selections | grep -q postgresql-server-dev; then  ## if postgresql-server-dev is not installed
            case "$CODENAME" in
               trusty)
@@ -125,14 +129,14 @@ if [[ $BUILDTIME ]]; then
             perl-Text-Template subversion \
             postgresql-devel file-devel \
             libxml2 \
-            boost-devel
+            boost-devel php-mbstring
          ;;
       RedHatEnterprise*|CentOS)
          yum $YesOpt install \
             postgresql-devel \
             gcc make file libxml2 \
             perl-Text-Template subversion \
-            boost-devel
+            boost-devel php-mbstring
          ;;
       *) echo "ERROR: distro not recognised, please fix and send a patch"; exit 1;;
    esac
@@ -195,7 +199,7 @@ if [[ $RUNTIME ]]; then
          yum $YesOpt install postgresql-server httpd
          yum $YesOpt install \
             postgresql \
-            php php-pear php-pgsql php-process \
+            php php-pear php-pgsql php-process php-mbstring\
             smtpdaemon \
             file libxml2 \
             binutils mailx boost


### PR DESCRIPTION
## Description

`php-mbstring` is a required dependency for composer dependencies.

PHPWord requires `php-zip` to be installed as a run time dependency which was missing from Debian control file.

### Changes

Added `php-mbstring` as a build time dependency.
Also added as runtime dependency for RHEL.

Also added `php-zip` as a dependency for `unifiedreport` for PHP >= 7.0 and added `php5` for Trusty as it do not have `php-zip` as a separate package.

## How to test

1. On a clean system (Ubuntu >= Xenial or Debian >= Stretch), run `sudo ./utils/fo-installdeps -b` to install build time dependencies.
1. Install composer dependencies.
    - On master, it will fail due to missing `php-mbstring`.
1. Checkout the branch and repeat the steps above.
    - The install should not fail.

Closes #1119