### PR TITLE
Refactor Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,6 +137,7 @@ jobs:
 #### PHPUnit tests ###########################
     - &phpunit-tests
       php: 5.6
+      addon: {}
       install: composer install --prefer-dist --working-dir=src
       before_script: ./utils/prepare-test -afty
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ addons:
 services: postgresql
 
 jobs:
+  fast_finish: true
   include:
     - name: Syntax Check
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,6 +147,9 @@ jobs:
     - &php7-phpunit-tests
       <<: *phpunit-tests
       php: 7.0
+      script:
+        - make build-lib VERSIONFILE build-cli
+        - phpdbg -qrr src/vendor/bin/phpunit -csrc/phpunit.xml --testsuite="Fossology PhpUnit Test Suite" --colors=always | grep -v 'script>\|c.log'
     - &php71-phpunit-tests
       <<: *php7-phpunit-tests
       php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,10 +82,14 @@ jobs:
       install:
         - composer install --prefer-dist --working-dir=src
         - ./install/scripts/install-spdx-tools.sh
+        - sudo /usr/sbin/update-ccache-symlinks
+        - ls /usr/lib/ccache/
       before_script: &default-before-script
         ./utils/prepare-test -afty
       script:
         - make test
+      after_success:
+        - ccache -s
     - <<: *compiler-tests
       env: CC=gcc-5 CXX=g++-5 CFLAGS='-Wall'
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ jobs:
       script:
         - make build-lib VERSIONFILE build-cli
         - src/vendor/bin/phpunit -csrc/phpunit.xml --testsuite="Fossology PhpUnit Test Suite"
-      after_success: php src/vendor/bin/php-coveralls -vv -x clover.xml
+      after_success: php src/vendor/bin/php-coveralls -vv -o coveralls.json -x clover.xml
     - &php7-phpunit-tests
       <<: *phpunit-tests
       php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ jobs:
       script:
         - make build-lib VERSIONFILE build-cli
         - src/vendor/bin/phpunit -csrc/phpunit.xml --testsuite="Fossology PhpUnit Test Suite"
-      after_success: php src/vendor/bin/coveralls -vv -x clover.xml
+      after_success: php src/vendor/bin/php-coveralls -vv -x clover.xml
     - &php7-phpunit-tests
       <<: *phpunit-tests
       php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,12 @@ dist: trusty
 php: 7.0
 cache:
   ccache: true
+  directories:
+    - $HOME/.composer
 env:
   global:
     - PATH="/usr/lib/ccache/:$PATH"
+    - COMPOSER_HOME="$HOME/.composer/"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@
 language: php
 dist: trusty
 php: 7.0
+cache:
+  ccache: true
+env:
+  global:
+    - PATH="/usr/lib/ccache/:$PATH"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,6 @@ addons:
 
 services: postgresql
 
-sudo: false
-
 jobs:
   include:
     - name: Syntax Check
@@ -57,7 +55,6 @@ jobs:
     - name: Docker Tests
       addons: {}
       services: docker
-      sudo: required
       before_script: docker-compose build
       script:
         - src/testing/docker/test-cluster.sh
@@ -65,7 +62,6 @@ jobs:
 #### C/C++ agent tests ###########################
     - &compiler-tests
       env: CC=gcc-4.8 CXX=g++-4.8 CFLAGS='-Wall'
-      sudo: required
       addons:
         apt:
           sources:
@@ -133,7 +129,6 @@ jobs:
 #### PHPUnit tests ###########################
     - &phpunit-tests
       php: 5.6
-      sudo: required
       install: composer install --prefer-dist --working-dir=src
       before_script: ./utils/prepare-test -afty
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,15 +135,16 @@ jobs:
         - make build-lib VERSIONFILE build-cli
         - src/vendor/bin/phpunit -csrc/phpunit.xml --testsuite="Fossology PhpUnit Test Suite"
       after_success: php src/vendor/bin/coveralls -vv -x clover.xml
-    - <<: *phpunit-tests
+    - &php7-phpunit-tests
+      <<: *phpunit-tests
       php: 7.0
-    - <<: *phpunit-tests
+    - &php71-phpunit-tests
+      <<: *php7-phpunit-tests
       php: 7.1
       install: composer update --ignore-platform-reqs --with-dependencies --prefer-dist --working-dir=src phpunit/phpunit
-    - <<: *phpunit-tests
+    - <<: *php71-phpunit-tests
       php: 7.2
-      install: composer update --ignore-platform-reqs --with-dependencies --prefer-dist --working-dir=src phpunit/phpunit
-    - <<: *phpunit-tests
+    - <<: *php71-phpunit-tests
       php: 7.2
       env: PGPORT=5432
       addons:
@@ -154,7 +155,6 @@ jobs:
             - postgresql-10
             - postgresql-client-10
       before_script: *postgres-before-script
-      install: composer update --ignore-platform-reqs --with-dependencies --prefer-dist --working-dir=src phpunit/phpunit
     - stage: GitHub Page Release
       name: GitHub Page deploy
       addons:


### PR DESCRIPTION
## Description

Update Travis CI configuration

### Changes

- Remove all deprecated `sudo:` keys in Travis CI `.travis.yml`
- Disable unnecessary addon to speed up tests
- Leverage yaml anchor for phpunit-tests (so we can easily enable phpdbg to speed up phpunit for php v7.0+)
- Enable ccache to speed up tests
- Enable composer cache to speed up tests
- Enable Fast-Finish to retrieve build result faster
- Fix Coveralls execution path (See previous `Could not open input file: src/vendor/bin/coveralls` error in build logs)
- Fix Coveralls output json file not writable issue
- Run PHPUnit via phpdbg to speed up tests (with a output workaround)

## How to test

Actually, Travis has migrated to the new infra and directly dropped this config, so basically, a passed CI build would be good enough.

It should be easy to find out the build time is shorten, and the Coveralls is working again.