### PR TITLE
feat(scanners) : ignore files from scanning using mimetype

### DIFF
--- a/src/copyright/agent/copyright.cc
+++ b/src/copyright/agent/copyright.cc
@@ -77,6 +77,7 @@ int main(int argc, char** argv)
   }
 
   bool json = cliOptions.doJsonOutput();
+  bool ignoreFilesWithMimeType = cliOptions.doignoreFilesWithMimeType();
   CopyrightState state = getState(std::move(cliOptions));
 
   if (!fileNames.empty())
@@ -144,7 +145,7 @@ int main(int argc, char** argv)
       if (arsId <= 0)
         return_sched(5);
 
-      if (!processUploadId(state, agentId, uploadId, copyrightDatabaseHandler))
+      if (!processUploadId(state, agentId, uploadId, copyrightDatabaseHandler, ignoreFilesWithMimeType))
         return_sched(2);
 
       fo_scheduler_heart(0);
@@ -154,6 +155,5 @@ int main(int argc, char** argv)
     /* do not use bail, as it would prevent the destructors from running */
     return_sched(0);
   }
-
 }
 

--- a/src/copyright/agent/copyrightState.cc
+++ b/src/copyright/agent/copyrightState.cc
@@ -53,11 +53,13 @@ const std::list<unptr::shared_ptr<scanner>>& CopyrightState::getScanners() const
  * \param verbosity Verbosity set by CLI
  * \param type      Type set by CLI
  * \param json      True to get output in JSON format
+ * \param ignoreFilesWithMimeType      True to ignore files with particular mimetype
  */
-CliOptions::CliOptions(int verbosity, unsigned int type, bool json) :
+CliOptions::CliOptions(int verbosity, unsigned int type, bool json, bool ignoreFilesWithMimeType) :
   verbosity(verbosity),
   optType(type),
   json(json),
+  ignoreFilesWithMimeType(ignoreFilesWithMimeType),
   cliScanners()
 {
 }
@@ -68,6 +70,7 @@ CliOptions::CliOptions(int verbosity, unsigned int type, bool json) :
 CliOptions::CliOptions() :
   verbosity(0),
   optType(ALL_TYPES),
+  ignoreFilesWithMimeType(false),
   cliScanners()
 {
 }
@@ -126,3 +129,11 @@ bool CliOptions::doJsonOutput() const
   return json;
 }
 
+/**
+ * \brief Check to ignore files with particular mimetype
+ * \return True if required, else false
+ */
+bool CliOptions::doignoreFilesWithMimeType() const
+{
+  return ignoreFilesWithMimeType;
+}

--- a/src/copyright/agent/copyrightState.hpp
+++ b/src/copyright/agent/copyrightState.hpp
@@ -37,6 +37,7 @@ private:
   int verbosity;                        /**< The verbosity level */
   unsigned int optType;                 /**< Scan type (2 => url, 4 => email, 8 => author, 16 => ecc) */
   bool json;                            /**< Whether to generate JSON output */
+  bool ignoreFilesWithMimeType;         /**< Whether to ignore files with particular mimetype */
   std::list<unptr::shared_ptr<scanner>> cliScanners; /**< List of available scanners */
 
 public:
@@ -45,11 +46,12 @@ public:
   unsigned int getOptType() const;
 
   bool doJsonOutput() const;
+  bool doignoreFilesWithMimeType() const;
 
   void addScanner(scanner* regexDesc);
   std::list<unptr::shared_ptr<scanner>> extractScanners();
 
-  CliOptions(int verbosity, unsigned int type, bool json);
+  CliOptions(int verbosity, unsigned int type, bool json, bool ignoreFilesWithMimeType);
   CliOptions();
 };
 

