### PR TITLE
feat(copyright): New directory scan and better JSON

### DIFF
--- a/src/copyright/agent/Makefile
+++ b/src/copyright/agent/Makefile
@@ -13,8 +13,9 @@ include $(VARS)
 CXXFLAGS_LOCAL = $(FO_CXXFLAGS) -I. -Wall -Wextra -fopenmp $(shell pkg-config --cflags jsoncpp)
 DEF = -DDATADIR='"$(MODDIR)"'
 CONFDIR = $(DESTDIR)$(SYSCONFDIR)
-CXXFLAGS_LINK = -lboost_regex -lboost_program_options $(ALL_CXXFLAGS) -lm -fopenmp $(FO_CXXLDFLAGS) \
-                $(shell pkg-config --libs jsoncpp)
+CXXFLAGS_LINK = -lboost_regex -lboost_program_options -lboost_system \
+                -lboost_filesystem $(ALL_CXXFLAGS) -lm -fopenmp \
+                $(FO_CXXLDFLAGS) $(shell pkg-config --libs jsoncpp)
 
 DEF_ID_COP = -DIDENTITY_COPYRIGHT
 DEF_ID_ECC = -DIDENTITY_ECC
@@ -28,7 +29,7 @@ EXE_COV = $(EXE_COP)_cov
 
 
 
-OBJECTS = copyright.o regscan.o scanners.o cleanEntries.o regexConfProvider.o regexConfParser.o
+OBJECTS = copyright.o regscan.o scanners.o cleanEntries.o regexConfProvider.o regexConfParser.o directoryScan.o
 OBJECTS_COP = copyscan_cop.o copyrightUtils_cop.o copyrightState_cop.o database_cop.o
 OBJECTS_ECC = copyrightUtils_ecc.o copyrightState_ecc.o database_ecc.o
 OBJECTS_KW = copyrightUtils_kw.o copyrightState_kw.o database_kw.o

--- a/src/copyright/agent/copyrightUtils.hpp
+++ b/src/copyright/agent/copyrightUtils.hpp
@@ -5,12 +5,12 @@
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2
  * as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 #include <list>
+#include <json/json.h>
 
 #include "scanners.hpp"
 #include "regscan.hpp"
@@ -47,7 +48,8 @@ void bail(int exitval);
 
 int writeARS(int agentId, int arsId, int uploadId, int success, const fo::DbManager& dbManager);
 
-bool parseCliOptions(int argc, char** argv, CliOptions& dest, std::vector<std::string>& fileNames);
+bool parseCliOptions(int argc, char** argv, CliOptions& dest,
+    std::vector<std::string>& fileNames, std::string& directoryToScan);
 
 CopyrightState getState(CliOptions&& cliOptions);
 
@@ -59,6 +61,14 @@ void normalizeContent(std::string& content);
 
 bool processUploadId(const CopyrightState& state, int agentId, int uploadId, CopyrightDatabaseHandler& handler);
 
+std::pair<std::string, std::list<match>> processSingleFile(const CopyrightState& state,
+  const std::string fileName);
+
+void appendToJson(const std::string fileName,
+    const std::pair<string, list<match>> resultPair, bool &printComma);
+
+void printResultToStdout(const std::string fileName,
+    const std::pair<string, list<match>> resultPair);
 
 #endif /* COPYRIGHTUTILS_HPP_ */
 

--- a/src/copyright/agent/directoryScan.cc
+++ b/src/copyright/agent/directoryScan.cc
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2019, Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+/**
+ * \file
+ * \brief Utilities to scan directories
+ */
+
+#include "directoryScan.hpp"
+
+using namespace std;
+namespace fs = boost::filesystem;
+
+void scanDirectory(const CopyrightState& state, const bool json,
+    const string directoryPath)
+{
+  fs::recursive_directory_iterator dirIterator(directoryPath);
+  fs::recursive_directory_iterator end;
+
+  vector<string> filePaths;
+
+  for (fs::path const &p : boost::make_iterator_range(dirIterator, {}))
+  {
+    if (fs::is_directory(p))
+    {
+      // Can not do anything with a directory
+      continue;
+    }
+    // Store the paths in a vector as of now since we can not `#pragma omp for`
+    // on recursive_directory_iterator
+    filePaths.push_back(p.string());
+  }
+  const unsigned long filePathsSize = filePaths.size();
+  bool printComma = false;
+
+  if (json)
+  {
+    cout << "[" << endl;
+  }
+
+#pragma omp parallel
+  {
+#pragma omp for
+    for (unsigned int i = 0; i < filePathsSize; i++)
+    {
+      string fileName = filePaths[i];
+      pair<string, list<match>> scanResult = processSingleFile(state, fileName);
+      if (json)
+      {
+        appendToJson(fileName, scanResult, printComma);
+      }
+      else
+      {
+        printResultToStdout(fileName, scanResult);
+      }
+    }
+  }
+  if (json)
+  {
+    cout << endl << "]" << endl;
+  }
+}

