### PR TITLE
fix(rest): Hide sensitive user info

### DIFF
--- a/src/www/ui/api/Helper/DbHelper.php
+++ b/src/www/ui/api/Helper/DbHelper.php
@@ -34,6 +34,7 @@ use Fossology\UI\Api\Models\Upload;
 use Fossology\UI\Api\Models\InfoType;
 use Fossology\UI\Api\Models\Info;
 use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\Auth\Auth;
 
 /**
  * @class DbHelper
@@ -176,12 +177,22 @@ FROM $tableName WHERE $idRowName= " . pg_escape_string($id))["count"])));
     if ($id === null) {
       $result = $result = $this->dbManager->getRows($usersSQL, [], $statement);
     } else {
-      $result = $result = $this->dbManager->getRows($usersSQL, [$id], $statement);
+      $result = $result = $this->dbManager->getRows($usersSQL, [$id],
+        $statement);
     }
+    $currentUser = Auth::getUserId();
+    $userIsAdmin = Auth::isAdmin();
     foreach ($result as $row) {
-      $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
-        $row["user_email"], $row["user_perm"], $row["root_folder_fk"],
-        $row["email_notify"], $row["user_agent_list"]);
+      $user = null;
+      if ($userIsAdmin ||
+        ($row["user_pk"] == $currentUser)) {
+        $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
+          $row["user_email"], $row["user_perm"], $row["root_folder_fk"],
+          $row["email_notify"], $row["user_agent_list"]);
+      } else {
+        $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
+          null, null, null, null, null);
+      }
       $users[] = $user->getArray();
     }
 

--- a/src/www/ui/api/Models/User.php
+++ b/src/www/ui/api/Models/User.php
@@ -193,15 +193,23 @@ class User
    */
   public function getArray()
   {
-    return [
-      "id"       => $this->id,
-      "name"         => $this->name,
-      "description"  => $this->description,
-      "email"        => $this->email,
-      "accessLevel"  => $this->accessLevel,
-      "rootFolderId" => $this->rootFolderId,
-      "emailNotification" => $this->emailNotification,
-      "agents"       => $this->analysis->getArray()
-    ];
+    $returnUser = array();
+    $returnUser["id"] = $this->id;
+    $returnUser["name"] = $this->name;
+    $returnUser["description"] = $this->description;
+    if ($this->email !== null) {
+      $returnUser["email"] = $this->email;
+      $returnUser["accessLevel"] = $this->accessLevel;
+    }
+    if ($this->rootFolderId !== null && $this->rootFolderId != 0) {
+      $returnUser["rootFolderId"] = $this->rootFolderId;
+    }
+    if ($this->emailNotification !== null) {
+      $returnUser["emailNotification"] = $this->emailNotification;
+    }
+    if ($this->agents !== null) {
+      $returnUser["agents"] = $this->analysis->getArray();
+    }
+    return $returnUser;
   }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -14,7 +14,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.0.6
+  version: 1.0.7
   contact:
     email: fossology@fossology.org
   license:
@@ -890,6 +890,10 @@ components:
           description: enable email notification when upload scan completes
         agents:
           $ref: '#/components/schemas/Analysis'
+      required:
+        - id
+        - name
+        - description
     Analysis:
       type: object
       properties:


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Hide sensitive user information from users list in `/users` endpoint if requesting user is not an admin.

Thank you @deveaud-m for pointing this out.

Depends on #1498 for API version.

### Changes

1. Check if user is admin or not requesting information about other users, then provide complete information as before.
1. If user is not admin and requesting information about other users, return only user ID, description and username.

## How to test

1. Create a normal user with no admin access and generate bearer token.
1. Using this bearer token, get list of all users at `/users` endpoint and individual users details using `/users{id}`.
    1. Except for the user accessing the endpoint, the information returned should only contain user id, description and username.
1. Generate bearer token for admin user and request same information mentioned in point 2.
    1. Every user information should be returned by the API.