### PR TITLE
feat(license-admin): Show obligations for license

### DIFF
--- a/src/lib/php/BusinessRules/ObligationMap.php
+++ b/src/lib/php/BusinessRules/ObligationMap.php
@@ -190,20 +190,19 @@ class ObligationMap
    */
   public function associateLicenseWithObligation($obId,$licId,$candidate=false)
   {
-    if ($candidate)
-    {
-      $sql = "INSERT INTO obligation_candidate_map (ob_fk, rf_fk) VALUES ($1, $2)";
-      $stmt = __METHOD__.".om_addcandidate_$obId";
+    if (! $this->isLicenseAssociated($obId, $licId, $candidate)) {
+      if ($candidate) {
+        $sql = "INSERT INTO obligation_candidate_map (ob_fk, rf_fk) VALUES ($1, $2)";
+        $stmt = __METHOD__ . ".om_addcandidate";
+      } else {
+        $sql = "INSERT INTO obligation_map (ob_fk, rf_fk) VALUES ($1, $2)";
+        $stmt = __METHOD__ . ".om_addlicense";
+      }
+      $this->dbManager->prepare($stmt, $sql);
+      $res = $this->dbManager->execute($stmt, array($obId,$licId));
+      $this->dbManager->fetchArray($res);
+      $this->dbManager->freeResult($res);
     }
-    else
-    {
-      $sql = "INSERT INTO obligation_map (ob_fk, rf_fk) VALUES ($1, $2)";
-      $stmt = __METHOD__.".om_addlicense_$obId";
-    }
-    $this->dbManager->prepare($stmt,$sql);
-    $res = $this->dbManager->execute($stmt,array($obId,$licId));
-    $this->dbManager->fetchArray($res);
-    $this->dbManager->freeResult($res);
   }
 
   /**
@@ -238,7 +237,7 @@ class ObligationMap
       {
         $sql = "DELETE FROM obligation_map WHERE ob_fk=$1 AND rf_fk=$2";
       }
-      $stmt = __METHOD__.".omdel_$licId";
+      $stmt = __METHOD__.".omdel_lic";
       $this->dbManager->prepare($stmt,$sql);
       $res = $this->dbManager->execute($stmt,array($obId,$licId));
     }
@@ -246,4 +245,25 @@ class ObligationMap
     $this->dbManager->freeResult($res);
   }
 
+  /**
+   * @brief Get all obligations from DB
+   * @return array
+   */
+  public function getObligations()
+  {
+    $sql = "SELECT * FROM obligation_ref;";
+    return $this->dbManager->getRows($sql);
+  }
+
+  /**
+   * @brief Get the obligation topic from the obligation id
+   * @param int     $ob_pk     Obligation id
+   * @return string Obligation topic
+   */
+  public function getTopicNameFromId($ob_pk)
+  {
+    $sql = "SELECT ob_topic FROM obligation_ref WHERE ob_pk = $1;";
+    $result = $this->dbManager->getSingleRow($sql,array($ob_pk));
+    return $result['ob_topic'];
+  }
 }

--- a/src/www/ui/template/admin_license-upload_form.html.twig
+++ b/src/www/ui/template/admin_license-upload_form.html.twig
@@ -74,6 +74,10 @@
       <td align="right">{{ 'Risk level'|trans }}</td>
       <td align="left">{{ macro.selectsingle('risk_level',range(0,5),'risk_level',risk_level) }}</td>
     </tr>
+    <tr>
+      <td align="right">{{ "Associated Obligations"|trans }}</td>
+      <td align="left">{{ macro.selectwitharray(obligationSelectorName, obligationTopics, obligationSelectorId, obligationSelected, 'style="min-width:575px;"', 8) }}</td>
+    </tr>
   </table>
   {% if rfId %}
     <a href="?mod=admin_license_to_csv&amp;rf={{ rfId }}" class="buttonLink">{{ 'Export as CSV'|trans }}</a>
@@ -85,5 +89,8 @@
 {% block foot %}
   {{ parent() }}
   {% set riskSelectId = 'risk_level' %}
