### PR TITLE
feat(copyright): Show text findings in copyright-hist

### DIFF
--- a/src/copyright/ui/HistogramBase.php
+++ b/src/copyright/ui/HistogramBase.php
@@ -76,16 +76,18 @@ abstract class HistogramBase extends FO_Plugin {
     $typeDescriptor = "";
     if($type !== "statement")
     {
-      $typeDescriptor = $type;
+      $typeDescriptor = $description;
     }
     $output = "<h4>Activated $typeDescriptor statements:</h4>
                <div><table border=1 width='100%' id='copyright".$type."'></table></div>
                <br/><br/>
                <div>
-                Replace: <input type='text' id='replaceText' style='width:80%'>
-                <br/><br/>
-                <a style='cursor: pointer; margin-left:10px;' id='replaceSelected".$type."' class='buttonLink'>Mark selected rows for replace</a>
-                <a style='cursor: pointer; margin-left:10px;' id='deleteSelected".$type."' class='buttonLink'>Mark selected rows for deletion</a>
+                 <span>
+                   Replace: <input type='text' id='replaceText".$type."' style='width:80%'>
+                 </span>
+               <br/><br/>
+               <a style='cursor: pointer; margin-left:10px;' id='replaceSelected".$type."' class='buttonLink'>Mark selected rows for replace</a>
+               <a style='cursor: pointer; margin-left:10px;' id='deleteSelected".$type."' class='buttonLink'>Mark selected rows for deletion</a>
                <br/><br/>
                <h4>Deactivated $typeDescriptor statements:</h4>
                </div>

--- a/src/copyright/ui/TextFindingsAjax.php
+++ b/src/copyright/ui/TextFindingsAjax.php
@@ -1,0 +1,389 @@
+<?php
+/**
+ * *********************************************************
+ * Copyright (C) 2019 Siemens AG
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *********************************************************
+ */
+namespace Fossology\Agent\Copyright\UI;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\CopyrightDao;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\Util\DataTablesUtility;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use CopyrightHistogram;
+
+/**
+ * @class TextFindingsAjax
+ * @brief Handles Ajax requests for text findings
+ */
+class TextFindingsAjax
+{
+  /** @var string $uploadtree_tablename
+   * Upload tree to be used
+   */
+  private $uploadtree_tablename;
+  /** @var DbManager $dbManager
+   * DbManager object
+   */
+  private $dbManager;
+  /** @var $uploadDao
+   * UploadDao UploadDao object
+   */
+  private $uploadDao;
+  /** @var CopyrightDao $copyrightDao
+   * CopyrightDao object
+   */
+  private $copyrightDao;
+  /** @var DataTablesUtility $dataTablesUtility
+   * DataTablesUtility object
+   */
+  private $dataTablesUtility;
+
+  function __construct($uploadTreeTableName)
+  {
+    global $container;
+    $this->dataTablesUtility = $container->get('utils.data_tables_utility');
+    $this->uploadDao = $container->get('dao.upload');
+    $this->dbManager = $container->get('db.manager');
+    $this->copyrightDao = $container->get('dao.copyright');
+    $this->uploadtree_tablename = $uploadTreeTableName;
+  }
+
+  /**
+   * @brief Handles GET request and create a JSON response
+   *
+   * Gets the text finding history for given upload and generate
+   * a JSONResponse using getTableData()
+   * @param string $type The text finding type ('copyright')
+   * @param int $upload Upload id to fetch results
+   * @param bool $activated True to get activated results, false for disabled
+   * @return JsonResponse JSON response for JavaScript
+   */
+  public function doGetData($type, $upload, $activated = true)
+  {
+    $item = GetParm("item", PARM_INTEGER);
+    $filter = GetParm("filter", PARM_STRING);
+    $listPage = $this->getViewName($type);
+
+    list ($aaData, $iTotalRecords, $iTotalDisplayRecords) = $this->getTableData(
+      $upload, $item, $type, $listPage, $filter, $activated);
+    return new JsonResponse(
+      array(
+        'sEcho' => intval($_GET['sEcho']),
+        'aaData' => $aaData,
+        'iTotalRecords' => $iTotalRecords,
+        'iTotalDisplayRecords' => $iTotalDisplayRecords
+      ));
+  }
+
+  /**
+   * @brief Get the text finding data and fill in expected format
+   * @param int $upload Upload id to get results from
+   * @param int $item Upload tree id of the item
+   * @param string $type The text finding type ('copyright')
+   * @param string $listPage Page slug to use
+   * @param string $filter Filter data from query
+   * @param boolean $activated True to get activated copyrights, else false
+   * @return array[][] Array of table data, total records in database, filtered
+   *         records
+   */
+  private function getTableData($upload, $item, $type, $listPage, $filter,
+    $activated = true)
+  {
+    list ($rows, $iTotalDisplayRecords, $iTotalRecords) = $this->getTextFindings(
+      $upload, $item, $type, $this->uploadtree_tablename, $filter, $activated);
+    $aaData = array();
+    if (! empty($rows)) {
+      $rw = $this->uploadDao->isEditable($upload, Auth::getGroupId());
+      foreach ($rows as $row) {
+        $aaData[] = $this->fillTableRow($row, $upload, $item, $type, $listPage,
+          $activated, $rw);
+      }
+    }
+
+    return array(
+      $aaData,
+      $iTotalRecords,
+      $iTotalDisplayRecords
+    );
+  }
+
+  /**
+   * @brief Get results from database and format for JSON
+   * @param int $upload_pk Upload id to get results from
+   * @param int $item Upload tree id of the item
+   * @param string $type The text finding type ('copyright')
+   * @param string $uploadTreeTableName Upload tree table to use
+   * @param string $filter Filter data from query
+   * @param boolean $activated True to get activated copyrights, else false
+   * @return array[][] Array of table records, filtered records, total records
+   */
+  protected function getTextFindings($upload_pk, $item, $type,
+    $uploadTreeTableName, $filter, $activated = true)
+  {
+    $offset = GetParm('iDisplayStart', PARM_INTEGER);
+    $limit = GetParm('iDisplayLength', PARM_INTEGER);
+
+    $tableName = $this->getTableName($type);
+    $orderString = $this->getOrderString();
+
+    list ($left, $right) = $this->uploadDao->getLeftAndRight($item,
+      $uploadTreeTableName);
+
+    if ($filter == "") {
+      $filter = "none";
+    }
+
+    $sql_upload = "";
+    if ('uploadtree_a' == $uploadTreeTableName) {
+      $sql_upload = " AND UT.upload_fk = $upload_pk ";
+    }
+
+    $join = "";
+    $filterQuery = "";
+    if ($filter == "nolic") {
+      $noLicStr = "No_license_found";
+      $voidLicStr = "Void";
+      $join = " INNER JOIN license_file AS LF on cp.pfile_fk = LF.pfile_fk ";
+      $filterQuery = " AND LF.rf_fk IN (" . "SELECT rf_pk FROM license_ref " .
+        "WHERE rf_shortname IN ('$noLicStr','$voidLicStr')) ";
+    }
+
+    $params = array(
+      $left,
+      $right
+    );
+
+    $filterParms = $params;
+    $searchFilter = $this->addSearchFilter($filterParms);
+    $unorderedQuery = "FROM $tableName AS cp " .
+      "INNER JOIN $uploadTreeTableName AS UT ON cp.pfile_fk = UT.pfile_fk " .
+      $join . "WHERE cp.textfinding != '' " .
+      "AND ( UT.lft BETWEEN  $1 AND  $2 ) " . "AND cp.is_enabled = " .
+      ($activated ? 'true' : 'false') . $sql_upload;
+    $totalFilter = $filterQuery . " " . $searchFilter;
+
+    $grouping = " GROUP BY hash ";
+
+    $countQuery = "SELECT count(*) FROM (SELECT hash $unorderedQuery $totalFilter $grouping) as K";
+    $iTotalDisplayRecordsRow = $this->dbManager->getSingleRow($countQuery,
+      $filterParms,
+      __METHOD__ . $tableName . ".count" . ($activated ? '' : '_deactivated'));
+    $iTotalDisplayRecords = $iTotalDisplayRecordsRow['count'];
+
+    $countAllQuery = "SELECT count(*) FROM (SELECT hash $unorderedQuery$grouping) as K";
+    $iTotalRecordsRow = $this->dbManager->getSingleRow($countAllQuery, $params,
+      __METHOD__, $tableName . "count.all" . ($activated ? '' : '_deactivated'));
+    $iTotalRecords = $iTotalRecordsRow['count'];
+
+    $range = "";
+    $filterParms[] = $offset;
+    $range .= ' OFFSET $' . count($filterParms);
+    $filterParms[] = $limit;
+    $range .= ' LIMIT $' . count($filterParms);
+
+    $sql = "SELECT textfinding, hash, count(*) as textfinding_count " .
+      $unorderedQuery . $totalFilter .
+      " GROUP BY textfinding, hash " . $orderString .
+      $range;
+    $statement = __METHOD__ . $filter . $tableName . $uploadTreeTableName .
+      ($activated ? '' : '_deactivated');
+    $this->dbManager->prepare($statement, $sql);
+    $result = $this->dbManager->execute($statement, $filterParms);
+    $rows = $this->dbManager->fetchAll($result);
+    $this->dbManager->freeResult($result);
+
+    return array(
+      $rows,
+      $iTotalDisplayRecords,
+      $iTotalRecords
+    );
+  }
+
+  /**
+   * @brief Create sorting string for database query
+   * @return string Sorting string
+   */
+  private function getOrderString()
+  {
+    $columnNamesInDatabase = array(
+      'textfinding_count',
+      'textfinding'
+    );
+
+    $defaultOrder = CopyrightHistogram::returnSortOrder();
+
+    return $this->dataTablesUtility->getSortingString($_GET,
+      $columnNamesInDatabase, $defaultOrder);
+  }
+
+  /**
+   * @brief Add filter on content
+   * @param[out] array $filterParams Parameters list for database query
+   * @return string Filter string for query
+   */
+  private function addSearchFilter(&$filterParams)
+  {
+    $searchPattern = GetParm('sSearch', PARM_STRING);
+    if (empty($searchPattern)) {
+      return '';
+    }
+    $filterParams[] = "%$searchPattern%";
+    return ' AND CP.content ilike $' . count($filterParams) . ' ';
+  }
+
+  /**
+   * @brief Helper to create action column for results
+   * @param string $hash   Unique hash of the decision
+   * @param int    $upload Upload id
+   * @param string $type   The text finding type ('copyright')
+   * @param boolean $activated True if content is activated, else false
+   * @param boolean $rw true if content is editable
+   * @return string
+   */
+  private function getTableRowAction($hash, $upload, $type, $activated = true,
+    $rw = true)
+  {
+    $ajaxType = $this->getDecisionTypeName($type);
+    if ($rw) {
+      $act = "<img";
+      if (! $activated) {
+        $act .= " hidden='true'";
+      }
+      $act .= " id='deleteHashDecision$ajaxType$hash' " .
+        "onClick='event.preventDefault();deleteHashDecision(\"$hash\",$upload,\"" .
+        $ajaxType . "\");' class=\"delete\" src=\"images/space_16.png\">";
+      $act .= "<span";
+      if ($activated) {
+        $act .= " hidden='true'";
+      }
+      $act .= " id='undoDeleteHashDecision$ajaxType$hash'> " .
+        "deactivated [<a href=\"#\" class='undo$type' " .
+        "onClick='event.preventDefault();undoHashDecision(\"$hash\",$upload,\"" .
+        $ajaxType . "\");return false;'>Undo</a>]</span>";
+      return $act;
+    }
+    if (! $activated) {
+      return "deactivated";
+    }
+    return "";
+  }
+
+  /**
+   * @brief Fill table content for JSON response
+   * @param array $row Result row from database
+   * @param int $upload Upload id
+   * @param int $item Upload tree id of the item
+   * @param string $type The text finding type ('copyright')
+   * @param string $listPage Page slug
+   * @param boolean $activated True to get activated results, false otherwise
+   * @return string[]
+   * @internal param boolean $normalizeString
+   */
+  private function fillTableRow($row, $upload, $item, $type, $listPage,
+    $activated = true, $rw = true)
+  {
+    $hash = $row['hash'];
+    $sql = "SELECT pfile_fk FROM " . $this->getTableName($type) .
+      " WHERE hash = $1;";
+    $statement = __METHOD__ . ".getPfiles";
+    $decisions = $this->dbManager->getRows($sql, [$hash], $statement);
+    $pfileIds = [];
+    foreach ($decisions as $decision) {
+      $pfileIds[] = $decision['pfile_fk'];
+    }
+    $output = array(
+      'DT_RowId' => $this->getDecisionTypeName($type) . ",$hash"
+    );
+
+    $link = "<a href='";
+    $link .= Traceback_uri();
+    $link .= "?mod=$listPage&agent=-1&item=$item" .
+      "&hash=$hash&type=$type&filter=all";
+    $link .= "'>". intval($row['textfinding_count']) . "</a>";
+    $output['0'] = $link;
+    $output['1'] = convertToUTF8($row['textfinding']);
+    $output['2'] = $this->getTableRowAction($hash, $upload, $type, $activated,
+      $rw);
+    if ($rw && $activated) {
+      $output['3'] = "<input type='checkbox' class='deleteBySelect$type' " .
+        "id='deleteBySelectfinding$hash' value='$hash,$upload," .
+        $this->getDecisionTypeName($type) . "'>";
+    } else {
+      $output['3'] = "";
+    }
+    return $output;
+  }
+
+  /**
+   * @brief Get table name based on decision type
+   *
+   * - copyFindings => copyright_decision
+   * @param string $type Result type
+   * @return string Table name
+   */
+  private function getTableName($type)
+  {
+    switch ($type) {
+      case "copyFindings":
+        $tableName = "copyright_decision";
+        break;
+      default:
+        $tableName = "copyright_decision";
+    }
+    return $tableName;
+  }
+
+  /**
+   * @brief Get type name for ajax calls based
+   *
+   * - copyFindings => copyright
+   * @param string $type Result type
+   * @return string Table name
+   */
+  private function getDecisionTypeName($type)
+  {
+    switch ($type) {
+      case "copyFindings":
+        $typeName = "copyright";
+        break;
+      default:
+        $typeName = "copyright";
+    }
+    return $typeName;
+  }
+
+  /**
+   * @brief Get name of view for links
+   *
+   * - copyFindings => copyright-view
+   * @param string $type Result type
+   * @return string View name
+   */
+  private function getViewName($type)
+  {
+    switch ($type) {
+      case "copyFindings":
+        $viewName = "copyright-list";
+        break;
+      default:
+        $viewName = "copyright-list";
+    }
+    return $viewName;
+  }
+}

--- a/src/copyright/ui/copyright-hist.php
+++ b/src/copyright/ui/copyright-hist.php
@@ -1,7 +1,7 @@
 <?php
 /***********************************************************
  * Copyright (C) 2010-2014 Hewlett-Packard Development Company, L.P.
- * Copyright (C) 2014-2017 Siemens AG
+ * Copyright (C) 2014-2017,2019 Siemens AG
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -45,14 +45,20 @@ class CopyrightHistogram extends HistogramBase {
    */
   protected function getTableContent($upload_pk, $uploadtreeId, $filter, $agentId)
   {
-    $type = 'statement';
-    $description = _("Copyright");
-
+    $typeDescriptionPairs = array(
+      'statement' => _("Agent Findings"),
+      'copyFindings' => _("User Findings")
+    );
     $tableVars = array();
     $output = array();
-    list($out, $vars) = $this->getTableForSingleType($type, $description, $upload_pk, $uploadtreeId, $filter, $agentId);
-    $tableVars[$type] = $vars;
-    $output[] = $out;
+    foreach($typeDescriptionPairs as $type=>$description)
+    {
+      list ($out, $vars) = $this->getTableForSingleType($type, $description,
+        $upload_pk, $uploadtreeId, $filter, $agentId);
+      $tableVars[$type] = $vars;
+      $output[] = $out;
+    }
+
     $output[] = $tableVars;
     return $output;
   }
@@ -64,10 +70,15 @@ class CopyrightHistogram extends HistogramBase {
    */
   protected function fillTables($upload_pk, $Uploadtree_pk, $filter, $agentId, $VF)
   {
-    list($VCopyright, $tableVars) = $this->getTableContent($upload_pk, $Uploadtree_pk, $filter, $agentId);
+    list ($vCopyright, $vTextFindings, $tableVars) = $this->getTableContent(
+      $upload_pk, $Uploadtree_pk, $filter, $agentId);
 
     $out = $this->renderString('copyrighthist_tables.html.twig',
-            array('contCopyright'=>$VCopyright, 'fileList'=>$VF));
+      array(
+        'contCopyright' => $vCopyright,
+        'contTextFindings' => $vTextFindings,
+        'fileList' => $VF
+      ));
     return array($out, $tableVars);
   }
 
@@ -85,12 +96,12 @@ class CopyrightHistogram extends HistogramBase {
     {
       if (GetParm("mod",PARM_STRING) == $this->Name)
       {
-        menu_insert("Browse::Copyright",10);
+        menu_insert("Browse::Copyright agent/user findings",10);
         menu_insert("Browse::[BREAK]",100);
       }
       else
       {
-        $text = _("View copyright histogram");
+        $text = _("View copyright agent/user findings histogram");
         menu_insert("Browse::Copyright",10,$URI,$text);
       }
     }
@@ -104,9 +115,21 @@ class CopyrightHistogram extends HistogramBase {
   {
     return "
 
+    var copyrightTabCookie = 'stickyCopyrightTab';
+
     $(document).ready(function() {
       tableCopyright =  createTablestatement();
-    } );
+      tableFindings = createPlainTablecopyFindings();
+      $('#copyrightFindingsTabs').tabs({
+        active: ($.cookie(copyrightTabCookie) || 0),
+        activate: function(e, ui){
+          // Get active tab index and update cookie
+          var idString = $(e.currentTarget).attr('id');
+          idString = parseInt(idString.slice(-1)) - 1;
+          $.cookie(copyrightTabCookie, idString);
+        }
+      });
+    });
     ";
   }
 

--- a/src/copyright/ui/email-hist.php
+++ b/src/copyright/ui/email-hist.php
@@ -107,11 +107,21 @@ class EmailHistogram extends HistogramBase {
   {
     return "
 
+    var emailTabCookie = 'stickyEmailTab';
+
     $(document).ready(function() {
       tableEmail = createTableemail();
       tableUrl = createTableurl();
       tableAuthor = createTableauthor();
-      $(\"#EmailUrlAuthorTabs\").tabs();
+      $(\"#EmailUrlAuthorTabs\").tabs({
+        active: ($.cookie(emailTabCookie) || 0),
+        activate: function(e, ui){
+          // Get active tab index and update cookie
+          var idString = $(e.currentTarget).attr('id');
+          idString = parseInt(idString.slice(-1)) - 1;
+          $.cookie(emailTabCookie, idString);
+        }
+      });
     });
     ";
   }

--- a/src/copyright/ui/list.php
+++ b/src/copyright/ui/list.php
@@ -101,17 +101,33 @@ class copyright_list extends FO_Plugin
     $lft = $row["lft"];
     $rgt = $row["rgt"];
     $upload_pk = $row["upload_fk"];
+    $params = [];
 
-    /* get all the copyright records for this uploadtree.  */
-    $sql = "SELECT content, type, uploadtree_pk, ufile_name, PF
-              from $tableName,
-              (SELECT uploadtree_pk, pfile_fk as PF, ufile_name from uploadtree
-                 where upload_fk=$1
-                   and uploadtree.lft BETWEEN $2 and $3) as SS
-              where PF=pfile_fk and agent_fk=$4 and hash=$5 and type=$6 order by uploadtree_pk";
+    if ($type == "copyFindings") {
+      $sql = "SELECT textfinding AS content, '$type' AS type, uploadtree_pk, ufile_name, PF
+              FROM $tableName,
+              (SELECT uploadtree_pk, pfile_fk AS PF, ufile_name FROM uploadtree
+                 WHERE upload_fk=$1
+                   AND uploadtree.lft BETWEEN $2 AND $3) AS SS
+              WHERE PF=pfile_fk AND hash=$4 ORDER BY uploadtree_pk";
+      $params = [
+        $upload_pk, $lft, $rgt, $hash
+      ];
+    } else {
+      /* get all the copyright records for this uploadtree.  */
+      $sql = "SELECT content, type, uploadtree_pk, ufile_name, PF
+                FROM $tableName,
+                (SELECT uploadtree_pk, pfile_fk AS PF, ufile_name FROM uploadtree
+                   WHERE upload_fk=$1
+                     AND uploadtree.lft BETWEEN $2 AND $3) AS SS
+                WHERE PF=pfile_fk AND agent_fk=$4 AND hash=$5 AND type=$6 ORDER BY uploadtree_pk";
+      $params = [
+        $upload_pk, $lft, $rgt, $Agent_pk, $hash, $type
+      ];
+    }
     $statement = __METHOD__.$tableName;
     $this->dbManager->prepare($statement, $sql);
-    $result = $this->dbManager->execute($statement,array($upload_pk, $lft, $rgt, $Agent_pk, $hash, $type));
+    $result = $this->dbManager->execute($statement,$params);
 
     $rows = $this->dbManager->fetchAll($result);
     $this->dbManager->freeResult($result);
@@ -255,7 +271,7 @@ class copyright_list extends FO_Plugin
     $filter = GetParm("filter",PARM_RAW);
     if (empty($uploadtree_pk) || empty($hash) || empty($type) || empty($agent_pk))
     {
-      $this->vars['pageContent'] = $this->Name . _("is missing required parameters");
+      $this->vars['pageContent'] = $this->Name . _(" is missing required parameters");
       return;
     }
 
@@ -314,6 +330,8 @@ class copyright_list extends FO_Plugin
         case "keyword":
           $TypeStr = _("Keyword Analysis");
           break;
+        case "copyFindings":
+          $TypeStr = _("User Findings");
       }
       $OutBuf .= "$NumInstances $TypeStr instances found in $RowCount  $text";
 
@@ -423,6 +441,11 @@ class copyright_list extends FO_Plugin
         break;
       case "statement" :
         $tableName = "copyright";
+        $modBack = "copyright-hist";
+        $viewName = "copyright-view";
+        break;
+      case "copyFindings" :
+        $tableName = "copyright_decision";
         $modBack = "copyright-hist";
         $viewName = "copyright-view";
         break;

--- a/src/copyright/ui/template/copyrighthist.html.twig
+++ b/src/copyright/ui/template/copyrighthist.html.twig
@@ -13,6 +13,7 @@
   <script src="scripts/jquery.dataTables.select.js" type="text/javascript"></script>
   <script src="scripts/jquery.jeditable.js" type="text/javascript"></script>
   <script src="scripts/jquery.validate.js" type="text/javascript"></script>
+  <script src="scripts/jquery.cookie.js" type="text/javascript"></script>
 
   {% include "copyrighthist_scripts.html.twig" %}
   <script language="javascript">

--- a/src/copyright/ui/template/copyrighthist_scripts.html.twig
+++ b/src/copyright/ui/template/copyrighthist_scripts.html.twig
@@ -5,5 +5,39 @@
     window.location.assign("?mod={{ name }}&upload=" + upload + "&item=" + item + "&filter=" + filter);
   }
 
