### PR TITLE
feat(upload_vcs.html.twig) make Git the default VCS rather than SVN

### DIFF
--- a/src/www/ui/template/upload_vcs.html.twig
+++ b/src/www/ui/template/upload_vcs.html.twig
@@ -19,8 +19,8 @@
   </label>
   <br/>
   <select name="{{ vcstypeField }}">
-    <option value='SVN'>SVN</option>
     <option value='Git'>Git</option>
+    <option value='SVN'>SVN</option>
   </select>
 </li>
 <li>

--- a/src/www/ui/template/upload_vcs.html.twig
+++ b/src/www/ui/template/upload_vcs.html.twig
@@ -19,8 +19,8 @@
   </label>
   <br/>
   <select name="{{ vcstypeField }}">
-    <option value='Git'>Git</option>
     <option value='SVN'>SVN</option>
+    <option value='Git' selected>Git</option>
   </select>
 </li>
 <li>


### PR DESCRIPTION
Signed-off-by: Toussaint Nicolas <nicolas1.toussaint@orange.com>

## Description

fixes #1485 

Just reorder the VCS in the drop down list so that Git is selected by default.

## How to test

Choose 'Upload From Version Control System', verify that Git is selected by default.