### PR TITLE
fix(ajaxExplorer): Reduce view creation

### DIFF
--- a/src/lib/php/BusinessRules/AgentLicenseEventProcessor.php
+++ b/src/lib/php/BusinessRules/AgentLicenseEventProcessor.php
@@ -181,7 +181,11 @@ class AgentLicenseEventProcessor
         $this->latestAgentMapCache[$uploadId][$agentName] = $agentMap;
       }
     }
-    return $this->latestAgentMapCache[$uploadId];
+    if (array_key_exists($uploadId, $this->latestAgentMapCache)) {
+      return $this->latestAgentMapCache[$uploadId];
+    } else {
+      return array();
+    }
   }
 
   /**

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -1143,7 +1143,7 @@
   $Schema["TABLE"]["personal_access_tokens"]["token_key"]["ALTER"] = "ALTER TABLE \"personal_access_tokens\" ALTER COLUMN \"token_key\" SET NOT NULL";
 
   $Schema["TABLE"]["personal_access_tokens"]["active"]["DESC"] = "COMMENT ON COLUMN \"personal_access_tokens\".\"active\" IS 'True if token is active, false otherwise'";
-  $Schema["TABLE"]["personal_access_tokens"]["active"]["ADD"] = "ALTER TABLE \"personal_access_tokens\" ADD COLUMN \"active\" boolean";
+  $Schema["TABLE"]["personal_access_tokens"]["active"]["ADD"] = "ALTER TABLE \"personal_access_tokens\" ADD COLUMN \"active\" bool";
   $Schema["TABLE"]["personal_access_tokens"]["active"]["ALTER"] = "ALTER TABLE \"personal_access_tokens\" ALTER COLUMN \"active\" SET NOT NULL";
 
 


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Since PR #1314, the number of times `UploadTreeProxy` is materialized is increased (2 per folder in the view). Each call takes significant amount of time depending on the entries in DB.

This PR tires to reduce these calls to only 2 per UI load.

The average amount of time taken to load `?mod=ajax_explorer` for an upload with 10 files is reduced from ~600ms to ~350ms.

### Changes

1. Create upload view proxy in DB only once with the complete `ItemTreeBounds`.
2. Fix PHP warnings for `AgentLicenseEventProcessor.php` when browsing license for an empty file.

## How to test

1. Upload a huge package and check the loading time for License Browser table.
1. Install the fix and brows the same package.
    - The load time should reduce.