### PR TITLE
chore(decisions): Store SHA256 of text findings

### DIFF
--- a/install/db/Makefile
+++ b/install/db/Makefile
@@ -22,6 +22,7 @@ install: all
 	$(INSTALL_DATA) dbmigrate_2.0-2.5-pre.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_2.0-2.5-pre.php
 	$(INSTALL_DATA) dbmigrate_2.5-2.6.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_2.5-2.6.php
 	$(INSTALL_DATA) dbmigrate_3.3-3.4.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.3-3.4.php
+	$(INSTALL_DATA) dbmigrate_3.5-3.6.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.5-3.6.php
 	$(INSTALL_DATA) dbmigrate_clearing-event.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_clearing-event.php
 	$(INSTALL_DATA) dbmigrate_real-parent.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_real-parent.php
 	$(INSTALL_DATA) dbmigrate_bulk_license.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_bulk_license.php
@@ -53,6 +54,7 @@ uninstall:
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_2.0-2.5-pre.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_2.5-2.6.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.3-3.4.php
+	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.5-3.6.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_clearing-event.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_real-parent.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_bulk_license.php

--- a/install/db/dbmigrate_3.5-3.6.php
+++ b/install/db/dbmigrate_3.5-3.6.php
@@ -1,0 +1,152 @@
+<?php
+/***********************************************************
+ Copyright (C) 2019 Siemens AG
+ Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***********************************************************/
+
+use Fossology\Lib\Db\DbManager;
+
+/**
+ * @file
+ * @brief Migrate DB from release 3.5.0 to 3.6.0 with new column for decision
+ * tables.
+ */
+
+/**
+ * @brief Removes duplicate decisions based on same textfinding for same pfile
+ *
+ * The function first tries to remove all duplicate decisions from deactivated
+ * list then from active list.
+ * @param DbManager $dbManager
+ * @param string $tableName
+ */
+function cleanDecisionTable($dbManager, $tableName)
+{
+  if($dbManager == null){
+    echo "No connection object passed!\n";
+    return false;
+  }
+
+  echo "*** Removing any duplicate manual findings from $tableName ***\n";
+  // First remove only duplicate deactivated statements
+  $sql = "
+DELETE FROM $tableName
+WHERE " . $tableName . "_pk IN (SELECT " . $tableName . "_pk
+  FROM (SELECT " . $tableName . "_pk, is_enabled,
+    ROW_NUMBER() OVER (PARTITION BY textfinding, pfile_fk
+                       ORDER BY " . $tableName . "_pk) AS rnum
+    FROM $tableName) AS a
+  WHERE a.is_enabled = FALSE AND a.rnum > 1);";
+  $dbManager->queryOnce($sql);
+
+  // Then remove any active duplicate statements
+  $sql = "
+DELETE FROM $tableName
+WHERE " . $tableName . "_pk IN (SELECT " . $tableName . "_pk
+  FROM (SELECT " . $tableName . "_pk,
+    ROW_NUMBER() OVER (PARTITION BY textfinding, pfile_fk
+                       ORDER BY " . $tableName . "_pk) AS rnum
+    FROM $tableName) AS a
+  WHERE a.rnum > 1);";
+  $dbManager->queryOnce($sql);
+}
+
+/**
+ * @brief Update the hash column of the table with value from textfinding.
+ * @param DbManager $dbManager
+ * @param string $tableName
+ * @return integer Number of entries updated
+ */
+function updateHash($dbManager, $tableName)
+{
+  if($dbManager == null){
+    echo "No connection object passed!\n";
+    return false;
+  }
+  if(DB_TableExists($tableName) != 1) {
+    // Table does not exists (migrating from old version)
+    echo "Table $tableName does not exists, not updating!\n";
+    return 0;
+  }
+
+  $sql = "SELECT " . $tableName . "_pk AS id, textfinding " .
+    "FROM $tableName WHERE hash IS NULL;";
+  $statement = __METHOD__ . ".getNullHash.$tableName";
+  $rows = $dbManager->getRows($sql, [], $statement);
+
+  $sql = "
+UPDATE $tableName
+  SET hash = $2
+  WHERE " . $tableName . "_pk = $1;
+";
+  $statement = __METHOD__ . ".updateHashOf.$tableName";
+  $dbManager->prepare($statement, $sql);
+  foreach ($rows as $row) {
+    $dbManager->execute($statement, [
+      $row["id"],
+      hash('sha256', $row['textfinding'])
+    ]);
+  }
+  return count($rows);
+}
+
+/**
+ * Migration from FOSSology 3.5.0 to 3.6.0
+ * @param DbManager $dbManager
+ * @param boolean $force Set true to force run the script.
+ */
+function migrate_35_36($dbManager, $force = false)
+{
+  $total = 0;
+  $tables = [
+    "copyright_decision",
+    "ecc_decision",
+    "keyword_decision"
+  ];
+  if (!$force) {
+    $sql = "WITH decision_tables AS(".
+    "  SELECT count(*) AS cnt FROM $tables[0] WHERE hash IS NULL" .
+    "  UNION" .
+    "  SELECT count(*) AS cnt FROM $tables[1] WHERE hash IS NULL" .
+    "  UNION" .
+    "  SELECT count(*) AS cnt FROM $tables[2] WHERE hash IS NULL" .
+    ") SELECT SUM(cnt) AS total FROM decision_tables;";
+    $total = intval($dbManager->getSingleRow($sql, [],
+      __METHOD__ . ".checkIfMigrationDone")['total']);
+    if ($total == 0) {
+      // Migration not required
+      return;
+    }
+  }
+  try {
+    echo "*** Updating the hash values of manual copyright/ecc/keyword findings ***\n";
+    $count = 0;
+
+    $dbManager->begin();
+
+    // Foreign key constraints
+    foreach ($tables as $table) {
+      cleanDecisionTable($dbManager, $table);
+      $count += updateHash($dbManager, $table);
+    }
+
+    $dbManager->commit();
+    echo "*** Updated hash of $count/$total manual copyright/ecc/keyword findings ***\n";
+  } catch (Exception $e) {
+    echo "*** Something went wrong. Try running postinstall again! ***\n";
+    $dbManager->rollback();
+  }
+}

