### PR TITLE
feat(spdx2): SPDX output does not yet show license comments

### DIFF
--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -809,7 +809,7 @@ class SpdxTwoAgent extends Agent
    * @param int $uploadId
    * @return boolval License comment state (TRUE : show license comment, FALSE : don't show it)
    */
-  protected function getSPDXLicenseCommentState(int $uploadId)
+  protected function getSPDXLicenseCommentState($uploadId)
   {
     $sql = "SELECT spdx_license_comment from upload where upload_pk=$1";
     $param = array($uploadId);

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -324,7 +324,7 @@ class SpdxTwoAgent extends Agent
     $this->heartbeat(0);
 
     $upload = $this->uploadDao->getUpload($uploadId);
-    $fileNodes = $this->generateFileNodes($filesWithLicenses, $upload->getTreeTableName());
+    $fileNodes = $this->generateFileNodes($filesWithLicenses, $upload->getTreeTableName(), $uploadId);
 
     $mainLicenseIds = $this->clearingDao->getMainLicenseIds($uploadId, $this->groupId);
     $mainLicenses = array();
@@ -380,7 +380,10 @@ class SpdxTwoAgent extends Agent
           continue;
         }
 
-        if ($clearingEvent->getReportinfo()) {
+        /* ADD COMMENT */
+        $filesWithLicenses[$clearingDecision->getUploadTreeId()]['comment'] = $clearingLicense->getComment();
+        if($clearingEvent->getReportinfo())
+        {
           $customLicenseText = $clearingEvent->getReportinfo();
           $reportedLicenseShortname = $this->licenseMap->getProjectedShortname($this->licenseMap->getProjectedId($clearingLicense->getLicenseId())) .
                                     '-' . md5($customLicenseText);
@@ -634,13 +637,17 @@ class SpdxTwoAgent extends Agent
    * @brief Generate report nodes for files
    * @param string $filesWithLicenses
    * @param string $treeTableName
+   * @param int $uploadID
    * @return string Node content
    */
-  protected function generateFileNodes($filesWithLicenses, $treeTableName)
+  protected function generateFileNodes($filesWithLicenses, $treeTableName, $uploadId)
   {
-    if (strcmp($this->outputFormat, "dep5") !== 0) {
-      return $this->generateFileNodesByFiles($filesWithLicenses, $treeTableName);
-    } else {
+    if (strcmp($this->outputFormat, "dep5")!==0)
+    {
+      return $this->generateFileNodesByFiles($filesWithLicenses, $treeTableName, $uploadId);
+    }
+    else
+    {
       return $this->generateFileNodesByLicenses($filesWithLicenses, $treeTableName);
     }
   }
@@ -649,9 +656,10 @@ class SpdxTwoAgent extends Agent
    * @brief For each file, generate the nodes by files
    * @param string &$filesWithLicenses
    * @param string $treeTableName
+   * @param int $uploadID
    * @return string Node string
    */
-  protected function generateFileNodesByFiles($filesWithLicenses, $treeTableName)
+  protected function generateFileNodesByFiles($filesWithLicenses, $treeTableName, $uploadId)
   {
     /* @var $treeDao TreeDao */
     $treeDao = $this->container->get('dao.tree');
@@ -673,7 +681,7 @@ class SpdxTwoAgent extends Agent
       if (!is_array($licenses['scanner'])) {
         $licenses['scanner'] = array();
       }
-      $content .= $this->renderString($this->getTemplateFile('file'),array(
+      $array = array(
           'fileId'=>$fileId,
           'sha1'=>$hashes['sha1'],
           'md5'=>$hashes['md5'],
@@ -685,7 +693,13 @@ class SpdxTwoAgent extends Agent
           'concludedLicense'=>SpdxTwoUtils::implodeLicenses($licenses['concluded'], $this->spdxValidityChecker),
           'concludedLicenses'=> SpdxTwoUtils::addPrefixOnDemandList($licenses['concluded'], $this->spdxValidityChecker),
           'scannerLicenses'=>SpdxTwoUtils::addPrefixOnDemandList($licenses['scanner'], $this->spdxValidityChecker),
-          'copyrights'=>$licenses['copyrights']));
+          'copyrights'=>$licenses['copyrights'],
+          'licenseCommentState'=>$this->getSPDXLicenseCommentState($uploadId));
+      if($this->getSPDXLicenseCommentState($uploadId)) {
+        $array['licenseComment'] = $licenses['comment'];
+      }
+
+      $content .= $this->renderString($this->getTemplateFile('file'),$array);
     }
     $this->heartbeat($filesProceeded - $lastValue);
     return $content;
@@ -786,6 +800,21 @@ class SpdxTwoAgent extends Agent
     $filelistPack = $this->dbManager->getSingleRow($sql,$param,$stmt);
 
     return sha1($filelistPack['concat_sha1']);
+  }
+
+  /**
+   * @brief Get spdx license comment state for a given upload
+   *
+   * @param int $uploadId
+   * @return boolval License comment state (TRUE : show license comment, FALSE : don't show it)
+   */
+  protected function getSPDXLicenseCommentState(int $uploadId)
+  {
+    $sql = "SELECT spdx_license_comment from upload where upload_pk=$1";
+    $param[] = $uploadId;
+    $licensecomment = $this->dbManager->getSingleRow($sql,$param,__METHOD__.'.Spdx_license_comment');
+
+    return ($licensecomment['spdx_license_comment']=="t");
   }
 }
 

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -681,7 +681,8 @@ class SpdxTwoAgent extends Agent
       if (!is_array($licenses['scanner'])) {
         $licenses['scanner'] = array();
       }
-      $array = array(
+      $stateComment = $this->getSPDXLicenseCommentState($uploadId);
+      $dataTemplate = array(
           'fileId'=>$fileId,
           'sha1'=>$hashes['sha1'],
           'md5'=>$hashes['md5'],
@@ -694,12 +695,12 @@ class SpdxTwoAgent extends Agent
           'concludedLicenses'=> SpdxTwoUtils::addPrefixOnDemandList($licenses['concluded'], $this->spdxValidityChecker),
           'scannerLicenses'=>SpdxTwoUtils::addPrefixOnDemandList($licenses['scanner'], $this->spdxValidityChecker),
           'copyrights'=>$licenses['copyrights'],
-          'licenseCommentState'=>$this->getSPDXLicenseCommentState($uploadId));
-      if($this->getSPDXLicenseCommentState($uploadId)) {
-        $array['licenseComment'] = SpdxTwoUtils::implodeLicenses($licenses['comment']);
+          'licenseCommentState'=>$stateComment);
+      if($stateComment) {
+        $dataTemplate['licenseComment'] = SpdxTwoUtils::implodeLicenses($licenses['comment']);
       }
 
-      $content .= $this->renderString($this->getTemplateFile('file'),$array);
+      $content .= $this->renderString($this->getTemplateFile('file'),$dataTemplate);
     }
     $this->heartbeat($filesProceeded - $lastValue);
     return $content;
@@ -811,7 +812,7 @@ class SpdxTwoAgent extends Agent
   protected function getSPDXLicenseCommentState(int $uploadId)
   {
     $sql = "SELECT spdx_license_comment from upload where upload_pk=$1";
-    $param[] = $uploadId;
+    $param = array(1 => $uploadId);
     $licensecomment = $this->dbManager->getSingleRow($sql,$param,__METHOD__.'.Spdx_license_comment');
 
     return ($licensecomment['spdx_license_comment']=="t");

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -812,7 +812,7 @@ class SpdxTwoAgent extends Agent
   protected function getSPDXLicenseCommentState(int $uploadId)
   {
     $sql = "SELECT spdx_license_comment from upload where upload_pk=$1";
-    $param = array(1 => $uploadId);
+    $param = array($uploadId);
     $licensecomment = $this->dbManager->getSingleRow($sql,$param,__METHOD__.'.Spdx_license_comment');
 
     return ($licensecomment['spdx_license_comment']=="t");

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -382,8 +382,7 @@ class SpdxTwoAgent extends Agent
 
         /* ADD COMMENT */
         $filesWithLicenses[$clearingDecision->getUploadTreeId()]['comment'][] = $clearingLicense->getComment();
-        if($clearingEvent->getReportinfo())
-        {
+        if ($clearingEvent->getReportinfo()) {
           $customLicenseText = $clearingEvent->getReportinfo();
           $reportedLicenseShortname = $this->licenseMap->getProjectedShortname($this->licenseMap->getProjectedId($clearingLicense->getLicenseId())) .
                                     '-' . md5($customLicenseText);
@@ -642,12 +641,9 @@ class SpdxTwoAgent extends Agent
    */
   protected function generateFileNodes($filesWithLicenses, $treeTableName, $uploadId)
   {
-    if (strcmp($this->outputFormat, "dep5")!==0)
-    {
+    if (strcmp($this->outputFormat, "dep5")!==0) {
       return $this->generateFileNodesByFiles($filesWithLicenses, $treeTableName, $uploadId);
-    }
-    else
-    {
+    } else {
       return $this->generateFileNodesByLicenses($filesWithLicenses, $treeTableName);
     }
   }
@@ -696,7 +692,7 @@ class SpdxTwoAgent extends Agent
           'scannerLicenses'=>SpdxTwoUtils::addPrefixOnDemandList($licenses['scanner'], $this->spdxValidityChecker),
           'copyrights'=>$licenses['copyrights'],
           'licenseCommentState'=>$stateComment);
-      if($stateComment) {
+      if ($stateComment) {
         $dataTemplate['licenseComment'] = SpdxTwoUtils::implodeLicenses($licenses['comment']);
       }
 

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -381,7 +381,7 @@ class SpdxTwoAgent extends Agent
         }
 
         /* ADD COMMENT */
-        $filesWithLicenses[$clearingDecision->getUploadTreeId()]['comment'] = $clearingLicense->getComment();
+        $filesWithLicenses[$clearingDecision->getUploadTreeId()]['comment'][] = $clearingLicense->getComment();
         if($clearingEvent->getReportinfo())
         {
           $customLicenseText = $clearingEvent->getReportinfo();
@@ -696,7 +696,7 @@ class SpdxTwoAgent extends Agent
           'copyrights'=>$licenses['copyrights'],
           'licenseCommentState'=>$this->getSPDXLicenseCommentState($uploadId));
       if($this->getSPDXLicenseCommentState($uploadId)) {
-        $array['licenseComment'] = $licenses['comment'];
+        $array['licenseComment'] = SpdxTwoUtils::implodeLicenses($licenses['comment']);
       }
 
       $content .= $this->renderString($this->getTemplateFile('file'),$array);

--- a/src/spdx2/agent/template/spdx2-file.xml.twig
+++ b/src/spdx2/agent/template/spdx2-file.xml.twig
@@ -38,6 +38,13 @@
 {% else %}
     <spdx:licenseConcluded rdf:resource="http://spdx.org/rdf/terms#noassertion" />
 {% endif %}
+{% if licenseCommentState %}
+{% if licenseComment is empty %}
+    <spdx:licenseComments rdf:resource="http://spdx.org/rdf/terms#noassertion" />
+{% else %}
+    <spdx:licenseComments>{{ licenseComment|e }}</spdx:licenseComments>
+{% endif %}
+{% endif %}
 {% if scannerLicenses|default is empty %}
     <spdx:licenseInfoInFile rdf:resource="http://spdx.org/rdf/terms#noassertion" />
 {% else %}{% for res in scannerLicenses %}

--- a/src/spdx2/agent/template/spdx2tv-file.twig
+++ b/src/spdx2/agent/template/spdx2tv-file.twig
@@ -21,6 +21,14 @@ LicenseConcluded: {{ concludedLicense }}
 {% else %}
 LicenseConcluded: NOASSERTION
 {% endif %}
+{% if licenseCommentState %}
+{% if licenseComment is empty %}
+LicenseComment: NOCOMMENT
+{% else %}
+LicenseComments: <text>{{ licenseComment |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
+                                         |replace({'\f':''}) }} </text>
+{% endif %}
+{% endif %}
 {% if scannerLicenses|default is empty %}
 LicenseInfoInFile: NOASSERTION
 {% else %}

--- a/src/spdx2/agent/template/spdx2tv-file.twig
+++ b/src/spdx2/agent/template/spdx2tv-file.twig
@@ -22,9 +22,7 @@ LicenseConcluded: {{ concludedLicense }}
 LicenseConcluded: NOASSERTION
 {% endif %}
 {% if licenseCommentState %}
-{% if licenseComment is empty %}
-LicenseComment: NOCOMMENT
-{% else %}
+{% if licenseComment is not empty %}
 LicenseComments: <text>{{ licenseComment |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
                                          |replace({'\f':''}) }} </text>
 {% endif %}

--- a/src/www/ui/admin-upload-edit.php
+++ b/src/www/ui/admin-upload-edit.php
@@ -57,7 +57,7 @@ class upload_properties extends FO_Plugin
    *
    * @return 1 if the upload record is updated, 0 if not, 2 if no inputs
    **/
-  function UpdateUploadProperties($uploadId, $newName, $newDesc, $licenseComment) 
+  function UpdateUploadProperties($uploadId, $newName, $newDesc, $licenseComment)
   {
     if (empty($newName) and empty($newDesc)) {
       return 2;
@@ -93,8 +93,7 @@ class upload_properties extends FO_Plugin
         array($uploadId, $trimNewDesc), __METHOD__ . '.updateUpload.desc');
     }
 
-    if (isset($licenseComment))
-    {
+    if (isset($licenseComment)) {
       $licenseCommentValue = ( $licenseComment ? 't' : 'f' );
       $this->dbManager->getSingleRow("UPDATE upload SET spdx_license_comment=$2 WHERE upload_pk=$1",array($uploadId,$licenseCommentValue),__METHOD__.'.updateUpload.spdxlicenseComment');
     }
@@ -129,8 +128,7 @@ class upload_properties extends FO_Plugin
     }
 
     $rc = $this->UpdateUploadProperties($upload_pk, $NewName, $NewDesc, $licenseComment);
-    if($rc == 0)
-    {
+    if ($rc == 0) {
       $text = _("Nothing to Change");
       $this->vars['message'] = $text;
     } else if ($rc == 1) {
@@ -173,12 +171,10 @@ class upload_properties extends FO_Plugin
     }
 
     /* Test if it is the first call to display the Uploaded File Properties page */
-    if (GetParm('REQUEST_METHOD', PARM_STRING) == 'GET')
-    {
+    if (GetParm('REQUEST_METHOD', PARM_STRING) == 'GET') {
       /* if it is, read the spdx_license_comment value in database */
       $row=$this->dbManager->getSingleRow("SELECT spdx_license_comment FROM upload WHERE upload_pk=$1",array($upload_pk),__METHOD__.'.getSpdxLicenseComment');
-      if (!empty($row))
-      {
+      if (!empty($row)) {
         $licenseComment = ($row['spdx_license_comment'] == 't');
       }
     }
@@ -190,7 +186,7 @@ class upload_properties extends FO_Plugin
     $this->vars['uploadDesc'] = $upload ? $upload->getDescription() : '';
     $this->vars['content'] = $V;
     $this->vars['licenseComment']= $licenseComment;
-    
+
     return $this->render('admin_upload_edit.html.twig');
   }
 }

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -1520,6 +1520,10 @@
   $Schema["TABLE"]["upload"]["public_perm"]["ADD"] = "ALTER TABLE \"upload\" ADD COLUMN \"public_perm\" int4";
   $Schema["TABLE"]["upload"]["public_perm"]["ALTER"] = "ALTER TABLE \"upload\" ALTER COLUMN \"public_perm\" DROP NOT NULL";
 
+  $Schema["TABLE"]["upload"]["spdx_license_comment"]["DESC"] = "COMMENT ON COLUMN \"upload\".\"spdx_license_comment\" IS 'true: SPDX output show license comments, false: dont show it'";
+  $Schema["TABLE"]["upload"]["spdx_license_comment"]["ADD"] = "ALTER TABLE \"upload\" ADD COLUMN \"spdx_license_comment\" boolean DEFAULT false";
+  $Schema["TABLE"]["upload"]["spdx_license_comment"]["ALTER"] = "ALTER TABLE \"upload\" ALTER COLUMN \"spdx_license_comment\" DROP NOT NULL";
+
 
   $Schema["TABLE"]["upload_clearing"]["upload_fk"]["DESC"] = "";
   $Schema["TABLE"]["upload_clearing"]["upload_fk"]["ADD"] = "ALTER TABLE \"upload_clearing\" ADD COLUMN \"upload_fk\" int4";

--- a/src/www/ui/template/admin_upload_edit.html.twig
+++ b/src/www/ui/template/admin_upload_edit.html.twig
@@ -27,7 +27,11 @@
 
       <li>{{ 'Upload description'|trans }}:
         <input type="text" name="newdesc" size="60" value="{{ uploadDesc|e }}" />
-      </li> 
+      </li>
+
+			<li>{{ 'License comment'|trans }}:
+				<input type="checkbox" name="licensecomment" {%if licenseComment %}checked{% endif %} value="1" >
+			</li>
     </ol>
     <input type="submit" value="{{ 'Edit'|trans }}" />
   </form>


### PR DESCRIPTION
## Description

Implement SPDX output does not yet show license comments

### Changes

1. add a new column in spdx_license_comment in upload table.
2. add a new option in Organize/Uploads/Edit Properties to enable or disable this feature.
3. add the LicenseComment field for both SPDX: Tag-Value and SPDX: RDF exports only if the option is activated.

## How to test

Activate the new option in Organize/Uploads/Edit Properties and launch an export SPDX.

closing #645 