--- a/src/copyright/agent/copyrightUtils.cc
+++ b/src/copyright/agent/copyrightUtils.cc
@@ -117,6 +117,9 @@ bool parseCliOptions(int argc, char** argv, CliOptions& dest,
           "json,J", "output JSON"
         )
         (
+          "ignoreFilesWithMimeType,I", "ignoreFilesWithMimeType"
+        )
+        (
           "config,c", boost::program_options::value<string>(), "path to the sysconfigdir"
         )
         (
@@ -161,8 +164,9 @@ bool parseCliOptions(int argc, char** argv, CliOptions& dest,
 
     unsigned long verbosity = vm.count("verbose");
     bool json = vm.count("json") > 0 ? true : false;
+    bool ignoreFilesWithMimeType = vm.count("ignoreFilesWithMimeType") > 0 ? true : false;
 
-    dest = CliOptions(verbosity, type, json);
+    dest = CliOptions(verbosity, type, json, ignoreFilesWithMimeType);
 
     if (vm.count("regex"))
     {
@@ -400,11 +404,12 @@ void matchPFileWithLicenses(CopyrightState const& state, int agentId, unsigned l
  * \param agentId         Agent id
  * \param uploadId        Upload id to be processed
  * \param databaseHandler Database handler object
+ * \param ignoreFilesWithMimeType To ignore files with particular mimetype
  * \return True when upload is processed
  */
-bool processUploadId(const CopyrightState& state, int agentId, int uploadId, CopyrightDatabaseHandler& databaseHandler)
+bool processUploadId(const CopyrightState& state, int agentId, int uploadId, CopyrightDatabaseHandler& databaseHandler, bool ignoreFilesWithMimeType)
 {
-  vector<unsigned long> fileIds = databaseHandler.queryFileIdsForUpload(agentId, uploadId);
+  vector<unsigned long> fileIds = databaseHandler.queryFileIdsForUpload(agentId, uploadId, ignoreFilesWithMimeType);
 
 #pragma omp parallel
   {

--- a/src/copyright/agent/copyrightUtils.hpp
+++ b/src/copyright/agent/copyrightUtils.hpp
@@ -59,7 +59,7 @@ std::vector<CopyrightMatch> matchStringToRegexes(const std::string& content, std
 */
 void normalizeContent(std::string& content);
 
-bool processUploadId(const CopyrightState& state, int agentId, int uploadId, CopyrightDatabaseHandler& handler);
+bool processUploadId(const CopyrightState& state, int agentId, int uploadId, CopyrightDatabaseHandler& handler, bool ignoreFilesWithMimeType);
 
 std::pair<std::string, std::list<match>> processSingleFile(const CopyrightState& state,
   const std::string fileName);

--- a/src/copyright/agent/database.cc
+++ b/src/copyright/agent/database.cc
@@ -311,36 +311,48 @@ bool CopyrightDatabaseHandler::createTableClearing() const
  * \brief Get the list of pfile ids on which the given agent has no findings for a given upload
  * \param agentId  Agent id to be removed from result
  * \param uploadId Upload id to scan for files
+ * \param ignoreFilesWithMimeType to exclude filetypes with particular mimetype
  * \return List of pfiles on which the given agent has no findings
  */
-std::vector<unsigned long> CopyrightDatabaseHandler::queryFileIdsForUpload(int agentId, int uploadId)
+std::vector<unsigned long> CopyrightDatabaseHandler::queryFileIdsForUpload(int agentId, int uploadId, bool ignoreFilesWithMimeType)
 {
   std::string uploadTreeTableName = queryUploadTreeTableName(uploadId);
-
-  fo_dbManager_PreparedStatement* preparedStatement =
-      fo_dbManager_PrepareStamement(dbManager.getStruct_dbManager(),
-          ("queryFileIdsForUpload:" IDENTITY "Agent" + uploadTreeTableName).c_str(),
-          ("SELECT pfile_pk"
-            " FROM ("
-            "  SELECT distinct(pfile_fk) AS PF"
-            "  FROM " + uploadTreeTableName +
-            "  WHERE upload_fk = $1 and (ufile_mode&x'3C000000'::int)=0"
-            " ) AS SS "
-          "LEFT OUTER JOIN " IDENTITY " ON (PF = pfile_fk AND agent_fk = $2) "
+  fo_dbManager_PreparedStatement* preparedStatement;
+  std::string sql = "SELECT pfile_pk"
+    " FROM ("
+    "  SELECT distinct(pfile_fk) AS PF"
+    "  FROM " + uploadTreeTableName +
+    "  WHERE upload_fk = $1 and (ufile_mode&x'3C000000'::int)=0"
+    " ) AS SS "
+    "LEFT OUTER JOIN " IDENTITY " ON (PF = pfile_fk AND agent_fk = $2) "
 #ifdef IDENTITY_COPYRIGHT
-          "LEFT OUTER JOIN author AS au ON (PF = au.pfile_fk AND au.agent_fk = $2) "
+    "LEFT OUTER JOIN author AS au ON (PF = au.pfile_fk AND au.agent_fk = $2) "
 #endif
-          "INNER JOIN pfile ON (PF = pfile_pk) "
+    "INNER JOIN pfile ON (PF = pfile_pk) "
 #ifdef IDENTITY_COPYRIGHT
-          "WHERE copyright.copyright_pk IS NULL AND au.author_pk IS NULL;").c_str(),
+    "WHERE copyright.copyright_pk IS NULL AND au.author_pk IS NULL"
 #else
-          "WHERE " IDENTITY "_pk IS NULL OR agent_fk <> $2;").c_str(),
+    "WHERE (" IDENTITY "_pk IS NULL OR agent_fk <> $2)"
 #endif
-          int, int);
+    ;
+  std::string statementName = "queryFileIdsForUpload:" IDENTITY "Agent" + uploadTreeTableName;
+  if (ignoreFilesWithMimeType)
+  {
+    sql = sql + " AND (pfile_mimetypefk NOT IN ( "
+      "SELECT mimetype_pk FROM mimetype WHERE mimetype_name=ANY(string_to_array(( "
+      "SELECT conf_value FROM sysconfig WHERE variablename='SkipFiles'),','))));";
+    statementName = statementName + "withMimetype";
+  }
+  preparedStatement =
+    fo_dbManager_PrepareStamement(dbManager.getStruct_dbManager(),
+      statementName.c_str(),
+      sql.c_str(),
+      int, int);
   QueryResult queryResult = dbManager.execPrepared(preparedStatement,
       uploadId, agentId);
 
   return queryResult.getSimpleResults<unsigned long>(0, fo::stringToUnsignedLong);
+
 }
 
 /**

--- a/src/copyright/agent/database.hpp
+++ b/src/copyright/agent/database.hpp
@@ -71,7 +71,7 @@ public:
   bool createTables() const;
   bool insertInDatabase(DatabaseEntry& entry) const;
   bool insertNoResultInDatabase(long agentId, long pFileId) const;
-  std::vector<unsigned long> queryFileIdsForUpload(int agentId, int uploadId);
+  std::vector<unsigned long> queryFileIdsForUpload(int agentId, int uploadId, bool ignoreFilesWithMimeType);
 
 private:
   /**

--- a/src/copyright/ui/agent-copyright.php
+++ b/src/copyright/ui/agent-copyright.php
@@ -41,6 +41,49 @@ class CopyrightAgentPlugin extends AgentPlugin
   {
     return CheckARS($uploadId, $this->AgentName, "copyright scanner", "copyright_ars");
   }
+
+  /**
+   * @copydoc Fossology\Lib\Plugin\AgentPlugin::AgentAdd()
+   * @see \Fossology\Lib\Plugin\AgentPlugin::AgentAdd()
+   */
+  public function AgentAdd($jobId, $uploadId, &$errorMsg, $dependencies=array(), $arguments=null)
+  {
+    $unpackArgs = intval($_POST['scm']) == 1 ? '-I' : '';
+    if ($this->AgentHasResults($uploadId) == 1) {
+      return 0;
+    }
+
+    $jobQueueId = \IsAlreadyScheduled($jobId, $this->AgentName, $uploadId);
+    if ($jobQueueId != 0) {
+      return $jobQueueId;
+    }
+
+    $args = $unpackArgs;
+    if (!empty($unpackArgs)) {
+      return $this->doAgentAdd($jobId, $uploadId, $errorMsg, array("agent_mimetype"),$uploadId,$args);
+    } else {
+      return $this->doAgentAdd($jobId, $uploadId, $errorMsg, array("agent_adj2nest"), $uploadId);
+    }
+  }
+
+  /**
+   * Check if agent already included in the dependency list
+   * @param mixed  $dependencies Array of job dependencies
+   * @param string $agentName    Name of the agent to be checked for
+   * @return boolean true if agent already in dependency list else false
+   */
+  protected function isAgentIncluded($dependencies, $agentName)
+  {
+    foreach ($dependencies as $dependency) {
+      if ($dependency == $agentName) {
+        return true;
+      }
+      if (is_array($dependency) && $agentName == $dependency['name']) {
+        return true;
+      }
+    }
+    return false;
+  }
 }
 
 register_plugin(new CopyrightAgentPlugin());

--- a/src/copyright/ui/agent-ecc.php
+++ b/src/copyright/ui/agent-ecc.php
@@ -40,6 +40,49 @@ class EccAgentPlugin extends AgentPlugin
   {
     return CheckARS($uploadId, $this->AgentName, "ecc scanner", "ecc_ars");
   }
+
+  /**
+   * @copydoc Fossology\Lib\Plugin\AgentPlugin::AgentAdd()
+   * @see \Fossology\Lib\Plugin\AgentPlugin::AgentAdd()
+   */
+  public function AgentAdd($jobId, $uploadId, &$errorMsg, $dependencies=array(), $arguments=null)
+  {
+    $unpackArgs = intval($_POST['scm']) == 1 ? '-I' : '';
+    if ($this->AgentHasResults($uploadId) == 1) {
+      return 0;
+    }
+
+    $jobQueueId = \IsAlreadyScheduled($jobId, $this->AgentName, $uploadId);
+    if ($jobQueueId != 0) {
+      return $jobQueueId;
+    }
+
+    $args = $unpackArgs;
+    if (!empty($unpackArgs)) {
+      return $this->doAgentAdd($jobId, $uploadId, $errorMsg, array("agent_mimetype"),$uploadId,$args);
+    } else {
+      return $this->doAgentAdd($jobId, $uploadId, $errorMsg, array("agent_adj2nest"), $uploadId);
+    }
+  }
+
+  /**
+   * Check if agent already included in the dependency list
+   * @param mixed  $dependencies Array of job dependencies
+   * @param string $agentName    Name of the agent to be checked for
+   * @return boolean true if agent already in dependency list else false
+   */
+  protected function isAgentIncluded($dependencies, $agentName)
+  {
+    foreach ($dependencies as $dependency) {
+      if ($dependency == $agentName) {
+        return true;
+      }
+      if (is_array($dependency) && $agentName == $dependency['name']) {
+        return true;
+      }
+    }
+    return false;
+  }
 }
 
 register_plugin(new EccAgentPlugin());

--- a/src/copyright/ui/agent-keyword.php
+++ b/src/copyright/ui/agent-keyword.php
@@ -28,9 +28,57 @@ class KeywordAgentPlugin extends AgentPlugin
     parent::__construct();
   }
 
+  /**
+   * @copydoc Fossology::Lib::Plugin::AgentPlugin::AgentHasResults()
+   * @see Fossology::Lib::Plugin::AgentPlugin::AgentHasResults()
+   */
   function AgentHasResults($uploadId=0)
   {
     return CheckARS($uploadId, $this->AgentName, "keyword scanner", "keyword_ars");
+  }
+
+
+  /**
+   * @copydoc Fossology\Lib\Plugin\AgentPlugin::AgentAdd()
+   * @see \Fossology\Lib\Plugin\AgentPlugin::AgentAdd()
+   */
+  public function AgentAdd($jobId, $uploadId, &$errorMsg, $dependencies=array(), $arguments=null)
+  {
+    $unpackArgs = intval($_POST['scm']) == 1 ? '-I' : '';
+    if ($this->AgentHasResults($uploadId) == 1) {
+      return 0;
+    }
+
+    $jobQueueId = \IsAlreadyScheduled($jobId, $this->AgentName, $uploadId);
+    if ($jobQueueId != 0) {
+      return $jobQueueId;
+    }
+
+    $args = $unpackArgs;
+    if (!empty($unpackArgs)) {
+      return $this->doAgentAdd($jobId, $uploadId, $errorMsg, array("agent_mimetype"),$uploadId,$args);
+    } else {
+      return $this->doAgentAdd($jobId, $uploadId, $errorMsg, array("agent_adj2nest"), $uploadId);
+    }
+  }
+
+  /**
+   * Check if agent already included in the dependency list
+   * @param mixed  $dependencies Array of job dependencies
+   * @param string $agentName    Name of the agent to be checked for
+   * @return boolean true if agent already in dependency list else false
+   */
+  protected function isAgentIncluded($dependencies, $agentName)
+  {
+    foreach ($dependencies as $dependency) {
+      if ($dependency == $agentName) {
+        return true;
+      }
+      if (is_array($dependency) && $agentName == $dependency['name']) {
+        return true;
+      }
+    }
+    return false;
   }
 }
 

--- a/src/lib/c/libfossagent.h
+++ b/src/lib/c/libfossagent.h
@@ -20,12 +20,13 @@ along with this library; if not, write to the Free Software Foundation, Inc.0
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdbool.h>
 #include <libpq-fe.h>
 
 #include "libfossdbmanager.h"
 
 char* getUploadTreeTableName(fo_dbManager* dbManager, int uploadId);
-PGresult* queryFileIdsForUpload(fo_dbManager* dbManager, int uploadId);
+PGresult* queryFileIdsForUpload(fo_dbManager* dbManager, int uploadId, bool ignoreFilesWithMimeType);
 char* queryPFileForFileId(fo_dbManager* dbManager, long int fileId);
 int fo_GetAgentKey(PGconn* pgConn, const char* agent_name, long unused, const char* cpunused, const char* agent_desc);
 int fo_WriteARS(PGconn* pgConn, int ars_pk, int upload_pk, int agent_pk,
@@ -34,5 +35,7 @@ int fo_CreateARSTable(PGconn* pgConn, const char* table_name);
 int getEffectivePermissionOnUpload(PGconn* pgConn, long UploadPk, int user_pk, int user_perm);
 int GetUploadPerm(PGconn* pgConn, long UploadPk, int user_pk);
 char* GetUploadtreeTableName(PGconn* pgConn, int upload_pk);
+PGresult* checkDuplicateReq(PGconn* pgConn, int uploadPk, int agentPk);
+PGresult* getSelectedPFiles(PGconn* pgConn, int uploadPk, int agentPk, bool ignoreFilesWithMimeType);
 
 #endif

--- a/src/lib/c/libfossdb.c
+++ b/src/lib/c/libfossdb.c
@@ -257,3 +257,4 @@ int fo_tableExists(PGconn* pgConn, const char* tableName)
   PQclear(result);
   return (TabCount);
 } /* fo_tableExists()  */
+

--- a/src/lib/c/libfossdbmanager.h
+++ b/src/lib/c/libfossdbmanager.h
@@ -80,6 +80,7 @@ fo_dbManager_PrepareStamement_str(dbManager, \
   query, \
   #__VA_ARGS__\
 )
+
 fo_dbManager_PreparedStatement* fo_dbManager_PrepareStamement_str(fo_dbManager* dbManager, const char* name, const char* query, const char* paramtypes);
 
 PGresult* fo_dbManager_ExecPrepared(fo_dbManager_PreparedStatement* preparedStatement, ...);

--- a/src/lib/cpp/libfossAgentDatabaseHandler.cc
+++ b/src/lib/cpp/libfossAgentDatabaseHandler.cc
@@ -96,12 +96,13 @@ char* fo::AgentDatabaseHandler::getPFileNameForFileId(unsigned long pfileId) con
 /**
  * \brief Get pfile ids for a given upload id
  * \param uploadId Upload id to fetch from
+ * \param ignoreFilesWithMimeType ignore files with particular mimetype
  * \return Vector of pfile ids in given upload id
  * \sa queryFileIdsForUpload()
  */
-std::vector<unsigned long> fo::AgentDatabaseHandler::queryFileIdsVectorForUpload(int uploadId) const
+std::vector<unsigned long> fo::AgentDatabaseHandler::queryFileIdsVectorForUpload(int uploadId, bool ignoreFilesWithMimeType) const
 {
-  QueryResult queryResult(queryFileIdsForUpload(dbManager.getStruct_dbManager(), uploadId));
+  QueryResult queryResult(queryFileIdsForUpload(dbManager.getStruct_dbManager(), uploadId, ignoreFilesWithMimeType));
   return queryResult.getSimpleResults(0, fo::stringToUnsignedLong);
 }
 

--- a/src/lib/cpp/libfossAgentDatabaseHandler.hpp
+++ b/src/lib/cpp/libfossAgentDatabaseHandler.hpp
@@ -57,7 +57,7 @@ namespace fo
 
     char* getPFileNameForFileId(unsigned long pfileId) const;
     std::string queryUploadTreeTableName(int uploadId);
-    std::vector<unsigned long> queryFileIdsVectorForUpload(int uploadId) const;
+    std::vector<unsigned long> queryFileIdsVectorForUpload(int uploadId, bool ignoreFilesWithMimeType) const;
   };
 }
 

