### PR TITLE
fix(ui): decision and scope for licenses

### DIFF
--- a/src/www/ui/change-license-processPost.php
+++ b/src/www/ui/change-license-processPost.php
@@ -90,7 +90,6 @@ class changeLicenseProcessPost extends FO_Plugin
     $userId = Auth::getUserId();
     $groupId = Auth::getGroupId();
     $decisionMark = @$_POST['decisionMark'];
-
     if (! empty($decisionMark) && $decisionMark == "irrelevant") {
       if (! is_array($itemId)) {
         $responseMsg = $this->doMarkIrrelevant($itemId, $groupId, $userId);

--- a/src/www/ui/template/ui-clearing-view_rhs.html.twig
+++ b/src/www/ui/template/ui-clearing-view_rhs.html.twig
@@ -29,7 +29,7 @@
       <legend>
         {{ 'Clearing decision scope'| trans }}
       </legend>
-      <input type="checkbox" name="globalDecision"/> {{ 'Apply decision to all future occurrences of this file'|trans }}<img src="images/info_16.png" title="{{ 'Based on a hash computation of the file contents, Fossology will determine a future occurrence of the same file. Then, if  the same file is part of a subsequent upload, this clearing decision will apply there as well.  Consider that this decision will impact also upload of other users. It should be checked with much care'|trans }}" alt="" class="info-bullet"/>
+      <input type="checkbox" name="globalDecision" {% if selectedClearingScope==1 %}checked{% endif %}/> {{ 'Apply decision to all future occurrences of this file'|trans }}<img src="images/info_16.png" title="{{ 'Based on a hash computation of the file contents, Fossology will determine a future occurrence of the same file. Then, if  the same file is part of a subsequent upload, this clearing decision will apply there as well.  Consider that this decision will impact also upload of other users. It should be checked with much care'|trans }}" alt="" class="info-bullet"/ >
     </fieldset>
     <br/>
     <fieldset style="display: inline;" {% if tmpClearingType %}class="decTypeWip"{% endif %} id="decTypeSet">

--- a/src/www/ui/ui-clearing-view.php
+++ b/src/www/ui/ui-clearing-view.php
@@ -279,8 +279,10 @@ class ClearingView extends FO_Plugin
     }
 
     $selectedClearingType = false;
+    $selectedClearingScope = false;
     if (!empty($clearingDecisions)) {
       $selectedClearingType = $clearingDecisions[0]->getType();
+      $selectedClearingScope = $clearingDecisions[0]->getScope();
     }
     $bulkHistory = $this->clearingDao->getBulkHistory($itemTreeBounds, $groupId);
 
@@ -294,6 +296,7 @@ class ClearingView extends FO_Plugin
     $this->vars['legendData'] = $this->highlightRenderer->getLegendData($selectedAgentId || $clearingId);
     $this->vars['clearingTypes'] = $this->decisionTypes->getMap();
     $this->vars['selectedClearingType'] = $selectedClearingType;
+    $this->vars['selectedClearingScope'] = $selectedClearingScope;
     $this->vars['tmpClearingType'] = $this->clearingDao->isDecisionWip($uploadTreeId, $groupId);
     $this->vars['bulkHistory'] = $bulkHistory;
 
@@ -333,11 +336,9 @@ class ClearingView extends FO_Plugin
   protected function updateLastItem($userId, $groupId, $lastItem)
   {
     $type = GetParm("clearingTypes", PARM_INTEGER);
-    $global = GetParm("globalDecision", PARM_STRING) === "on";
-
+    $global = GetParm("globalDecision", PARM_STRING) === "on" ? 1 : 0;
     $uploadTreeTableName = $this->uploadDao->getUploadtreeTableName($lastItem);
     $itemBounds = $this->uploadDao->getItemTreeBounds($lastItem, $uploadTreeTableName);
-
     $this->clearingDecisionEventProcessor->makeDecisionFromLastEvents($itemBounds, $userId, $groupId, $type, $global);
   }
 }


### PR DESCRIPTION
Signed-off-by: Anupam Ghosh <anupam.ghosh@siemens.com>

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Unable to change the `decision type` for the files which are cleared under `Clearing decision scope : global(Scope) : Apply decision to all future occurrences of this file`.

Example : files with `Clearing decision type` : `To be discussed`  and
`Clearing decision scope : global(Scope) : Apply decision to all future occurrences of this file`

can not be changed to `Clearing decision type` : `To be discussed` with or without
`Clearing decision scope : global(Scope) : Apply decision to all future occurrences of this file`


### Changes

* Global and local scope of the decision type can be changed
* if applied `Clearing decision scope : global(Scope) : Apply decision to all future occurrences of this file`. the checkbox will be checked.

## How to test

As described in the description example