--- a/install/fossinit.php
+++ b/install/fossinit.php
@@ -277,11 +277,13 @@ if($isUpdating && empty($sysconfig['Release'])) {
   }
   $sysconfig['Release'] = '2.6';
 }
-if(!$isUpdating)
-{
-  require_once("$LIBEXECDIR/dbmigrate_2.1-2.2.php");
+if (! $isUpdating) {
+  require_once ("$LIBEXECDIR/dbmigrate_2.1-2.2.php");
   print "Creating default user\n";
   Migrate_21_22($Verbose);
+} else {
+  require_once ("$LIBEXECDIR/dbmigrate_3.5-3.6.php");
+  migrate_35_36($dbManager);
 }
 
 if(!$isUpdating || $sysconfig['Release'] == '2.6')

--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -111,13 +111,15 @@ class CopyrightDao
   public function saveDecision($tableName, $pfileId, $userId , $clearingType,
                                $description, $textFinding, $comment, $decision_pk=-1)
   {
-    $assocParams = array('user_fk'=>$userId,'pfile_fk'=>$pfileId,'clearing_decision_type_fk'=>$clearingType,
-        'description'=>$description, 'textfinding'=>$textFinding, 'comment'=>$comment );
+    $assocParams = array('user_fk' => $userId, 'pfile_fk' => $pfileId,
+      'clearing_decision_type_fk' => $clearingType, 'description' => $description,
+      'textfinding' => $textFinding, 'hash' => hash('sha256', $textFinding),
+      'comment'=>$comment);
     if ($decision_pk <= 0) {
       $primaryColumn = $tableName . '_pk';
       return $this->dbManager->insertTableRow($tableName, $assocParams, __METHOD__.'Insert.'.$tableName, $primaryColumn);
     } else {
-      $assocParams['is_enabled'] = True;
+      $assocParams['is_enabled'] = true;
       $primaryColumn = $tableName . '_pk';
       $this->dbManager->updateTableRow($tableName, $assocParams, $primaryColumn, $decision_pk, __METHOD__.'Update.'.$tableName);
       return $decision_pk;

--- a/src/lib/php/Db/DbManager.php
+++ b/src/lib/php/Db/DbManager.php
@@ -73,6 +73,16 @@ abstract class DbManager
     }
   }
 
+  public function rollback()
+  {
+    if ($this->transactionDepth > 0) {
+      $this->transactionDepth--;
+      $this->dbDriver->rollback();
+    } else if ($this->transactionDepth == 0) {
+      throw new \Exception('too much transaction rollbacks');
+    }
+  }
+
   /**
    * @param $statementName
    * @param $sqlStatement

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -372,6 +372,10 @@
   $Schema["TABLE"]["copyright_decision"]["textfinding"]["ADD"] = "ALTER TABLE \"copyright_decision\" ADD COLUMN \"textfinding\" text";
   $Schema["TABLE"]["copyright_decision"]["textfinding"]["ALTER"] = "ALTER TABLE \"copyright_decision\" ALTER COLUMN \"textfinding\" DROP NOT NULL";
 
+  $Schema["TABLE"]["copyright_decision"]["hash"]["DESC"] = "COMMENT ON COLUMN \"copyright_decision\".\"hash\" IS 'SHA256 hash of textfinding for grouping statements.'";
+  $Schema["TABLE"]["copyright_decision"]["hash"]["ADD"] = "ALTER TABLE \"copyright_decision\" ADD COLUMN \"hash\" char(64)";
+  $Schema["TABLE"]["copyright_decision"]["hash"]["ALTER"] = "ALTER TABLE \"copyright_decision\" ALTER COLUMN \"hash\" DROP NOT NULL";
+
   $Schema["TABLE"]["copyright_decision"]["comment"]["DESC"] = "";
   $Schema["TABLE"]["copyright_decision"]["comment"]["ADD"] = "ALTER TABLE \"copyright_decision\" ADD COLUMN \"comment\" text";
   $Schema["TABLE"]["copyright_decision"]["comment"]["ALTER"] = "ALTER TABLE \"copyright_decision\" ALTER COLUMN \"comment\" DROP NOT NULL";
@@ -479,6 +483,10 @@
   $Schema["TABLE"]["ecc_decision"]["textfinding"]["ADD"] = "ALTER TABLE \"ecc_decision\" ADD COLUMN \"textfinding\" text";
   $Schema["TABLE"]["ecc_decision"]["textfinding"]["ALTER"] = "ALTER TABLE \"ecc_decision\" ALTER COLUMN \"textfinding\" DROP NOT NULL";
 
+  $Schema["TABLE"]["ecc_decision"]["hash"]["DESC"] = "COMMENT ON COLUMN \"ecc_decision\".\"hash\" IS 'SHA256 hash of textfinding for grouping statements.'";
+  $Schema["TABLE"]["ecc_decision"]["hash"]["ADD"] = "ALTER TABLE \"ecc_decision\" ADD COLUMN \"hash\" char(64)";
+  $Schema["TABLE"]["ecc_decision"]["hash"]["ALTER"] = "ALTER TABLE \"ecc_decision\" ALTER COLUMN \"hash\" DROP NOT NULL";
+
   $Schema["TABLE"]["ecc_decision"]["comment"]["DESC"] = "";
   $Schema["TABLE"]["ecc_decision"]["comment"]["ADD"] = "ALTER TABLE \"ecc_decision\" ADD COLUMN \"comment\" text";
   $Schema["TABLE"]["ecc_decision"]["comment"]["ALTER"] = "ALTER TABLE \"ecc_decision\" ALTER COLUMN \"comment\" DROP NOT NULL";
@@ -547,6 +555,10 @@
   $Schema["TABLE"]["keyword_decision"]["textfinding"]["DESC"] = "";
   $Schema["TABLE"]["keyword_decision"]["textfinding"]["ADD"] = "ALTER TABLE \"keyword_decision\" ADD COLUMN \"textfinding\" text";
   $Schema["TABLE"]["keyword_decision"]["textfinding"]["ALTER"] = "ALTER TABLE \"keyword_decision\" ALTER COLUMN \"textfinding\" DROP NOT NULL";
+
+  $Schema["TABLE"]["keyword_decision"]["hash"]["DESC"] = "COMMENT ON COLUMN \"keyword_decision\".\"hash\" IS 'SHA256 hash of textfinding for grouping statements.'";
+  $Schema["TABLE"]["keyword_decision"]["hash"]["ADD"] = "ALTER TABLE \"keyword_decision\" ADD COLUMN \"hash\" char(64)";
+  $Schema["TABLE"]["keyword_decision"]["hash"]["ALTER"] = "ALTER TABLE \"keyword_decision\" ALTER COLUMN \"hash\" DROP NOT NULL";
 
   $Schema["TABLE"]["keyword_decision"]["comment"]["DESC"] = "";
   $Schema["TABLE"]["keyword_decision"]["comment"]["ADD"] = "ALTER TABLE \"keyword_decision\" ADD COLUMN \"comment\" text";
@@ -1927,11 +1939,13 @@
   $Schema["CONSTRAINT"]["copyright_pfile_fk_fkey"] = "ALTER TABLE \"copyright\" ADD CONSTRAINT \"copyright_pfile_fk_fkey\" FOREIGN KEY (\"pfile_fk\") REFERENCES \"pfile\" (\"pfile_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["copyright_decision_pkey"] = "ALTER TABLE \"copyright_decision\" ADD CONSTRAINT \"copyright_decision_pkey\" PRIMARY KEY (\"copyright_decision_pk\");";
   $Schema["CONSTRAINT"]["copyright_decision_pfile_fk_fkey"] = "ALTER TABLE \"copyright_decision\" ADD CONSTRAINT \"copyright_decision_pfile_fk_fkey\" FOREIGN KEY (\"pfile_fk\") REFERENCES \"pfile\" (\"pfile_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
+  $Schema["CONSTRAINT"]["copyright_decision_pfile_hash_ukey"] = "ALTER TABLE \"copyright_decision\" ADD CONSTRAINT \"copyright_decision_pfile_hash_ukey\" UNIQUE (\"pfile_fk\", \"hash\");";
   $Schema["CONSTRAINT"]["ecc_pkey"] = "ALTER TABLE \"ecc\" ADD CONSTRAINT \"ecc_pkey\" PRIMARY KEY (\"ecc_pk\");";
   $Schema["CONSTRAINT"]["ecc_agent_fk_fkey"] = "ALTER TABLE \"ecc\" ADD CONSTRAINT \"ecc_agent_fk_fkey\" FOREIGN KEY (\"agent_fk\") REFERENCES \"agent\" (\"agent_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["ecc_pfile_fk_fkey"] = "ALTER TABLE \"ecc\" ADD CONSTRAINT \"ecc_pfile_fk_fkey\" FOREIGN KEY (\"pfile_fk\") REFERENCES \"pfile\" (\"pfile_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["ecc_decision_pkey"] = "ALTER TABLE \"ecc_decision\" ADD CONSTRAINT \"ecc_decision_pkey\" PRIMARY KEY (\"ecc_decision_pk\");";
   $Schema["CONSTRAINT"]["ecc_decision_pfile_fk_fkey"] = "ALTER TABLE \"ecc_decision\" ADD CONSTRAINT \"ecc_decision_pfile_fk_fkey\" FOREIGN KEY (\"pfile_fk\") REFERENCES \"pfile\" (\"pfile_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
+  $Schema["CONSTRAINT"]["ecc_decision_pfile_hash_ukey"] = "ALTER TABLE \"ecc_decision\" ADD CONSTRAINT \"ecc_decision_pfile_hash_ukey\" UNIQUE (\"pfile_fk\", \"hash\");";
   $Schema["CONSTRAINT"]["file_picker_pkey"] = "ALTER TABLE \"file_picker\" ADD CONSTRAINT \"file_picker_pkey\" PRIMARY KEY (\"file_picker_pk\");";
   $Schema["CONSTRAINT"]["file_picker_user_fk_ukey"] = "ALTER TABLE \"file_picker\" ADD CONSTRAINT \"file_picker_user_fk_ukey\" UNIQUE (\"user_fk\",\"uploadtree_fk1\",\"uploadtree_fk2\");";
   $Schema["CONSTRAINT"]["folder_pkey"] = "ALTER TABLE \"folder\" ADD CONSTRAINT \"folder_pkey\" PRIMARY KEY (\"folder_pk\");";
@@ -1954,6 +1968,7 @@
   $Schema["CONSTRAINT"]["keyword_pfile_fk_fkey"] = "ALTER TABLE \"keyword\" ADD CONSTRAINT \"keyword_pfile_fk_fkey\" FOREIGN KEY (\"pfile_fk\") REFERENCES \"pfile\" (\"pfile_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["keyword_decision_pkey"] = "ALTER TABLE \"keyword_decision\" ADD CONSTRAINT \"keyword_decision_pkey\" PRIMARY KEY (\"keyword_decision_pk\");";
   $Schema["CONSTRAINT"]["keyword_decision_pfile_fk_fkey"] = "ALTER TABLE \"keyword_decision\" ADD CONSTRAINT \"keyword_decision_pfile_fk_fkey\" FOREIGN KEY (\"pfile_fk\") REFERENCES \"pfile\" (\"pfile_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
+  $Schema["CONSTRAINT"]["keyword_decision_pfile_hash_ukey"] = "ALTER TABLE \"keyword_decision\" ADD CONSTRAINT \"keyword_decision_pfile_hash_ukey\" UNIQUE (\"pfile_fk\", \"hash\");";
   $Schema["CONSTRAINT"]["license_candidate_fkey"] = "ALTER TABLE \"license_candidate\" ADD CONSTRAINT \"license_candidate_fkey\" FOREIGN KEY (\"group_fk\") REFERENCES \"groups\" (\"group_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["license_file_pkey"] = "ALTER TABLE \"license_file\" ADD CONSTRAINT \"license_file_pkey\" PRIMARY KEY (\"fl_pk\");";
   $Schema["CONSTRAINT"]["license_file_pfile_fk_fkey"] = "ALTER TABLE \"license_file\" ADD CONSTRAINT \"license_file_pfile_fk_fkey\" FOREIGN KEY (\"pfile_fk\") REFERENCES \"pfile\" (\"pfile_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
@@ -2042,6 +2057,7 @@
   $Schema["INDEX"]["copyright_decision"]["copyright_decision_clearing_decision_type_fk_index"] = "CREATE INDEX copyright_decision_clearing_decision_type_fk_index ON copyright_decision USING btree (clearing_decision_type_fk);";
   $Schema["INDEX"]["copyright_decision"]["copyright_decision_pfile_fk_index"] = "CREATE INDEX copyright_decision_pfile_fk_index ON copyright_decision USING btree (pfile_fk);";
   $Schema["INDEX"]["copyright_decision"]["copyright_decision_user_fk_index"] = "CREATE INDEX copyright_decision_user_fk_index ON copyright_decision USING btree (user_fk);";
+  $Schema["INDEX"]["copyright_decision"]["copyright_decision_pfile_hash_index"] = "CREATE INDEX copyright_decision_pfile_hash_index ON copyright_decision USING btree (hash, pfile_fk);";
 
   $Schema["INDEX"]["author"]["author_agent_fk_idx"] = "CREATE INDEX author_agent_fk_idx ON author USING btree (agent_fk);";
   $Schema["INDEX"]["author"]["author_pfile_fk_index"] = "CREATE INDEX author_pfile_fk_index ON author USING btree (pfile_fk);";
@@ -2055,14 +2071,18 @@
   $Schema["INDEX"]["ecc_decision"]["ecc_decision_clearing_decision_type_fk_index"] = "CREATE INDEX ecc_decision_clearing_decision_type_fk_index ON ecc_decision USING btree (clearing_decision_type_fk);";
   $Schema["INDEX"]["ecc_decision"]["ecc_decision_pfile_fk_index"] = "CREATE INDEX ecc_decision_pfile_fk_index ON ecc_decision USING btree (pfile_fk);";
   $Schema["INDEX"]["ecc_decision"]["ecc_decision_user_fk_index"] = "CREATE INDEX ecc_decision_user_fk_index ON ecc_decision USING btree (user_fk);";
+  $Schema["INDEX"]["ecc_decision"]["ecc_decision_pfile_hash_index"] = "CREATE INDEX ecc_decision_pfile_hash_index ON ecc_decision USING btree (hash, pfile_fk);";
 
   $Schema["INDEX"]["keyword"]["keyword_agent_fk_index"] = "CREATE INDEX keyword_agent_fk_index ON keyword USING btree (agent_fk);";
   $Schema["INDEX"]["keyword"]["keyword_hash_index"] = "CREATE INDEX keyword_hash_index ON keyword USING btree (hash);";
   $Schema["INDEX"]["keyword"]["keyword_pfile_fk_index"] = "CREATE INDEX keyword_pfile_fk_index ON keyword USING btree (pfile_fk);";
   $Schema["INDEX"]["keyword"]["keyword_pfile_hash_idx"] = "CREATE INDEX keyword_pfile_hash_idx ON keyword using btree (hash, pfile_fk);";
+
   $Schema["INDEX"]["keyword_decision"]["keyword_decision_clearing_decision_type_fk_index"] = "CREATE INDEX keyword_decision_clearing_decision_type_fk_index ON keyword_decision USING btree (clearing_decision_type_fk);";
   $Schema["INDEX"]["keyword_decision"]["keyword_decision_pfile_fk_index"] = "CREATE INDEX keyword_decision_pfile_fk_index ON keyword_decision USING btree (pfile_fk);";
   $Schema["INDEX"]["keyword_decision"]["keyword_decision_user_fk_index"] = "CREATE INDEX keyword_decision_user_fk_index ON keyword_decision USING btree (user_fk);";
+  $Schema["INDEX"]["keyword_decision"]["keyword_decision_pfile_hash_index"] = "CREATE INDEX keyword_decision_pfile_hash_index ON keyword_decision USING btree (hash, pfile_fk);";
+
   $Schema["INDEX"]["highlight"]["highlight_fl_fk_idx"] = "CREATE INDEX highlight_fl_fk_idx ON highlight USING btree (fl_fk);";
 
   $Schema["INDEX"]["highlight_keyword"]["highlight_keyword_pfile_fk_idx"] = "CREATE INDEX highlight_keyword_pfile_fk_idx ON highlight_keyword USING btree (pfile_fk);";


### PR DESCRIPTION
## Description

This PR adds additional column to copyright/ecc/keyword decision tables to store the hash (MD5) of the text findings. This will help in reducing the duplicates in the tables and also aid in aggregating the entries for PR #1311 .

### Changes

Add new column, index and unique constraints to copyright/ecc/keyword decision tables.

## How to test

Install the branch on old instance and check if the installation goes through without causing any issue.