### PR TITLE
fix(apache): Add rewrite string to apache conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,6 @@ RUN /fossology/install/scripts/php-conf-fix.sh --overwrite
 # configure apache
 COPY ./install/src-install-apache-example.conf /etc/apache2/conf-available/fossology.conf
 RUN a2enconf fossology.conf \
- && a2enmod rewrite \
  && mkdir -p /var/log/apache2/ \
  && ln -sf /proc/self/fd/1 /var/log/apache2/access.log \
  && ln -sf /proc/self/fd/1 /var/log/apache2/error.log

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,7 +52,6 @@ sudo /usr/local/lib/fossology/fo-postinstall
 
 sudo cp /fossology/install/src-install-apache-example.conf /etc/apache2/conf-available/fossology.conf
 sudo a2enconf fossology.conf
-sudo a2enmod rewrite
 
 # increase upload size
 sudo /fossology/install/scripts/php-conf-fix.sh --overwrite

--- a/install/fo-apache.conf
+++ b/install/fo-apache.conf
@@ -5,7 +5,15 @@ Alias /repo /usr/share/fossology/www/ui
 <Directory "/usr/share/fossology/www/ui">
 	AllowOverride None
 	Options FollowSymLinks MultiViews
-	
+
+    <IfModule mod_rewrite.c>
+        RewriteEngine on
+        RewriteCond %{REQUEST_FILENAME} !-d
+        RewriteCond %{REQUEST_FILENAME} !-f
+        RewriteRule "^api/(.*)" "/repo/api/index.php" [QSA,L]
+        RewriteRule .* - [env=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+    </IfModule>
+
     <IfVersion < 2.3>
         order allow,deny
         allow from all

--- a/install/fo-postinstall.in
+++ b/install/fo-postinstall.in
@@ -285,6 +285,21 @@ if [[ $WEBONLY ]]; then
      usermod --groups $PROJECTGROUP --append apache
    fi
 
+   # Enable mod_rewrite for REST API
+   if [[ -f /etc/httpd/conf.modules.d/00-base.conf ]]; then
+     # We are on RHEL
+     if ! egrep -q "^LoadModule rewrite_module modules/mod_rewrite.so" /etc/httpd/conf.modules.d/00-base.conf; then
+       echo "NOTE: Enabling apache module rewrite"
+       echo "LoadModule rewrite_module modules/mod_rewrite.so" >> /etc/httpd/conf.modules.d/00-base.conf
+       systemctl restart httpd
+     fi
+   else
+     # We are on Debian
+     echo "NOTE: Enabling apache module rewrite"
+     a2enmod rewrite
+     apachectl restart
+   fi
+
    # apache2 reload is only necessary when it is running.
    if /etc/init.d/apache2 status > /dev/null; then
      /etc/init.d/apache2 reload


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The rewrite string for Debian packaging's apache conf was missing for the REST API.

### Changes

Added the missing rewrite rule for FOSSology's apache conf file.

## How to test

1. Build and install the Debian package.
1. Check if the REST API can be used.