### PR TITLE
fix(fo_nomos_license_list.php): change function name

### DIFF
--- a/src/cli/fo_nomos_license_list.php
+++ b/src/cli/fo_nomos_license_list.php
@@ -140,7 +140,7 @@ function GetLicenseList($uploadtree_pk, $upload_pk, $showContainer, $excluding, 
   }
   $agent_pk = $AgentRec[0]["agent_fk"];
 
-  $uploadtreeTablename = GetUploadtreeTableName($upload_pk);
+  $uploadtreeTablename = getUploadtreeTableName($upload_pk);
   /** @var ItemTreeBounds */
   $itemTreeBounds = $uploadDao->getItemTreeBounds($uploadtree_pk, $uploadtreeTablename);
   $licensesPerFileName = $licenseDao->getLicensesPerFileNameForAgentId(


### PR DESCRIPTION
Getting uploadtreeTableName, couldn't find a function named 'GetUploadtreeTableName' but could find 'getUploadtreeTableName', attempting fix by replacing 'G' with 'g'.