### PR TITLE
fix(dbmigrate_3.5-3.6): add single quotes to string and calculate act…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,7 @@ src/reportImport/agent/reportImport
 /src/cli/fo_ninka_license_list
 /install/scripts/php.ini
 /install/scripts/php.ini.orig
+/install/db/dbmigrate_pfile_calculate_sha256.php
 
 # Add all the Ubuntu consol log file
 ubuntu-*

--- a/install/db/dbmigrate_3.5-3.6.php
+++ b/install/db/dbmigrate_3.5-3.6.php
@@ -124,8 +124,8 @@ function updateHash($dbManager, $tableName)
       "SET hash = c.sha256 FROM (VALUES ";
     $fileShaList = [];
     foreach ($rows as $row) {
-      $fileShaList[] = "(" . $row["id"] . "," .
-      hash('sha256', $row['textfinding']) . ")";
+      $fileShaList[] = "(" . $row["id"] . ",'" .
+      hash('sha256', $row['textfinding']) . "')";
     }
     $sql .= join(",", $fileShaList);
     $sql .= ") AS c(id, sha256) WHERE c.id = m.$tableName" . "_pk;";
@@ -212,10 +212,11 @@ function updatePfileSha256($dbManager, $force = false)
     // Ask the user for confirmation
     $timePerJob = 0.00905919;
     $totalTime = floatval($totalPfile) * $timePerJob;
-    $hours = intval($totalTime / 3600.0);
     $minutes = intval($totalTime / 60.0);
+    $hours = floor($minutes / 60);
+    $actualMinutes = $minutes - ($hours * 60);
     echo "*** Calculation of SHA256 for pfiles will require approx $hours hrs " .
-      "$minutes mins. ***\n";
+      "$actualMinutes mins. ***\n";
     if ($hours > 0 || $minutes > 45) {
       $REDCOLOR = "\033[0;31m";
       $NOCOLOR = "\033[0m";


### PR DESCRIPTION
## Description 

* add single quotes to escape the string when we insert a record
* calculate actual time.

## How to test

* on a large instance execute fo-postinstall and check the time and execution