### PR TITLE
fix(bulk): Fix dropdown bulk on folder level

### DIFF
--- a/src/lib/php/UI/template/include/foot.html.twig
+++ b/src/lib/php/UI/template/include/foot.html.twig
@@ -10,9 +10,16 @@
 <script type="text/javascript">
   function renderSelect2() {
     if(!$('.ui-render-select2').attr("size") > 0) {
-      $('.ui-render-select2').select2({
-        width: 'style',
-        dropdownAutoWidth : true
+      $('.ui-render-select2').each(function() {
+        var dropdownParent = $(document.body);
+        if ($(this).parents('.modal').length !== 0) {
+          dropdownParent = $(this).parents('.modal');
+        }
+        $(this).select2({
+          width: 'style',
+          dropdownAutoWidth : true,
+          dropdownParent: dropdownParent
+        });
       });
     }
   }

--- a/src/www/ui/scripts/change-license-browse.js
+++ b/src/www/ui/scripts/change-license-browse.js
@@ -1,16 +1,16 @@
 /*
  Copyright (C) 2014-2018, Siemens AG
  Author: Daniele Fognini, Johannes Najjar
- 
+
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
  version 2 as published by the Free Software Foundation.
- 
+
  This program is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License along
  with this program; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -116,4 +116,17 @@ function deleteMarkedDecisions() {
       error: function(responseobject) { scheduledDeciderError(responseobject, resultEntity); }
       });
   }
+}
+
+function cleanText() {
+  var $textField = $('#bulkRefText');
+  var text = $textField.val();
+
+  text = text.replace(/ [ ]*/gi, ' ')
+             .replace(/(^|\n)[ \t]*/gi,'$1')
+             .replace(/(^|\n) ?\/[\*\/]+/gi, '$1')
+             .replace(/[\*]+\//gi, '')
+             .replace(/(^|\n) ?#+/gi,'$1')
+             ;
+  $textField.val(text);
 }

--- a/src/www/ui/scripts/change-license-view.js
+++ b/src/www/ui/scripts/change-license-view.js
@@ -1,16 +1,16 @@
 /*
  Copyright (C) 2014-2018, Siemens AG
  Author: Daniele Fognini, Johannes Najjar
- 
+
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
  version 2 as published by the Free Software Foundation.
- 
+
  This program is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License along
  with this program; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.

--- a/src/www/ui/template/browse_file.js.twig
+++ b/src/www/ui/template/browse_file.js.twig
@@ -68,7 +68,7 @@ function createDirlistTable() {
 
 $(document).ready(function () {
   createDirlistTable();
-  $(document).tooltip();
+  $('img').tooltip();
   $("#lichistogram_length select").css('text-align','right');
   $("#dirlist_length select").css('text-align','right');
 

--- a/src/www/ui/template/file-browse.js.twig
+++ b/src/www/ui/template/file-browse.js.twig
@@ -49,8 +49,8 @@ function createDirlistTable() {
 
 $(document).ready(function () {
   createDirlistTable();
-  $(document).tooltip();
+  $('img').tooltip();
   $("#lichistogram_length select").css('text-align','right');
-  $("#dirlist_length select").css('text-align','right');  
+  $("#dirlist_length select").css('text-align','right');
 });
 


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The dropdown in modal view for bulk option in aggregated license view was not rendering.

This PR uses `dropdownParent` property of `select2` to fix the issue.

### Changes

1. Change the `dropdownParent` of any `ui-render-select2` element which has a parent class `.modal`.
1. Change the call to `tooltip` class from `$(document)` to `$('img')`.

## How to test

1. Upload a package and goto aggregated license browser.
1. Select `[Bulk]`.
    1. Check if the dropdown renders properly.
1. Check if other occurances of `select2` are not effected.