--- a/src/copyright/agent/directoryScan.hpp
+++ b/src/copyright/agent/directoryScan.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2013-2014, Siemens AG
- * Author: Daniele Fognini, Andreas Wuerl
+ * Copyright (C) 2019, Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2
@@ -16,15 +16,16 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#ifndef COPYRIGHT_HPP
-#define COPYRIGHT_HPP
+#ifndef DIRECTORYSCAN_HPP_
+#define DIRECTORYSCAN_HPP_
 
-#include <vector>
+#include <boost/filesystem.hpp>
+#include <boost/range/iterator_range.hpp>
+#include <iostream>
+
 #include "copyrightUtils.hpp"
-#include "directoryScan.hpp"
 
-extern "C" {
-#include "libfossagent.h"
-}
+void scanDirectory(const CopyrightState& state, const bool json,
+    const std::string directoryPath);
 
-#endif // COPYRIGHT_HPP
+#endif /* DIRECTORYSCAN_HPP_ */

--- a/src/copyright/agent_tests/Unit/Makefile
+++ b/src/copyright/agent_tests/Unit/Makefile
@@ -11,10 +11,11 @@ include $(VARS)
 
 LOCALAGENTDIR = ../../agent
 # -Werror -Wextra
-CXXFLAGS_LOCAL = $(FO_CXXFLAGS) -I. -Wall -I$(LOCALAGENTDIR) -fopenmp
+CXXFLAGS_LOCAL = $(FO_CXXFLAGS) -I. -Wall -I$(LOCALAGENTDIR) -fopenmp $(shell pkg-config --cflags jsoncpp)
 DEF = -DDATADIR='"$(MODDIR)"'
 CONFDIR = $(DESTDIR)$(SYSCONFDIR)
-CXXFLAGS_LINK = -lboost_regex -lboost_program_options $(FO_CXXLDFLAGS) -lm  -lstdc++ -lcppunit -ldl -fopenmp
+CXXFLAGS_LINK = -lboost_regex -lboost_program_options $(FO_CXXLDFLAGS) -lm \
+                -lstdc++ -lcppunit -ldl -fopenmp
 
 EXE = test_copyright
 

--- a/src/copyright/mod_deps
+++ b/src/copyright/mod_deps
@@ -77,7 +77,7 @@ if [[ $BUILDTIME ]]; then
   case "$DISTRO" in
     Debian|Ubuntu)
       apt-get $YesOpt install \
-        libjsoncpp-dev
+        libjsoncpp-dev libboost-system-dev libboost-filesystem-dev
       ;;
     Fedora)
       yum $YesOpt install \
@@ -98,9 +98,15 @@ if [[ $RUNTIME ]]; then
     Debian|Ubuntu)
       case "$CODENAME" in
         jessie)
-          apt-get $YesOpt install libjsoncpp0;;
-        stretch|buster|sid|artful|bionic|xenial|cosmic)
-          apt-get $YesOpt install libjsoncpp1;;
+          apt-get $YesOpt install libjsoncpp0 libboost-filesystem1.55.0;;
+        stretch)
+          apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.62.0;;
+        buster|sid)
+          apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.67.0;;
+        xenial)
+          apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.58.0;;
+        bionic)
+          apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.65.1;;
         *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
       esac;;
     Fedora)


### PR DESCRIPTION
## Description

Provide a new directory flag to allow users to pass a directory for recursive scan like nomos.

Also improve the JSON output.

### Changes

1. Add a new `-d, --directory` flag to copyright and child agents.
1. Improve the JSON output.
    - Earlier, the JSON output just contain the result object and no information about the file itself. Also the result objects were separate for each file eventhough the list of files were passed.
    - Now, for each file passed (or picked from directory), there will will be a `file` key denoting the file for which the result is stored and a `results` key holding the agent findings. All these objects will be bounded in a single array as they are result of a single call.

### Old JSON format

```json
{
  "results": [{
    "content": "Copyright 2018",
    "end": 428,
    "start": 381,
    "type":"statement"
  },{
    "content": "johndoe@example.com",
    "end": 427,
    "start": 411,
    "type":"email"
  }]
}
{
  "results": [{
    "content": "Copyright 2018",
    "end": 150,
    "start": 180,
    "type":"statement"
  },{
    "content": "johndoe@example.com",
    "end": 427,
    "start": 411,
    "type":"email"
  }]
}
```

### New JSON format

```json
[
  {"file":"path/to/the/file1", "results":[{"content":"Copyright 2018","end":428,"start":381,"type":"statement"},{"content":"johndoe@example.com","end":427,"start":411,"type":"email"}]},
  {"file":"path/to/the/file2","results":[{"content":"Copyright 2018","end":150,"start":180,"type":"statement"},{"content":"johndoe@example.com","end":427,"start":411,"type":"email"}]}
]
```

## How to test

For all child agents:
1. Check the JSON output using `-J` or `--json` flag.
1. Check the directory scan using `-d` or `--directory` flag.
1. Check the JSON output with directory scan using both `-J` and `-d` flags.
1. Check the text output for a list of files.
1. Check the text output for directory scan.