### PR TITLE
fix(apache): Enable fossology on source install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ VERSION
 .vagrant/
 *.orig
 .#*
+tags
 
 # compiled or derived files
 install/db/dbcreate

--- a/Makefile.conf
+++ b/Makefile.conf
@@ -94,6 +94,10 @@ SHELL = /bin/sh
 INSTALL = /usr/bin/install -D
 INSTALL_PROGRAM = $(INSTALL)
 INSTALL_DATA = ${INSTALL} -m 644
+APACHE_CTL = /usr/sbin/apachectl
+APACHE2_EN_SITE = /usr/sbin/a2ensite
+APACHE2_SITE_DIR = /etc/apache2/sites-available
+HTTPD_SITE_DIR = /etc/httpd/conf.d
 MV = mv -f
 ifeq ($(origin CC), default)
 CC = gcc
@@ -144,7 +148,7 @@ export PATH := $(TOP)/src/vendor/bin:$(PATH)
 # directory containing the php iPATHFILE include file
 FOWWWDIR = $(FOSRCDIR)/www/ui
 
-# for use when coverage C code 
+# for use when coverage C code
 FLAG_COV = -O0 -fprofile-arcs -ftest-coverage
 
 # to run phpunit tests

--- a/install/Makefile
+++ b/install/Makefile
@@ -98,6 +98,16 @@ install: all
 	@if [ ! -f $(DESTDIR)$(CONFPATH)/conf/src-install-apache-example.conf -o "$(OVERWRITE)" ]; then \
 		echo "NOTE: using default version for $(DESTDIR)$(CONFPATH)/conf/src-install-apache-example.conf"; \
 	 	$(INSTALL) -m 666 src-install-apache-example.conf $(DESTDIR)$(CONFPATH)/conf/src-install-apache-example.conf; \
+		if [ -d $(APACHE2_SITE_DIR) ]; then \
+			echo "NOTE: enabling fossology site for apache2"; \
+			ln -s $(DESTDIR)$(CONFPATH)/conf/src-install-apache-example.conf $(APACHE2_SITE_DIR)/fossology.conf; \
+			$(APACHE2_EN_SITE) fossology.conf; \
+			$(APACHE_CTL) restart; \
+		elif [ -d $(HTTPD_SITE_DIR) ]; then \
+			echo "NOTE: enabling fossology site for httpd"; \
+			ln -s $(DESTDIR)$(CONFPATH)/conf/src-install-apache-example.conf $(HTTPD_SITE_DIR)/fossology.conf; \
+			$(APACHE_CTL) restart; \
+		fi; \
 	else \
 		echo "WARNING: $(DESTDIR)$(CONFPATH)/conf/src-install-apache-example.conf already exists."; \
 		echo "  Not overwriting, consider checking it by hand or use the OVERWRITE option."; \


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Enable fossology site on source install.

### Changes

1. Check if the default location for Debian based distro exists, then
   install conf file Debian style. Otherwise check for RedHat directory
   and install RedHat style.

## How to test

1. Do a clean install of FOSSology from source on Debian and RedHat
   based Linux Distros.
1. Check if FOSSology (`http://localhost/repo`) is enabled.

Closes #182