### PR TITLE
perf(ui): Reduce load time for license browser

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -71,41 +71,40 @@ class ClearingDao
     $sql_upload = "";
     if ('uploadtree' === $uploadTreeTable || 'uploadtree_a' === $uploadTreeTable) {
       $params[] = $itemTreeBounds->getUploadId(); $p = "$". count($params);
-      $sql_upload = "ut.upload_fk=$p AND ";
+      $sql_upload = " AND ut.upload_fk=$p";
     }
     if (!empty($condition)) {
       $statementName .= ".(".$condition.")";
-      $condition .= " AND ";
+      $condition = " AND $condition";
     }
 
     $filterClause = $onlyCurrent ? "DISTINCT ON(itemid)" : "";
+    $sortClause = $onlyCurrent ? "ORDER BY itemid, scope, id DESC" : "";
 
     $statementName .= "." . $uploadTreeTable . ($onlyCurrent ? ".current": "");
 
     $globalScope = DecisionScopes::REPO;
     $localScope = DecisionScopes::ITEM;
 
-    return "WITH allDecs AS (
+    return "WITH decision AS (
               SELECT
+                $filterClause
                 cd.clearing_decision_pk AS id,
                 cd.pfile_fk AS pfile_id,
                 ut.uploadtree_pk AS itemid,
                 cd.user_fk AS user_id,
                 cd.decision_type AS type_id,
                 cd.scope AS scope,
-                EXTRACT(EPOCH FROM cd.date_added) AS ts_added,
-                CASE cd.scope WHEN $globalScope THEN 1 ELSE 0 END AS scopesort
+                EXTRACT(EPOCH FROM cd.date_added) AS ts_added
               FROM clearing_decision cd
                 INNER JOIN $uploadTreeTable ut
-                  ON (ut.pfile_fk = cd.pfile_fk AND cd.scope = $globalScope)
+                  ON (
+                    (ut.pfile_fk = cd.pfile_fk AND cd.scope = $globalScope)
                     OR (ut.uploadtree_pk = cd.uploadtree_fk
-                      AND cd.scope = $localScope AND cd.group_fk = $p2)
-              WHERE $sql_upload $condition
-                cd.decision_type!=$p1),
-            decision AS (
-              SELECT $filterClause *
-              FROM allDecs
-              ORDER BY itemid, scopesort, id DESC
+                      AND cd.scope = $localScope AND cd.group_fk = $p2))
+                  $sql_upload $condition
+              WHERE cd.decision_type != $p1
+              $sortClause
             )";
   }
 
@@ -130,9 +129,10 @@ class ClearingDao
               lr.rf_fullname AS fullname
             FROM decision
               INNER JOIN clearing_decision_event cde ON cde.clearing_decision_fk = decision.id
-              INNER JOIN clearing_event ce ON ce.clearing_event_pk = cde.clearing_event_fk
+              INNER JOIN clearing_event ce ON
+                (ce.clearing_event_pk = cde.clearing_event_fk AND NOT ce.removed)
               INNER JOIN license_ref lr ON lr.rf_pk = ce.rf_fk
-            WHERE NOT ce.removed AND type_id!=$".count($params)."
+            WHERE type_id != $".count($params)."
             GROUP BY license_id,shortname,fullname";
 
     $this->dbManager->prepare($statementName, $sql);
