### PR TITLE
fix(showjobs): Check empty for allusers before updating

### DIFF
--- a/src/www/ui/async/AjaxShowJobs.php
+++ b/src/www/ui/async/AjaxShowJobs.php
@@ -393,7 +393,9 @@ class AjaxShowJobs extends \FO_Plugin
       $uri .= "&upload=$uploadPk";
     }
 
-    $allusers = 0;
+    if (empty($allusers)) {
+      $allusers = 0;
+    }
     $totalPages = 0;
     if ($uploadPk > 0) {
       $upload_pks = array($uploadPk);


### PR DESCRIPTION
## Description

Check #1385.

### Changes

Check if the `$allusers` variable is empty before updating the value.

## How to test

Check #1385.

Closes #1385