+  function deleteHashDecision(hash, upload, type) {
+    $.ajax({
+      type: 'POST',
+      dataType: 'json',
+      url: '?mod=ajax-copyright-hist&action=deleteHashDecision&type=' + type,
+      data: {
+        'hash': hash,
+        'upload': upload
+      },
+      success: function(data) {
+        $("#deleteHashDecision" + type + hash).hide();
+        $("#undoDeleteHashDecision" + type + hash).show();
+      },
+      error: function() { alert('error'); }
+    });
+  }
+
+  function undoHashDecision(hash, upload, type) {
+    $.ajax({
+      type: 'POST',
+      dataType: 'json',
+      url: '?mod=ajax-copyright-hist&action=undoHashDecision&type=' + type,
+      data: {
+        'hash': hash,
+        'upload': upload
+      },
+      success: function(data) {
+        $("#undoDeleteHashDecision" + type + hash).hide();
+        $("#deleteHashDecision" + type + hash).show();
+      },
+      error: function() { alert('error'); }
+    });
+  }
+
   {{ scriptBlock }}
 </script>

--- a/src/copyright/ui/template/copyrighthist_tables.html.twig
+++ b/src/copyright/ui/template/copyrighthist_tables.html.twig
@@ -1,4 +1,4 @@
-{# Copyright 2014-2017 Siemens AG
+{# Copyright 2014-2017,2019 Siemens AG
 
    Copying and distribution of this file, with or without modification,
    are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
@@ -7,8 +7,18 @@
 <table border="0" width="100%">
 <tr>
   <td valign="top">
-    {{ contCopyright }}
-    <br/>
+    <div id="copyrightFindingsTabs" style="padding-bottom:2em">
+      <ul>
+        <li><a href="#copyrightTab">Agent Findings</a></li>
+        <li><a href="#textFindingsTab">User Findings</a></li>
+      </ul>
+      <div id="copyrightTab">
+        {{ contCopyright }}
+      </div>
+      <div id="textFindingsTab">
+        {{ contTextFindings }}
+      </div>
+    </div>
   </td>
   <td valign="top">{{ fileList }}</td>
 </tr>

--- a/src/copyright/ui/template/emailhist_tables.html.twig
+++ b/src/copyright/ui/template/emailhist_tables.html.twig
@@ -7,7 +7,7 @@
 <table border="0" width="100%">
 <tr>
   <td valign="top">
-    <div id="EmailUrlAuthorTabs">
+    <div id="EmailUrlAuthorTabs" style="padding-bottom:2em">
       <ul>
         <li><a href="#EmailTab">Email</a></li>
         <li><a href="#UrlTab">URL</a></li>

--- a/src/copyright/ui/template/histTable.js.twig
+++ b/src/copyright/ui/template/histTable.js.twig
@@ -88,17 +88,82 @@ function createTable{{ table.type }}() {
   });
 
   $('#replaceSelected{{ table.type }}').click(function () {
+    var replaceText = $('#replaceText{{ table.type }}').val().trim();
+    var replaceIsValid = (replaceText) && !(/^\s*$/.test(replaceText));
+    if(replaceIsValid){
+      $("input:checkbox[class=deleteBySelect{{ table.type }}]:checked").each(function () {
+        currentValue = $(this).val();
+        var currUploadData = currentValue.split(',');
+        updateRows{{ table.type }}(currUploadData[0], currUploadData[1], currUploadData[2], currUploadData[3], replaceText);
+      });
+      location.reload(true);
+    }
+  });
+
+  return enabledTable;
+}
+
+function createPlaneTableBase{{ table.type }}(activated) {
+  var aoColumns = [
+      { "sTitle": "{{ 'Count'| trans }}", "sClass": "right read_only", "sWidth": "5%" },
+      { "sTitle": "{{ table.description }}", "sClass": "left"},
+      { "sTitle": "", "sClass": "center read_only", "sWidth": "10%", "bSortable": false }
+    ];
+  if (activated)
+  {
+    var id = '#copyright{{ table.type }}';
+    var action = 'getData'
+    aoColumns = aoColumns.concat([
+      { "sTitle": "<input type='checkbox' name='selectDelete{{ table.type }}' id='selectDelete{{ table.type }}' style='margin-left:11px'>", "sClass": "center read_only", "sWidth": "5%", "bSortable": false }
+    ]);
+  }
+  else
+  {
+    var id = '#copyright{{ table.type }}deactivated';
+    var action = 'getDeactivatedData'
+  }
+
+  return $(id).dataTable({
+    "bServerSide": true,
+    "sAjaxSource": "?mod=ajax-copyright-hist&action=" + action,
+    "fnServerData": function (sSource, aoData, fnCallback) {
+      aoData.push({ "name":"upload", "value": "{{ table.uploadId }}" });
+      aoData.push({ "name":"item", "value": "{{ table.uploadTreeId }}" });
+      aoData.push({ "name":"type", "value": "{{ table.type }}" });
+      aoData.push({ "name":"filter", "value": "{{ table.filter }}" });
+      $.getJSON(sSource, aoData, fnCallback).fail(function() {
+        if (confirm("You are not logged in. Go to login page?"))
+          window.location.href = "?mod=auth";
+      });
+    },
+    "sPaginationType": "listbox",
+    "aoColumns": aoColumns,
+    "aaSorting": {{ table.sorting }},
+    "iDisplayLength": 50,
+    "bProcessing": true,
+    "bStateSave": true,
+    "bRetrieve": true
+  });
+}
+
+function createPlainTable{{ table.type }}() {
+  var enabledTable = createPlaneTableBase{{ table.type }}(true);
+  createPlaneTableBase{{ table.type }}(false);
+
+  $('#selectDelete{{ table.type }}').change(function () {
+    $('.deleteBySelect{{ table.type }}').prop('checked', $(this).prop("checked"));
+  });
+
+  $('#deleteSelected{{ table.type }}').click(function () {
     $("input:checkbox[class=deleteBySelect{{ table.type }}]:checked").each(function () {
       currentValue = $(this).val();
       var currUploadData = currentValue.split(',');
-      var replaceText = $('#replaceText').val().trim();
-      var replaceIsValid = (replaceText) && !(/^\s*$/.test(replaceText));
-      if(replaceIsValid){
-        updateRows{{ table.type }}(currUploadData[0], currUploadData[1], currUploadData[2], currUploadData[3], replaceText);
-      }
+      deleteHashDecision(currUploadData[0], currUploadData[1], currUploadData[2]);
     });
-    location.reload(true);
   });
+
+  $('#replaceText{{ table.type }}').parent().remove();
+  $('#replaceSelected{{ table.type }}').remove();
 
   return enabledTable;
 }

