### PR TITLE
fix(Vagrantfile): Enable mod rewrite in vagrant for REST API

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,6 +52,7 @@ sudo /usr/local/lib/fossology/fo-postinstall
 
 sudo cp /fossology/install/src-install-apache-example.conf /etc/apache2/conf-available/fossology.conf
 sudo a2enconf fossology.conf
+sudo a2enmod rewrite
 
 # increase upload size
 sudo /fossology/install/scripts/php-conf-fix.sh --overwrite


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Rest API requires Apache's `mod-rewrite` which needs to be enabled explicitly.

### Changes

Enable `mod-rewrite` for Vagrant.

## How to test

Build a vagrant container and call the REST API.

Thanks to @maxhbr for pointing this out.