### PR TITLE
fix(AdviceLicense): Show error message on failure

### DIFF
--- a/src/www/ui/page/AdminLicenseCandidate.php
+++ b/src/www/ui/page/AdminLicenseCandidate.php
@@ -118,7 +118,12 @@ class AdminLicenseCandidate extends DefaultPlugin
       case 'verify':
       case 'variant':
         $rfParent = ($request->get('do')=='verify') ? $rf : $suggest;
-        $ok = $this->verifyCandidate($rf,$shortname,$rfParent);
+        try{
+          $ok = $this->verifyCandidate($rf,$shortname,$rfParent);
+        } catch (\Throwable $th) {
+          $vars['message'] = 'The license text already exists.';
+          break;
+        }
         if ($ok) {
           $with = $rfParent ? '' : " as variant of <i>$vars[suggest_shortname]</i> ($rfParent)";
           $vars = array(


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

If the license text in ```advice license``` already existed in a ```main license```, clicking ```verify as a new license```  showed a blank page.

This is a fix for issue #1507 
### Changes

An error message is shown if the above case occurs.

Closes #1507
Closes #938