### PR TITLE
chore(docker-compose): harmonize versions with sw360chores

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@
 #
 # Description: Recipe for setting up a multi container FOSSology
 #              Docker setup with separate Database instance
-version: '3'
+version: '3.5'
 services:
   scheduler:
     build:


### PR DESCRIPTION
The SW360chores docker compose project uses version 3.5. Bumping the version
here has no negative effects (except for probably old distributions having not a
new enough docker-compose, needs Docker Engine 17.12.0+).

The advantage is, that this allows the deployments to work in sync and one can
start both at the same time e.g. via:
```
./sw360chores.pl --build -- -f path/to/fossology/docker-compose.yml up
```