### PR TITLE
fix(copyright): Fix pagination of copyright-list

### DIFF
--- a/src/copyright/ui/list.php
+++ b/src/copyright/ui/list.php
@@ -268,7 +268,7 @@ class copyright_list extends FO_Plugin
     }
 
     $Page = GetParm("page",PARM_INTEGER);
-    if (empty($Page)) {
+    if (empty($Page) || $Page == -1) {
       $Page=0;
     }
 
@@ -326,7 +326,7 @@ class copyright_list extends FO_Plugin
       /* Get the page menu */
       if (($RowCount >= $Max) && ($Page >= 0))
       {
-        $PagingMenu = "<P />\n" . MenuPage($Page,intval((($RowCount+$Offset)/$Max))) . "<P />\n";
+        $PagingMenu = "<P />\n" . MenuPage($Page, intval($RowCount / $Max)) . "<P />\n";
         $OutBuf .= $PagingMenu;
       }
       else
@@ -349,6 +349,9 @@ class copyright_list extends FO_Plugin
         if ($RowNum < $Offset) {
           continue;
         }
+        if ($RowNum > $Offset + $Max) {
+          break;
+        }
 
         // Allow user to exclude files with this extension
         $FileExt = GetFileExt($row['ufile_name']);
@@ -365,13 +368,15 @@ class copyright_list extends FO_Plugin
         if ($excl)
         {
           $ExclArray = explode(":", $excl);
-          if (in_array($FileExt, $ExclArray)) { $ok = false;
+          if (in_array($FileExt, $ExclArray)) {
+            $ok = false;
           }
         }
 
         if ($ok)
         {
-          $OutBuf .= Dir2Browse($modBack, $row['uploadtree_pk'], $LinkLast, $ShowBox, $ShowMicro, $RowNum, $Header, '', $uploadtree_tablename);
+          $OutBuf .= Dir2Browse($modBack, $row['uploadtree_pk'], $LinkLast,
+            $ShowBox, $ShowMicro, $RowNum, $Header, '', $uploadtree_tablename);
         }
       }
     }


### PR DESCRIPTION
## Description

The copyright list produces pagination links but does not follow them.

This PR fixes it.

### Changes

Check if the max limit is crossed while generating the output, break the loop.

## How to test

1. Upload a package with copyright text repeating for more than 50 files and schedule copyright agent.
1. Open the **Copyright Browser** for the upload and check all the files for a given copyright.
    - ![image](https://user-images.githubusercontent.com/18077542/60157162-c47b7c00-980b-11e9-8727-ee2ceb59de65.png)
1. Check if the pagination link works.
    - ![image](https://user-images.githubusercontent.com/18077542/60157246-f1c82a00-980b-11e9-89da-6fb9c6c11112.png)
1. Check for ECC and Keyword lists as well.