### PR TITLE
fix(license-csv): Update license if exists

### DIFF
--- a/src/lib/php/Application/LicenseCsvExport.php
+++ b/src/lib/php/Application/LicenseCsvExport.php
@@ -76,22 +76,34 @@ class LicenseCsvExport
    */
   public function createCsv($rf=0)
   {
-    $sql = "SELECT rf.rf_shortname,rf.rf_fullname,rf.rf_text,rc.rf_shortname parent_shortname,rr.rf_shortname report_shortname,rf.rf_url,rf.rf_notes,rf.rf_source,rf.rf_risk
-            FROM license_ref rf
-              LEFT JOIN license_map mc ON mc.rf_fk=rf.rf_pk AND mc.usage=$2
-              LEFT JOIN license_ref rc ON mc.rf_parent=rc.rf_pk
-              LEFT JOIN license_map mr ON mr.rf_fk=rf.rf_pk AND mr.usage=$3
-              LEFT JOIN license_ref rr ON mr.rf_parent=rr.rf_pk
-            WHERE rf.rf_detector_type=$1";
-    $param = array($userDetected=1,LicenseMap::CONCLUSION,LicenseMap::REPORT);
-    if ($rf>0) {
-      $stmt = __METHOD__.'.rf';
+    $sql = "WITH marydoneCand AS (
+  SELECT * FROM license_candidate
+  WHERE marydone = true
+), allLicenses AS (
+SELECT DISTINCT ON(rf_pk) * FROM
+  ONLY license_ref
+  NATURAL FULL JOIN marydoneCand)
+SELECT
+  rf.rf_shortname, rf.rf_fullname, rf.rf_text, rc.rf_shortname parent_shortname,
+  rr.rf_shortname report_shortname, rf.rf_url, rf.rf_notes, rf.rf_source,
+  rf.rf_risk, gp.group_name
+FROM allLicenses AS rf
+  FULL JOIN groups AS gp ON gp.group_pk = rf.group_fk
+  LEFT JOIN license_map mc ON mc.rf_fk=rf.rf_pk AND mc.usage=$2
+  LEFT JOIN license_ref rc ON mc.rf_parent=rc.rf_pk
+  LEFT JOIN license_map mr ON mr.rf_fk=rf.rf_pk AND mr.usage=$3
+  LEFT JOIN license_ref rr ON mr.rf_parent=rr.rf_pk
+WHERE rf.rf_detector_type=$1";
+    $param = array(1, LicenseMap::CONCLUSION, LicenseMap::REPORT);
+    if ($rf > 0) {
+      $stmt = __METHOD__ . '.rf';
       $param[] = $rf;
-      $sql .= ' AND rf.rf_pk=$'.count($param);
+      $sql .= ' AND rf.rf_pk = $'.count($param);
       $row = $this->dbManager->getSingleRow($sql,$param,$stmt);
       $vars = $row ? array( $row ) : array();
     } else {
       $stmt = __METHOD__;
+      $sql .= ' ORDER BY rf.rf_pk';
       $this->dbManager->prepare($stmt,$sql);
       $res = $this->dbManager->execute($stmt,$param);
       $vars = $this->dbManager->fetchAll( $res );
@@ -100,7 +112,9 @@ class LicenseCsvExport
 
     $out = fopen('php://output', 'w');
     ob_start();
-    $head = array('shortname','fullname','text','parent_shortname','report_shortname','url','notes','source','risk');
+    $head = array(
+      'shortname', 'fullname', 'text', 'parent_shortname', 'report_shortname',
+      'url', 'notes', 'source', 'risk', 'group');
     fputcsv($out, $head, $this->delimiter, $this->enclosure);
     foreach ($vars as $row) {
       fputcsv($out, $row, $this->delimiter, $this->enclosure);

--- a/src/lib/php/Application/test/LicenseCsvExportTest.php
+++ b/src/lib/php/Application/test/LicenseCsvExportTest.php
@@ -20,7 +20,7 @@ namespace Fossology\Lib\Application;
 
 use Fossology\Lib\BusinessRules\LicenseMap;
 use Fossology\Lib\Db\DbManager;
-use Fossology\Lib\Test\TestLiteDb;
+use Fossology\Lib\Test\TestPgDb;
 use Mockery as M;
 
 /**
@@ -58,28 +58,60 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
    */
   public function testCreateCsv()
   {
-    $testDb = new TestLiteDb();
-    $testDb->createPlainTables(array('license_ref','license_map'));
+    $testDb = new TestPgDb("licenseCsvExport");
+    $testDb->createPlainTables(array('license_ref','license_map','groups'));
+    $testDb->createInheritedTables(array('license_candidate'));
     $dbManager = $testDb->getDbManager();
     $licenses = array();
-    for ($i=1; $i<4; $i++) {
-      $licenses[$i] = array('rf_pk'=>$i,'rf_shortname'=>'lic'.$i,'rf_fullname'=>'lice'.$i,
-          'rf_text'=>'text'.$i,'rf_url'=>$i.$i,'rf_notes'=>'note'.$i,'rf_source'=>'s'.$i,
-          'rf_detector_type'=>1,'rf_risk'=>($i-1));
+    $candLicenses = array();
+    $dbManager->insertTableRow('groups', array(
+      'group_pk' => 2, 'group_name' => 'test'
+    ));
+    for ($i = 1; $i < 4; $i ++) {
+      $licenses[$i] = array(
+        'rf_pk' => $i,
+        'rf_shortname' => 'lic' . $i,
+        'rf_fullname' => 'lice' . $i,
+        'rf_text' => 'text' . $i,
+        'rf_url' => $i . $i,
+        'rf_notes' => 'note' . $i,
+        'rf_source' => 's' . $i,
+        'rf_detector_type' => 1,
+        'rf_risk' => ($i - 1)
+      );
       $dbManager->insertTableRow('license_ref', $licenses[$i]);
+    }
+    for ($i = 1; $i <= 4; $i ++) {
+      $candLicenses[$i] = array(
+        'rf_pk' => $i + 4,
+        'rf_shortname' => 'candlic' . $i,
+        'rf_fullname' => 'candlice' . $i,
+        'rf_text' => 'text' . $i,
+        'rf_url' => $i . $i,
+        'rf_notes' => 'note' . $i,
+        'rf_source' => 's' . $i,
+        'rf_detector_type' => 1,
+        'rf_risk' => ($i - 1),
+        'marydone' => false,
+        'group_fk' => 2
+      );
+      if ($i % 2 == 0) {
+        $candLicenses[$i]['marydone'] = true;
+      }
+      $dbManager->insertTableRow('license_candidate', $candLicenses[$i]);
     }
 
     $dbManager->insertTableRow('license_map', array('rf_fk'=>3,'rf_parent'=>1,'usage'=>LicenseMap::CONCLUSION));
     $dbManager->insertTableRow('license_map', array('rf_fk'=>3,'rf_parent'=>2,'usage'=>LicenseMap::REPORT));
 
     $licenseCsvExport = new LicenseCsvExport($dbManager);
-    $head = array('shortname','fullname','text','parent_shortname','report_shortname','url','notes','source','risk');
+    $head = array('shortname','fullname','text','parent_shortname','report_shortname','url','notes','source','risk','group');
     $out = fopen('php://output', 'w');
 
     $csv = $licenseCsvExport->createCsv();
     ob_start();
     fputcsv($out, $head);
-        fputcsv($out, array($licenses[1]['rf_shortname'],
+    fputcsv($out, array($licenses[1]['rf_shortname'],
         $licenses[1]['rf_fullname'],
         $licenses[1]['rf_text'],
         null,
@@ -87,7 +119,8 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
         $licenses[1]['rf_url'],
         $licenses[1]['rf_notes'],
         $licenses[1]['rf_source'],
-        $licenses[1]['rf_risk']));
+        $licenses[1]['rf_risk'],
+        null));
 
     fputcsv($out, array($licenses[2]['rf_shortname'],
         $licenses[2]['rf_fullname'],
@@ -97,7 +130,8 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
         $licenses[2]['rf_url'],
         $licenses[2]['rf_notes'],
         $licenses[2]['rf_source'],
-        $licenses[2]['rf_risk']));
+        $licenses[2]['rf_risk'],
+        null));
 
     fputcsv($out, array($licenses[3]['rf_shortname'],
         $licenses[3]['rf_fullname'],
@@ -107,10 +141,34 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
         $licenses[3]['rf_url'],
         $licenses[3]['rf_notes'],
         $licenses[3]['rf_source'],
-        $licenses[3]['rf_risk']));
+        $licenses[3]['rf_risk'],
+        null));
+
+    fputcsv($out, array($candLicenses[2]['rf_shortname'],
+      $candLicenses[2]['rf_fullname'],
+      $candLicenses[2]['rf_text'],
+      null,
+      null,
+      $candLicenses[2]['rf_url'],
+      $candLicenses[2]['rf_notes'],
+      $candLicenses[2]['rf_source'],
+      $candLicenses[2]['rf_risk'],
+      "test"));
+
+    fputcsv($out, array($candLicenses[4]['rf_shortname'],
+      $candLicenses[4]['rf_fullname'],
+      $candLicenses[4]['rf_text'],
+      null,
+      null,
+      $candLicenses[4]['rf_url'],
+      $candLicenses[4]['rf_notes'],
+      $candLicenses[4]['rf_source'],
+      $candLicenses[4]['rf_risk'],
+      "test"));
     $expected = ob_get_contents();
     ob_end_clean();
-    assertThat($csv,is(equalTo($expected)));
+
+    assertThat($csv, is(equalTo($expected)));
 
     $delimiter = '|';
     $licenseCsvExport->setDelimiter($delimiter);
@@ -125,11 +183,13 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
           $licenses[3]['rf_url'],
           $licenses[3]['rf_notes'],
           $licenses[3]['rf_source'],
-          $licenses[3]['rf_risk']),
+          $licenses[3]['rf_risk'],
+          null
+        ),
         $delimiter);
     $expected3 = ob_get_contents();
     ob_end_clean();
