### PR TITLE
fix(showjob): General fix after refactor

### DIFF
--- a/src/www/ui/async/AjaxShowJobs.php
+++ b/src/www/ui/async/AjaxShowJobs.php
@@ -227,6 +227,7 @@ class AjaxShowJobs extends \FO_Plugin
         if (! empty($singleJobQueue["jq_endtime"])) {
           $numSecs = strtotime($singleJobQueue['jq_endtime']) -
             strtotime($singleJobQueue['jq_starttime']);
+          $numSecs = ($numSecs == 0) ? 1 : $numSecs; // If difference is in milliseconds
         } else {
           $numSecs = time() - strtotime($singleJobQueue['jq_starttime']);
         }
@@ -293,7 +294,7 @@ class AjaxShowJobs extends \FO_Plugin
           'uploadId' => $jobs['upload']['upload_pk'],
           'uploadDesc' => $jobs['upload']['upload_desc'],
           'uploadItem' => $jobs['uploadtree']['uploadtree_pk'],
-          'uploadEta' => $this->showJobsDao->getEstimatedTime($jobId)
+          'uploadEta' => $this->showJobsDao->getEstimatedTime($jobs['job']['job_pk'], '', 0, $jobs['upload']['upload_pk'])
         );
       } else {
         $uploadArr = null;

--- a/src/www/ui/template/ui-showjobs.js.twig
+++ b/src/www/ui/template/ui-showjobs.js.twig
@@ -71,20 +71,32 @@ function createShowJobsTable(data)
   mainTBody.empty();
   $("#paginationdown").empty();
 
-  var i = 0;
-  while (i < joblist.length) {
-    var tableTemplate = createTableForJob(joblist[i]);
-    fillTableWithJobInfo(tableTemplate, joblist[i].job);
-    while ((i < (joblist.length - 1)) &&
-      (joblist[i].upload !== null && joblist[i+1].upload !== null) &&
-      (joblist[i].upload.uploadId === joblist[i+1].upload.uploadId)) {
-      i = i + 1;
+  if (joblist.showJobsData == "There are no jobs to display") {
+    var emptyTr = jQuery("<tr/>");
+    var tableTemplate = jQuery('<table/>', {
+      class: "jobTable",
+      border: "1"
+    }).html("<tbody><tr><td style='text-align:center'>" +
+      joblist.showJobsData + "</td></th></tbody>");
+    emptyTr.append(tableTemplate);
+    mainTBody.append(emptyTr);
+  }
+  else {
+    var i = 0;
+    while (i < joblist.length) {
+      var tableTemplate = createTableForJob(joblist[i]);
       fillTableWithJobInfo(tableTemplate, joblist[i].job);
+      while ((i < (joblist.length - 1)) &&
+        (joblist[i].upload !== null && joblist[i+1].upload !== null) &&
+        (joblist[i].upload.uploadId === joblist[i+1].upload.uploadId)) {
+        i = i + 1;
+        fillTableWithJobInfo(tableTemplate, joblist[i].job);
+      }
+      var tr = jQuery("<tr/>").html(tableTemplate);
+      mainTBody.append(tr);
+      mainTBody.append($("<tr><td colspan='8'><hr /></td></tr>"));
+      i = i + 1;
     }
-    var tr = jQuery("<tr/>").html(tableTemplate);
-    mainTBody.append(tr);
-    mainTBody.append($("<tr><td colspan='8'><hr /></td></tr>"));
-    i = i + 1;
   }
   $("#paginationup").append(data.pagination);
   $("#paginationdown").append(data.pagination);
@@ -109,8 +121,8 @@ function createTableForJob(job) {
     uploadETA = job.upload.uploadEta;
   }
   tableTemplate.html('<thead><tr><th></th>' +
-    '<th colspan="6">' + uploadLink + '</th><th>' + uploadETA + '</th></tr>' +
-    '</thead><tbody></tbody>');
+    '<th colspan="6">' + uploadLink + '</th><th style="color:black">' +
+    uploadETA + '</th></tr>' + '</thead><tbody></tbody>');
   return tableTemplate;
 }
 
@@ -165,7 +177,7 @@ function fillTableWithJobInfo(tableTemplate, job) {
       jqTime += ' - ' + jobQueueData.jq_endtime.substring(0,16);
       trClass = "jobFinished";
     }
-    var jqItemsPerSec = jobQueueData.itemsPerSec.toPrecision(3);
+    var jqItemsPerSec = jobQueueData.itemsPerSec.toPrecision(5);
     var jqETA = "";
     if ('eta' in jobQueueData) {
       if (jobQueueData.eta !== null) {


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

General fixes after refactoring of showjobs to match old UI.

1. Show message if no jobs to display.
1. Increase the items/sec precision to accommodate big numbers.
1. For upload ETA, do not rely on job, check whole upload.
1. Fix numbers of seconds took to complete a task

### Changes

1. Check if the `showJobsData` contains the value "There are no jobs to display" and handle the case.
1. Increase the precision of items/sec to accommodate values like `1377.7631` which earlier render to something like `1.4e+3`.
1. Pass the Upload PK to calculate `uploadEta` since the ununpack job can be in different job.
1. If job start time and end time differ in milliseconds, it is no handled by PHP strtotime.