### PR TITLE
feat(scm): ignore scm data when scanning

### DIFF
--- a/src/adj2nest/ui/agent_adj2nest.php
+++ b/src/adj2nest/ui/agent_adj2nest.php
@@ -79,7 +79,7 @@ class Adj2nestAgentPlugin extends AgentPlugin
    * @copydoc Fossology\Lib\Plugin\AgentPlugin::AgentAdd()
    * @see \Fossology\Lib\Plugin\AgentPlugin::AgentAdd()
    */
-  public function AgentAdd($jobId, $uploadId, &$errorMsg, $dependencies=array(), $arguments=null)
+  public function AgentAdd($jobId, $uploadId, &$errorMsg, $dependencies=array(), $arguments=null, $unpackArgs=null)
   {
     if ($this->AgentHasResults($uploadId) == 1)
     {
@@ -93,7 +93,7 @@ class Adj2nestAgentPlugin extends AgentPlugin
     }
 
     if (!$this->isAgentIncluded($dependencies, 'agent_unpack')) {
-      $dependencies[] = "agent_unpack";
+      $dependencies[] = array('name' => "agent_unpack", 'args' => $unpackArgs);
     }
     $args = is_array($arguments) ? '' : $arguments;
     return $this->doAgentAdd($jobId, $uploadId, $errorMsg, $dependencies, $uploadId, $args);

--- a/src/cli/cp2foss.php
+++ b/src/cli/cp2foss.php
@@ -226,7 +226,7 @@ function UploadOne($FolderPath, $UploadArchive, $UploadName, $UploadDescription,
   global $vcsuser;
   global $vcspass;
   global $TarExcludeList;
-  global $scm;
+  global $scmarg;
   $jobqueuepk = 0;
 
   if (empty($UploadName)) {

--- a/src/cli/cp2foss.php
+++ b/src/cli/cp2foss.php
@@ -66,6 +66,7 @@ $Usage = "Usage: " . basename($argv[0]) . " [options] [archives]
     NOTE: By default, no analysis agents are queued up.
     -T       = TEST. No database or repository updates are performed.
                Test mode enables verbose mode.
+    -I       = ignore scm data scanning
 
   FOSSology source options:
     archive  = file, directory, or URL to the archive.
@@ -225,6 +226,7 @@ function UploadOne($FolderPath, $UploadArchive, $UploadName, $UploadDescription,
   global $vcsuser;
   global $vcspass;
   global $TarExcludeList;
+  global $scm;
   $jobqueuepk = 0;
 
   if (empty($UploadName)) {
@@ -312,7 +314,7 @@ function UploadOne($FolderPath, $UploadArchive, $UploadName, $UploadDescription,
   }
   if (!$Test) {
     $unpackplugin = &$Plugins[plugin_find_id("agent_unpack") ];
-    $ununpack_jq_pk = $unpackplugin->AgentAdd($jobpk, $UploadPk, $ErrorMsg, array("wget_agent"));
+    $ununpack_jq_pk = $unpackplugin->AgentAdd($jobpk, $UploadPk, $ErrorMsg, array("wget_agent"), $scmarg);
     if ($ununpack_jq_pk < 0) {
       echo  $ErrorMsg;
       return 1;
@@ -378,6 +380,7 @@ $QueueList = "";
 $TarExcludeList = "";
 $bucket_size = 3;
 $public_flag = 0;
+$scmarg = NULL;
 $OptionS = "";
 
 $user = $passwd = "";
@@ -503,6 +506,9 @@ for ($i = 1;$i < $argc;$i++) {
       break;
     case '-G': /* upload from git repo */
       $VCS = 'Git';
+      break;
+    case '-I': /* ignore scm data when scanning */
+      $scmarg = '-I';
       break;
     default:
       if (substr($argv[$i], 0, 1) == '-') {

--- a/src/lib/php/common-job.php
+++ b/src/lib/php/common-job.php
@@ -53,8 +53,8 @@ use Fossology\Lib\Db\DbManager;
  * \param int $groupId       Group creating the job
  * \param string $job_name   Job name
  * \param string $filename   For upload from URL, this is the URL.\n
- *                    For upload from file, this is the filename.\n
- *                    For upload from server, this is the file path.\n
+ *                           For upload from file, this is the filename.\n
+ *                           For upload from server, this is the file path.\n
  * \param string $desc       Optional user file description.
  * \param int $UploadMode    1<<2=URL, 1<<3=upload from server or file
  * \param int $folder_pk     The folder to contain this upload
@@ -73,7 +73,7 @@ function JobAddUpload($userId, $groupId, $job_name, $filename, $desc, $UploadMod
       empty($UploadMode) or empty($folder_pk)) return;
 
   $row = $dbManager->getSingleRow("INSERT INTO upload
-      (upload_desc,upload_filename,user_fk,upload_mode,upload_origin, public_perm) VALUES ($1,$2,$3,$4,$5,$6) RETURNING upload_pk",
+      (upload_desc,upload_filename,user_fk,upload_mode,upload_origin,public_perm) VALUES ($1,$2,$3,$4,$5,$6) RETURNING upload_pk",
       array($desc,$job_name,$userId,$UploadMode,$filename, $public_perm),__METHOD__.'.insert.upload');
   $uploadId = $row['upload_pk'];
 

--- a/src/ununpack/agent/externs.h
+++ b/src/ununpack/agent/externs.h
@@ -27,6 +27,7 @@ extern int UnlinkSource;        ///< Remove recursive sources after unpacking?
 extern int UnlinkAll;           ///< Remove ALL unpacked files when done (clean up)?
 extern int ForceContinue;       ///< Force continue when unpack tool fails?
 extern int ForceDuplicate;      ///< When using db, should it process duplicates?
+extern int IgnoreSCMData;       ///< 1: Ignore SCM data, 0: dont ignore it.
 extern int PruneFiles;          ///< Remove links? >1 hard links, zero files, etc
 extern int SetContainerArtifact;  ///< Should initial container be an artifact?
 extern FILE *ListOutFile;       ///< File to store unpack list

--- a/src/ununpack/agent/ununpack.c
+++ b/src/ununpack/agent/ununpack.c
@@ -86,6 +86,7 @@
  * | -L out | Generate a log of files extracted (in XML) to out |
  * | -F     | Using files from the repository |
  * | -i     | Initialize the database queue system, then exit |
+ * | -I     | Ignore SCM data |
  * | -Q     | Using scheduler queue system. (Includes -F) |
  * | ^      | If -L is used, unpacked files are placed in 'files' |
  * | -T rep | Set gold repository name to 'rep' (for testing) |
@@ -138,7 +139,7 @@ int	main(int argc, char *argv[])
   /* connect to the scheduler */
   fo_scheduler_connect(&argc, argv, &pgConn);
 
-  while((c = getopt(argc,argv,"ACc:d:FfHhL:m:PQiqRr:T:t:U:VvXx")) != -1)
+  while((c = getopt(argc,argv,"ACc:d:FfHhL:m:PQiIqRr:T:t:U:VvXx")) != -1)
   {
     switch(c)
     {
@@ -164,6 +165,7 @@ int	main(int argc, char *argv[])
           LOG_WARNING("dpkg-source is not available on this system.  This means that debian source packages will NOT be unpacked.");
         SafeExit(0);
         break; /* never reached */
+      case 'I': IgnoreSCMData=1; break;
       case 'Q':
         UseRepository=1;
 

--- a/src/ununpack/agent/ununpack_globals.h
+++ b/src/ununpack/agent/ununpack_globals.h
@@ -38,6 +38,7 @@ int PruneFiles=0;
 int SetContainerArtifact=1;	/* should initial container be an artifact? */
 FILE *ListOutFile=NULL;
 int ReunpackSwitch=0;
+int IgnoreSCMData=0;
 
 /* for the repository */
 int UseRepository=0;

--- a/src/ununpack/agent/utils.c
+++ b/src/ununpack/agent/utils.c
@@ -1334,7 +1334,12 @@ int	DBInsertUploadTree	(ContainerInfo *CI, int Mask)
     strncpy(UfileName, EscBuf, sizeof(UfileName));
   }
 
-  // Begin add by vincent
+  /*
+   * Tests for SCM Data: IgnoreSCMData is global and defined in ununpack_globals.h with false value
+   * and pass to true if ununpack is called with -I option to ignore SCM data. 
+   * So if IgnoreSCMData is false the right test is true.
+   * Otherwise if IgnoreSCMData is true and CI->Source is not a SCM data then add it in database.
+  */
   if(ReunpackSwitch && ((IgnoreSCMData && !TestSCMData(CI->Source)) || !IgnoreSCMData))
   {
     /* postgres 8.3 seems to have a problem escaping binary characters
@@ -1374,7 +1379,6 @@ int	DBInsertUploadTree	(ContainerInfo *CI, int Mask)
     CI->uploadtree_pk = atol(PQgetvalue(result,0,0));
     PQclear(result);
   }
-  //End add by Vincent
   TotalItems++;
   fo_scheduler_heart(1);
   return(0);

--- a/src/ununpack/agent/utils.c
+++ b/src/ununpack/agent/utils.c
@@ -20,6 +20,7 @@
  */
 #include "ununpack.h"
 #include "externs.h"
+#include "regex.h"
 
 /**
  * \brief File mode BITS
@@ -29,6 +30,12 @@ enum BITS {
   BITS_ARTIFACT = 28,
   BITS_CONTAINER = 29
 };
+
+/**
+ * regular expression to detect SCM data
+ */
+const char* SCM_REGEX = "/\\.git|\\.hg|\\.bzr|CVS/ROOT|\\.svn/";
+
 
 
 /**
@@ -1198,6 +1205,70 @@ int	DBInsertPfile	(ContainerInfo *CI, char *Fuid)
 } /* DBInsertPfile() */
 
 /**
+ * @brief Search for SCM data in the filename
+ *
+ * SCM data is one of these:
+ *   Git (.git)Data(char *FileName)
+ *   Mercurial (.hg)
+ *   Bazaar (.bzr)
+ *   CVS (CVS/Root)
+ *   Subversion (.svn)
+ * @param sourcefilename
+ * @returns 1 if SCM data is found
+ **/
+int TestSCMData(char *sourcefilename)
+{
+  regex_t preg;
+  int err;
+  int found=0;
+
+  err = regcomp (&preg, SCM_REGEX, REG_NOSUB | REG_EXTENDED);
+  if (err == 0)
+  {
+    int match;
+
+    match = regexec (&preg, sourcefilename, 0, NULL, 0);
+    regfree (&preg);
+    if(match == 0)
+    {
+      found = 1;
+      if (Verbose) LOG_DEBUG("match found %s",sourcefilename);
+    }
+    else if(match == REG_NOMATCH)
+    {
+      found = 0;
+      if (Verbose) LOG_DEBUG("match not found %s",sourcefilename);
+    }
+    else
+    {
+      char *text;
+      size_t size;
+      size = regerror (err, &preg, NULL, 0);
+      text = malloc (sizeof (*text) * size);
+      if(text)
+      {
+        regerror (err, &preg, text, size);
+        LOG_ERROR("Error regexc '%s' '%s' return %d, error %s",SCM_REGEX,sourcefilename,match,text);
+      }
+      else
+      {
+        LOG_ERROR("Not enough memory (%lu)",sizeof (*text) * size);
+        SafeExit(127);
+      }
+      found = 0;
+    }
+  }
+  else
+  {
+     LOG_ERROR("Error regcomp(%d)",err);
+     SafeExit(127);
+  }
+
+
+  return(found);
+} /* TestSCMData() */
+
+/**
  * @brief Insert an UploadTree record.
  *
  * If the tree is a duplicate, then we need to replicate
@@ -1264,7 +1335,7 @@ int	DBInsertUploadTree	(ContainerInfo *CI, int Mask)
   }
 
   // Begin add by vincent
-  if(ReunpackSwitch)
+  if(ReunpackSwitch && ((IgnoreSCMData && !TestSCMData(CI->Source)) || !IgnoreSCMData))
   {
     /* postgres 8.3 seems to have a problem escaping binary characters
      * (it works in 8.4).  So manually substitute '~' for any unprintable and slash chars.
@@ -1640,6 +1711,7 @@ void	Usage	(char *Name, char *Version)
   fprintf(stderr,"  -L out :: Generate a log of files extracted (in XML) to out.\n");
   fprintf(stderr,"  -F     :: Using files from the repository.\n");
   fprintf(stderr,"  -i     :: Initialize the database queue system, then exit.\n");
+  fprintf(stderr,"  -I     :: Ignore SCM Data.\n");
   fprintf(stderr,"  -Q     :: Using scheduler queue system. (Includes -F)\n");
   fprintf(stderr,"            If -L is used, unpacked files are placed in 'files'.\n");
   fprintf(stderr,"      -T rep :: Set gold repository name to 'rep' (for testing)\n");

--- a/src/ununpack/ui/agent-unpack.php
+++ b/src/ununpack/ui/agent-unpack.php
@@ -60,7 +60,7 @@ class UnpackAgentPlugin extends AgentPlugin
        return $jobQueueId;
     }
 
-    return $this->doAgentAdd($jobId, $uploadId, $errorMsg, $dependencies, $uploadId, '');
+    return $this->doAgentAdd($jobId, $uploadId, $errorMsg, $dependencies, $uploadId, $arguments);
   }
 }
 

--- a/src/www/ui/page/UploadFilePage.php
+++ b/src/www/ui/page/UploadFilePage.php
@@ -120,7 +120,6 @@ class UploadFilePage extends UploadPageBase
     $uploadMode = (1 << 3); // code for "it came from web upload"
     $userId = Auth::getUserId();
     $groupId = Auth::getGroupId();
-
     $uploadId = JobAddUpload($userId, $groupId, $originalFileName, $originalFileName, $description, $uploadMode, $folderId, $publicPermission);
     if (empty($uploadId))
     {

--- a/src/www/ui/page/UploadPageBase.php
+++ b/src/www/ui/page/UploadPageBase.php
@@ -113,13 +113,14 @@ abstract class UploadPageBase extends DefaultPlugin
       $jobId = JobAddJob($userId, $groupId, $fileName, $uploadId);
     }
     $dummy = "";
+    $unpackArgs = intval($request->get('scm') == 1) ? '-I' : '';
     $adj2nestDependencies = array();
     if ($wgetDependency)
     {
-      $adj2nestDependencies = array(array('name'=>'agent_unpack',AgentPlugin::PRE_JOB_QUEUE=>array('wget_agent')));
+      $adj2nestDependencies = array(array('name'=>'agent_unpack','args'=>$unpackArgs,AgentPlugin::PRE_JOB_QUEUE=>array('wget_agent')));
     }
     $adj2nestplugin = \plugin_find('agent_adj2nest');
-    $adj2nestplugin->AgentAdd($jobId, $uploadId, $dummy, $adj2nestDependencies);
+    $adj2nestplugin->AgentAdd($jobId, $uploadId, $dummy, $adj2nestDependencies, null, (empty($adj2nestDependencies) ? $unpackArgs : ''));
 
     $checkedAgents = checkedAgents();
     AgentSchedule($jobId, $uploadId, $checkedAgents);

--- a/src/www/ui/page/UploadSrvPage.php
+++ b/src/www/ui/page/UploadSrvPage.php
@@ -270,7 +270,8 @@ class UploadSrvPage extends UploadPageBase
 
     /* schedule agents */
     $unpackplugin = &$Plugins[plugin_find_id("agent_unpack")];
-    $ununpack_jq_pk = $unpackplugin->AgentAdd($jobpk, $uploadId, $ErrorMsg, array("wget_agent"));
+    $unpackArgs = intval($request->get('scm') == 1) ? '-I' : '';
+    $ununpack_jq_pk = $unpackplugin->AgentAdd($jobpk, $uploadId, $ErrorMsg, array("wget_agent"), $unpackargs);
     if ($ununpack_jq_pk < 0)
     {
       return array(false, $text, _($ErrorMsg));

--- a/src/www/ui/page/UploadUrlPage.php
+++ b/src/www/ui/page/UploadUrlPage.php
@@ -111,7 +111,7 @@ class UploadUrlPage extends UploadPageBase
       return array(false, "Failed to insert task 'wget_agent' into job queue", $description);
     }
     
-    $message = $this->postUploadAddJobs($request, $shortName, $uploadId, $jobId, $jobqueueId);
+    $message = $this->postUploadAddJobs($request, $shortName, $uploadId, $jobId, true);
     return array(true, $message, $description);
   }
   

--- a/src/www/ui/page/UploadVcsPage.php
+++ b/src/www/ui/page/UploadVcsPage.php
@@ -154,7 +154,8 @@ class UploadVcsPage extends UploadPageBase
     }
     /* schedule agents */
     $unpackplugin = &$Plugins[plugin_find_id("agent_unpack") ];
-    $ununpack_jq_pk = $unpackplugin->AgentAdd($jobpk, $uploadId, $ErrorMsg, array("wget_agent"));
+    $unpackArgs = intval($request->get('scm') == 1) ? '-I' : '';
+    $ununpack_jq_pk = $unpackplugin->AgentAdd($jobpk, $uploadId, $ErrorMsg, array("wget_agent"), $unpackArgs);
     if ($ununpack_jq_pk < 0)
     {
       return array(false, _($ErrorMsg), $description);

--- a/src/www/ui/template/include/upload.html.twig
+++ b/src/www/ui/template/include/upload.html.twig
@@ -36,6 +36,9 @@
         </label>
       </li>
       <li>
+          <input type="checkbox" name="scm" value="1"/> {{ 'Ignore SCM files (Git, SVN, TFS)'| trans }}<br/>
+      </li>
+      <li>
         <input type="radio" name="public" value="private"/> {{ 'Visible only for active group'| trans }}<img src="images/info_16.png" title="{{'which is the currently selected group'|trans}}" alt="" class="info-bullet"/><br/>
         <input type="radio" name="public" value="protected" checked="checked"/> {{ 'Visible for all groups'| trans }}<img src="images/info_16.png" title="{{'which are accessible by you now'|trans}}" alt="" class="info-bullet"/><br/>
         <input type="radio" name="public" value="public"/> {{ 'Make Public'| trans }}<img src="images/info_16.png" title="{{'visible for all users'|trans}}" alt="" class="info-bullet"/><br/>


### PR DESCRIPTION
### Description 
Implement ignore scm data when scanning an upload (see #1251)

### Changes
1. Add a new column scm in upload table
1. Add a new option to enable this feature when adding a new upload. 
1. Add a new function in ununpack/agent/utils.c to test SCM data file (see SCM_REGEX constant to search git, svn, TFS, mercurial).

## How to test
Add a new upload with scm data files. Enable this new option to not scanning SCM data files.

This is a duplicate of  #1264 to resolve multiple commits problem
Closes #1251 