### PR TITLE
fix(nomos) : CC-BY-SA identification

### DIFF
--- a/src/nomos/agent/STRINGS.in
+++ b/src/nomos/agent/STRINGS.in
@@ -7833,7 +7833,7 @@ k
 #
 %ENTRY% _TITLE_CC_BY_SA
 %KEY% "a(gree|ttribut|vailabl|uthor)"
-%STR% "creative commons attribution[ -]share[ -]alike"
+%STR% "creative commons attribution[ -]share.?alike"
 #
 %ENTRY% _TITLE_CC_BY_SA_10
 %KEY% "a(gree|ttribut|vailabl|uthor)"


### PR DESCRIPTION
Signed-off-by: Anupam Ghosh <anupam.ghosh@siemens.com>

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

FOSSology does not identify the following phrase:
"This document may be reused under a Creative Commons Attribution-ShareAlike
License."
Nomos identifies it as CCPL.
