### PR TITLE
chore(ninka): Remove Ninka packaging from master

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -152,9 +152,9 @@ endif
            PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
            -C src/monk install-monkbulk
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-ninka \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/ninka install
+#	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-ninka \
+#           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
+#           -C src/ninka install
 
 	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-ojo \
            PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \

--- a/src/Makefile
+++ b/src/Makefile
@@ -21,7 +21,6 @@ DIRS = \
 	maintagent \
 	mimetype \
 	monk \
-	ninka \
 	nomos \
 	ojo \
 	pkgagent \
@@ -34,6 +33,7 @@ DIRS = \
 	ununpack \
 	wget_agent \
 	www
+#	ninka \
 
 # create lists of targets for various operations
 # these are phony targets (declared at bottom) of convenience so we can


### PR DESCRIPTION
## Description

Remove Ninka from packaging since ninka is no longer supported on new distros.

### Changes

1. Remove ninka from Debian rule file.
1. Remove ninka from `src/Makefile`.

## How to test

Check if ninka is not build and packaged in `.deb` using regular steps.