### PR TITLE
fix(strings): correct typo

### DIFF
--- a/src/nomos/agent/STRINGS.in
+++ b/src/nomos/agent/STRINGS.in
@@ -6270,7 +6270,7 @@ k
 #####
 %ENTRY% _LT_SEE_COPYING_LICENSE_1
 %KEY% =NULL=
-%STR% "see =FEW= (copyright notices?|license|legal notices?|copying|copyright\.?txt|license\.?txt|readme\.?txt|file) =FEW= (for|with|in|at) =FEW= (details|licens(e|ing)|distribut|information|foder|directory|https?|ftp)"
+%STR% "see =FEW= (copyright notices?|license|legal notices?|copying|copyright\.?txt|license\.?txt|readme\.?txt|file) =FEW= (for|with|in|at) =FEW= (details|licens(e|ing)|distribut|information|folder|directory|https?|ftp)"
 #
 %ENTRY% _LT_SEE_COPYING_LICENSE_2
 %KEY% =NULL=
@@ -6278,7 +6278,7 @@ k
 #
 %ENTRY% _LT_SEE_URL
 %KEY% =NULL=
-%STR% "see (https?|ftp) =SOME= (for|with|in) =FEW= (details|license|distribut|information|foder|directory)"
+%STR% "see (https?|ftp) =SOME= (for|with|in) =FEW= (details|license|distribut|information|folder|directory)"
 #
 %ENTRY% _LT_SEE_URL_ref1
 %KEY% =NULL=


### PR DESCRIPTION
## Description

This corrects a typo in STRINGS.in, which I believe was introduced in [2014](https://github.com/fossology/fossology/commit/f16f6f9fe431b11ba2dfa21a1209bc2ec35a4240).

### Changes

Renames "foder" to "folder" in the "_LT_SEE_URL" and "_LT_SEE_COPYING_LICENSE_1" string matchers.

