### PR TITLE
fix(wget_agent): Prevent possible memory corruption

### DIFF
--- a/src/wget_agent/agent/main.c
+++ b/src/wget_agent/agent/main.c
@@ -115,16 +115,16 @@ int main  (int argc, char *argv[])
   int user_pk;
   char *agent_desc = "Network downloader.  Uses wget(1).";
 
-  memset(GlobalTempFile,'\0',MAXCMD);
-  memset(GlobalURL,'\0',MAXCMD);
-  memset(GlobalParam,'\0',MAXCMD);
-  memset(GlobalType,'\0',MAXCMD);
+  memset(GlobalTempFile,'\0',STRMAX);
+  memset(GlobalURL,'\0',URLMAX);
+  memset(GlobalParam,'\0',STRMAX);
+  memset(GlobalType,'\0',STRMAX);
   GlobalUploadKey = -1;
   int upload_pk = 0;           // the upload primary key
   //int Agent_pk;
   char *COMMIT_HASH;
   char *VERSION;
-  char agent_rev[MAXCMD];
+  char agent_rev[STRMAX];
 
   /* open the connection to the scheduler and configuration */
   fo_scheduler_connect(&argc, argv, &pgConn);
@@ -156,16 +156,16 @@ int main  (int argc, char *argv[])
           strcpy(GlobalTempFile,"wget.default_download");
         break;
       case 'A':
-        strncat(GlobalParam, " -A ", MAXCMD - strlen(GlobalParam) -1);
-        strncat(GlobalParam, optarg, MAXCMD - strlen(GlobalParam) -1);
+        strncat(GlobalParam, " -A ", STRMAX - strlen(GlobalParam) -1);
+        strncat(GlobalParam, optarg, STRMAX - strlen(GlobalParam) -1);
         break;
       case 'R':
-        strncat(GlobalParam, " -R ", MAXCMD - strlen(GlobalParam) -1);
-        strncat(GlobalParam, optarg, MAXCMD - strlen(GlobalParam) -1);
+        strncat(GlobalParam, " -R ", STRMAX - strlen(GlobalParam) -1);
+        strncat(GlobalParam, optarg, STRMAX - strlen(GlobalParam) -1);
         break;
       case 'l':
-        strncat(GlobalParam, " -l ", MAXCMD - strlen(GlobalParam) -1);
-        strncat(GlobalParam, optarg, MAXCMD - strlen(GlobalParam) -1);
+        strncat(GlobalParam, " -l ", STRMAX - strlen(GlobalParam) -1);
+        strncat(GlobalParam, optarg, STRMAX - strlen(GlobalParam) -1);
         break;
       case 'c': break; /* handled by fo_scheduler_connect() */
       case 'C':
@@ -229,7 +229,7 @@ int main  (int argc, char *argv[])
       LOG_VERBOSE0("It's a file -- GlobalUploadKey = %ld",GlobalUploadKey);
       if (GlobalUploadKey != -1)
       {
-        memcpy(GlobalTempFile,GlobalURL,MAXCMD);
+        memcpy(GlobalTempFile,GlobalURL,STRMAX);
         DBLoadGold();
       }
     }
@@ -256,9 +256,9 @@ int main  (int argc, char *argv[])
           continue;
         }
 
-        char TempDir[MAXCMD];
-        memset(TempDir,'\0',MAXCMD);
-        snprintf(TempDir, MAXCMD-1, "%s/wget", TempFileDir); // /var/local/lib/fossology/agents/wget
+        char TempDir[STRMAX];
+        memset(TempDir,'\0',STRMAX);
+        snprintf(TempDir, STRMAX-1, "%s/wget", TempFileDir); // /var/local/lib/fossology/agents/wget
         struct stat Status = {};
 
         if (GlobalType[0])

--- a/src/wget_agent/agent/wget_agent.c
+++ b/src/wget_agent/agent/wget_agent.c
@@ -117,14 +117,14 @@ void DBLoadGold()
     SafeExit(ASPRINTF_MEM_ERROR);
   }
 