@@ -870,14 +870,14 @@ INSERT INTO clearing_decision (
       $this->dbManager->prepare($statementName, $decisionsCte
           .' INSERT INTO clearing_decision (uploadtree_fk,pfile_fk,user_fk,group_fk,decision_type,scope)
              SELECT itemid,pfile_id, $'.$a.', $'.($a+1).', $'.($a+2).', $'.($a+3).'
-               FROM allDecs ad WHERE type_id != $'.($a+2));
+               FROM decision ad WHERE type_id != $'.($a+2));
     } else {
       $params[] = $decisionMark;
       $a = count($params);
       $this->dbManager->prepare($statementName, $decisionsCte
           .' DELETE FROM clearing_decision WHERE decision_type = $'.$a.'
                 AND clearing_decision_pk IN (
-             SELECT id FROM allDecs WHERE type_id = $'.$a.')');
+             SELECT id FROM decision WHERE type_id = $'.$a.')');
     }
     $res = $this->dbManager->execute($statementName,$params);
     $this->dbManager->freeResult($res);
@@ -983,76 +983,6 @@ INSERT INTO clearing_decision (
     } else {
       return count(array_unique($bulkIds));
     }
-  }
-
-  /**
-   * Get the count of items cleared for the given upload from
-   * clearing_decision table.
-   * @param integer $uploadId Upload id
-   * @param integer $groupId  Group id for the decisions
-   * @return integer Number of items cleared.
-   */
-  public function getClearingDecisionsCount($uploadId, $groupId)
-  {
-    $itemTreeBounds = $this->uploadDao->getParentItemBounds($uploadId);
-    $statementName = "";
-    $params = array();
-
-    $cte = $this->getRelevantDecisionsCte($itemTreeBounds, $groupId, true,
-      $statementName, $params);
-
-    $statementName = __METHOD__ . $statementName;
-    $sql = "$cte SELECT COUNT(*) AS cnt FROM decision WHERE type_id <> ".DecisionTypes::TO_BE_DISCUSSED;
-
-    $clearedCounter = $this->dbManager->getSingleRow($sql, $params,
-      $statementName);
-    return $clearedCounter['cnt'];
-  }
-
-  /**
-   * Get the count of items with either agent license finding or user license
-   * finding.
-   * @param integer $uploadId Upload id
-   * @param integer $groupId  Group id
-   * @return integer Number of items with license findings.
-   */
-  public function getTotalDecisionCount($uploadId, $groupId)
-  {
-    $uploadTreeTable = $this->uploadDao->getUploadtreeTableName($uploadId);
-    $scanJobProxy = new ScanJobProxy($GLOBALS['container']->get('dao.agent'), $uploadId);
-    $scanJobProxy->createAgentStatus(array_keys(AgentRef::AGENT_LIST));
-    $latestAgentIds = $scanJobProxy->getLatestSuccessfulAgentIds();
-    $agentIds = "{" . implode(",", $latestAgentIds) . "}";
-
-    $globalScope = DecisionScopes::REPO;
-    $params = array($groupId, $uploadId, $agentIds);
-    $statement = __METHOD__ . "." . $uploadTreeTable;
-    $sql = "
-WITH allDecs AS (
-  SELECT DISTINCT ON (ut.uploadtree_pk) * FROM $uploadTreeTable AS ut
-    LEFT JOIN license_file AS lf
-      ON lf.pfile_fk = ut.pfile_fk
-      AND lf.agent_fk = ANY($3::int[])
-      AND lf.rf_fk NOT IN (SELECT rf_pk FROM license_ref
-        WHERE rf_shortname = ANY(VALUES('No_license_found'),('Void'))
-      )
-      AND lf.rf_fk IS NOT NULL
-    LEFT JOIN clearing_decision AS cd ON
-      (ut.uploadtree_pk = cd.uploadtree_fk)
-      OR (ut.pfile_fk = cd.pfile_fk AND cd.scope = $globalScope)
-      AND cd.group_fk = $1
-  WHERE ut.upload_fk = $2 AND (
-    CASE
-      WHEN lf.fl_pk IS NULL AND cd.clearing_decision_pk IS NULL
-        THEN FALSE
-        ELSE TRUE
-      END
-  )
-)
-SELECT count(*) AS cnt
-FROM (SELECT DISTINCT uploadtree_pk FROM allDecs) AS no_license_uploadtree;";
-    $foundCounter = $this->dbManager->getSingleRow($sql, $params, $statement);
-    return $foundCounter['cnt'];
   }
 
   /**

--- a/src/lib/php/Data/ClearingDecision.php
+++ b/src/lib/php/Data/ClearingDecision.php
@@ -234,7 +234,9 @@ class ClearingDecision
   {
     $output = "ClearingDecision(#" . $this->clearingId . ", ";
 
-    foreach ($this->clearingLicenses as $clearingLicense) {
+    $clearingLicenses = $this->getClearingLicenses();
+
+    foreach ($clearingLicenses as $clearingLicense) {
       $output .= ($clearingLicense->isRemoved() ? "-" : ""). $clearingLicense->getShortName() . ", ";
     }
 

--- a/src/lib/php/Proxy/UploadTreeProxy.php
+++ b/src/lib/php/Proxy/UploadTreeProxy.php
@@ -37,6 +37,7 @@ class UploadTreeProxy extends DbViewProxy
   const OPT_SCAN_REF = 'scanRef';
   const OPT_CONCLUDE_REF = 'conRef';
   const OPT_SKIP_ALREADY_CLEARED = 'alreadyCleared';
+  const OPT_ONLY_MAIN_LICENSE = 'onlyMainLicense';
 
   /** @var string */
   private $uploadTreeTableName;
