### PR TITLE
feat(decider): add auto conclusion for ojo findings

### DIFF
--- a/src/decider/ui/DeciderAgentPlugin.php
+++ b/src/decider/ui/DeciderAgentPlugin.php
@@ -97,6 +97,12 @@ class DeciderAgentPlugin extends AgentPlugin
           $dependencies[] = 'agent_monk';
           $rulebits |= 0x4;
           break;
+        case 'ojoNoContradiction':
+          $dependencies[] = 'agent_nomos';
+          $dependencies[] = 'agent_monk';
+          $dependencies[] = 'agent_ojo';
+          $rulebits |= 0x10;
+          break;
         case 'wipScannerUpdates':
           $this->addScannerDependencies($dependencies, $request);
           $rulebits |= 0x8;

--- a/src/decider/ui/template/agent_decider.html.twig
+++ b/src/decider/ui/template/agent_decider.html.twig
@@ -4,6 +4,7 @@
   {{ 'Automatic Concluded License Decider'|trans }}<img src="images/info_16.png" title="{{ 'only for relevant files'|trans }}" alt="" class="info-bullet"/>,
   {{ 'based on'|trans }}<br/>
   <input type="checkbox" name="deciderRules[]" value="nomosInMonk" /> {{ '... scanners matches if all Nomos findings are within the Monk findings'|trans }}<br />
+  <input type="checkbox" name="deciderRules[]" value="ojoNoContradiction" /> {{ '... scanners matches if Ojo findings are no contradiction with other findings'|trans }}<br />
   {% if isNinkaInstalled %}
   <input type="checkbox" name="deciderRules[]" value="nomosMonkNinka" /> {{ '... scanners matches if Nomos, Monk and Ninka find the same license'|trans }}<br />
   {% endif %}


### PR DESCRIPTION
## Description

Auto-Decide all OJO findings and OJO findings where no contradiction with Nomos and Monk.  

## How to test

* Select a package with All agents selected(at-least Nomos, Monk and OJO ).
* select option " ... scanners matches Ojo findings are no contradiction with other findings"  before you click in upload.
* check if the auto decisions are applied.