### PR TITLE
fix(delagent): Fix possible buffer overrun

### DIFF
--- a/src/delagent/agent/util.c
+++ b/src/delagent/agent/util.c
@@ -386,7 +386,7 @@ int deleteUpload (long uploadId, int userId, int userPerm)
   PQexecCheckClear("Deleting tag_uploadtree", SQL, __FILE__, __LINE__);
 
   /* Delete uploadtree_nnn table */
-  char uploadtree_tablename[1024];
+  char uploadtree_tablename[1000];
   snprintf(SQL,MAXSQL,"SELECT uploadtree_tablename FROM upload WHERE upload_pk = %ld;",uploadId);
   result = PQexec(pgConn, SQL);
   if (fo_checkPQresult(pgConn, result, SQL, __FILE__, __LINE__)) {


### PR DESCRIPTION
Limit uploadtree_tablename to 1000 characters.

Signed-off-by: Andreas J. Reichel <andreas.reichel@tngtech.com>

## Description

Prevent a possible buffer overflow

Closes #1418 

### Changes

Limit uploadtree_tablename to 1000 characters.