-    assertThat($csv3,is(equalTo($expected3)));
+    assertThat($csv3, is(equalTo($expected3)));
   }
 
   /**

--- a/src/lib/php/Application/test/LicenseCsvImportTest.php
+++ b/src/lib/php/Application/test/LicenseCsvImportTest.php
@@ -23,6 +23,7 @@ use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Exception;
 use Fossology\Lib\Test\Reflectory;
 use Fossology\Lib\Test\TestLiteDb;
+use Fossology\Lib\Dao\UserDao;
 use Mockery as M;
 
 /**
@@ -65,13 +66,34 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
     $testDb->createPlainTables(array('license_ref'));
     $shortname = 'licA';
     $knownId = 101;
+    $knownGroup = 4;
     /*** @var DbManager ***/
     $dbManager = &$testDb->getDbManager();
     $dbManager->insertTableRow('license_ref', array('rf_pk'=>$knownId,'rf_shortname'=>$shortname));
-    $licenseCsvImport = new LicenseCsvImport($dbManager);
+    $this->createCandidateTable($dbManager);
+    $dbManager->insertTableRow('license_candidate', array(
+      'rf_pk' => $knownId + 2,
+      'rf_shortname' => "candidate-$shortname",
+      'group_fk' => $knownGroup
+    ));
+    $userDao = M::mock(UserDao::class);
+    $userDao->shouldReceive('getGroupIdByName')
+      ->with("fossy")
+      ->once()
+      ->andReturn(4);
+    $licenseCsvImport = new LicenseCsvImport($dbManager, $userDao);
 
     assertThat(Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,'getKeyFromShortname', array($shortname)), equalTo($knownId));
     assertThat(Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,'getKeyFromShortname', array("no $shortname")), equalTo(false));
