### PR TITLE
feat(cp2foss): cp2foss prints out FolderPk as well

### DIFF
--- a/src/cli/cp2foss.php
+++ b/src/cli/cp2foss.php
@@ -277,6 +277,7 @@ function UploadOne($FolderPath, $UploadArchive, $UploadName, $UploadDescription,
     }
     $UploadPk = JobAddUpload($user_pk, $group_pk, $UploadName, $Src, $UploadDescription, $Mode, $FolderPk, $public_flag);
     print "  UploadPk is: '$UploadPk'\n";
+    print "  FolderPk is: '$FolderPk'\n";
   }
 
   /* Prepare the job: job "wget" */


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

It would be nice if cp2foss prints out FolderPk as well, since scheduling some agents using POST request requires both UploadPk and FolderPk. 
This is quite convenient if Fossology is used in Continuous Integration process.

### Changes

Add a print command to print FolderPk.

## How to test

Upload a file to server using cp2foss command.
