### PR TITLE
hotfix(download): Fix a call to non-static function

### DIFF
--- a/src/www/ui/async/AjaxShowJobs.php
+++ b/src/www/ui/async/AjaxShowJobs.php
@@ -258,7 +258,7 @@ class AjaxShowJobs extends \FO_Plugin
         }
 
         $jobArr['jobQueue'][$key]['canDoActions'] = ($_SESSION[Auth::USER_LEVEL] ==
-          PLUGIN_DB_ADMIN) || (Auth::getUserId() == $job['job']['job_user_fk']);
+          PLUGIN_DB_ADMIN) || (Auth::getUserId() == $jobs['job']['job_user_fk']);
         $jobArr['jobQueue'][$key]['isInProgress'] = ($singleJobQueue['jq_end_bits'] ==
           0);
         $jobArr['jobQueue'][$key]['isReady'] = ($singleJobQueue['jq_end_bits'] ==

--- a/src/www/ui/ui-download.php
+++ b/src/www/ui/ui-download.php
@@ -218,7 +218,7 @@ class ui_download extends FO_Plugin
 
     $logger = $container->get("logger");
     $logger->pushHandler(new NullHandler(Logger::DEBUG));
-    BrowserConsoleHandler::reset();
+    BrowserConsoleHandler::resetStatic();
 
     return $response;
   }


### PR DESCRIPTION
## Description

1. FOSSology calls a non-static function defined by monolog in a static way which results in error on PHP5.
1. During the code refactor of jobs page, a variable was not renamed to new name.

### Changes

1. Replace call to `BrowserConsoleHandler::reset()` by `BrowserConsoleHandler::resetStatic()`.
1. Rename the variable `$job` with `$jobs` in jobs page.

## How to test

1. Install FOSSology on system with PHP5 and download a report.
1. Check the apache error log.