@@ -116,10 +117,10 @@ class UploadTreeProxy extends DbViewProxy
       $this->dbViewName .= "_".self::OPT_SKIP_ALREADY_CLEARED;
       $groupAlias = $this->addParamAndGetExpr('groupId', $options[self::OPT_GROUP_ID]);
       if (array_key_exists(self::OPT_RANGE, $options)) {
-        $filter .= ' AND '.self::getQueryCondition(self::OPT_SKIP_ALREADY_CLEARED, $groupAlias, $agentFilter);
+        $filter .= ' AND '.self::getQueryCondition(self::OPT_SKIP_ALREADY_CLEARED, $options, $groupAlias, $agentFilter);
       } elseif (array_key_exists(self::OPT_SKIP_ALREADY_CLEARED, $options) && array_key_exists(self::OPT_GROUP_ID, $options)
               && array_key_exists(self::OPT_AGENT_SET, $options) && array_key_exists(self::OPT_REALPARENT, $options)) {
-        $childFilter = self::getQueryCondition(self::OPT_SKIP_ALREADY_CLEARED, $groupAlias, $agentFilter);
+        $childFilter = self::getQueryCondition(self::OPT_SKIP_ALREADY_CLEARED, $options, $groupAlias, $agentFilter);
         $filter .= ' AND EXISTS(SELECT * FROM '.$this->uploadTreeTableName.' utc WHERE utc.upload_fk='.$this->uploadId
                 . ' AND (utc.lft BETWEEN ut.lft AND ut.rgt) AND utc.ufile_mode&(3<<28)=0 AND '
                    .preg_replace('/([a-z])ut\./', '\1utc.', $childFilter).')';
@@ -230,7 +231,7 @@ class UploadTreeProxy extends DbViewProxy
       case "noCopyright":
       case "noEcc":
 
-        $queryCondition = self::getQueryCondition($skipThese, $groupId, $agentFilter)." ".$additionalCondition;
+        $queryCondition = self::getQueryCondition($skipThese, $options, $groupId, $agentFilter)." ".$additionalCondition;
         if ('uploadtree' === $uploadTreeTableName || 'uploadtree_a' == $uploadTreeTableName) {
           $queryCondition = "ut.upload_fk=$uploadId AND ($queryCondition)";
         }
@@ -257,12 +258,12 @@ class UploadTreeProxy extends DbViewProxy
 
     if (array_key_exists(self::OPT_AGENT_SET, $options)) {
       $agentIds = 'array[' . implode(',',$options[self::OPT_AGENT_SET]) . ']';
-      $agentFilter = " AND lf.agent_fk=ANY($agentIds)";
+      $agentFilter = " AND lf.agent_fk = ANY($agentIds)";
     } else {
       $scanJobProxy = new ScanJobProxy($GLOBALS['container']->get('dao.agent'),$uploadId);
       $scanJobProxy->createAgentStatus(array_keys(AgentRef::AGENT_LIST));
       $latestAgentIds = $scanJobProxy->getLatestSuccessfulAgentIds();
-      $agentFilter = $latestAgentIds ? " AND lf.agent_fk=ANY(array[".implode(',',$latestAgentIds)."])" : "AND 0=1";
+      $agentFilter = $latestAgentIds ? " AND lf.agent_fk = ANY(array[".implode(',',$latestAgentIds)."])" : "AND 0=1";
     }
     return $agentFilter;
   }
@@ -271,30 +272,32 @@ class UploadTreeProxy extends DbViewProxy
    * @param $skipThese
    * @return string
    */
