### PR TITLE
feat(spdx2): Ignore files with no info in SPDX reports

### DIFF
--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -638,12 +638,9 @@ class SpdxTwoAgent extends Agent
    */
   protected function generateFileNodes($filesWithLicenses, $treeTableName, $uploadId)
   {
-    if (strcmp($this->outputFormat, "dep5")!==0)
-    {
+    if (strcmp($this->outputFormat, "dep5")!==0) {
       return $this->generateFileNodesByFiles($filesWithLicenses, $treeTableName, $uploadId);
-    }
-    else
-    {
+    } else {
       return $this->generateFileNodesByLicenses($filesWithLicenses, $treeTableName);
     }
   }
@@ -678,9 +675,8 @@ class SpdxTwoAgent extends Agent
         $licenses['scanner'] = array();
       }
       $stateWoInfos = $this->getIgnoreFilesWOinfo($uploadId);
-      if(!$stateWoInfos ||
-         ($stateWoInfos && (!empty($licenses['concluded']) || (!empty($licenses['scanner']) && !empty($licenses['scanner'][0])) || !empty($licenses['copyrights']))))
-      {
+      if (!$stateWoInfos ||
+          ($stateWoInfos && (!empty($licenses['concluded']) || (!empty($licenses['scanner']) && !empty($licenses['scanner'][0])) || !empty($licenses['copyrights'])))) {
         $content .= $this->renderString($this->getTemplateFile('file'),array(
           'fileId'=>$fileId,
           'sha1'=>$hashes['sha1'],

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -677,8 +677,9 @@ class SpdxTwoAgent extends Agent
       if (!is_array($licenses['scanner'])) {
         $licenses['scanner'] = array();
       }
-      if(!$this->getIgnoreFilesWOinfo($uploadId) ||
-         ($this->getIgnoreFilesWOinfo($uploadId) && (!empty($licenses['concluded']) || (!empty($licenses['scanner']) && !empty($licenses['scanner'][0])) || !empty($licenses['copyrights']))))
+      $stateWoInfos = $this->getIgnoreFilesWOinfo($uploadId);
+      if(!$stateWoInfos ||
+         ($stateWoInfos && (!empty($licenses['concluded']) || (!empty($licenses['scanner']) && !empty($licenses['scanner'][0])) || !empty($licenses['copyrights']))))
       {
         $content .= $this->renderString($this->getTemplateFile('file'),array(
           'fileId'=>$fileId,
@@ -805,7 +806,7 @@ class SpdxTwoAgent extends Agent
   protected function getIgnoreFilesWOinfo(int $uploadId)
   {
     $sql = "SELECT ignore_files_wo_infos from upload where upload_pk=$1";
-    $param[] = $uploadId;
+    $param = array(1 => $uploadId);
     $row = $this->dbManager->getSingleRow($sql,$param,__METHOD__.'.Ignore_files_wo_infos');
     return ($row['ignore_files_wo_infos']=='t');
   }

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -803,10 +803,10 @@ class SpdxTwoAgent extends Agent
    * @param int $uploadId
    * @return boolval current state (TRUE : SPDX output dont show files wo infos, FALSE : show it)
    */
-  protected function getIgnoreFilesWOinfo(int $uploadId)
+  protected function getIgnoreFilesWOinfo($uploadId)
   {
     $sql = "SELECT ignore_files_wo_infos from upload where upload_pk=$1";
-    $param = array(1 => $uploadId);
+    $param = array($uploadId);
     $row = $this->dbManager->getSingleRow($sql,$param,__METHOD__.'.Ignore_files_wo_infos');
     return ($row['ignore_files_wo_infos']=='t');
   }

--- a/src/www/ui/admin-upload-edit.php
+++ b/src/www/ui/admin-upload-edit.php
@@ -93,8 +93,7 @@ class upload_properties extends FO_Plugin
         array($uploadId, $trimNewDesc), __METHOD__ . '.updateUpload.desc');
     }
 
-    if (isset($ignoreFilesWOInfos))
-    {
+    if (isset($ignoreFilesWOInfos)) {
       $ignoreFilesWOInfosValue = ( $ignoreFilesWOInfos ? 't' : 'f' );
       $this->dbManager->getSingleRow("UPDATE upload SET ignore_files_wo_infos=$2 WHERE upload_pk=$1",array($uploadId,$ignoreFilesWOInfosValue),__METHOD__.'.updateUpload.ignoreFilesWOInfos');
     }
@@ -129,8 +128,7 @@ class upload_properties extends FO_Plugin
     }
 
     $rc = $this->UpdateUploadProperties($upload_pk, $NewName, $NewDesc, $ignoreFilesWOInfos);
-    if($rc == 0)
-    {
+    if ($rc == 0) {
       $text = _("Nothing to Change");
       $this->vars['message'] = $text;
     } else if ($rc == 1) {
@@ -173,12 +171,10 @@ class upload_properties extends FO_Plugin
     }
 
     /* Test if it is the first call to display the Uploaded File Properties page */
-    if (GetParm('REQUEST_METHOD', PARM_STRING) == 'GET' && !empty($upload))
-    {
+    if (GetParm('REQUEST_METHOD', PARM_STRING) == 'GET' && !empty($upload)) {
       /* if it is, read the ignore_files_wo_infos value in database */
       $row=$this->dbManager->getSingleRow("SELECT ignore_files_wo_infos FROM upload WHERE upload_pk=$1",array($upload_pk),__METHOD__.'.getIgnoreFilesWOInfos');
-      if (!empty($row))
-      {
+      if (!empty($row)) {
         $ignoreFilesWOInfos = ($row['ignore_files_wo_infos'] == 't');
       }
     }

--- a/src/www/ui/admin-upload-edit.php
+++ b/src/www/ui/admin-upload-edit.php
@@ -45,17 +45,19 @@ class upload_properties extends FO_Plugin
   }
 
   /**
-   * @brief Update upload properties (name and description)
+   * @brief Update upload properties (name, description and ignore files wo infos state)
    *
    * @param $uploadId upload.upload_pk of record to update
    * @param $newName New upload.upload_filename, and uploadtree.ufle_name
    *        If null, old value is not changed.
    * @param $newDesc New upload description (upload.upload_desc)
    *        If null, old value is not changed.
+   * @param $ignoreFilesWOInfos Must be at true to exclude files without info in SPDX reports
+   *        If null, old value is not changed.
    *
    * @return 1 if the upload record is updated, 0 if not, 2 if no inputs
    **/
-  function UpdateUploadProperties($uploadId, $newName, $newDesc)
+  function UpdateUploadProperties($uploadId, $newName, $newDesc, $ignoreFilesWOInfos)
   {
     if (empty($newName) and empty($newDesc)) {
       return 2;
@@ -90,6 +92,13 @@ class upload_properties extends FO_Plugin
       $this->dbManager->getSingleRow("UPDATE upload SET upload_desc=$2 WHERE upload_pk=$1",
         array($uploadId, $trimNewDesc), __METHOD__ . '.updateUpload.desc');
     }
+
+    if (isset($ignoreFilesWOInfos))
+    {
+      $ignoreFilesWOInfosValue = ( $ignoreFilesWOInfos ? 't' : 'f' );
+      $this->dbManager->getSingleRow("UPDATE upload SET ignore_files_wo_infos=$2 WHERE upload_pk=$1",array($uploadId,$ignoreFilesWOInfosValue),__METHOD__.'.updateUpload.ignoreFilesWOInfos');
+    }
+
     return 1;
   }
 
@@ -108,6 +117,7 @@ class upload_properties extends FO_Plugin
     $NewName = GetArrayVal("newname", $_POST);
     $NewDesc = GetArrayVal("newdesc", $_POST);
     $upload_pk = GetArrayVal("upload_pk", $_POST);
+    $ignoreFilesWOInfos = (GetArrayVal("ignorefileswoinfo", $_POST) == 1);
     if (empty($upload_pk)) {
       $upload_pk = GetParm('upload', PARM_INTEGER);
     }
@@ -118,8 +128,9 @@ class upload_properties extends FO_Plugin
       return "<h2>$text</h2>";
     }
 
-    $rc = $this->UpdateUploadProperties($upload_pk, $NewName, $NewDesc);
-    if ($rc == 0) {
+    $rc = $this->UpdateUploadProperties($upload_pk, $NewName, $NewDesc, $ignoreFilesWOInfos);
+    if($rc == 0)
+    {
       $text = _("Nothing to Change");
       $this->vars['message'] = $text;
     } else if ($rc == 1) {
@@ -161,12 +172,24 @@ class upload_properties extends FO_Plugin
       $upload = null;
     }
 
+    /* Test if it is the first call to display the Uploaded File Properties page */
+    if (GetParm('REQUEST_METHOD', PARM_STRING) == 'GET' && !empty($upload))
+    {
+      /* if it is, read the ignore_files_wo_infos value in database */
+      $row=$this->dbManager->getSingleRow("SELECT ignore_files_wo_infos FROM upload WHERE upload_pk=$1",array($upload_pk),__METHOD__.'.getIgnoreFilesWOInfos');
+      if (!empty($row))
+      {
+        $ignoreFilesWOInfos = ($row['ignore_files_wo_infos'] == 't');
+      }
+    }
+
     $baseFolderUri = $this->vars['baseUri']."$folder_pk&upload=";
     $this->vars['uploadAction'] = "onchange=\"js_url(this.value, '$baseFolderUri')\"";
 
     $this->vars['uploadFilename'] = $upload ? $upload->getFilename() : '';
     $this->vars['uploadDesc'] = $upload ? $upload->getDescription() : '';
     $this->vars['content'] = $V;
+    $this->vars['ignoreFilesWOInfo'] = $ignoreFilesWOInfos;
 
     return $this->render('admin_upload_edit.html.twig');
   }

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -1520,6 +1520,10 @@
   $Schema["TABLE"]["upload"]["public_perm"]["ADD"] = "ALTER TABLE \"upload\" ADD COLUMN \"public_perm\" int4";
   $Schema["TABLE"]["upload"]["public_perm"]["ALTER"] = "ALTER TABLE \"upload\" ALTER COLUMN \"public_perm\" DROP NOT NULL";
 
+  $Schema["TABLE"]["upload"]["ignore_files_wo_infos"]["DESC"] = "COMMENT ON COLUMN \"upload\".\"ignore_files_wo_infos\" IS 'true: SPDX output dont show files wo infos, false: show it'";
+  $Schema["TABLE"]["upload"]["ignore_files_wo_infos"]["ADD"] = "ALTER TABLE \"upload\" ADD COLUMN \"ignore_files_wo_infos\" boolean DEFAULT false";
+  $Schema["TABLE"]["upload"]["ignore_files_wo_infos"]["ALTER"] = "ALTER TABLE \"upload\" ALTER COLUMN \"ignore_files_wo_infos\" DROP NOT NULL";
+
 
   $Schema["TABLE"]["upload_clearing"]["upload_fk"]["DESC"] = "";
   $Schema["TABLE"]["upload_clearing"]["upload_fk"]["ADD"] = "ALTER TABLE \"upload_clearing\" ADD COLUMN \"upload_fk\" int4";

--- a/src/www/ui/template/admin_upload_edit.html.twig
+++ b/src/www/ui/template/admin_upload_edit.html.twig
@@ -27,7 +27,11 @@
 
       <li>{{ 'Upload description'|trans }}:
         <input type="text" name="newdesc" size="60" value="{{ uploadDesc|e }}" />
-      </li> 
+      </li>
+
+      <li>{{ 'Ignore files with no info in SPDX reports'|trans }}:
+        <input type="checkbox" name="ignorefileswoinfo" {%if ignoreFilesWOInfo %}checked{% endif %} value="1" >
+      </li>
     </ol>
     <input type="submit" value="{{ 'Edit'|trans }}" />
   </form>


### PR DESCRIPTION
## Description

Implement ignore files with no info in SPDX reports (see #1161)

### Changes

1. add a new column ignore_files_wo_infos in upload table
2. add a new option in Organize/Uploads/Edit Properties to enable or disable this feature.

## How to test

Activate the new option in Organize/Uploads/Edit Properties and launch an export SPDX. Verify only files with info are in SPDX export.

closing #1161 