### PR TITLE
fix(pfile): Fix warnings in ununpack and wget

### DIFF
--- a/src/ununpack/agent/utils.c
+++ b/src/ununpack/agent/utils.c
@@ -18,10 +18,6 @@
  * \file
  * \brief Contains all utility functions used by FOSSology
  */
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
 #include "ununpack.h"
 #include "externs.h"
 #include "regex.h"
@@ -1569,18 +1565,22 @@ int	DisplayContainerInfo	(ContainerInfo *CI, int Cmd)
   {
     CksumFile *CF;
     Cksum *Sum;
-    char SHA256[64], command[1000] = "sha256sum ";
-    strcat(command,CI->Source);
+    char SHA256[65];
+    char command[PATH_MAX + 13];
     int retcode = -1;
+    int read = 0;
+
+    memset(SHA256, '\0', sizeof(SHA256));
 
     CF = SumOpenFile(CI->Source);
+    snprintf(command, PATH_MAX + 13, "sha256sum '%s'", CI->Source);
     FILE* file = popen(command, "r");
     if (file != (FILE*) NULL)
     {
-      fscanf(file, "%64s", SHA256);
+      read = fscanf(file, "%64s", SHA256);
       retcode = WEXITSTATUS(pclose(file));
     }
-    if (file == (FILE*) NULL || retcode != 0)
+    if (file == (FILE*) NULL || retcode != 0 || read != 1)
     {
       LOG_FATAL("Unable to calculate SHA256 of %s\n", CI->Source);
       SafeExit(56);
@@ -1766,7 +1766,6 @@ void	Usage	(char *Name, char *Version)
   fprintf(stderr,"  Boot partitions: x86, vmlinuz\n");
   CheckCommands(Quiet);
 } /* Usage() */
-
 
 /**
  * @brief Dummy postgresql notice processor.

--- a/src/wget_agent/agent/wget_agent.c
+++ b/src/wget_agent/agent/wget_agent.c
@@ -94,16 +94,19 @@ void DBLoadGold()
   char SQL[MAXCMD];
   long PfileKey;
   char *Path;
-  char SHA256[64], command[1000] = "sha256sum ";
+  char SHA256[65], command[PATH_MAX + 13];
   FILE *Fin;
-  int rc;
+  int rc = -1;
   PGresult *result;
-  int retcode = -1;
+  int read = 0;
+
+  memset(SHA256, '\0', sizeof(SHA256));
 
   LOG_VERBOSE0("Processing %s",GlobalTempFile);
   Fin = fopen(GlobalTempFile,"rb");
+
   // Calculate sha256 value
-  strcat(command,GlobalTempFile);
+  snprintf(command, PATH_MAX + 13, "sha256sum '%s'", GlobalTempFile);
   FILE* file = popen(command, "r");
 
   if (!Fin)
@@ -114,13 +117,13 @@ void DBLoadGold()
   }
   if (file != (FILE*) NULL)
   {
-    fscanf(file, "%64s", SHA256);
-    retcode = WEXITSTATUS(pclose(file));
+    read = fscanf(file, "%64s", SHA256);
+    rc = WEXITSTATUS(pclose(file));
   }
-  if (file == (FILE*) NULL || retcode != 0)
+  if (file == (FILE*) NULL || rc != 0 || read != 1)
   {
     LOG_FATAL("Unable to calculate SHA256 of %s\n", GlobalTempFile);
-    SafeExit(2);
+    SafeExit(56);
   }
   Sum = SumComputeFile(Fin);
   fclose(Fin);


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

* Due to recent changes, ununpack agent and wget agent were generating following warnings:

```c
utils.c: In function ‘DisplayContainerInfo’:
utils.c:1580:7: warning: ignoring return value of ‘fscanf’, declared with attribute warn_unused_result [-Wunused-result]
       fscanf(file, "%64s", SHA256);
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
```c
wget_agent.c: In function ‘DBLoadGold’:
wget_agent.c:117:5: warning: ignoring return value of ‘fscanf’, declared with attribute warn_unused_result [-Wunused-result]
     fscanf(file, "%64s", SHA256);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

* Also, if the file path contains any special characters, the call to sha256sum fails.

### Changes

1. Fix the warnings in ununpack agent and wget agent due to ignored return value of fscanf.
2. Remove unnecessary includes in utils.c
3. Enclose the file path in `' '` quotes to accommodate special characters in file path.