### PR TITLE
feat(nomos): Fix the JSON output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
       - libcunit1-dev
       - libdbd-sqlite3-perl
       - libjsoncpp-dev
+      - libjson-c-dev
       - liblocal-lib-perl
       - libmagic-dev
       - librpm-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY ./utils/utils.sh ./utils/utils.sh
 COPY ./src/copyright/mod_deps ./src/copyright/
 COPY ./src/delagent/mod_deps ./src/delagent/
 COPY ./src/mimetype/mod_deps ./src/mimetype/
+COPY ./src/nomos/mod_deps ./src/nomos/
 COPY ./src/pkgagent/mod_deps ./src/pkgagent/
 COPY ./src/scheduler/mod_deps ./src/scheduler/
 COPY ./src/ununpack/mod_deps ./src/ununpack/

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: fossology
 Section: utils
 Priority: extra
 Maintainer: Michael Jaeger <michael.c.jaeger@siemens.com>
-Build-Depends: debhelper, libglib2.0-dev, libmagic-dev, libxml2-dev, libmxml-dev, libtext-template-perl, librpm-dev, subversion, rpm, libpcre3-dev, libssl-dev, postgresql-server-dev-all, libboost-regex-dev, libboost-program-options-dev, libjsoncpp-dev, php5-cli|php7.0-cli|php7.2-cli, php-mbstring|php5, php-zip|php5, php-xml|php5
+Build-Depends: debhelper, libglib2.0-dev, libmagic-dev, libxml2-dev, libmxml-dev, libtext-template-perl, librpm-dev, subversion, rpm, libpcre3-dev, libssl-dev, postgresql-server-dev-all, libboost-regex-dev, libboost-program-options-dev, libjsoncpp-dev, libjson-c-dev, php5-cli|php7.0-cli|php7.2-cli, php-mbstring|php5, php-zip|php5, php-xml|php5
 Standards-Version: 3.9.1
 Homepage: http://fossology.org
 

--- a/src/nomos/agent/Makefile
+++ b/src/nomos/agent/Makefile
@@ -13,14 +13,16 @@ PRE = PRECHECK
 PDATA =_split_words
 LICFIX = GENSEARCHDATA
 
-OBJS = licenses.o list.o parse.o process.o nomos_regex.o util.o nomos_gap.o nomos_utils.o doctorBuffer_utils.o # sources.o DMalloc.o
+OBJS = licenses.o list.o parse.o process.o nomos_regex.o util.o nomos_gap.o nomos_utils.o doctorBuffer_utils.o json_writer.o # sources.o DMalloc.o
 GENOBJS = _precheck.o _autodata.o
 HDRS = nomos.h $(OBJS:.o=.h) _autodefs.h
 COVERAGE = $(OBJS:%.o=%_cov.o)
 GENOBJS_COV = $(GENOBJS:%.o=%_cov.o)
 
-CFLAGS_LOCAL = $(FO_CFLAGS) -Werror
+CFLAGS_LOCAL = $(FO_CFLAGS) -Werror $(shell pkg-config --cflags json-c)
 CFLAGS_LOCALO = $(FO_CFLAGS)
+
+FO_LDFLAGS += $(shell pkg-config --libs json-c) -lpthread -lrt
 
 all: encode nomos libnomos.a
 

--- a/src/nomos/agent/Makefile.sa
+++ b/src/nomos/agent/Makefile.sa
@@ -14,19 +14,21 @@ PRE = PRECHECK
 PDATA =_split_words
 LICFIX = GENSEARCHDATA
 
-OBJS = standalone.o licenses.o list.o parse.o process.o nomos_regex.o util.o nomos_gap.o nomos_utils.o doctorBuffer_utils.o # sources.o DMalloc.o
+OBJS = standalone.o licenses.o list.o parse.o process.o nomos_regex.o util.o nomos_gap.o nomos_utils.o doctorBuffer_utils.o json_writer.o # sources.o DMalloc.o
 GENOBJS = _precheck.o _autodata.o
 HDRS = nomos.h $(OBJS:.o=.h) _autodefs.h
 
 #CFLAGS_LOCAL = -DSTANDALONE -g -O2 -Wall -D_FILE_OFFSET_BITS=64
