### PR TITLE
fix(decider): do not add global decisions through ojo

### DIFF
--- a/src/decider/agent/DeciderAgent.php
+++ b/src/decider/agent/DeciderAgent.php
@@ -281,7 +281,7 @@ class DeciderAgent extends Agent
     }
 
     if ($licenseMatchExists) {
-      $this->clearingDecisionProcessor->makeDecisionFromLastEvents($itemTreeBounds, $this->userId, $this->groupId, DecisionTypes::IDENTIFIED, $global=true);
+      $this->clearingDecisionProcessor->makeDecisionFromLastEvents($itemTreeBounds, $this->userId, $this->groupId, DecisionTypes::IDENTIFIED, $global=false);
     }
     return $licenseMatchExists;
   }


### PR DESCRIPTION
closes #1584 
## Description

do not add global decisions through ojo


## How to test

test ojo with ......scanners matches if ojo findings are no contradiction with other findings