-  FILE* file = popen(cmd, "r");
-
   if (!Fin)
   {
     LOG_FATAL("upload %ld Unable to open temp file %s from %s",
         GlobalUploadKey,GlobalTempFile,GlobalURL);
     SafeExit(1);
   }
+  
+  FILE* file = popen(cmd, "r");
 
   if (!file)
   {

--- a/src/wget_agent/agent/wget_agent.c
+++ b/src/wget_agent/agent/wget_agent.c
@@ -297,6 +297,34 @@ int TaintURL(char *Sin, char *Sout, int SoutSize)
   return(Sin[i]=='\0');
 } /* TaintURL() */
 
+
+/**
+ * \brief Prepare directory for wget.
+ * \param TempFile
+ * \param TempFileDir
+ * \param TempFileDirectory
+ * \parblock
+ * Internal helper function for function GetURL 
+ * \endparblock
+ * \return destination for wget download or NULL
+ */
+char *PrepareWgetDest(char *TempFile, char *TempFileDir, char *TempFileDirectory)
+{
+  if (TempFile && TempFile[0])
+  {
+    /* Delete the temp file if it exists */
+    unlink(TempFile);
+    return TempFileDirectory;
+  }
+  else if(TempFileDir && TempFileDir[0])
+  {
+    return TempFileDir;
+  }
+    
+  return NULL;
+}
+
+
 /**
  * \brief Do the wget.
  * \param TempFile
@@ -376,23 +404,21 @@ int GetURL(char *TempFile, char *URL, char *TempFileDir)
     snprintf(no_proxy, MAXCMD-1, "-e no_proxy='%s'", GlobalProxy[3]);
   }
 
-  if (TempFile && TempFile[0])
-  {
-    /* Delete the temp file if it exists */
-    unlink(TempFile);
+  char *dest;
+
+  dest = PrepareWgetDest(TempFile, TempFileDir, TempFileDirectory);
+
+  if (dest) {
     snprintf(CMD,MAXCMD-1," %s /usr/bin/wget -q %s -P '%s' '%s' %s %s 2>&1",
-        proxy, WgetArgs,TempFileDirectory,TaintedURL,GlobalParam, no_proxy);
-  }
-  else if(TempFileDir && TempFileDir[0])
-  {
-    snprintf(CMD,MAXCMD-1," %s /usr/bin/wget -q %s -P '%s' '%s' %s %s 2>&1",
-        proxy, WgetArgs, TempFileDir, TaintedURL, GlobalParam, no_proxy);
+        proxy, WgetArgs, dest, TaintedURL, GlobalParam, no_proxy);
   }
   else
   {
     snprintf(CMD,MAXCMD-1," %s /usr/bin/wget -q %s '%s' %s %s 2>&1",
-        proxy, WgetArgs,TaintedURL, GlobalParam, no_proxy);
+        proxy, WgetArgs, TaintedURL, GlobalParam, no_proxy);
   }
+
+
   /* the command is like
   ". /usr/local/etc/fossology/Proxy.conf;
      /usr/bin/wget -q --no-check-certificate --progress=dot -rc -np -e robots=off -P

--- a/src/wget_agent/agent/wget_agent.c
+++ b/src/wget_agent/agent/wget_agent.c
@@ -527,7 +527,6 @@ int GetVersionControl()
 
   int rc = 0;
   int resethome = 0; // 0: default; 1: home is null before setting, should rollback
-  int rc_system =0;
   char *homeenv = NULL;
   int res;
 
@@ -579,8 +578,8 @@ int GetVersionControl()
     */
     LOG_FATAL("please make sure the URL of repo is correct, also add correct proxy for your version control system, command is:%s, GlobalTempFile is:%s, rc is:%d. \n", command, GlobalTempFile, rc);
     /* remove the temp dir /srv/fossology/repository/localhost/wget/wget.xxx.dir/ for this upload */