-CFLAGS_LOCAL = -DSTANDALONE -Wall -D_FILE_OFFSET_BITS=64 `pkg-config glib-2.0 --cflags --libs`
+CFLAGS_LOCAL = -DSTANDALONE -Wall -D_FILE_OFFSET_BITS=64 $(shell pkg-config glib-2.0 --cflags) $(shell pkg-config --cflags json-c)
+
+FO_LDFLAGS += $(shell pkg-config glib-2.0 --libs) $(shell pkg-config --libs json-c) -lpthread -lrt
 
 all: encode $(EXE)
 
 debug: nomos-gl
 
 $(EXE): nomos.o $(OBJS) $(GENOBJS)
-	$(CC) nomos.o $(OBJS) $(GENOBJS) $(CFLAGS_LOCAL) -o $(EXE)
+	$(CC) nomos.o $(OBJS) $(GENOBJS) $(CFLAGS_LOCAL) $(FO_LDFLAGS) -o $(EXE)
 
 nomos.o: nomos.c $(HDRS) $(DB) $(REPO) $(AGENTLIB) $(VARS)
 	$(CC) -c $< $(CFLAGS_LOCAL) $(DEFS)

--- a/src/nomos/agent/json_writer.c
+++ b/src/nomos/agent/json_writer.c
@@ -1,0 +1,158 @@
+/***************************************************************
+ Copyright (C) 2019 Siemens AG
+ Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+ ***************************************************************/
+
+#include "json_writer.h"
+#include "nomos.h"
+#include "nomos_utils.h"
+#include "json-c/json.h"
+
+void writeToTemp()
+{
+  char realPathOfTarget[PATH_MAX];
+  if (optionIsSet(OPTS_LONG_CMD_OUTPUT))
+  {
+    if (!realpath(cur.targetFile, realPathOfTarget))
+    {
+      strcpy(realPathOfTarget, basename(cur.targetFile));
+    }
+  }
+  else
+  {
+    strcpy(realPathOfTarget, basename(cur.targetFile));
+  }
+  sem_wait(&cur.mutexTempJson);
+  fprintf(cur.tempJsonPath, "%s;%s\n", realPathOfTarget, cur.compLic);
+  fflush(cur.tempJsonPath);
+  sem_post(&cur.mutexTempJson);
+}
+
+void writeToStdOut()
+{
+  json_object *root = json_object_new_object();
+  json_object *results = json_object_new_array();
+  json_object *result = json_object_new_object();
+  json_object *licenses = json_object_new_array();
+  json_object *fileLocation = NULL;
+  json_object *aLicense = NULL;
+  char realPathOfTarget[PATH_MAX];
+  parseLicenseList();
+  size_t i = 0;
+  while (cur.licenseList[i] != NULL)
+  {
+    aLicense = json_object_new_string(cur.licenseList[i]);
+    json_object_array_add(licenses, aLicense);
+    ++i;
+  }
+  if (optionIsSet(OPTS_LONG_CMD_OUTPUT)
+      && realpath(cur.targetFile, realPathOfTarget))
+  {
+    fileLocation = json_object_new_string(realPathOfTarget);
+  }
+  else
+  {
+    fileLocation = json_object_new_string(basename(cur.targetFile));
+  }
+  json_object_object_add(result, "file", fileLocation);
+  json_object_object_add(result, "licenses", licenses);
+  json_object_array_add(results, result);
+  json_object_object_add(root, "results", results);
+  const char *prettyJson = unescapePathSeparator(
+      (char*) json_object_to_json_string_ext(root,
+      JSON_C_TO_STRING_PRETTY));
+  printf("%s\n", prettyJson);
+  json_object_put(root);
+}
+
+void parseTempJson()
+{
+  char *line = NULL;
+  size_t len = 0;
+  ssize_t read;
+  json_object *root = json_object_new_object();
+  json_object *results = json_object_new_array();
+  json_object *result = NULL;
+  json_object *licenses = NULL;
+  json_object *fileLocation = NULL;
+  json_object *aLicense = NULL;
+
+  fseek(cur.tempJsonPath, 0, SEEK_SET);
+  while ((read = getline(&line, &len, cur.tempJsonPath)) != -1)
+  {
+    if (line[read - 1] == '\n')
+    {
+      line[read - 1] = '\0';
+    }
+    fileLocation = json_object_new_string(strtok(line, ";"));
+    strcpy(cur.compLic, strtok(NULL, ";"));
+    parseLicenseList();
+
+    licenses = json_object_new_array();
+    size_t i = 0;
+    while (cur.licenseList[i] != NULL)
+    {
+      aLicense = json_object_new_string(cur.licenseList[i]);
+      json_object_array_add(licenses, aLicense);
+      ++i;
+    }
+    result = json_object_new_object();
+    json_object_object_add(result, "file", fileLocation);
+    json_object_object_add(result, "licenses", licenses);
+    json_object_array_add(results, result);
+  }
+  json_object_object_add(root, "results", results);
+  const char *prettyJson = unescapePathSeparator(
+      (char*) json_object_to_json_string_ext(root,
+      JSON_C_TO_STRING_PRETTY));
+  printf("%s\n", prettyJson);
+  json_object_put(root);
+  if (line)
+  {
+    free(line);
+  }
+}
+
+char *unescapePathSeparator(char* json)
+{
+  const char *escapedSeparator = "\\/";
+  const char *pathSeparator = "/";
+  const int escPathLen = 2;
+  char *result;
+  char *tmp;
+  int count;
+  if (!json)
+  {
+    return NULL;
+  }
+
+  tmp = json;
+  for (count = 0; (tmp = strstr(tmp, escapedSeparator)); count++)
+  {
+    tmp += escPathLen;
+  }
+
+  result = malloc(sizeof(char) * ((strlen(json) - (escPathLen * count)) + 1));
+
+  strcpy(result, strtok(json, escapedSeparator));
+  while (count--)
+  {
+    strcat(result, pathSeparator);
+    strcat(result, strtok(NULL, escapedSeparator));
+  }
+  return result;
+}

