### PR TITLE
fix(reuser): Run decider after reuser

### DIFF
--- a/src/decider/ui/DeciderAgentPlugin.php
+++ b/src/decider/ui/DeciderAgentPlugin.php
@@ -101,6 +101,7 @@ class DeciderAgentPlugin extends AgentPlugin
         case 'reuseBulk':
           $dependencies[] = 'agent_nomos';
           $dependencies[] = 'agent_monk';
+          $dependencies[] = 'agent_reuser';
           $rulebits |= 0x4;
           break;
         case 'ojoNoContradiction':

--- a/src/reuser/ui/agent-reuser.php
+++ b/src/reuser/ui/agent-reuser.php
@@ -31,6 +31,8 @@ use Fossology\Lib\Plugin\AgentPlugin;
 use Fossology\Lib\Util\StringOperation;
 use Symfony\Component\HttpFoundation\Request;
 
+include_once(dirname(__DIR__) . "/agent/version.php");
+
 /**
  * @class ReuserAgentPlugin
  * @brief UI element for reuser during Uploading new package
@@ -53,15 +55,6 @@ class ReuserAgentPlugin extends AgentPlugin
     parent::__construct();
 
     $this->uploadDao = $GLOBALS['container']->get('dao.upload');
-  }
-
-  /**
-   * @copydoc Fossology::Lib::Plugin::AgentPlugin::doAgentAdd()
-   * @see Fossology::Lib::Plugin::AgentPlugin::doAgentAdd()
-   */
-  public function doAgentAdd($jobId, $uploadId, &$errorMsg, $dependencies, $jqargs = "", $jq_cmd_args = null)
-  {
-    parent::doAgentAdd($jobId, $uploadId, $errorMsg, $dependencies, $jqargs, $jq_cmd_args);
   }
 
   /**
@@ -105,7 +98,8 @@ class ReuserAgentPlugin extends AgentPlugin
    */
   public function scheduleAgent($jobId, $uploadId, &$errorMsg, $request)
   {
-    $reuseUploadPair = explode(',', $request->get(self::UPLOAD_TO_REUSE_SELECTOR_NAME), 2);
+    $reuseUploadPair = explode(',',
+      $request->get(self::UPLOAD_TO_REUSE_SELECTOR_NAME), 2);
     if (count($reuseUploadPair) == 2) {
       list($reuseUploadId, $reuseGroupId) = $reuseUploadPair;
     } else {
@@ -115,6 +109,8 @@ class ReuserAgentPlugin extends AgentPlugin
     $groupId = $request->get('groupId', Auth::getGroupId());
 
     $getReuseValue = $request->get('reuseMode') ?: array();
+    $reuserDependencies = array("agent_adj2nest");
+
     $reuseMode = UploadDao::REUSE_NONE;
     foreach ($getReuseValue as $currentReuseValue) {
       switch ($currentReuseValue) {
@@ -130,9 +126,14 @@ class ReuserAgentPlugin extends AgentPlugin
       }
     }
 
-    $this->createPackageLink($uploadId, $reuseUploadId, $groupId, $reuseGroupId, $reuseMode);
+    $reuserDependencies = array_merge($reuserDependencies,
+      $this->getReuserDependencies($request));
 
-    return $this->doAgentAdd($jobId, $uploadId, $errorMsg, array("agent_adj2nest"), $uploadId);
+    $this->createPackageLink($uploadId, $reuseUploadId, $groupId, $reuseGroupId,
+      $reuseMode);
+
+    return $this->doAgentAdd($jobId, $uploadId, $errorMsg,
+      array_unique($reuserDependencies), $uploadId);
   }
 
   /**
@@ -161,6 +162,29 @@ class ReuserAgentPlugin extends AgentPlugin
     $packageDao->addUploadToPackage($uploadId, $package);
 
     $this->uploadDao->addReusedUpload($uploadId, $reuseUploadId, $groupId, $reuseGroupId, $reuseMode);
+  }
+
+  /**
+   * Add scanners as reuser dependencies.
+   * @param Request $request Symfony request
+   * @return array List of agent dependencies
+   */
+  private function getReuserDependencies($request)
+  {
+    $dependencies = array();
+    if ($request->get("Check_agent_nomos", false)) {
+      $dependencies[] = "agent_nomos";
+    }
+    if ($request->get("Check_agent_monk", false)) {
+      $dependencies[] = "agent_monk";
+    }
+    if ($request->get("Check_agent_ojo", false)) {
+      $dependencies[] = "agent_ojo";
+    }
+    if ($request->get("Check_agent_ninka", false)) {
+      $dependencies[] = "agent_ninka";
+    }
+    return $dependencies;
   }
 }
 

--- a/src/www/ui/page/UploadPageBase.php
+++ b/src/www/ui/page/UploadPageBase.php
@@ -126,6 +126,9 @@ abstract class UploadPageBase extends DefaultPlugin
     $parmAgentList = MenuHook::getAgentPluginNames("ParmAgents");
     $plainAgentList = MenuHook::getAgentPluginNames("Agents");
     $agentList = array_merge($plainAgentList, $parmAgentList);
+
+    $this->rearrangeDependencies($parmAgentList);
+
     foreach ($parmAgentList as $parmAgent) {
       $agent = plugin_find($parmAgent);
       $agent->scheduleAgent($jobId, $uploadId, $errorMsg, $request, $agentList);
@@ -251,5 +254,21 @@ abstract class UploadPageBase extends DefaultPlugin
     $str = str_replace('`', '\`', $str);
     $str = str_replace('$', '\$', $str);
     return $str;
+  }
+
+  /**
+   * Make sure reuser is scheduled before decider so decider does not run
+   * another reuser as dependency
+   * @param[in,out] array $parmList List of parameterized agents
+   */
+  private function rearrangeDependencies(&$parmList)
+  {
+    $deciderKey = array_search('agent_decider', $parmList);
+    $reuserKey = array_search('agent_reuser', $parmList);
+    if ($deciderKey !== false && $reuserKey !== false) {
+      $temp = $parmList[$deciderKey];
+      $parmList[$deciderKey] = $parmList[$reuserKey];
+      $parmList[$reuserKey] = $temp;
+    }
   }
 }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

If an upload is done with reuse but the new upload has new findings, the reuser simply copied the previous decision ignoring the conflicts.

### Changes

1. Add scanner dependency to reuser.
2. Add reuser as dependency to decider if monkbulk decisions are being reused.

## How to test

1. On master branch. upload a package and do clearing (both manual and with monkbulk).
1. From the previous upload, copy a text portion of a file and make it as a new license so monk will add new license for next upload.
1. Install this branch to change the agent IDs to include newly created license.
1. Reupload the package but reusing the previously cleared package.
    1. Upload with "bulk phrases from reused packages"
    1. Upload without "bulk phrases from reused packages"
1. Check if files with new license findings (new license added in step 2) have WIP or no decisions.