-    rc_system = system(delete_tmpdir_cmd);
-    if (!WIFEXITED(rc_system)) systemError(__LINE__, rc_system, delete_tmpdir_cmd)
+    rc = system(delete_tmpdir_cmd);
+    if (!WIFEXITED(rc)) systemError(__LINE__, rc, delete_tmpdir_cmd)
     free(tmp_file_directory);
     free(delete_tmpdir_cmd);
     return 1;
@@ -593,16 +592,16 @@ int GetVersionControl()
   {
     systemError(__LINE__, rc, command)
     /* remove the temp dir /srv/fossology/repository/localhost/wget/wget.xxx.dir/ for this upload */
-    rc_system = system(delete_tmpdir_cmd);
-    if (!WIFEXITED(rc_system)) systemError(__LINE__, rc_system, delete_tmpdir_cmd)
+    rc = system(delete_tmpdir_cmd);
+    if (!WIFEXITED(rc)) systemError(__LINE__, rc, delete_tmpdir_cmd)
     LOG_FATAL("DeleteTempDirCmd is:%s\n", delete_tmpdir_cmd);
     free(delete_tmpdir_cmd);
     return 1;
   }
 
   /* remove the temp dir /srv/fossology/repository/localhost/wget/wget.xxx.dir/ for this upload */
-  rc_system = system(delete_tmpdir_cmd);
-  if (!WIFEXITED(rc_system)) systemError(__LINE__, rc_system, delete_tmpdir_cmd)
+  rc = system(delete_tmpdir_cmd);
+  if (!WIFEXITED(rc)) systemError(__LINE__, rc, delete_tmpdir_cmd)
   free(delete_tmpdir_cmd);
 
   return 0; // succeed to retrieve source

--- a/src/wget_agent/agent/wget_agent.c
+++ b/src/wget_agent/agent/wget_agent.c
@@ -22,6 +22,9 @@
  * \file wget_agent.c
  * \brief wget_agent: Retrieve a file and put it in the database.
  */
+#define _GNU_SOURCE           // for asprintf
+
+#define ASPRINTF_MEM_ERROR  88
 
 #include "wget_agent.h"
 
@@ -518,13 +521,15 @@ int GetURL(char *TempFile, char *URL, char *TempFileDir)
 int GetVersionControl()
 {
   char *command = NULL;
-  char TempFileDirectory[MAXCMD];
-  char DeleteTempDirCmd[MAXCMD];
-  char TempHome[MAXCMD];
+  char *tmp_file_directory;
+  char *delete_tmpdir_cmd;
+  char *tmp_home;
+
   int rc = 0;
   int resethome = 0; // 0: default; 1: home is null before setting, should rollback
   int rc_system =0;
   char *homeenv = NULL;
+  int res;
 
   homeenv = getenv("HOME");
   if(NULL == homeenv) resethome = 1;
@@ -532,12 +537,28 @@ int GetVersionControl()
   /* We need HOME to point to where .gitconfig is installed
    * path is the repository path and .gitconfig is installed in its parent directory
    */
-  snprintf(TempHome, sizeof(TempHome), "%s/..", fo_config_get(sysconfig, "FOSSOLOGY", "path", NULL));
-  setenv("HOME", TempHome, 1);
+  res = asprintf(&tmp_home, "%s/..", fo_config_get(sysconfig, "FOSSOLOGY", "path", NULL));
+  if (res == -1)
+  {
+    return ASPRINTF_MEM_ERROR;
+  }
+
+  setenv("HOME", tmp_home, 1);
+  free(tmp_home);
 
   /* save each upload files in /srv/fossology/repository/localhost/wget/wget.xxx.dir/ */
-  sprintf(TempFileDirectory, "%s.dir", GlobalTempFile);
-  sprintf(DeleteTempDirCmd, "rm -rf %s", TempFileDirectory);
+  res = asprintf(&tmp_file_directory, "%s.dir", GlobalTempFile);
+  if (res == -1)
+  {
+    return ASPRINTF_MEM_ERROR;
+  }
+
+  res = asprintf(&delete_tmpdir_cmd, "rm -rf %s", tmp_file_directory);
+  if (res == -1)
+  {
+    free(tmp_file_directory);
+    return ASPRINTF_MEM_ERROR;
+  }
 
   command = GetVersionControlCommand(1);
 
@@ -558,26 +579,31 @@ int GetVersionControl()
     */
     LOG_FATAL("please make sure the URL of repo is correct, also add correct proxy for your version control system, command is:%s, GlobalTempFile is:%s, rc is:%d. \n", command, GlobalTempFile, rc);
     /* remove the temp dir /srv/fossology/repository/localhost/wget/wget.xxx.dir/ for this upload */
-    rc_system = system(DeleteTempDirCmd);
-    if (!WIFEXITED(rc_system)) systemError(__LINE__, rc_system, DeleteTempDirCmd)
+    rc_system = system(delete_tmpdir_cmd);
+    if (!WIFEXITED(rc_system)) systemError(__LINE__, rc_system, delete_tmpdir_cmd)
+    free(tmp_file_directory);
+    free(delete_tmpdir_cmd);
     return 1;
   }
 
