### PR TITLE
fix(scheduler): Respect max run limit of agents

### DIFF
--- a/src/scheduler/agent/agent.h
+++ b/src/scheduler/agent/agent.h
@@ -98,6 +98,7 @@ typedef struct
     char* version_source;       ///< the machine that reported the version information
     char* version;              ///< the version of the agent that is running on all hosts
     int valid;                  ///< flag indicating if the meta_agent is valid
+    int run_count;              ///< the count of agents in running state
 } meta_agent_t;
 
 /**
@@ -179,5 +180,8 @@ void kill_agents(scheduler_t* scheduler);
 
 int  is_meta_special(meta_agent_t* ma, int special_type);
 int  is_agent_special(agent_t* agent, int special_type);
+
+void meta_agent_increase_count(meta_agent_t*);
+void meta_agent_decrease_count(meta_agent_t*);
 
 #endif /* AGENT_H_INCLUDE */

--- a/src/scheduler/agent/defconf/init.d/fossology.in
+++ b/src/scheduler/agent/defconf/init.d/fossology.in
@@ -27,7 +27,7 @@ test -x $DAEMON || exit 0
 ENABLED=1
 
 # Include scheduler defaults if available
-SCHEDULEROPT="--daemon --reset --verbose=1" 
+SCHEDULEROPT="--daemon --reset --verbose=1"
 if [ -f {$SYSCONFDIR}/default/fossology ] ; then
     # This can override SCHEDULEROPT.
     # Be sure to keep "-d" for daemon mode


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Currently, the max limit set by agents in their **<agent>.conf** was read and set by scheduler but never checked before scheduling the agent.

This PR checks the same before scheduling the new job/agent.

### Changes

1. Added one new parameter (`run_count`) to the `meta_agent_t` structure to keep the count of running instances of the agent.
1. This count is increased when the agent is scheduled/resumed and decreased when the agent is killed/paused/finished.
1. Check this `run_count` against the agent's `max_run` before scheduling the job.

## How to test

1. Reduce the **max** of an agent by editing it's **.conf**
1. Stop the scheduler and schedule the agent from the UI (this is to give buffer for scheduling enough jobs before scheduler picks them up).
1. Start the scheduler and check the running processes.