### PR TITLE
feat(rest): Provide API version as an endpoint

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -62,7 +62,7 @@ Description: architecture for analyzing software, common files
 
 Package: fossology-web
 Architecture: any
-Depends: fossology-common, apache2,
+Depends: fossology-common, apache2, php-yaml|php5,
  libapache2-mod-php5|libapache2-mod-php7.0|libapache2-mod-php7.2|libapache2-mod-php7.3,
  ${misc:Depends}
 Recommends: fossology-db

--- a/src/www/ui/Makefile
+++ b/src/www/ui/Makefile
@@ -29,7 +29,7 @@ OBSOLETEFILES = admin-tag-ns.php admin-change-owner.php admin-tag-ns-perm.php ad
                 upload_permissions.php upload-srv-files.php upload-vcs.php template/components \
                 template/include
 
-OTHERFILES = `find . -type f | grep -v svn |grep -v tests | grep -E "(css|htc|gif|png|ico|htm)$$"`
+OTHERFILES = `find . -type f | grep -v svn |grep -v tests | grep -E "(css|htc|gif|png|ico|htm|openapi.yaml)$$"`
 
 RMFILES = FILES = `find . -type f | grep -v svn |grep -v tests | grep -E "(php|css|htm|html|dtd|htc|gif|png|dat|po|mo)$$"`
 

--- a/src/www/ui/api/Controllers/VersionController.php
+++ b/src/www/ui/api/Controllers/VersionController.php
@@ -1,0 +1,57 @@
+<?php
+/***************************************************************
+ Copyright (C) 2019 Siemens AG
+ Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Controller to get REST API version
+ */
+
+namespace Fossology\UI\Api\Controllers;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @class VersionController
+ * @brief Controller for REST API version
+ */
+class VersionController extends RestController
+{
+  /**
+   * Get the current API version and authentication methods
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseInterface $response
+   * @param array $args
+   * @return ResponseInterface
+   */
+  public function getVersion($request, $response, $args)
+  {
+    $yamlDocArray = yaml_parse_file(__DIR__ .
+      "/../documentation/openapi.yaml");
+    $apiVersion = $yamlDocArray["info"]["version"];
+    $security = array();
+    foreach ($yamlDocArray["security"] as $secMethod) {
+      $security[] = key($secMethod);
+    }
+    return $response->withJson(array(
+      "version" => $apiVersion,
+      "security" => $security
+    ), 200);
+  }
+}

--- a/src/www/ui/api/Middlewares/RestAuthMiddleware.php
+++ b/src/www/ui/api/Middlewares/RestAuthMiddleware.php
@@ -51,6 +51,8 @@ class RestAuthMiddleware
     $requestUri = $request->getUri();
     if (stristr($requestUri->getPath(), "/auth") !== false) {
       $response = $next($request, $response);
+    } elseif (stristr($requestUri->getPath(), "/version") !== false) {
+      $response = $next($request, $response);
     } elseif (stristr($requestUri->getPath(), "/tokens") !== false &&
       stristr($request->getMethod(), "post") !== false) {
       $response = $next($request, $response);

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -10,11 +10,16 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-openapi: 3.0.0
+openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.0.4
+  version: 1.0.5
+  contact:
+    email: fossology@fossology.org
+  license:
+    name: GPL-2.0-only
+    url: https://github.com/fossology/fossology/blob/master/LICENSE
 servers:
   - url: http://localhost/repo/api/v1
     description: Localhost instance
@@ -97,6 +102,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /version:
+    get:
+      security: []
+      summary: Get the current API information
+      description: >
+        Get the current API version and supported authentication methods
+      responses:
+        '200':
+          description: The version and security information
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                      type: string
+                      description: Current API version as per documentation
+                  security:
+                      type: array
+                      items: {
+                        type: string
+                      }
         default:
           $ref: '#/components/responses/defaultResponse'
 

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -38,6 +38,7 @@ use Fossology\UI\Api\Controllers\ReportController;
 use Fossology\UI\Api\Controllers\SearchController;
 use Fossology\UI\Api\Controllers\UploadController;
 use Fossology\UI\Api\Controllers\UserController;
+use Fossology\UI\Api\Controllers\VersionController;
 use Fossology\UI\Api\Middlewares\RestAuthMiddleware;
 use Fossology\UI\Api\Middlewares\FossologyInitMiddleware;
 use Fossology\UI\Api\Models\Info;
@@ -146,6 +147,12 @@ $app->group(VERSION_1 . 'report',
     $this->get('', ReportController::class . ':getReport');
     $this->get('/{id:\\d+}', ReportController::class . ':downloadReport');
     $this->any('/{params:.*}', BadRequestController::class);
+  });
+
+////////////////////////////VERSION/////////////////////
+$app->group(VERSION_1 . 'version',
+  function (){
+    $this->get('', VersionController::class . ':getVersion');
   });
 
 $app->run();

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -178,15 +178,19 @@ if [[ $RUNTIME ]]; then
                  php7.0-cli php7.0-curl php7.0-mbstring php7.0-zip s-nail libboost-program-options1.58.0 libboost-regex1.58.0;;
             stretch)
                apt-get $YesOpt install postgresql-9.6 php7.0 php7.0-pgsql libapache2-mod-php7.0 php7.0-pgsql \
