### PR TITLE
feat(rest): Upload packages from VCS

### DIFF
--- a/src/www/ui/api/Controllers/ReportController.php
+++ b/src/www/ui/api/Controllers/ReportController.php
@@ -129,6 +129,9 @@ class ReportController extends RestController
     if (! $uploadDao->isAccessible($uploadId, $this->restHelper->getGroupId())) {
       $upload = new Info(403, "Upload is not accessible!", InfoType::ERROR);
     }
+    if ($upload !== null) {
+      return $upload;
+    }
     $upload = $uploadDao->getUpload($uploadId);
     if ($upload === null) {
       $upload = new Info(404, "Upload does not exists!", InfoType::ERROR);

--- a/src/www/ui/api/Helper/UploadHelper.php
+++ b/src/www/ui/api/Helper/UploadHelper.php
@@ -1,81 +1,250 @@
 <?php
-/***************************************************************
- Copyright (C) 2018 Siemens AG
- Author: Gaurav Mishra <mishra.gaurav@siemens.com>
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***************************************************************/
 /**
- * @file
- * @brief Helper to handle file uploads
+ * *************************************************************
+ * Copyright (C) 2018 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *************************************************************
  */
 
+/**
+ * @file
+ * @brief Helper to handle package uploads
+ */
 namespace Fossology\UI\Api\Helper;
 
-use Fossology\UI\Page\UploadFilePage;
 use Psr\Http\Message\ServerRequestInterface;
-use Slim\Http\UploadedFile;
+use Fossology\UI\Api\Helper\UploadHelper\HelperToUploadFilePage;
+use Fossology\UI\Api\Helper\UploadHelper\HelperToUploadVcsPage;
 
 /**
  * @class UploadHelper
  * @brief Handle new file uploads from Slim framework and move to FOSSology
  */
-class UploadHelper extends UploadFilePage
+class UploadHelper
 {
+  /**
+   * @var HelperToUploadFilePage $uploadFilePage
+   * Object to handle file based uploads
+   */
+  private $uploadFilePage;
+
+  /**
+   * @var HelperToUploadVcsPage $uploadVcsPage
+   * Object to handle VCS based uploads
+   */
+  private $uploadVcsPage;
+
+  /**
+   * @var array VALID_VCS_TYPES
+   * Array of valid inputs for vcsType parameter
+   */
+  const VALID_VCS_TYPES = array(
+    "git",
+    "svn"
+  );
+
+  /**
+   * Constructor to get UploadFilePage and UploadVcsPage objects.
+   */
+  public function __construct()
+  {
+    $this->uploadFilePage = new HelperToUploadFilePage();
+    $this->uploadVcsPage = new HelperToUploadVcsPage();
+  }
 
   /**
    * Get a request from Slim and translate to Symfony request to be
    * processed by FOSSology
    *
    * @param ServerRequestInterface $request
-   * @param string $folderName
-   * @param string $fileDescription
-   * @param string $isPublic
-   * @return boolean[]|string[]|unknown[]|NULL[]|mixed[]
+   * @param string $folderName Name of the folder to upload the file
+   * @param string $fileDescription Description of file uploaded
+   * @param string $isPublic   Upload is `public, private or protected`
+   * @param boolean $ignoreScm True if the SCM should be ignored.
+   * @return array Array with status, message and upload id
+   * @see createVcsUpload()
+   * @see createFileUpload()
    */
   public function createNewUpload(ServerRequestInterface $request, $folderName,
-    $fileDescription, $isPublic)
+    $fileDescription, $isPublic, $ignoreScm)
   {
     $uploadedFile = $request->getUploadedFiles();
-    if (! isset($uploadedFile[self::FILE_INPUT_NAME])) {
-      return array(
-        false,
-        "Missing file",
-        "File " . self::FILE_INPUT_NAME . " missing from request",
-        -1
-      );
+    $vcsData = $request->getParsedBody();
+
+    if (! empty($ignoreScm) && ($ignoreScm == "true" || $ignoreScm)) {
+      // If SCM should be ignored
+      $ignoreScm = 1;
     } else {
-      $uploadedFile = $uploadedFile[self::FILE_INPUT_NAME];
+      $ignoreScm = 0;
     }
+
+    if (empty($uploadedFile) ||
+      ! isset($uploadedFile[$this->uploadFilePage::FILE_INPUT_NAME])) {
+      if (empty($vcsData)) {
+        return array(false, "Missing input",
+          "Send file with parameter " . $this->uploadFilePage::FILE_INPUT_NAME .
+          " or JSON with VCS parameters.",
+          - 1
+        );
+      }
+      return $this->createVcsUpload($vcsData, $folderName, $fileDescription,
+        $isPublic, $ignoreScm);
+    } else {
+      $uploadedFile = $uploadedFile[$this->uploadFilePage::FILE_INPUT_NAME];
+      return $this->createFileUpload($uploadedFile, $folderName,
+        $fileDescription, $isPublic, $ignoreScm);
+    }
+  }
+
+  /**
+   * Create request required by UploadFilePage
+   *
+   * @param array $uploadedFile Uploaded file object by Slim
+   * @param string $folderName  Name of the folder to upload the file
+   * @param string $fileDescription Description of file uploaded
+   * @param string $isPublic    Upload is `public, private or protected`
+   * @param boolean $ignoreScm  True if the SCM should be ignored.
+   * @return array Array with status, message and upload id
+   */
+  private function createFileUpload($uploadedFile, $folderName, $fileDescription,
+    $isPublic, $ignoreScm = 0)
+  {
     $path = $uploadedFile->file;
     $originalName = $uploadedFile->getClientFilename();
     $originalMime = $uploadedFile->getClientMediaType();
     $originalError = $uploadedFile->getError();
-    $symfonyFile = new \Symfony\Component\HttpFoundation\File\UploadedFile($path,
-      $originalName, $originalMime, $originalError);
+    $symfonyFile = new \Symfony\Component\HttpFoundation\File\UploadedFile(
+      $path, $originalName, $originalMime, $originalError);
     $symfonyRequest = new \Symfony\Component\HttpFoundation\Request();
     $symfonySession = $GLOBALS['container']->get('session');
-    $symfonySession->set(self::UPLOAD_FORM_BUILD_PARAMETER_NAME, "restUpload");
+    $symfonySession->set(
+      $this->uploadFilePage::UPLOAD_FORM_BUILD_PARAMETER_NAME, "restUpload");
 
-    $symfonyRequest->request->set(self::FOLDER_PARAMETER_NAME, $folderName);
-    $symfonyRequest->request->set(self::DESCRIPTION_INPUT_NAME, $fileDescription);
-    $symfonyRequest->files->set(self::FILE_INPUT_NAME, $symfonyFile);
+    $symfonyRequest->request->set($this->uploadFilePage::FOLDER_PARAMETER_NAME,
+      $folderName);
+    $symfonyRequest->request->set($this->uploadFilePage::DESCRIPTION_INPUT_NAME,
+      $fileDescription);
+    $symfonyRequest->files->set($this->uploadFilePage::FILE_INPUT_NAME,
+      $symfonyFile);
     $symfonyRequest->setSession($symfonySession);
-    $symfonyRequest->request->set(self::UPLOAD_FORM_BUILD_PARAMETER_NAME,
-      "restUpload");
+    $symfonyRequest->request->set(
+      $this->uploadFilePage::UPLOAD_FORM_BUILD_PARAMETER_NAME, "restUpload");
     $symfonyRequest->request->set('public', $isPublic);
+    $symfonyRequest->request->set('scm', $ignoreScm);
 
-    return $this->handleUpload($symfonyRequest);
+    return $this->uploadFilePage->handleRequest($symfonyRequest);
+  }
+
+  /**
+   * Create request required by UploadVcsPage
+   *
+   * @param array $vcsData     Parsed VCS object from request
+   * @param string $folderName Name of the folder to upload the file
+   * @param string $fileDescription Description of file uploaded
+   * @param string $isPublic   Upload is `public, private or protected`
+   * @param boolean $ignoreScm True if the SCM should be ignored.
+   * @return array Array with status, message and upload id
+   */
+  private function createVcsUpload($vcsData, $folderName, $fileDescription,
+    $isPublic, $ignoreScm = 0)
+  {
+    $sanity = $this->sanitizeVcsData($vcsData);
+    if ($sanity !== true) {
+      return $sanity;
+    }
+    $vcsType = $vcsData["vcsType"];
+    $vcsUrl = $vcsData["vcsUrl"];
+    $vcsName = $vcsData["vcsName"];
+    $vcsUsername = $vcsData["vcsUsername"];
+    $vcsPasswd = $vcsData["vcsPassword"];
+
+    $symfonySession = $GLOBALS['container']->get('session');
+    $symfonySession->set($this->uploadVcsPage::UPLOAD_FORM_BUILD_PARAMETER_NAME,
+      "restUpload");
+
+    $symfonyRequest = new \Symfony\Component\HttpFoundation\Request();
+    $symfonyRequest->setSession($symfonySession);
+
+    $symfonyRequest->request->set($this->uploadVcsPage::FOLDER_PARAMETER_NAME,
+      $folderName);
+    $symfonyRequest->request->set($this->uploadVcsPage::DESCRIPTION_INPUT_NAME,
+      $fileDescription);
+    $symfonyRequest->request->set($this->uploadVcsPage::GETURL_PARAM, $vcsUrl);
+    $symfonyRequest->request->set(
+      $this->uploadVcsPage::UPLOAD_FORM_BUILD_PARAMETER_NAME, "restUpload");
+    $symfonyRequest->request->set('public', $isPublic);
+    $symfonyRequest->request->set('name', $vcsName);
+    $symfonyRequest->request->set('vcstype', $vcsType);
+    $symfonyRequest->request->set('username', $vcsUsername);
+    $symfonyRequest->request->set('passwd', $vcsPasswd);
+    $symfonyRequest->request->set('scm', $ignoreScm);
+
+    return $this->uploadVcsPage->handleRequest($symfonyRequest);
+  }
+
+  /**
+   * @brief Check if the passed VCS object is correct or not.
+   *
+   * 1. Check if all the required parameters are passed by user.
+   * 2. Translate the `vcsType` to required values.
+   * 3. Add missing keys with empty data to prevent warnings.
+   *
+   * @param array $vcsData Parsed VCS object to be sanitized
+   * @return array|boolean True if everything is correct, error array otherwise
+   */
+  private function sanitizeVcsData(&$vcsData)
+  {
+    $message = "";
+    $statusDescription = "";
+    $code = 0;
+
+    if (! array_key_exists("vcsType", $vcsData) ||
+      ! in_array($vcsData["vcsType"], self::VALID_VCS_TYPES)) {
+      $message = "Missing vcsType";
+      $statusDescription = "vcsType should be any of (" .
+        implode(", ", self::VALID_VCS_TYPES) . ")";
+      $code = 400;
+    }
+    $vcsType = "";
+    if ($vcsData["vcsType"] == "git") {
+      $vcsType = "Git";
+    } else {
+      $vcsType = "SVN";
+    }
+
+    if (! array_key_exists("vcsUrl", $vcsData)) {
+      $message = "Missing vcsUrl";
+      $statusDescription = "vcsUrl should be passed.";
+      $code = 400;
+    }
+
+    if (! array_key_exists("vcsName", $vcsData)) {
+      $vcsData["vcsName"] = "";
+    }
+    if (! array_key_exists("vcsUsername", $vcsData)) {
+      $vcsData["vcsUsername"] = "";
+    }
+    if (! array_key_exists("vcsPassword", $vcsData)) {
+      $vcsData["vcsPassword"] = "";
+    }
+    $vcsData["vcsType"] = $vcsType;
+    if ($code !== 0) {
+      return array(false, $message, $statusDescription, $code);
+    } else {
+      return true;
+    }
   }
 }

--- a/src/www/ui/api/Helper/UploadHelper/HelperToUploadFilePage.php
+++ b/src/www/ui/api/Helper/UploadHelper/HelperToUploadFilePage.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * *************************************************************
+ * Copyright (C) 2019 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *************************************************************
+ */
+
+/**
+ * @file
+ * @brief Helper to handle file uploads via REST API
+ */
+namespace Fossology\UI\Api\Helper\UploadHelper;
+
+use Fossology\UI\Page\UploadFilePage;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @class HelperToUploadFilePage
+ * Child class helper to access protected methods of UploadFilePage
+ */
+class HelperToUploadFilePage extends UploadFilePage
+{
+
+  /**
+   * Handles the Symfony Request object and pass it to handleUpload() of
+   * UploadFilePage.
+   *
+   * @param Request $request Symfony Request object holding information about
+   *        the upload
+   */
+  public function handleRequest(Request $request)
+  {
+    return $this->handleUpload($request);
+  }
+}

--- a/src/www/ui/api/Helper/UploadHelper/HelperToUploadVcsPage.php
+++ b/src/www/ui/api/Helper/UploadHelper/HelperToUploadVcsPage.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * *************************************************************
+ * Copyright (C) 2019 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *************************************************************
+ */
+
+/**
+ * @file
+ * @brief  Helper to handle VCS uploads via REST API
+ */
+
+/**
+ * @namespace Fossology::UI::Api::Helper::UploadHelper
+ *            Holds various helpers to handle child classes of UploadPageBase
+ */
+namespace Fossology\UI\Api\Helper\UploadHelper;
+
+use Fossology\UI\Page\UploadVcsPage;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @class HelperToUploadVcsPage
+ * Child class helper to access protected methods of UploadVcsPage
+ */
+class HelperToUploadVcsPage extends UploadVcsPage
+{
+
+  /**
+   * Handles the Symfony Request object and pass it to handleUpload() of
+   * UploadVcsPage.
+   *
+   * @param Request $request Symfony Request object holding information about
+   *        the upload
+   */
+  public function handleRequest(Request $request)
+  {
+    return $this->handleUpload($request);
+  }
+}

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -14,7 +14,7 @@ openapi: 3.0.0
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.0.3
+  version: 1.0.4
 servers:
   - url: http://localhost/repo/api/v1
     description: Localhost instance
@@ -122,6 +122,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Upload'
+        '503':
+          description: >
+            The ununpack agent has not started yet. Please check the 'Look-at'
+            header for more information
+          headers:
+            'Look-at':
+              description: Contains the URL to get jobs for the given upload
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
     delete:
@@ -207,6 +220,9 @@ paths:
         Endpoint to create a new upload in FOSSology
       requestBody:
         content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VcsUpload'
           multipart/form-data:
             schema:
               type: object
@@ -238,6 +254,13 @@ paths:
               - protected
               - public
             default: protected
+        - name: ignoreScm
+          description: Ignore SCM files (Git, SVN, TFS)
+          in: header
+          required: false
+          schema:
+            type: boolean
+            default: false
       responses:
         '201':
           description: Upload is created
@@ -909,7 +932,9 @@ components:
           description: Friendly name of the token
         token_scope:
           type: string
-          enum: ["read", "write"]
+          enum:
+            - read
+            - write
           description: The scope of the token.
         token_expire:
           type: string
@@ -921,6 +946,31 @@ components:
         - token_name
         - token_scope
         - token_expire
+    VcsUpload:
+      description: To create an upload from a version control system
+      type: object
+      properties:
+        vcsType:
+          description: VCS type
+          type: string
+          enum:
+            - svn
+            - git
+        vcsUrl:
+          description: URL of the repository
+          type: string
+        vcsName:
+          description: Display name of the upload
+          type: string
+        vcsUsername:
+          description: Username for the VCS
+          type: string
+        vcsPassword:
+          description: Password for the VCS
+          type: string
+      required:
+        - vcsType
+        - vcsUrl
   responses:
     defaultResponse:
           description: Some error occured. Check the "message"

--- a/src/www/ui/page/UploadPageBase.php
+++ b/src/www/ui/page/UploadPageBase.php
@@ -111,7 +111,7 @@ abstract class UploadPageBase extends DefaultPlugin
       $jobId = JobAddJob($userId, $groupId, $fileName, $uploadId);
     }
     $dummy = "";
