### PR TITLE
fix(ununpack): Increase buffer sizes to prevent overflow

### DIFF
--- a/src/ununpack/agent/traverse.c
+++ b/src/ununpack/agent/traverse.c
@@ -137,7 +137,8 @@ void	TraverseChild	(int Index, ContainerInfo *CI, char *NewDir)
       if (CI->TopContainer && UseRepository)
       {
         RemovePostfix(UploadFileName);
-        strncpy(CI->PartnameNew, UploadFileName, sizeof(CI->PartnameNew) - 1);
+        memcpy(CI->PartnameNew, UploadFileName, sizeof(CI->PartnameNew));
+	CI->PartnameNew[sizeof(CI->PartnameNew)-1] = 0;
       }
       else
         /**

--- a/src/ununpack/agent/traverse.c
+++ b/src/ununpack/agent/traverse.c
@@ -138,7 +138,7 @@ void	TraverseChild	(int Index, ContainerInfo *CI, char *NewDir)
       {
         RemovePostfix(UploadFileName);
         memcpy(CI->PartnameNew, UploadFileName, sizeof(CI->PartnameNew));
-	CI->PartnameNew[sizeof(CI->PartnameNew)-1] = 0;
+        CI->PartnameNew[sizeof(CI->PartnameNew)-1] = 0;
       }
       else
         /**

--- a/src/ununpack/agent/ununpack-disk.c
+++ b/src/ununpack/agent/ununpack-disk.c
@@ -299,7 +299,7 @@ permlist *	SetDiskPerm	(char *inode, permlist *List,
 int	ExtractDisk	(char *Source, char *FStype, char *Destination)
 {
   int rc;
-  char Cmd[FILENAME_MAX*4]; /* command to run */
+  char Cmd[FILENAME_MAX*7]; /* command to run */
   char Line[FILENAME_MAX*2];
   char *s;
   FILE *Fin;

--- a/src/ununpack/agent/ununpack-iso.c
+++ b/src/ununpack/agent/ununpack-iso.c
@@ -78,7 +78,7 @@ mode_t	GetISOMode	(char *Line)
  **/
 int	ExtractISO	(char *Source, char *Destination)
 {
-  char Cmd[FILENAME_MAX*4]; /* command to run */
+  char Cmd[FILENAME_MAX*5]; /* command to run */
   char Line[FILENAME_MAX];
   int Len;
   char *s; /* generic string pointer */

--- a/src/ununpack/agent/utils.c
+++ b/src/ununpack/agent/utils.c
@@ -51,9 +51,9 @@ int IsInflatedFile(char *FileName, int InflateSize)
 {
   int result = 0;
   char FileNameParent[PATH_MAX];
-  memset(FileNameParent, 0, PATH_MAX);
   struct stat st, stParent;
-  strncpy(FileNameParent, FileName, sizeof(FileNameParent));
+  memcpy(FileNameParent, FileName, sizeof(FileNameParent));
+  FileNameParent[PATH_MAX-1] = 0;
   char  *lastSlashPos = strrchr(FileNameParent, '/');
   if (NULL != lastSlashPos)
   {

--- a/src/ununpack/agent/utils.c
+++ b/src/ununpack/agent/utils.c
@@ -630,7 +630,7 @@ void	CheckCommands	(int Show)
 int	RunCommand	(char *Cmd, char *CmdPre, char *File, char *CmdPost,
     char *Out, char *Where)
 {
-  char Cmd1[FILENAME_MAX * 3];
+  char Cmd1[FILENAME_MAX * 5];
   char CWD[FILENAME_MAX];
   int rc;
   char TempPre[FILENAME_MAX];


### PR DESCRIPTION
Fix string buffer sizes to be large enough.

Compiled with gcc 8.3.0 without warnings on ubuntu/bionic.

Signed-off-by: Andreas J. Reichel <andreas.reichel@tngtech.com>

## Description

Prevents a buffer overflow. Closes #1423 

### Changes

Multiplied buffer sizes.

## How to test

Upgrade vagrant vm to ubuntu/bionic and install gcc-8. Go into directory of ununpack agent and build with

make clean
make