### PR TITLE
chore(fo-installdeps): drop unsupported distros

### DIFF
--- a/src/copyright/mod_deps
+++ b/src/copyright/mod_deps
@@ -75,7 +75,7 @@ CODENAME=$(lsb_release --codename --short)
 if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu|LinuxMint)
+    Debian|Ubuntu)
       apt-get $YesOpt install \
         libjsoncpp-dev
       ;;
@@ -97,7 +97,7 @@ if [[ $RUNTIME ]]; then
   case "$DISTRO" in
     Debian|Ubuntu)
       case "$CODENAME" in
-        jessie|trusty)
+        jessie)
           apt-get $YesOpt install libjsoncpp0;;
         stretch|buster|sid|artful|bionic|xenial|cosmic)
           apt-get $YesOpt install libjsoncpp1;;

--- a/src/delagent/mod_deps
+++ b/src/delagent/mod_deps
@@ -74,7 +74,7 @@ DISTRO=$(lsb_release --id --short)
 if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu|LinuxMint)
+    Debian|Ubuntu)
       apt-get $YesOpt install \
         libssl-dev
       ;;

--- a/src/mimetype/mod_deps
+++ b/src/mimetype/mod_deps
@@ -74,7 +74,7 @@ DISTRO=$(lsb_release --id --short)
 if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu|LinuxMint)
+    Debian|Ubuntu)
       apt-get $YesOpt install \
         libmagic-dev
       ;;
@@ -88,7 +88,7 @@ fi
 if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu|LinuxMint)
+    Debian|Ubuntu)
       apt-get $YesOpt install \
         libmagic1
       ;;

--- a/src/nomos/mod_deps
+++ b/src/nomos/mod_deps
@@ -75,7 +75,7 @@ CODENAME=$(lsb_release --codename --short)
 if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu|LinuxMint)
+    Debian|Ubuntu)
       apt-get $YesOpt install \
         libjson-c-dev
       ;;
@@ -92,7 +92,7 @@ if [[ $RUNTIME ]]; then
   case "$DISTRO" in
     Debian|Ubuntu)
       case "$CODENAME" in
-        jessie|trusty|xenial)
+        jessie|xenial)
           apt-get $YesOpt install libjson-c2;;
         stretch|buster|sid|bionic|cosmic)
           apt-get $YesOpt install libjson-c3;;

--- a/src/pkgagent/mod_deps
+++ b/src/pkgagent/mod_deps
@@ -74,7 +74,7 @@ DISTRO=$(lsb_release --id --short)
 if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu|LinuxMint)
+    Debian|Ubuntu)
       apt-get $YesOpt install \
         librpm-dev
       ;;
@@ -88,7 +88,7 @@ fi
 if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu|LinuxMint)
+    Debian|Ubuntu)
       apt-get $YesOpt install \
         rpm
       ;;

--- a/src/scheduler/mod_deps
+++ b/src/scheduler/mod_deps
@@ -74,7 +74,7 @@ DISTRO=$(lsb_release --id --short)
 if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu|LinuxMint)
+    Debian|Ubuntu)
       apt-get $YesOpt install \
         libglib2.0-dev
       ;;
@@ -89,7 +89,7 @@ fi
 if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu|LinuxMint)
+    Debian|Ubuntu)
       apt-get $YesOpt install \
         libglib2.0-0
       ;;

--- a/src/ununpack/mod_deps
+++ b/src/ununpack/mod_deps
@@ -78,7 +78,7 @@ fi
 if [ $RUNTIME ]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu|LinuxMint)
+    Debian|Ubuntu)
       apt-get $YesOpt install \
         bzip2 cabextract cpio genisoimage p7zip poppler-utils rpm tar upx-ucl unzip gzip sleuthkit p7zip-full unrar-free
       ;;

--- a/src/wget_agent/mod_deps
+++ b/src/wget_agent/mod_deps
@@ -78,7 +78,7 @@ fi
 if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu|LinuxMint)
+    Debian|Ubuntu)
       apt-get $YesOpt install \
         subversion git wget
       ;;

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -98,7 +98,7 @@ echo "install core dependencies"
 if [[ $BUILDTIME ]]; then
    echo "*** Installing $DISTRO buildtime dependencies ***";
    case "$DISTRO" in
-      Debian|Ubuntu|LinuxMint)
+      Debian|Ubuntu)
          echo "DB: Installing build essential....."
          apt-get $YesOpt install \
             libmxml-dev curl libxml2-dev libcunit1-dev \
@@ -113,8 +113,6 @@ if [[ $BUILDTIME ]]; then
          esac
          if ! dpkg --get-selections | grep -q postgresql-server-dev; then  ## if postgresql-server-dev is not installed
            case "$CODENAME" in
-              trusty)
-                apt-get $YesOpt install postgresql-server-dev-9.3;;
               jessie)
                 apt-get $YesOpt install postgresql-server-dev-9.4;;
               xenial)
@@ -154,7 +152,7 @@ if [[ $RUNTIME ]]; then
    echo "*** installed. Consult with your system administrator. Or try ***";
    echo "*** apt-get install mail-transport-agent, pick one and install it***";
    case "$DISTRO" in
-      Debian|Ubuntu|LinuxMint)
+      Debian|Ubuntu)
         echo "doing runtime"
          apt-get $YesOpt install apache2
          apt-get $YesOpt install php-pear \
@@ -166,8 +164,6 @@ if [[ $RUNTIME ]]; then
             subversion git \
             dpkg-dev
          case "$CODENAME" in
-            trusty)
-               apt-get $YesOpt install postgresql-9.3 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl heirloom-mailx libboost-program-options1.54.0 libboost-regex1.54.0;;
             jessie)
                apt-get $YesOpt install postgresql-9.4 libapache2-mod-php5 php5 php5-pgsql php5-cli php5-curl heirloom-mailx libboost-program-options1.55.0 libboost-regex1.55.0;;
             xenial)


### PR DESCRIPTION
Drop distros from `fo-installdeps.sh` which only support php <5.6. They are no longer supported and should not be listed in the script. This especially affects trusty support.