### PR TITLE
feat(maintagent): add feature to delete orphaned records from database

### DIFF
--- a/src/maintagent/agent/maintagent.c
+++ b/src/maintagent/agent/maintagent.c
@@ -97,8 +97,10 @@ int main(int argc, char **argv)
   int ProcessExpiredExe = 0;
   int RemoveOrphanedFilesExe = 0;
   int reIndexAllTablesExe = 0;
+  int removeOrphanedRowsExe = 0;
+
   /* command line options */
-  while ((cmdopt = getopt(argc, argv, "aADFghIpNPRTUZivVc:")) != -1)
+  while ((cmdopt = getopt(argc, argv, "aADEFghIpNPRTUZivVc:")) != -1)
   {
     switch (cmdopt)
     {
@@ -223,6 +225,12 @@ int main(int argc, char **argv)
           if(reIndexAllTablesExe == 0){
             reIndexAllTables();
             reIndexAllTablesExe = 1;
+          }
+          break;
+      case 'E': /* Remove orphaned files from the database */
+          if(removeOrphanedRowsExe == 0){   
+            removeOrphanedRows();
+            removeOrphanedRowsExe = 1;
           }
           break;
       case 'i': /* "Initialize" */

--- a/src/maintagent/agent/maintagent.c
+++ b/src/maintagent/agent/maintagent.c
@@ -1,6 +1,6 @@
 /***************************************************************
  Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2014, Siemens AG
+ Copyright (C) 2014,2019 Siemens AG
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -61,10 +61,6 @@ char BuildVersion[]="maintagent build version: " VERSION_S " r(" COMMIT_HASH_S "
 char BuildVersion[]="maintagent build version: NULL.\n";
 #endif
 
-/**********  Globals  *************/
-PGconn    *pgConn = 0;        ///< database connection
-
-
 /**
  * \brief Main entry point for the agent
  */
@@ -73,8 +69,8 @@ int main(int argc, char **argv)
   int cmdopt;
   char *COMMIT_HASH;
   char *VERSION;
-  char agent_rev[myBUFSIZ];
-  char *agent_desc = "Maintenance Agent";
+  char agentRev[myBUFSIZ];
+  char *agentDesc = "Maintenance Agent";
 
   /* connect to the scheduler */
   fo_scheduler_connect(&argc, argv, &pgConn);
@@ -84,18 +80,18 @@ int main(int argc, char **argv)
    */
   COMMIT_HASH = fo_sysconfig("maintagent", "COMMIT_HASH");
   VERSION = fo_sysconfig("maintagent", "VERSION");
-  snprintf(agent_rev, sizeof(agent_rev), "%s.%s", VERSION, COMMIT_HASH);
+  snprintf(agentRev, sizeof(agentRev), "%s.%s", VERSION, COMMIT_HASH);
   /* insert/update agent data if necessary */
-  fo_GetAgentKey(pgConn, basename(argv[0]), 0, agent_rev, agent_desc);
+  fo_GetAgentKey(pgConn, basename(argv[0]), 0, agentRev, agentDesc);
 
-  int ValidateFoldersExe = 0;
-  int VerifyFilePermsExe = 0;
-  int RemoveUploadsExe = 0;
-  int NormalizeUploadPrioritiesExe = 0;
-  int RemoveTempsExe = 0;
-  int VacAnalyzeExe = 0;
-  int ProcessExpiredExe = 0;
-  int RemoveOrphanedFilesExe = 0;
+  int validateFoldersExe = 0;
+  int verifyFilePermsExe = 0;
+  int removeUploadsExe = 0;
+  int normalizeUploadPrioritiesExe = 0;
+  int removeTempsExe = 0;
+  int vacAnalyzeExe = 0;
+  int processExpiredExe = 0;
+  int removeOrphanedFilesExe = 0;
   int reIndexAllTablesExe = 0;
   int removeOrphanedRowsExe = 0;
 
@@ -105,150 +101,157 @@ int main(int argc, char **argv)
     switch (cmdopt)
     {
       case 'a': /* All non slow operations */
-          if(ValidateFoldersExe == 0){
-            ValidateFolders();
-            ValidateFoldersExe = 1;
+          if (validateFoldersExe == 0) {
+            validateFolders();
+            validateFoldersExe = 1;
           }
-          if(VerifyFilePermsExe == 0){
-            VerifyFilePerms(1);
-            VerifyFilePermsExe = 1;
+          if (verifyFilePermsExe == 0) {
+            verifyFilePerms(1);
+            verifyFilePermsExe = 1;
           }
-          if(RemoveUploadsExe == 0){
-            RemoveUploads();
-            RemoveUploadsExe = 1;
+          if (removeUploadsExe == 0) {
+            removeUploads();
+            removeUploadsExe = 1;
           }
-          if(NormalizeUploadPrioritiesExe == 0){
-            NormalizeUploadPriorities();
-            NormalizeUploadPrioritiesExe = 1;
+          if (normalizeUploadPrioritiesExe == 0) {
+            normalizeUploadPriorities();
+            normalizeUploadPrioritiesExe = 1;
           }
-          if(RemoveTempsExe == 0){
-            RemoveTemps();
-            RemoveTempsExe = 1;
+          if (removeTempsExe == 0) {
+            removeTemps();
+            removeTempsExe = 1;
           }
-          if(VacAnalyzeExe == 0){
-            VacAnalyze();
-            VacAnalyzeExe = 1;
+          if (vacAnalyzeExe == 0) {
+            vacAnalyze();
+            vacAnalyzeExe = 1;
           }
           break;
       case 'A': /* All operations */
-          if(ValidateFoldersExe == 0){
-            ValidateFolders();
-            ValidateFoldersExe = 1;
+          if (validateFoldersExe == 0) {
+            validateFolders();
+            validateFoldersExe = 1;
           }
-          if(VerifyFilePermsExe == 0){
-            VerifyFilePerms(1);
-            VerifyFilePermsExe = 1;
+          if (verifyFilePermsExe == 0) {
+            verifyFilePerms(1);
+            verifyFilePermsExe = 1;
           }
-          if(RemoveUploadsExe == 0){
-            RemoveUploads();
-            RemoveUploadsExe = 1;
+          if (removeUploadsExe == 0) {
+            removeUploads();
+            removeUploadsExe = 1;
           }
-          if(NormalizeUploadPrioritiesExe == 0){
-            NormalizeUploadPriorities();
-            NormalizeUploadPrioritiesExe = 1;
+          if (normalizeUploadPrioritiesExe == 0) {
+            normalizeUploadPriorities();
+            normalizeUploadPrioritiesExe = 1;
           }
-          if(RemoveTempsExe == 0){
-            RemoveTemps();
-            RemoveTempsExe = 1;
+          if (removeTempsExe == 0) {
+            removeTemps();
+            removeTempsExe = 1;
           }
-          if(VacAnalyzeExe == 0){
-            VacAnalyze();
-            VacAnalyzeExe = 1;
+          if (vacAnalyzeExe == 0) {
+            vacAnalyze();
+            vacAnalyzeExe = 1;
           }
-          if(ProcessExpiredExe == 0){
-            ProcessExpired();
-            ProcessExpiredExe = 1;
+          if (processExpiredExe == 0) {
+            processExpired();
+            processExpiredExe = 1;
           }
-          if(RemoveOrphanedFilesExe == 0){
-            RemoveOrphanedFiles();
-            RemoveOrphanedFilesExe = 1;
+          if (removeOrphanedFilesExe == 0) {
+            removeOrphanedFiles();
+            removeOrphanedFilesExe = 1;
+          }
+          if (reIndexAllTablesExe == 0) {
+            reIndexAllTables();
+            reIndexAllTablesExe = 1;
+          }
+          if (removeOrphanedRowsExe == 0) {
+            removeOrphanedRows();
+            removeOrphanedRowsExe = 1;
           }
           break;
       case 'D': /* Vac/Analyze (slow) */
-          if(VacAnalyzeExe == 0){
-            VacAnalyze();
-            VacAnalyzeExe = 1;
+          if (vacAnalyzeExe == 0) {
+            vacAnalyze();
+            vacAnalyzeExe = 1;
           }
           break;
       case 'F': /* Validate folder contents */
-          if(ValidateFoldersExe == 0){
-            ValidateFolders();
-            ValidateFoldersExe = 1;
+          if (validateFoldersExe == 0) {
+            validateFolders();
+            validateFoldersExe = 1;
           }
           break;
       case 'g': /* Delete orphan gold files */
-          DeleteOrphanGold();
+          deleteOrphanGold();
           break;
       case 'h':
-            Usage(argv[0]);
-            ExitNow(0);
+            usage(argv[0]);
+            exitNow(0);
       case 'N': /* Remove uploads with no pfiles */
-          if(NormalizeUploadPrioritiesExe == 0){
-            NormalizeUploadPriorities();
-            NormalizeUploadPrioritiesExe = 1;
+          if (normalizeUploadPrioritiesExe == 0) {
+            normalizeUploadPriorities();
+            normalizeUploadPrioritiesExe = 1;
           }
           break;
       case 'p': /* Verify file permissions */
-          VerifyFilePerms(0);
+          verifyFilePerms(0);
           break;
       case 'P': /* Verify and fix file permissions */
-          if(VerifyFilePermsExe == 0){
-            VerifyFilePerms(1);
-            VerifyFilePermsExe = 1;
+          if (verifyFilePermsExe == 0) {
+            verifyFilePerms(1);
+            verifyFilePermsExe = 1;
           }
           break;
       case 'R': /* Remove uploads with no pfiles */
-          if(RemoveUploadsExe == 0){
-            RemoveUploads();
-            RemoveUploadsExe = 1;
+          if (removeUploadsExe == 0) {
+            removeUploads();
+            removeUploadsExe = 1;
           }
           break;
       case 'T': /* Remove orphaned temp tables */
-          if(RemoveTempsExe == 0){
-            RemoveTemps();
-            RemoveTempsExe = 1;
+          if (removeTempsExe == 0) {
+            removeTemps();
+            removeTempsExe = 1;
           }
           break;
       case 'U': /* Process expired uploads (slow) */
-          if(ProcessExpiredExe == 0){
-            ProcessExpired();
-            ProcessExpiredExe = 1;
+          if (processExpiredExe == 0) {
+            processExpired();
+            processExpiredExe = 1;
           }
           break;
       case 'Z': /* Remove orphaned files from the repository (slow) */
-          if(RemoveOrphanedFilesExe == 0){
-            RemoveOrphanedFiles();
-            RemoveOrphanedFilesExe = 1;
+          if (removeOrphanedFilesExe == 0) {
+            removeOrphanedFiles();
+            removeOrphanedFilesExe = 1;
           }
           break;
       case 'I': /* Reindexing of database */
-          if(reIndexAllTablesExe == 0){
+          if (reIndexAllTablesExe == 0) {
             reIndexAllTables();
             reIndexAllTablesExe = 1;
           }
           break;
       case 'E': /* Remove orphaned files from the database */
-          if(removeOrphanedRowsExe == 0){   
+          if (removeOrphanedRowsExe == 0) {
             removeOrphanedRows();
             removeOrphanedRowsExe = 1;
           }
           break;
       case 'i': /* "Initialize" */
-            ExitNow(0);
+            exitNow(0);
       case 'v': /* verbose output for debugging  */
           agent_verbose++;   // global agent verbose flag.  Can be changed in running agent by the scheduler on each fo_scheduler_next() call
             break;
       case 'V': /* print version info */
             printf("%s", BuildVersion);
-            ExitNow(0);
+            exitNow(0);
       case 'c': break; /* handled by fo_scheduler_connect() */
       default:
-            Usage(argv[0]);
-            ExitNow(-1);
+            usage(argv[0]);
+            exitNow(-1);
     }
   }
 
-
-  ExitNow(0);  /* success */
+  exitNow(0);  /* success */
   return(0);   /* Never executed but prevents compiler warning */
 } /* main() */

--- a/src/maintagent/agent/maintagent.h
+++ b/src/maintagent/agent/maintagent.h
@@ -36,13 +36,13 @@
 /**
  * Maximum buffer to use
  */
-#define myBUFSIZ	2048
+#define myBUFSIZ 2048
 
 /* File utils.c */
-void ExitNow        (int ExitVal);
+void ExitNow(int ExitVal);
 
 /* File usage.c */
-void Usage          (char *Name);
+void Usage(char *Name);
 
 /* File process.c */
 void VacAnalyze();
@@ -55,5 +55,6 @@ void RemoveOrphanedFiles();
 void DeleteOrphanGold();
 void NormalizeUploadPriorities();
 void reIndexAllTables();
+void removeOrphanedRows();
 
 #endif /* _MAINTAGENT_H */

--- a/src/maintagent/agent/maintagent.h
+++ b/src/maintagent/agent/maintagent.h
@@ -1,5 +1,6 @@
 /***************************************************************
  Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
+ Copyright (C) 2019 Siemens AG
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -33,27 +34,35 @@
 #include <libfossology.h>
 #define FUNCTION
 
+/* for DB */
+extern PGconn* pgConn;
+
 /**
  * Maximum buffer to use
  */
 #define myBUFSIZ 2048
 
+/**
+ * Maximum length of SQL commands
+ */
+#define MAXSQL 1024
+
 /* File utils.c */
-void ExitNow(int ExitVal);
+void exitNow(int exitVal);
 
 /* File usage.c */
-void Usage(char *Name);
+void usage(char *name);
 
 /* File process.c */
-void VacAnalyze();
-void ValidateFolders();
-void VerifyFilePerms(int fix);
-void RemoveUploads();
-void RemoveTemps();
-void ProcessExpired();
-void RemoveOrphanedFiles();
-void DeleteOrphanGold();
-void NormalizeUploadPriorities();
+void vacAnalyze();
+void validateFolders();
+void verifyFilePerms(int fix);
+void removeUploads();
+void removeTemps();
+void processExpired();
+void removeOrphanedFiles();
+void deleteOrphanGold();
+void normalizeUploadPriorities();
 void reIndexAllTables();
 void removeOrphanedRows();
 

--- a/src/maintagent/agent/process.c
+++ b/src/maintagent/agent/process.c
@@ -1,6 +1,6 @@
 /***************************************************************
  Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2014-2015, Siemens AG
+ Copyright (C) 2014-2015,2019 Siemens AG
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -24,80 +24,102 @@
 #include "maintagent.h"
 
 /**********  Globals  *************/
-extern PGconn    *pgConn;        ///< database connection
+PGconn* pgConn = NULL;        ///< the connection to Database
 
+/**
+ * \brief simple wrapper which includes PQexec and fo_checkPQcommand
+ * \param exitNumber exit number
+ * \param SQL  SQL command executed
+ * \param file source file name
+ * \param line source line number
+ * \return PQexec query result
+ */
+PGresult * PQexecCheck(int exitNumber, char *SQL, char *file, const int line)
+{
+  PGresult *result;
+  result = PQexec(pgConn, SQL);
+  if (fo_checkPQcommand(pgConn, result, SQL, file, line)) {
+    PQclear(result);
+    exitNow(exitNumber);
+  }
+  return result;
+}
+
+/**
+ * \brief Execute SQL query and create the result
+ * and clear the result.
+ * \see PQexecCheck()
+ */
+FUNCTION void PQexecCheckClear(int exitNumber, char *SQL, char *file, const int line)
+{
+  PGresult *result;
+  result = PQexecCheck(exitNumber, SQL, file, line);
+  PQclear(result);
+}
 
 /**
  * @brief Do database vacuum and analyze
- *
  * @returns void but writes status to stdout
  */
-FUNCTION void VacAnalyze()
+FUNCTION void vacAnalyze()
 {
-  PGresult* result; // the result of the database access
-  long StartTime, EndTime;
-  char *sql="vacuum analyze ";
+  long startTime, endTime;
+  char *SQL = "VACUUM ANALYZE";
 
-  StartTime = (long)time(0);
+  startTime = (long)time(0);
 
   /* Vacuum and Analyze */
-  result = PQexec(pgConn, sql);
-  if (fo_checkPQcommand(pgConn, result, sql, __FILE__, __LINE__)) ExitNow(-110);
-  PQclear(result);
+  PQexecCheckClear(-110, SQL, __FILE__, __LINE__);
 
-  EndTime = (long)time(0);
-  printf("Vacuum Analyze took %ld seconds\n", EndTime-StartTime);
+  endTime = (long)time(0);
+  printf("Vacuum Analyze took %ld seconds\n", endTime-startTime);
 
   fo_scheduler_heart(1);  // Tell the scheduler that we are alive and update item count
   return;  // success
 }
-
 
 /**
  * @brief Validate folder and foldercontents tables
  *
  * @returns void but writes status to stdout
  */
-FUNCTION void ValidateFolders()
+FUNCTION void validateFolders()
 {
   PGresult* result; // the result of the database access
-  char *StatStr;
-  char *InvalidUploadRefs="DELETE FROM foldercontents WHERE foldercontents_mode = 2 AND child_id NOT IN (SELECT upload_pk FROM upload)";
-  char *InvalidUploadtreeRefs="DELETE FROM foldercontents WHERE foldercontents_mode = 4 AND child_id NOT IN (SELECT uploadtree_pk FROM uploadtree)";
-  char *UnrefFolders="DELETE FROM folder WHERE folder_pk \
-   NOT IN (SELECT child_id FROM foldercontents WHERE foldercontents_mode = 1) AND folder_pk != '1'";
-  long StartTime, EndTime;
+  char *countTuples;
 
-  StartTime = (long)time(0);
+  char *invalidUploadRefs = "DELETE FROM foldercontents WHERE foldercontents_mode = 2 AND child_id NOT IN (SELECT upload_pk FROM upload)";
+  char *invalidUploadtreeRefs = "DELETE FROM foldercontents WHERE foldercontents_mode = 4 AND child_id NOT IN (SELECT uploadtree_pk FROM uploadtree)";
+  char *unRefFolders = "DELETE FROM folder WHERE folder_pk \
+                        NOT IN (SELECT child_id FROM foldercontents WHERE foldercontents_mode = 1) AND folder_pk != '1'";
+  long startTime, endTime;
+
+  startTime = (long)time(0);
 
   /* Remove folder contents with invalid upload references */
-  result = PQexec(pgConn, InvalidUploadRefs);
-  if (fo_checkPQcommand(pgConn, result, InvalidUploadRefs, __FILE__, __LINE__)) ExitNow(-120);
-  StatStr = PQcmdTuples(result);
+  result = PQexecCheck(-120, invalidUploadRefs, __FILE__, __LINE__);
+  countTuples = PQcmdTuples(result);
   PQclear(result);
-  printf("%s Invalid folder upload References\n", StatStr);
+  printf("%s Invalid folder upload References\n", countTuples);
 
   /* Remove folder contents with invalid uploadtree references */
-  result = PQexec(pgConn, InvalidUploadtreeRefs);
-  if (fo_checkPQcommand(pgConn, result, InvalidUploadtreeRefs, __FILE__, __LINE__)) ExitNow(-121);
-  StatStr = PQcmdTuples(result);
+  result = PQexecCheck(-121, invalidUploadtreeRefs, __FILE__, __LINE__);
+  countTuples = PQcmdTuples(result);
   PQclear(result);
-  printf("%s Invalid folder uploadtree References\n", StatStr);
+  printf("%s Invalid folder uploadtree References\n", countTuples);
 
   /* Remove unreferenced folders */
-  result = PQexec(pgConn, UnrefFolders);
-  if (fo_checkPQcommand(pgConn, result, UnrefFolders, __FILE__, __LINE__)) ExitNow(-122);
-  StatStr = PQcmdTuples(result);
+  result = PQexecCheck(-122, unRefFolders, __FILE__, __LINE__);
+  countTuples = PQcmdTuples(result);
   PQclear(result);
-  printf("%s unreferenced folders\n", StatStr);
+  printf("%s unreferenced folders\n", countTuples);
 
-  EndTime = (long)time(0);
-  printf("Validate folders took %ld seconds\n", EndTime-StartTime);
+  endTime = (long)time(0);
+  printf("Validate folders took %ld seconds\n", endTime-startTime);
 
   fo_scheduler_heart(1);  // Tell the scheduler that we are alive and update item count
   return;  // success
 }
-
 
 /**
  * @brief Verify and optionally fix file permissions
@@ -114,7 +136,7 @@ FUNCTION void ValidateFolders()
  * @returns void but writes status to stdout
  * @todo Verify file permissions is not implemented yet
  */
-FUNCTION void VerifyFilePerms(int fix)
+FUNCTION void verifyFilePerms(int fix)
 {
 /*
   long StartTime, EndTime;
@@ -130,92 +152,83 @@ FUNCTION void VerifyFilePerms(int fix)
   EndTime = (long)time(0);
   printf("Verify File Permissions took %ld seconds\n", EndTime-StartTime);
 */
-LOG_NOTICE("Verify file permissions is not implemented yet");
+  LOG_NOTICE("Verify file permissions is not implemented yet");
 
   fo_scheduler_heart(1);  // Tell the scheduler that we are alive and update item count
   return;  // success
 }
-
 
 /**
  * @brief Remove Uploads with no pfiles
- *
  * @returns void but writes status to stdout
  * @todo Optimize query
  */
-FUNCTION void RemoveUploads()
+FUNCTION void removeUploads()
 {
   PGresult* result; // the result of the database access
-  long StartTime, EndTime;
-  char *StatStr;
-  char *sql="DELETE FROM upload WHERE upload_pk  \
-    IN (SELECT upload_fk FROM uploadtree WHERE parent IS NULL AND pfile_fk IS NULL)  \
-      OR upload_pk NOT IN (SELECT upload_fk FROM uploadtree)";
+  char *countTuples;
+  long startTime, endTime;
 
-  StartTime = (long)time(0);
+  char *SQL = "DELETE FROM upload WHERE upload_pk  \
+               IN (SELECT upload_fk FROM uploadtree WHERE parent IS NULL AND pfile_fk IS NULL)  \
+               OR upload_pk NOT IN (SELECT upload_fk FROM uploadtree)";
 
-  result = PQexec(pgConn, sql);
-  if (fo_checkPQcommand(pgConn, result, sql, __FILE__, __LINE__)) ExitNow(-130);
-  StatStr = PQcmdTuples(result);
+  startTime = (long)time(0);
+
+  result = PQexecCheck(-130, SQL, __FILE__, __LINE__);
+  countTuples = PQcmdTuples(result);
   PQclear(result);
-  EndTime = (long)time(0);
-  printf("%s Uploads with no pfiles (%ld seconds)\n", StatStr, EndTime-StartTime);
+
+  endTime = (long)time(0);
+  printf("%s Uploads with no pfiles (%ld seconds)\n", countTuples, endTime-startTime);
 
   fo_scheduler_heart(1);  // Tell the scheduler that we are alive and update item count
   return;  // success
 }
-
 
 /**
  * @brief Remove orphaned temp tables from deprecated pkgmettagetta and old delagent
- *
  * @returns void but writes status to stdout
  */
-FUNCTION void RemoveTemps()
+FUNCTION void removeTemps()
 {
   PGresult* result;
-  PGresult* DropResult;
   int row;
-  int NumRows;
-  int DroppedCount = 0;
-  long StartTime, EndTime;
-  char *sql="select table_name FROM information_schema.tables WHERE table_type = 'BASE TABLE'  \
-   AND table_schema = 'public' AND (table_name SIMILAR TO '^metaanalysis_[[:digit:]]+$' \
-     or table_name similar to '^delup_%')";
-  char sqlBuf[1024];
+  int countTuples;
+  int droppedCount = 0;
+  char SQLBuf[MAXSQL];
+  long startTime, endTime;
 
-  StartTime = (long)time(0);
+  char *SQL = "SELECT table_name FROM information_schema.tables WHERE table_type = 'BASE TABLE'"
+              "AND table_schema = 'public' AND (table_name SIMILAR TO '^metaanalysis_[[:digit:]]+$'"
+              "OR table_name SIMILAR TO '^delup_%');";
 
-  result = PQexec(pgConn, sql);
-  if (fo_checkPQresult(pgConn, result, sql, __FILE__, __LINE__)) ExitNow(-140);
-  NumRows = PQntuples(result);
+  startTime = (long)time(0);
 
+  result = PQexec(pgConn, SQL);
+  if (fo_checkPQresult(pgConn, result, SQL, __FILE__, __LINE__)) exitNow(-140);
+  countTuples = PQntuples(result);
   /* Loop through the temp table names, dropping the tables */
-  for (row = 0; row < NumRows; row++)
-  {
-    snprintf(sqlBuf, sizeof(sqlBuf), "drop table %s", PQgetvalue(result, row, 0));
-    DropResult = PQexec(pgConn, sqlBuf);
-    if (fo_checkPQcommand(pgConn, DropResult, sql, __FILE__, __LINE__)) ExitNow(-141);
-    PQclear(DropResult);
-    DroppedCount++;
+  for (row = 0; row < countTuples; row++) {
+    snprintf(SQLBuf, MAXSQL, "DROP TABLE %s", PQgetvalue(result, row, 0));
+    PQexecCheckClear(-141, SQLBuf, __FILE__, __LINE__);
+    droppedCount++;
   }
-
   PQclear(result);
-  EndTime = (long)time(0);
-  printf("%d Orphaned temp tables were dropped (%ld seconds)\n", DroppedCount, EndTime-StartTime);
+
+  endTime = (long)time(0);
+  printf("%d Orphaned temp tables were dropped (%ld seconds)\n", droppedCount, endTime-startTime);
 
   fo_scheduler_heart(1);  // Tell the scheduler that we are alive and update item count
   return;  // success
 }
 
-
 /**
  * @brief Process expired uploads (slow)
- *
  * @returns void but writes status to stdout
  * @todo Process expired uploads is not implemented yet
  */
-FUNCTION void ProcessExpired()
+FUNCTION void processExpired()
 {
 /*
   PGresult* result; // the result of the database access
@@ -227,23 +240,20 @@ FUNCTION void ProcessExpired()
   EndTime = (long)time(0);
   printf("Process expired uploads took %ld seconds\n", EndTime-StartTime);
 */
-LOG_NOTICE("Process expired uploads is not implemented yet");
+  LOG_NOTICE("Process expired uploads is not implemented yet");
 
   fo_scheduler_heart(1);  // Tell the scheduler that we are alive and update item count
   return;  // success
 }
-
 
 /**
  * @brief Remove orphaned files from the repository (slow)
- *
  * Loop through each file in the repository and make sure there is a pfile table entry.
  * Then make sure the pfile_pk is used by uploadtree.
- *
  * @returns void but writes status to stdout
  * @todo Remove orphaned files from the repository is not implemented yet
  */
-FUNCTION void RemoveOrphanedFiles()
+FUNCTION void removeOrphanedFiles()
 {
 /*
   PGresult* result; // the result of the database access
@@ -255,22 +265,19 @@ FUNCTION void RemoveOrphanedFiles()
   EndTime = (long)time(0);
   printf("Remove orphaned files from the repository took %ld seconds\n", EndTime-StartTime);
 */
-LOG_NOTICE("Remove orphaned files from the repository is not implemented yet");
+  LOG_NOTICE("Remove orphaned files from the repository is not implemented yet");
 
   fo_scheduler_heart(1);  // Tell the scheduler that we are alive and update item count
   return;  // success
 }
-
 
 /**
  * @brief Delete orphaned gold files from the repository
- *
  * Loop through each gold file in the repository and make sure there is a pfile entry in the upload table.
- *
  * @returns void but writes status to stdout
  * @todo Remove orphaned gold files from the repository is not implemented yet
  */
-FUNCTION void DeleteOrphanGold()
+FUNCTION void deleteOrphanGold()
 {
 /*
   PGresult* result; // the result of the database access
@@ -282,43 +289,32 @@ FUNCTION void DeleteOrphanGold()
   EndTime = (long)time(0);
   printf("Remove orphaned files from the repository took %ld seconds\n", EndTime-StartTime);
 */
-LOG_NOTICE("Remove orphaned gold files from the repository is not implemented yet");
+  LOG_NOTICE("Remove orphaned gold files from the repository is not implemented yet");
 
   fo_scheduler_heart(1);  // Tell the scheduler that we are alive and update item count
   return;  // success
 }
 
-
-
-
 /**
  * @brief Normalize priority of Uploads
-  * @returns void but writes status to stdout
+ * @returns void but writes status to stdout
  */
-FUNCTION void NormalizeUploadPriorities()
+FUNCTION void normalizeUploadPriorities()
 {
-  PGresult* result; // the result of the database access
-  long StartTime, EndTime;
-  char *sql1="create temporary table tmp_upload_prio(ordprio serial,uploadid int,groupid int)";
-  char *sql2="insert into tmp_upload_prio (uploadid, groupid) (   select upload_fk uploadid, group_fk groupid from upload_clearing order by priority asc  )";
-  char *sql3="UPDATE upload_clearing SET priority = ordprio FROM tmp_upload_prio WHERE uploadid=upload_fk AND group_fk=groupid";
+  long startTime, endTime;
 
-  StartTime = (long)time(0);
+  char *SQL1 = "CREATE TEMPORARY TABLE tmp_upload_prio(ordprio serial, uploadid int, groupid int)";
+  char *SQL2 = "INSERT INTO tmp_upload_prio (uploadid, groupid) (SELECT upload_fk uploadid, group_fk groupid FROM upload_clearing ORDER BY priority ASC);";
+  char *SQL3 = "UPDATE upload_clearing SET priority = ordprio FROM tmp_upload_prio WHERE uploadid=upload_fk AND group_fk=groupid;";
 
-  result = PQexec(pgConn, sql1);
-  if (fo_checkPQcommand(pgConn, result, sql1, __FILE__, __LINE__)) ExitNow(-211);
-  PQclear(result);
+  startTime = (long)time(0);
 
-  result = PQexec(pgConn, sql2);
-  if (fo_checkPQcommand(pgConn, result, sql2, __FILE__, __LINE__)) ExitNow(-212);
-  PQclear(result);
+  PQexecCheckClear(-180, SQL1, __FILE__, __LINE__);
+  PQexecCheckClear(-181, SQL2, __FILE__, __LINE__);
+  PQexecCheckClear(-182, SQL3, __FILE__, __LINE__);
 
-  result = PQexec(pgConn, sql3);
-  if (fo_checkPQcommand(pgConn, result, sql3, __FILE__, __LINE__)) ExitNow(-213);
-  PQclear(result);
-
-  EndTime = (long)time(0);
-  printf("Normalized upload priorities (%ld seconds)\n", EndTime-StartTime);
+  endTime = (long)time(0);
+  printf("Normalized upload priorities (%ld seconds)\n", endTime-startTime);
 
   fo_scheduler_heart(1);  // Tell the scheduler that we are alive and update item count
   return;  // success
@@ -331,23 +327,22 @@ FUNCTION void NormalizeUploadPriorities()
 FUNCTION void reIndexAllTables()
 {
   PGresult* result; // the result of the database access
-  char SQL[100];
-  long StartTime, EndTime;
-  char *sql= "SELECT table_catalog FROM information_schema.tables WHERE table_type = 'BASE TABLE' AND table_schema = 'public' AND (table_name SIMILAR TO 'upload%') LIMIT 1";
+  char SQLBuf[MAXSQL];
+  long startTime, endTime;
+  char *SQL= "SELECT table_catalog FROM information_schema.tables WHERE table_type = 'BASE TABLE' AND table_schema = 'public' AND (table_name SIMILAR TO 'upload%') LIMIT 1";
 
-  StartTime = (long)time(0);
+  startTime = (long)time(0);
 
-  result = PQexec(pgConn, sql);
-  if (fo_checkPQresult(pgConn, result, sql, __FILE__, __LINE__)) exit(-214);
-
-  memset(SQL,'\0',sizeof(SQL));
-  snprintf(SQL,sizeof(SQL),"REINDEX DATABASE %s;", PQgetvalue(result, 0, 0));
-  PQclear(result);
   result = PQexec(pgConn, SQL);
-  if (fo_checkPQcommand(pgConn, result, SQL, __FILE__, __LINE__)) ExitNow(-215);
+  if (fo_checkPQresult(pgConn, result, SQL, __FILE__, __LINE__)) exitNow(-190);
 
-  EndTime = (long)time(0);
-  printf("Time taken for reindexing the database : %ld seconds\n", EndTime-StartTime);
+  memset(SQLBuf,'\0',sizeof(SQLBuf));
+  snprintf(SQLBuf,sizeof(SQLBuf),"REINDEX DATABASE %s;", PQgetvalue(result, 0, 0));
+  PQclear(result);
+  PQexecCheckClear(-191, SQLBuf, __FILE__, __LINE__);
+
+  endTime = (long)time(0);
+  printf("Time taken for reindexing the database : %ld seconds\n", endTime-startTime);
 
   fo_scheduler_heart(1);  // Tell the scheduler that we are alive and update item count
   return;  // success
@@ -360,87 +355,94 @@ FUNCTION void reIndexAllTables()
 FUNCTION void removeOrphanedRows()
 {
   PGresult* result; // the result of the database access
-  char *uploadTreeOrphaned;
-  char *clearingDecisionOrphaned;
-  char *clearingDecisionEventOrphaned;
-  char *clearingEventOrphaned;
-  char *obligationMapOrphaned;
-  char *obligationCandidateMapOrphaned;
+  char *countTuples;
   long startTime, endTime;
 
-  char *sql1 = " DELETE FROM uploadtree "
-                 " WHERE uploadtree_pk IN (SELECT DISTINCT(uploadtree_pk) "
-               " FROM uploadtree UT LEFT OUTER JOIN upload U ON U.upload_pk = UT.upload_fk "
-                 " WHERE U.upload_pk IS NULL); ";
+  char *SQL1 = "DELETE FROM uploadtree UT "
+               " WHERE NOT EXISTS ( "
+               "  SELECT 1 "
+               "  FROM upload U "
+               "  WHERE UT.upload_fk = U.upload_pk "
+               " );";
 
-  char *sql2 = " DELETE FROM clearing_decision "
-                 " WHERE uploadtree_fk IN (SELECT DISTINCT(uploadtree_fk) "
-               " FROM clearing_decision CD LEFT OUTER JOIN uploadtree UT ON UT.uploadtree_pk = CD.uploadtree_fk "
-                 " WHERE UT.uploadtree_pk IS NULL); ";
+  char *SQL2 = "DELETE FROM clearing_decision AS CD "
+               " WHERE NOT EXISTS ( "
+               "  SELECT 1 "
+               "  FROM uploadtree UT  "
+               "  WHERE CD.uploadtree_fk = UT.uploadtree_pk "
+               " );";
 
-  char *sql3 = " DELETE FROM clearing_decision_event CDE USING clearing_event CE "
-                 " WHERE CDE.clearing_event_fk = CE.clearing_event_pk AND "
-                 "  CE.uploadtree_fk IN (SELECT DISTINCT(uploadtree_fk) "
-               " FROM clearing_event CE LEFT OUTER JOIN uploadtree UT ON UT.uploadtree_pk = CE.uploadtree_fk "
-                 " WHERE UT.uploadtree_pk IS NULL); ";
+  char *SQL3 = "DELETE FROM clearing_decision_event CDE"
+               " WHERE NOT EXISTS ( "
+               "  SELECT 1 "
+               "  FROM uploadtree UT  "
+               "  INNER JOIN clearing_event CE "
+               "  ON CE.uploadtree_fk = UT.uploadtree_pk "
+               "  WHERE CDE.clearing_event_fk = CE.clearing_event_pk "
+               " );";
 
-  char *sql4 = " DELETE FROM clearing_event "
-                 " WHERE uploadtree_fk IN (SELECT DISTINCT(uploadtree_fk) "
-               " FROM clearing_event CE LEFT OUTER JOIN uploadtree UT ON UT.uploadtree_pk = CE.uploadtree_fk "
-                 " WHERE UT.uploadtree_pk IS NULL); ";
+  char *SQL4 = " DELETE FROM clearing_event CE "
+               " WHERE NOT EXISTS ( "
+               "  SELECT 1 "
+               "  FROM uploadtree UT  "
+               "  WHERE CE.uploadtree_fk = UT.uploadtree_pk "
+               " );";
 
-  char *sql5 = " DELETE FROM obligation_map "
-                 " WHERE rf_fk IN (SELECT DISTINCT(rf_fk) "
-               " FROM obligation_map OM LEFT OUTER JOIN license_ref LR ON LR.rf_pk = OM.rf_fk "
-                 " WHERE LR.rf_pk IS NULL); ";
+  char *SQL5 = " DELETE FROM obligation_map OM "
+               " WHERE NOT EXISTS ( "
+               "  SELECT 1 "
+               "  FROM license_ref LR  "
+               "  WHERE OM.rf_fk = LR.rf_pk "
+               " );";
 
-  char *sql6 = " DELETE FROM obligation_candidate_map "
-                 " WHERE rf_fk IN (SELECT DISTINCT(rf_fk) "
-               " FROM obligation_candidate_map OCM LEFT OUTER JOIN license_candidate LC ON LC.rf_pk = OCM.rf_fk "
-                 " WHERE LC.rf_pk IS NULL); ";
+  char *SQL6 = " DELETE FROM obligation_candidate_map OCM "
+               " WHERE NOT EXISTS ( "
+               "  SELECT 1 "
+               "  FROM license_ref LR  "
+               "  WHERE OCM.rf_fk = LR.rf_pk "
+               " );";
 
   startTime = (long)time(0);
 
-  result = PQexec(pgConn, sql1);
-  if (fo_checkPQcommand(pgConn, result, sql1, __FILE__, __LINE__)) ExitNow(-411);
-  uploadTreeOrphaned = PQcmdTuples(result);
+  result = PQexecCheck(-200, SQL1, __FILE__, __LINE__);
+  countTuples = PQcmdTuples(result);
   PQclear(result);
-  printf("%s Orphaned records have been removed from uploadtree table\n", uploadTreeOrphaned);
+  printf("%s Orphaned records have been removed from uploadtree table\n", countTuples);
+  fo_scheduler_heart(1);
 
-  result = PQexec(pgConn, sql2);
-  if (fo_checkPQcommand(pgConn, result, sql2, __FILE__, __LINE__)) ExitNow(-412);
-  clearingDecisionOrphaned = PQcmdTuples(result);
+  result = PQexecCheck(-201, SQL2, __FILE__, __LINE__);
+  countTuples = PQcmdTuples(result);
   PQclear(result);
-  printf("%s Orphaned records have been removed from clearing_decision table\n", clearingDecisionOrphaned);
+  printf("%s Orphaned records have been removed from clearing_decision table\n", countTuples);
+  fo_scheduler_heart(1);
 
-  result = PQexec(pgConn, sql3);
-  if (fo_checkPQcommand(pgConn, result, sql3, __FILE__, __LINE__)) ExitNow(-413);
-  clearingDecisionEventOrphaned = PQcmdTuples(result);
+  result = PQexecCheck(-202, SQL3, __FILE__, __LINE__);
+  countTuples = PQcmdTuples(result);
   PQclear(result);
-  printf("%s Orphaned records have been removed from clearing_decision_event table\n", clearingDecisionEventOrphaned);
+  printf("%s Orphaned records have been removed from clearing_decision_event table\n", countTuples);
+  fo_scheduler_heart(1);
 
-  result = PQexec(pgConn, sql4);
-  if (fo_checkPQcommand(pgConn, result, sql4, __FILE__, __LINE__)) ExitNow(-414);
-  clearingEventOrphaned = PQcmdTuples(result);
+  result = PQexecCheck(-203, SQL4, __FILE__, __LINE__);
+  countTuples = PQcmdTuples(result);
   PQclear(result);
-  printf("%s Orphaned records have been removed from clearing_event table\n", clearingEventOrphaned);
+  printf("%s Orphaned records have been removed from clearing_event table\n", countTuples);
+  fo_scheduler_heart(1);
 
-  result = PQexec(pgConn, sql5);
-  if (fo_checkPQcommand(pgConn, result, sql5, __FILE__, __LINE__)) ExitNow(-415);
-  obligationMapOrphaned = PQcmdTuples(result);
+  result = PQexecCheck(-204, SQL5, __FILE__, __LINE__);
+  countTuples = PQcmdTuples(result);
   PQclear(result);
-  printf("%s Orphaned records have been removed from obligation_map table\n", obligationMapOrphaned);
+  printf("%s Orphaned records have been removed from obligation_map table\n", countTuples);
+  fo_scheduler_heart(1);
 
-  result = PQexec(pgConn, sql6);
-  if (fo_checkPQcommand(pgConn, result, sql6, __FILE__, __LINE__)) ExitNow(-416);
-  obligationCandidateMapOrphaned = PQcmdTuples(result);
+  result = PQexecCheck(-205, SQL6, __FILE__, __LINE__);
+  countTuples = PQcmdTuples(result);
   PQclear(result);
-  printf("%s Orphaned records have been removed from obligation_candidate_map table\n", obligationCandidateMapOrphaned);
+  printf("%s Orphaned records have been removed from obligation_candidate_map table\n", countTuples);
+  fo_scheduler_heart(1); // Tell the scheduler that we are alive and update item count
 
   endTime = (long)time(0);
 
   printf("Time taken for removing orphaned rows from database : %ld seconds\n", endTime-startTime);
 
-  fo_scheduler_heart(1);  // Tell the scheduler that we are alive and update item count
   return;  // success
 }

--- a/src/maintagent/agent/usage.c
+++ b/src/maintagent/agent/usage.c
@@ -1,5 +1,6 @@
 /***************************************************************
  Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
+ Copyright (C) 2019 Siemens AG
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -24,11 +25,11 @@
 
 /**
  * \biref Print usage message to user
- * \param Name absolute path to the binary
+ * \param name absolute path to the binary
  */
-FUNCTION void Usage(char *Name)
+FUNCTION void usage(char *name)
 {
-  printf("Usage: %s [options]\n", Name);
+  printf("Usage: %s [options]\n", name);
   printf("  -a   :: Run all non slow maintenance operations.\n");
   printf("  -A   :: Run all maintenance operations.\n");
   printf("  -D   :: Vacuum Analyze the database.\n");
@@ -42,12 +43,10 @@ FUNCTION void Usage(char *Name)
   printf("  -T   :: Remove orphaned temp tables.\n");
   printf("  -U   :: Process expired uploads (slow).\n");
   printf("  -Z   :: Remove orphaned files from the repository (slow).\n");
-  printf("  -E   :: Remove orphaned rows from database.\n");
+  printf("  -E   :: Remove orphaned rows from database (slow).\n");
   printf("  -i   :: Initialize the database, then exit.\n");
   printf("  -I   :: Reindexing of database (This activity may take 5-10 mins. Execute only when system is not in use).\n");
   printf("  -v   :: verbose (turns on debugging output)\n");
   printf("  -V   :: print the version info, then exit.\n");
   printf("  -c SYSCONFDIR :: Specify the directory for the system configuration. \n");
 } /* Usage() */
-
-

--- a/src/maintagent/agent/usage.c
+++ b/src/maintagent/agent/usage.c
@@ -42,6 +42,7 @@ FUNCTION void Usage(char *Name)
   printf("  -T   :: Remove orphaned temp tables.\n");
   printf("  -U   :: Process expired uploads (slow).\n");
   printf("  -Z   :: Remove orphaned files from the repository (slow).\n");
+  printf("  -E   :: Remove orphaned rows from database.\n");
   printf("  -i   :: Initialize the database, then exit.\n");
   printf("  -I   :: Reindexing of database (This activity may take 5-10 mins. Execute only when system is not in use).\n");
   printf("  -v   :: verbose (turns on debugging output)\n");

--- a/src/maintagent/agent/utils.c
+++ b/src/maintagent/agent/utils.c
@@ -1,5 +1,6 @@
 /***************************************************************
  Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
+ Copyright (C) 2019 Siemens AG
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -22,23 +23,19 @@
 
 #include "maintagent.h"
 
-/**********  Globals  *************/
-extern PGconn    *pgConn;        ///< database connection
-
-
 /**
  * @brief Exit function.  This does all cleanup and should be used
  *        instead of calling exit() or main() return.
  *
- * @param ExitVal Exit value
+ * @param exitVal Exit value
  * @returns void Calls exit()
  */
-FUNCTION void ExitNow(int ExitVal)
+FUNCTION void exitNow(int exitVal)
 {
   if (pgConn) PQfinish(pgConn);
 
-  if (ExitVal) LOG_ERROR("Exiting with status %d", ExitVal);
+  if (exitVal) LOG_ERROR("Exiting with status %d", exitVal);
 
-  fo_scheduler_disconnect(ExitVal);
-  exit(ExitVal);
+  fo_scheduler_disconnect(exitVal);
+  exit(exitVal);
 } /* ExitNow() */

--- a/src/maintagent/ui/maintagent.php
+++ b/src/maintagent/ui/maintagent.php
@@ -81,6 +81,7 @@ class maintagent extends FO_Plugin {
                      "A"=>_("Run all maintenance operations."),
                      "F"=>_("Validate folder contents."),
               //       "g"=>_("Remove orphaned gold files."),
+                     "E"=>_("Remove orphaned rows from database."),
                      "N"=>_("Normalize priority "),
               //       "p"=>_("Verify file permissions (report only)."),
               //       "P"=>_("Verify and fix file permissions."),

--- a/src/maintagent/ui/maintagent.php
+++ b/src/maintagent/ui/maintagent.php
@@ -1,6 +1,7 @@
 <?php
 /***********************************************************
  Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
+ Copyright (C) 2019 Siemens AG
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License


### PR DESCRIPTION
## Description

Functionality to delete all the orphaned records from fossology database

### Changes

Removed Orphan records from uploadtree, clearing_event, clearing_decision, clearing_decision_event, obligation_map, obligation_candidate_maps table.

## How to test

* Upload a package Do clearing for all the files.
* Login to fossology database and delete the uploaded package from upload table.
* Login to fossology UI and add a candidate license and normal license.
* Add this licenses to obligations and delete the added licenses.
* Run maintagent and check if the all the orphaned records deleted from the above tables
