### PR TITLE
fix(scheduler): Check if max_run is -1 (unlimited)

### DIFF
--- a/src/scheduler/agent/scheduler.c
+++ b/src/scheduler/agent/scheduler.c
@@ -410,12 +410,17 @@ void scheduler_destroy(scheduler_t* scheduler)
  * @brief Check if the current agent's max limit is respected.
  *
  * Compare the number of running agents and run limit of the agent.
+ * @note For agents wth no max limit, `max_run = -1`
  * @param agent     Agent which has to be scheduled.
  * @return True if the agent can be scheduled (no. of running agents < max run
  *         limit of the agent), false otherwise.
  */
 static gboolean isMaxLimitReached(meta_agent_t* agent)
 {
+  if (agent->max_run == -1)
+  {
+    return FALSE;
+  }
   if (agent->max_run <= agent->run_count)
   {
     return TRUE;


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

With PR #1305, a check for max agent run was set.
With the change, if agent has max limit as -1 (unlimited), the scheduler will not run another instance of the agent which is not expected.

### Changes

Check if max_run = -1 in `isMaxLimitReached`.

## How to test

1. Schedule multiple instances of agent with `max = -1` in agent's conf file.