-                 php7.0-cli php7.0-curl php7.0-xml php7.0-zip php7.0-mbstring s-nail libboost-program-options1.62.0 libboost-regex1.62.0;;
+                 php7.0-cli php7.0-curl php7.0-xml php7.0-zip php7.0-mbstring s-nail libboost-program-options1.62.0 \
+                 libboost-regex1.62.0 php-yaml;;
             buster)
                apt-get $YesOpt install postgresql-11 php7.3 php7.3-pgsql libapache2-mod-php7.3 php7.3-pgsql \
-                 php7.3-cli php7.3-curl php7.3-xml php7.3-zip php7.3-mbstring s-nail libboost-program-options1.67.0 libboost-regex1.67.0;;
+                 php7.3-cli php7.3-curl php7.3-xml php7.3-zip php7.3-mbstring s-nail libboost-program-options1.67.0 \
+                 libboost-regex1.67.0 php-yaml;;
             bionic)
                apt-get $YesOpt install postgresql-10 php7.2 php7.2-pgsql libapache2-mod-php7.2 php7.2-pgsql \
-                 php7.2-cli php7.2-curl php7.2-xml php7.2-zip php7.2-mbstring s-nail libboost-program-options1.65.1 libboost-regex1.65.1;;
+                 php7.2-cli php7.2-curl php7.2-xml php7.2-zip php7.2-mbstring s-nail libboost-program-options1.65.1 \
+                 libboost-regex1.65.1 php-yaml;;
             sid)
-               apt-get $YesOpt install postgresql php php-pgsql php-cli php-curl php-xml php-zip php-mbstring s-nail libboost-program-options1.67.0 libboost-regex1.67.0;;
+               apt-get $YesOpt install postgresql php php-pgsql php-cli php-curl php-xml php-zip php-mbstring s-nail \
+                 libboost-program-options1.67.0 libboost-regex1.67.0 php-yaml;;
             *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
          esac
          ;;
@@ -195,6 +199,7 @@ if [[ $RUNTIME ]]; then
          yum $YesOpt install \
             postgresql \
             php php-pear php-pgsql php-process php-xml php-mbstring\
+            php-yaml \
             smtpdaemon \
             libxml2 \
             binutils mailx \
@@ -215,6 +220,7 @@ if [[ $RUNTIME ]]; then
          yum $YesOpt install \
             postgresql \
             php php-pear php-pgsql php-process php-mbstring\
+            php-yaml \
             smtpdaemon \
             file libxml2 \
             binutils mailx boost


### PR DESCRIPTION
## Description

Provide information about REST API via an endpoint.

### Changes

Create a new endpoint `/version` to get following information about REST API:
    - Version
    - Authentication methods allowed

## How to test

1. Check if the current API version returned by `/version` endpoint matches with `src/www/ui/api/documentation/openapi.yaml`.
1. Check if other endpoints are not effected.

Closes #1474 