-  snprintf(command,MAXCMD-1, "tar -cf  '%s' -C '%s' ./ 1>/dev/null", GlobalTempFile, TempFileDirectory);
+  snprintf(command,MAXCMD-1, "tar -cf  '%s' -C '%s' ./ 1>/dev/null", GlobalTempFile, tmp_file_directory);
+  free(tmp_file_directory);
   rc = system(command);
   if (rc != 0)
   {
-    systemError(__LINE__, rc_system, DeleteTempDirCmd)
+    systemError(__LINE__, rc, command)
     /* remove the temp dir /srv/fossology/repository/localhost/wget/wget.xxx.dir/ for this upload */
-    rc_system = system(DeleteTempDirCmd);
-    if (!WIFEXITED(rc_system)) systemError(__LINE__, rc_system, DeleteTempDirCmd)
-    LOG_FATAL("DeleteTempDirCmd is:%s\n", DeleteTempDirCmd);
+    rc_system = system(delete_tmpdir_cmd);
+    if (!WIFEXITED(rc_system)) systemError(__LINE__, rc_system, delete_tmpdir_cmd)
+    LOG_FATAL("DeleteTempDirCmd is:%s\n", delete_tmpdir_cmd);
+    free(delete_tmpdir_cmd);
     return 1;
   }
 
   /* remove the temp dir /srv/fossology/repository/localhost/wget/wget.xxx.dir/ for this upload */
-  rc_system = system(DeleteTempDirCmd);
-  if (!WIFEXITED(rc_system)) systemError(__LINE__, rc_system, DeleteTempDirCmd)
+  rc_system = system(delete_tmpdir_cmd);
+  if (!WIFEXITED(rc_system)) systemError(__LINE__, rc_system, delete_tmpdir_cmd)
+  free(delete_tmpdir_cmd);
 
   return 0; // succeed to retrieve source
 }

--- a/src/wget_agent/agent/wget_agent.h
+++ b/src/wget_agent/agent/wget_agent.h
@@ -47,19 +47,20 @@ typedef struct stat stat_t;
 
 #include "../../ununpack/agent/checksum.h"
 
-#define MAXCMD  2048
+#define URLMAX   3072
+#define STRMAX   2048
 #define FILEPATH 2048
 
-extern char SQL[MAXCMD];
+extern char SQL[STRMAX];
 
 /* for the DB */
 extern PGconn *pgConn;
 /* input for this system */
 extern long GlobalUploadKey;
-extern char GlobalTempFile[MAXCMD];
-extern char GlobalURL[MAXCMD];
-extern char GlobalParam[MAXCMD];
-extern char GlobalType[MAXCMD];
+extern char GlobalTempFile[STRMAX];
+extern char GlobalURL[URLMAX];
+extern char GlobalParam[STRMAX];
+extern char GlobalType[STRMAX];
 extern int GlobalImportGold; /* set to 0 to not store file in gold repository */
 extern gid_t ForceGroup;
 

