### PR TITLE
feat(rest): Provide group ID during POST upload

### DIFF
--- a/src/www/ui/api/Helper/UploadHelper.php
+++ b/src/www/ui/api/Helper/UploadHelper.php
@@ -74,12 +74,14 @@ class UploadHelper
    * @param string $fileDescription Description of file uploaded
    * @param string $isPublic   Upload is `public, private or protected`
    * @param boolean $ignoreScm True if the SCM should be ignored.
+   * @param integer $groupId   Group under which the upload should happen.
+   *        Use default group id if not provided.
    * @return array Array with status, message and upload id
    * @see createVcsUpload()
    * @see createFileUpload()
    */
   public function createNewUpload(ServerRequestInterface $request, $folderName,
-    $fileDescription, $isPublic, $ignoreScm)
+    $fileDescription, $isPublic, $ignoreScm, $groupId = -1)
   {
     $uploadedFile = $request->getUploadedFiles();
     $vcsData = $request->getParsedBody();
@@ -101,11 +103,11 @@ class UploadHelper
         );
       }
       return $this->createVcsUpload($vcsData, $folderName, $fileDescription,
-        $isPublic, $ignoreScm);
+        $isPublic, $ignoreScm, $groupId);
     } else {
       $uploadedFile = $uploadedFile[$this->uploadFilePage::FILE_INPUT_NAME];
       return $this->createFileUpload($uploadedFile, $folderName,
-        $fileDescription, $isPublic, $ignoreScm);
+        $fileDescription, $isPublic, $ignoreScm, $groupId);
     }
   }
 
@@ -117,10 +119,12 @@ class UploadHelper
    * @param string $fileDescription Description of file uploaded
    * @param string $isPublic    Upload is `public, private or protected`
    * @param boolean $ignoreScm  True if the SCM should be ignored.
+   * @param integer $groupId   Group under which the upload should happen.
+   *        Use default group id if not provided.
    * @return array Array with status, message and upload id
    */
   private function createFileUpload($uploadedFile, $folderName, $fileDescription,
-    $isPublic, $ignoreScm = 0)
+    $isPublic, $ignoreScm = 0, $groupId = -1)
   {
     $path = $uploadedFile->file;
     $originalName = $uploadedFile->getClientFilename();
@@ -144,6 +148,9 @@ class UploadHelper
       $this->uploadFilePage::UPLOAD_FORM_BUILD_PARAMETER_NAME, "restUpload");
     $symfonyRequest->request->set('public', $isPublic);
     $symfonyRequest->request->set('scm', $ignoreScm);
+    if ($groupId > 0) {
+      $symfonyRequest->request->set($this->uploadFilePage::UPLOAD_GROUP, $groupId);
+    }
 
     return $this->uploadFilePage->handleRequest($symfonyRequest);
   }
@@ -156,10 +163,12 @@ class UploadHelper
    * @param string $fileDescription Description of file uploaded
    * @param string $isPublic   Upload is `public, private or protected`
    * @param boolean $ignoreScm True if the SCM should be ignored.
+   * @param integer $groupId   Group under which the upload should happen.
+   *        Use default group id if not provided.
    * @return array Array with status, message and upload id
    */
   private function createVcsUpload($vcsData, $folderName, $fileDescription,
-    $isPublic, $ignoreScm = 0)
+    $isPublic, $ignoreScm = 0, $groupId = -1)
   {
     $sanity = $this->sanitizeVcsData($vcsData);
     if ($sanity !== true) {
@@ -191,6 +200,9 @@ class UploadHelper
     $symfonyRequest->request->set('username', $vcsUsername);
     $symfonyRequest->request->set('passwd', $vcsPasswd);
     $symfonyRequest->request->set('scm', $ignoreScm);
+    if ($groupId > 0) {
+      $symfonyRequest->request->set($this->uploadVcsPage::UPLOAD_GROUP, $groupId);
+    }
 
     return $this->uploadVcsPage->handleRequest($symfonyRequest);
   }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -14,7 +14,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.0.5
+  version: 1.0.6
   contact:
     email: fossology@fossology.org
   license:
@@ -291,6 +291,13 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: groupId
+          description: The group id to chose while uploading the package
+          in: header
+          required: false
+          schema:
+            type: integer
+            description: Group id, from last login if not provided
       responses:
         '201':
           description: Upload is created

--- a/src/www/ui/page/UploadFilePage.php
+++ b/src/www/ui/page/UploadFilePage.php
@@ -118,7 +118,7 @@ class UploadFilePage extends UploadPageBase
     /* Create an upload record. */
     $uploadMode = (1 << 3); // code for "it came from web upload"
     $userId = Auth::getUserId();
-    $groupId = Auth::getGroupId();
+    $groupId = intval($request->get(self::UPLOAD_GROUP, Auth::getGroupId()));
     $uploadId = JobAddUpload($userId, $groupId, $originalFileName,
       $originalFileName, $description, $uploadMode, $folderId, $publicPermission);
     if (empty($uploadId)) {

--- a/src/www/ui/page/UploadPageBase.php
+++ b/src/www/ui/page/UploadPageBase.php
@@ -37,6 +37,7 @@ abstract class UploadPageBase extends DefaultPlugin
   const UPLOAD_FORM_BUILD_PARAMETER_NAME = 'uploadformbuild';
   const PUBLIC_ALL = 'public';
   const PUBLIC_GROUPS = 'protected';
+  const UPLOAD_GROUP = 'groupId';
 
   /** @var FolderDao */
   private $folderDao;

--- a/src/www/ui/page/UploadVcsPage.php
+++ b/src/www/ui/page/UploadVcsPage.php
@@ -107,7 +107,7 @@ class UploadVcsPage extends UploadPageBase
     /* Create an upload record. */
     $uploadMode = (1 << 2); // code for "it came from wget"
     $userId = Auth::getUserId();
-    $groupId = Auth::getGroupId();
+    $groupId = intval($request->get(self::UPLOAD_GROUP, Auth::getGroupId()));
     $uploadId = JobAddUpload($userId, $groupId, $ShortName, $getUrl,
       $description, $uploadMode, $folderId, $publicPermission);
     if (empty($uploadId)) {


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The PR allows user to define the group ID to be used while creating a new upload via REST API.

Depends on #1496 for API version.

### Changes

1. Read the group ID via header ~`uploadGroupId`~ `groupId`.
1. Pass the group ID in the request object to upload pages.

## How to test

1. Do a normal upload without group id and check if the upload is done under default group (last chosen by user in UI).
1. Do an upload providing a valid group id and check if the upload is done under the provided group id.
1. Do an upload providing an invalid/inaccessible group id and check if the request fails.

Closes #1468