+    // Candidates
+    assertThat(Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,
+      'getKeyFromShortname',
+      array("candidate-$shortname", "fossy")),
+      equalTo($knownId + 2));
+    assertThat(Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,
+      'getKeyFromShortname',
+      array("candidate-$shortname")),
+      equalTo(false));
   }
 
   /**
@@ -91,13 +113,16 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
 
     $dbManager = M::mock(DbManager::class);
     $dbManager->shouldReceive('getSingleRow')
-      ->with('SELECT rf_pk FROM license_ref WHERE rf_md5=md5($1)', array($licenseText))
+      ->with('SELECT rf_pk FROM ONLY license_ref WHERE rf_md5=md5($1)',
+        array($licenseText))
       ->once()
       ->andReturn(array('rf_pk' => $knownId));
     $dbManager->shouldReceive('getSingleRow')
-      ->with('SELECT rf_pk FROM license_ref WHERE rf_md5=md5($1)', array($falseLicenseText))
+      ->with('SELECT rf_pk FROM ONLY license_ref WHERE rf_md5=md5($1)',
+        array($falseLicenseText))
       ->andReturnNull();
-    $licenseCsvImport = new LicenseCsvImport($dbManager);
+    $userDao = M::mock(UserDao::class);
+    $licenseCsvImport = new LicenseCsvImport($dbManager, $userDao);
 
     assertThat(Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,
       'getKeyFromMd5', array($licenseText)), equalTo($knownId));
@@ -115,8 +140,18 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
   public function testHandleCsvLicense()
   {
     $dbManager = M::mock(DbManager::class);
-    $licenseCsvImport = new LicenseCsvImport($dbManager);
-    $nkMap = array('licA'=>101,'licB'=>false,'licC'=>false,'licE'=>false,'licF'=>false,'licG'=>false,'licH'=>false,'licZ'=>100);
+    $nkMap = array(
+      'licA' => 101,
+      'licB' => false,
+      'licC' => false,
+      'licE' => false,
+      'licF' => false,
+      'licG' => false,
+      'licH' => false,
+      'licZ' => 100,
+      'canLicAfossy' => 200,
+      'canLicBfossy' => false
+    );
     $mdkMap = array(
       md5('txA') => 101,
       md5('txB') => false,
@@ -126,76 +161,261 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
       md5('txF') => false,
       md5('txG') => false,
       md5('txH') => false,
-      md5('txZ') => 100
+      md5('txZ') => 100,
+      md5('txCan') => 200,
+      md5('Text of candidate license') => false
     );
+    $userDao = M::mock(UserDao::class);
+    $userDao->shouldReceive('getGroupIdByName')
+      ->with("fossy")
+      ->times(3)
+      ->andReturn(4);
+
+    $licenseCsvImport = new LicenseCsvImport($dbManager, $userDao);
     Reflectory::setObjectsProperty($licenseCsvImport, 'nkMap', $nkMap);
     Reflectory::setObjectsProperty($licenseCsvImport, 'mdkMap', $mdkMap);
 
-    $singleRowA = array('rf_shortname'=>'licA','rf_fullname'=>'licennnseA',
-      'rf_text'=>'someRandom','rf_url'=>'','rf_notes'=>'','rf_source'=>'','rf_risk'=>4);
+    $singleRowA = array(
+      'rf_shortname' => 'licA',
+      'rf_fullname' => 'licennnseA',
+      'rf_text' => 'someRandom',
+      'rf_md5' => md5('someRandom'),
+      'rf_detector_type' => 1,
+      'rf_url' => '',
+      'rf_notes' => '',
+      'rf_source' => '',
+      'rf_risk' => 4
+    );
     $dbManager->shouldReceive('getSingleRow')
-            ->with('SELECT rf_shortname, rf_fullname, rf_text, rf_url, rf_notes, rf_source, rf_risk ' .
-              'FROM license_ref WHERE rf_pk = $1', array(101), anything())
-            ->once()
-            ->andReturn($singleRowA);
-    $dbManager->shouldReceive('prepare');
-    $dbManager->shouldReceive('execute');
-    $dbManager->shouldReceive('freeResult');
+      ->with(
+      'SELECT rf_shortname, rf_fullname, rf_text, rf_url, rf_notes, rf_source, rf_risk ' .
+      'FROM license_ref WHERE rf_pk = $1', array(101), anything())
+      ->once()
+      ->andReturn($singleRowA);
 
-    $dbManager->shouldReceive('insertTableRow')->withArgs(array('license_map',
-        array('rf_fk'=>103,'rf_parent'=>101,'usage'=>LicenseMap::CONCLUSION)))->once();
-    $dbManager->shouldReceive('fetchArray')->withAnyArgs()->andReturn(array('rf_pk' => 103));
-    $returnB = Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,'handleCsvLicense', array(
-        array('shortname'=>'licB','fullname'=>'liceB','text'=>'txB','url'=>'','notes'=>'','source'=>'','risk'=>0,
-                'parent_shortname'=>'licA','report_shortname'=>null)));
+    // Test for licB insert
+    $dbManager->shouldReceive('insertTableRow')
+      ->withArgs(array(
+        'license_map', array(
+          'rf_fk' => 103, 'rf_parent' => 101, 'usage' => LicenseMap::CONCLUSION
+      )))
+      ->once();
+    $singleRowB = $singleRowA;
+    $singleRowB["rf_shortname"] = "licB";
+    $singleRowB["rf_fullname"] = "liceB";
+    $singleRowB["rf_text"] = "txB";
+    $singleRowB["rf_md5"] = md5("txB");
+    $singleRowB["rf_risk"] = 0;
+    $this->addLicenseInsertToDbManager($dbManager, $singleRowB, 103);
+    $returnB = Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,
+      'handleCsvLicense', array(array(
+        'shortname' => 'licB',
+        'fullname' => 'liceB',
+        'text' => 'txB',
+        'url' => '',
+        'notes' => '',
+        'source' => '',
+        'risk' => 0,
+        'parent_shortname' => 'licA',
+        'report_shortname' => null,
+        'group' => null
+      )));
     assertThat($returnB, is("Inserted 'licB' in DB with conclusion 'licA'"));
 
-    $dbManager->shouldReceive('fetchArray')->withAnyArgs()->andReturn(array('rf_pk' => 104));
-    $dbManager->shouldReceive('insertTableRow')->withArgs(array('license_map',
-        array('rf_fk'=>103,'rf_parent'=>100,'usage'=>LicenseMap::REPORT)))->once();
-    $returnF = Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,'handleCsvLicense', array(
-            array('shortname'=>'licF','fullname'=>'liceF','text'=>'txF','url'=>'','notes'=>'','source'=>'','risk'=>1,
-                'parent_shortname'=>null,'report_shortname'=>'licZ')));
+    // Test for licF insert
+    $singleRowF = $singleRowA;
+    $singleRowF["rf_shortname"] = "licF";
+    $singleRowF["rf_fullname"] = "liceF";
+    $singleRowF["rf_text"] = "txF";
+    $singleRowF["rf_md5"] = md5("txF");
+    $singleRowF["rf_risk"] = 1;
+    $this->addLicenseInsertToDbManager($dbManager, $singleRowF, 104);
+    $dbManager->shouldReceive('insertTableRow')
+      ->withArgs(array(
+        'license_map', array(
+          'rf_fk' => 104,
+          'rf_parent' => 100,
+          'usage' => LicenseMap::REPORT
+      )))
+      ->once();
+    $returnF = Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,
+      'handleCsvLicense', array(array(
+        'shortname' => 'licF',
+        'fullname' => 'liceF',
+        'text' => 'txF',
+        'url' => '',
+        'notes' => '',
+        'source' => '',
+        'risk' => 1,
+        'parent_shortname' => null,
+        'report_shortname' => 'licZ',
+        'group' => null
+      )));
     assertThat($returnF, is("Inserted 'licF' in DB reporting 'licZ'"));
 
-    $dbManager->shouldReceive('fetchArray')->withAnyArgs()->andReturn(array('rf_pk' => 105));
-    $returnC = Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,'handleCsvLicense', array(
-            array('shortname'=>'licC','fullname'=>'liceC','text'=>'txC','url'=>'','notes'=>'','source'=>'','risk'=>2,
-                'parent_shortname'=>null,'report_shortname'=>null)));
+    // Test licC insert
+    $singleRowC = $singleRowA;
+    $singleRowC["rf_shortname"] = "licC";
+    $singleRowC["rf_fullname"] = "liceC";
+    $singleRowC["rf_text"] = "txC";
+    $singleRowC["rf_md5"] = md5("txC");
+    $singleRowC["rf_risk"] = 2;
+    $this->addLicenseInsertToDbManager($dbManager, $singleRowC, 105);
+    $returnC = Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,
+      'handleCsvLicense', array(array(
+        'shortname' => 'licC',
+        'fullname' => 'liceC',
+        'text' => 'txC',
+        'url' => '',
+        'notes' => '',
+        'source' => '',
+        'risk' => 2,
+        'parent_shortname' => null,
+        'report_shortname' => null,
+        'group' => null
+      )));
     assertThat($returnC, is("Inserted 'licC' in DB"));
 
-    $dbManager->shouldReceive('getSingleRow')->with("UPDATE license_ref SET " .
+    // Test canlicC update
+    $canLicA = $singleRowA;
+    $canLicA["rf_shortname"] = "canLicA";
+    $canLicA["rf_fullname"] = "canLiceA";
+    $canLicA["rf_text"] = "txcan";
+    $canLicA["rf_risk"] = 0;
+    $canLicA["rf_group"] = 4;
+    $dbManager->shouldReceive('getSingleRow')
+    ->with(
+      'SELECT rf_shortname, rf_fullname, rf_text, rf_url, rf_notes, rf_source, rf_risk ' .
+      'FROM license_ref WHERE rf_pk = $1', array(200), anything())
+      ->once()
+      ->andReturn($canLicA);
+    $dbManager->shouldReceive('getSingleRow')
+      ->with(
+        "UPDATE license_candidate SET " .
+        "rf_fullname=$2,rf_text=$3,rf_md5=md5($3) WHERE rf_pk=$1;",
+        array(200, 'canDidateLicenseA', 'Text of candidate license'),
+        anything())
+      ->once();
+    $dbManager->shouldReceive('getSingleRow')
+      ->with(
+        'SELECT rf_parent FROM license_map WHERE rf_fk = $1 AND usage = $2;',
+        anyof(array(200, LicenseMap::CONCLUSION), array(200, LicenseMap::REPORT)),
+        anything())
+        ->twice()
+        ->andReturn(array('rf_parent' => null));
+    $returnC = Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,
+      'handleCsvLicense', array(array(
+        'shortname' => 'canLicA',
+        'fullname' => 'canDidateLicenseA',
+        'text' => 'Text of candidate license',
+        'url' => '', 'notes' => '', 'source' => '', 'risk' => 0,
+        'parent_shortname' => null, 'report_shortname' => null,
+        'group' => 'fossy'
+      )));
+    assertThat($returnC, is(
+      "License 'canLicA' already exists in DB (id = 200)" .
+      ", updated fullname, updated text"
+    ));
+
+    // Test licA update
+    $dbManager->shouldReceive('getSingleRow')
+      ->with(
+      "UPDATE license_ref SET " .
       "rf_fullname=$2,rf_text=$3,rf_md5=md5($3),rf_risk=$4 WHERE rf_pk=$1;",
       array(101, 'liceB', 'txA', 2), anything())
       ->once();
     $dbManager->shouldReceive('getSingleRow')
-      ->with('SELECT rf_parent FROM license_map WHERE rf_fk = $1 AND usage = $2;',
-        anyof(array(101, LicenseMap::CONCLUSION), array(101, LicenseMap::REPORT)), anything())
+      ->with(
+        'SELECT rf_parent FROM license_map WHERE rf_fk = $1 AND usage = $2;',
+        anyof(array(101, LicenseMap::CONCLUSION), array(101, LicenseMap::REPORT)),
+        anything())
       ->twice()
       ->andReturn(array('rf_parent' => null));
-    $returnA = Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,'handleCsvLicense', array(
-            array('shortname'=>'licA','fullname'=>'liceB','text'=>'txA','url'=>'','notes'=>'','source'=>'','risk'=>2,
-                'parent_shortname'=>null,'report_shortname'=>null)));
-    assertThat($returnA, is("License 'licA' already exists in DB (id = 101)" .
-      ", updated fullname, updated text, updated the risk level"));
+    $returnA = Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,
+      'handleCsvLicense', array(array(
+        'shortname' => 'licA',
+        'fullname' => 'liceB',
+        'text' => 'txA',
+        'url' => '',
+        'notes' => '',
+        'source' => '',
+        'risk' => 2,
+        'parent_shortname' => null,
+        'report_shortname' => null,
+        'group' => null
+      )));
+    assertThat($returnA, is(
+        "License 'licA' already exists in DB (id = 101)" .
+        ", updated fullname, updated text, updated the risk level"));
 
-    $returnE = Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,'handleCsvLicense', array(
-            array('shortname'=>'licE','fullname'=>'liceE','text'=>'txD','url'=>'','notes'=>'','source'=>'','risk'=>false,
-                'parent_shortname'=>null,'report_shortname'=>null)));
-    assertThat($returnE, is("Error: MD5 checksum of 'licE' collides with license id=102"));
+    // Test licE md5 collision
+    $returnE = Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,
+      'handleCsvLicense', array(array(
+        'shortname' => 'licE',
+        'fullname' => 'liceE',
+        'text' => 'txD',
+        'url' => '',
+        'notes' => '',
+        'source' => '',
+        'risk' => false,
+        'parent_shortname' => null,
+        'report_shortname' => null,
+        'group' => null
+      )));
+    assertThat($returnE, is(
+      "Error: MD5 checksum of 'licE' collides with license id=102"));
 
-    $returnG = Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,'handleCsvLicense', array(
-            array('shortname'=>'licG','fullname'=>'liceG','text'=>'txD','url'=>'','notes'=>'','source'=>'_G_go_G_',
-                'parent_shortname'=>null,'report_shortname'=>null,'risk'=>false)));
-    assertThat($returnG, is("Error: MD5 checksum of 'licG' collides with license id=102"));
+    // Test licG md5 collision
+    $returnG = Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,
+      'handleCsvLicense', array(array(
+        'shortname' => 'licG',
+        'fullname' => 'liceG',
+        'text' => 'txD',
+        'url' => '',
+        'notes' => '',
+        'source' => '_G_go_G_',
+        'parent_shortname' => null,
+        'report_shortname' => null,
+        'risk' => false,
+        'group' => null
+      )));
+    assertThat($returnG, is(
+      "Error: MD5 checksum of 'licG' collides with license id=102"));
 
-    $returnH = Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,'handleCsvLicense', array(
-            array('shortname'=>'licH','fullname'=>'liceH','text'=>'txD','url'=>'','notes'=>'','source'=>'_G_go_G_',
-                'parent_shortname'=>null,'report_shortname'=>null,'risk'=>3)));
-    assertThat($returnH, is("Error: MD5 checksum of 'licH' collides with license id=102"));
+    // Test canlicB insert
+    $canlicB = $singleRowA;
+    $canlicB["rf_shortname"] = "canLicB";
+    $canlicB["rf_fullname"] = "canLiceB";
+    $canlicB["rf_text"] = "txCan";
+    $canlicB["rf_md5"] = md5("txCan");
+    $canlicB["rf_risk"] = 2;
+    $canlicB["group_fk"] = 4;
+    $canlicB["marydone"] = 't';
+    $this->addLicenseInsertToDbManager($dbManager, $canlicB, 201,
+      "license_candidate");
+    $dbManager->shouldReceive('booleanToDb')
+      ->with(true)
+      ->once()
+      ->andReturn('t');
+    $returnC = Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,
+      'handleCsvLicense', array(array(
+        'shortname' => 'canLicB',
+        'fullname' => 'canLiceB',
+        'text' => 'txCan',
+        'url' => '',
+        'notes' => '',
+        'source' => '',
+        'risk' => 2,
+        'parent_shortname' => null,
+        'report_shortname' => null,
+        'group' => 'fossy'
+      )));
+    assertThat($returnC, is("Inserted 'canLicB' in DB" .
+      " as candidate license under group fossy"));
   }
 
   /**
+   *
    * @brief Test for LicenseCsvImport::handleHeadCsv()
    * @test
    * -# Initialize LicenseCsvImport.
@@ -207,13 +427,32 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
   public function testHandleHeadCsv()
   {
     $dbManager = M::mock(DbManager::class);
-    $licenseCsvImport = new LicenseCsvImport($dbManager);
+    $userDao = M::mock(UserDao::class);
+    $licenseCsvImport = new LicenseCsvImport($dbManager, $userDao);
 
-    assertThat(Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,'handleHeadCsv',array(array('shortname','foo','text','fullname','notes','bar'))),
-            is( array('shortname'=>0,'fullname'=>3,'text'=>2,'parent_shortname'=>false,'report_shortname'=>false,'url'=>false,'notes'=>4,'source'=>false,'risk'=>0) ) );
+    assertThat(
+      Reflectory::invokeObjectsMethodnameWith($licenseCsvImport, 'handleHeadCsv',
+        array(array(
+          'shortname', 'foo', 'text', 'fullname', 'notes', 'bar'
+        ))),
+      is(array(
+        'shortname' => 0, 'fullname' => 3, 'text' => 2,
+        'parent_shortname' => false, 'report_shortname' => false,
+        'url' => false, 'notes' => 4, 'source' => false, 'risk' => 0,
+        'group' => false
+      )));
 
-    assertThat(Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,'handleHeadCsv',array(array('Short Name','URL','text','fullname','notes','Foreign ID'))),
-            is( array('shortname'=>0,'fullname'=>3,'text'=>2,'parent_shortname'=>false,'report_shortname'=>false,'url'=>1,'notes'=>4,'source'=>5,'risk'=>false) ) );
+    assertThat(
+      Reflectory::invokeObjectsMethodnameWith($licenseCsvImport, 'handleHeadCsv',
+        array(array(
+          'Short Name', 'URL', 'text', 'fullname', 'notes', 'Foreign ID',
+          'License group'
+        ))),
+      is(array(
+        'shortname' => 0, 'fullname' => 3, 'text' => 2,
+        'parent_shortname' => false, 'report_shortname' => false, 'url' => 1,
+        'notes' => 4, 'source' => 5, 'risk' => false, 'group' => 6
+      )));
   }
 
   /**
@@ -227,7 +466,8 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
   public function testHandleHeadCsv_missingMandidatoryKey()
   {
     $dbManager = M::mock(DbManager::class);
-    $licenseCsvImport = new LicenseCsvImport($dbManager);
+    $userDao = M::mock(UserDao::class);
+    $licenseCsvImport = new LicenseCsvImport($dbManager, $userDao);
     Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,'handleHeadCsv',array(array('shortname','foo','text')));
   }
 
@@ -243,7 +483,8 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
   public function testSetDelimiter()
   {
     $dbManager = M::mock(DbManager::class);
-    $licenseCsvImport = new LicenseCsvImport($dbManager);
+    $userDao = M::mock(UserDao::class);
+    $licenseCsvImport = new LicenseCsvImport($dbManager, $userDao);
 
     $licenseCsvImport->setDelimiter('|');
     assertThat(Reflectory::getObjectsProperty($licenseCsvImport,'delimiter'),is('|'));
@@ -264,7 +505,8 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
   public function testSetEnclosure()
   {
     $dbManager = M::mock(DbManager::class);
-    $licenseCsvImport = new LicenseCsvImport($dbManager);
+    $userDao = M::mock(UserDao::class);
+    $licenseCsvImport = new LicenseCsvImport($dbManager, $userDao);
 
     $licenseCsvImport->setEnclosure('|');
     assertThat(Reflectory::getObjectsProperty($licenseCsvImport,'enclosure') ,is('|'));
@@ -283,23 +525,43 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
   public function testHandleCsv()
   {
     $dbManager = M::mock(DbManager::class);
-    $licenseCsvImport = new LicenseCsvImport($dbManager);
+    $userDao = M::mock(UserDao::class);
+    $licenseCsvImport = new LicenseCsvImport($dbManager, $userDao);
 
-    Reflectory::invokeObjectsMethodnameWith($licenseCsvImport, 'handleCsv', array(array('shortname','foo','text','fullname','notes')));
-    assertThat(Reflectory::getObjectsProperty($licenseCsvImport,'headrow'),is(notNullValue()));
+    Reflectory::invokeObjectsMethodnameWith($licenseCsvImport, 'handleCsv',
+      array(array('shortname', 'foo', 'text', 'fullname', 'notes')));
+    assertThat(Reflectory::getObjectsProperty($licenseCsvImport, 'headrow'),
+      is(notNullValue()));
 
     $dbManager->shouldReceive('getSingleRow')
-      ->with('SELECT rf_shortname,rf_source,rf_pk,rf_risk FROM license_ref WHERE rf_md5=md5($1)',anything())
+      ->with(
+        'SELECT rf_shortname,rf_source,rf_pk,rf_risk FROM license_ref WHERE rf_md5=md5($1)',
+        anything())
       ->andReturn(false);
-    $dbManager->shouldReceive('prepare');
-    $dbManager->shouldReceive('execute');
-    $dbManager->shouldReceive('freeResult');
-    $dbManager->shouldReceive('fetchArray')->andReturn(array('rf_pk'=>101,'rf_risk'=>1));
-    Reflectory::setObjectsProperty($licenseCsvImport, 'nkMap', array('licA'=>false));
-    Reflectory::setObjectsProperty($licenseCsvImport, 'mdkMap', array(md5('txA')=>false));
-    Reflectory::invokeObjectsMethodnameWith($licenseCsvImport, 'handleCsv', array(array('licA','bar','txA','liceA','noteA')));
-    assertThat(Reflectory::getObjectsProperty($licenseCsvImport, 'nkMap'),is(array('licA'=>101)));
-    assertThat(Reflectory::getObjectsProperty($licenseCsvImport, 'mdkMap'),is(array(md5('txA')=>101)));
+    $licenseRow = array(
+      "rf_shortname" => "licA",
+      "rf_fullname" => "liceA",
+      "rf_text" => "txA",
+      "rf_md5" => md5("txA"),
+      "rf_detector_type" => 1,
+      "rf_url" => '',
+      "rf_notes" => 'noteA',
+      "rf_source" => '',
+      "rf_risk" => 0
+    );
+    $this->addLicenseInsertToDbManager($dbManager, $licenseRow, 101);
+    Reflectory::setObjectsProperty($licenseCsvImport, 'nkMap', array(
+        'licA' => false
+    ));
+    Reflectory::setObjectsProperty($licenseCsvImport, 'mdkMap', array(
+        md5('txA') => false
+    ));
+    Reflectory::invokeObjectsMethodnameWith($licenseCsvImport, 'handleCsv',
+      array(array('licA', 'bar', 'txA', 'liceA', 'noteA')));
+    assertThat(Reflectory::getObjectsProperty($licenseCsvImport, 'nkMap'),
+      is(array('licA' => 101)));
+    assertThat(Reflectory::getObjectsProperty($licenseCsvImport, 'mdkMap'),
+      is(array(md5('txA') => 101)));
   }
 
   /**
@@ -311,7 +573,8 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
   public function testHandleFileIfFileNotExists()
   {
     $dbManager = M::mock(DbManager::class);
-    $licenseCsvImport = new LicenseCsvImport($dbManager);
+    $userDao = M::mock(UserDao::class);
+    $licenseCsvImport = new LicenseCsvImport($dbManager, $userDao);
     $msg = $licenseCsvImport->handleFile('/tmp/thisFileNameShouldNotExists');
     assertThat($msg, is(equalTo(_('Internal error'))));
   }
@@ -325,7 +588,8 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
   public function testHandleFileIfFileIsNotParsable()
   {
     $dbManager = M::mock(DbManager::class);
-    $licenseCsvImport = new LicenseCsvImport($dbManager);
+    $userDao = M::mock(UserDao::class);
+    $licenseCsvImport = new LicenseCsvImport($dbManager, $userDao);
     $msg = $licenseCsvImport->handleFile(__FILE__);
     assertThat($msg, startsWith( _('Error while parsing file')));
   }
@@ -340,7 +604,8 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
   public function testHandleFile()
   {
     $dbManager = M::mock(DbManager::class);
-    $licenseCsvImport = new LicenseCsvImport($dbManager);
+    $userDao = M::mock(UserDao::class);
+    $licenseCsvImport = new LicenseCsvImport($dbManager, $userDao);
     $filename = tempnam("/tmp", "FOO");
     $handle = fopen($filename, 'w');
     fwrite($handle, "shortname,fullname,text");
@@ -378,7 +643,8 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
       'rf_pk' => $reportId,
       'rf_shortname' => "Reported License"
     ));
-    $licenseCsvImport = new LicenseCsvImport($dbManager);
+    $userDao = M::mock(UserDao::class);
+    $licenseCsvImport = new LicenseCsvImport($dbManager, $userDao);
 
     assertThat(Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,
       'setMap', array($parentId, $licenseId, LicenseMap::CONCLUSION)),
@@ -419,7 +685,8 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
       'rf_pk' => $licenseId,
       'rf_shortname' => "Main License"
     ));
-    $licenseCsvImport = new LicenseCsvImport($dbManager);
+    $userDao = M::mock(UserDao::class);
+    $licenseCsvImport = new LicenseCsvImport($dbManager, $userDao);
 
     assertThat(Reflectory::invokeObjectsMethodnameWith($licenseCsvImport,
       'setMap', array($parentId, $licenseId, LicenseMap::CONCLUSION)),
@@ -437,5 +704,33 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
     $row = $dbManager->getSingleRow($sql, array($licenseId,
       LicenseMap::REPORT), $statement);
     assertThat($row, equalTo(false));
+  }
+
+  /**
+   * Create candidate license table
+   * @param DbManager $dbManager
+   */
+  private function createCandidateTable($dbManager)
+  {
+    $sql = "CREATE TABLE license_candidate (" .
+      "rf_pk, rf_shortname, rf_fullname, rf_text, rf_md5, rf_url, rf_notes, " .
+      "marydone, rf_source, rf_risk, rf_detector_type, group_fk)";
+    $dbManager->queryOnce($sql);
+  }
+
+  /**
+   * Add a new mockery handler for new license insertion in DB
+   * @param DbManager $dbManager The mock object of DbManager
+   * @param array $row    The associated array
+   * @param mixed $return The value which should be returned
+   * @param string $table The table where new data should go
+   */
+  private function addLicenseInsertToDbManager(&$dbManager, $row, $return,
+    $table = "license_ref")
+  {
+    $dbManager->shouldReceive('insertTableRow')
+      ->with($table, $row, anything(), 'rf_pk')
+      ->once()
+      ->andReturn($return);
   }
 }