-  <script>{% include "riskLevel_select.js.twig" %}</script>
+  <script type="text/javascript">{% include "riskLevel_select.js.twig" %}</script>
+  <script type="text/javascript">
+    $('#{{ obligationSelectorId }}').select2({'placeholder': 'Select obligations associated with this license'});
+  </script>
 {% endblock %}

--- a/src/www/ui/template/admin_license_file.html.twig
+++ b/src/www/ui/template/admin_license_file.html.twig
@@ -12,11 +12,15 @@
 
   <p>{{ dataMessage }}</p>
   {% if data %}
-  <table id='adminLicenseTable' rules='rows' width='100%' cellpadding='3'>
+  <table id='adminLicenseTable' rules='rows' width='100%' style="width:100%" cellpadding='3'>
     <tfoot class="footAsHead">
       <tr style="background:lightsteelblue">
-        <td><strong>Search:</strong></td><td></td>
-        <td></td><th>Shortname</th><th>Fullname</th><th>Text</th><th>URL</th>
+        <td colspan="3" style="width:15%"><strong>Search:</strong></td>
+        <th style="width:15%">Shortname</th>
+        <th style="width:22%">Fullname</th>
+        <th style="width:20%">Text</th>
+        <th style="width:11%">URL</th>
+        <th style="width:17%">Obligation topics</th>
       </tr>
     </tfoot>
   </table>

--- a/src/www/ui/template/admin_license_file.js.twig
+++ b/src/www/ui/template/admin_license_file.js.twig
@@ -50,7 +50,8 @@ function getDataForTable() {
     "rf_shortname":       "{{ entry['rf_shortname']|escape('js') }}",
     "rf_fullname":        "{{ entry['rf_fullname']|escape('js') }}",
     "rf_text":            [ "{{ entry['rf_pk'] }}", "{{ entry['rf_text'][:120]|escape('js') }}" ],
-    "rf_url":             "{{ entry['rf_url'] }}"
+    "rf_url":             "{{ entry['rf_url'] }}",
+    "ob_topic":           "{{ entry['ob_topic'] }}"
   });
   {% endfor %}
 
@@ -76,7 +77,8 @@ function createLicenseTable() {
       {title: "Shortname", data: "rf_shortname", defaultContent: ""},
       {title: "Fullname", data: "rf_fullname", defaultContent: ""},
       {title: "Text", data: "rf_text", defaultContent: "", render: renderLicenseText},
-      {title: "URL", data: "rf_url", defaultContent: "", render: renderLink}
+      {title: "URL", data: "rf_url", defaultContent: "", render: renderLink},
+      {title: "Obligation topic", data: "ob_topic", defaultContent: "", render: renderObligation}
     ],
     order: [[ 3, "asc" ]]
   });
@@ -116,9 +118,25 @@ function createLicenseTable() {
 
     return "<textarea readonly class=\"licenseTextArea\" id=\"licenseTextArea" + licenseID + "\" " +
            "data-licenseid=\"" + licenseID + "\" data-textloaded=\"false\" " +
-           "rows=\"3\" cols=\"40\">" +
+           "rows=\"3\" cols=\"40\" style=\"width:100%\">" +
            licenseText +
            "</textarea>";
+  }
+
+  function renderObligation(data) {
+    if (! data) {
+      return "";
+    }
+
+    var ob_topics = data.split(";");
+
+    var options = [];
+    for (var i = 0, len = ob_topics.length; i< len; i++) {
+      options.push("<option>" + ob_topics[i] + "</option>");
+    }
+    return "<div style='overflow:auto;max-width:280px'>" +
+      "<select size='4' readonly>" + options.join("") +
+      "</select></div>";
   }
 
   // Add a text input to each footer cell


### PR DESCRIPTION
## Description

1. Display the obligations attached to the license next to it in license admin view.
1. Also allow addition and removal of obligations from license edit view.

### Changes

Show obligations for each license in UI.

## How to test

1. Add obligations to FOSSology.
1. Add licenses to obligations.
1. Goto Admin -> License Admin -> Select License.
    1. Check if the obligations are displayed next to the license.
1. Edit license with obligations.
    1. Add / remove obligations to the license.
    1. Check if the changes are reflected.
1. Add new license and assign obligations to it.
    1. Check if the license is saved with obligations assigned.

#### Note
This change uses `string_agg` function of PostgreSQL which is available only in 9 and newer versions.