### PR TITLE
fix(obligation): Associate all candidate licenses with same name

### DIFF
--- a/install/db/Makefile
+++ b/install/db/Makefile
@@ -27,6 +27,7 @@ install: all
 	$(INSTALL_DATA) dbmigrate_2.5-2.6.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_2.5-2.6.php
 	$(INSTALL_DATA) dbmigrate_3.3-3.4.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.3-3.4.php
 	$(INSTALL_DATA) dbmigrate_3.5-3.6.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.5-3.6.php
+	$(INSTALL_DATA) dbmigrate_3.6-3.7.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.6-3.7.php
 	$(INSTALL_DATA) dbmigrate_clearing-event.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_clearing-event.php
 	$(INSTALL_DATA) dbmigrate_real-parent.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_real-parent.php
 	$(INSTALL_DATA) dbmigrate_bulk_license.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_bulk_license.php
@@ -62,6 +63,7 @@ uninstall:
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_2.5-2.6.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.3-3.4.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.5-3.6.php
+	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.6-3.7.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_clearing-event.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_real-parent.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_bulk_license.php

--- a/install/db/dbmigrate_3.6-3.7.php
+++ b/install/db/dbmigrate_3.6-3.7.php
@@ -1,0 +1,145 @@
+<?php
+/***********************************************************
+ Copyright (C) 2019 Siemens AG
+ Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***********************************************************/
+
+/**
+ * @file
+ * @brief Migrate DB from release 3.6.0 to 3.7.0 with new obligation fixes
+ */
+
+/**
+ * @brief Move licenses from obligation map to obligation candidate map.
+ *
+ * Remove licenses from obligation_map which are candidate license and add them
+ * to obligation_candidate_map.
+ * @param DbManager $dbManager DB Manager to use
+ * @param integer $obPk        Obligation ID
+ * @param boolean $verbose     Set TRUE to print verbose message
+ * @return integer Number of entries deleted
+ */
+function moveCandidateLicenseMap($dbManager, $obPk, $verbose)
+{
+  if($dbManager == NULL){
+    echo "No connection object passed!\n";
+    return false;
+  }
+
+  $sql = "SELECT rf_fk FROM obligation_map WHERE rf_fk NOT IN (" .
+    "SELECT rf_pk FROM ONLY license_ref) AND ob_fk = $1;";
+  $statement = __METHOD__ . ".getLicenseList";
+  $licenses = $dbManager->getRows($sql, array($obPk), $statement);
+  foreach ($licenses as $license) {
+    $dbManager->begin();
+    if ($verbose) {
+      echo "* Moving license " . $license['rf_fk'] . " to candidate map of " .
+        "obligation $obPk *\n";
+    }
+    $sql = "SELECT om_pk FROM obligation_candidate_map WHERE " .
+      "ob_fk = $1 AND rf_fk = $2;";
+    $statement = __METHOD__ . ".checkMaping";
+    $exists = $dbManager->getSingleRow($sql, array($obPk, $license['rf_fk']),
+      $statement);
+    if (empty($exists)) {
+      $statement = __METHOD__ . ".insertCandidateMap";
+      $dbManager->insertTableRow("obligation_candidate_map", array(
+        "ob_fk" => $obPk,
+        "rf_fk" => $license['rf_fk']
+      ), $statement);
+    }
+
+    $sql = "DELETE FROM obligation_map WHERE ob_fk = $1 AND rf_fk = $2;";
+    $statement = __METHOD__ . ".removeMap";
+    $dbManager->getSingleRow($sql, array($obPk, $license['rf_fk']), $statement);
+    $dbManager->commit();
+  }
+}
+
+/**
+ * Check if migration is required.
+ * @param DbManager $dbManager
+ * @return boolean True if migration is required, false otherwise
+ */
+function checkMigrate3637Required($dbManager)
+{
+  if($dbManager == NULL){
+    echo "No connection object passed!\n";
+    return false;
+  }
+  $requiredTables = array(
+    "obligation_map",
+    "obligation_candidate_map",
+    "license_ref"
+  );
+  $migRequired = true;
+  foreach ($requiredTables as $table) {
+    if (DB_TableExists($table) != 1) {
+      $migRequired = false;
+      break;
+    }
+  }
+  if ($migRequired) {
+    $sql = "SELECT count(*) AS cnt FROM obligation_map WHERE rf_fk NOT IN (" .
+      "SELECT rf_pk FROM ONLY license_ref);";
+    $row = $dbManager->getSingleRow($sql);
+    $migRequired = false;
+    if (array_key_exists("cnt", $row) && $row["cnt"] > 0) {
+      $migRequired = true;
+    }
+  }
+
+  return $migRequired;
+}
+
+ /**
+ * @brief Get all obligations and move licenses.
+ * @param DbManager $dbManager
+ * @param boolean $verbose
+ */
+function moveObligation($dbManager, $verbose)
+{
+  if($dbManager == NULL){
+    echo "No connection object passed!\n";
+    return false;
+  }
+
+  $sql = "SELECT ob_pk FROM obligation_ref;";
+  $obligations = $dbManager->getRows($sql);
+  foreach ($obligations as $obligation) {
+    moveCandidateLicenseMap($dbManager, $obligation['ob_pk'], $verbose);
+  }
+}
+
+/**
+ * Migration from FOSSology 3.6.0 to 3.7.0
+ * @param DbManager $dbManager
+ * @param boolean $dryRun
+ */
+function Migrate_36_37($dbManager, $verbose)
+{
+  if (! checkMigrate3637Required($dbManager)) {
+    // Migration not required
+    return;
+  }
+  try {
+    echo "*** Moving candidate licenses from obligation map ***\n";
+    moveObligation($dbManager, $verbose);
+  } catch (Exception $e) {
+    echo "Something went wrong. Try running postinstall again!\n";
+    $dbManager->rollback();
+  }
+}

