### PR TITLE
fix(scheduler): add check for empty results from query

### DIFF
--- a/src/scheduler/agent/database.c
+++ b/src/scheduler/agent/database.c
@@ -215,10 +215,10 @@ static gboolean email_replace(const GMatchInfo* match, GString* ret,
     sql = g_strdup_printf(folder_name, job->id);
     db_result = database_exec(args->scheduler, sql);
 
-    if(PQresultStatus(db_result) != PGRES_TUPLES_OK)
+    if(PQresultStatus(db_result) != PGRES_TUPLES_OK || PQntuples(db_result) == 0)
     {
       g_string_append_printf(ret,
-          "[ERROR: unable to select folder name for upload %d]", job->id);
+          "[NOTICE: unable to select folder name for upload %d]", job->id);
     }
     else
     {


### PR DESCRIPTION
## Description

After executing the delagent and maintenance agent  the scheduler will crash.

### Changes

Check the results of the query in case of empty rows.

## How to test

* Login with fossy user and Upload a package.
* Go to Organize -> Uploads -> Delete uploaded file.
* Delete the uploaded file. and upload a new file.
* Check if the scheduler is running properly through Admin -> Scheduler. 
