### PR TITLE
fix(maintagent): do not delete the global decisions

### DIFF
--- a/src/maintagent/agent/process.c
+++ b/src/maintagent/agent/process.c
@@ -370,32 +370,35 @@ FUNCTION void removeOrphanedRows()
                "  SELECT 1 "
                "  FROM uploadtree UT  "
                "  WHERE CD.uploadtree_fk = UT.uploadtree_pk "
-               " );";
+               " ) AND CD.scope = '0';";
 
-  char *SQL3 = "DELETE FROM clearing_decision_event CDE"
-               " WHERE NOT EXISTS ( "
-               "  SELECT 1 "
-               "  FROM uploadtree UT  "
-               "  INNER JOIN clearing_event CE "
-               "  ON CE.uploadtree_fk = UT.uploadtree_pk "
-               "  WHERE CDE.clearing_event_fk = CE.clearing_event_pk "
-               " );";
-
-  char *SQL4 = " DELETE FROM clearing_event CE "
+  char *SQL3 = "DELETE FROM clearing_event CE "
                " WHERE NOT EXISTS ( "
                "  SELECT 1 "
                "  FROM uploadtree UT  "
                "  WHERE CE.uploadtree_fk = UT.uploadtree_pk "
+               " ) AND NOT EXISTS ( "
+               "  SELECT 1 "
+               "  FROM clearing_decision CD"
+               "  WHERE CD.uploadtree_fk = CE.uploadtree_fk "
+               "  AND CD.scope = '1'"
                " );";
 
-  char *SQL5 = " DELETE FROM obligation_map OM "
+  char *SQL4 = "DELETE FROM clearing_decision_event CDE"
+               " WHERE NOT EXISTS ( "
+               "  SELECT 1 "
+               "  FROM clearing_event CE  "
+               "  WHERE CE.clearing_event_pk = CDE.clearing_event_fk "
+               " );";
+
+  char *SQL5 = "DELETE FROM obligation_map OM "
                " WHERE NOT EXISTS ( "
                "  SELECT 1 "
                "  FROM license_ref LR  "
                "  WHERE OM.rf_fk = LR.rf_pk "
                " );";
 
-  char *SQL6 = " DELETE FROM obligation_candidate_map OCM "
+  char *SQL6 = "DELETE FROM obligation_candidate_map OCM "
                " WHERE NOT EXISTS ( "
                "  SELECT 1 "
                "  FROM license_ref LR  "
@@ -419,13 +422,13 @@ FUNCTION void removeOrphanedRows()
   result = PQexecCheck(-202, SQL3, __FILE__, __LINE__);
   countTuples = PQcmdTuples(result);
   PQclear(result);
-  printf("%s Orphaned records have been removed from clearing_decision_event table\n", countTuples);
+  printf("%s Orphaned records have been removed from clearing_event table\n", countTuples);
   fo_scheduler_heart(1);
 
   result = PQexecCheck(-203, SQL4, __FILE__, __LINE__);
   countTuples = PQcmdTuples(result);
   PQclear(result);
-  printf("%s Orphaned records have been removed from clearing_event table\n", countTuples);
+  printf("%s Orphaned records have been removed from clearing_decision_event table\n", countTuples);
   fo_scheduler_heart(1);
 
   result = PQexecCheck(-204, SQL5, __FILE__, __LINE__);


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Do not delete the global decisions while running the maintagent agent for orphan records.

### Changes

Changed the query that deletes the global license identification. added the check for global license.

## How to test

* Upload a package A to fossology.
* Do some clearing with the global decision i.e "Apply decision to all future occurrences of this file".
* Upload the package A(duplicate) again.
* Delete the The package A(original).
* Now go to admin-> Maintenance and Run all Maintenance jobs.
* Go to package A(duplicate) and check the clearing decisions.
* All the global decisions applied should exists.

closes #1291 
