### PR TITLE
fix(ojo): Add lower limit to license length

### DIFF
--- a/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan
+++ b/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan
@@ -1305,6 +1305,7 @@ File NomosTestfiles/SPDX/GPL-1.0+ contains license(s) GPL-1.0+
 File NomosTestfiles/SPDX/GPL-1.0-or-later contains license(s) GPL-1.0+
 File NomosTestfiles/SPDX/GPL-2.0 contains license(s) GPL-2.0
 File NomosTestfiles/SPDX/GPL-2.0-only contains license(s) GPL-2.0
+File NomosTestfiles/SPDX/GPL-2.0-with-code.js contains license(s) Dual-license,GPL-2.0
 File NomosTestfiles/SPDX/GPL-2.0+ contains license(s) GPL-2.0+
 File NomosTestfiles/SPDX/GPL-2.0-or-later contains license(s) GPL-2.0+
 File NomosTestfiles/SPDX/GPL-3.0 contains license(s) GPL-3.0

--- a/src/nomos/agent_tests/testdata/NomosTestfiles/SPDX/GPL-2.0-with-code.js
+++ b/src/nomos/agent_tests/testdata/NomosTestfiles/SPDX/GPL-2.0-with-code.js
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0
+
+var spdxRegex = "/(SPDX-License-Identifier: .*)/"
+var result = file.match(spdxRegex)
+if (result == null) {
+	return "Missing or malformed SPDX-License-Identifier tag"
+} else {
+	return result[1]
+}

--- a/src/ojo/agent/ojoregex.hpp
+++ b/src/ojo/agent/ojoregex.hpp
@@ -29,19 +29,19 @@
  *
  * -# The regex first finds occurance of `spdx-license-identifier` in the text
  * -# Throw the text `spdx-license-identifier`
- * -# Matches at most 5 identifiers each with max length of 37 (based on
+ * -# Matches at most 5 identifiers each with length between 3 and 37 (based on
  * https://github.com/spdx/license-list-data/tree/master/html)
  */
-#define SPDX_LICENSE_LIST "spdx-licen[cs]e(?:id|[- ]identifier): \\K((?:(?: (?:and|or|with) )?\\(?(?:[\\w\\d\\.\\+\\-]{1,37})\\)?){1,5})"
+#define SPDX_LICENSE_LIST "spdx-licen[cs]e(?:id|[- ]identifier): \\K((?:(?: (?:and|or|with) )?\\(?(?:[\\w\\d\\.\\+\\-]{3,37})\\)?){1,5})"
 /**
  * @def SPDX_LICENSE_NAMES
  * @brief Regex to filter license names from list of license list
  *
  * -# License names will consist of words, digits, dots and hyphens.
- * -# Maximum length of license name will be 37 (based on
+ * -# Length of license names between 3 and 37 (based on
  * https://github.com/spdx/license-list-data/tree/master/html)
  */
-#define SPDX_LICENSE_NAMES "(?: and | or | with )?\\(?([\\w\\d\\.\\+\\-]{1,37})\\)?"
+#define SPDX_LICENSE_NAMES "(?: and | or | with )?\\(?([\\w\\d\\.\\+\\-]{3,37})\\)?"
 /**
  * @def SPDX_DUAL_LICENSE
  * @brief Regex to check if Dual-license

--- a/src/ojo/agent_tests/Functional/regexTest.json
+++ b/src/ojo/agent_tests/Functional/regexTest.json
@@ -201,6 +201,7 @@
   {"file":"../../../nomos/agent_tests/testdata/NomosTestfiles/SPDX/GPL-1.0","results":[{"end":32,"len":7,"license":"GPL-1.0","start":25}]},
   {"file":"../../../nomos/agent_tests/testdata/NomosTestfiles/SPDX/GPL-1.0+","results":[{"end":33,"len":8,"license":"GPL-1.0+","start":25}]},
   {"file":"../../../nomos/agent_tests/testdata/NomosTestfiles/SPDX/GPL-2.0-only","results":[{"end":37,"len":12,"license":"GPL-2.0-only","start":25}]},
+  {"file":"../../../nomos/agent_tests/testdata/NomosTestfiles/SPDX/GPL-2.0-with-code.js","results":[{"end":34,"len":7,"license":"GPL-2.0","start":27}]},
   {"file":"../../../nomos/agent_tests/testdata/NomosTestfiles/SPDX/GPL-2.0-or-later","results":[{"end":41,"len":16,"license":"GPL-2.0-or-later","start":25}]},
   {"file":"../../../nomos/agent_tests/testdata/NomosTestfiles/SPDX/GPL-2.0","results":[{"end":32,"len":7,"license":"GPL-2.0","start":25}]},
   {"file":"../../../nomos/agent_tests/testdata/NomosTestfiles/SPDX/GPL-2.0+","results":[{"end":33,"len":8,"license":"GPL-2.0+","start":25}]},


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

ojo currently had a length limit on license name between 1 and 37.
It is fixed by setting the limit to 3 and 37 as per the licenses in [spdx-license-list-data](https://github.com/spdx/license-list-data/tree/master/html).

### Changes

1. Patch the license length regex to {3,37}

## How to test

1. Scan a file with bogus `SPDX-License-Identifier` of length bellow 3.
1. Scan [checkpatch.pl](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/scripts/checkpatch.pl?h=v5.5-rc7&id=9f3a89926d6dfc30a4fd1bbcb92cc7b218d3786d) from GNU/Linux Kernel.