### PR TITLE
fix(advicelicense): fix double select of risk in advice license

### DIFF
--- a/src/reportImport/ui/ReportImportPlugin.php
+++ b/src/reportImport/ui/ReportImportPlugin.php
@@ -109,9 +109,6 @@ class ReportImportPlugin extends DefaultPlugin
     $vars['folderStructure'] = $folderStructure;
     $vars['baseUri'] = $Uri = Traceback_uri() . "?mod=" . self::NAME . "&folder=";
 
-    $baseFolderUri = $vars['baseUri']."$folder_pk&upload=";
-    $vars['uploadAction'] = "onchange=\"js_url(this.value, '$baseFolderUri')\"";
-
     return $this->render('ReportImportPlugin.html.twig', $this->mergeWithDefault($vars));
   }
 

--- a/src/reportImport/ui/template/ReportImportPlugin.html.twig
+++ b/src/reportImport/ui/template/ReportImportPlugin.html.twig
@@ -15,7 +15,7 @@ This file is offered as-is, without any warranty.
       <li>{{ "Select the upload you wish to edit"|trans }}:
         {% if uploadList is not empty %}
           {% import "include/macros.html.twig" as macro %}
-          {{ macro.select('uploadselect',uploadList,'uploadselect',uploadId,uploadAction) }}
+          {{ macro.select('uploadselect',uploadList,'uploadselect',uploadId,'class="ui-render-select2"') }}
         {% else %}
           {{ 'No upload available in this folder'|trans }}
         {% endif %}

--- a/src/www/ui/template/admin_group_delete.html.twig
+++ b/src/www/ui/template/admin_group_delete.html.twig
@@ -12,7 +12,7 @@
  <form name="formy" method="post" action="{{ uri }}">
     {{ "Select the group to delete"|trans }}:
     {% import "include/macros.html.twig" as macro %}
-    {{ macro.select('grouppk',groupMap,'grouppk') }}
+    {{ macro.select('grouppk',groupMap,'grouppk','','class="ui-render-select2"') }}
     <input type="submit" value="{{ 'Delete'|trans }}"/>
   </form>
 {% endblock %}

--- a/src/www/ui/template/admin_group_users.html.twig
+++ b/src/www/ui/template/admin_group_users.html.twig
@@ -10,7 +10,7 @@
   
 {{ "Select the group to manage"|trans }}:
 {% import "include/macros.html.twig" as macro %}
-{{ macro.select('groupselect',groupMap,'groupselect',groupId,groupMapAction) }}
+{{ macro.select('groupselect',groupMap,'groupselect',groupId,groupMapAction ~ 'class="ui-render-select2"') }}
 
 <table border="1">
   <tr><th>{{ "User"|trans }}</th><th>{{ 'Permission'|trans }}</th></tr>
@@ -26,7 +26,7 @@
   {% if existsOtherUsers %}
     <tr>
       <td>
-      {{ macro.select("userselectnew", otherUsers, "userselectnew", '', ' onchange="js_url(this.value, newpermurl)"') }}
+      {{ macro.select("userselectnew", otherUsers, "userselectnew", '', ' class="ui-render-select2" onchange="js_url(this.value, newpermurl)"') }}
     </td>
     <td>
       {{ macro.select("permselectnew",newPermissionMap, "permselectnew",-1,' onchange="setNewPermUrl(this.value)"') }}

--- a/src/www/ui/template/admin_license-upload_form.html.twig
+++ b/src/www/ui/template/admin_license-upload_form.html.twig
@@ -64,11 +64,11 @@
     </tr>
     <tr>
       <td align="right">{{ 'Conclusion'|trans }}</td>
-      <td align="left">{{ macro.select('rf_parent',parentMap,'rf_parent',rf_parent) }}</td>
+      <td align="left">{{ macro.select('rf_parent',parentMap,'rf_parent',rf_parent, 'class="ui-render-select2"') }}</td>
     </tr>
     <tr>
       <td align="right">{{ 'Reported license'|trans }}</td>
-      <td align="left">{{ macro.select('rf_report',reportMap,'rf_report',rf_report) }}</td>
+      <td align="left">{{ macro.select('rf_report',reportMap,'rf_report',rf_report, 'class="ui-render-select2"') }}</td>
     </tr>
     <tr>
       <td align="right">{{ 'Risk level'|trans }}</td>