--- a/src/lib/php/Db/DbManager.php
+++ b/src/lib/php/Db/DbManager.php
@@ -92,7 +92,7 @@ abstract class DbManager
 
   /**
    * Note: this builds a query which is not useable with SQLite
-   * one should use SqLiteE::nsertPreparedAndReturn() instead
+   * one should use SqLiteE::insertPreparedAndReturn() instead
    *
    * @param $statementName
    * @param $sqlStatement

--- a/src/lib/php/services.xml.in
+++ b/src/lib/php/services.xml.in
@@ -145,6 +145,7 @@ without any warranty.
 
         <service id="app.license_csv_import" class="Fossology\Lib\Application\LicenseCsvImport">
             <argument type="service" id="db.manager"/>
+            <argument type="service" id="dao.user"/>
         </service>
 
         <service id="app.obligation_csv_import" class="Fossology\Lib\Application\ObligationCsvImport">

--- a/src/www/ui/page/AdminLicenseFromCSV.php
+++ b/src/www/ui/page/AdminLicenseFromCSV.php
@@ -75,6 +75,8 @@ class AdminLicenseFromCSV extends DefaultPlugin
     $errMsg = '';
     if (! ($uploadedFile instanceof UploadedFile)) {
       $errMsg = _("No file selected");
+    } elseif ($uploadedFile->getError() !== UPLOAD_ERR_OK) {
+      $errMsg = $uploadedFile->getErrorMessage();
     } elseif ($uploadedFile->getSize() == 0 && $uploadedFile->getError() == 0) {
       $errMsg = _("Larger than upload_max_filesize ") .
         ini_get(self::KEY_UPLOAD_MAX_FILESIZE);


### PR DESCRIPTION
## Description

With the current implementation, if a license already exists in the DB where CSV is being imported, it is skipped altogether. And if the license does not exists, but it's MD5 matches with other license, the other license is updated with new license.

This PR fixes this behavior as following:
1. If the license shortname already exists
    1. If the MD5 of new license does not collide with any other license, update the license else print an error.
1. If the license shortname does not exists
    1. If the MD5 of the new license collides with any other license, print an error.
    1. Otherwise insert it as a new license.

This PR also provides way to differentiate candidate licenses with main licenses by creating additional column called `group` in the exported CSV and checking this column while importing the license to determine if the license is candidate or not.
1. If the row contains `group` value, it is candidate.
1. The MD5 collisions will not be checked.
1. If the group does not exists in current DB, skip the license and print an error.

Also, while exporting the licenses, do not export candidate licenses which do not have merge request open (`marydone`). And while importing licenses, open merge request for all candidate licenses.

## How to test

1. Export your license list with modified licenses, new licenses, candidate licenses with and without merge request.
1. Examine if the exported CSV have groups against candidate licenses and nothing against main licenses.
1. Import the list on different server (with some licenses).
    1. Check if existing licenses are updated.
    1. Check if new licenses are created.
    1. Check if candidate licenses are behaving as expected.
1. Import an old export (without `group` column), the import should not break.