### PR TITLE
feat(spdx): add user found copyrights to SPDX reports

### DIFF
--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -527,9 +527,13 @@ class SpdxTwoAgent extends Agent
     /* @var $copyrightDao CopyrightDao */
     $copyrightDao = $this->container->get('dao.copyright');
     $uploadtreeTable = $this->uploadDao->getUploadtreeTableName($uploadId);
-    $allEntries = $copyrightDao->getAllEntries('copyright', $uploadId, $uploadtreeTable, $type='statement');
-    foreach ($allEntries as $finding) {
+    $allScannerEntries = $copyrightDao->getScannerEntries('copyright', $uploadtreeTable, $uploadId, $type='statement', $extrawhere=null);
+    $allEditedEntries = $copyrightDao->getEditedEntries('copyright_decision', $uploadtreeTable, $uploadId, $decisionType=null);
+    foreach ($allScannerEntries as $finding) {
       $filesWithLicenses[$finding['uploadtree_pk']]['copyrights'][] = \convertToUTF8($finding['content'],false);
+    }
+    foreach ($allEditedEntries as $finding) {
+      $filesWithLicenses[$finding['uploadtree_pk']]['copyrights'][] = \convertToUTF8($finding['textfinding'],false);
     }
   }
 


### PR DESCRIPTION
###  Description

PR adds user found Copyright entries to SPDX reports

Fixes #1362 

### Changes

src/spdx2/agent/spdx2.php - read copyright entries from copyright_decision table and add them to result array (merged with scanner results)

## How to test

1. Add new Copyright in GUI
2. Generate SPDX report
3. Check if previously added copyright can be found on report
