### PR TITLE
fix(nomos): nomos crash (#1337)

### DIFF
--- a/src/nomos/agent/nomos.h
+++ b/src/nomos/agent/nomos.h
@@ -132,7 +132,7 @@
 #define	PROC_TRACE
 #endif	/* PROC_TRACE_SWITCH */
 
-#define	myBUFSIZ	2048      ///< Buffer max length
+#define	myBUFSIZ	4096      ///< Buffer max length
 #define	MAX_RENAME	1000    ///< Max rename length
 #define TEMP_FILE_LEN 100   ///< Max temp file length
 

--- a/src/nomos/agent/nomos_regex.c
+++ b/src/nomos/agent/nomos_regex.c
@@ -447,7 +447,7 @@ int idxGrep_base(int index, char *data, int flags, int mode)
     else if (cur.currentLicenceIndex > -1 ) {
        rememberWhatWeFound( getLicenceAndMatchPositions(cur.theMatches, cur.currentLicenceIndex )->matchPositions , allmatches, index, mode);
     }
-
+    g_array_free(allmatches, 1);
     CALL_IF_DEBUG_MODE(printf("Bye!\n");)
  }
 


### PR DESCRIPTION
## Description

Nomos crashes when scanning https://github.com/spdx/license-list-data.

### Changes

Buffer size increased that stores the detected licenses.

## How to test

Download and scan https://github.com/spdx/license-list-data.

Closes #1337