### PR TITLE
fix(decider): remove force dependency of nomos and monk for ojo decider

### DIFF
--- a/src/decider/ui/DeciderAgentPlugin.php
+++ b/src/decider/ui/DeciderAgentPlugin.php
@@ -77,6 +77,12 @@ class DeciderAgentPlugin extends AgentPlugin
     $dependencies = array();
 
     $rules = $request->get('deciderRules') ?: array();
+    $agents = $request->get('agents') ?: array();
+    if (in_array('agent_nomos', $agents)) {
+      $checkAgentNomos = true;
+    } else {
+      $checkAgentNomos = $request->get('Check_agent_nomos') ?: false;
+    }
     $rulebits = 0;
 
     foreach ($rules as $rule) {
@@ -98,8 +104,9 @@ class DeciderAgentPlugin extends AgentPlugin
           $rulebits |= 0x4;
           break;
         case 'ojoNoContradiction':
-          $dependencies[] = 'agent_nomos';
-          $dependencies[] = 'agent_monk';
+          if ($checkAgentNomos) {
+            $dependencies[] = 'agent_nomos';
+          }
           $dependencies[] = 'agent_ojo';
           $rulebits |= 0x10;
           break;

--- a/src/www/ui/api/Controllers/JobController.php
+++ b/src/www/ui/api/Controllers/JobController.php
@@ -145,7 +145,7 @@ class JobController extends RestController
       try {
         if (array_key_exists("reuse", $scanOptionsJSON) && ! empty($scanOptionsJSON["reuse"])) {
           $reuser->setUsingArray($scanOptionsJSON["reuse"]);
-        $parametersSent = true;
+          $parametersSent = true;
         }
       } catch (\UnexpectedValueException $e) {
         $error = new Info($e->getCode(), $e->getMessage(), InfoType::ERROR);

--- a/src/www/ui/api/Models/ScanOptions.php
+++ b/src/www/ui/api/Models/ScanOptions.php
@@ -176,5 +176,8 @@ class ScanOptions
       $deciderRules[] = 'ojoNoContradiction';
     }
     $request->request->set('deciderRules', $deciderRules);
+    if ($this->analysis->getNomos()) {
+      $request->request->set('Check_agent_nomos', 1);
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

remove force dependency of nomos and monk for ojo decisions through decider. and add nomos dependency if the user checks nomos scans.

## How to test

* Upload a package and schedule ojo and decider. without other agents. 