### PR TITLE
Fix `vagrant up` on Windows

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,8 +64,8 @@ SCRIPT
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
   config.vm.post_up_message = $post_up_message
-  config.vm.synced_folder ".", "/vagrant", disabled: true
-  config.vm.synced_folder ".", "/fossology"
+  config.vm.synced_folder ".", "/vagrant", type: "rsync", disabled: true
+  config.vm.synced_folder ".", "/fossology", type: "rsync"
 
   config.vm.provider "virtualbox" do |vbox|
     vbox.customize ["modifyvm", :id, "--memory", "4096"]


### PR DESCRIPTION
Windows 10 would fail, even when using an administrator CMD prompt,
to do `vagrant up` with messages such as the following:

```
default: make[3]: Leaving directory '/fossology/src/cli'
    default: Generating fo_wrapper ...
    default: ln:
    default: failed to create symbolic link 'cp2foss'
    default: : Protocol error
```

It looks like this can potentially be worked around by enabling
symlink support for VirtualBox, but this opens a security hole.
See https://www.virtualbox.org/ticket/10085#comment:7

The above security issue remains open.

While I'm a complete vagrant novice, I'm hoping changing the
basic folder sync to use rsync instead of symlinks is an acceptible
fix. (Works on Windows 10 host, not tested on the other platforms).