-  private static function getQueryCondition($skipThese, $groupId = null, $agentFilter='')
+  private static function getQueryCondition($skipThese, $options, $groupId = null, $agentFilter='')
   {
-    $conditionQueryHasLicense = "(EXISTS (SELECT 1 FROM license_ref lr INNER JOIN license_file lf"
-      . " ON lf.rf_fk=lr.rf_pk WHERE rf_shortname NOT IN ('No_license_found', 'Void') AND lf.pfile_fk = ut.pfile_fk $agentFilter LIMIT 1)
-        OR EXISTS (SELECT 1 FROM clearing_decision AS cd WHERE cd.group_fk = $groupId AND ut.uploadtree_pk = cd.uploadtree_fk LIMIT 1))";
+    $only = "";
+    if (array_key_exists(self::OPT_ONLY_MAIN_LICENSE, $options)) {
+      $only = "ONLY";
+    }
+    $conditionQueryHasLicense = "(EXISTS (SELECT 1 FROM $only license_ref lr INNER JOIN license_file lf"
+      . " ON lf.rf_fk=lr.rf_pk AND lf.pfile_fk = ut.pfile_fk $agentFilter WHERE rf_shortname NOT IN ('No_license_found', 'Void'))
+          OR EXISTS (SELECT 1 FROM clearing_decision AS cd WHERE cd.group_fk = $groupId AND ut.uploadtree_pk = cd.uploadtree_fk))";
 
     switch ($skipThese) {
       case "noLicense":
         return $conditionQueryHasLicense;
       case self::OPT_SKIP_ALREADY_CLEARED:
         $decisionQuery = "
-SELECT decision_type, ROW_NUMBER() OVER (
-  PARTITION BY pfile_fk ORDER BY clearing_decision_pk
-) AS rnum
-FROM (
-  SELECT * FROM clearing_decision cd
-  WHERE (
-    ut.uploadtree_pk = cd.uploadtree_fk AND cd.group_fk = $groupId
-  ) OR (
-    cd.pfile_fk = ut.pfile_fk AND cd.scope=".DecisionScopes::REPO."
-  )
-) AS filtered_clearing_decision ORDER BY rnum DESC LIMIT 1";
+SELECT cd.decision_type
+FROM clearing_decision cd
+WHERE (
+  ut.uploadtree_pk = cd.uploadtree_fk AND cd.group_fk = $groupId
+  AND cd.scope = ".DecisionScopes::ITEM."
+) OR (
+  cd.pfile_fk = ut.pfile_fk AND cd.scope=".DecisionScopes::REPO."
+)
+ORDER BY cd.clearing_decision_pk DESC LIMIT 1";
         return " $conditionQueryHasLicense
-            AND NOT EXISTS (SELECT 1 FROM ($decisionQuery) as latest_decision WHERE latest_decision.decision_type IN (".DecisionTypes::IRRELEVANT.",".DecisionTypes::IDENTIFIED.",".DecisionTypes::DO_NOT_USE.") )";
+            AND NOT EXISTS (SELECT 1 FROM ($decisionQuery) AS latest_decision WHERE latest_decision.decision_type IN (".DecisionTypes::IRRELEVANT.",".DecisionTypes::IDENTIFIED.",".DecisionTypes::DO_NOT_USE."))";
       case "noCopyright":
         return "EXISTS (SELECT copyright_pk FROM copyright cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null )";
       case "noEcc":

--- a/src/lib/php/Proxy/test/UploadTreeProxyTest.php
+++ b/src/lib/php/Proxy/test/UploadTreeProxyTest.php
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 namespace Fossology\Lib\Proxy;
 
+use Fossology\Lib\Data\DecisionScopes;
 use Fossology\Lib\Data\DecisionTypes;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
 use Fossology\Lib\Test\TestPgDb;
@@ -223,10 +224,10 @@ class UploadTreeProxyTest extends \PHPUnit\Framework\TestCase
     assertThat($zipDescendantsT, equalTo(array(103)) );
   }
 
