### PR TITLE
feat(unifiedReport): exclude scanner found copyrights of irrelevent f…

### DIFF
--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -30,6 +30,8 @@ class CopyrightDao
   private $dbManager;
   /** @var UploadDao */
   private $uploadDao;
+  /** @var ClearingDao */
+  private $clearingDao;
   /** @var Logger */
   private $logger;
 
@@ -38,6 +40,8 @@ class CopyrightDao
     $this->dbManager = $dbManager;
     $this->uploadDao = $uploadDao;
     $this->logger = new Logger(self::class);
+    global $container;
+    $this->clearingDao = $container->get('dao.clearing');
   }
 
   /**
@@ -261,11 +265,21 @@ class CopyrightDao
    * @param $extrawhere
    * @return array
    */
-  public function getAllEntriesReport($tableName, $uploadId, $uploadTreeTableName, $type=null, $onlyCleared=false, $decisionType=null, $extrawhere=null)
+  public function getAllEntriesReport($tableName, $uploadId, $uploadTreeTableName, $type=null, $onlyCleared=false, $decisionType=null, $extrawhere=null, $groupId=null)
   {
     $tableNameDecision = $tableName."_decision";
     if ($tableName == 'copyright') {
       $scannerEntries = $this->getScannerEntries($tableName, $uploadTreeTableName, $uploadId, $type, $extrawhere);
+      if (!empty($groupId)) {
+        $itemTreeBounds = $this->uploadDao->getParentItemBounds($uploadId, $uploadTreeTableName);
+        $irrelevantDecisions = $this->clearingDao->getIrrelevantFilesFolder($itemTreeBounds, $groupId);
+        $uniqueIrrelevantDecisions = array_unique(array_column($irrelevantDecisions, 'uploadtree_pk'));
+        foreach ($scannerEntries as $key => $value) {
+          if (in_array($value['uploadtree_pk'], $uniqueIrrelevantDecisions)) {
+            unset($scannerEntries[$key]);
+          }
+        }
+      }
       $editedEntries = $this->getEditedEntries($tableNameDecision, $uploadTreeTableName, $uploadId, $decisionType);
       return array_merge($scannerEntries, $editedEntries);
     } else {

--- a/src/lib/php/Report/XpClearedGetter.php
+++ b/src/lib/php/Report/XpClearedGetter.php
@@ -61,7 +61,7 @@ class XpClearedGetter extends ClearedGetterCommon
     }
     $this->extrawhere .= ' agent_fk='.$latestXpAgentId;
 
-    return $this->copyrightDao->getAllEntriesReport($this->tableName, $uploadId, $uploadTreeTableName, $this->type, $this->getOnlyCleared, DecisionTypes::IDENTIFIED, $this->extrawhere);
+    return $this->copyrightDao->getAllEntriesReport($this->tableName, $uploadId, $uploadTreeTableName, $this->type, $this->getOnlyCleared, DecisionTypes::IDENTIFIED, $this->extrawhere, $groupId);
   }
 }
 


### PR DESCRIPTION

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Exclude scanner found copyrights from report for irrelevant files.

### Changes

Get list of all irrelevant files from clearing decisions and remove copyrights by comparing uploadtreeId.

## How to test

* Upload a package
* Go to folder view and click on edit for any folder.
* Click on Mark files as irrelevant for that folder.
* Generate unified report and check copyrights the irrelevant files shouldn't appear.    
