### PR TITLE
fix(copyright): show more than 100 copyrights on one page

### DIFF
--- a/src/copyright/ui/template/histTable.js.twig
+++ b/src/copyright/ui/template/histTable.js.twig
@@ -43,6 +43,7 @@ function createTableBase{{ table.type }}(activated) {
       });
     },
     "sPaginationType": "listbox",
+    "lengthMenu": [10, 25, 50, 75, 100, 200, 500, 1000],
     "aoColumns": aoColumns,
     "aaSorting": {{ table.sorting }},
     "iDisplayLength": 50,
@@ -137,6 +138,7 @@ function createPlaneTableBase{{ table.type }}(activated) {
       });
     },
     "sPaginationType": "listbox",
+    "lengthMenu": [10, 25, 50, 75, 100, 200, 500, 1000],
     "aoColumns": aoColumns,
     "aaSorting": {{ table.sorting }},
     "iDisplayLength": 50,


### PR DESCRIPTION
This enables the user to select 200, 500 and 1000 copyrights to
be displayed in the list on one page.

Signed-off-by: Andreas J. Reichel <andreas.reichel@tngtech.com>

## Description

Add more choices to the amount of lines displayed in the copyright view data tables.
The user can now display up to 1000 table lines on a single page.

This closes issue #1345 

### Changes

* Specify the lengthMenu item of the datatable object

## How to test

There is no test needed. This is a standard feature of jQuery data table.

Closes #1345