### PR TITLE
feat(license): Provide predefined license comments

### DIFF
--- a/src/lib/php/Dao/LicenseStdCommentDao.php
+++ b/src/lib/php/Dao/LicenseStdCommentDao.php
@@ -1,0 +1,244 @@
+<?php
+/***********************************************************
+ * Copyright (C) 2019 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***********************************************************/
+/**
+ * @file
+ * DAO layer for license_std_comment table.
+ */
+namespace Fossology\Lib\Dao;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Db\DbManager;
+
+/**
+ * @class LicenseStdCommentDao
+ * DAO layer for license_std_comment table.
+ */
+class LicenseStdCommentDao
+{
+  /** @var DbManager $dbManager
+   * DB manager in use */
+  private $dbManager;
+
+  function __construct(DbManager $dbManager)
+  {
+    $this->dbManager = $dbManager;
+  }
+
+  /**
+   * Get all the comments and their name stored in the DB, sorted by their ID
+   * in ascending order.
+   * @param boolean $skipNotSet Skip the entries where the name is not changed
+   *        or are disabled.
+   * @return array All comments from the DB
+   */
+  public function getAllComments($skipNotSet = false)
+  {
+    $where = "";
+    if ($skipNotSet) {
+      $where = "WHERE name <> 'not-set' AND is_enabled = TRUE";
+    }
+    $sql = "SELECT lsc_pk, name, comment, is_enabled " .
+      "FROM license_std_comment $where " .
+      "ORDER BY lsc_pk ASC;";
+    return $this->dbManager->getRows($sql);
+  }
+
+  /**
+   * Update single comment
+   * @param int $commentPk     The comment id
+   * @param string $newName    New name of the comment
+   * @param string $newComment Updated comment
+   * @return boolean True if the comments are updated, false otherwise.
+   */
+  function updateComment($commentPk, $newName, $newComment)
+  {
+    if (!Auth::isAdmin()) {
+      // Only admins can update the comments.
+      return false;
+    }
+    $this->isCommentIdValid($commentPk);
+
+    $userFk = Auth::getUserId();
+
+    $sql = "UPDATE license_std_comment " .
+      "SET name = $2, comment = $3, updated = NOW(), user_fk = $4 " .
+      "WHERE lsc_pk = $1 " .
+      "RETURNING 1 AS updated;";
+    $row = $this->dbManager->getSingleRow($sql,
+      [$commentPk, $newName, $newComment, $userFk]);
+    return $row['updated'] == 1;
+  }
+
+  /**
+   * Insert a new comment
+   *
+   * @param string $name Name of the comment
+   * @param string $comment Comment
+   * @return int New comment ID if inserted successfully, -1 otherwise or -2 in
+   *         case of exception.
+   */
+  function insertComment($name, $comment)
+  {
+    if (! Auth::isAdmin()) {
+      // Only admins can add comments.
+      return -1;
+    }
+
+    $name = trim($name);
+    $comment = trim($comment);
+
+    if (empty($name) || empty($comment)) {
+      // Cannot insert empty fields.
+      return -1;
+    }
+
+    $userFk = Auth::getUserId();
+
+    $params = [
+      'name' => $name,
+      'comment' => $comment,
+      'user_fk' => $userFk
+    ];
+    $statement = __METHOD__ . ".insertNewLicStdComment";
+    $returning = "lsc_pk";
+    $returnVal = -1;
+    try {
+      $returnVal = $this->dbManager->insertTableRow("license_std_comment",
+        $params, $statement, $returning);
+    } catch (\Exception $e) {
+      $returnVal = -2;
+    }
+    return $returnVal;
+  }
+
+  /**
+   * @brief Update the comments based only on the values provided.
+   *
+   * Takes an array as input and update only the fields passed.
+   * @param array $commentArray Associative array with comment id as the index,
+   *        name and comment as child index with corresponding values.
+   * @return int Count of values updated
+   * @throws \UnexpectedValueException If an entry does not contain any field,
+   *         throws unexpected value exception.
+   */
+  function updateCommentFromArray($commentArray)
+  {
+    if (!Auth::isAdmin()) {
+      // Only admins can update the comments.
+      return false;
+    }
+
+    $userFk = Auth::getUserId();
+    $updated = 0;
+
+    foreach ($commentArray as $commentPk => $comment) {
+      if (count($comment) < 1 ||
+        (! array_key_exists("name", $comment) &&
+        ! array_key_exists("comment", $comment))) {
+        throw new \UnexpectedValueException(
+          "At least name or comment is " . "required for entry " . $commentPk);
+      }
+      $this->isCommentIdValid($commentPk);
+      $statement = __METHOD__;
+      $params = [$commentPk, $userFk];
+      $updateStatement = [];
+      if (array_key_exists("name", $comment)) {
+        $params[] = $comment["name"];
+        $updateStatement[] = "name = $" . count($params);
+        $statement .= ".name";
+      }
+      if (array_key_exists("comment", $comment)) {
+        $params[] = $comment["comment"];
+        $updateStatement[] = "comment = $" . count($params);
+        $statement .= ".comment";
+      }
+      $sql = "UPDATE license_std_comment " .
+        "SET updated = NOW(), user_fk = $2, " . join(",", $updateStatement) .
+        "WHERE lsc_pk = $1 " .
+        "RETURNING 1 AS updated;";
+      $retVal = $this->dbManager->getSingleRow($sql, $params, $statement);
+      $updated += intval($retVal);
+    }
+    return $updated;
+  }
+
+  /**
+   * Get the comment for the given comment id
+   * @param int $commentPk The comment id
+   * @return string|null Comment from the DB (if set, null otherwise)
+   */
+  function getComment($commentPk)
+  {
+    $this->isCommentIdValid($commentPk);
+    $sql = "SELECT comment FROM license_std_comment " . "WHERE lsc_pk = $1;";
+    $statement = __METHOD__ . ".getComment";
+
+    $comment = $this->dbManager->getSingleRow($sql, [$commentPk], $statement);
+    $comment = $comment['comment'];
+    if (strcasecmp($comment, "null") === 0) {
+      return null;
+    }
+    return $comment;
+  }
+
+  /**
+   * Toggle comment status.
+   *
+   * @param int $commentPk The comment id
+   * @return boolean True if the comment is toggled, false otherwise.
+   */
+  function toggleComment($commentPk)
+  {
+    if (! Auth::isAdmin()) {
+      // Only admins can update the comments.
+      return false;
+    }
+    $this->isCommentIdValid($commentPk);
+
+    $userFk = Auth::getUserId();
+
+    $sql = "UPDATE license_std_comment " .
+      "SET is_enabled = NOT is_enabled, user_fk = $2 " .
+      "WHERE lsc_pk = $1;";
+
+    $this->dbManager->getSingleRow($sql, [$commentPk, $userFk]);
+    return true;
+  }
+
+  /**
+   * Check if the given comment id is an integer and exists in DB.
+   * @param int $commentPk Comment id to check for
+   * @throws \UnexpectedValueException Throw exception in comment id is not int
+   *         or does not exists in DB.
+   */
+  private function isCommentIdValid($commentPk)
+  {
+    if (! is_int($commentPk)) {
+      throw new \UnexpectedValueException("Inavlid comment id");
+    }
+    $sql = "SELECT count(*) AS cnt FROM license_std_comment " .
+      "WHERE lsc_pk = $1;";
+
+    $commentCount = $this->dbManager->getSingleRow($sql, [$commentPk]);
+    if ($commentCount['cnt'] < 1) {
+      // Invalid comment id
+      throw new \UnexpectedValueException("Inavlid comment id");
+    }
+  }
+}

