### PR TITLE
fix(db): Optimize license browse queries

### DIFF
--- a/src/lib/php/Dao/HighlightDao.php
+++ b/src/lib/php/Dao/HighlightDao.php
@@ -133,8 +133,10 @@ class HighlightDao
     $uploadTreeTableName = $itemTreeBounds->getUploadTreeTableName();
     $stmt = __METHOD__.$uploadTreeTableName;
     $sql = "SELECT start,len
-             FROM highlight_keyword
-             WHERE pfile_fk = (SELECT pfile_fk FROM $uploadTreeTableName WHERE uploadtree_pk = $1)";
+            FROM highlight_keyword AS hk
+            INNER JOIN $uploadTreeTableName AS ut
+            ON hk.pfile_fk = ut.pfile_fk
+            WHERE ut.uploadtree_pk = $1";
     $this->dbManager->prepare($stmt, $sql);
     $result = $this->dbManager->execute($stmt, array($itemTreeBounds->getItemId()));
     $highlightEntries = array();

--- a/src/www/ui/ui-clearing-view.php
+++ b/src/www/ui/ui-clearing-view.php
@@ -261,7 +261,6 @@ class ClearingView extends FO_Plugin
     if ($isSingleFile && $hasWritePermission) {
       $this->vars['bulkUri'] = Traceback_uri() . "?mod=popup-license";
       $licenseArray = $this->licenseDao->getLicenseArray($groupId);
-      // $clearingDecision = $this->clearingDao->getRelevantClearingDecision($itemTreeBounds, $groupId);
       list($addedResults, $removedResults) = $this->clearingDecisionEventProcessor->getCurrentClearings($itemTreeBounds, $groupId, LicenseMap::CONCLUSION);
       if (count($addedResults)+count($removedResults)>0) {
         array_unshift($licenseArray, array('id'=>0,'fullname'=>'','shortname'=>'------'));
@@ -298,20 +297,12 @@ class ClearingView extends FO_Plugin
     $this->vars['tmpClearingType'] = $this->clearingDao->isDecisionWip($uploadTreeId, $groupId);
     $this->vars['bulkHistory'] = $bulkHistory;
 
-    $noLicenseUploadTreeView = new UploadTreeProxy($uploadId,
-    $options = array(UploadTreeProxy::OPT_SKIP_THESE=>"noLicense", UploadTreeProxy::OPT_GROUP_ID=>$groupId),
-    $uploadTreeTableName,
-    $viewName = 'no_license_uploadtree' . $uploadId);
-    $filesOfInterest = $noLicenseUploadTreeView->count();
+    $filesOfInterest = $this->clearingDao->getTotalDecisionCount($uploadId,
+      $groupId);
+    $filesCleared = $this->clearingDao->getClearingDecisionsCount($uploadId,
+      $groupId);
 
-    $nonClearedUploadTreeView = new UploadTreeProxy($uploadId,
-        $options = array(UploadTreeProxy::OPT_SKIP_THESE => "alreadyCleared", UploadTreeProxy::OPT_GROUP_ID=>$groupId),
-        $uploadTreeTableName,
-        $viewName = 'already_cleared_uploadtree' . $uploadId);
-    $filesToBeCleared = $nonClearedUploadTreeView->count();
-
-    $filesAlreadyCleared = $filesOfInterest - $filesToBeCleared;
-    $this->vars['message'] = _("Cleared").": $filesAlreadyCleared/$filesOfInterest";
+    $this->vars['message'] = _("Cleared").": $filesCleared/$filesOfInterest";
 
     return $this->render("ui-clearing-view.html.twig");
   }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Optimizing some SQL queries.

### Changes

1. Optimize query to select latest `clearing_decision`.
1. Optimize query to select `highlight_keyword`.
1. Load the clearing status using SQL joins instead of UploadProxyView to increase the loading time for huge DBs.