--- a/src/nomos/agent/json_writer.h
+++ b/src/nomos/agent/json_writer.h
@@ -1,0 +1,60 @@
+/***************************************************************
+ Copyright (C) 2019 Siemens AG
+ Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+ ***************************************************************/
+
+/**
+ * \file
+ * \brief Handle JSON outputs
+ */
+
+#ifndef _JSON_WRITER_H_
+#define _JSON_WRITER_H_
+
+/**
+ * \brief Write the scan output to a temp file
+ *
+ * The function writes the output of a scan result to a temp file in append
+ * mode which is read by parseTempJson() to create a single JSON output.
+ */
+void writeToTemp();
+
+/**
+ * \brief Write the scan result as JSON to STDOUT
+ */
+void writeToStdOut();
+
+/**
+ * \brief Read temp file and print a JSON to STDOUT
+ *
+ * Reads the temp file created by writeToTemp(), parse it and create a JSON.
+ * Then writes this JSON to STDOUT.
+ */
+void parseTempJson();
+
+/**
+ * \brief Unescape the path separator from JSON
+ *
+ * Unescape the path separator from JSON string to make it readable.
+ *
+ * `"\/folder\/folder2\/file" => "/folder/folder2/file"
+ * @param json String to unescape
+ * @return The JSON with unescaped path separator.
+ */
+char *unescapePathSeparator(char* json);
+
+#endif /* _JSON_WRITER_H_ */

