### PR TITLE
chore(changelog): adding 3.6.0-rc2 info to changelog files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog of FOSSology
 
+
+### 3.6.0-RC2 (Aug 24th 2019)
+
+This pre-release adds important corrections to 3.6.0-RC2.
+
+#### Corrections
+
+* `f4c2de9df` fix(dbMigrate): Fix PHP syntax error
+* `69b03a368` fix(copyright): Check if empty decision sent
+* `83897a185` fix(obligation): add default value if the obligation type and classification is empty
+* `90b7f551f` feat(unifiedreport): add candidate licenses to the list of obligations
+* `49d901c02` fix(ojo): Remove call to omitEndingLineFeed on<0.6
+
 ### 3.6.0-RC1 (Aug 12th 2019)
 
 This release brings a number of corrections (see below) and changes to the infrastructure. But it also adds nw features to FOSSology, including:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+fossology (3.6.0~rc2-1) unstable; urgency=low
+
+  * New upstream release
+  * https://github.com/fossology/fossology/releases/tag/3.6.0-rc2 for details
+
+ -- Anupam Ghosh <anupam.ghosh@siemens.com>  Sat, 24 Aug 2019 14:09:58 +0530
+
 fossology (3.6.0~rc1-1) unstable; urgency=low
 
   * New upstream release


### PR DESCRIPTION
Signed-off-by: Anupam Ghosh <anupam.ghosh@siemens.com>
## Description

Added CHANGELOG.md and debian/changelog information for 3.6.0-rc2

### Changes

fix bugs of release 3.6.0.-rc1.

## How to test

Review the changes in github.