--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -111,17 +111,32 @@ class CopyrightDao
   public function saveDecision($tableName, $pfileId, $userId , $clearingType,
                                $description, $textFinding, $comment, $decision_pk=-1)
   {
-    $assocParams = array('user_fk' => $userId, 'pfile_fk' => $pfileId,
-      'clearing_decision_type_fk' => $clearingType, 'description' => $description,
-      'textfinding' => $textFinding, 'hash' => hash('sha256', $textFinding),
-      'comment'=>$comment);
+    $primaryColumn = $tableName . '_pk';
+    $assocParams = array(
+      'user_fk' => $userId,
+      'pfile_fk' => $pfileId,
+      'clearing_decision_type_fk' => $clearingType,
+      'description' => $description,
+      'textfinding' => $textFinding,
+      'hash' => hash('sha256', $textFinding),
+      'comment'=> $comment
+    );
+
     if ($decision_pk <= 0) {
-      $primaryColumn = $tableName . '_pk';
-      return $this->dbManager->insertTableRow($tableName, $assocParams, __METHOD__.'Insert.'.$tableName, $primaryColumn);
+      $rows = $this->getDecisionsFromHash($tableName, $assocParams['hash']);
+      foreach ($rows as $row) {
+        if ($row['pfile_fk'] == $pfileId) {
+          $decision_pk = $row[$primaryColumn];
+        }
+      }
+    }
+    if ($decision_pk <= 0) {
+      return $this->dbManager->insertTableRow($tableName, $assocParams,
+        __METHOD__.'Insert.'.$tableName, $primaryColumn);
     } else {
       $assocParams['is_enabled'] = true;
-      $primaryColumn = $tableName . '_pk';
-      $this->dbManager->updateTableRow($tableName, $assocParams, $primaryColumn, $decision_pk, __METHOD__.'Update.'.$tableName);
+      $this->dbManager->updateTableRow($tableName, $assocParams, $primaryColumn,
+        $decision_pk, __METHOD__.'Update.'.$tableName);
       return $decision_pk;
     }
   }
