### PR TITLE
feat(ui): Show both user description and user name in 'Assigned to' list

### DIFF
--- a/src/lib/php/Dao/UserDao.php
+++ b/src/lib/php/Dao/UserDao.php
@@ -58,12 +58,12 @@ class UserDao
     }
     $userChoices = array();
     $statementN = __METHOD__;
-    $sql = "SELECT user_pk, user_name FROM users LEFT JOIN group_user_member AS gum ON users.user_pk = gum.user_fk"
+    $sql = "SELECT user_pk, user_name, user_desc FROM users LEFT JOIN group_user_member AS gum ON users.user_pk = gum.user_fk"
             . " WHERE gum.group_fk = $1";
     $this->dbManager->prepare($statementN, $sql);
     $res = $this->dbManager->execute($statementN, array($groupId));
     while ($rw = $this->dbManager->fetchArray($res)) {
-      $userChoices[$rw['user_pk']] = $rw['user_name'];
+      $userChoices[$rw['user_pk']] = $rw['user_desc'] . ' (' . $rw['user_name'] . ')';
     }
     $this->dbManager->freeResult($res);
     return $userChoices;


### PR DESCRIPTION
## Description
Proposition to fix https://github.com/fossology/fossology/issues/1393

### Changes

Get the `user_desc`from the DB, and display it along the `user_id` in the "Assigned to" dropdown list, on the Browse page.
It shows **Full Name (user_id)**, like it has been done for Issue https://github.com/fossology/fossology/issues/1351

## How to test

1. Go to the Browse page
1. Click on a list in the "Assigned to" column