### PR TITLE
feat(api): Return job's ETA and status

### DIFF
--- a/src/lib/php/services.xml.in
+++ b/src/lib/php/services.xml.in
@@ -191,7 +191,8 @@ without any warranty.
             <argument type="service" id="dao.folder"/>
             <argument type="service" id="helper.dbHelper"/>
             <argument type="service" id="helper.authHelper"/>
-            <argument type="service" id="logger"/>
+            <argument type="service" id="dao.job"/>
+            <argument type="service" id="dao.show_jobs"/>
         </service>
     </services>
 </container>

--- a/src/www/ui/api/Controllers/JobController.php
+++ b/src/www/ui/api/Controllers/JobController.php
@@ -31,6 +31,7 @@ use Fossology\UI\Api\Models\Analysis;
 use Fossology\UI\Api\Models\Decider;
 use Fossology\UI\Api\Models\Reuser;
 use Fossology\UI\Api\Models\ScanOptions;
+use Fossology\UI\Api\Models\Job;
 
 /**
  * @class JobController
@@ -38,6 +39,26 @@ use Fossology\UI\Api\Models\ScanOptions;
  */
 class JobController extends RestController
 {
+  /**
+   * Get query parameter name for upload filtering
+   */
+  private const UPLOAD_PARAM = "upload";
+  /**
+   * Job completed successfully
+   */
+  private const JOB_COMPLETED = 0x1 << 1;
+  /**
+   * Job started by scheduler
+   */
+  private const JOB_STARTED = 0x1 << 2;
+  /**
+   * Job waiting to be queued
+   */
+  private const JOB_QUEUED = 0x1 << 3;
+  /**
+   * Job failed
+   */
+  private const JOB_FAILED = 0x1 << 4;
   /**
    * Get all jobs by a user
    *
@@ -48,6 +69,8 @@ class JobController extends RestController
    */
   public function getJobs($request, $response, $args)
   {
+    $query = $request->getQueryParams();
+
     $limit = 0;
     if ($request->hasHeader('limit')) {
       $limit = $request->getHeaderLine('limit');
@@ -58,6 +81,7 @@ class JobController extends RestController
         return $response->withJson($returnVal->getArray(), $returnVal->getCode());
       }
     }
+
     $id = null;
     if (isset($args['id'])) {
       $id = intval($args['id']);
@@ -67,11 +91,19 @@ class JobController extends RestController
         return $response->withJson($returnVal->getArray(), $returnVal->getCode());
       }
     }
-    $jobs = $this->dbHelper->getJobs($limit, $id);
+
     if ($id !== null) {
-      $jobs = $jobs[0];
+      /* If the ID is passed, don't check for upload */
+      return $this->getAllResults($id, $response, $limit);
     }
