### PR TITLE
fix(UI): increased the size of upload to resuse window in upload files

### DIFF
--- a/src/www/ui/css/select2.custom.css
+++ b/src/www/ui/css/select2.custom.css
@@ -1,0 +1,3 @@
+.select2-container--default .select2-results>.select2-results__options{
+    max-height: 500px !important;
+}

--- a/src/www/ui/template/include/upload.html.twig
+++ b/src/www/ui/template/include/upload.html.twig
@@ -8,6 +8,7 @@
 {% block styles %}
 {{ parent() }}
 <link rel="stylesheet" type="text/css" href="css/select2.min.css"/>
+<link rel="stylesheet" type="text/css" href="css/select2.custom.css"/>
 {% endblock %}
 {% block content %}
   <p>


### PR DESCRIPTION
## Description

The box height for "select upload to reuse" in page "upload file" is increased.  Hence giving users access to more number of files before scrolling down.

### Changes

To make it easy to search and select upload to reuse items in Upload Files Page, the size of upload to reuse window is increased from 200px to 500px.

## How to test

### Before Issue Fix.

1. Start Fossology.
2. Go to Upload Files from Menu Option.
3. Scroll down to "Upload To Reuse" select option.
4. The height of the list options is small.

### After Issue fix

1. Move to the same location.
2. The height of the list options is increased. Thus more options are available on the current display, making it easier to search and find files in the scroll menu.

Closes: #1347 

### Old UI
---
![old UI](https://user-images.githubusercontent.com/30703636/58385375-106cb280-800d-11e9-8f84-2a271fc2c177.PNG)

### New UI
---
![new ui](https://user-images.githubusercontent.com/30703636/58385379-15316680-800d-11e9-87da-aa2a3ab0103d.PNG)