@@ -345,6 +360,43 @@ class CopyrightDao
     $orderTablePk = $tableName.'_pk';
     $sql = "SELECT * FROM $tableName where pfile_fk = $1 and is_enabled order by $orderTablePk desc";
     $params = array($pfileId);
+
+    return $this->dbManager->getRows($sql, $params, $statementName);
+  }
+
+  /**
+   * @brief Get all the decisions based on hash
+   *
+   * Get all the decisions which matches the given hash. If the upload is null,
+   * get decision from all uploads, otherwise get decisions only for the given
+   * upload.
+   *
+   * @param string $tableName Decision table name
+   * @param string $hash      Hash of the decision
+   * @param int    $upload    Upload id
+   * @param string $uploadtreetable Name of the upload tree table
+   * @return array
+   */
+  public function getDecisionsFromHash($tableName, $hash, $upload = null, $uploadtreetable = null)
+  {
+    $statementName = __METHOD__ . ".$tableName";
+    $orderTablePk = $tableName.'_pk';
+    $join = "";
+    $joinWhere = "";
+    $params = [$hash];
+
+    if ($upload != null) {
+      if (empty($uploadtreetable)) {
+        return -1;
+      }
+      $statementName.= ".filterUpload";
+      $params[] = $upload;
+      $join = "INNER JOIN $uploadtreetable AS ut ON cp.pfile_fk = ut.pfile_fk";
+      $joinWhere = "AND ut.upload_fk = $" . count($params);
+    }
+
+    $sql = "SELECT * FROM $tableName AS cp $join " .
+      "WHERE cp.hash = $1 $joinWhere ORDER BY $orderTablePk;";
 
     return $this->dbManager->getRows($sql, $params, $statementName);
   }