-    return $response->withJson($jobs, 200);
+
+    if (array_key_exists(self::UPLOAD_PARAM, $query)) {
+      /* If the upload is passed, filter accordingly */
+      return $this->getFilteredResults(intval($query[self::UPLOAD_PARAM]),
+        $response, $limit);
+    } else {
+      return $this->getAllResults($id, $response, $limit);
+    }
   }
 
   /**
@@ -114,5 +146,150 @@ class JobController extends RestController
       $error = new Info(400, "Folder id and upload id should be integers!", InfoType::ERROR);
       return $response->withJson($error->getArray(), $error->getCode());
     }
+  }
+
+  /**
+   * Get all jobs for the current user.
+   * @param integer $id
+   * @param ResponseInterface $response
+   * @param integer $limit
+   * @return ResponseInterface
+   */
+  private function getAllResults($id, $response, $limit)
+  {
+    $jobs = $this->dbHelper->getJobs($limit, $id);
+    $finalJobs = [];
+    foreach ($jobs as $job) {
+      $this->updateEtaAndStatus($job);
+      $finalJobs[] = $job->getArray();
+    }
+    if ($id !== null) {
+      $finalJobs = $finalJobs[0];
+    }
+    return $response->withJson($finalJobs, 200);
+  }
+
+  /**
+   * Get all jobs for the given upload.
+   * @param integer $uploadId
+   * @param ResponseInterface $response
+   * @param integer $limit
+   * @return ResponseInterface
+   */
+  private function getFilteredResults($uploadId, $response, $limit)
+  {
+    if (! $this->dbHelper->doesIdExist("upload", "upload_pk", $uploadId)) {
+      $returnVal = new Info(404, "Upload id " . $uploadId . " doesn't exist",
+        InfoType::ERROR);
+      return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+    }
+    $jobs = $this->dbHelper->getJobs($limit, null, $uploadId);
+    $finalJobs = [];
+    foreach ($jobs as $job) {
+      $this->updateEtaAndStatus($job);
+      $finalJobs[] = $job->getArray();
+    }
+    return $response->withJson($finalJobs, 200);
+  }
+
+  /**
+   * Update the ETA and status for the given job
+   *
+   * @param[in,out] Job $job The job to be updated
+   */
+  private function updateEtaAndStatus(&$job)
+  {
+    $jobDao = $this->restHelper->getJobDao();
+
+    $eta = 0;
+    $status = "";
+    $jobqueue = [];
+
+    /* Check if the job has no upload like Maintenance job */
+    if (empty($job->getUploadId())) {
+      $sql = "SELECT jq_pk, jq_end_bits from jobqueue WHERE jq_job_fk = $1;";
+      $statement = __METHOD__ . ".getJqpk";
+      $rows = $this->dbHelper->getDbManager()->getRows($sql, [$job->getId()],
+        $statement);
+      if (count($rows) > 0) {
+        $jobqueue[$rows[0]['jq_pk']] = $rows[0]['jq_end_bits'];
+      }
+    } else {
+      $jobqueue = $jobDao->getAllJobStatus($job->getUploadId(),
+        $job->getUserId(), $job->getGroupId());
+    }
+
+    $job->setEta($this->getUploadEtaInSeconds($job->getId(),
+      $job->getUploadId()));
+
+    $job->setStatus($this->getJobStatus(array_keys($jobqueue)));
+  }
+
+  /**
+   * Get the ETA in seconds for the upload.
+   *
+   * @param integer $jobId    The job ID for which the ETA is required
+   * @param integer $uploadId Upload for which the ETA is required
+   * @return integer ETA in seconds (0 if job already finished)
+   */
+  private function getUploadEtaInSeconds($jobId, $uploadId)
+  {
+    $showJobDao = $this->restHelper->getShowJobDao();
+    $eta = $showJobDao->getEstimatedTime($jobId, '', 0, $uploadId);
+    $eta = explode(":", $eta);
+    if (count($eta) > 1) {
+      $eta = ($eta[0] * 3600) + ($eta[1] * 60) + ($eta[2]);
+    } else {
+      $eta = 0;
+    }
+    return $eta;
+  }
+
+  /**
+   * Get the job status based on jobqueue.
+   *
+   * @param array $jobqueue The job queue with job id as values
+   * @return string Job status (Completed, Processing, Queued or Failed)
+   */
+  private function getJobStatus($jobqueue)
+  {
+    $showJobDao = $this->restHelper->getShowJobDao();
+    $jobStatus = 0;
+    /* Check each job in queue */
+    foreach ($jobqueue as $jobId) {
+      $jobInfo = $showJobDao->getDataForASingleJob($jobId);
+      $endtext = $jobInfo['jq_endtext'];
+      switch ($endtext) {
+        case 'Completed':
+          $jobStatus |= self::JOB_COMPLETED;
+          break;
+        case 'Started':
+        case 'Restarted':
+        case 'Paused':
+          $jobStatus |= self::JOB_STARTED;
+          break;
+        default:
+          if (empty($jobInfo['jq_endtime'])) {
+            $jobStatus |= self::JOB_QUEUED;
+          } else {
+            $jobStatus |= self::JOB_FAILED;
+          }
+      }
+    }
+
+    $jobStatusString = "";
+    if ($jobStatus & self::JOB_STARTED) {
+      /* If at least one job is started, set status as processing */
+      $jobStatusString = "Processing";
+    } else if ($jobStatus & self::JOB_QUEUED) {
+      $jobStatusString = "Queued";
+    } else if ($jobStatus & self::JOB_FAILED) {
+      /* If at least one job is failed, set status as failed */
+      $jobStatusString = "Failed";
+    } else {
+      /* If everything completed successfully, set status as completed */
+      $jobStatusString = "Completed";
+    }
+    return $jobStatusString;
   }
 }

