### PR TITLE
feat(email-smtp-config): Add SMTP User field into Fossology email con…

### DIFF
--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -350,11 +350,17 @@ function Populate_sysconfig()
   $valueArray[$variable] = array("'$variable'", "'L'", "'$smtpAuthPrompt'",
     strval(CONFIG_TYPE_DROP), "'SMTP'", "3", "'$smtpAuthDesc'", "null", "'Login{L}|None{N}|Plain{P}'");
 
+  $variable = "SMTPFrom";
+  $smtpFrom = _('SMTP Email');
+  $smtpFromDesc = _('e.g.: "user@domain.com"<br>Sender email.');
+  $valueArray[$variable] = array("'$variable'", "null", "'$smtpFrom'",
+    strval(CONFIG_TYPE_TEXT), "'SMTP'", "4", "'$smtpFromDesc'", "'check_email_address'", "null");
+
   $variable = "SMTPAuthUser";
   $smtpAuthUserPrompt = _('SMTP User');
-  $smtpAuthUserDesc = _('e.g.: "user@domain.com"<br>Email to be used for login in SMTP and for from address.');
+  $smtpAuthUserDesc = _('e.g.: "user"<br>Login to be used for login on SMTP Server.');
   $valueArray[$variable] = array("'$variable'", "null", "'$smtpAuthUserPrompt'",
-    strval(CONFIG_TYPE_TEXT), "'SMTP'", "4", "'$smtpAuthUserDesc'", "'check_email_address'", "null");
+    strval(CONFIG_TYPE_TEXT), "'SMTP'", "5", "'$smtpAuthUserDesc'", "null", "null");
 
   $variable = "SMTPAuthPasswd";
   $smtpAuthPasswdPrompt = _('SMTP Login Password');

--- a/src/scheduler/agent/database.c
+++ b/src/scheduler/agent/database.c
@@ -1098,16 +1098,22 @@ char* get_email_command(scheduler_t* scheduler, char* user_email)
         g_string_append_printf(client_cmd, " -S smtp-auth=plain");
       }
     }
+
     if(g_hash_table_contains(smtpvariables, "SMTPAuthUser"))
     {
-      g_string_append_printf(client_cmd, " -S smtp-auth-user=\"%s\" -S from=\"%s\"",
-          (char *)g_hash_table_lookup(smtpvariables, "SMTPAuthUser"),
+      g_string_append_printf(client_cmd, " -S smtp-auth-user=\"%s\"" ,
           (char *)g_hash_table_lookup(smtpvariables, "SMTPAuthUser"));
+    }
+
+    if(g_hash_table_contains(smtpvariables, "SMTPFrom"))
+    {
+      g_string_append_printf(client_cmd, " -S from=\"%s\"",
+          (char *)g_hash_table_lookup(smtpvariables, "SMTPFrom"));
     }
     if(g_hash_table_contains(smtpvariables, "SMTPAuthPasswd"))
     {
       g_string_append_printf(client_cmd, " -S smtp-auth-password=\"%s\"",
-         (char *)g_hash_table_lookup(smtpvariables, "SMTPAuthPasswd"));
+          (char *)g_hash_table_lookup(smtpvariables, "SMTPAuthPasswd"));
     }
     if(g_hash_table_contains(smtpvariables, "SMTPSslVerify"))
     {


### PR DESCRIPTION
Add SMTP User field into Fossology email configuration to separate "login" and "sender email" (mandatory for Exchange Server)

Closes #1607 

## Description

Add new field to SMTP User to authenticate exchange account 

### Changes

src/lib/php/common-sysconfig.php
src/scheduler/agent/database.c

## How to test

Place you valid smtp exchange credentials and run a test job