--- a/src/wget_agent/agent_tests/Unit/wget_agent/testDBLoadGold.c
+++ b/src/wget_agent/agent_tests/Unit/wget_agent/testDBLoadGold.c
@@ -42,9 +42,9 @@ static fo_dbManager* dbManager;
  */
 int  DBLoadGoldInit()
 {
-  char URL[MAXCMD];
-  char TempFileDir[MAXCMD];
-  char TempFile[MAXCMD];
+  char URL[URLMAX];
+  char TempFileDir[STRMAX];
+  char TempFile[STRMAX];
 
   /** -# Create db */
   dbManager = createTestEnvironment(AGENT_DIR, "wget_agent", 1);
@@ -65,8 +65,8 @@ int  DBLoadGoldInit()
   strcpy(GlobalURL, "https://mirrors.kernel.org/fossology/releases/3.0.0/ubuntu/14.04/");
 
   /** -# Delete the record that upload_filename is wget.tar, pre testing */
-  memset(SQL,'\0',MAXCMD);
-  snprintf(SQL,MAXCMD, "DELETE FROM upload where upload_filename = 'fossology.sources.list';");
+  memset(SQL,'\0',STRMAX);
+  snprintf(SQL,STRMAX, "DELETE FROM upload where upload_filename = 'fossology.sources.list';");
   result = PQexec(pgConn, SQL);
   if (fo_checkPQcommand(pgConn, result, SQL, __FILE__ ,__LINE__))
   {
@@ -76,8 +76,8 @@ int  DBLoadGoldInit()
   PQclear(result);
 
   /** -# Insert upload wget.tar */
-  memset(SQL,'\0',MAXCMD);
-  snprintf(SQL,MAXCMD,"INSERT INTO upload (upload_filename,upload_mode,upload_ts) VALUES ('fossology.sources.list',40,now());");
+  memset(SQL,'\0',STRMAX);
+  snprintf(SQL,STRMAX,"INSERT INTO upload (upload_filename,upload_mode,upload_ts) VALUES ('fossology.sources.list',40,now());");
   result = PQexec(pgConn, SQL);
   if (fo_checkPQcommand(pgConn, result, SQL, __FILE__ ,__LINE__))
   {
@@ -86,8 +86,8 @@ int  DBLoadGoldInit()
   }
   PQclear(result);
   /** -# Get upload id */
-  memset(SQL,'\0',MAXCMD);
-  snprintf(SQL,MAXCMD,"SELECT upload_pk from upload where upload_filename = 'fossology.sources.list';");
+  memset(SQL,'\0',STRMAX);
+  snprintf(SQL,STRMAX,"SELECT upload_pk from upload where upload_filename = 'fossology.sources.list';");
   result = PQexec(pgConn, SQL);
   if (fo_checkPQresult(pgConn, result, SQL, __FILE__ ,__LINE__))
   {
@@ -100,8 +100,8 @@ int  DBLoadGoldInit()
   GError* error = NULL;
   char* foConf = get_confFile();
 
-  char cmd[MAXCMD+1];
-  snprintf(cmd, MAXCMD, "sed -i 's|depth.*|depth=3|' %s", foConf);
+  char cmd[STRMAX+1];
+  snprintf(cmd, STRMAX, "sed -i 's|depth.*|depth=3|' %s", foConf);
   if (system(cmd) != 0) {
     printf("cannot reset depth to 3 with %s\n", cmd);
     return 1;
@@ -121,10 +121,10 @@ int  DBLoadGoldInit()
  */
 int DBLoadGoldClean()
 {
-  memset(GlobalTempFile, 0, MAXCMD);
-  memset(GlobalURL, 0, MAXCMD);
-  memset(GlobalParam, 0, MAXCMD);
-  char TempFileDir[MAXCMD];
+  memset(GlobalTempFile, 0, STRMAX);
+  memset(GlobalURL, 0, URLMAX);
+  memset(GlobalParam, 0, STRMAX);
+  char TempFileDir[STRMAX];
 
   strcpy(TempFileDir, "./test_result");
   if (file_dir_existed(TempFileDir))
@@ -136,8 +136,8 @@ int DBLoadGoldClean()
     fo_config_free(sysconfig);
   }
 
-  char repoDir[MAXCMD+1];
-  if (snprintf(repoDir, MAXCMD, "%s/repo", get_sysconfdir())>0) {
+  char repoDir[STRMAX+1];
+  if (snprintf(repoDir, STRMAX, "%s/repo", get_sysconfdir())>0) {
     RemoveDir(repoDir);
   }
 
@@ -175,12 +175,12 @@ void testDBLoadGold()
   //printf("db start\n");
   DBLoadGold();
   //printf("db end\n");
-  char SQL[MAXCMD];
+  char SQL[STRMAX];
   char *pfile_sha1;
   char *pfile_md5;
-  memset(SQL, 0, MAXCMD);
+  memset(SQL, 0, STRMAX);
   PGresult *result;
-  snprintf(SQL, MAXCMD-1, "select pfile_sha1, pfile_md5 from pfile where pfile_pk in (select pfile_fk from "
+  snprintf(SQL, STRMAX-1, "select pfile_sha1, pfile_md5 from pfile where pfile_pk in (select pfile_fk from "
       "upload where upload_pk = %ld);", GlobalUploadKey);
   result =  PQexec(pgConn, SQL); /* SELECT */
   if (fo_checkPQresult(pgConn, result, SQL, __FILE__, __LINE__))
@@ -194,8 +194,8 @@ void testDBLoadGold()
   string_tolower(pfile_sha1);
   string_tolower(pfile_md5);
   //printf("pfile_sha1, pfile_md5 are:%s, %s\n", pfile_sha1, pfile_md5 );
-  char file_name_file[MAXCMD] = {0};
-  char file_name_gold[MAXCMD] = {0};
+  char file_name_file[STRMAX] = {0};
+  char file_name_gold[STRMAX] = {0};
   char string0[3] = {0};
   char string1[3] = {0};
   char string2[3] = {0};

--- a/src/wget_agent/agent_tests/Unit/wget_agent/testSetEnv.c
+++ b/src/wget_agent/agent_tests/Unit/wget_agent/testSetEnv.c
@@ -36,9 +36,9 @@ static char TempFileDir[MAX_LENGTH];
 int  SetEnvInit()
 {
   GlobalUploadKey = -1;
-  memset(GlobalTempFile, 0, MAXCMD);
-  memset(GlobalURL, 0, MAXCMD);
-  memset(GlobalParam, 0, MAXCMD);
+  memset(GlobalTempFile, 0, STRMAX);
+  memset(GlobalURL, 0, URLMAX);
+  memset(GlobalParam, 0, STRMAX);
   return 0;
 }
 
@@ -48,9 +48,9 @@ int  SetEnvInit()
 int  SetEnvClean()
 {
   GlobalUploadKey = -1;
-  memset(GlobalTempFile, 0, MAXCMD);
-  memset(GlobalURL, 0, MAXCMD);
-  memset(GlobalParam, 0, MAXCMD);
+  memset(GlobalTempFile, 0, STRMAX);
+  memset(GlobalURL, 0, URLMAX);
+  memset(GlobalParam, 0, STRMAX);
   return 0;
 }
 /**


### PR DESCRIPTION
Fix wget_agent's obviously possible memory corruption

Closes #1424 

## Description

A lot of snprintf/printfs are replaced by asprintf, which allocates memory dynamically and sufficiently.

### Changes

* Unneeded memset is removed
* Unneeded malloc is removed
* Some pointer checks are introduced
* Some memory leaks are corrected
* New error code for out of memory error
* Some simplifications in program flow
* One minor change in wget_agent.c where rc was used in an error message instead of rc_system
* Lots of new asprintf / free (this most probably needs review!!!)