--- a/src/lib/php/Dao/test/LicenseStdCommentDaoTest.php
+++ b/src/lib/php/Dao/test/LicenseStdCommentDaoTest.php
@@ -1,0 +1,452 @@
+<?php
+/**
+ * Copyright (C) 2019 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+/**
+ * @file
+ * Tests for LicenseStdCommentDao class
+ */
+namespace Fossology\Lib\Dao;
+
+use Fossology\Lib\Db\DbManager;
+use PHPUnit\Framework\TestCase;
+use Fossology\Lib\Test\TestPgDb;
+
+/**
+ * @class LicenseStdCommentDaoTest
+ * Tests for LicenseStdCommentDao class
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class LicenseStdCommentDaoTest extends TestCase
+{
+
+  /**
+   * @var integer COMMENTS_IN_DB
+   * Number of rows in license standard comments table. */
+  const COMMENTS_IN_DB = 7;
+
+  /** @var TestPgDb $testDb
+   *       Test DB */
+  private $testDb;
+
+  /** @var DbManager $dbManager
+   *       DB manager to use */
+  private $dbManager;
+
+  /** @var LicenseStdCommentDao $licenseStdCommentDao
+   *       LicenseStdCommentDao object for test */
+  private $licenseStdCommentDao;
+
+  /** @var int $assertCountBefore */
+  private $assertCountBefore;
+
+  private $authClass;
+
+  protected function setUp()
+  {
+    $this->testDb = new TestPgDb("licensestdcommentdao");
+    $this->dbManager = $this->testDb->getDbManager();
+    $this->licenseStdCommentDao = new LicenseStdCommentDao($this->dbManager);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+    $this->testDb->createPlainTables(["users", "license_std_comment"]);
+    $this->testDb->createSequences(["license_std_comment_lsc_pk_seq"]);
+    $this->testDb->alterTables(["license_std_comment"]);
+    $this->testDb->insertData(["users", "license_std_comment"]);
+    $this->authClass = \Mockery::mock('alias:Fossology\Lib\Auth\Auth');
+    $this->authClass->expects('getUserId')->andReturn(2);
+  }
+
+  protected function tearDown()
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    $this->testDb = null;
+    $this->dbManager = null;
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::getAllComments() with no skips
+   * @test
+   * -# Fetch all set and unset comments
+   * -# Check the length of the array matches 7
+   * -# Check some values
+   */
+  public function testGetAllCommentsEverything()
+  {
+    $allComments = $this->licenseStdCommentDao->getAllComments();
+    $this->assertCount(self::COMMENTS_IN_DB, $allComments);
+    $this->assertContains([
+      "lsc_pk" => 2,
+      "name" => "Test comment #1",
+      "comment" => "This will be your first comment!",
+      "is_enabled" => "t"
+    ], $allComments, false);
+    $this->assertContains([
+      "lsc_pk" => 8,
+      "name" => "not-set",
+      "comment" => "This comment is not set!",
+      "is_enabled" => "f"
+    ], $allComments, false);
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::getAllComments() with skips
+   * @test
+   * -# Fetch all set comments only
+   * -# Check the length of the array matches 6
+   * -# Check unset comment is not in the array
+   */
+  public function testGetAllCommentsWithSkips()
+  {
+    $filteredComments = $this->licenseStdCommentDao->getAllComments(true);
+    $this->assertCount(self::COMMENTS_IN_DB - 1, $filteredComments);
+    $this->assertContains([
+      "lsc_pk" => 2,
+      "name" => "Test comment #1",
+      "comment" => "This will be your first comment!",
+      "is_enabled" => true
+    ], $filteredComments, false);
+    $this->assertNotContains([
+      "lsc_pk" => 8,
+      "name" => "not-set",
+      "comment" => "This comment is not set!",
+      "is_enabled" => false
+    ], $filteredComments);
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::updateComment() as an admin
+   * @test
+   * -# Update a comment with some value
+   * -# Check if the function returns true
+   * -# Check if the values are actually updated in DB
+   */
+  public function testUpdateCommentAsAdmin()
+  {
+    $this->authClass->expects('isAdmin')->andReturn(true);
+
+    $returnVal = $this->licenseStdCommentDao->updateComment(2,
+      "Updated comment #1", "This comment is updated!");
+    $this->assertTrue($returnVal);
+    $sql = "SELECT * FROM license_std_comment WHERE lsc_pk = 2;";
+    $row = $this->dbManager->getSingleRow($sql);
+    $this->assertEquals("Updated comment #1", $row["name"]);
+    $this->assertEquals("This comment is updated!", $row["comment"]);
+    $this->assertRegExp("/^" . date('Y-m-d') . ".*/", $row['updated']);
+    $this->assertEquals(2, $row['user_fk']);
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::updateComment() as non admin
+   * @test
+   * -# Update a comment with some value
+   * -# Check if the function returns false
+   * -# Check if the values are not updated in DB
+   */
+  public function testUpdateCommentAsNonAdmin()
+  {
+    $this->authClass->expects('isAdmin')->andReturn(false);
+
+    $returnVal = $this->licenseStdCommentDao->updateComment(3,
+      "Updated comment #2", "This comment is updated!");
+    $this->assertFalse($returnVal);
+    $sql = "SELECT name, comment FROM license_std_comment WHERE lsc_pk = 3;";
+    $row = $this->dbManager->getSingleRow($sql);
+    $this->assertNotEquals("Updated comment #2", $row["name"]);
+    $this->assertNotEquals("This comment is updated!", $row["comment"]);
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::updateComment() with invalid id
+   * @test
+   * -# Pass invalid comment id
+   * -# Check if the function throws exception
+   */
+  public function testUpdateCommentAsAdminInvalidId()
+  {
+    $this->authClass->expects('isAdmin')->andReturn(true);
+
+    $this->expectException(\UnexpectedValueException::class);
+    $this->licenseStdCommentDao->updateComment(- 1, "Invalid comment #1",
+      "This comment is invalid!");
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::updateCommentFromArray() as admin
+   * @test
+   * -# Set user as admin
+   * -# Update two comments
+   * -# Check if the function returns 2
+   * -# Check if the DB is updated
+   */
+  public function testUpdateCommentFromArrayAsAdmin()
+  {
+    $this->authClass->expects('isAdmin')->andReturn(true);
+
+    $newValues = [];
+    $newValues[3]['name'] = "Updated comment #2";
+    $newValues[3]['comment'] = "This comment is updated!";
+    $newValues[4]['name'] = "Updated comment #3";
+    $newValues[4]['comment'] = "This comment is updated!";
+
+    $returnVal = $this->licenseStdCommentDao->updateCommentFromArray($newValues);
+
+    $this->assertEquals(2, $returnVal);
+    $sql = "SELECT * FROM license_std_comment WHERE lsc_pk IN (3, 4);";
+    $rows = $this->dbManager->getRows($sql);
+    $id = 3;
+    foreach ($rows as $row) {
+      $this->assertEquals("Updated comment #" . ($id - 1), $row["name"]);
+      $this->assertEquals("This comment is updated!", $row["comment"]);
+      $this->assertRegExp("/^" . date('Y-m-d') . ".*/", $row['updated']);
+      $this->assertEquals(2, $row['user_fk']);
+      $id++;
+    }
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::updateCommentFromArray() as non admin
+   * @test
+   * -# Set user as non admin
+   * -# Call function
+   * -# Check if the function returns false
+   */
+  public function testUpdateCommentFromArrayAsNonAdmin()
+  {
+    $this->authClass->expects('isAdmin')->andReturn(false);
+
+    $newValues = [];
+    $newValues[5]['name'] = "Updated comment #4";
+    $newValues[5]['comment'] = "This comment is updated!";
+
+    $returnVal = $this->licenseStdCommentDao->updateCommentFromArray($newValues);
+
+    $this->assertFalse($returnVal);
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::updateCommentFromArray() with
+   *        invalid id
+   * @test
+   * -# Set user as admin
+   * -# Call function with invalid data
+   * -# Check if the function throws exception
+   */
+  public function testUpdateCommentFromArrayInvalidId()
+  {
+    $this->authClass->expects('isAdmin')->andReturn(true);
+
+    $newValues = [];
+    $newValues[-1]['name'] = "Updated comment #4";
+    $newValues[-1]['comment'] = "This comment is updated!";
+
+    $this->expectException(\UnexpectedValueException::class);
+
+    $this->licenseStdCommentDao->updateCommentFromArray($newValues);
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::updateCommentFromArray() with
+   *        missing fields
+   * @test
+   * -# Set user as admin
+   * -# Call function with missing fields
+   * -# Check if the function throws exception
+   */
+  public function testUpdateCommentFromArrayInvalidFields()
+  {
+    $this->authClass->expects('isAdmin')->andReturn(true);
+
+    $newValues = [];
+    $newValues[5]['naaaaame'] = "Updated comment #4";
+    $newValues[5]['commmmmment'] = "This comment is updated!";
+
+    $this->expectException(\UnexpectedValueException::class);
+
+    $this->licenseStdCommentDao->updateCommentFromArray($newValues);
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::updateCommentFromArray() with
+   *        empty array
+   * @test
+   * -# Set user as admin
+   * -# Call function with empty array
+   * -# Check if the function returns 0
+   */
+  public function testUpdateCommentFromArrayEmptyArray()
+  {
+    $this->authClass->expects('isAdmin')->andReturn(true);
+
+    $newValues = [];
+
+    $returnVal = $this->licenseStdCommentDao->updateCommentFromArray($newValues);
+    $this->assertEquals(0, $returnVal);
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::updateCommentFromArray() with
+   *        empty values
+   * @test
+   * -# Set user as admin
+   * -# Call function with empty values
+   * -# Check if the function throws exception
+   */
+  public function testUpdateCommentFromArrayEmptyValues()
+  {
+    $this->authClass->expects('isAdmin')->andReturn(true);
+
+    $newValues = [3 => []];
+
+    $this->expectException(\UnexpectedValueException::class);
+
+    $this->licenseStdCommentDao->updateCommentFromArray($newValues);
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::getComment() with valid id
+   * @test
+   * -# Call function with valid id
+   * -# Check if the function returns string or null
+   * -# Check if the function returns correct value
+   */
+  public function testGetCommentValid()
+  {
+    $commentId = 7;
+    $returnVal = $this->licenseStdCommentDao->getComment($commentId);
+
+    $this->assertTrue(is_string($returnVal) || $returnVal === null);
+    if ($returnVal !== null) {
+      $this->assertEquals("This will be the sixth comment!", $returnVal);
+    }
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::getComment() with invalid id
+   * @test
+   * -# Call function with invalid id
+   * -# Check if the function throws exception
+   */
+  public function testGetCommentInvalid()
+  {
+    $this->expectException(\UnexpectedValueException::class);
+
+    $commentId = -1;
+    $returnVal = $this->licenseStdCommentDao->getComment($commentId);
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::insertComment() as an admin
+   * @test
+   * -# Add a new comment with some value
+   * -# Check if the function returns integer
+   * -# Check if the values are actually inserted in DB
+   */
+  public function testInsertCommentAsAdmin()
+  {
+    $this->authClass->expects('isAdmin')->andReturn(true);
+
+    $returnVal = $this->licenseStdCommentDao->insertComment("Inserted comment #1",
+      "This first inserted comment!");
+    $this->assertTrue(is_numeric($returnVal));
+    $this->assertEquals(1, $returnVal);
+    $sql = "SELECT * FROM license_std_comment WHERE lsc_pk = $1;";
+    $row = $this->dbManager->getSingleRow($sql, [$returnVal]);
+    $this->assertEquals("Inserted comment #1", $row["name"]);
+    $this->assertEquals("This first inserted comment!", $row["comment"]);
+    $this->assertRegExp("/^" . date('Y-m-d') . ".*/", $row['updated']);
+    $this->assertEquals(2, $row['user_fk']);
+    $this->assertEquals("t", $row["is_enabled"]);
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::insertComment() as non admin
+   * @test
+   * -# Add a new comment with some value
+   * -# Check if the function returns -1
+   */
+  public function testInsertCommentAsNonAdmin()
+  {
+    $this->authClass->expects('isAdmin')->andReturn(false);
+
+    $returnVal = $this->licenseStdCommentDao->insertComment("Inserted comment #1",
+      "This first inserted comment!");
+    $this->assertEquals(-1, $returnVal);
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::insertComment() with empty values
+   * @test
+   * -# Add a new comment with empty values
+   * -# Check if the function returns -1
+   */
+  public function testInsertCommentEmptyValues()
+  {
+    $this->authClass->expects('isAdmin')->andReturn(true);
+
+    $returnVal = $this->licenseStdCommentDao->insertComment("",
+      "       ");
+    $this->assertEquals(-1, $returnVal);
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::toggleComment() as admin
+   * @test
+   * -# Toggle the comment
+   * -# Check if the function returns true
+   * -# Check if the values are updated in DB
+   */
+  public function testToggleCommentAsAdmin()
+  {
+    $this->authClass->expects('isAdmin')->andReturn(true);
+
+    $returnVal = $this->licenseStdCommentDao->toggleComment(5);
+    $this->assertTrue($returnVal);
+    $sql = "SELECT is_enabled FROM license_std_comment WHERE lsc_pk = 5;";
+    $row = $this->dbManager->getSingleRow($sql);
+    $this->assertEquals("f", $row["is_enabled"]);
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::toggleComment() as non admin
+   * @test
+   * -# Toggle the comment as non admin
+   * -# Check if the function returns false
+   */
+  public function testToggleCommentAsNonAdmin()
+  {
+    $this->authClass->expects('isAdmin')->andReturn(false);
+
+    $returnVal = $this->licenseStdCommentDao->toggleComment(5);
+    $this->assertFalse($returnVal);
+  }
+
+  /**
+   * @brief Test for LicenseStdCommentDao::toggleComment() bad id
+   * @test
+   * -# Toggle the comment with bad id
+   * -# Check if the function throws an exception
+   */
+  public function testToggleCommentInvalidId()
+  {
+    $this->authClass->expects('isAdmin')->andReturn(true);
+
+    $this->expectException(\UnexpectedValueException::class);
+
+    $commentId = -1;
+    $returnVal = $this->licenseStdCommentDao->toggleComment($commentId);
+  }
+}

--- a/src/lib/php/Test/testdata.sql
+++ b/src/lib/php/Test/testdata.sql
@@ -696,6 +696,13 @@ INSERT INTO license_ref VALUES (2, 'LGPL-2.1-or-later', 'LGPL 2.1 or later', NUL
 INSERT INTO license_ref VALUES (3, 'GPL-2.0-or-later', 'GPL 2.0 or later', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, true, false, NULL, 3, NULL, NULL, false, 1);
 INSERT INTO license_ref VALUES (4, 'MIT', 'MIT', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, true, false, NULL, 3, NULL, NULL, false, 1);
 INSERT INTO license_ref VALUES (6, 'Classpath-exception-2.0', 'Classpath exception 2.0', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, true, false, NULL, 3, NULL, NULL, false, 1)
+INSERT INTO license_std_comment (lsc_pk, name, comment, updated, user_fk, is_enabled) VALUES (2, 'Test comment #1', 'This will be your first comment!', '2019-05-14 10:12:46.622755+05:30', 2, true);
+INSERT INTO license_std_comment (lsc_pk, name, comment, updated, user_fk, is_enabled) VALUES (3, 'Test comment #2', 'This will be the second comment!', '2019-05-14 10:12:46.624386+05:30', 2, true);
+INSERT INTO license_std_comment (lsc_pk, name, comment, updated, user_fk, is_enabled) VALUES (4, 'Test comment #3', 'This will be the third comment!', '2019-05-14 10:12:46.626194+05:30', 2, true);
+INSERT INTO license_std_comment (lsc_pk, name, comment, updated, user_fk, is_enabled) VALUES (5, 'Test comment #4', 'This will be the fourth comment!', '2019-05-14 10:12:46.627571+05:30', 2, true);
+INSERT INTO license_std_comment (lsc_pk, name, comment, updated, user_fk, is_enabled) VALUES (6, 'Test comment #5', 'This will be the fifth comment!', '2019-05-14 10:12:46.62906+05:30', 2, true);
+INSERT INTO license_std_comment (lsc_pk, name, comment, updated, user_fk, is_enabled) VALUES (7, 'Test comment #6', 'This will be the sixth comment!', '2019-05-14 10:12:46.630884+05:30', 2, true);
+INSERT INTO license_std_comment (lsc_pk, name, comment, updated, user_fk, is_enabled) VALUES (8, 'not-set', 'This comment is not set!', '2019-05-14 10:12:46.632193+05:30', 2, false);
 INSERT INTO mimetype_ars (ars_pk, agent_fk, upload_fk, ars_success, ars_status, ars_starttime, ars_endtime) VALUES (3, 1, 1, true, NULL, '2014-08-07 09:57:20.475587+00', '2014-08-07 09:57:20.593476+00');
 INSERT INTO mimetype_ars (ars_pk, agent_fk, upload_fk, ars_success, ars_status, ars_starttime, ars_endtime) VALUES (8, 1, 2, true, NULL, '2014-08-07 09:57:27.733091+00', '2014-08-07 09:57:27.77946+00');
 INSERT INTO monk_ars (ars_pk, agent_fk, upload_fk, ars_success, ars_status, ars_starttime, ars_endtime) VALUES (6, 5, 1, true, NULL, '2014-08-07 09:57:20.771017+00', '2014-08-07 09:57:21.017807+00');

--- a/src/lib/php/services.xml.in
+++ b/src/lib/php/services.xml.in
@@ -65,6 +65,9 @@ without any warranty.
         <service id="dao.license" class="Fossology\Lib\Dao\LicenseDao">
             <argument type="service" id="db.manager"/>
         </service>
+        <service id="dao.license.stdc" class="Fossology\Lib\Dao\LicenseStdCommentDao">
+            <argument type="service" id="db.manager"/>
+        </service>
         <service id="dao.clearing" class="Fossology\Lib\Dao\ClearingDao">
             <argument type="service" id="db.manager"/>
             <argument type="service" id="dao.upload"/>

--- a/src/www/ui/async/AjaxLicenseStdComments.php
+++ b/src/www/ui/async/AjaxLicenseStdComments.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * *********************************************************
+ * Copyright (C) 2019 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *********************************************************
+ */
+/**
+ * @file
+ * Handles ajax calls for standard license comments.
+ */
+namespace Fossology\UI\Ajax;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\LicenseStdCommentDao;
+use Fossology\Lib\Plugin\DefaultPlugin;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * @class AjaxLicenseStdComments
+ * Handles ajax calls for standard license comments.
+ */
+class AjaxLicenseStdComments extends DefaultPlugin
+{
+
+  /**
+   * @var string NAME
+   *      Mod name
+   */
+  const NAME = "ajax_license_std_comments";
+
+  /**
+   * @var LicenseStdCommentDao $licenseCommentDao
+   *      License comment DAO in use
+   */
+  private $licenseCommentDao;
+
+  function __construct()
+  {
+    parent::__construct(self::NAME,
+      array(
+        self::REQUIRES_LOGIN => true,
+        self::PERMISSION => Auth::PERM_READ
+      ));
+    $this->licenseCommentDao = $this->getObject('dao.license.stdc');
+  }
+
+  /**
+   * @brief Load the license comments based on request type.
+   */
+  protected function handle(Request $request)
+  {
+    $toggleCommentPk = $request->get("toggle");
+    if ($toggleCommentPk !== null) {
+      $status = false;
+      try {
+        $status = $this->licenseCommentDao->toggleComment(intval($toggleCommentPk));
+      } catch (\UnexpectedValueException $e) {
+        $status = $e->getMessage();
+      }
+      return new JsonResponse(["status" => $status]);
+    }
+    $reqScope = $request->get("scope", "all");
+    $responseArray = null;
+    if (strcasecmp($reqScope, "all") === 0) {
+      $responseArray = $this->licenseCommentDao->getAllComments();
+    } else if (strcasecmp($reqScope, "visible") === 0) {
+      $responseArray = $this->licenseCommentDao->getAllComments(true);
+    } else {
+      try {
+        $responseArray = [
+          "comment" => $this->licenseCommentDao->getComment(intval($reqScope))
+        ];
+      } catch (\UnexpectedValueException $e) {
+        $responseArray = [
+          "status" => false,
+          "error" => $e->getMessage()
+        ];
+        return new JsonResponse($responseArray, JsonResponse::HTTP_NOT_FOUND);
+      }
+    }
+    return new JsonResponse($responseArray, JsonResponse::HTTP_OK);
+  }
+}
+
+register_plugin(new AjaxLicenseStdComments());

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -1015,6 +1015,31 @@
   $Schema["TABLE"]["license_set_bulk"]["acknowledgement"]["ALTER"] = "ALTER TABLE \"license_set_bulk\" ALTER COLUMN \"acknowledgement\" DROP NOT NULL";
 
 
+  $Schema["TABLE"]["license_std_comment"]["lsc_pk"]["DESC"] = "COMMENT ON COLUMN \"license_std_comment\".\"lsc_pk\" IS 'Comment id'";
+  $Schema["TABLE"]["license_std_comment"]["lsc_pk"]["ADD"] = "ALTER TABLE \"license_std_comment\" ADD COLUMN \"lsc_pk\" integer NOT NULL DEFAULT nextval('license_std_comment_lsc_pk_seq'::regclass)";
+  $Schema["TABLE"]["license_std_comment"]["lsc_pk"]["ALTER"] = "ALTER TABLE \"license_std_comment\" ALTER COLUMN \"lsc_pk\" SET NOT NULL, ALTER COLUMN \"lsc_pk\" SET DEFAULT nextval('license_std_comment_lsc_pk_seq'::regclass)";
+
+  $Schema["TABLE"]["license_std_comment"]["name"]["DESC"] = "COMMENT ON COLUMN \"license_std_comment\".\"name\" IS 'Friendly name of the comment'";
+  $Schema["TABLE"]["license_std_comment"]["name"]["ADD"] = "ALTER TABLE \"license_std_comment\" ADD COLUMN \"name\" text";
+  $Schema["TABLE"]["license_std_comment"]["name"]["ALTER"] = "ALTER TABLE \"license_std_comment\" ALTER COLUMN \"name\" SET NOT NULL, ALTER COLUMN \"name\" SET DEFAULT 'not-set'";
+
+  $Schema["TABLE"]["license_std_comment"]["comment"]["DESC"] = "COMMENT ON COLUMN \"license_std_comment\".\"comment\" IS 'The standard license comment'";
+  $Schema["TABLE"]["license_std_comment"]["comment"]["ADD"] = "ALTER TABLE \"license_std_comment\" ADD COLUMN \"comment\" text";
+  $Schema["TABLE"]["license_std_comment"]["comment"]["ALTER"] = "ALTER TABLE \"license_std_comment\" ALTER COLUMN \"comment\" DROP NOT NULL";
+
+  $Schema["TABLE"]["license_std_comment"]["updated"]["DESC"] = "COMMENT ON COLUMN \"license_std_comment\".\"updated\" IS 'When this comment was last updated'";
+  $Schema["TABLE"]["license_std_comment"]["updated"]["ADD"] = "ALTER TABLE \"license_std_comment\" ADD COLUMN \"updated\" timestamptz DEFAULT now()";
+  $Schema["TABLE"]["license_std_comment"]["updated"]["ALTER"] = "ALTER TABLE \"license_std_comment\" ALTER COLUMN \"updated\" SET NOT NULL, ALTER COLUMN \"updated\" SET DEFAULT now()";
+
+  $Schema["TABLE"]["license_std_comment"]["user_fk"]["DESC"] = "COMMENT ON COLUMN \"license_std_comment\".\"user_fk\" IS 'Which user did the last update'";
+  $Schema["TABLE"]["license_std_comment"]["user_fk"]["ADD"] = "ALTER TABLE \"license_std_comment\" ADD COLUMN \"user_fk\" int4";
+  $Schema["TABLE"]["license_std_comment"]["user_fk"]["ALTER"] = "ALTER TABLE \"license_std_comment\" ALTER COLUMN \"user_fk\" DROP NOT NULL";
+
+  $Schema["TABLE"]["license_std_comment"]["is_enabled"]["DESC"] = "COMMENT ON COLUMN \"license_std_comment\".\"is_enabled\" IS 'Is the comment enabled?'";
+  $Schema["TABLE"]["license_std_comment"]["is_enabled"]["ADD"] = "ALTER TABLE \"license_std_comment\" ADD COLUMN \"is_enabled\" boolean DEFAULT TRUE";
+  $Schema["TABLE"]["license_std_comment"]["is_enabled"]["ALTER"] = "ALTER TABLE \"license_std_comment\" ALTER COLUMN \"is_enabled\" SET NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT TRUE";
+
+
   $Schema["TABLE"]["mimetype"]["mimetype_pk"]["DESC"] = "";
   $Schema["TABLE"]["mimetype"]["mimetype_pk"]["ADD"] = "ALTER TABLE \"mimetype\" ADD COLUMN \"mimetype_pk\" int4 DEFAULT nextval('mimetype_mimetype_pk_seq'::regclass)";
   $Schema["TABLE"]["mimetype"]["mimetype_pk"]["ALTER"] = "ALTER TABLE \"mimetype\" ALTER COLUMN \"mimetype_pk\" SET NOT NULL, ALTER COLUMN \"mimetype_pk\" SET DEFAULT nextval('mimetype_mimetype_pk_seq'::regclass)";
@@ -1836,6 +1861,9 @@
   $Schema["SEQUENCE"]["license_ref_bulk_lrb_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"license_ref_bulk_lrb_pk_seq\"";
   $Schema["SEQUENCE"]["license_ref_bulk_lrb_pk_seq"]["UPDATE"] = "SELECT setval('license_ref_bulk_lrb_pk_seq',(SELECT greatest(1,max(lrb_pk)) val FROM license_ref_bulk))";
 
+  $Schema["SEQUENCE"]["license_std_comment_lsc_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"license_std_comment_lsc_pk_seq\"";
+  $Schema["SEQUENCE"]["license_std_comment_lsc_pk_seq"]["UPDATE"] = "SELECT setval('license_std_comment_lsc_pk_seq',(SELECT greatest(1,max(lsc_pk)) val FROM license_std_comment))";
+
   $Schema["SEQUENCE"]["mimetype_mimetype_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"mimetype_mimetype_pk_seq\"";
   $Schema["SEQUENCE"]["mimetype_mimetype_pk_seq"]["UPDATE"] = "SELECT setval('mimetype_mimetype_pk_seq',(SELECT greatest(1,max(mimetype_pk)) val FROM mimetype))";
 
@@ -1984,6 +2012,7 @@
   $Schema["CONSTRAINT"]["license_file_pfile_fk_fkey"] = "ALTER TABLE \"license_file\" ADD CONSTRAINT \"license_file_pfile_fk_fkey\" FOREIGN KEY (\"pfile_fk\") REFERENCES \"pfile\" (\"pfile_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["license_map_pkpk"] = "ALTER TABLE \"license_map\" ADD CONSTRAINT \"license_map_pkpk\" PRIMARY KEY (\"license_map_pk\");";
   $Schema["CONSTRAINT"]["license_map_rf_fkfk"] = "ALTER TABLE \"license_map\" ADD CONSTRAINT \"license_map_rf_fkfk\" FOREIGN KEY (\"rf_fk\") REFERENCES \"license_ref\" (\"rf_pk\") ON UPDATE NO ACTION ON DELETE NO ACTION;";
+  $Schema["CONSTRAINT"]["license_std_comment_user_fk_fkey"] = "ALTER TABLE \"license_std_comment\" ADD CONSTRAINT \"license_std_comment_user_fk_fkey\" FOREIGN KEY (\"user_fk\") REFERENCES \"users\" (\"user_pk\") ON UPDATE SET NULL ON DELETE SET NULL";
   $Schema["CONSTRAINT"]["rf_pkpk"] = "ALTER TABLE \"license_ref\" ADD CONSTRAINT \"rf_pkpk\" PRIMARY KEY (\"rf_pk\");";
   $Schema["CONSTRAINT"]["rf_md5unique"] = "ALTER TABLE \"license_ref\" ADD CONSTRAINT \"rf_md5unique\" UNIQUE (\"rf_md5\");";
   $Schema["CONSTRAINT"]["license_ref_bulk_pkey"] = "ALTER TABLE \"license_ref_bulk\" ADD CONSTRAINT \"license_ref_bulk_pkey\" PRIMARY KEY (\"lrb_pk\");";

--- a/src/www/ui/page/AdminLicenseStdComments.php
+++ b/src/www/ui/page/AdminLicenseStdComments.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * *********************************************************
+ * Copyright (C) 2019 Siemens AG
+ *
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *********************************************************
+ */
+
+/**
+ * @file
+ * Allows users to manage set of standard license comments.
+ */
+namespace Fossology\UI\Page;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\LicenseStdCommentDao;
+use Fossology\Lib\Plugin\DefaultPlugin;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @class AdminLicenseStdComments
+ * Page to allow users to manage the standard license comments.
+ */
+class AdminLicenseStdComments extends DefaultPlugin
+{
+
+  /**
+   * @var string NAME
+   *      Mod name
+   */
+  const NAME = "admin_license_std_comments";
+
+  /**
+   * @var string UPDATE_PARAM_NAME
+   *      Name of the parameter to denote form submit
+   */
+  const UPDATE_PARAM_NAME = "formUpdated";
+
+  /**
+   * @var string COMMENT_PARAM_NAME
+   *      Parameter storing the comment names
+   */
+  const COMMENT_PARAM_NAME = "licenseStdComment";
+
+  /**
+   * @var string COMMENT_ID_PARAM_NAME
+   *      Parameter storing the comment IDs
+   */
+  const COMMENT_ID_PARAM_NAME = "licenseCommentLscPK";
+
+  /**
+   * @var string COMMENT_NAME_PARAM_NAME
+   *      Parameter storing the comments
+   */
+  const COMMENT_NAME_PARAM_NAME = "licenseCommentName";
+
+  /**
+   * @var string INSERT_NAME_PARAM_NAME
+   *      Parameter storing the new names
+   */
+  const INSERT_NAME_PARAM_NAME = "insertStdLicNames";
+
+  /**
+   * @var string INSERT_NAME_PARAM_NAME
+   *      Parameter storing the new comments
+   */
+  const INSERT_COMMENT_PARAM_NAME = "insertStdLicComments";
+
+  /**
+   * @var string ENABLE_PARAM_NAME
+   *      Parameter storing the comment status
+   */
+  const ENABLE_PARAM_NAME = "stdLicCommentEnabled";
+
+  /**
+   * @var LicenseStdCommentDao $licenseCommentDao
+   *      License comment DAO in use
+   */
+  private $licenseCommentDao;
+
+  function __construct()
+  {
+    parent::__construct(self::NAME,
+      array(
+        self::TITLE => "Admin Standard License Comments",
+        self::MENU_LIST => "Admin::License Admin::Standard Comments",
+        self::REQUIRES_LOGIN => true,
+        self::PERMISSION => Auth::PERM_ADMIN
+      ));
+    $this->licenseCommentDao = $this->getObject('dao.license.stdc');
+  }
+
+  /**
+   * @param Request $request
+   * @return Response
+   */
+  protected function handle(Request $request)
+  {
+    if ($request->get(self::UPDATE_PARAM_NAME, 0) == 1) {
+      return new JsonResponse($this->updateComments($request),
+        JsonResponse::HTTP_OK);
+    }
+
+    $vars = [];
+    $vars["updateParam"] = self::UPDATE_PARAM_NAME;
+    $vars["commentParam"] = self::COMMENT_PARAM_NAME;
+    $vars["commentIdParam"] = self::COMMENT_ID_PARAM_NAME;
+    $vars["commentNameParam"] = self::COMMENT_NAME_PARAM_NAME;
+    $vars["enableParam"] = self::ENABLE_PARAM_NAME;
+
+    $vars['commentArray'] = $this->licenseCommentDao->getAllComments();
+    return $this->render('admin_license_std_comments.html.twig',
+      $this->mergeWithDefault($vars));
+  }
+
+  /**
+   * Get the parameters from the request and update the comments.
+   *
+   * @param Request $request The request
+   * @return array Number of comments updated/inserted as value of
+   *         corresponding keys, or error (if any).
+   */
+  private function updateComments(Request $request)
+  {
+    $comments = [];
+    $update = [
+      "updated" => -1,
+      "inserted" => []
+    ];
+    $commentStrings = $request->get(self::COMMENT_PARAM_NAME);
+    $commentNames = $request->get(self::COMMENT_NAME_PARAM_NAME);
+    $insertNames = $request->get(self::INSERT_NAME_PARAM_NAME);
+    $insertComments = $request->get(self::INSERT_COMMENT_PARAM_NAME);
+    if ($commentStrings !== null && !empty($commentStrings)) {
+      foreach ($commentStrings as $commentPk => $comment) {
+        $comments[$commentPk]['comment'] = $comment;
+      }
+    }
+    if ($commentNames !== null && !empty($commentNames)) {
+      foreach ($commentNames as $commentPk => $name) {
+        $comments[$commentPk]['name'] = $name;
+      }
+    }
+    if (! empty($comments)) {
+      try {
+        $update['updated'] = $this->licenseCommentDao->updateCommentFromArray(
+          $comments);
+      } catch (\UnexpectedValueException $e) {
+        $update['updated'] = $e->getMessage();
+      }
+    }
+    $update["inserted"] = $this->insertComments($insertNames, $insertComments);
+    return $update;
+  }
+
+  /**
+   * Insert new comments
+   *
+   * @param array $namesArray    Array containing new names
+   * @param array $commentsArray Array containing new comments
+   * @return number[]
+   */
+  private function insertComments($namesArray, $commentsArray)
+  {
+    $returnVal = [];
+    if (($namesArray !== null && $commentsArray !== null) &&
+      (! empty($namesArray) && !empty($commentsArray))) {
+      for ($i = 0; $i < count($namesArray); $i++) {
+        $returnVal[] = $this->licenseCommentDao->insertComment($namesArray[$i],
+          $commentsArray[$i]);
+      }
+      $returnVal['status'] = 0;
+      // Check if at least one value was inserted
+      if (count(array_filter($returnVal, function($val) {
+        return $val > 0; // No error
+      })) > 0) {
+        $returnVal['status'] |= 1;
+      }
+      // Check if an error occurred while insertion
+      if (in_array(-1, $returnVal)) {
+        $returnVal['status'] |= 1 << 1;
+      }
+      // Check if an exception occurred while insertion
+      if (in_array(-2, $returnVal)) {
+        $returnVal['status'] |= 1 << 2;
+      }
+    }
+    return $returnVal;
+  }
+}
+
+register_plugin(new AdminLicenseStdComments());

--- a/src/www/ui/scripts/admin-license-std-comments.js
+++ b/src/www/ui/scripts/admin-license-std-comments.js
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2019, Siemens AG
+ *
+ * Author: Gaurav Mishra, <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+function showTheMessage(message) {
+  $("html, body").animate({ scrollTop: 0 }, "slow");
+  $("#messageSpace").html(message + "<hr />").fadeIn(500).delay(5000).fadeOut(500);
+}
+
+$(document).ready(function() {
+
+  var form = $('form#adminLicenseCommentForm');
+
+  var t = $("#adminLicenseCommentTable").DataTable({
+    "processing": true,
+    "paginationType": "listbox",
+    "order": [[ 1, 'asc' ]],
+    "autoWidth": false,
+    "columnDefs": [{
+      "createdCell": function (cell) {
+        $(cell).attr("style", "text-align:center");
+      },
+      "searchable": false,
+      "targets": [0]
+    },{
+      "orderable": false,
+      "targets": [0,2,3]
+    },{
+      "orderable": true,
+      "targets": [1]
+    }],
+  });
+
+  t.on('order.dt search.dt', function () {
+    t.column(0, {search:'applied', order:'applied'}).nodes().each( function (cell, i) {
+      cell.innerHTML = i+1;
+    });
+  }).draw();
+
+  form.find("input[type=text],textarea").on("change", function(){
+    $(this).addClass("inputChanged");
+  });
+
+  form.submit(function(event) {
+    var updatedFields = form.find(".inputChanged").serializeArray();
+    var insertedFields = form.find(".newCommentInputs").serializeArray();
+    if (updatedFields.length > 0 || insertedFields.length > 0) {
+      var itemsToSend = $.merge(updatedFields, insertedFields);
+      itemsToSend.push({"name": "formUpdated", "value": 1});
+      $.ajax({
+        url : '?mod=admin_license_std_comments',
+        type : 'post',
+        dataType : 'json',
+        data : itemsToSend,
+        success : function(data) {
+          var message = "";
+          if (data.updated == -1) {
+            message = "No comments updated";
+          } else if (data.updated > 0) {
+            form.find(".inputChanged").removeClass("inputChanged");
+            message = "Comments updated succesfully";
+          } else {
+            message = data.updated;
+          }
+          var messageIns = [];
+          if (data.inserted.status != 0) {
+            if (data.inserted.status & 1) {
+              form.find(".newCommentInputs").each(function(){
+                if ($(this).val().trim()) {
+                  $(this).removeClass("newCommentInputs");
+                }
+              });
+              messageIns.push("Comments inserted successfully");
+            }
+            if (data.inserted.status & 1<<1) {
+              messageIns.push("errors during insertion");
+            }
+            if (data.inserted.status & 1<<2) {
+              messageIns.push("exceptions during insertion");
+            }
+          }
+          showTheMessage(message + ".<br />" + messageIns.join(" with some ") + ".");
+        },
+        error : function(data) {
+          showTheMessage(data);
+        }
+      });
+    }
+    event.preventDefault();
+  });
+
+  $("#addStdLicComment").on('click', function(){
+    t.row.add([
+      null,
+      '<input type="text" name="insertStdLicNames[]" ' +
+        'placeholder="Please enter a name for the comment" ' +
+        'class="newCommentInputs" />',
+      '<textarea rows="7" cols="80" name="insertStdLicComments[]" ' +
+        'placeholder="Please enter a comment statement" ' +
+        'class="newCommentInputs"></textarea>',
+      '<input type="checkbox" checked disabled />'
+    ]).draw(false);
+  });
+
+  $(".licStdCommentToggle").change(function(){
+    var changedBox = $(this);
+    var boxName = changedBox.attr("name");
+    var idRegex = /stdLicCommentEnabled\[(\d+)\]/g;
+    var commId = idRegex.exec(boxName);
+    commId = commId[1];
+    $.ajax({
+      url : '?mod=ajax_license_std_comments',
+      type : 'post',
+      dataType : 'json',
+      data : {"toggle": commId},
+      success : function(data) {
+        if (data.status != true) {
+          // Not updated, revert the UI
+          var current = changedBox.prop("checked");
+          changedBox.prop("checked", !current);
+        }
+      }
+    });
+  });
+});

--- a/src/www/ui/template/admin_license_std_comments.html.twig
+++ b/src/www/ui/template/admin_license_std_comments.html.twig
@@ -1,0 +1,65 @@
+{# Copyright 2019 Siemens AG
+
+   Copying and distribution of this file, with or without modification,
+   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
+   This file is offered as-is, without any warranty.
+#}
+{% extends "include/base.html.twig" %}
+
+{% block content %}
+
+  <p id="messageSpace"></p>
+  <form name="adminLicenseCommentForm" id="adminLicenseCommentForm">
+    <table id="adminLicenseCommentTable" class="simpleTable" cellpadding="3">
+      <thead>
+        <tr>
+          <th>Sl. No.</th>
+          <th>Name</th>
+          <th>Comment</th>
+          <th>Enabled</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for comment in commentArray %}
+        <tr>
+          <td style="text-align:center">{{ loop.index }}</td>
+          <td>
+            <input type="text" name="{{ commentNameParam }}[{{ comment.lsc_pk }}]"
+              value="{{ comment.name }}"
+              placeholder="{{ "Please enter a name for the comment"|trans }}" />
+          </td>
+          <td>
+            <textarea rows="7" cols="80" name="{{ commentParam }}[{{ comment.lsc_pk }}]"
+              placeholder="{{ "Please enter a comment statement"|trans }}">{{ comment.comment }}</textarea>
+          </td>
+          <td>
+            <input type="checkbox" name="{{ enableParam }}[{{ comment.lsc_pk }}]"
+              value="t" class="licStdCommentToggle"
+              {% if comment.is_enabled starts with 't' %}checked{% endif %} />
+          </td>
+        </tr>
+      {% endfor %}
+      </tbody>
+      <tfoot>
+        <tr>
+          <td colspan="4">
+            <button id="addStdLicComment" title="{{ "Add a new comment"|trans }}"
+              style="width:100%" type="button">
+              <img src="images/icons/add_16.png" />{{ "Add a new comment"|trans }}
+            </button>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="4"><input type="submit" value="Save" style="width:auto" /></td>
+        </tr>
+      </tfoot>
+    </table>
+  </form>
+{% endblock %}
+
+{% block foot %}
+  {{ parent() }}
+  <script type="text/javascript" src="scripts/jquery.dataTables.min.js"></script>
+  <script type="text/javascript" src="scripts/jquery.dataTables.select.js"></script>
+  <script type="text/javascript" src="scripts/admin-license-std-comments.js"></script>
+{% endblock %}


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This feature will allow admins to add some predefined license comments which can be used by users during clearing with the help of a simple drop down in License Comment window.

Admins can navigate to **Admin >> License Admin >> Standard Comments**.

~Currently admins can add **only 7** comments at max to keep the interface simple.~

### Changes

1. Add new table to hold predefined license comments.
1. Allow users to select these comments with the help of a drop down menu.

## How to test

1. Insert some comments from the **Admin Standard License Comments** page.
1. Clear some files and add the comments.
    1. Try adding comments from the decision table.
    1. Try adding comments from the buik table.
1. Add the comments added from the first step should be visible.
1. Added comments should appear in the reports.

**P.S.:** Whenever a change is done in the comments, the user who changed the comment and timestamp is stored as well. It will help in auditing but is never shown in the UI or returned by any API.