### PR TITLE
feat(rest): Get upload summary

### DIFF
--- a/src/delagent/ui/delete-helper.php
+++ b/src/delagent/ui/delete-helper.php
@@ -87,7 +87,7 @@ function initDeletion($uploadpks)
   $errorMessages = [];
   $deleteResponse = null;
   for ($i=0; $i < sizeof($uploadpks); $i++) {
-    $deleteResponse = $this->TryToDelete(intval($uploadpks[$i]));
+    $deleteResponse = TryToDelete(intval($uploadpks[$i]));
 
     if ($deleteResponse->getDeleteMessageCode() != DeleteMessages::SUCCESS) {
       $errorMessages[] = $deleteResponse;

--- a/src/www/ui/Makefile
+++ b/src/www/ui/Makefile
@@ -27,7 +27,7 @@ UIFILES = `find . -type f | grep -v svn |grep -v tests | grep -E "(php|dat|dtd|j
 OBSOLETEFILES = admin-tag-ns.php admin-change-owner.php admin-tag-ns-perm.php admin-folder-delete.php \
                 admin-dashboard.php ajax-showjobs.php group-manage-self.php group-manage.php ajax-perms.php \
                 upload_permissions.php upload-srv-files.php upload-vcs.php template/components \
-                template/include 
+                template/include ui-browse-license.php
 
 OTHERFILES = `find . -type f | grep -v svn |grep -v tests | grep -E "(css|htc|gif|png|ico|htm|openapi.yaml)$$"`
 

--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -1,6 +1,6 @@
 <?php
 /***************************************************************
- Copyright (C) 2018 Siemens AG
+ Copyright (C) 2018,2020 Siemens AG
  Author: Gaurav Mishra <mishra.gaurav@siemens.com>
 
  This program is free software; you can redistribute it and/or
@@ -25,7 +25,7 @@ namespace Fossology\UI\Api\Controllers;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Fossology\Lib\Auth\Auth;
+use Fossology\DelAgent\UI\DeleteMessages;
 use Fossology\UI\Page\UploadPageBase;
 use Fossology\UI\Api\Models\Info;
 use Fossology\UI\Api\Models\InfoType;
@@ -48,34 +48,48 @@ class UploadController extends RestController
    */
   public function getUploads($request, $response, $args)
   {
-    $thisSession = $this->restHelper->getAuthHelper()->getSession();
     $id = null;
     if (isset($args['id'])) {
       $id = intval($args['id']);
-      if (! $this->dbHelper->doesIdExist("upload", "upload_pk", $id)) {
-        $returnVal = new Info(404, "Upload does not exist", InfoType::ERROR);
-        return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+      $upload = $this->uploadAccessible($this->restHelper->getGroupId(), $id);
+      if ($upload !== true) {
+        return $response->withJson($upload->getArray(), $upload->getCode());
+      }
+      $temp = $this->isAdj2nestDone($id, $response);
+      if ($temp !== true) {
+        return $temp;
       }
     }
-    $uploads = $this->dbHelper->getUploads($thisSession->get(Auth::USER_ID), $id);
+    $uploads = $this->dbHelper->getUploads($this->restHelper->getUserId(), $id);
     if ($id !== null) {
-      if ($uploads === null) {
-        $returnVal = new Info(404, "Upload does not exist", InfoType::ERROR);
-        return $response->withJson($returnVal->getArray(), $returnVal->getCode());
-      }
-      if (! empty($uploads)) {
-        $uploads = $uploads[0];
-      } else {
-        $returnVal = new Info(503,
-          "Ununpack job not started. Please check job status at " .
-          "/api/v1/jobs?upload=" . $id,
-          InfoType::INFO);
-        return $response->withHeader('Retry-After',
-          '60')->withHeader('Look-at', "/api/v1/jobs?upload=" .
-          $id)->withJson($returnVal->getArray(), $returnVal->getCode());
-      }
+      $uploads = $uploads[0];
     }
     return $response->withJson($uploads, 200);
+  }
+
+  /**
+   * Get summary of given upload
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseInterface $response
+   * @param array $args
+   * @return ResponseInterface
+   */
+  public function getUploadSummary($request, $response, $args)
+  {
+    $id = intval($args['id']);
+    $upload = $this->uploadAccessible($this->restHelper->getGroupId(), $id);
+    if ($upload !== true) {
+      return $response->withJson($upload->getArray(), $upload->getCode());
+    }
+    $temp = $this->isAdj2nestDone($id, $response);
+    if ($temp !== true) {
+      return $temp;
+    }
+    $uploadHelper = new UploadHelper();
+    $uploadSummary = $uploadHelper->generateUploadSummary($id,
+      $this->restHelper->getGroupId());
+    return $response->withJson($uploadSummary->getArray(), 200);
   }
 
   /**
@@ -92,14 +106,19 @@ class UploadController extends RestController
       "/delagent/ui/delete-helper.php";
     $returnVal = null;
     $id = intval($args['id']);
-    if ($this->dbHelper->doesIdExist("upload", "upload_pk", $id)) {
-      TryToDelete($id, $this->restHelper->getUserId(),
-        $this->restHelper->getGroupId(), $this->restHelper->getUploadDao());
+
+    $upload = $this->uploadAccessible($this->restHelper->getGroupId(), $id);
+    if ($upload !== true) {
+      return $response->withJson($upload->getArray(), $upload->getCode());
+    }
+    $result = TryToDelete($id, $this->restHelper->getUserId(),
+      $this->restHelper->getGroupId(), $this->restHelper->getUploadDao());
+    if ($result->getDeleteMessageCode() !== DeleteMessages::SUCCESS) {
+      $returnVal = new Info(500, $result->getDeleteMessageString(),
+        InfoType::ERROR);
+    } else {
       $returnVal = new Info(202, "Delete Job for file with id " . $id,
         InfoType::INFO);
-    } else {
-      $returnVal = new Info(404, "Upload " . $id . " doesn't exist",
-        InfoType::ERROR);
     }
     return $response->withJson($returnVal->getArray(), $returnVal->getCode());
   }
@@ -167,12 +186,12 @@ class UploadController extends RestController
     if ($request->hasHeader('folderId') &&
       is_numeric($folderId = $request->getHeaderLine('folderId')) && $folderId > 0) {
 
-      $allFolderIds = $this->container->get('dao.folder')->getAllFolderIds();
+      $allFolderIds = $this->restHelper->getFolderDao()->getAllFolderIds();
       if (!in_array($folderId, $allFolderIds)) {
         $error = new Info(404, "folderId $folderId does not exists!", InfoType::ERROR);
         return $response->withJson($error->getArray(), $error->getCode());
       }
-      if (!$this->container->get('dao.folder')->isFolderAccessible($folderId)) {
+      if (!$this->restHelper->getFolderDao()->isFolderAccessible($folderId)) {
         $error = new Info(403, "folderId $folderId is not accessible!",
           InfoType::ERROR);
         return $response->withJson($error->getArray(), $error->getCode());
@@ -203,8 +222,47 @@ class UploadController extends RestController
       }
       return $response->withJson($info->getArray(), $info->getCode());
     } else {
-      $error = new Info(400, "folderId must be a positive integer!", InfoType::ERROR);
+      $error = new Info(400, "folderId must be a positive integer!",
+        InfoType::ERROR);
       return $response->withJson($error->getArray(), $error->getCode());
     }
+  }
+
+  /**
+   * Check if upload is accessible
+   * @param integer $groupId Group ID
+   * @param integer $id      Upload ID
+   * @return Fossology::UI::Api::Models::Info|boolean Info object on failure or
+   *         true otherwise
+   */
+  private function uploadAccessible($groupId, $id)
+  {
+    if (! $this->dbHelper->doesIdExist("upload", "upload_pk", $id)) {
+      return new Info(404, "Upload does not exist", InfoType::ERROR);
+    } else if (! $this->restHelper->getUploadDao()->isAccessible($id, $groupId)) {
+      return new Info(403, "Upload is not accessible", InfoType::ERROR);
+    }
+    return true;
+  }
+
+  /**
+   * Check if adj2nest agent finished on upload
+   * @param integer $id Upload ID
+   * @param ResponseInterface $response
+   * @return ResponseInterface|boolean Response if failure, true otherwise
+   */
+  private function isAdj2nestDone($id, $response)
+  {
+    $itemTreeBounds = $this->restHelper->getUploadDao()->getParentItemBounds(
+      $id);
+    if ($itemTreeBounds === false || empty($itemTreeBounds->getLeft())) {
+      $returnVal = new Info(503,
+        "Ununpack job not started. Please check job status at " .
+        "/api/v1/jobs?upload=" . $id, InfoType::INFO);
+      return $response->withHeader('Retry-After', '60')
+        ->withHeader('Look-at', "/api/v1/jobs?upload=" . $id)
+        ->withJson($returnVal->getArray(), $returnVal->getCode());
+    }
+    return true;
   }
 }

--- a/src/www/ui/api/Models/UploadSummary.php
+++ b/src/www/ui/api/Models/UploadSummary.php
@@ -1,0 +1,248 @@
+<?php
+/***************************************************************
+Copyright (C) 2020 Siemens AG
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Upload summary model
+ */
+namespace Fossology\UI\Api\Models;
+
+use Fossology\Lib\Data\UploadStatus;
+
+/**
+ * @class UploadSummary
+ * @brief Model class to hold Upload info
+ */
+class UploadSummary
+{
+
+  /**
+   * @var string $mainLicense
+   * Main license selected on upload
+   */
+  private $mainLicense;
+  /**
+   * @var integer $uniqueLicenses
+   * Number of unique licenses found in upload
+   */
+  private $uniqueLicenses;
+  /**
+   * @var integer $uploadId
+   * Current upload id
+   */
+  private $uploadId;
+  /**
+   * @var integer $totalLicenses
+   * Total licenses found in upload
+   */
+  private $totalLicenses;
+  /**
+   * @var string $uploadName
+   * Upload name
+   */
+  private $uploadName;
+  /**
+   * @var integer $uniqueConcludedLicenses
+   * No of unique licenses concluded for upload
+   */
+  private $uniqueConcludedLicenses;
+  /**
+   * @var integer $totalConcludedLicenses
+   * Total licenses concluded for upload
+   */
+  private $totalConcludedLicenses;
+  /**
+   * @var integer $filesToBeCleared
+   * Files without clearing
+   */
+  private $filesToBeCleared;
+  /**
+   * @var integer $filesCleared
+   * Files with clearing
+   */
+  private $filesCleared;
+  /**
+   * @var UploadStatus $clearingStatus
+   * Clearing status
+   */
+  private $clearingStatus;
+  /**
+   * @var integer $copyrightCount
+   * No of files with copyrights
+   */
+  private $copyrightCount;
+
+  public function __construct()
+  {
+    $this->mainLicense = null;
+    $this->uniqueLicenses = 0;
+    $this->uploadId = null;
+    $this->totalLicenses = 0;
+    $this->uploadName = null;
+    $this->uniqueConcludedLicenses = 0;
+    $this->totalConcludedLicenses = 0;
+    $this->filesToBeCleared = 0;
+    $this->filesCleared = 0;
+    $this->clearingStatus = UploadStatus::OPEN;
+    $this->copyrightCount = 0;
+  }
+
+  /**
+   * Get current upload in JSON representation
+   * @return string
+   */
+  public function getJSON()
+  {
+    return json_encode($this->getArray());
+  }
+
+  /**
+   * Get the upload element as an associative array
+   * @return array
+   */
+  public function getArray()
+  {
+    return [
+      "id"                      => $this->uploadId,
+      "uploadName"              => $this->uploadName,
+      "mainLicense"             => $this->mainLicense,
+      "uniqueLicenses"          => $this->uniqueLicenses,
+      "totalLicenses"           => $this->totalLicenses,
+      "uniqueConcludedLicenses" => $this->uniqueConcludedLicenses,
+      "totalConcludedLicenses"  => $this->totalConcludedLicenses,
+      "filesToBeCleared"        => $this->filesToBeCleared,
+      "filesCleared"            => $this->filesCleared,
+      "clearingStatus"          => self::statusToString($this->clearingStatus),
+      "copyrightCount"          => $this->copyrightCount
+    ];
+  }
+
+  /**
+   * @param string $mainLicense
+   */
+  public function setMainLicense($mainLicense)
+  {
+    $this->mainLicense = $mainLicense;
+  }
+
+  /**
+   * @param number $uniqueLicenses
+   */
+  public function setUniqueLicenses($uniqueLicenses)
+  {
+    $this->uniqueLicenses = intval($uniqueLicenses);
+  }
+
+  /**
+   * @param number $uploadId
+   */
+  public function setUploadId($uploadId)
+  {
+    $this->uploadId = intval($uploadId);
+  }
+
+  /**
+   * @param number $totalLicenses
+   */
+  public function setTotalLicenses($totalLicenses)
+  {
+    $this->totalLicenses = intval($totalLicenses);
+  }
+
+  /**
+   * @param string $uploadName
+   */
+  public function setUploadName($uploadName)
+  {
+    $this->uploadName = $uploadName;
+  }
+
+  /**
+   * @param number $uniqueConcludedLicenses
+   */
+  public function setUniqueConcludedLicenses($uniqueConcludedLicenses)
+  {
+    $this->uniqueConcludedLicenses = intval($uniqueConcludedLicenses);
+  }
+
+  /**
+   * @param number $totalConcludedLicenses
+   */
+  public function setTotalConcludedLicenses($totalConcludedLicenses)
+  {
+    $this->totalConcludedLicenses = intval($totalConcludedLicenses);
+  }
+
+  /**
+   * @param number $filesToBeCleared
+   */
+  public function setFilesToBeCleared($filesToBeCleared)
+  {
+    $this->filesToBeCleared = intval($filesToBeCleared);
+  }
+
+  /**
+   * @param number $filesCleared
+   */
+  public function setFilesCleared($filesCleared)
+  {
+    $this->filesCleared = intval($filesCleared);
+  }
+
+  /**
+   * @param Fossology::Lib::Data::UploadStatus $clearingStatus
+   */
+  public function setClearingStatus($clearingStatus)
+  {
+    $this->clearingStatus = $clearingStatus;
+  }
+
+  /**
+   * @param number $copyrightCount
+   */
+  public function setCopyrightCount($copyrightCount)
+  {
+    $this->copyrightCount = intval($copyrightCount);
+  }
+
+  /**
+   * Convert internal clearing status to strings
+   * @param Fossology::Lib::Data::UploadStatus $status
+   * @return string
+   */
+  public static function statusToString($status)
+  {
+    $string = null;
+    switch ($status) {
+      case UploadStatus::OPEN:
+        $string = "Open";
+        break;
+      case UploadStatus::IN_PROGRESS:
+        $string = "InProgress";
+        break;
+      case UploadStatus::CLOSED:
+        $string = "Closed";
+        break;
+      case UploadStatus::REJECTED:
+        $string = "Rejected";
+        break;
+      default:
+        $string = "NA";
+    }
+    return $string;
+  }
+}

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1,4 +1,4 @@
-# Copyright (C) Siemens AG 2017-2019
+# Copyright (C) Siemens AG 2017-2020
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # version 2 as published by the Free Software Foundation.
@@ -14,7 +14,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.0.7
+  version: 1.0.9
   contact:
     email: fossology@fossology.org
   license:
@@ -301,6 +301,43 @@ paths:
       responses:
         '201':
           description: Upload is created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /uploads/{id}/summary:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+    get:
+      tags:
+        - Upload
+      summary: Get single upload summary
+      description:
+        Returns summary for single upload
+      responses:
+        '200':
+          description: Get summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UploadSummary'
+        '503':
+          description: >
+            The ununpack agent has not started yet. Please check the 'Look-at'
+            header for more information
+          headers:
+            'Look-at':
+              description: Contains the URL to get jobs for the given upload
+              schema:
+                type: string
           content:
             application/json:
               schema:
@@ -814,6 +851,47 @@ components:
         filesize:
           type: integer
           description: Filesize in Bytes.
+    UploadSummary:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Upload id of the upload.
+        uploadName:
+          type: string
+          description: Display name of the upload.
+        mainLicense:
+          type: string
+          description: Main license selected on the upload.
+        uniqueLicenses:
+          type: integer
+          description: No. of unique licenses found.
+        totalLicenses:
+          type: integer
+          description: Total no. of licenses found.
+        uniqueConcludedLicenses:
+          type: integer
+          description: Unique licenses concluded.
+        totalConcludedLicenses:
+          type: integer
+          description: Total concluded licenses.
+        filesToBeCleared:
+          type: integer
+          description: Files without clearing decisions.
+        filesCleared:
+          type: integer
+          description: Files with clearing decisions.
+        clearingStatus:
+          type: string
+          enum:
+            - Open
+            - InProgress
+            - Closed
+            - Rejected
+          description: Upload is clearing status.
+        copyrightCount:
+          type: integer
+          description: No. of copyrights found in the upload.
     Job:
       type: object
       properties:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -105,6 +105,7 @@ $app->group(VERSION_1 . 'uploads',
     $this->patch('/{id:\\d+}', UploadController::class . ':moveUpload');
     $this->put('/{id:\\d+}', UploadController::class . ':copyUpload');
     $this->post('', UploadController::class . ':postUpload');
+    $this->get('/{id:\\d+}/summary', UploadController::class . ':getUploadSummary');
     $this->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui/page/BrowseLicense.php
+++ b/src/www/ui/page/BrowseLicense.php
@@ -17,6 +17,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  ***********************************************************/
 
+namespace Fossology\UI\Page;
+
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\BusinessRules\ClearingDecisionFilter;
 use Fossology\Lib\BusinessRules\LicenseMap;
@@ -38,7 +40,7 @@ use Fossology\Lib\Data\AgentRef;
  * \brief browse a directory to display all licenses in this directory
  */
 
-class ui_browse_license extends DefaultPlugin
+class BrowseLicense extends DefaultPlugin
 {
   const NAME = "license";
 
@@ -314,6 +316,16 @@ class ui_browse_license extends DefaultPlugin
   {
     return $this->renderer->loadTemplate($templateName)->render($vars);
   }
+
+  /**
+   * Get the upload histogram generated
+   * @param ItemTreeBounds $itemTreeBounds
+   * @return array
+   */
+  public function getUploadHist($itemTreeBounds)
+  {
+    return $this->showUploadHist($itemTreeBounds);
+  }
 }
 
-register_plugin(new ui_browse_license());
+register_plugin(new BrowseLicense());


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Get an upload's summart from REST. Following are the contents of the summary:
```json
{
  "id": 1245,
  "uploadname": "library-2.0.1.tar.gz",
  "mainLicense": "MIT,BSD0",
  "uniqueLicenses": 10,
  "totalLicenses": 41,
  "uniqueConcludedLicenses": 2,
  "totalConcludedLicenses": 8,
  "filesToBeCleared": 20,
  "filesCleared": 4,
  "clearingStatus": "Open",
  "copyrightCount": 25
}
```

### Changes

1. Provide new endpoint `GET: /api/v1/uploads/{id}/summary`
1. Moved class `ui_browse_license` (file `src/www/ui/ui-browse-license.php`) → class `BrowseLicense` (file `src/www/ui/page/BrowseLicense.php`) under `Fossology\UI\Page` namespace.

## How to test

1. For a given upload, call the summary endpoint and verify correctness of response.
1. Check if other `/uploads/` enpoints are working.
1. Fetch upload which is not accessible by current user.
1. Fetch upload which is not available in DB.

Closes #1552