### PR TITLE
Fix first fossology start failure with vagrant file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,6 +57,8 @@ sudo a2enconf fossology.conf
 sudo /fossology/install/scripts/php-conf-fix.sh --overwrite
 
 sudo /etc/init.d/apache2 restart
+
+sudo systemctl daemon-reload
 SCRIPT
 
 Vagrant.configure("2") do |config|


### PR DESCRIPTION
Update systemd configuration before starting the init.d script,
so that systemd generates the missing fossology.service in time.

Signed-off-by: Andreas J. Reichel <andreas.reichel@tngtech.com>

## Description

Vagrant:
Reload systemd configuration before first startup of fossology

### Changes

Added a systemctl daemon-reload

## How to test

vagrant destroy
vagrant up

Fossology now starts correctly. Before it did not.
