### PR TITLE
fix(rest): getUploads - invoke getRows with proper parameters 

### DIFF
--- a/src/www/ui/api/Helper/DbHelper.php
+++ b/src/www/ui/api/Helper/DbHelper.php
@@ -86,8 +86,10 @@ FROM upload
 INNER JOIN folderlist ON folderlist.upload_pk = upload.upload_pk
 INNER JOIN folder ON folder.folder_pk = folderlist.parent
 INNER JOIN pfile ON pfile.pfile_pk = upload.pfile_fk
-WHERE upload.user_fk = " . pg_escape_string($userId) . "
+WHERE upload.user_fk = $1
 ORDER BY upload.upload_pk;";
+      $statementName = __METHOD__ . ".getAllUploads";
+      $params = [$userId];
     } else {
       $sql = "SELECT
 upload.upload_pk, upload.upload_desc, upload.upload_ts, upload.upload_filename,
@@ -96,12 +98,13 @@ FROM upload
 INNER JOIN folderlist ON folderlist.upload_pk = upload.upload_pk
 INNER JOIN folder ON folder.folder_pk = folderlist.parent
 INNER JOIN pfile ON pfile.pfile_pk = upload.pfile_fk
-WHERE upload.user_fk = " . pg_escape_string($userId) . "
-AND upload.upload_pk = " . pg_escape_string($uploadId) . "
+WHERE upload.user_fk = $1
+AND upload.upload_pk = $2
 ORDER BY upload.upload_pk;";
+      $statementName = __METHOD__ . ".getSpecificUpload";
+      $params = [$userId,$uploadId];
     }
-
-    $result = $this->dbManager->getRows($sql);
+    $result = $this->dbManager->getRows($sql, $params, $statementName);
     $uploads = [];
     foreach ($result as $row) {
       $upload = new Upload($row["folder_pk"], $row["folder_name"],


### PR DESCRIPTION
## Description

This PR fixes problem with incoherent search results using REST API
Fixes #1481 

### Changes

src/www/ui/api/Helper/DbHelper.php - call to dbManager.getRows method passes correct parameters (query parameters in array and statementName) to enable running multiple calls from one method with different params

## How to test

when: using api/v1/search to find file that has multiple occurences in different uploads

before: for files in different uploads, result JSON lists the same upload details (same as first element)

after fix: upload details are correct in result JSON