-  protected function insertDecisionEvent($decisionId,$eventId,$rfId,$groupId,$item,$pfileId,$type,$removed,$date)
+  protected function insertDecisionEvent($decisionId,$eventId,$rfId,$groupId,$item,$pfileId,$type,$removed,$date,$scope=DecisionScopes::ITEM)
   {
     $this->dbManager->insertTableRow('clearing_decision',array('clearing_decision_pk'=>$decisionId,'pfile_fk'=>$pfileId,'uploadtree_fk'=>$item,
-        'group_fk'=>$groupId,'date_added'=>$date,'decision_type'=> $type));
+        'group_fk'=>$groupId,'date_added'=>$date,'decision_type'=> $type,'scope'=>$scope));
     $this->dbManager->insertTableRow('clearing_event',array('clearing_event_pk'=>$eventId,'rf_fk'=>$rfId,'group_fk'=>$groupId,'uploadtree_fk'=>$item,
         'date_added'=>$date,'removed'=>$removed));
     if ($type != DecisionTypes::WIP) {

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -2195,11 +2195,12 @@
   $Schema["INDEX"]["clearing_decision"]["clearing_decision_group_fk_idx"] = "CREATE INDEX clearing_decision_group_fk_idx ON clearing_decision USING btree (group_fk);";
   $Schema["INDEX"]["clearing_decision"]["clearing_decision_uploadtree_group_pfile_idx"] = "CREATE INDEX clearing_decision_uploadtree_group_pfile_idx ON clearing_decision USING btree (uploadtree_fk, group_fk, pfile_fk);";
 
-  $Schema["INDEX"]["clearing_decision_event"]["clearing_decision_event_clearing_fk_idx"] = "CREATE INDEX clearing_decision_event_clearing_fk_idx ON clearing_decision_event USING btree (clearing_decision_fk);";
+  $Schema["INDEX"]["clearing_decision_event"]["clearing_decision_event_idx"] = "CREATE INDEX clearing_decision_event_idx ON clearing_decision_event USING btree (clearing_decision_fk, clearing_event_fk);";
 
   $Schema["INDEX"]["clearing_event"]["clearing_event_job_fk_idx"] = "CREATE INDEX clearing_event_job_fk_idx ON clearing_event USING btree (job_fk);";
   $Schema["INDEX"]["clearing_event"]["clearing_event_uploadtree_fk_idx"] = "CREATE INDEX clearing_event_uploadtree_fk_idx ON clearing_event USING btree (uploadtree_fk);";
   $Schema["INDEX"]["clearing_event"]["clearing_event_uploadtree_group_fk_idx"] = "CREATE INDEX clearing_event_uploadtree_group_fk_idx ON clearing_event USING btree (uploadtree_fk, group_fk, date_added);";
+  $Schema["INDEX"]["clearing_event"]["clearing_event_pk_removed_idx"] = "CREATE INDEX clearing_event_pk_removed_idx ON clearing_event USING btree(clearing_event_pk, removed, rf_fk) WHERE NOT removed;";
 
   $Schema["INDEX"]["copyright"]["copyright_agent_fk_idx"] = "CREATE INDEX copyright_agent_fk_idx ON copyright USING btree (agent_fk);";
   $Schema["INDEX"]["copyright"]["copyright_pfile_fk_index"] = "CREATE INDEX copyright_pfile_fk_index ON copyright USING btree (pfile_fk);";

--- a/src/www/ui/ui-clearing-view.php
+++ b/src/www/ui/ui-clearing-view.php
@@ -301,12 +301,22 @@ class ClearingView extends FO_Plugin
     $this->vars['tmpClearingType'] = $this->clearingDao->isDecisionWip($uploadTreeId, $groupId);
     $this->vars['bulkHistory'] = $bulkHistory;
 
-    $filesOfInterest = $this->clearingDao->getTotalDecisionCount($uploadId,
-      $groupId);
-    $filesCleared = $this->clearingDao->getClearingDecisionsCount($uploadId,
-      $groupId);
+    $noLicenseUploadTreeView = new UploadTreeProxy($uploadId,
+      array(UploadTreeProxy::OPT_SKIP_THESE => "noLicense",
+        UploadTreeProxy::OPT_GROUP_ID => $groupId),
+      $uploadTreeTableName,
+      'no_license_uploadtree' . $uploadId);
+    $filesOfInterest = $noLicenseUploadTreeView->count();
 
-    $this->vars['message'] = _("Cleared").": $filesCleared/$filesOfInterest";
+    $nonClearedUploadTreeView = new UploadTreeProxy($uploadId,
+      array(UploadTreeProxy::OPT_SKIP_THESE => "alreadyCleared",
+        UploadTreeProxy::OPT_GROUP_ID => $groupId),
+      $uploadTreeTableName,
+      'already_cleared_uploadtree' . $uploadId);
+    $filesToBeCleared = $nonClearedUploadTreeView->count();
+
+    $filesAlreadyCleared = $filesOfInterest - $filesToBeCleared;
+    $this->vars['message'] = _("Cleared").": $filesAlreadyCleared/$filesOfInterest";
 
     return $this->render("ui-clearing-view.html.twig");
   }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The PR tries to improve the load time of tree view by optimizing some SQL queries, reducing calls to DB and introducing new indexes.

### Changes

1. Update CTE provided by `ClearingDao::getRelevantDecisionsCte()` to sort and unique only if required and reduce CTE count from 2 to 1 (will benefit PG < 12).
2. Remove `getClearingDecisionsCount()` and `getClearingDecisionsCount()` as they are no longer helpful.
3. Update `UploadTreeProxy::getQueryCondition()` to use simple SORT and DISTINCT instead of WindowAgg.
4. In `AjaxExplorer`, new function `updateFilesToBeCleared()` to cache itemtree bounds which are already calculated to reduce DB reads.
5. Updated index `clearing_decision_event_clearing_fk_idx` to include `clearing_event_fk` making join on cde as `INDEX ONLY SCAN`.
6. New index `clearing_event_pk_removed_idx` to optimize ajax view query.

## How to test
1. Upload a package.
1. Do some clearing with both Global and Local decisions.
1. Upload the same package again.
    1. Check if global decisions are reflected.
    1. Previous local decisions are not effected.
    1. New local decisions on the package does not effect previous package.
    1. New global decisions on new package are reflected on previous package.
1. Check that **to be discussed** decisions are not counted while finding the number of files cleared in single file view.
1. Overall significant improvement on load time.
1. Folders with single file (example `Folder/Folder/File`) should show respective license names and clearing status as they are expanded by License Browser.