### PR TITLE
fix(obligation): Refer to license conclusions

### DIFF
--- a/install/db/dbmigrate_3.6-3.7.php
+++ b/install/db/dbmigrate_3.6-3.7.php
@@ -1,4 +1,7 @@
 <?php
+use Fossology\Lib\BusinessRules\LicenseMap;
+use Fossology\Lib\BusinessRules\ObligationMap;
+
 /***********************************************************
  Copyright (C) 2019 Siemens AG
  Author: Gaurav Mishra <mishra.gaurav@siemens.com>
@@ -95,7 +98,8 @@ function checkMigrate3637Required($dbManager)
   if ($migRequired) {
     $sql = "SELECT count(*) AS cnt FROM obligation_map WHERE rf_fk NOT IN (" .
       "SELECT rf_pk FROM ONLY license_ref);";
-    $row = $dbManager->getSingleRow($sql);
+    $statement = __METHOD__ . ".candCount";
+    $row = $dbManager->getSingleRow($sql, array(), $statement);
     $migRequired = false;
     if (array_key_exists("cnt", $row) && $row["cnt"] > 0) {
       $migRequired = true;
@@ -105,7 +109,36 @@ function checkMigrate3637Required($dbManager)
   return $migRequired;
 }
 
- /**
+/**
+ * Get the entries for which migration is required for non concluded licenses.
+ * @param DbManager $dbManager
+ * @return array Entries from which require migration
+ */
+function getLicConObligationMigrate($dbManager)
+{
+  if($dbManager == NULL){
+    echo "No connection object passed!\n";
+    return false;
+  }
+  $requiredTables = array(
+    "obligation_map",
+    "license_ref",
+    "license_map"
+  );
+  foreach ($requiredTables as $table) {
+    if (DB_TableExists($table) != 1) {
+      return array();
+    }
+  }
+
+  $sql = "WITH comp AS (" . LicenseMap::getMappedLicenseRefView() .
+    ") SELECT * FROM obligation_map WHERE rf_fk NOT IN " .
+    "(SELECT rf_pk FROM comp);";
+  $statement = __METHOD__ . ".conclusionMigrate";
+  return $dbManager->getRows($sql, array(LicenseMap::CONCLUSION), $statement);
+}
+
+/**
  * @brief Get all obligations and move licenses.
  * @param DbManager $dbManager
  * @param boolean $verbose
@@ -131,7 +164,7 @@ function moveObligation($dbManager, $verbose)
  */
 function migrateReuseValueForEnhanceWithMainLicense($dbManager)
 {
-  if($dbManager == NULL){
+  if ($dbManager === NULL) {
     echo "No connection object passed!\n";
     return false;
   }
@@ -144,16 +177,60 @@ function migrateReuseValueForEnhanceWithMainLicense($dbManager)
 
   if ($row['exists']) {
     echo "*** Changing enhance reuse with main license value to 6 from 8 ***\n";
-    $stmt = __METHOD__."ReplaceValuesFrom8to6";
+    $stmt = __METHOD__ . "ReplaceValuesFrom8to6";
     $dbManager->prepare($stmt,
       "UPDATE upload_reuse
        SET reuse_mode = $1 WHERE reuse_mode = $2"
-      );
+    );
     $dbManager->freeResult($dbManager->execute($stmt, array(6,8)));
     return true;
   }
   return false;
 }
