### PR TITLE
fix(copyright): Wait for ajax calls during bulk replace

### DIFF
--- a/src/copyright/ui/template/histTable.js.twig
+++ b/src/copyright/ui/template/histTable.js.twig
@@ -91,13 +91,18 @@ function createTable{{ table.type }}() {
   $('#replaceSelected{{ table.type }}').click(function () {
     var replaceText = $('#replaceText{{ table.type }}').val().trim();
     var replaceIsValid = (replaceText) && !(/^\s*$/.test(replaceText));
+    var ajaxList = new Array();
     if(replaceIsValid){
       $("input:checkbox[class=deleteBySelect{{ table.type }}]:checked").each(function () {
         currentValue = $(this).val();
         var currUploadData = currentValue.split(',');
-        updateRows{{ table.type }}(currUploadData[0], currUploadData[1], currUploadData[2], currUploadData[3], replaceText);
+        ajaxList.push(updateRows{{ table.type }}(currUploadData[0],
+          currUploadData[1], currUploadData[2], currUploadData[3], replaceText));
       });
-      location.reload(true);
+      // Wait for all ajax calls to resolve
+      $.when.apply($, ajaxList).done(function(){
+        location.reload(true)
+      });
     }
   });
 
@@ -171,19 +176,19 @@ function createPlainTable{{ table.type }}() {
 }
 
 function updateRows{{ table.type }}(upload, item, hash, kind, replaceText) {
-  $.ajax({
+  return $.ajax({
     type: 'POST',
     dataType: 'text',
     url: '?mod=ajax-copyright-hist&action=update&type={{ table.type }}',
     data: { id : upload + ',' + item + ',' + hash + ',' + kind, value : replaceText },
-      success: function(data) {
-        var updateElement = $("#update{{ table.type }}" + hash);
-        $("#delete{{ table.type }}" + hash).hide();
-        updateElement.html("updating...");
-      },
-      error: function(errorResponse) {
-        alert(errorResponse.responseText);
-      }
+    success: function(data) {
+      var updateElement = $("#update{{ table.type }}" + hash);
+      $("#delete{{ table.type }}" + hash).hide();
+      updateElement.html("updating...");
+    },
+    error: function(errorResponse) {
+      alert(errorResponse.responseText);
+    }
   });
 }
 


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Wait for bulk replace ajax calls to resolve before reloading the page.

### Changes

1. Get all the ajax calls in an array while calling `updateRows{{ table.type }}` to update the text.
1. Wait for all ajax calls to be resolved before reloading the page.

## How to test

1. Run copyright agent on an upload.
1. Goto Copyright Browser and select multiple rows to update the text.
1. Insert the new text in the Replace text box and hit **Mark selected rows for replace** button.
    1. Check if the page reloaded only after all calls are solved using the browser console.
    1. Make sure no error message popped-up during the operation.
    1. Check if all the selected rows are updated.