--- a/src/lib/php/UI/template/include/upload.html.twig
+++ b/src/lib/php/UI/template/include/upload.html.twig
@@ -37,7 +37,7 @@
         </label>
       </li>
       <li>
-          <input type="checkbox" name="scm" value="1"/> {{ 'Ignore SCM files (Git, SVN, TFS)'| trans }}<br/>
+          <input type="checkbox" name="scm" value="1"/> {{ 'Ignore SCM files (Git, SVN, TFS) and files with particular Mimetype'| trans }}<img src="images/info_16.png" title="{{'Configure mimetypes from Admin-Customize-Skip MimeTypes from scanning'|trans}}" alt="" class="info-bullet"/><br/>
       </li>
       <li>
         <input type="radio" name="public" value="private"/> {{ 'Visible only for active group'| trans }}<img src="images/info_16.png" title="{{'which is the currently selected group'|trans}}" alt="" class="info-bullet"/><br/>

--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -380,6 +380,12 @@ function Populate_sysconfig()
   $valueArray[$variable] = array("'$variable'", "30", "'$patTokenValidityPrompt'",
     strval(CONFIG_TYPE_INT), "'PAT'", "1", "'$patTokenValidityDesc'", "null", "null");
 
+  $variable = "SkipFiles";
+  $mimeTypeToSkip = _("Skip MimeTypes from scanning");
+  $mimeTypeDesc = _("add  comma (,) separated mimetype to exclude files from scanning");
+  $valueArray[$variable] = array("'$variable'", "null", "'$mimeTypeToSkip'",
+    strval(CONFIG_TYPE_TEXT), "'Skip'", "1", "'$mimeTypeDesc'", "null", "null");
+
   /* Doing all the rows as a single insert will fail if any row is a dupe.
    So insert each one individually so that new variables get added.
   */

