### PR TITLE
chore(lib): Move agent list to common place

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -32,6 +32,7 @@ use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Proxy\UploadTreeProxy;
 use Fossology\Lib\Proxy\ScanJobProxy;
 use Monolog\Logger;
+use Fossology\Lib\Data\AgentRef;
 
 class ClearingDao
 {
@@ -955,7 +956,7 @@ INSERT INTO clearing_decision (
   {
     $uploadTreeTable = $this->uploadDao->getUploadtreeTableName($uploadId);
     $scanJobProxy = new ScanJobProxy($GLOBALS['container']->get('dao.agent'), $uploadId);
-    $scanJobProxy->createAgentStatus(array('nomos', 'monk', 'ninka', 'reportImport', 'ojo'));
+    $scanJobProxy->createAgentStatus(array_keys(AgentRef::AGENT_LIST));
     $latestAgentIds = $scanJobProxy->getLatestSuccessfulAgentIds();
     $agentIds = "{" . implode(",", $latestAgentIds) . "}";
 

--- a/src/lib/php/Data/AgentRef.php
+++ b/src/lib/php/Data/AgentRef.php
@@ -21,6 +21,18 @@ namespace Fossology\Lib\Data;
 
 class AgentRef
 {
+
+  /**
+   * @var array $AGENT_LIST
+   * List of agents FOSSology uses to get agent ids
+   */
+  const AGENT_LIST = array(
+    'nomos' => 'N',
+    'monk' => 'M',
+    'ninka' => 'Nk',
+    'reportImport' => 'I',
+    'ojo' => 'O'
+  );
   /**
    * @var int
    */

--- a/src/lib/php/Proxy/UploadTreeProxy.php
+++ b/src/lib/php/Proxy/UploadTreeProxy.php
@@ -22,6 +22,7 @@ use Fossology\Lib\BusinessRules\LicenseMap;
 use Fossology\Lib\Data\DecisionScopes;
 use Fossology\Lib\Data\DecisionTypes;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
+use Fossology\Lib\Data\AgentRef;
 
 class UploadTreeProxy extends DbViewProxy
 {
@@ -259,7 +260,7 @@ class UploadTreeProxy extends DbViewProxy
       $agentFilter = " AND lf.agent_fk=ANY($agentIds)";
     } else {
       $scanJobProxy = new ScanJobProxy($GLOBALS['container']->get('dao.agent'),$uploadId);
-      $scanJobProxy->createAgentStatus(array('nomos','monk','ninka','reportImport','ojo'));
+      $scanJobProxy->createAgentStatus(array_keys(AgentRef::AGENT_LIST));
       $latestAgentIds = $scanJobProxy->getLatestSuccessfulAgentIds();
       $agentFilter = $latestAgentIds ? " AND lf.agent_fk=ANY(array[".implode(',',$latestAgentIds)."])" : "AND 0=1";
     }

--- a/src/lib/php/Report/LicenseClearedGetter.php
+++ b/src/lib/php/Report/LicenseClearedGetter.php
@@ -26,6 +26,7 @@ use Fossology\Lib\Data\ClearingDecision;
 use Fossology\Lib\Data\DecisionTypes;
 use Fossology\Lib\Proxy\ScanJobProxy;
 use Fossology\Lib\Data\License;
+use Fossology\Lib\Data\AgentRef;
 
 class LicenseClearedGetter extends ClearedGetterCommon
 {
@@ -42,7 +43,7 @@ class LicenseClearedGetter extends ClearedGetterCommon
   /** @var string[] */
   private $licenseCache = array();
   /** @var agentNames */
-  protected $agentNames = array('nomos' => 'N', 'monk' => 'M', 'ninka' => 'Nk', 'reportImport' => 'I', 'ojo' => 'O');
+  protected $agentNames = AgentRef::AGENT_LIST;
 
   public function __construct()
   {

--- a/src/lib/php/UI/template/include/base.html.twig
+++ b/src/lib/php/UI/template/include/base.html.twig
@@ -4,6 +4,10 @@
    are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
    This file is offered as-is, without any warranty.
 #}
+{# Set common list of agents. Displayed by various pages #}
+{%
+  set agent_list = "(N: nomos, M: monk, Nk: ninka, I: reportImport, O: ojo)"
+%}
 <!DOCTYPE html>
 <html>
   <head lang="en">

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -69,6 +69,7 @@ use Fossology\Lib\Proxy\ScanJobProxy;
 use Fossology\Lib\Proxy\UploadTreeProxy;
 use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Data\License;
+use Fossology\Lib\Data\AgentRef;
 
 include_once(__DIR__ . "/spdx2utils.php");
 
@@ -114,7 +115,7 @@ class SpdxTwoAgent extends Agent
   /** @var array $agentNames
    * Agent names mapping
    */
-  protected $agentNames = array('nomos' => 'N', 'monk' => 'M', 'ninka' => 'Nk', 'reportImport' => 'I', 'ojo' => 'O');
+  protected $agentNames = AgentRef::AGENT_LIST;
   /** @var array $includedLicenseIds
    * License ids included
    */

--- a/src/www/ui/async/AjaxExplorer.php
+++ b/src/www/ui/async/AjaxExplorer.php
@@ -36,6 +36,7 @@ use Fossology\Lib\Proxy\UploadTreeProxy;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Fossology\Lib\Data\AgentRef;
 
 /**
  * \file ui-browse-license.php
@@ -70,7 +71,7 @@ class AjaxExplorer extends DefaultPlugin
    * DB proxy view to hold upload tree entries for files with no license */
   private $noLicenseUploadTreeView;
   /** @var array */
-  protected $agentNames = array('nomos' => 'N', 'monk' => 'M', 'ninka' => 'Nk', 'reportImport' => 'I', 'ojo' => 'O');
+  protected $agentNames = AgentRef::AGENT_LIST;
 
   public function __construct()
   {

--- a/src/www/ui/async/AjaxFileBrowser.php
+++ b/src/www/ui/async/AjaxFileBrowser.php
@@ -32,6 +32,7 @@ use Fossology\Lib\Proxy\UploadTreeProxy;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Fossology\Lib\Data\AgentRef;
 
 /**
  * \file ui-browse-license.php
@@ -52,7 +53,7 @@ class AjaxFileBrowser extends DefaultPlugin
   /** @var LicenseMap */
   private $licenseProjector;
   /** @var array */
-  protected $agentNames = array('nomos' => 'N', 'monk' => 'M', 'ninka' => 'Nk', 'reportImport' => 'I', 'ojo' => 'O');
+  protected $agentNames = AgentRef::AGENT_LIST;
 
   public function __construct()
   {

--- a/src/www/ui/template/browse_file.js.twig
+++ b/src/www/ui/template/browse_file.js.twig
@@ -27,7 +27,7 @@ function createDirlistTable() {
         }
     },
     "aoColumns": [{"sTitle":"Files","sClass":"left"},
-        {"sTitle":"Scanner Results (N: nomos, M: monk, Nk: ninka, I: reportImport, O: ojo)","sClass":"left","bSortable":false},
+        {"sTitle":"Scanner Results&nbsp;{{ agent_list }}","sClass":"left","bSortable":false},
         {"sTitle":"Edited Results","sClass":"left","bSortable":false},
         {"sTitle":"Clearing Status","sClass":"clearingStatus center","bSortable":false,"bSearchable":false,"sWidth":"5%","mRender":function ( data, type, full ) {
             if(type!='display') return data;

--- a/src/www/ui/template/file-browse.js.twig
+++ b/src/www/ui/template/file-browse.js.twig
@@ -25,7 +25,7 @@ function createDirlistTable() {
         }
     },
     "aoColumns": [{"sTitle":"Files","sClass":"left"},
-        {"sTitle":"Scanner Results (N: nomos, M: monk, Nk: ninka, I: reportImport, O: ojo)","sClass":"left","bSortable":false},
+        {"sTitle":"Scanner Results&nbsp;{{ agent_list }}","sClass":"left","bSortable":false},
         {"sTitle":"Actions","sClass":"left","bSortable":false,"bSearchable":false}],
     "sPaginationType": "listbox",
     "iDisplayLength": 25,

--- a/src/www/ui/template/ui-browse-license_file-list.js.twig
+++ b/src/www/ui/template/ui-browse-license_file-list.js.twig
@@ -8,7 +8,7 @@ function createDirlistTable() {
   $('#dirlist').dataTable( {
     "aaData": {{ aaData }},
     "aoColumns":[{"sTitle":"Files","sClass":"left"},
-      {"sTitle":"Scanner Results (N: nomos, M: monk, Nk: ninka, I: reportImport, O: ojo)","sClass":"left"},
+      {"sTitle":"Scanner Results&nbsp;{{ agent_list }}","sClass":"left"},
       {"sTitle":"Edited Results","sClass":"left"},
       {"sTitle":"Clearing Status","sClass":"clearingStatus center","bSearchable":false,"sWidth":"5%","mRender":function ( data, type, full ) {
           if(type!='display') return data;

--- a/src/www/ui/ui-browse-license.php
+++ b/src/www/ui/ui-browse-license.php
@@ -31,6 +31,7 @@ use Fossology\Lib\Proxy\ScanJobProxy;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Fossology\Lib\Data\AgentRef;
 
 /**
  * \file ui-browse-license.php
@@ -55,7 +56,7 @@ class ui_browse_license extends DefaultPlugin
   /** @var LicenseMap */
   private $licenseProjector;
   /** @var array */
-  protected $agentNames = array('nomos' => 'N', 'monk' => 'M', 'ninka' => 'Nk', 'reportImport' => 'I', 'ojo' => 'O');
+  protected $agentNames = AgentRef::AGENT_LIST;
 
   public function __construct()
   {

--- a/src/www/ui/ui-clearing-view.php
+++ b/src/www/ui/ui-clearing-view.php
@@ -26,6 +26,7 @@ use Fossology\Lib\Dao\ClearingDao;
 use Fossology\Lib\Dao\HighlightDao;
 use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Data\AgentRef;
 use Fossology\Lib\Data\Clearing\ClearingResult;
 use Fossology\Lib\Data\ClearingDecision;
 use Fossology\Lib\Data\DecisionScopes;
@@ -113,7 +114,7 @@ class ClearingView extends FO_Plugin
     $unmaskAgents = $selectedAgentId;
     if (empty($selectedAgentId)) {
       $scanJobProxy = new ScanJobProxy($this->agentsDao,$uploadId);
-      $scanJobProxy->createAgentStatus(array('nomos','monk','ninka','reportImport','ojo'));
+      $scanJobProxy->createAgentStatus(array_keys(AgentRef::AGENT_LIST));
       $unmaskAgents = $scanJobProxy->getLatestSuccessfulAgentIds();
     }
     $highlightEntries = $this->highlightDao->getHighlightEntries($itemTreeBounds,

--- a/src/www/ui/ui-file-browse.php
+++ b/src/www/ui/ui-file-browse.php
@@ -28,6 +28,7 @@ use Fossology\Lib\Proxy\ScanJobProxy;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Fossology\Lib\Data\AgentRef;
 
 /**
  * \file ui-browse-license.php
@@ -48,7 +49,7 @@ class ui_file_browse extends DefaultPlugin
   /** @var LicenseMap */
   private $licenseProjector;
   /** @var array */
-  protected $agentNames = array('nomos' => 'N', 'monk' => 'M', 'ninka' => 'Nk', 'reportImport' => 'I', 'ojo' => 'O');
+  protected $agentNames = AgentRef::AGENT_LIST;
 
   public function __construct()
   {

--- a/src/www/ui/ui-license-list-files.php
+++ b/src/www/ui/ui-license-list-files.php
@@ -20,6 +20,7 @@ use Fossology\Lib\Dao\AgentDao;
 use Fossology\Lib\Dao\UploadDao;
 use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Proxy\ScanJobProxy;
+use Fossology\Lib\Data\AgentRef;
 
 /**
  * \file ui-list-lic-files.php
@@ -45,7 +46,7 @@ class LicenseListFiles extends FO_Plugin
   private $agentDao;
 
   /** @var Array */
-  protected $agentNames = array('nomos' => 'N', 'monk' => 'M', 'ninka' => 'Nk', 'reportImport' => 'I', 'ojo' => 'O');
+  protected $agentNames = AgentRef::AGENT_LIST;
 
   function __construct()
   {


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

In the codebase, many places defines a list of agents to fetch the records from DB.

Eventhough they all contain the same value, if someone adds a new agent to fossology, they'll have to find all instance and apply the changes.

This PR moves all such instances to a common base class helping in reduced changes required.

### Changes

1. Move the array of agents to a common base PHP class.
1. Move the list of agents to base twig file.

## How to test

1. Check if aggregated license view and file browser view works fine.
1. Check if SPDX agent works fine.