### PR TITLE
fix(geekyscan): make full job report link more descriptive

### DIFF
--- a/src/www/ui/async/AjaxShowJobs.php
+++ b/src/www/ui/async/AjaxShowJobs.php
@@ -159,7 +159,7 @@ class AjaxShowJobs extends \FO_Plugin
           }
           if (filesize($row[$field]) > self::MAX_LOG_OUTPUT) {
             $value = "<pre>" .file_get_contents($row[$field],false,null,-1,self::MAX_LOG_OUTPUT)."</pre>"
-                    .'<a href="'.Traceback_uri() . '?mod=download&log=' . $row['jq_pk'] . '">...</a>';
+                    .'<a href="'.Traceback_uri() . '?mod=download&log=' . $row['jq_pk'] . '">Download full log</a>';
           } else {
             $value = "<pre>" . file_get_contents($row[$field]). "</pre>";
           }


### PR DESCRIPTION
fixes issue #1346 

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This pull request changes the three dots(...) in the view full log hyper link to show "display full log" which is more descriptive

### Changes

changed [this file](https://github.com/fossology/fossology/blob/9d0765c2eda0b72c4a5aaac640322d4f59ffd7f4/src/www/ui/async/AjaxShowJobs.php#L156-L166)

## How to test

Upload a project as compressed file, allow job to complete, click on job to view details, if log is too long you should see the "Download full log" link instead of "..."

Closes #1346 