### PR TITLE
fix(init.d): Implement missing function

### DIFF
--- a/debian/fossology-scheduler.lintian-overrides
+++ b/debian/fossology-scheduler.lintian-overrides
@@ -1,0 +1,2 @@
+# We use #DEBHELPER# to generate the update-rc and invoke-rc calls
+fossology-scheduler: script-in-etc-init.d-not-registered-via-update-rc.d etc/init.d/fossology

--- a/debian/fossology-scheduler/usr/share/lintian/overrides/fossology-scheduler
+++ b/debian/fossology-scheduler/usr/share/lintian/overrides/fossology-scheduler
@@ -1,0 +1,2 @@
+# We use #DEBHELPER# to generate the update-rc and invoke-rc calls
+fossology-scheduler: script-in-etc-init.d-not-registered-via-update-rc.d etc/init.d/fossology

--- a/src/scheduler/agent/Makefile
+++ b/src/scheduler/agent/Makefile
@@ -133,7 +133,6 @@ $(COVERAGE): %_cov.o: %.c $(HEAD) $(DEPEN)
 install: all install-conf
 	$(INSTALL_PROGRAM) fo_scheduler $(DESTDIR)$(MODDIR)/scheduler/agent/fo_scheduler
 	$(INSTALL_PROGRAM) fo_cli $(DESTDIR)$(MODDIR)/scheduler/agent/fo_cli
-	$(INSTALL_PROGRAM) defconf/$(INITFILE) $(DESTDIR)$(INITDIR)/$(INITFILE)
 	@if test ! -e $(CONFDIR)/mods-enabled/scheduler; then \
 		ln -s $(MODDIR)/scheduler $(CONFDIR)/mods-enabled; \
 	fi

--- a/src/scheduler/agent/defconf/init.d/fossology.in
+++ b/src/scheduler/agent/defconf/init.d/fossology.in
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 # Init script for the {$PROJECT} scheduler.
 # Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
 #
@@ -10,6 +10,7 @@
 # Provides:          {$PROJECT}
 # Required-Start:    $network $local_fs $remote_fs $syslog $named
 # Required-Stop:     $network $local_fs $remote_fs $syslog $named
+# Should-Start:      postgresql
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: FOSSology scheduler daemon
@@ -20,6 +21,9 @@ DAEMON={$MODDIR}/scheduler/agent/fo_scheduler
 CLI={$MODDIR}/scheduler/agent/fo_cli
 NAME=fossology
 DESC="FOSSology job scheduler"
+
+# Include default init-functions for Debian
+[ -e /lib/lsb/init-functions ] && . /lib/lsb/init-functions
 
 test -x $DAEMON || exit 0
 
@@ -39,44 +43,52 @@ test "$ENABLED" != "0" || exit 0
 
 set -e
 
-case "$1" in
-  start)
+start () \{
     echo -n "Starting $DESC: "
     $DAEMON $SCHEDULEROPT
     echo "$NAME."
-    ;;
-  stop)
+\}
+
+stop () \{
     echo -n "Stopping $DESC: "
     # we don't really care about the exit code as long as it's stopped
     $DAEMON --kill || echo -n "no "
     echo "$NAME killed."
-    ;;
-  graceful-stop)
+\}
+
+gracefulstop () \{
     echo -n "Gracefully shutting down $DESC after all current jobs finish: "
     # we don't really care about the exit code as long as it's stopped
     $DAEMON --shutdown
     echo "$NAME shutdown."
+\}
+
+reload () \{
+    $CLI --reload
+\}
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  graceful-stop)
+    gracefulstop
     ;;
   restart)
     echo -n "Restarting $DESC: "
-    $DAEMON --kill || true
+    stop
     sleep 1
-    $DAEMON $SCHEDULEROPT
-    echo "$NAME."
+    start
     ;;
-  reload)
-    #
-    #	If the daemon can reload its config files on the fly
-    #	for example by sending it SIGHUP, do it here.
-    #
-    #	If the daemon responds to changes in its config file
-    #	directly anyway, make this a do-nothing entry.
-    #
-    $CLI --reload
+  reload|force-reload)
+    reload
     ;;
   *)
     N={$INITDIR}/init.d/$NAME
-    echo "Usage: $N \{start|stop|graceful-stop|restart|reload\}" >&2
+    echo "Usage: $N \{start|stop|graceful-stop|restart|reload|force-reload\}" >&2
     exit 1
 	;;
 esac


### PR DESCRIPTION
## Description

This commit adds a weak dependency on postgresql on start.

Fix some warnings be lintian.

### Changes

1. Implement `force-reload` (required function) in `init.d` script.
1. Include default init-functions for Debian.
1. Add lintian override for `script-in-etc-init.d-not-registered-via-update-rc.d` as it is done by `#DEBHELPER#`.
1. Add a weak dependency on postgresql for start.

## How to test

Build the package using `debuild`, check the lintian logs.

Closes #1171
Closes #441