### PR TITLE
fix(admin): Allow read user to edit user

### DIFF
--- a/src/www/ui/template/user_edit.html.twig
+++ b/src/www/ui/template/user_edit.html.twig
@@ -121,7 +121,8 @@
               <tbody>
                 <tr>
                   <td>
-                    <input type="radio" name="pat_scope" value="r" id="pat_scope_r" />
+                    <input type="radio" name="pat_scope" value="r"
+                      id="pat_scope_r" checked="checked" />
                   </td>
                   <td style="width:100%">
                     <label class="font-weight:bold" for="pat_scope_r">
@@ -134,6 +135,7 @@
                     </label>
                   </td>
                 </tr>
+              {% if writeAccess %}
                 <tr>
                   <td>
                     <input type="radio" name="pat_scope" value="w" id="pat_scope_w" />
@@ -149,6 +151,7 @@
                     </label>
                   </td>
                 </tr>
+              {% endif %}
               </tbody>
             </table>
           </td>

--- a/src/www/ui/user-edit.php
+++ b/src/www/ui/user-edit.php
@@ -45,7 +45,7 @@ class UserEditPage extends DefaultPlugin
         self::TITLE => _("Edit User Account"),
         self::MENU_LIST => 'Admin::Users::Edit User Account',
         self::REQUIRES_LOGIN => true,
-        self::PERMISSION => Auth::PERM_WRITE
+        self::PERMISSION => Auth::PERM_READ
     ));
 
     $this->dbManager = $this->getObject('db.manager');
@@ -117,6 +117,7 @@ class UserEditPage extends DefaultPlugin
     $vars['tokenList'] = $this->getListOfActiveTokens();
     $vars['expiredTokenList'] = $this->getListOfExpiredTokens();
     $vars['maxTokenDate'] = $this->authHelper->getMaxTokenValidity();
+    $vars['writeAccess'] = ($_SESSION[Auth::USER_LEVEL] >= 3);
 
     return $this->render('user_edit.html.twig', $this->mergeWithDefault($vars));
   }
@@ -360,7 +361,11 @@ class UserEditPage extends DefaultPlugin
     $user_pk = Auth::getUserId();
     $tokenName = GetParm('pat_name', PARM_STRING);
     $tokenExpiry = GetParm('pat_expiry', PARM_STRING);
-    $tokenScope = GetParm('pat_scope', PARM_STRING);
+    if ($_SESSION[Auth::USER_LEVEL] < 3) {
+      $tokenScope = 'r';
+    } else {
+      $tokenScope = GetParm('pat_scope', PARM_STRING);
+    }
     $tokenScope = array_search($tokenScope, RestHelper::SCOPE_DB_MAP);
     $restHelper = $container->get('helper.restHelper');
     $isTokenRequestValid = $restHelper->validateTokenRequest($tokenExpiry,


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Allow users with read-only access to edit their user info.

### Changes

1. Update the minimum required permission to load `user-edit` page to `Auth::PERM_READ`.
1. Disallow user with permission < 3 (`PERM_WRITE`) to create REST API tokens with Read/Write scopes.

## How to test

1. Create a new user with read only access.
1. Check if the user can update the password.
1. Check if the user can create REST API tokens
1. The user should not be allowed to make read/write API tokens.

Closes #900