+
+/**
+ * @brief Remove identified licenses from obligations.
+ *
+ * The function removes the obligation map sent from $migrationData. To do so,
+ * the function first gets the list of licenses along with their parent license.
+ * Then makes sure that the parent is part of the obligation to prevent data
+ * loss. Then it finally removes the obligation map.
+ * @param DbManager $dbManager
+ * @param array     $migrationData
+ */
+function removeNonConcLicensesFromObligation($dbManager, $migrationData)
+{
+  $obligationMap = new ObligationMap($dbManager);
+  $mappedLicenses = [];
+
+  $sql = LicenseMap::getMappedLicenseRefView();
+  $params = array(LicenseMap::CONCLUSION);
+  $statement = __METHOD__ . ".getLicenseMap";
+  $rows = $dbManager->getRows($sql, $params, $statement);
+  foreach ($rows as $row) {
+    $mappedLicenses[$row["rf_origin"]] = $row;
+  }
+
+  foreach ($migrationData as $row) {
+    $dbManager->begin();
+    $obligationId = $row["ob_fk"];
+    $licenseId = $row["rf_fk"];
+    $parentId = $mappedLicenses[$licenseId]["rf_pk"];
+
+    $licenseName = $obligationMap->getShortnameFromId($row["rf_fk"]);
+    $obligationTopic = $obligationMap->getTopicNameFromId($row["ob_fk"]);
+    echo "    Removed '$licenseName' license from '$obligationTopic' obligation";
+    if (! $obligationMap->isLicenseAssociated($obligationId, $parentId)) {
+      $obligationMap->associateLicenseWithObligation($obligationId, $parentId);
+      echo " replacing with parent license '" .
+        $obligationMap->getShortnameFromId($parentId) . "'";
+    }
+    echo ".\n";
+    $obligationMap->unassociateLicenseFromObligation($obligationId, $licenseId);
+    $dbManager->commit();
+  }
+}
+
 /**
  * Migration from FOSSology 3.6.0 to 3.7.0
  * @param DbManager $dbManager
@@ -162,13 +239,22 @@ function migrateReuseValueForEnhanceWithMainLicense($dbManager)
 function Migrate_36_37($dbManager, $verbose)
 {
   migrateReuseValueForEnhanceWithMainLicense($dbManager);
-  if (! checkMigrate3637Required($dbManager)) {
+  $candidateMigration = checkMigrate3637Required($dbManager);
+  $concLicenseMigration = getLicConObligationMigrate($dbManager);
+  if (! ($candidateMigration || (count($concLicenseMigration) > 0))) {
     // Migration not required
     return;
   }
   try {
-    echo "*** Moving candidate licenses from obligation map ***\n";
-    moveObligation($dbManager, $verbose);
+    if ($candidateMigration) {
+      echo "*** Moving candidate licenses from obligation map ***\n";
+      moveObligation($dbManager, $verbose);
+    }
+    if (count($concLicenseMigration) > 0) {
+      echo "*** Removed following obligation map (" .
+        count($concLicenseMigration) . ") ***\n";
+      removeNonConcLicensesFromObligation($dbManager, $concLicenseMigration);
+    }
   } catch (Exception $e) {
     echo "Something went wrong. Try running postinstall again!\n";
     $dbManager->rollback();

--- a/src/lib/php/BusinessRules/ObligationMap.php
+++ b/src/lib/php/BusinessRules/ObligationMap.php
@@ -41,21 +41,27 @@ class ObligationMap
   }
 
   /**
-   * @brief Get the license id from the shortname
+   * @brief Get the list of license shortnames
+   *
+   * If candidate license, return list of all licenses.
+   * If not-candidate license, return list of licenses which have conclusion on
+   * self.
    * @param bool $candidate Is a candidate license
    * @return string[] Array of license shortnames
    */
   public function getAvailableShortnames($candidate=false)
   {
+    $params = [];
     if ($candidate) {
       $sql = "SELECT rf_shortname FROM license_candidate;";
       $stmt = __METHOD__.".rf_candidate_shortnames";
     } else {
-      $sql = "SELECT rf_shortname FROM ONLY license_ref;";
+      $sql = LicenseMap::getMappedLicenseRefView();
       $stmt = __METHOD__.".rf_shortnames";
+      $params[] = LicenseMap::CONCLUSION;
     }
     $this->dbManager->prepare($stmt,$sql);
-    $res = $this->dbManager->execute($stmt);
+    $res = $this->dbManager->execute($stmt, $params);
     $vars = $this->dbManager->fetchAll($res);
     $this->dbManager->freeResult($res);
 
@@ -74,7 +80,7 @@ class ObligationMap
    * @param bool   $candidate Is a candidate license?
    * @return int[] License ids
    */
-  public function getIdFromShortname($shortname,$candidate=false)
+  public function getIdFromShortname($shortname, $candidate=false)
   {
     $tableName = "";
     if ($candidate) {

--- a/src/lib/php/Report/ObligationsGetter.php
+++ b/src/lib/php/Report/ObligationsGetter.php
@@ -72,8 +72,8 @@ class ObligationsGetter
     }
 
     $bulkAddIds = $this->getBulkAddLicenseList($uploadId, $groupId);
-    $obligationRef = $this->licenseDao->getLicenseObligations($allLicenseIds, 'obligation_map') ?: array();
-    $obligationCandidate = $this->licenseDao->getLicenseObligations($allLicenseIds, 'obligation_candidate_map') ?: array();
+    $obligationRef = $this->licenseDao->getLicenseObligations($allLicenseIds) ?: array();
+    $obligationCandidate = $this->licenseDao->getLicenseObligations($allLicenseIds, true) ?: array();
     $obligations = array_merge($obligationRef, $obligationCandidate);
     $onlyLicenseIdsWithObligation = array_column($obligations, 'rf_fk');
     if (!empty($bulkAddIds)) {

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -1060,7 +1060,7 @@
   $Schema["TABLE"]["obligation_map"]["ob_fk"]["ADD"] = "ALTER TABLE \"obligation_map\" ADD COLUMN \"ob_fk\" int8";
   $Schema["TABLE"]["obligation_map"]["ob_fk"]["ALTER"] = "ALTER TABLE \"obligation_map\" ALTER COLUMN \"ob_fk\" SET NOT NULL";
 
-  $Schema["TABLE"]["obligation_map"]["rf_fk"]["DESC"] = "COMMENT ON COLUMN \"obligation_map\".\"rf_fk\" IS 'Reference license key as in rf_license'";
+  $Schema["TABLE"]["obligation_map"]["rf_fk"]["DESC"] = "COMMENT ON COLUMN \"obligation_map\".\"rf_fk\" IS 'Parent license key as in license_ref'";
   $Schema["TABLE"]["obligation_map"]["rf_fk"]["ADD"] = "ALTER TABLE \"obligation_map\" ADD COLUMN \"rf_fk\" int8";
   $Schema["TABLE"]["obligation_map"]["rf_fk"]["ALTER"] = "ALTER TABLE \"obligation_map\" ALTER COLUMN \"rf_fk\" SET NOT NULL";
 

--- a/src/www/ui/template/admin_obligation-upload_form.html.twig
+++ b/src/www/ui/template/admin_obligation-upload_form.html.twig
@@ -50,7 +50,7 @@
       <td align="left">{{ macro.select('ob_modifications',YesNoMap,'ob_modifications',ob_modifications) }}</td>
     </tr>
     <tr>
-      <td align="right">{{ "Associated Licenses"|trans }}</td>
+      <td align="right">{{ "Associated Licenses (conclusions)"|trans }}</td>
       <td align="left">{{ macro.selectwitharray(licenseSelectorName, licenseShortnames, licenseSelectorId, licnames, 'style="min-width:575px;"', 8) }}</td>
     </tr>
     <tr>

--- a/src/www/ui/ui-report-conf.php
+++ b/src/www/ui/ui-report-conf.php
@@ -217,8 +217,8 @@ class ui_report_conf extends FO_Plugin
         $allClearedLicenses[] = $licenseMap->getProjectedId($getLicenseId);
       }
     }
-    $obligationsForLicenses = $this->licenseDao->getLicenseObligations($allClearedLicenses, 'obligation_map') ?: array();
-    $obligationsForLicenseCandidates = $this->licenseDao->getLicenseObligations($allClearedLicenses, 'obligation_candidate_map') ?: array();
+    $obligationsForLicenses = $this->licenseDao->getLicenseObligations($allClearedLicenses) ?: array();
+    $obligationsForLicenseCandidates = $this->licenseDao->getLicenseObligations($allClearedLicenses, true) ?: array();
     $allObligations = array_merge($obligationsForLicenses, $obligationsForLicenseCandidates);
     $groupedObligations = array();
     foreach ($allObligations as $obligations) {


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

With the current implementation of obligations, the FOSSology stores the license references in the obligation map.

This results in additional efforts required for keeping track of child licenses (a license using different license as conclusion).

This PR attempts to solve the situation by storing (and displaying) only the licenses which are used as conclusion in some license (including self conclusion, which is the default behavior for all licenses). And while generating the unified report, get the obligations associated with the decided license's conclusion.

This will result in reducing the efforts required to attach all child licenses to the obligation.

**Note:** This will not alter candidate licenses as they do not have provision to conclude to other licenses.

### Changes

1. Display only licenses which are concluded by some license in the obligation edit view.
1. While fetching the obligations for a given license, fetch the obligations for the conclusion of the given license.
1. Remove licenses which are not concluded by any license from `obligation_map` making sure to keep the parent of removed license in the obligation.

## How to test

1. Create some child licenses with conclusion to the parent license.
1. Add each license to an obligation (additional work PR trying to solve).
1. Add a child license to an obligation without adding the parent license.
1. Upload a package which contains license signatures of the child licenses.
    1. Do some clearing and generate unified report.
    1. Check if the report contains the intended obligations.
1. Install the branch and check for the output of `fo-postinstall`.
    1. It should indicate removal of child licenses from obligation.
    1. It should indicate addition of parent license to the obligation where only child license was associated.
1. Regenerate the unified report and check if the obligations are correct.