### PR TITLE
docs(templates): Fix minor typos in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,9 @@
-Before filling this issue, please read the Wiki (https://github.com/fossology/fossology/wiki)
-and search if the bug do not already exists in the issues (https://github.com/fossology/fossology/issues).
+<!-- Before filling this issue, please read the Wiki (https://github.com/fossology/fossology/wiki)
+and search if the bug do not already exists in the issues (https://github.com/fossology/fossology/issues). -->
 
 ### Description
 
-Please describle your situation in few words here.
+Please describe your situation in few words here.
 
 #### How to reproduce
 
@@ -22,9 +22,9 @@ If applicable, add screenshots to help explain your problem.
 
 ### Logs
 
-Any logs (if any) genereated in
+Any logs (if any) generated in
 
-#### Fossology logs
+#### FOSSology logs
 
 Logs generated under /var/log/fossology/fossology.log
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,14 +1,15 @@
 ---
 name: Bug report
 about: Create a report to help us improve
+labels: bug
 ---
 
-Before filling this issue, please read the Wiki (https://github.com/fossology/fossology/wiki)
-and search if the bug do not already exists in the issues (https://github.com/fossology/fossology/issues).
+<!-- Before filling this issue, please read the wiki (https://github.com/fossology/fossology/wiki)
+and search if the bug do not already exists in the issues (https://github.com/fossology/fossology/issues). -->
 
 ### Description
 
-Please describle your issue in few words here.
+Please describe your issue in few words here.
 
 #### How to reproduce
 
@@ -25,9 +26,9 @@ If applicable, add screenshots to help explain your problem.
 
 ### Logs
 
-Any logs (if any) genereated in
+Any logs (if any) generated in
 
-#### Fossology logs
+#### FOSSology logs
 
 Logs generated under /var/log/fossology/fossology.log
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,14 +1,15 @@
 ---
 name: Feature request
 about: Request a new feature in FOSSology
+labels: enhancement
 ---
 
-Before filling this issue, please read the Wiki (https://github.com/fossology/fossology/wiki)
-and search if the bug do not already exists in the issues (https://github.com/fossology/fossology/issues).
+<!-- Before filling this issue, please read the Wiki (https://github.com/fossology/fossology/wiki)
+and search if the bug do not already exists in the issues (https://github.com/fossology/fossology/issues). -->
 
 ### Description
 
-Please describle your situation in few words here.
+Please describe your situation in few words here.
 
 #### Steps followed and expected result
 
@@ -17,4 +18,3 @@ Describe the steps followed by you and your expected results after following the
 #### Screenshots
 
 If applicable, add screenshots to help explain your problem.
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
-Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
-before creating the pull request to make sure you follow all the standards.
+<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
+before creating the pull request to make sure you follow all the standards. -->
 
 ## Description
 
@@ -16,4 +16,3 @@ Describe the steps required to test the changes proposed in the pull request.
 Please consider using the closing keyword if the pull request is proposed to
 fix an issue already created in the repository
 (https://help.github.com/articles/closing-issues-using-keywords/)
-


### PR DESCRIPTION
## Description

Fix minor typos in GitHub templates.

### Changes

1. Fix minor typos.
1. Add comments to the warnings.
    - This prevents them from showing in UI if user forgot to remove them.
1. Auto add labels to bugs and feature requests.
    - `bug` label for bug reports.
    - `enhancement` label for feature requests.