### PR TITLE
Blank uploadtree_pk was causing search for blank upload_fk

### DIFF
--- a/src/cli/fo_nomos_license_list.php
+++ b/src/cli/fo_nomos_license_list.php
@@ -126,7 +126,7 @@ function GetLicenseList($uploadtree_pk, $upload_pk, $showContainer, $excluding, 
   $licenseDao = $GLOBALS['container']->get("dao.license");
 
   if (empty($uploadtree_pk)) {
-      $uploadtreeRec = $dbManager->getSingleRow('SELECT uploadtree_pk FROM uploadtree WHERE parent IS NULL AND upload_fk=$1',
+      $uploadtreeRec = $dbManager->getSingleRow('SELECT uploadtree_pk FROM uploadtree WHERE parent IS NULL AND upload_fk=$2',
               array($upload_pk),
               __METHOD__.'.find.uploadtree.to.use.in.browse.link' );
       $uploadtree_pk = $uploadtreeRec['uploadtree_pk'];


### PR DESCRIPTION
Should be searching for upload_fk=$upload_pk ($2 rather than $1)

## Description

A blank $item (as is default) was causing: `"SELECT * FROM $uploadtreeTableName WHERE uploadtree_pk = '' "` in `getSingleRow`, as a primary key shouldn't be blank, this was causing the query to return nothing. This caused `getSinglerow` to return an empty array, which was then passed into `createItemTreeBounds` as `uploadEntryData`. As an empty array == false in php, this caused an exception to be thrown, and in turn causing the scan to fail - but not fatally, just with the following error message:
```
did not find uploadTreeId in uploadtree_astring(442) "#0 /usr/local/share/fossology/lib/php/Dao/UploadDao.php(94): Fossology\Lib\Dao\UploadDao->createItemTreeBounds(false, 'uploadtree_a') #1 /usr/local/lib/fossology/fo_nomos_license_list.php(145): Fossology\Lib\Dao\UploadDao->getItemTreeBounds(NULL, 'uploadtree_a') #2 /usr/local/lib/fossology/fo_nomos_license_list.php(171): GetLicenseList(NULL, '2', 0, '', 0) #3 /usr/local/lib/fossology/fo_wrapper(77): require('/usr/local/lib/...') #4 {main}"
```

I'm hoping that this simple edit should fix things.