--- a/install/fossinit.php
+++ b/install/fossinit.php
@@ -384,6 +384,11 @@ $dbManager->insertTableRow('sysconfig',
 $dbManager->commit();
 /* email/url/author data migration to other table */
 require_once("$LIBEXECDIR/dbmigrate_copyright-author.php");
+
+// Migration script to move candidate licenses in obligations
+require_once("$LIBEXECDIR/dbmigrate_3.6-3.7.php");
+Migrate_36_37($dbManager, $Verbose);
+
 /* sanity check */
 require_once ("$LIBEXECDIR/sanity_check.php");
 $checker = new SanityChecker($dbManager,$Verbose);

--- a/src/lib/php/BusinessRules/ObligationMap.php
+++ b/src/lib/php/BusinessRules/ObligationMap.php
@@ -69,20 +69,27 @@ class ObligationMap
   }
 
   /**
-   * @brief Get the license id from the shortname
+   * @brief Get the license ids from the shortname
    * @param string $shortname Short name of the license
    * @param bool   $candidate Is a candidate license?
-   * @return int License id
+   * @return int[] License ids
    */
   public function getIdFromShortname($shortname,$candidate=false)
   {
+    $tableName = "";
     if ($candidate) {
-      $sql = "SELECT * from license_candidate where rf_shortname = $1;";
+      $tableName = "license_candidate";
     } else {
-      $sql = "SELECT * from license_ref where rf_shortname = $1;";
+      $tableName = "license_ref";
     }
-    $result = $this->dbManager->getSingleRow($sql,array($shortname));
-    return $result['rf_pk'];
+    $sql = "SELECT * FROM ONLY $tableName WHERE rf_shortname = $1;";
+    $statement = __METHOD__ . ".getLicId.$tableName";
+    $results = $this->dbManager->getRows($sql, array($shortname), $statement);
+    $licenseIds = array();
+    foreach ($results as $row) {
+      $licenseIds[] = $row['rf_pk'];
+    }
+    return $licenseIds;
   }
 
   /**
@@ -111,28 +118,23 @@ class ObligationMap
    */
   public function getLicenseList($obId,$candidate=false)
   {
-    $liclist = "";
+    $liclist = array();
     if ($candidate) {
-      $sql = "SELECT rf_fk FROM obligation_candidate_map WHERE ob_fk=$obId;";
-      $stmt = __METHOD__.".om_candidate_$obId";
+      $sql = "SELECT rf_fk FROM obligation_candidate_map WHERE ob_fk=$1;";
+      $stmt = __METHOD__.".om_candidate";
     } else {
-      $sql = "SELECT rf_fk FROM obligation_map WHERE ob_fk=$obId;";
-      $stmt = __METHOD__.".om_license_$obId";
+      $sql = "SELECT rf_fk FROM obligation_map WHERE ob_fk=$1;";
+      $stmt = __METHOD__.".om_license";
     }
     $this->dbManager->prepare($stmt,$sql);
-    $res = $this->dbManager->execute($stmt);
+    $res = $this->dbManager->execute($stmt, array($obId));
     $vars = $this->dbManager->fetchAll($res);
     $this->dbManager->freeResult($res);
     foreach ($vars as $map_entry) {
-      $licname = $this->getShortnameFromId($map_entry['rf_fk'], $candidate);
-      if ($liclist == "") {
-        $liclist = "$licname";
-      } else {
-        $liclist .= ";$licname";
-      }
+      $liclist[] = $this->getShortnameFromId($map_entry['rf_fk'], $candidate);
     }
 
-    return $liclist;
+    return join(";", array_unique($liclist));
   }
 
   /**
@@ -144,13 +146,15 @@ class ObligationMap
    */
   public function isLicenseAssociated($obId,$licId,$candidate=false)
   {
+    $tableName = "";
     if ($candidate) {
-      $sql = "SELECT * from obligation_candidate_map where ob_fk = $1 and rf_fk = $2;";
-      $stmt = __METHOD__.".om_testcandidate_$obId";
+      $stmt = __METHOD__.".om_testcandidate";
+      $tableName .= "obligation_candidate_map";
     } else {
-      $sql = "SELECT * from obligation_map where ob_fk = $1 and rf_fk = $2;";
-      $stmt = __METHOD__.".om_testlicense_$obId";
+      $stmt = __METHOD__.".om_testlicense";
+      $tableName .= "obligation_map";
     }
+    $sql = "SELECT * FROM $tableName WHERE ob_fk = $1 AND rf_fk = $2;";
     $this->dbManager->prepare($stmt,$sql);
     $res = $this->dbManager->execute($stmt,array($obId,$licId));
     $vars = $this->dbManager->fetchAll($res);
@@ -195,21 +199,23 @@ class ObligationMap
   public function unassociateLicenseFromObligation($obId,$licId=0,$candidate=false)
   {
     if ($licId == 0) {
+      $stmt = __METHOD__.".omdel_all";
       if ($candidate) {
         $sql = "DELETE FROM obligation_candidate_map WHERE ob_fk=$1";
+        $stmt .= ".candidate";
       } else {
         $sql = "DELETE FROM obligation_map WHERE ob_fk=$1";
       }
-      $stmt = __METHOD__.".omdel_all";
       $this->dbManager->prepare($stmt,$sql);
       $res = $this->dbManager->execute($stmt,array($obId));
     } else {
+      $stmt = __METHOD__.".omdel_lic";
       if ($candidate) {
         $sql = "DELETE FROM obligation_candidate_map WHERE ob_fk=$1 AND rf_fk=$2";
+        $stmt .= ".candidate";
       } else {
         $sql = "DELETE FROM obligation_map WHERE ob_fk=$1 AND rf_fk=$2";
       }
-      $stmt = __METHOD__.".omdel_lic";
       $this->dbManager->prepare($stmt,$sql);
       $res = $this->dbManager->execute($stmt,array($obId,$licId));
     }
@@ -237,5 +243,37 @@ class ObligationMap
     $sql = "SELECT ob_topic FROM obligation_ref WHERE ob_pk = $1;";
     $result = $this->dbManager->getSingleRow($sql,array($ob_pk));
     return $result['ob_topic'];
+  }
+
+  /**
+   * Associate a list of license IDs with given obligation.
+   * @param integer $obligationId Obligation to be associated
+   * @param array   $licenses     Array of licenses to be associated
+   * @param boolean $candidate    Is a candidate association?
+   * @return boolean True if new association is made, false otherwise.
+   */
+  public function associateLicenseFromLicenseList($obligationId, $licenses, $candidate = false)
+  {
+    $updated = false;
+    foreach ($licenses as $license) {
+      if (! $this->isLicenseAssociated($obligationId, $license, $candidate)) {
+        $this->associateLicenseWithObligation($obligationId, $license, $candidate);
+        $updated = true;
+      }
+    }
+    return $updated;
+  }
+
+  /**
+   * Unassociate a list of license IDs with given obligation.
+   * @param integer $obligationId Obligation to be unassociated
+   * @param array   $licenses     Array of licenses to be unassociated
+   * @param boolean $candidate    Is a candidate association?
+   */
+  public function unassociateLicenseFromLicenseList($obligationId, $licenses, $candidate = false)
+  {
+    foreach ($licenses as $license) {
+        $this->unassociateLicenseFromObligation($obligationId, $license, $candidate);
+    }
   }
 }