--- a/src/www/ui/template/admin_upload_edit.html.twig
+++ b/src/www/ui/template/admin_upload_edit.html.twig
@@ -15,7 +15,7 @@
       <li>{{ "Select the upload you wish to edit"|trans }}:
         {% if uploadId is not empty %}<input type="hidden" name="upload_pk" value="{{ uploadId }}" />
           {% import "include/macros.html.twig" as macro %}
-          {{ macro.select('uploadselect',uploadList,'uploadselect',uploadId,uploadAction) }}
+          {{ macro.select('uploadselect',uploadList,'uploadselect',uploadId,uploadAction ~ 'class="ui-render-select2"') }}
         {% else %}
           {{ 'No upload available in this folder'|trans }}
         {% endif %}

--- a/src/www/ui/template/advice_license-edit.html.twig
+++ b/src/www/ui/template/advice_license-edit.html.twig
@@ -33,8 +33,8 @@
       <td><textarea name="note" cols="120" rows="10">{{ rf_notes|e }}</textarea></td>
     </tr>
     <tr>
-      <td align="right">{{ 'Risk level'|trans }}</td>
-      <td align="left">
+      <td valign="top">{{ 'Risk level'|trans }}:</td>
+      <td>
         {% import 'include/macros.html.twig' as macro %}
         {{ macro.select('risk',range(0,5),'risk',rf_risk) }}
       </td>

--- a/src/www/ui/template/components/menu.html.twig
+++ b/src/www/ui/template/components/menu.html.twig
@@ -40,7 +40,7 @@
               {%else%}       
                 <form action="{{ backtraceUri }}" method="post">
                   {% import "include/macros.html.twig" as macro %}
-                  {{ macro.select('selectMemberGroup',allAssignedGroups,'selectMemberGroup',groupId,' onchange="this.form.submit()"') }}
+                  {{ macro.select('selectMemberGroup',allAssignedGroups,'selectMemberGroup',groupId,' class="ui-render-select2" onchange="this.form.submit()"') }}
               </form>
               {% endif %}
             </td>

--- a/src/www/ui/template/include/macros.html.twig
+++ b/src/www/ui/template/include/macros.html.twig
@@ -34,7 +34,7 @@
     {% set size = 0 %}
   {% endif %}
   <select name="{{ name }}"{% if id is defined %} id="{{ id }}"{% endif %}{% if size > 0  %} multiple="multiple" size="{{ size }}"{% endif %}{% if action is defined %}
-    {{ action}}{% endif %} class="ui-render-select2">
+    {{ action}}{% endif %}>
     {% for key, value in options %}
       <option value="{{ key }}"{% if selected == key %} selected="selected"{% endif %}>
         {{ value|e }}

--- a/src/www/ui/template/upload_permissions.html.twig
+++ b/src/www/ui/template/upload_permissions.html.twig
@@ -40,7 +40,7 @@
       {% if additableGroups is not empty %}
       <tr>
         <td>
-          {{ macro.select('groupselectnew',additableGroups,'groupselectnew',newGroup) }}
+          {{ macro.select('groupselectnew', additableGroups, 'groupselectnew', newGroup, 'class="ui-render-select2"') }}
         </td>
         <td>
           {% if permNamesWithReuse is defined %}

--- a/src/www/ui/template/user_edit.html.twig
+++ b/src/www/ui/template/user_edit.html.twig
@@ -15,7 +15,7 @@
   {%  if isSessionAdmin %}
     {{ "Select the user to edit"|trans }}:
     {% import "include/macros.html.twig" as macro %}
-    {{ macro.select('userid', allUsers, 'userid', userId, ' onchange="RefreshPage(this.value);"') }}
+    {{ macro.select('userid', allUsers, 'userid', userId, ' class="ui-render-select2" onchange="RefreshPage(this.value);"') }}
   {% endif %}
     
   <table style="border:1px solid black; border-collapse: collapse;" width="100%">


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Removed the class of select to from macro initialization.

## How to test

add a advise license and check if the UI looks ok.
