### PR TITLE
fix(lib/c): Prevent possible buffer overflow/-run

### DIFF
--- a/src/lib/c/libfossdb.c
+++ b/src/lib/c/libfossdb.c
@@ -20,7 +20,7 @@ along with this library; if not, write to the Free Software Foundation, Inc.0
  \brief Common libpq database functions.
  */
 
-#define ERRBUFSIZE 1024
+#define ERRBUFSIZE 11264
 
 #include "libfossdb.h"
 

--- a/src/lib/c/libfossrepo.c
+++ b/src/lib/c/libfossrepo.c
@@ -971,7 +971,8 @@ int fo_RepOpenFull(fo_conf* config)
     fprintf(stderr, "ERROR %s.%d: %s\n", __FILE__, __LINE__, error->message);
     return 0;
   }
-  strncpy(RepPath, path, sizeof(RepPath));
+  strncpy(RepPath, path, sizeof(RepPath)-1);
+  RepPath[sizeof(RepPath)-1] = 0;
 
   return 1;
 } /* fo_RepOpen() */


### PR DESCRIPTION
Make sure the dest buffer of snprintf has enough space and use
strncpy correctly to make sure the dest buffer has a terminating 0.

Signed-off-by: Andreas J. Reichel <andreas.reichel@tngtech.com>

## Description

Closes #1416 