--- a/src/monk/agent/match.c
+++ b/src/monk/agent/match.c
@@ -108,10 +108,10 @@ static char* getFileName(MonkState* state, long pFileId) {
 int matchPFileWithLicenses(MonkState* state, long pFileId, const Licenses* licenses, const MatchCallbacks* callbacks) {
   File file;
   file.id = pFileId;
+  int result = 0;
 
   file.fileName = getFileName(state, pFileId);
-
-  int result = 0;
+  
   if (file.fileName != NULL) {
     result = readTokensFromFile(file.fileName, &(file.tokens), DELIMITERS);
 

--- a/src/monk/agent/monk.c
+++ b/src/monk/agent/monk.c
@@ -34,7 +34,7 @@ void parseArguments(MonkState* state, int argc, char** argv, int* fileOptInd) {
                                          {"jobId", required_argument, 0, 'j'},
                                          {NULL, 0, NULL, 0}};
   int option_index = 0;
-  while ((c = getopt_long(argc, argv, "VvJhs:k:c:", long_options, &option_index)) != -1) {
+  while ((c = getopt_long(argc, argv, "VvJhIs:k:c:", long_options, &option_index)) != -1) {
     switch (c) {
       case 'c':
         break;
@@ -66,6 +66,9 @@ void parseArguments(MonkState* state, int argc, char** argv, int* fileOptInd) {
       case 'k':
         state->scanMode = MODE_CLI_OFFLINE;
         state->knowledgebaseFile = optarg;
+        break;
+      case 'I':
+        state->ignoreFilesWithMimeType = true;
         break;
       case 'h':
       case '?':
@@ -113,12 +116,14 @@ void parseArguments(MonkState* state, int argc, char** argv, int* fileOptInd) {
 
 int main(int argc, char** argv) {
   int fileOptInd;
+
   MonkState stateStore = { .dbManager = NULL,
                            .agentId = 0,
                            .scanMode = 0,
                            .verbosity = 0,
                            .knowledgebaseFile = NULL,
                            .json = 0,
+                           .ignoreFilesWithMimeType = false,
                            .ptr = NULL };
   MonkState* state = &stateStore;
   parseArguments(state, argc, argv, &fileOptInd);

--- a/src/monk/agent/monk.h
+++ b/src/monk/agent/monk.h
@@ -44,6 +44,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MIN_ALLOWED_RANK 66
 
 #include <glib.h>
+#include <stdbool.h>
 #include "libfossdbmanager.h"
 
 #if GLIB_CHECK_VERSION(2,32,0)
@@ -58,6 +59,7 @@ typedef struct {
   int verbosity;
   char* knowledgebaseFile;
   int json;
+  bool ignoreFilesWithMimeType;
   void* ptr;
 } MonkState;
 

--- a/src/monk/agent/scheduler.c
+++ b/src/monk/agent/scheduler.c
@@ -32,7 +32,7 @@ MatchCallbacks schedulerCallbacks =
   };
 
 int processUploadId(MonkState* state, int uploadId, const Licenses* licenses) {
-  PGresult* fileIdResult = queryFileIdsForUpload(state->dbManager, uploadId);
+  PGresult* fileIdResult = queryFileIdsForUpload(state->dbManager, uploadId, state->ignoreFilesWithMimeType);
 
   if (!fileIdResult)
     return 0;

--- a/src/monk/ui/agent-monk.php
+++ b/src/monk/ui/agent-monk.php
@@ -34,6 +34,49 @@ class MonkAgentPlugin extends AgentPlugin
   {
     return CheckARS($uploadId, $this->AgentName, "monk agent", "monk_ars");
   }
+
+  /**
+   * @copydoc Fossology\Lib\Plugin\AgentPlugin::AgentAdd()
+   * @see \Fossology\Lib\Plugin\AgentPlugin::AgentAdd()
+   */
+  public function AgentAdd($jobId, $uploadId, &$errorMsg, $dependencies=array(), $arguments=null)
+  {
+    $unpackArgs = intval($_POST['scm']) == 1 ? '-I' : '';
+    if ($this->AgentHasResults($uploadId) == 1) {
+      return 0;
+    }
+
+    $jobQueueId = \IsAlreadyScheduled($jobId, $this->AgentName, $uploadId);
+    if ($jobQueueId != 0) {
+      return $jobQueueId;
+    }
+
+    $args = $unpackArgs;
+    if (!empty($unpackArgs)) {
+      return $this->doAgentAdd($jobId, $uploadId, $errorMsg, array("agent_mimetype"),$uploadId,$args);
+    } else {
+      return $this->doAgentAdd($jobId, $uploadId, $errorMsg, array("agent_adj2nest"), $uploadId);
+    }
+  }
+
+  /**
+   * Check if agent already included in the dependency list
+   * @param mixed  $dependencies Array of job dependencies
+   * @param string $agentName    Name of the agent to be checked for
+   * @return boolean true if agent already in dependency list else false
+   */
+  protected function isAgentIncluded($dependencies, $agentName)
+  {
+    foreach ($dependencies as $dependency) {
+      if ($dependency == $agentName) {
+        return true;
+      }
+      if (is_array($dependency) && $agentName == $dependency['name']) {
+        return true;
+      }
+    }
+    return false;
+  }
 }
 
 register_plugin(new MonkAgentPlugin());

--- a/src/nomos/agent/nomos.c
+++ b/src/nomos/agent/nomos.c
@@ -62,15 +62,15 @@ char BuildVersion[] = "nomos build version: NULL.\n";
  *
  * At the end, make an entry in the ars using fo_WriteARS().
  * \param cacheroot Root for hash table
+ * \param ignoreFilesWithMimeType to exclude files with particular mimetype
  */
-void arsNomos(cacheroot_t* cacheroot){
+void arsNomos(cacheroot_t* cacheroot, bool ignoreFilesWithMimeType) {
   int i;
   int upload_pk = 0;
   int numrows;
   int ars_pk = 0;
   int user_pk = 0;
   char *AgentARSName = "nomos_ars";
-  char sqlbuf[1024];
   PGresult *result;
 
   char *repFile;
@@ -90,14 +90,8 @@ void arsNomos(cacheroot_t* cacheroot){
       LOG_ERROR("You have no update permissions on upload %d", upload_pk);
       continue;
     }
-    /* if it is duplicate request (same upload_pk, sameagent_fk), then do not repeat */
-    snprintf(sqlbuf, sizeof(sqlbuf),
-        "select ars_pk from nomos_ars,agent \
-                where agent_pk=agent_fk and ars_success=true \
-                  and upload_fk='%d' and agent_fk='%d'",
-        upload_pk, gl.agentPk);
-    result = PQexec(gl.pgConn, sqlbuf);
-    if (fo_checkPQresult(gl.pgConn, result, sqlbuf, __FILE__, __LINE__))
+    result = checkDuplicateReq(gl.pgConn, upload_pk, gl.agentPk);
+    if (fo_checkPQresult(gl.pgConn, result, NULL, __FILE__, __LINE__))
       Bail(-__LINE__);
     if (PQntuples(result) != 0)
     {
@@ -106,17 +100,12 @@ void arsNomos(cacheroot_t* cacheroot){
       continue;
     }
     PQclear(result);
+
     /* Record analysis start in nomos_ars, the nomos audit trail. */
     ars_pk = fo_WriteARS(gl.pgConn, ars_pk, upload_pk, gl.agentPk, AgentARSName, 0, 0);
-    /* retrieve the records to process */
-    snprintf(sqlbuf, sizeof(sqlbuf),
-        "SELECT pfile_pk, pfile_sha1 || '.' || pfile_md5 || '.' || pfile_size AS pfilename \
-         FROM (SELECT distinct(pfile_fk) AS PF FROM uploadtree WHERE upload_fk='%d' and (ufile_mode&x'3C000000'::int)=0) as SS \
-              left outer join license_file on (PF=pfile_fk and agent_fk='%d') inner join pfile on PF=pfile_pk\
-         WHERE fl_pk IS null or agent_fk <>'%d'",
-        upload_pk, gl.agentPk, gl.agentPk);
-    result = PQexec(gl.pgConn, sqlbuf);
-    if (fo_checkPQresult(gl.pgConn, result, sqlbuf, __FILE__, __LINE__))
+
+    result = getSelectedPFiles(gl.pgConn, upload_pk, gl.agentPk, ignoreFilesWithMimeType);
+    if (fo_checkPQresult(gl.pgConn, result, NULL, __FILE__, __LINE__))
       Bail(-__LINE__);
     numrows = PQntuples(result);
     /* process all files in this upload */
@@ -288,6 +277,7 @@ int main(int argc, char **argv)
   cacheroot_t cacheroot;
   char *scanning_directory= NULL;
   int process_count = 0;
+  bool ignoreFilesWithMimeType = false;
 
   /* connect to the scheduler */
   fo_scheduler_connect(&argc, argv, &(gl.pgConn));
@@ -354,7 +344,7 @@ int main(int argc, char **argv)
   }
 
   /* Process command line options */
-  while ((c = getopt(argc, argv, "VJSNvhilc:d:n:")) != -1)
+  while ((c = getopt(argc, argv, "VJSNvhiIlc:d:n:")) != -1)
   {
     switch (c) {
       case 'c': break; /* handled by fo_scheduler_connect() */
@@ -367,15 +357,15 @@ int main(int argc, char **argv)
         break;
       case 'v':
         Verbose++; break;
-    case 'J':
-      gl.progOpts |= OPTS_JSON_OUTPUT;
-      break;
-    case 'S':
-      gl.progOpts |= OPTS_HIGHLIGHT_STDOUT;
-      break;
-    case 'N':
-      gl.progOpts |= OPTS_NO_HIGHLIGHTINFO;
-      break;
+      case 'J':
+        gl.progOpts |= OPTS_JSON_OUTPUT;
+        break;
+      case 'S':
+        gl.progOpts |= OPTS_HIGHLIGHT_STDOUT;
+        break;
+      case 'N':
+        gl.progOpts |= OPTS_NO_HIGHLIGHTINFO;
+        break;
       case 'V':
         printf("%s", BuildVersion);
         Bail(0);
@@ -394,6 +384,9 @@ int main(int argc, char **argv)
         break;
       case 'n': /* spawn mutiple processes to scan */
         process_count = atoi(optarg);
+        break;
+      case 'I':
+        ignoreFilesWithMimeType = true;
         break;
       case 'h':
       default:
@@ -415,7 +408,7 @@ int main(int argc, char **argv)
 
   if (file_count == 0 && !scanning_directory)
   {
-    arsNomos(&cacheroot);
+    arsNomos(&cacheroot, ignoreFilesWithMimeType);
   }
   else
   { /******** Files on the command line ********/

--- a/src/nomos/agent/nomos.h
+++ b/src/nomos/agent/nomos.h
@@ -104,6 +104,7 @@
 #include "nomos_gap.h"
 #include <stdbool.h>
 #include <semaphore.h>
+#include <stdbool.h>
 #include "json_writer.h"
 
 /** Use nomos in standalone mode (no FOSSology DB) */
@@ -469,10 +470,10 @@ typedef struct licensetext licText_t;
  * License scan result
  */
 struct scanResults {
-    int score;        ///< License match score
+  int score;        ///< License match score
   int kwbm;
   int size;
-    int flag;         ///< Flags
+  int flag;         ///< Flags
   int dataOffset;
   char fullpath[myBUFSIZ];
   char linkname[16];

--- a/src/nomos/ui/agent-nomos.php
+++ b/src/nomos/ui/agent-nomos.php
@@ -47,6 +47,49 @@ class NomosAgentPlugin extends AgentPlugin
   {
     return CheckARS($uploadId, $this->AgentName, "license scanner", "nomos_ars");
   }
+
+  /**
+   * @copydoc Fossology\Lib\Plugin\AgentPlugin::AgentAdd()
+   * @see \Fossology\Lib\Plugin\AgentPlugin::AgentAdd()
+   */
+  public function AgentAdd($jobId, $uploadId, &$errorMsg, $dependencies=array(), $arguments=null)
+  {
+    $unpackArgs = intval($_POST['scm']) == 1 ? '-I' : '';
+    if ($this->AgentHasResults($uploadId) == 1) {
+      return 0;
+    }
+
+    $jobQueueId = \IsAlreadyScheduled($jobId, $this->AgentName, $uploadId);
+    if ($jobQueueId != 0) {
+      return $jobQueueId;
+    }
+
+    $args = $unpackArgs;
+    if (!empty($unpackArgs)) {
+      return $this->doAgentAdd($jobId, $uploadId, $errorMsg, array("agent_mimetype"),$uploadId,$args);
+    } else {
+      return $this->doAgentAdd($jobId, $uploadId, $errorMsg, array("agent_adj2nest"), $uploadId);
+    }
+  }
+
+  /**
+   * Check if agent already included in the dependency list
+   * @param mixed  $dependencies Array of job dependencies
+   * @param string $agentName    Name of the agent to be checked for
+   * @return boolean true if agent already in dependency list else false
+   */
+  protected function isAgentIncluded($dependencies, $agentName)
+  {
+    foreach ($dependencies as $dependency) {
+      if ($dependency == $agentName) {
+        return true;
+      }
+      if (is_array($dependency) && $agentName == $dependency['name']) {
+        return true;
+      }
+    }
+    return false;
+  }
 }
 
 register_plugin(new NomosAgentPlugin());

--- a/src/ojo/agent/OjoState.cc
+++ b/src/ojo/agent/OjoState.cc
@@ -58,9 +58,10 @@ const OjoAgent& OjoState::getOjoAgent() const
  * @brief Constructor for OjoCliOptions
  * @param verbosity Verbosity set by CLI
  * @param json      True to get output in JSON format
+ * @param ignoreFilesWithMimeType To ignore files with particular mimetype
  */
-OjoCliOptions::OjoCliOptions(int verbosity, bool json) :
-    verbosity(verbosity), json(json)
+OjoCliOptions::OjoCliOptions(int verbosity, bool json, bool ignoreFilesWithMimeType) :
+    verbosity(verbosity), json(json), ignoreFilesWithMimeType(ignoreFilesWithMimeType)
 {
 }
 
@@ -68,7 +69,7 @@ OjoCliOptions::OjoCliOptions(int verbosity, bool json) :
  * @brief Default constructor for OjoCliOptions
  */
 OjoCliOptions::OjoCliOptions() :
-    verbosity(0), json(false)
+    verbosity(0), json(false), ignoreFilesWithMimeType(false)
 {
 }
 
@@ -98,3 +99,13 @@ bool OjoCliOptions::doJsonOutput() const
 {
   return json;
 }
+
+/**
+ * @brief Check ignore files with particular mimetype is required
+ * @return True if required, else false
+ */
+bool OjoCliOptions::doignoreFilesWithMimeType() const
+{
+  return ignoreFilesWithMimeType;
+}
+

--- a/src/ojo/agent/OjoState.hpp
+++ b/src/ojo/agent/OjoState.hpp
@@ -36,12 +36,14 @@ class OjoCliOptions
   private:
     int verbosity;  /**< The verbosity level */
     bool json;      /**< Whether to generate JSON output */
+    bool ignoreFilesWithMimeType; /**< Ignore files with particular mimetype */
 
   public:
     bool isVerbosityDebug() const;
     bool doJsonOutput() const;
+    bool doignoreFilesWithMimeType() const;
 
-    OjoCliOptions(int verbosity, bool json);
+    OjoCliOptions(int verbosity, bool json, bool ignoreFilesWithMimeType);
     OjoCliOptions();
 };
 

--- a/src/ojo/agent/OjoUtils.cc
+++ b/src/ojo/agent/OjoUtils.cc
@@ -107,13 +107,14 @@ void bail(int exitval)
  * @param state           State of the agent
  * @param uploadId        Upload ID to be scanned
  * @param databaseHandler Database handler to be used
+ * @param ignoreFilesWithMimeType To ignore files with particular mimetype
  * @return True in case of successful scan, false otherwise.
  */
 bool processUploadId(const OjoState &state, int uploadId,
-    OjosDatabaseHandler &databaseHandler)
+    OjosDatabaseHandler &databaseHandler, bool ignoreFilesWithMimeType)
 {
-  vector<unsigned long> fileIds = databaseHandler.queryFileIdsForScan(
-      uploadId, state.getAgentId());
+  vector<unsigned long> fileIds = databaseHandler.queryFileIdsForUpload(
+      uploadId, ignoreFilesWithMimeType);
   char const *repoArea = "files";
 
   bool errors = false;
@@ -254,6 +255,9 @@ bool parseCliOptions(int argc, char **argv, OjoCliOptions &dest,
       "json,J", "output JSON"
     )
     (
+      "ignoreFilesWithMimeType,I", "ignoreFilesWithMimeType"
+    )
+    (
       "config,c",
       boost::program_options::value<string>(),
       "path to the sysconfigdir"
@@ -308,8 +312,9 @@ bool parseCliOptions(int argc, char **argv, OjoCliOptions &dest,
 
     unsigned long verbosity = vm.count("verbose");
     bool json = vm.count("json") > 0 ? true : false;
+    bool  ignoreFilesWithMimeType = vm.count("ignoreFilesWithMimeType") > 0 ?  true : false;
 
-    dest = OjoCliOptions(verbosity, json);
+    dest = OjoCliOptions(verbosity, json, ignoreFilesWithMimeType);
 
     if (vm.count("directory"))
     {

--- a/src/ojo/agent/OjoUtils.hpp
+++ b/src/ojo/agent/OjoUtils.hpp
@@ -45,7 +45,7 @@ int writeARS(const OjoState &state, int arsId, int uploadId, int success,
   fo::DbManager &dbManager);
 void bail(int exitval);
 bool processUploadId(const OjoState &state, int uploadId,
-  OjosDatabaseHandler &databaseHandler);
+  OjosDatabaseHandler &databaseHandler, bool ignoreFilesWithMimeType);
 bool storeResultInDb(const vector<ojomatch> &matches,
   OjosDatabaseHandler &databaseHandle, const int agent_fk,
   const int pfile_fk);

--- a/src/ojo/agent/OjosDatabaseHandler.cc
+++ b/src/ojo/agent/OjosDatabaseHandler.cc
@@ -36,34 +36,12 @@ OjosDatabaseHandler::OjosDatabaseHandler(DbManager dbManager) :
 /**
  * Get a vector of all file id for a given upload id.
  * @param uploadId Upload ID to be queried
+ * @param ignoreFilesWithMimeType To ignore files with particular mimetype
  * @return List of all pfiles for the given upload
  */
-vector<unsigned long> OjosDatabaseHandler::queryFileIdsForUpload(int uploadId)
+vector<unsigned long> OjosDatabaseHandler::queryFileIdsForUpload(int uploadId, bool ignoreFilesWithMimeType)
 {
-  return queryFileIdsVectorForUpload(uploadId);
-}
-
-/**
- * Get a vector of all file id for a given upload id which are not scanned by the given agentId.
- * @param uploadId Upload ID to be queried
- * @param agentId  ID of the agent
- * @return List of all pfiles for the given upload
- */
-vector<unsigned long> OjosDatabaseHandler::queryFileIdsForScan(int uploadId, int agentId)
-{
-  string uploadtreeTableName = queryUploadTreeTableName(uploadId);
-
-  QueryResult queryResult = dbManager.execPrepared(
-    fo_dbManager_PrepareStamement(dbManager.getStruct_dbManager(),
-      ("pfileForUploadFilterAgent" + uploadtreeTableName).c_str(),
-      ("SELECT distinct(ut.pfile_fk) FROM " + uploadtreeTableName + " AS ut "
-      "LEFT JOIN license_file AS lf ON ut.pfile_fk = lf.pfile_fk "
-      "AND lf.agent_fk = $2 WHERE lf.pfile_fk IS NULL "
-      "AND ut.upload_fk = $1 AND (ut.ufile_mode&x'3C000000'::int)=0;").c_str(),
-      int, int),
-    uploadId, agentId);
-
-  return queryResult.getSimpleResults(0, fo::stringToUnsignedLong);
+  return queryFileIdsVectorForUpload(uploadId, ignoreFilesWithMimeType);
 }
 
 /**

--- a/src/ojo/agent/OjosDatabaseHandler.hpp
+++ b/src/ojo/agent/OjosDatabaseHandler.hpp
@@ -79,8 +79,8 @@ class OjosDatabaseHandler: public fo::AgentDatabaseHandler
     ;
     OjosDatabaseHandler spawn() const;
 
-    std::vector<unsigned long> queryFileIdsForUpload(int uploadId);
-    std::vector<unsigned long> queryFileIdsForScan(int uploadId, int agentId);
+    std::vector<unsigned long> queryFileIdsForUpload(int uploadId, bool ignoreFilesWithMimeType);
+    std::vector<unsigned long> queryFileIdsForScan(int uploadId, int agentId, bool ignoreFilesWithMimeType);
     unsigned long saveLicenseToDatabase(OjoDatabaseEntry &entry) const;
     bool insertNoResultInDatabase(OjoDatabaseEntry &entry) const;
     bool saveHighlightToDatabase(const ojomatch &match,

--- a/src/ojo/agent/ojos.cc
+++ b/src/ojo/agent/ojos.cc
@@ -75,6 +75,7 @@ int main(int argc, char **argv)
   }
 
   bool json = cliOptions.doJsonOutput();
+  bool ignoreFilesWithMimeType = cliOptions.doignoreFilesWithMimeType();
   OjoState state = getState(std::move(cliOptions));
 
   if (!fileNames.empty())
@@ -147,7 +148,7 @@ int main(int argc, char **argv)
       if (arsId <= 0)
         bail(5);
 
-      if (!processUploadId(state, uploadId, databaseHandler))
+      if (!processUploadId(state, uploadId, databaseHandler, ignoreFilesWithMimeType))
         bail(2);
 
       fo_scheduler_heart(0);

--- a/src/ojo/ui/agent-ojos.php
+++ b/src/ojo/ui/agent-ojos.php
@@ -35,5 +35,47 @@ class OjosAgentPlugin extends AgentPlugin
     return CheckARS($uploadId, $this->AgentName, "ojo agent", "ojo_ars");
   }
   
+  /**
+   * @copydoc Fossology\Lib\Plugin\AgentPlugin::AgentAdd()
+   * @see \Fossology\Lib\Plugin\AgentPlugin::AgentAdd()
+   */
+  public function AgentAdd($jobId, $uploadId, &$errorMsg, $dependencies=array(), $arguments=null)
+  {
+    $unpackArgs = intval($_POST['scm']) == 1 ? '-I' : '';
+    if ($this->AgentHasResults($uploadId) == 1) {
+      return 0;
+    }
+
+    $jobQueueId = \IsAlreadyScheduled($jobId, $this->AgentName, $uploadId);
+    if ($jobQueueId != 0) {
+      return $jobQueueId;
+    }
+
+    $args = $unpackArgs;
+    if (!empty($unpackArgs)) {
+      return $this->doAgentAdd($jobId, $uploadId, $errorMsg, array("agent_mimetype"),$uploadId,$args);
+    } else {
+      return $this->doAgentAdd($jobId, $uploadId, $errorMsg, array("agent_adj2nest"), $uploadId);
+    }
+  }
+
+  /**
+   * Check if agent already included in the dependency list
+   * @param mixed  $dependencies Array of job dependencies
+   * @param string $agentName    Name of the agent to be checked for
+   * @return boolean true if agent already in dependency list else false
+   */
+  protected function isAgentIncluded($dependencies, $agentName)
+  {
+    foreach ($dependencies as $dependency) {
+      if ($dependency == $agentName) {
+        return true;
+      }
+      if (is_array($dependency) && $agentName == $dependency['name']) {
+        return true;
+      }
+    }
+    return false;
+  }
 }
 register_plugin(new OjosAgentPlugin());

--- a/src/www/ui/agent-add.php
+++ b/src/www/ui/agent-add.php
@@ -98,6 +98,7 @@ class AgentAdder extends DefaultPlugin
    */
   private function agentsAdd($uploadId, $agentsToStart, Request $request)
   {
+    $mimetypeIgnore = intval($request->get('scm') == 1) ? '-I' : '';
     if (! is_array($agentsToStart)) {
       return "bad parameters";
     }
@@ -128,7 +129,11 @@ class AgentAdder extends DefaultPlugin
     }
 
     foreach ($agents as &$agent) {
-      $rv = $agent->AgentAdd($jobId, $uploadId, $errorMsg, array());
+      if (!empty($mimetypeIgnore)) {
+        $rv = $agent->AgentAdd($jobId, $uploadId, $errorMsg, array("agent_mimetype"), $mimetypeIgnore);
+      } else {
+        $rv = $agent->AgentAdd($jobId, $uploadId, $errorMsg, array());
+      }
       if ($rv == -1) {
         return $errorMsg;
       }

--- a/src/www/ui/template/agent_adder.html.twig
+++ b/src/www/ui/template/agent_adder.html.twig
@@ -28,6 +28,9 @@
           </select>
         </div>
       </li>
+      <li>
+         <input type="checkbox" name="scm" value="1"/> {{ 'Ignore files with particular Mimetype'| trans }}<img src="images/info_16.png" title="{{'Configure mimetypes from Admin-Customize-Skip MimeTypes from scanning'|trans}}" alt="" class="info-bullet"/><br/>
+     </li>
       <li> {{ "Select additional analysis."|trans }}<br/>
         <div id="agentsdiv">
           <select multiple size="10" id="agents" name="agents[]"></select>


### PR DESCRIPTION
Signed-off-by: Anupam Ghosh <anupam.ghosh@siemens.com>

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Sometime scanner ( like nomos takes longtime to finish),
Idea is to skip files with particular mimetypes those not require eg : .class , image, doc, binary  

### Changes

New field in Admin-->Customize --> "Skip MimeTypes from scanning"
   -- to add mimetypes of the files need to be included 

User can decide to include or not to include the mimetype/s included in Admin-->customized page 
(using the checkbox "Ignore SCM files (Git, SVN, TFS) and files with particular Mimetype" in upload page) 


## How to test

1. Add mimetypes that need to be excluded by scanner(now only for nomos) 
in Admin-->Customize --> "Skip MimeTypes from scanning
1. check the checkbox on upload page "Ignore SCM files (Git, SVN, TFS) and files with particular Mimetype"
1. include nomos from scanner list
(https://help.github.com/articles/closing-issues-using-keywords/)
