### PR TITLE
fix(ojo): Remove call to omitEndingLineFeed on json cpp < 0.7

### DIFF
--- a/src/ojo/agent/directoryScan.cc
+++ b/src/ojo/agent/directoryScan.cc
@@ -40,7 +40,7 @@ void scanDirectory(const bool json, const string &directoryPath)
 
   vector<string> filePaths;
 
-  for (fs::path const &p : dirIterator)
+  for (fs::path const &p : boost::make_iterator_range(dirIterator, {}))
   {
     if (fs::is_directory(p))
     {

--- a/src/ojo/agent/directoryScan.hpp
+++ b/src/ojo/agent/directoryScan.hpp
@@ -19,6 +19,7 @@
 #define SRC_OJO_AGENT_DIRECTORYSCAN_HPP_
 
 #include <boost/filesystem.hpp>
+#include <boost/range/iterator_range.hpp>
 #include <iostream>
 
 #include "OjoUtils.hpp"


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

`libjsoncpp` prior to 0.7.0 does not support `omitEndingLineFeed()` which removes extra `\n` at end.

But since version 1.4.0, `FastWriter` class itself is deprecated. So, till version 1.3.x, remove the `\n` at end explecitly and from 1.4.0 onwards, use `StreamWriterBuilder` class.

Also use boost range iterator since `recursive_directory_iterator` does not have begin and end on version 1.55 (Debian 8).

### Changes

1. Use `FastWriter` only if json cpp is < 1.4.0, use `StreamWriterBuilder` since 1.4.0.
1. Wrap `recursive_directory_iterator` with `iterator_range`.

## How to test

1. Build `ojo` on Debian 8
1. Check if the JSON output is correct.
1. Check if the directory scan is working.