### PR TITLE
chore(travis): Set pipefail in Travis CI PHPUnit on PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -162,6 +162,7 @@ jobs:
       php: 7.0
       install: composer update --ignore-platform-reqs --with-dependencies --prefer-dist --working-dir=src phpunit/phpunit
       script:
+        - set -o pipefail
         - make build-lib VERSIONFILE build-cli
         - phpdbg -qrr src/vendor/bin/phpunit -csrc/phpunit.xml --testsuite="Fossology PhpUnit Test Suite" --colors=always | grep -v 'script>\|c.log'
     - &php71-phpunit-tests


### PR DESCRIPTION
## Description

Fix #1333

### Changes

Set shell option pipefail

>  If  set,  the  return value of a pipeline is the value of the last (rightmost)  command  to  exit  with  a non-zero status, or zero if all commands in the pipeline exit successfully.  This  option is disabled by default.

## How to test

Apply the patch on those should fail but didn't.