### PR TITLE
New Dashboard statistics page

### DIFF
--- a/src/www/ui/Makefile
+++ b/src/www/ui/Makefile
@@ -25,9 +25,9 @@ DIRS = css images locale scripts ajaxPHP
 
 UIFILES = `find . -type f | grep -v svn |grep -v tests | grep -E "(php|dat|dtd|js|html|twig)$$"`
 OBSOLETEFILES = admin-tag-ns.php admin-change-owner.php admin-tag-ns-perm.php admin-folder-delete.php \
-                ajax-showjobs.php group-manage-self.php group-manage.php ajax-perms.php \
+                admin-dashboard.php ajax-showjobs.php group-manage-self.php group-manage.php ajax-perms.php \
                 upload_permissions.php upload-srv-files.php upload-vcs.php template/components \
-                template/include
+                template/include 
 
 OTHERFILES = `find . -type f | grep -v svn |grep -v tests | grep -E "(css|htc|gif|png|ico|htm)$$"`
 

--- a/src/www/ui/admin-dashboard-general.php
+++ b/src/www/ui/admin-dashboard-general.php
@@ -2,6 +2,7 @@
 /***********************************************************
  Copyright (C) 2008-2013 Hewlett-Packard Development Company, L.P.
  Copyright (C) 2015-2018 Siemens AG
+ Copyright (C) 2019 Orange
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -17,7 +18,7 @@
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  ***********************************************************/
 
-define("TITLE_DASHBOARD", _("Dashboard"));
+define("TITLE_DASHBOARD_GENERAL", _("Overview Dashboard"));
 
 use Fossology\Lib\Db\DbManager;
 
@@ -31,8 +32,8 @@ class dashboard extends FO_Plugin
   function __construct()
   {
     $this->Name       = "dashboard";
-    $this->Title      = TITLE_DASHBOARD;
-    $this->MenuList   = "Admin::Dashboard";
+    $this->Title      = TITLE_DASHBOARD_GENERAL;
+    $this->MenuList   = "Admin::Dashboards::Overview";
     $this->DBaccess   = PLUGIN_DB_ADMIN;
     parent::__construct();
     $this->dbManager = $GLOBALS['container']->get('db.manager');
@@ -403,7 +404,9 @@ class dashboard extends FO_Plugin
     $V .= $this->DiskFree();
     $V .= "</td>";
     $V .= "</tr>";
+
     $V .= "</table>\n";
+    $V .= "<br><br>";
     return $V;
   }
 

--- a/src/www/ui/admin-dashboard-stats.php
+++ b/src/www/ui/admin-dashboard-stats.php
@@ -1,0 +1,83 @@
+<?php
+/***********************************************************
+ Copyright (C) 2019 Orange
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***********************************************************/
+
+define("TITLE_DASHBOARD_STATISTICS", _("Statistics Dashboard"));
+
+use Fossology\Lib\Db\DbManager;
+
+class dashboardReporting extends FO_Plugin
+{
+  protected $pgVersion;
+
+  /** @var DbManager */
+  private $dbManager;
+
+  function __construct()
+  {
+    $this->Name       = "dashboard-statistics";
+    $this->Title      = TITLE_DASHBOARD_STATISTICS;
+    $this->MenuList   = "Admin::Dashboards::Statistics";
+    $this->DBaccess   = PLUGIN_DB_ADMIN;
+    parent::__construct();
+    $this->dbManager = $GLOBALS['container']->get('db.manager');
+  }
+
+  /**
+   * \brief Lists number of ever quequed jobs per job type (agent)..
+   */
+  function CountAllJobs()
+  {
+    $query = "SELECT ag.agent_name,ag.agent_desc,count(jq.*) AS fired_jobs ";
+    $query.= "FROM agent ag LEFT OUTER JOIN jobqueue jq ON (jq.jq_type = ag.agent_name) ";
+    $query.= "GROUP BY ag.agent_name,ag.agent_desc ORDER BY fired_jobs DESC;";
+
+    $rows = $this->dbManager->getRows($query);
+
+    $V = "<table border=1>";
+    $V .= "<tr><th>".("AgentName")."</th><th>"._("Description")."</th><th>"._("Number of jobs")."</th></tr>";
+
+    foreach ($rows as $agData) {
+      $V .= "<tr><td>".$agData['agent_name']."</td><td>".$agData['agent_desc']."</td><td align='right'>".$agData['fired_jobs']."</td></tr>";
+    }
+
+    $V .= "</table>";
+
+    return $V;
+  }
+
+  public function Output()
+  {
+      $V = "<h1> Statistics </h1>";
+      $V .= "<table style='width: 100%;' border=0>\n";
+
+      $V .= "<tr>";
+      $V .= "<td class='dashboard'>";
+      $text = _("Jobs Sumary");
+      $V .= "<h2>$text</h2>\n";
+      $V .= $this->CountAllJobs();
+      $V .= "</td>";
+      $V .= "</tr>";
+
+      $V .= "</table>";
+
+      return $V;
+  }
+}
+
+$dash = new dashboardReporting ;
+$dash->Initialize();


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
New dashboard page added. 
Old dashboard page also relocated to `Dashboards` submenu to keep things grouped together.
For the moment there is a single report on agents usage, however more statistics will come soon.
The idea with the new dashboard was to distinguish the statistics original info dashboard with technical/instance related info.

### Changes

New `Admin/Dashboards` submenu added.
Old `Admin/Dashboard` moved to `Admin/Dashboards/Overview`.
New `Admin/Dashboards/Statisctics` added as new page.

## How to test

Open your browser to  `/repo/?mod=dashboard-statistics` to see the new dashboard.

Closes #1502 
