### PR TITLE
chore(docker): bump docker base image to stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 #
 # Description: Docker container image recipe
 
-FROM debian:jessie-slim as builder
+FROM debian:stretch-slim as builder
 
 LABEL maintainer="Fossology <fossology@fossology.org>"
 
@@ -19,7 +19,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       git \
       lsb-release \
-      php5-cli \
+      php7.0-cli \
       sudo \
  && rm -rf /var/lib/apt/lists/*
 
@@ -48,7 +48,7 @@ RUN /fossology/utils/install_composer.sh
 RUN make install clean
 
 
-FROM debian:jessie-slim
+FROM debian:stretch-slim
 
 LABEL maintainer="Fossology <fossology@fossology.org>"
 

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -105,11 +105,11 @@ if [[ $BUILDTIME ]]; then
             build-essential libtext-template-perl subversion rpm librpm-dev libmagic-dev libglib2.0 libboost-regex-dev libboost-program-options-dev
          case "$CODENAME" in
            xenial)
-             apt-get $YesOpt install php-mbstring;;
+             apt-get $YesOpt install php-mbstring php7.0-zip;;
            stretch|buster|sid)
-             apt-get $YesOpt install php-mbstring php7.0-xml;;
+             apt-get $YesOpt install php-mbstring php7.0-xml php7.0-zip;;
            bionic)
-             apt-get $YesOpt install php-mbstring php7.2-xml;;
+             apt-get $YesOpt install php-mbstring php7.2-xml php7.2-zip;;
            *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
          esac
          if ! dpkg --get-selections | grep -q postgresql-server-dev; then  ## if postgresql-server-dev is not installed

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -104,8 +104,13 @@ if [[ $BUILDTIME ]]; then
             libmxml-dev curl libxml2-dev libcunit1-dev \
             build-essential libtext-template-perl subversion rpm librpm-dev libmagic-dev libglib2.0 libboost-regex-dev libboost-program-options-dev
          case "$CODENAME" in
-           xenial|stretch|buster|sid|bionic)
+           xenial)
              apt-get $YesOpt install php-mbstring;;
+           stretch|buster|sid)
+             apt-get $YesOpt install php-mbstring php7.0-xml;;
+           bionic)
+             apt-get $YesOpt install php-mbstring php7.2-xml;;
+           *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
          esac
          if ! dpkg --get-selections | grep -q postgresql-server-dev; then  ## if postgresql-server-dev is not installed
            case "$CODENAME" in


### PR DESCRIPTION
## Description

Bump docker base image from jessie to stretch, to get rid of the php-5 dependency as suggested on the mailing list by @NicolasToussaint.

## How to test

test the docker image