--- a/src/lib/php/BusinessRules/ObligationMap.php
+++ b/src/lib/php/BusinessRules/ObligationMap.php
@@ -101,9 +101,9 @@ class ObligationMap
   public function getShortnameFromId($rfId,$candidate=false)
   {
     if ($candidate) {
-      $sql = "SELECT * FROM license_candidate WHERE rf_pk = $1;";
+      $sql = "SELECT * FROM ONLY license_candidate WHERE rf_pk = $1;";
     } else {
-      $sql = "SELECT * FROM license_ref WHERE rf_pk = $1;";
+      $sql = "SELECT * FROM ONLY license_ref WHERE rf_pk = $1;";
     }
     $statement = __METHOD__ . "." . ($candidate ? "candidate" : "license");
     $result = $this->dbManager->getSingleRow($sql,array($rfId), $statement);

--- a/src/www/ui/admin-obligation-file.php
+++ b/src/www/ui/admin-obligation-file.php
@@ -410,7 +410,7 @@ class admin_obligation_file extends FO_Plugin
       $_POST['ob_classification'],
       $_POST['ob_text_updatable'],
       $comment);
-    $this->dbManager->prepare($stmt=__METHOD__.".$md5term", $sql);
+    $this->dbManager->prepare($stmt=__METHOD__.".update", $sql);
     $this->dbManager->freeResult($this->dbManager->execute($stmt,$params));
 
     // Add new licenses and new candiate licenses
