### PR TITLE
fix(rest): Remove hostname from JWT

### DIFF
--- a/src/www/ui/api/Controllers/AuthController.php
+++ b/src/www/ui/api/Controllers/AuthController.php
@@ -122,8 +122,7 @@ class AuthController extends RestController
           }
           if (isset($jti['jti']) && ! empty($jti['jti'])) {
             $theJwtToken = $this->restHelper->getAuthHelper()->generateJwtToken(
-              $request->getUri()->getHost(), $expire, $jti['created_on'],
-              $jti['jti'], $scope, $key);
+              $expire, $jti['created_on'], $jti['jti'], $scope, $key);
             $returnVal = $response->withJson([
               "Authorization" => "Bearer " . $theJwtToken
             ], 201);

--- a/src/www/ui/api/Middlewares/RestAuthMiddleware.php
+++ b/src/www/ui/api/Middlewares/RestAuthMiddleware.php
@@ -59,8 +59,10 @@ class RestAuthMiddleware
     } else {
       $authHelper = $GLOBALS['container']->get('helper.authHelper');
       $jwtToken = $request->getHeader('Authorization')[0];
-      $tokenValid = $authHelper->verifyAuthToken($jwtToken,
-        $requestUri->getHost(), $userId, $tokenScope);
+      $userId = -1;
+      $tokenScope = false;
+      $tokenValid = $authHelper->verifyAuthToken($jwtToken, $userId,
+        $tokenScope);
       if ($tokenValid === true && (stristr($request->getMethod(), "get") === false &&
           stristr($tokenScope, "write") === false)) {
         /*

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -14,7 +14,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.0.12
+  version: 1.0.13
   contact:
     email: fossology@fossology.org
   license:

--- a/src/www/ui/async/AjaxManageToken.php
+++ b/src/www/ui/async/AjaxManageToken.php
@@ -103,7 +103,7 @@ class AjaxManageToken extends DefaultPlugin
     $tokenInfo = $restDbHelper->getTokenKey($tokenPk);
     $tokenScope = array_search($tokenInfo['token_scope'], RestHelper::SCOPE_DB_MAP);
 
-    $jwtToken = $authHelper->generateJwtToken($hostname, $tokenInfo['expire_on'],
+    $jwtToken = $authHelper->generateJwtToken($tokenInfo['expire_on'],
       $tokenInfo['created_on'], $jti, $tokenScope, $tokenInfo['token_key']);
     return array(
       "status" => true,

--- a/src/www/ui/user-edit.php
+++ b/src/www/ui/user-edit.php
@@ -394,8 +394,8 @@ class UserEditPage extends DefaultPlugin
       } catch (DuplicateTokenNameException $e) {
         throw new \UnexpectedValueException($e->getMessage());
       }
-      return $this->authHelper->generateJwtToken($request->getHost(), $tokenExpiry,
-          $jti['created_on'], $jti['jti'], $tokenScope, $key);
+      return $this->authHelper->generateJwtToken($tokenExpiry,
+        $jti['created_on'], $jti['jti'], $tokenScope, $key);
     }
   }
 


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Removed hostname from JWT token as requested in #1512

### Changes

1. Removed hostname from all token related functions
1. Removed hostname check while authenticating with token.

## How to test

1. Generate a new token from UI and REST API
    - Inspect it using jwt.io and verify if `iss` and `aud` claims are not in the token.
1. Use old token to access FOSSology (with `iss` and `aud`)
    - Should work without any issue
1. Use new token to access FOSSology (without `iss` and `aud`)
    - Should work without any issue

Closes #1512