--- a/src/www/ui/api/Helper/RestHelper.php
+++ b/src/www/ui/api/Helper/RestHelper.php
@@ -30,6 +30,8 @@ use Fossology\Lib\Dao\UserDao;
 use Fossology\UI\Api\Models\Info;
 use Fossology\UI\Api\Models\InfoType;
 use Fossology\Lib\Plugin\Plugin;
+use Fossology\Lib\Dao\JobDao;
+use Fossology\Lib\Dao\ShowJobsDao;
 
 /**
  * @class RestHelper
@@ -78,6 +80,16 @@ class RestHelper
    */
   private $userDao;
   /**
+   * @var JobDao $jobDao
+   * Job DAO object
+   */
+  private $jobDao;
+  /**
+   * @var ShowJobsDao $showJobDao
+   * Show job DAO object
+   */
+  private $showJobDao;
+  /**
    * @var AuthHelper $authHelper
    * Auth helper to provide authentication
    */
@@ -90,7 +102,8 @@ class RestHelper
    */
   public function __construct(UploadPermissionDao $uploadPermissionDao,
     UploadDao $uploadDao, UserDao $userDao, FolderDao $folderDao,
-    DbHelper $dbHelper, AuthHelper $authHelper)
+    DbHelper $dbHelper, AuthHelper $authHelper, JobDao $jobDao,
+    ShowJobsDao $showJobDao)
   {
     $this->uploadPermissionDao = $uploadPermissionDao;
     $this->uploadDao = $uploadDao;
@@ -98,6 +111,8 @@ class RestHelper
     $this->folderDao = $folderDao;
     $this->dbHelper = $dbHelper;
     $this->authHelper = $authHelper;
+    $this->jobDao = $jobDao;
+    $this->showJobDao = $showJobDao;
   }
 
   /**
@@ -142,7 +157,6 @@ class RestHelper
     return $this->folderDao;
   }
 
-
   /**
    * @return UploadPermissionDao
    */
@@ -165,6 +179,22 @@ class RestHelper
   public function getDbHelper()
   {
     return $this->dbHelper;
+  }
+
+  /**
+   * @return JobDao
+   */
+  public function getJobDao()
+  {
+    return $this->jobDao;
+  }
+
+  /**
+   * @return ShowJobsDao
+   */
+  public function getShowJobDao()
+  {
+    return $this->showJobDao;
   }
 
   /**

--- a/src/www/ui/api/Models/Analysis.php
+++ b/src/www/ui/api/Models/Analysis.php
@@ -65,6 +65,11 @@ class Analysis
    */
   private $nomos;
   /**
+   * @var boolean $ojo
+   * Whether to schedule ojo agent or not
+   */
+  private $ojo;
+  /**
    * @var boolean $pkgagent
    * Whether to schedule package agent or not
    */
@@ -79,10 +84,11 @@ class Analysis
    * @param boolean $mime
    * @param boolean $monk
    * @param boolean $nomos
+   * @param boolean $ojo
    * @param boolean $package
    */
   public function __construct($bucket = false, $copyright = false, $ecc = false, $keyword = false,
-    $mimetype = false, $monk = false, $nomos = false, $pkgagent = false)
+    $mimetype = false, $monk = false, $nomos = false, $ojo = false, $pkgagent = false)
   {
     $this->bucket = $bucket;
     $this->copyright = $copyright;
@@ -91,6 +97,7 @@ class Analysis
     $this->mimetype = $mimetype;
     $this->monk = $monk;
     $this->nomos = $nomos;
+    $this->ojo = $ojo;
     $this->pkgagent = $pkgagent;
   }
 
@@ -126,6 +133,9 @@ class Analysis
     if (array_key_exists("nomos", $analysisArray)) {
       $this->nomos = filter_var($analysisArray["nomos"], FILTER_VALIDATE_BOOLEAN);
     }