@@ -421,7 +421,7 @@ class admin_obligation_file extends FO_Plugin
     $unassociatedLicenses = $this->removeLicenses($licnames,$obId);
     $unassociatedCandidateLicenses = $this->removeLicenses($candidatenames,$obId,true);
 
-    $ob .= "Obligation '$topic' was updated -  ";
+    $ob = "Obligation '$topic' was updated -  ";
     $ob .= $newAssociatedLicenses ? "New licenses: '$newAssociatedLicenses' - " : "";
     $ob .= $newCandidateLicenses ? "New candidate licenses:  '$newCandidateLicenses' - " : "";
     $ob .= $unassociatedLicenses ? "Removed licenses: '$unassociatedLicenses' - " : "";

--- a/src/www/ui/admin-obligation-file.php
+++ b/src/www/ui/admin-obligation-file.php
@@ -439,8 +439,8 @@ class admin_obligation_file extends FO_Plugin
   function Adddb()
   {
     $topic = trim($_POST['ob_topic']);
-    $licnames = empty($_POST['licenseSelector']) ? '' : $_POST['licenseSelector'];
-    $candidatenames = empty($_POST['candidateSelector']) ? '' : $_POST['candidateSelector'];
+    $licnames = empty($_POST['licenseSelector']) ? array() : $_POST['licenseSelector'];
+    $candidatenames = empty($_POST['candidateSelector']) ? array() : $_POST['candidateSelector'];
     $text = trim($_POST['ob_text']);
     $comment = trim($_POST['ob_comment']);
     $message = "";
@@ -498,6 +498,7 @@ class admin_obligation_file extends FO_Plugin
     $res = $this->dbManager->execute($stmt,array($_POST['ob_pk']));
 
     $this->obligationMap->unassociateLicenseFromObligation($_POST['ob_pk']);
+    $this->obligationMap->unassociateLicenseFromObligation($_POST['ob_pk'], 0, true);
 
     return "<p>Obligation has been deleted.</p>";
   }
