### PR TITLE
fix(highlight): highlight for reference text that exists in different…

### DIFF
--- a/src/lib/php/Dao/HighlightDao.php
+++ b/src/lib/php/Dao/HighlightDao.php
@@ -196,4 +196,24 @@ class HighlightDao
     $highlightEntries = array_merge(array_merge($highlightDiffs,$highlightKeywords),$highlightBulk);
     return $highlightEntries;
   }
+
+  /**
+   * @param licenseMatchId
+   * @return page number
+   */
+  public function getPageNumberOfHighlightEntry($licenseMatchId)
+  {
+    $row = $this->dbManager->getSingleRow(
+      "SELECT FLOOR(
+                (
+                  SELECT start FROM highlight WHERE fl_fk=$1 ORDER BY start ASC LIMIT 1
+                ) / (
+                  SELECT conf_value FROM sysconfig WHERE variablename LIKE 'BlockSizeText'
+                )::numeric
+              )
+       AS page;",
+      array($licenseMatchId)
+    );
+    return $row['page'];
+  }
 }

--- a/src/www/ui/ajax-clearing-view.php
+++ b/src/www/ui/ajax-clearing-view.php
@@ -115,9 +115,9 @@ class AjaxClearingView extends FO_Plugin
       $row = array(
           '0' => date('Y-m-d', $clearingDecision->getTimeStamp()),
           '1' => $clearingDecision->getUserName(),
-        '2' => $scope->getTypeName($clearingDecision->getScope()),
-        '3' => $this->decisionTypes->getTypeName($clearingDecision->getType()),
-        '4' => implode(", ", $licenseOutputs)
+          '2' => $scope->getTypeName($clearingDecision->getScope()),
+          '3' => $this->decisionTypes->getTypeName($clearingDecision->getType()),
+          '4' => implode(", ", $licenseOutputs)
       );
       $table[] = $row;
     }
@@ -380,8 +380,9 @@ class AjaxClearingView extends FO_Plugin
       $agentId = $agentDecisionEvent->getAgentId();
       $matchId = $agentDecisionEvent->getMatchId();
       $percentage = $agentDecisionEvent->getPercentage();
+      $page = $this->highlightDao->getPageNumberOfHighlightEntry($matchId);
       $agentResults[$agentDecisionEvent->getAgentName()][] = array(
-          "uri" => $uberUri . "&item=$uploadTreeId&agentId=$agentId&highlightId=$matchId#highlight",
+          "uri" => $uberUri . "&item=$uploadTreeId&agentId=$agentId&highlightId=$matchId&page=$page#highlight",
           "text" => $percentage ? " (" . $percentage . " %)" : ""
       );
     }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add page number to the URL which shows highlight.

## How to test

* Upload a package with multiple license findings for a single page.
* Go to admin -> Customize -> Change "Chars per page in text view" to 100 or 50 depending upon your license texts length( different license references should fall under different pages). 
* Click on reference number under source for particular agent finding.
* Check if it takes you to the page where license reference text exists.   