--- a/src/nomos/agent/licenses.c
+++ b/src/nomos/agent/licenses.c
@@ -1226,18 +1226,16 @@ static void saveLicenseData(scanres_t *scores, int nCand, int nElem,
   /* DBug: printf("saveLicenseData on return gl.initwd is:%s\n",gl.initwd); */
   if(cur.cliMode)
   {
-    if (gl.progOpts & OPTS_JSON_OUTPUT) {
-      printf("[");
-      parseLicenseList();
-      size_t i = 0;
-      while (cur.licenseList[i] != NULL) {
-        printf("\"%s\"", cur.licenseList[i]);
-        if (cur.licenseList[i+1] != NULL) {
-          printf(",");
-        }
-        ++i;
+    if (optionIsSet(OPTS_JSON_OUTPUT))
+    {
+      if (optionIsSet(OPTS_SCANNING_DIRECTORY))
+      {
+        writeToTemp();
       }
-      printf("]");
+      else
+      {
+        writeToStdOut();
+      }
     } else {
       if (optionIsSet(OPTS_LONG_CMD_OUTPUT) && realpath(cur.targetFile, realPathOfTarget))
         {

--- a/src/nomos/agent/nomos.h
+++ b/src/nomos/agent/nomos.h
@@ -103,6 +103,8 @@
 #include <sys/time.h>
 #include "nomos_gap.h"
 #include <stdbool.h>
+#include <semaphore.h>
+#include "json_writer.h"
 
 /** Use nomos in standalone mode (no FOSSology DB) */
 #ifdef STANDALONE
@@ -151,6 +153,7 @@
 #define OPTS_HIGHLIGHT_STDOUT 0x8
 #define OPTS_NO_HIGHLIGHTINFO 0x10
 #define OPTS_JSON_OUTPUT 0x20
+#define OPTS_SCANNING_DIRECTORY 0x40
 
 char debugStr[myBUFSIZ];        ///< Debug string
 char dbErrString[myBUFSIZ];     ///< DB error string
@@ -398,11 +401,11 @@ typedef struct  {
   \brief Struct that tracks state related to current file being scanned.
  */
 struct curScan {
-    char cwd[myBUFSIZ]; /**< CDB, Would like to workaround and eliminate. */
+  char cwd[myBUFSIZ];      /**< CDB, Would like to workaround and eliminate. */
   char targetDir[myBUFSIZ]; 	/**< Directory where file is */ /* check */
   char targetFile[myBUFSIZ]; 	/**< File we're scanning (tmp file)*/ /* check */
   char filePath[myBUFSIZ];    /**< the original file path passed in */
-    long pFileFk; /**< [in] pfile_fk from scheduler */
+  long pFileFk;            /**< [in] pfile_fk from scheduler */
   char pFile[myBUFSIZ];       /**< [in] pfilename from scheduler */
   char *licPara;
   char *matchBase;
@@ -416,18 +419,20 @@ struct curScan {
   list_t offList;
   list_t lList;
   char compLic[myBUFSIZ];  	/**< the license(s) found, None or NotLikely.
-    							     comma separated if multiple names are found.
-   */
+                                comma separated if multiple names are found. */
   int nLines;
   int cliMode;                /**< boolean to indicate running from command line */
   char *tmpLics;              /**< pointer to storage for parsed names */
   char *licenseList[512];     /**< list of license names found, can be a single name */
 
-    GArray* indexList; /**< List of license indexes */
-    GArray* theMatches; /**< List of matches */
-    GArray* keywordPositions; /**< List of matche positions */
+  GArray* indexList; /**< List of license indexes */
+  GArray* theMatches; /**< List of matches */
+  GArray* keywordPositions; /**< List of matche positions */
   GArray* docBufferPositionsAndOffsets;
   int currentLicenceIndex;
+  FILE *tempJsonPath; /**< File descriptor for temporary file where
+                           intermediate outputs for json are stored */
+  sem_t mutexTempJson; /**< Mutex to handle writes to tempJsonPath */
 };
 
 /**

--- a/src/nomos/agent_tests/Unit/Makefile
+++ b/src/nomos/agent_tests/Unit/Makefile
@@ -17,7 +17,7 @@ LOCALAGENTDIR = ../../agent
 TESTDIR = $(TOP)/src/testing/lib/c
 TESTLIB = -L$(TESTDIR) -lfocunit -lcunit 
 CFLAGS_LOCAL = $(FO_CFLAGS) -I$(LOCALAGENTDIR) -I$(TESTDIR) -std=c99 -DCU_VERSION_P=$(CUNIT_VERSION)
-LDFLAGS_LOCAL = $(FO_LDFLAGS) -lcunit $(TESTLIB)
+LDFLAGS_LOCAL = $(FO_LDFLAGS) -lcunit $(TESTLIB) $(shell pkg-config --libs json-c) -lpthread -lrt
 DEF = -DDATADIR='"$(DATADIR)"'
 EXE = test_nomos
 

--- a/src/nomos/mod_deps
+++ b/src/nomos/mod_deps
@@ -2,7 +2,7 @@
 # FOSSology mod_deps script
 # This script helps you install dependencies on a system. for a module
 #
-# Copyright (C) 2018 Siemens AG
+# Copyright (C) 2019 Siemens AG
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # version 2 as published by the Free Software Foundation.
@@ -77,16 +77,11 @@ if [[ $BUILDTIME ]]; then
   case "$DISTRO" in
     Debian|Ubuntu|LinuxMint)
       apt-get $YesOpt install \
-        libjsoncpp-dev
+        libjson-c-dev
       ;;
-    Fedora)
+    Fedora|RedHatEnterprise*|CentOS)
       yum $YesOpt install \
-        jsoncpp-devel
-      ;;
-    RedHatEnterprise*|CentOS)
-      yum $YesOpt install epel-release;
-      yum $YesOpt install \
-        jsoncpp-devel
+        json-c-devel
       ;;
     *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
   esac
@@ -97,20 +92,15 @@ if [[ $RUNTIME ]]; then
   case "$DISTRO" in
     Debian|Ubuntu)
       case "$CODENAME" in
-        jessie|trusty)
-          apt-get $YesOpt install libjsoncpp0;;
-        stretch|buster|sid|artful|bionic|xenial|cosmic)
-          apt-get $YesOpt install libjsoncpp1;;
+        jessie|trusty|xenial)
+          apt-get $YesOpt install libjson-c2;;
+        stretch|buster|sid|bionic|cosmic)
+          apt-get $YesOpt install libjson-c3;;
         *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
       esac;;
-    Fedora)
+    Fedora|RedHatEnterprise*|CentOS)
       yum $YesOpt install \
-        jsoncpp
-      ;;
-    RedHatEnterprise*|CentOS)
-      yum $YesOpt install epel-release;
-      yum $YesOpt install \
-        jsoncpp
+        json-c
       ;;
     *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
   esac


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix the JSON output while scanning using `-J` flag.

See old output in #953 

### Changes

The JSON output now following following syntax:

```json
{
  "results":[
    {
      "file": "relative-path-to-file.c",
      "licenses":[
        "EPL-1.0",
        "Apache-2.0"
      ]
    },
    {
      "file": "absolute-path-to-file-using-l-flag.c",
      "licenses":[
        "GPL-2.0",
        "LGPL-2.1"
      ]
    },
    ...
  ]
}
```

## How to test

1. Run nomos with `-J` flag on a single file
    - The result should be a valid JSON.
1. Run nomos with `-J -l` flags on a single file
    - The result should be a valid JSON with absolute file path.
1. Run nomos with `-J -d` flags on a directory
    - The result should be a valid JSON with results in an array.
1. Run nomos with `-J -l -d` flags on a directory
    - The result should be a valid JSON with absolute file path.
1. Run nomos without `-J` flag
    - The result should not be effected.
1. Run nomos from UI
    - The result should not be effected.

Closes #953 