### PR TITLE
feat(auth): Add external authentification feature

### DIFF
--- a/install/defconf/fossology.conf.in
+++ b/install/defconf/fossology.conf.in
@@ -77,6 +77,17 @@ PROJECTSTATEDIR=$LOCALSTATEDIR/lib/$PROJECT
 ; cache folder
 CACHEDIR=$LOCALSTATEDIR/cache/$PROJECT
 
+; Use external Authentication
+CONF_EXT_AUTH_ENABLE=false
+; Environment variable where to find the User name
+CONF_EXT_AUTH_ENV_USER=
+; Environment variable where to find the User email
+CONF_EXT_AUTH_ENV_MAIL=
+; Environment variable where to find the User Description
+CONF_EXT_AUTH_ENV_DESC=
+; Set to true to use lowercase usernames
+CONF_EXT_AUTH_ENV_LOWERCASE_USER=
+
 ; project logdir
 LOGDIR=/var/log/$PROJECT
 

--- a/src/lib/php/common-auth.php
+++ b/src/lib/php/common-auth.php
@@ -42,7 +42,36 @@ function siteminder_check()
 } // siteminder_check()
 
 /**
- * \brief Check if this account is correct
+ * \brief Check if the external HTTP authentication is enabled.
+ *  The mapping variables should be configured in fossology.conf
+ *  Usernames are forced lowercase.
+ * \return false if not enabled
+ */
+function auth_external_check()
+{
+  $EXT_AUTH_ENABLE = array_key_exists('CONF_EXT_AUTH_ENABLE', $GLOBALS) ? $GLOBALS['CONF_EXT_AUTH_ENABLE'] : false;
+  if ($EXT_AUTH_ENABLE) {
+    $EXT_AUTH_USER = $_SERVER[$GLOBALS['CONF_EXT_AUTH_ENV_USER']];
+    $EXT_AUTH_LOWERCASE = array_key_exists('CONF_EXT_AUTH_ENV_LOWERCASE_USER', $GLOBALS) ? $GLOBALS['CONF_EXT_AUTH_ENV_LOWERCASE_USER'] : false;
+    if ($EXT_AUTH_LOWERCASE) {
+        $EXT_AUTH_USER = strtolower($EXT_AUTH_USER);
+    }
+    $EXT_AUTH_MAIL = $_SERVER[$GLOBALS['CONF_EXT_AUTH_ENV_MAIL']];
+    $EXT_AUTH_DESC = $_SERVER[$GLOBALS['CONF_EXT_AUTH_ENV_DESC']];
+    if (isset($EXT_AUTH_USER) && !empty($EXT_AUTH_USER)) {
+      $out['useAuthExternal']         = true;
+      $out['loginAuthExternal']       = $EXT_AUTH_USER;
+      $out['passwordAuthExternal']    = sha1($EXT_AUTH_USER);
+      $out['emailAuthExternal']       = $EXT_AUTH_MAIL;
+      $out['descriptionAuthExternal'] = $EXT_AUTH_DESC;
+      return $out;
+    }
+  }
+  return $out['useAuthExternal'] = false;
+}
+
+/**
+ * \brief check if this account is correct
  *
  * \param string &$user   User name, reference variable
  * \param string &$passwd Password, reference variable

--- a/src/www/ui/core-auth.php
+++ b/src/www/ui/core-auth.php
@@ -95,8 +95,7 @@ class core_auth extends FO_Plugin
       $this->checkUsernameAndPassword($this->authExternal['loginAuthExternal'], $this->authExternal['passwordAuthExternal']);
     }
 
-    if (array_key_exists('selectMemberGroup', $_POST))
-    {
+    if (array_key_exists('selectMemberGroup', $_POST)) {
       $selectedGroupId = intval($_POST['selectMemberGroup']);
       $this->userDao->setDefaultGroupMembership(intval($_SESSION[Auth::USER_ID]), $selectedGroupId);
       $_SESSION[Auth::GROUP_ID] = $selectedGroupId;
@@ -261,34 +260,32 @@ class core_auth extends FO_Plugin
    */
   function checkUsernameAndPassword($userName, $password)
   {
-      //Check the user for external authentication
-      if ($this->authExternal['useAuthExternal']) {
-        $username = $this->authExternal['loginAuthExternal'];
-        //checking if user exist
-        try {
-          $this->userDao->getUserAndDefaultGroupByUserName($username);
-        } catch (Exception $e) {
-            // If user does not exist then we create it
-            $User = trim(str_replace("'", "''", $this->authExternal['loginAuthExternal']));
-            $Pass = $this->authExternal['passwordAuthExternal'] ;
-            $Seed = rand() . rand();
-            $Hash = sha1($Seed . $Pass);
-            $Desc = $this->authExternal['descriptionAuthExternal'];
-            $Perm = 3;
-            $Folder = 1;
-            $Email_notify = "y";
-            $Email = $this->authExternal['emailAuthExternal'];
-            // Set default list of agents when a new user is created
-            $agentList = "agent_bucket,agent_copyright,agent_keyword,agent_mimetype,agent_monk,agent_nomos,agent_ojo";
-            $default_bucketpool_fk = 2;
-            $this->user-add_user($User,$Desc,$Seed,$Hash,$Perm,$Email,
-                $Email_notify,$agentList,$Folder, $default_bucketpool_fk);
-          }
+    /* Check the user for external authentication */
+    if ($this->authExternal['useAuthExternal']) {
+      $username = $this->authExternal['loginAuthExternal'];
+      /* checking if user exist */
+      try {
+        $this->userDao->getUserAndDefaultGroupByUserName($username);
+      } catch (Exception $e) {
+        /* If user does not exist then we create it */
+        $User = trim(str_replace("'", "''", $this->authExternal['loginAuthExternal']));
+        $Pass = $this->authExternal['passwordAuthExternal'] ;
+        $Seed = rand() . rand();
+        $Hash = sha1($Seed . $Pass);
+        $Desc = $this->authExternal['descriptionAuthExternal'];
+        $Perm = 3;
+        $Folder = 1;
+        $Email_notify = "y";
+        $Email = $this->authExternal['emailAuthExternal'];
+        /* Set default list of agents when a new user is created */
+        $agentList = "agent_bucket,agent_copyright,agent_keyword,agent_mimetype,agent_monk,agent_nomos,agent_ojo";
+        $default_bucketpool_fk = 2;
+        $this->user-add_user($User,$Desc,$Seed,$Hash,$Perm,$Email,
+          $Email_notify,$agentList,$Folder, $default_bucketpool_fk);
       }
-      //End for external authentication
+    }
 
-    if (empty($userName) || $userName == 'Default User')
-    {
+    if (empty($userName) || $userName == 'Default User') {
       return false;
     }
     try {


### PR DESCRIPTION
### Description
Partially fixes #1273 

This PR introduces external authentication, delegated to Apache.
Apache can be configured to perform any kind of authentication, and places relevent information (login, user name, email), etc. in environment variables.
- on first login, the user's account is automatically created
- then a session is opened for the user.

Optionally, all logins may be lower cased.

Further possible improvements:
1. Make the configuration available in the GUI
1. Configure the default list of agents for each newly created user
1. Add the 'logout' feature (logout is ineffective in this version)

### Changes

- Added configuration options in `fossology.conf.in`
- In `src/lib/php/common-auth.php` : new function to check external authentication validity
- In `src/www/ui/core-auth.php` : check authenticatino and create new account if needed

## How to test

Configure the Apache authentication, fossology.conf, and log in.

[Sample configurations](https://github.com/fossology/fossology/issues/1273#issuecomment-576890182)