--- a/src/lib/php/Dao/UploadDao.php
+++ b/src/lib/php/Dao/UploadDao.php
@@ -71,6 +71,23 @@ class UploadDao
   }
 
   /**
+   * Get the first entry for uploadtree_pk for a given pfile in a given upload.
+   * @param integer $uploadFk Upload id
+   * @param integer $pfileFk  Pfile id
+   * @return integer Uploadtree_pk
+   */
+  public function getUploadtreeIdFromPfile($uploadFk, $pfileFk)
+  {
+    $uploadTreeTableName = $this->getUploadtreeTableName($uploadFk);
+    $stmt = __METHOD__ . ".$uploadTreeTableName";
+    $uploadEntry = $this->dbManager->getSingleRow("SELECT uploadtree_pk " .
+      "FROM $uploadTreeTableName " .
+      "WHERE upload_fk = $1 AND pfile_fk = $2",
+      array($uploadFk, $pfileFk), $stmt);
+    return intval($uploadEntry['uploadtree_pk']);
+  }
+
+  /**
    * @param int $uploadId
    * @return Upload|null
    */


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Show the text findings done manually by the user in `copyright-hist` view in the UI.

### Changes

1. Create new functions to create a simple table (without edit capabilities) to show text findings.
1. Create new class to handle ajax call to create such tables.

## How to test

1. Browse some files for a given upload and add copyright text findings for some files.
1. Browse `mod=copyright-hist` for the same upload.
    1. You should get two tabs for **Copyrights** and **Text findings**.
    1. **Text findings** tab should show the findings added above.
1. Deactivating the text findings should work.
1. The link to goto file should take you to proper file.

At the same time, other views (URL, ECC, Keywords, etc.) should not be effected.