### PR TITLE
feat(ui): Place DataTables processing at top

### DIFF
--- a/src/www/ui/css/jquery.dataTables.css
+++ b/src/www/ui/css/jquery.dataTables.css
@@ -195,7 +195,7 @@ table.dataTable tr.even td.sorting_3 { background-color: #F9F9FF; }
  */
 .dataTables_processing {
   position: absolute;
-  top: 50%;
+  top: 10%;
   left: 50%;
   width: 250px;
   height: 30px;
@@ -205,8 +205,9 @@ table.dataTable tr.even td.sorting_3 { background-color: #F9F9FF; }
   border: 1px solid #ddd;
   text-align: center;
   color: #999;
-  font-size: 14px;
+  font-size: 12pt;
   background-color: white;
+  z-index: 999;
 }
 
 


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Place the DataTables processing message at top of the table as it might be difficult for user to find it and understand something is going on.

### Changes

1. Change the `top` possition of processing message box to 10% from 50%.
1. Change the `z-index` of message box to `999` to keep it on top.

## How to test

1. Check the loading on following pages:
    1. Browse
    1. License Browser
    1. File Browser
    1. Change concluded License
    1. Copyright Browser