@@ -505,10 +506,9 @@ class admin_obligation_file extends FO_Plugin
   /**
    * \brief Associate selected licenses to the obligation
    *
-   * @param string  $licList - the list of licences to be returned
-   *        array   $shortnames - new licenses to be associated
-   *        int     $obId - obligation being processed
-   *        boolean $candidate - do we handle candidate licenses?
+   * @param array   $shortnames - new licenses to be associated
+   * @param int     $obId - obligation being processed
+   * @param boolean $candidate - do we handle candidate licenses?
    * @return string the list of associated licences
    */
   function addNewLicenses($shortnames,$obId,$candidate=false)
@@ -516,19 +516,16 @@ class admin_obligation_file extends FO_Plugin
     if (!empty($shortnames)) {
       $licList = "";
       foreach ($shortnames as $license) {
-        $licId = $this->obligationMap->getIdFromShortname($license,$candidate);
-        $res = $this->obligationMap->isLicenseAssociated($obId,$licId,$candidate);
-        if ($res) {
-          continue;
+        $licIds = $this->obligationMap->getIdFromShortname($license,$candidate);
+        $newLic = $this->obligationMap->associateLicenseFromLicenseList($obId,
+          $licIds, $candidate);
+        if ($newLic) {
+          if ($licList == "") {
+            $licList = "$license";
+          } else {
+            $licList .= ";$license";
+          }
         }
-
-        $this->obligationMap->associateLicenseWithObligation($obId,$licId,$candidate);
-        if ($licList == "") {
-          $licList = "$license";
-        } else {
-          $licList .= ";$license";
-        }
-
       }
       return $licList;
     }
@@ -540,8 +537,8 @@ class admin_obligation_file extends FO_Plugin
    * \brief Unassociate selected licenses to the obligation
    *
    * @param array   $shortnames - new licenses to be associated
-   *        int     $obId - obligation being processed
-   *        boolean $candidate - do we handle candidate licenses?
+   * @param int     $obId - obligation being processed
+   * @param boolean $candidate - do we handle candidate licenses?
    * @return string the list of associated licences
    */
   function removeLicenses($shortnames,$obId,$candidate=false)
@@ -557,9 +554,9 @@ class admin_obligation_file extends FO_Plugin
 
     if ($obsoleteLicenses) {
       foreach ($obsoleteLicenses as $toBeRemoved) {
-        $licId = $this->obligationMap->getIdFromShortname($toBeRemoved,
+        $licIds = $this->obligationMap->getIdFromShortname($toBeRemoved,
           $candidate);
-        $this->obligationMap->unassociateLicenseFromObligation($obId, $licId,
+        $this->obligationMap->unassociateLicenseFromLicenseList($obId, $licIds,
           $candidate);
         if ($unassociatedLicenses == "") {
           $unassociatedLicenses = "$toBeRemoved";


### PR DESCRIPTION
## Description

Associate all candidate licenses with same name to the obligations.

### Changes

1. Get the list of all licenses which shares the same name `ObligationMap`.
1. Associate all licenses with the given license while creating the obligation map in DB.

## How to test

1. Create a candidate license in `Group - 1`.
1. Create another candidate license in `Group - 2` with same shortname.
1. Create an obligation using `Group - 1` and associate the candidate license.
1. Edit the same obligation using `Group - 2`. The candidate license will create problems saving the obligation reliably.

Install the branch.

1. Repeat the steps above.
    1. Both candidate licenses should be associated with the obligation (no issue while updating the license in UI).
    1. Check if there are different entries for the candidate licenses in `obligation_candidate_map` table.
1. During clearing, select the candidate license and generate the report.
    - Check if the report contains the obligations.