+    if (array_key_exists("ojo", $analysisArray)) {
+      $this->ojo = filter_var($analysisArray["ojo"], FILTER_VALIDATE_BOOLEAN);
+    }
     if (array_key_exists("package", $analysisArray)) {
       $this->pkgagent = filter_var($analysisArray["package"],
         FILTER_VALIDATE_BOOLEAN);
@@ -160,6 +170,9 @@ class Analysis
     }
     if (stristr($analysisString, "nomos")) {
       $this->nomos = true;
+    }
+    if (stristr($analysisString, "ojo")) {
+      $this->ojo = true;
     }
     if (stristr($analysisString, "pkgagent")) {
       $this->pkgagent = true;
@@ -222,6 +235,14 @@ class Analysis
   public function getNomos()
   {
     return $this->nomos;
+  }
+
+  /**
+   * @return boolean
+   */
+  public function getOjo()
+  {
+    return $this->ojo;
   }
 
   /**
@@ -290,6 +311,14 @@ class Analysis
   }
 
   /**
+   * @param boolean $ojo
+   */
+  public function setOjo($ojo)
+  {
+    $this->ojo = filter_var($ojo, FILTER_VALIDATE_BOOLEAN);
+  }
+
+  /**
    * @param boolean $package
    */
   public function setPackage($package)
@@ -311,6 +340,7 @@ class Analysis
       "mimetype"  => $this->mimetype,
       "monk"      => $this->monk,
       "nomos"     => $this->nomos,
+      "ojo"       => $this->ojo,
       "package"   => $this->pkgagent
     ];
   }

--- a/src/www/ui/api/Models/Job.php
+++ b/src/www/ui/api/Models/Job.php
@@ -59,17 +59,36 @@ class Job
    * Group id for current job
    */
   private $groupId;
+  /**
+   * @var integer $eta
+   * Estimated time of completion of job
+   */
+  private $eta;
+
+  /**
+   * @var string $status
+   * The status of the job. Can be one of following:\n
+   *      - Completed
+   *      - Failed
+   *      - Queued
+   *      - Processing
+   */
+  private $status;
 
   /**
    * Job constructor.
+   *
    * @param integer $id
    * @param string $name
    * @param string $queueDate
    * @param integer $uploadId
    * @param integer $userId
    * @param integer $groupId
+   * @param integer $eta
+   * @param string $status
    */
-  public function __construct($id, $name, $queueDate, $uploadId, $userId, $groupId)
+  public function __construct($id, $name = "", $queueDate = "", $uploadId = 0,
+    $userId = 0, $groupId = 0, $eta = 0, $status = "")
   {
     $this->id = intval($id);
     $this->name = $name;
@@ -77,6 +96,8 @@ class Job
     $this->uploadId = intval($uploadId);
     $this->userId = intval($userId);
     $this->groupId = intval($groupId);
+    $this->eta = intval($eta);
+    $this->status = $status;
   }
 
   /**
@@ -100,7 +121,144 @@ class Job
       'queueDate' => $this->queueDate,
       'uploadId'  => $this->uploadId,
       'userId'    => $this->userId,
-      'groupId'   => $this->groupId
+      'groupId'   => $this->groupId,
+      'eta'       => $this->eta,
+      'status'    => $this->status
     ];
+  }
+
+  /**
+   * Get the job ID
+   * @return number Job id
+   */
+  public function getId()
+  {
+    return $this->id;
+  }
+
+  /**
+   * Get the job name
+   * @return string Job name
+   */
+  public function getName()
+  {
+    return $this->name;
+  }
+
+  /**
+   * Get date with timezone when job was added
+   * @return string Job date
+   */
+  public function getQueueDate()
+  {
+    return $this->queueDate;
+  }
+
+  /**
+   * Get upload id
+   * @return number Upload id
+   */
+  public function getUploadId()
+  {
+    return $this->uploadId;
+  }
+
+  /**
+   * Get user id
+   * @return number User id
+   */
+  public function getUserId()
+  {
+    return $this->userId;
+  }
+
+  /**
+   * Get group id
+   * @return number Group id
+   */
+  public function getGroupId()
+  {
+    return $this->groupId;
+  }
+
+  /**
+   * Get job ETA in seconds
+   * @return number Job ETA in seconds
+   */
+  public function getEta()
+  {
+    return $this->eta;
+  }
+
+  /**
+   * Get job status
+   * @return string Job status
+   */
+  public function getStatus()
+  {
+    return $this->status;
+  }
+
+  /**
+   * Set the job name
+   * @param string $name Job name
+   */
+  public function setName($name)
+  {
+    $this->name = $name;
+  }
+
+  /**
+   * Set the job queue date
+   * @param string $queueDate New queue date
+   */
+  public function setQueueDate($queueDate)
+  {
+    $this->queueDate = $queueDate;
+  }
+
+  /**
+   * Set the job upload id
+   * @param number $uploadId Job upload id
+   */
+  public function setUploadId($uploadId)
+  {
+    $this->uploadId = $uploadId;
+  }
+
+  /**
+   * Set the user id
+   * @param number $userId User id
+   */
+  public function setUserId($userId)
+  {
+    $this->userId = $userId;
+  }
+
+  /**
+   * Set the group id
+   * @param number $groupId New group id
+   */
+  public function setGroupId($groupId)
+  {
+    $this->groupId = $groupId;
+  }
+
+  /**
+   * Set the job ETA
+   * @param number $eta Job ETA
+   */
+  public function setEta($eta)
+  {
+    $this->eta = $eta;
+  }
+
+  /**
+   * Set the job status
+   * @param string $status Job status
+   */
+  public function setStatus($status)
+  {
+    $this->status = $status;
   }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -380,6 +380,12 @@ paths:
               type: integer
               minimum: 0
             in: header
