### PR TITLE
fix(buckets): Prevent possible buffer overflow/-run

### DIFF
--- a/src/buckets/agent/buckets.h
+++ b/src/buckets/agent/buckets.h
@@ -36,7 +36,8 @@
 #include "liccache.h"
 #define FUNCTION
 
-#define myBUFSIZ	2048
+#define myBUFSIZ       2048
+#define MAXSQL         1024
 
 #define IsContainer(mode)  ((mode & 1<<29) != 0)
 #define IsArtifact(mode)   ((mode & 1<<28) != 0)

--- a/src/buckets/agent/liccache.c
+++ b/src/buckets/agent/liccache.c
@@ -257,8 +257,8 @@ FUNCTION long get_rfpk(PGconn *pgConn, cacheroot_t *pcroot, char *rf_shortname)
 FUNCTION long add2license_ref(PGconn *pgConn, char *licenseName)
 {
     PGresult *result;
-    char  query[256];
-    char  insert[256];
+    char  query[MAXSQL];
+    char  insert[MAXSQL];
     char  escLicName[256];
     char *specialLicenseText;
     long rf_pk;

--- a/src/buckets/agent/walk.c
+++ b/src/buckets/agent/walk.c
@@ -222,19 +222,23 @@ FUNCTION int processFile(PGconn *pgConn, pbucketdef_t bucketDefArray,
      */
     if (isPkg)
     {
-      strncpy(package.pkgname, PQgetvalue(result, 0, 0), sizeof(package.pkgname));
+      strncpy(package.pkgname, PQgetvalue(result, 0, 0), sizeof(package.pkgname)-1);
+      package.pkgname[sizeof(package.pkgname)-1] = 0;
       if (package.pkgname[strlen(package.pkgname)-1] == '\n')
         package.pkgname[strlen(package.pkgname)-1] = 0;
 
-      strncpy(package.pkgvers, PQgetvalue(result, 0, 1), sizeof(package.pkgvers));
+      strncpy(package.pkgvers, PQgetvalue(result, 0, 1), sizeof(package.pkgvers)-1);
+      package.pkgvers[sizeof(package.pkgvers)-1] = 0;
       if (package.pkgvers[strlen(package.pkgvers)-1] == '\n')
         package.pkgvers[strlen(package.pkgvers)-1] = 0;
 
-      strncpy(package.vendor, PQgetvalue(result, 0, 2), sizeof(package.vendor));
+      strncpy(package.vendor, PQgetvalue(result, 0, 2), sizeof(package.vendor)-1);
+      package.vendor[sizeof(package.vendor)-1] = 0;
       if (package.vendor[strlen(package.vendor)-1] == '\n')
         package.vendor[strlen(package.vendor)-1] = 0;
 
-      strncpy(package.srcpkgname, PQgetvalue(result, 0, 3), sizeof(package.srcpkgname));
+      strncpy(package.srcpkgname, PQgetvalue(result, 0, 3), sizeof(package.srcpkgname)-1);
+      package.srcpkgname[sizeof(package.srcpkgname)-1] = 0;
       if (package.srcpkgname[strlen(package.srcpkgname)-1] == '\n')
         package.srcpkgname[strlen(package.srcpkgname)-1] = 0;
     }


### PR DESCRIPTION
Allocate enough space for sprintf, use strncpy correctly to be sure
to have a 0 at the end of the dest buffer.

Signed-off-by: Andreas J. Reichel <andreas.reichel@tngtech.com>

## Description

Closes #1417 

