### PR TITLE
feat(rest): Add group context (groupName param) for REST Api calls

### DIFF
--- a/src/www/ui/api/Middlewares/RestAuthMiddleware.php
+++ b/src/www/ui/api/Middlewares/RestAuthMiddleware.php
@@ -70,8 +70,21 @@ class RestAuthMiddleware
         $tokenValid = new Info(403, "Do not have required scope.", InfoType::ERROR);
       }
       if ($tokenValid === true) {
-        $authHelper->updateUserSession($userId, $tokenScope);
-        $response = $next($request, $response);
+        $groupName = "";
+        $groupName = strval($request->getHeaderLine('groupName'));
+        if (!empty($groupName)) { // if request contains groupName
+          $userHasGroupAccess = $authHelper->userHasGroupAccess($userId, $groupName);
+          if ($userHasGroupAccess === true) {
+            $authHelper->updateUserSession($userId, $tokenScope, $groupName);
+            $response = $next($request, $response);
+          } else { // no group access or group does not exist
+            $response = $response->withJson($userHasGroupAccess->getArray(),
+            $userHasGroupAccess->getCode());
+          }
+        } else { // no groupName passed, use defult groupId saved in DB
+          $authHelper->updateUserSession($userId, $tokenScope);
+          $response = $next($request, $response);
+        }
       } else {
         $response = $response->withJson($tokenValid->getArray(),
           $tokenValid->getCode());

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -14,7 +14,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.0.9
+  version: 1.0.10
   contact:
     email: fossology@fossology.org
   license:
@@ -172,6 +172,14 @@ paths:
         - Upload
         - Organize
       summary: Delete upload by id
+      parameters:
+        - name: groupName
+          description: The group name to chose while deleting the package
+          in: header
+          required: false
+          schema:
+            type: string
+            description: Group name, from last login if not provided  
       responses:
         '202':
           description: Upload will be deleted
@@ -193,6 +201,13 @@ paths:
           required: true
           schema:
             type: integer
+        - name: groupName
+          description: The group name to chose while changing the package
+          in: header
+          required: false
+          schema:
+            type: string
+            description: Group name, from last login if not provided
       responses:
         '202':
           description: Upload will be moved
@@ -298,6 +313,13 @@ paths:
           schema:
             type: integer
             description: Group id, from last login if not provided
+        - name: groupName
+          description: The group name to chose while uploading the package
+          in: header
+          required: false
+          schema:
+            type: string
+            description: Group name, from last login if not provided    
       responses:
         '201':
           description: Upload is created
@@ -351,6 +373,13 @@ paths:
           - Search
         description: Search the FOSSology for a specific file
         parameters:
+          - name: groupName
+            description: The group name to chose while performing search
+            in: header
+            required: false
+            schema:
+              type: string
+              description: Group name, from last login if not provided
           - name: searchType
             # use 'allfiles', if not given
             required: false
@@ -522,6 +551,13 @@ paths:
             required: true
             schema:
               type: integer
+          - name: groupName
+            description: The group name to chose while scheduling jobs
+            in: header
+            required: false
+            schema:
+              type: string
+              description: Group name, from last login if not provided    
         requestBody:
           description: Agents to be scheduled with the job
           required: true
@@ -736,6 +772,13 @@ paths:
               - spdx2tv
               - readmeoss
               - unifiedreport
+        - name: groupName
+          description: The group name to chose while generating a report
+          in: header
+          required: false
+          schema:
+            type: string
+            description: Group name, from last login if not provided      
       responses:
         '201':
           description: Report generation is scheduled. Link to download report will be in message
@@ -753,6 +796,13 @@ paths:
         description: Id the report to download
         schema:
           type: integer
+      - name: groupName
+        description: The group name to chose while downloading specific report
+        in: header
+        required: false
+        schema:
+          type: string
+          description: Group name, from last login if not provided    
     get:
       tags:
       - Job


### PR DESCRIPTION
## Description

PR adds option to provide groupName for REST  API calls, to do stuff in given groupName context (not the one set in DB as user-default group)

Fixes #1529 , while previous PR #1498 will no longer be needed.

### Changes

REST API accepts additional parameter (groupName) which changes behaviour only for subset of possible paths (please see openapi.yaml file)

RestAuthMiddleware verifies given group existence and user access - if user has no access to given group or group does not exist, error is returned.
In case of positive verification, AuthHelper.updateUserSession method is called with proper paremetrs, to alter and set correct group for specific user session

## How to test

Try to call REST APi with/without additional groupName parameter to verify if things are done for proper group (passed or not by user), using also group that does not exist or group that user has no access to.
