### PR TITLE
fix(filter): Update the filter in license browser

### DIFF
--- a/src/www/ui/template/browse_file.js.twig
+++ b/src/www/ui/template/browse_file.js.twig
@@ -50,6 +50,9 @@ function createDirlistTable() {
     "bFilter": true,
     "bAutoWidth": true,
     "iDisplayLength":50,
+    "fnDrawCallback": function() {
+      renderSelect2();
+    },
     "oLanguage":{"sInfo":"Showing _START_ to _END_ of _TOTAL_ files" ,
       "sSearch":'_INPUT_<button onclick="clearSearchFiles();" title=\"{{ 'Clear file filter'|trans }}\" >Clear<\/button>',
       "sLengthMenu":'Display <select><option value="10">10<\/option><option value="25">25<\/option><option value="50">50<\/option><option value="100">100<\/option><\/select> {#

--- a/src/www/ui/template/include/foot.html.twig
+++ b/src/www/ui/template/include/foot.html.twig
@@ -8,13 +8,16 @@
 <script src="scripts/jquery-ui.js" type="text/javascript"></script>
 <script src="scripts/select2.full.min.js" type="text/javascript"></script>
 <script type="text/javascript">
-  $(document).ready(function() {
+  function renderSelect2() {
     if(!$('.ui-render-select2').attr("size") > 0) {
       $('.ui-render-select2').select2({
         width: 'resolve',
         dropdownAutoWidth : true
       });
     }
+  }
+  $(document).ready(function() {
+    renderSelect2();
   });
 </script>
 {{ scripts }}


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Update the Select2 drop-down whenever the data table is updated in License Browser.

### Changes

Use the `fnDrawCallback` option of datatable to redraw select2 whenever datatable is drawn.

## How to test

Check the issue.

Closes #1275