### PR TITLE
hotfix(process): Fix the PHP agent installation

### DIFF
--- a/Makefile.conf
+++ b/Makefile.conf
@@ -101,7 +101,6 @@ endif
 ifeq ($(origin CXX), default)
 CXX = g++
 endif
-SED = /bin/sed
 
 # these are the default cflags, recommended but not fully _required_
 # if a user sets CFLAGS they get what they set it to and lose any they

--- a/Makefile.process
+++ b/Makefile.process
@@ -37,8 +37,4 @@ $(VARIABLES):
 		echo "$@=\"$($@)\"" >>$(TOP)/variable.list; \
 	fi
 
-define make_exec_file =
-	$(SED) -i '1s/^/\#\!\/usr\/bin\/env $(1)/' $(2)
-endef
-
 .PHONY: $(VARIABLES)

--- a/src/decider/agent/Makefile
+++ b/src/decider/agent/Makefile
@@ -34,8 +34,7 @@ install: all
 	$(INSTALL_PROGRAM) -d $(DESTDIR)$(MODDIR)/$(MODNAME)/agent/
 	for file in $(EXE); do \
 		echo "installing $$file"; \
-		$(INSTALL_PROGRAM) $$file $(DESTDIR)$(MODDIR)/$(MODNAME)/agent/$$file; \
-		$(call make_exec_file,php,$(DESTDIR)$(MODDIR)/$(MODNAME)/agent/$$file); \
+		$(INSTALL_DATA) $$file $(DESTDIR)$(MODDIR)/$(MODNAME)/agent/$$file; \
 	done
 	for file in $(WRAP); do \
 		echo "Making wrapper for $$file"; \

--- a/src/deciderjob/agent/Makefile
+++ b/src/deciderjob/agent/Makefile
@@ -34,8 +34,7 @@ install: all
 	$(INSTALL_PROGRAM) -d $(DESTDIR)$(MODDIR)/$(MODNAME)/agent/
 	for file in $(EXE); do \
 		echo "installing $$file"; \
-		$(INSTALL_PROGRAM) $$file $(DESTDIR)$(MODDIR)/$(MODNAME)/agent/$$file; \
-		$(call make_exec_file,php,$(DESTDIR)$(MODDIR)/$(MODNAME)/agent/$$file); \
+		$(INSTALL_DATA) $$file $(DESTDIR)$(MODDIR)/$(MODNAME)/agent/$$file; \
 	done
 	for file in $(WRAP); do \
 		echo "Making wrapper for $$file"; \

--- a/src/readmeoss/agent/Makefile
+++ b/src/readmeoss/agent/Makefile
@@ -25,8 +25,7 @@ install: all
 	$(INSTALL_PROGRAM) -d $(DESTDIR)$(MODDIR)/$(MODNAME)/agent/
 	for file in $(EXE); do \
 		echo "installing $$file"; \
-		$(INSTALL_PROGRAM) $$file $(DESTDIR)$(MODDIR)/$(MODNAME)/agent/$$file; \
-		$(call make_exec_file,php,$(DESTDIR)$(MODDIR)/$(MODNAME)/agent/$$file); \
+		$(INSTALL_DATA) $$file $(DESTDIR)$(MODDIR)/$(MODNAME)/agent/$$file; \
 	done
 	for file in $(WRAP); do \
 		echo "Making wrapper for $$file"; \

--- a/src/reportImport/agent/Makefile
+++ b/src/reportImport/agent/Makefile
@@ -33,8 +33,7 @@ install: all
 	$(INSTALL_PROGRAM) -d $(DESTDIR)$(MODDIR)/$(MODNAME)/agent/
 	for file in $(EXE); do \
 		echo "installing $$file"; \
-		$(INSTALL_PROGRAM) $$file $(DESTDIR)$(MODDIR)/$(MODNAME)/agent/$$file; \
-		$(call make_exec_file,php,$(DESTDIR)$(MODDIR)/$(MODNAME)/agent/$$file); \
+		$(INSTALL_DATA) $$file $(DESTDIR)$(MODDIR)/$(MODNAME)/agent/$$file; \
 	done
 	for file in $(WRAP); do \
 		echo "Making wrapper for $$file"; \

--- a/src/reuser/agent/Makefile
+++ b/src/reuser/agent/Makefile
@@ -30,8 +30,7 @@ install: all
 	$(INSTALL_PROGRAM) -d $(DESTDIR)$(MODDIR)/reuser/agent/
 	for file in $(COPY); do \
 		echo "installing $$file"; \
-		$(INSTALL_PROGRAM) $$file $(DESTDIR)$(MODDIR)/$(MODNAME)/agent/$$file; \
-		$(call make_exec_file,php,$(DESTDIR)$(MODDIR)/$(MODNAME)/agent/$$file); \
+		$(INSTALL_DATA) $$file $(DESTDIR)$(MODDIR)/$(MODNAME)/agent/$$file; \
 	done
 	for file in $(WRAP); do \
 		echo "Making wrapper for $$file"; \

--- a/src/spdx2/agent/Makefile
+++ b/src/spdx2/agent/Makefile
@@ -34,8 +34,7 @@ install: all
 	done
 	for file in $(EXE); do \
 		echo "installing $$file"; \
-		$(INSTALL_PROGRAM) $$file $(DESTDIR)$(MODDIR)/$(MOD_NAME)/$(MOD_SUBDIR)/$$file; \
-		$(call make_exec_file,php,$(DESTDIR)$(MODDIR)/$(MOD_NAME)/$(MOD_SUBDIR)/$$file); \
+		$(INSTALL_DATA) $$file $(DESTDIR)$(MODDIR)/$(MOD_NAME)/$(MOD_SUBDIR)/$$file; \
 	done
 	echo "Making wrapper for $(MOD_NAME)"
 	ln -sf $(LIBEXECDIR)/fo_wrapper  $(DESTDIR)$(MODDIR)/$(MOD_NAME)/agent/$(MOD_NAME)

--- a/src/unifiedreport/agent/Makefile
+++ b/src/unifiedreport/agent/Makefile
@@ -30,8 +30,7 @@ install: all
 	$(INSTALL_PROGRAM) -d $(DESTDIR)$(MODDIR)/$(MODNAME)/agent/
 	for file in $(EXE); do \
 		echo "installing $$file"; \
-		$(INSTALL_PROGRAM) $$file $(DESTDIR)$(MODDIR)/$(MODNAME)/agent/$$file; \
-		$(call make_exec_file,php,$(DESTDIR)$(MODDIR)/$(MODNAME)/agent/$$file); \
+		$(INSTALL_DATA) $$file $(DESTDIR)$(MODDIR)/$(MODNAME)/agent/$$file; \
 	done
 	for file in $(WRAP); do \
 		echo "Making wrapper for $$file"; \


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

After merger of #1348, some artifacts start showing up on the UI failing the twig files as well.

This PR is a hotfix for the issue.

### Changes

1. Do not add `#!/usr/bin/env php` to every PHP file (this will fail `require()` calls in PHP).
1. Remove `x` flag from PHP files in agent which are not executed directly (it is done by the `fo_wrapper` link in the same dir).

## How to test

1. Install current master, you will see `#!/usr/bin/env php` all over the UI rendering it useless.
1. Install the branch and check if the issue is resolved.
1. Also check if lintian cries warning for which the fix was introduced in #1348 (see the PR for more info).