-    $unpackArgs = intval($request->get('scm') == 1) ? '-I' : '';
+    $unpackArgs = intval($request->get('scm')) == 1 ? '-I' : '';
     $adj2nestDependencies = array();
     if ($wgetDependency) {
       $adj2nestDependencies = array(array('name'=>'agent_unpack','args'=>$unpackArgs,AgentPlugin::PRE_JOB_QUEUE=>array('wget_agent')));

--- a/src/www/ui/page/UploadVcsPage.php
+++ b/src/www/ui/page/UploadVcsPage.php
@@ -145,7 +145,7 @@ class UploadVcsPage extends UploadPageBase
     }
     /* schedule agents */
     $unpackplugin = &$Plugins[plugin_find_id("agent_unpack") ];
-    $unpackArgs = intval($request->get('scm') == 1) ? '-I' : '';
+    $unpackArgs = intval($request->get('scm')) == 1 ? '-I' : '';
     $ununpack_jq_pk = $unpackplugin->AgentAdd($jobpk, $uploadId, $ErrorMsg, array("wget_agent"), $unpackArgs);
     if ($ununpack_jq_pk < 0) {
       return array(false, _($ErrorMsg), $description);
@@ -170,7 +170,7 @@ class UploadVcsPage extends UploadPageBase
     $text1 = _("has been queued. It is");
     $msg .= "$text $Name $text1 ";
     $keep =  "<a href='$Url'>upload #" . $uploadId . "</a>.\n";
-    return array(true, $msg.$keep, $description);
+    return array(true, $msg.$keep, $description, $uploadId);
   }
 }
 


### PR DESCRIPTION
## Description

Added option allow users to upload packages from VCS.

### Changes

1. Added content type `application/json` for `POST /uploads` for VCS uploads.
1. VCS JSON includes info of `vcsType`, `vcsUrl`, `vcsName`, `vcsUsername`, `vcsPassword`.
1. Added missing `ignoreScm` input for uploads introduced by #1283.
1. If the upload has first agent as `wget_agent` and does not have `ununpack` started, the the endpoint `/uploads/{id}` returns null on GET request. Now it will return additional information in the message and headers too.

## How to test

1. Send a POST request to `/uploads` with `application/json` as `Content-Type` header and appropriate values.
    1. Also, check the GET request to `/uploads/{id}` with the `wget_agent` agent running.
1. Send a POST request to `/uploads` with `multipart/form-data` as `Content-Type` header and binary file as before.

Closes #1467