### PR TITLE
fix(restApi): Fix for missing plugins

### DIFF
--- a/src/www/ui/api/Middlewares/RestAuthMiddleware.php
+++ b/src/www/ui/api/Middlewares/RestAuthMiddleware.php
@@ -1,0 +1,64 @@
+<?php
+/***************************************************************
+ Copyright (C) 2018 Siemens AG
+ Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @dir
+ * @brief Middlewares for the Slim framework
+ * @file
+ * @brief Auth middleware for Slim
+ */
+
+namespace Fossology\UI\Api\Middlewares;
+
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Fossology\UI\Api\Helper\AuthHelper;
+
+/**
+ * @class RestAuthMiddleware
+ * @brief Authentication middleware for Slim framework
+ */
+class RestAuthMiddleware
+{
+  /**
+   * Check authentication for all calls, except for /auth/
+   *
+   * @param  \Psr\Http\Message\ServerRequestInterface $request  PSR7 request
+   * @param  \Psr\Http\Message\ResponseInterface      $response PSR7 response
+   * @param  callable                                 $next     Next middleware
+   *
+   * @return \Psr\Http\Message\ResponseInterface
+   */
+  public function __invoke($request, $response, $next)
+  {
+    if(stristr($request->getUri()->getPath(), "/auth") !== false) {
+      $response = $next($request, $response);
+    } else {
+      $authHelper = new AuthHelper();
+      $username = $request->getHeaderLine("php-auth-user");
+      $password = $request->getHeaderLine("php-auth-pw");
+      if(!$authHelper->checkUsernameAndPassword($username, $password)) {
+        $error = new Info(403, "Not authorized", InfoType::ERROR);
+        $response = $response->withJson($error->getArray(), $error->getCode());
+      } else {
+        $response = $next($request, $response);
+      }
+    }
+    return $response;
+  }
+}


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Currently, some plugins are getting missed if user calls REST API without maintaining the cookies.

The plugins which require access more than `READ` on were unloaded as the call was made before setting the `$_SESSION` for a given user.

This PR creates a new middleware to handle this issue and loads the plugins again once the authentication is done for the user.

### Changes

1. Create a new middleware (`FossologyInitMiddleware`) to load and unload plugins.
1. Rename middleware `RestAuthHelper` => `RestAuthMiddleware`.

## How to test

Check endpoints mentioned in #1287 

Closes #1287 