### PR TITLE
fix(trac.php): correct typo `fLAse` instead of `fALse`

### DIFF
--- a/utils/freshmeat/trac.php
+++ b/utils/freshmeat/trac.php
@@ -167,7 +167,7 @@ $PF = fopen('ol-projects-in-FM', 'w') or die("Can't open file, $php_errormsg\n")
 foreach($projects as $line)
 {
 //  print "line is:$line\n";
-  if(fputcsv($PF, $line) === flase)
+  if(fputcsv($PF, $line) === false)
   {
     print "ERROR: can't write $line\n";
   }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The word `flase` is an undefined constant, which by default is initialized to its name.

```
php > echo flase;
PHP Warning:  Use of undefined constant flase - assumed 'flase' (this will throw an Error in a future version of PHP) in php shell code on line 1
flase
```

Note that:
```
php > var_dump('flase' == true);
bool(true)
```

### Changes

Just changed `return flase` to `return false`.