+          - name: upload
+            required: false
+            schema:
+              type: integer
+            in: query
+            description: Return jobs for the given upload id only
         responses:
           '200':
             description: OK
@@ -755,6 +761,17 @@ components:
         groupId:
           type: integer
           description: Group under which the job was scheduled
+        eta:
+          type: integer
+          description: ETA of job to finish in seconds
+        status:
+          type: string
+          enum:
+            - Completed
+            - Failed
+            - Queued
+            - Processing
+          description: Denotes the current status of the job in the queue
     Info:
       type: object
       properties:

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -14,7 +14,7 @@ openapi: 3.0.0
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.0.2
+  version: 1.0.3
 servers:
   - url: http://localhost/repo/api/v1
     description: Localhost instance
@@ -378,7 +378,13 @@ paths:
             required: false
             schema:
               type: integer
-              minimum: 0
+              minimum: 1
+            in: header
+          - name: page
+            required: false
+            schema:
+              type: integer
+              minimum: 1
             in: header
           - name: upload
             required: false
@@ -389,6 +395,11 @@ paths:
         responses:
           '200':
             description: OK
+            headers:
+              X-Total-Pages:
+                description: Total number of pages which can be generated based on limit
+                schema:
+                  type: integer
             content:
               application/json:
                 schema:

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -843,6 +843,9 @@ components:
         nomos:
           type: boolean
           description: Should Nomos Analysis be run on this upload.
+        ojo:
+          type: boolean
+          description: Should OJO Analysis be run on this upload.
         package:
           type: boolean
           description: Should Package Analysis be run on this upload.


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The jobs endpoint was not returning the job status which confuses users if the job was finished or not.

This PR also intoduces filtering jobs based on upload id, pagination on jobs and missing ojo analysis to REST API.

### Changes

1. Add ETA and job status to the job object returned by `/jobs` endpoint.
    1. The job ETA is in seconds and can be 0 for completed/failed jobs.
    1. The job status can have one of the following values:
        - Completed
        - Failed
        - Queued
        - Processing
1. New filter based on upload id in `/jobs` endpoint.
    - The filter is passed as query parameter `upload` with the request.
1. Added pagination to the `/jobs` endpoint.
    - The request will return total number of pages by `X-Total-Pages` header in response.
    - Accept page number from the request headers along with limit.
1. Added missing agent `ojo` to the analysis on POST request to `/jobs`.

## How to test

1. Check if the job status and ETA are returned for every job.
1. Check if the limit and page works as expected and returns `X-Total-Pages` header.
1. Check if the jobs can be filtered based on upload id.
1. Check if ojo can be scheduled using the rest API.

Related issue: #1301 