### PR TITLE
Force the VERSION variable to be < 23 chars

### DIFF
--- a/Makefile.conf
+++ b/Makefile.conf
@@ -136,6 +136,9 @@ VERSION=`git describe --tags > /dev/null 2>&1 && git describe --tags | head -1 |
 BRANCH=`git rev-parse --abbrev-ref HEAD > /dev/null 2>&1 && git rev-parse --abbrev-ref HEAD | head -1 || echo "unknown"`
 COMMIT_HASH=`git show > /dev/null 2>&1 && git show | head -1 | awk '{print substr($$2,1,6)}' || echo "unknown"`
 
+# Force the VERSION variable to be < 23 chars
+override VERSION:= $(shell echo ${VERSION} | cut -b1-23)
+
 export PATH := $(TOP)/src/vendor/bin:$(PATH)
 
 # directory containing the php iPATHFILE include file


### PR DESCRIPTION
## Description

The issue https://github.com/fossology/fossology/issues/1322 shows that the scheduler crashed if fossology was built with a VERSION variable longer than 23 characters.

This PR simply forces the variable down to 23 characters directly in the Makefile.
There might be a way, more desirable, to make it not crash at all, but at least this solution will prevent the unwanted behaviour for the moment.

### Changes

Simply forcibly truncated the `VERSION`vairable in the file `Makefile.conf`:

`override VERSION:= $(shell echo ${VERSION} | cut -b1-23)`


## How to test

Build Fossology with: `make VERSION=V2345678901234567890123456789 install` and check that:
- the scheduler does not crash at startup
- the top banner shows the truncated version: `Version: [V2345678901234567890123]`
Describe the steps required to test the changes proposed in the pull request.
