### PR TITLE
feat(ojo): Remove upper limit from license name

### DIFF
--- a/src/ojo/agent/Makefile
+++ b/src/ojo/agent/Makefile
@@ -24,7 +24,7 @@ COVERAGE = $(OBJECTS:%.o=%_cov.o)
 
 all: $(CXXFOLIB) $(EXE)
 
-$(EXE): $(CXXFOLIB) $(VARS) $(OBJECTS)
+$(EXE): $(CXXFOLIB) $(VARS) ojoregex.hpp $(OBJECTS)
 	$(CXX) $(OBJECTS) $(DEF) $(CXXFLAGS_LINK) -o $@
 
 $(EXE)_cov: $(CXXFOLIB) $(VARS) $(COVERAGE)

--- a/src/ojo/agent/ojoregex.hpp
+++ b/src/ojo/agent/ojoregex.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019, Siemens AG
+ * Copyright (C) 2020, Siemens AG
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -29,19 +29,19 @@
  *
  * -# The regex first finds occurance of `spdx-license-identifier` in the text
  * -# Throw the text `spdx-license-identifier`
- * -# Matches at most 5 identifiers each with length between 3 and 37 (based on
+ * -# Matches at most 5 identifiers each with length greater than 3 (based on
  * https://github.com/spdx/license-list-data/tree/master/html)
  */
-#define SPDX_LICENSE_LIST "spdx-licen[cs]e(?:id|[- ]identifier): \\K((?:(?: (?:and|or|with) )?\\(?(?:[\\w\\d\\.\\+\\-]{3,37})\\)?){1,5})"
+#define SPDX_LICENSE_LIST "spdx-licen[cs]e(?:id|[- ]identifier): \\K((?:(?: (?:and|or|with) )?\\(?(?:[\\w\\d\\.\\+\\-]{3,})\\)?){1,5})"
 /**
  * @def SPDX_LICENSE_NAMES
  * @brief Regex to filter license names from list of license list
  *
  * -# License names will consist of words, digits, dots and hyphens.
- * -# Length of license names between 3 and 37 (based on
+ * -# Length of license names greater than 3 (based on
  * https://github.com/spdx/license-list-data/tree/master/html)
  */
-#define SPDX_LICENSE_NAMES "(?: and | or | with )?\\(?([\\w\\d\\.\\+\\-]{3,37})\\)?"
+#define SPDX_LICENSE_NAMES "(?: and | or | with )?\\(?([\\w\\d\\.\\+\\-]{3,})\\)?"
 /**
  * @def SPDX_DUAL_LICENSE
  * @brief Regex to check if Dual-license

--- a/src/ojo/agent_tests/Functional/schedulerTest.php
+++ b/src/ojo/agent_tests/Functional/schedulerTest.php
@@ -330,10 +330,16 @@ class OjoScheduledTest extends \PHPUnit\Framework\TestCase
     $resultArray = $result[0]["results"];
 
     $this->assertEquals($testFile, $result[0]["file"]);
-    $this->assertTrue($this->resultArrayContainsLicense($resultArray, "MPL-2.0-no-copyleft-exception"));
-    $this->assertTrue($this->resultArrayContainsLicense($resultArray, "BSD-2-Clause"));
-    $this->assertTrue($this->resultArrayContainsLicense($resultArray, "MIT"));
-    $this->assertTrue($this->resultArrayContainsLicense($resultArray, "Apache-2.0"));
+    $this->assertTrue($this->resultArrayContainsLicense($resultArray,
+      "MPL-2.0-no-copyleft-exception"));
+    $this->assertTrue($this->resultArrayContainsLicense($resultArray,
+      "BSD-2-Clause"));
+    $this->assertTrue($this->resultArrayContainsLicense($resultArray,
+      "MIT"));
+    $this->assertTrue($this->resultArrayContainsLicense($resultArray,
+      "Apache-2.0"));
+    $this->assertTrue($this->resultArrayContainsLicense($resultArray,
+      "Dual-license"));
   }
 
   /**

--- a/src/ojo/agent_tests/Unit/test_regex.cc
+++ b/src/ojo/agent_tests/Unit/test_regex.cc
@@ -1,5 +1,5 @@
 /*********************************************************************
-Copyright (C) 2014, Siemens AG
+Copyright (C) 2019, Siemens AG
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -33,6 +33,7 @@ using namespace std;
 class regexTest : public CPPUNIT_NS :: TestFixture {
   CPPUNIT_TEST_SUITE (regexTest);
   CPPUNIT_TEST (regTest);
+  CPPUNIT_TEST (badNameTest);
 
   CPPUNIT_TEST_SUITE_END ();
 
@@ -51,9 +52,10 @@ protected:
 
     const std::string gplLicense = "GPL-2.0";
     const std::string lgplLicense = "LGPL-2.1+";
-    std::string content = "SPDX-License-Identifier: " + gplLicense + " AND " + lgplLicense;
-    boost::regex listRegex (SPDX_LICENSE_LIST, boost::regex_constants::icase);
-    boost::regex nameRegex (SPDX_LICENSE_NAMES, boost::regex_constants::icase);
+    std::string content = "SPDX-License-Identifier: " + gplLicense + " AND "
+        + lgplLicense;
+    boost::regex listRegex(SPDX_LICENSE_LIST, boost::regex_constants::icase);
+    boost::regex nameRegex(SPDX_LICENSE_NAMES, boost::regex_constants::icase);
 
     std::string::const_iterator begin = content.begin();
     std::string::const_iterator end = content.end();
@@ -88,10 +90,77 @@ protected:
     size_t expectedNos = 2;
     size_t actualNos = licensesFound.size();
     // Check if 2 licenses are found
-    CPPUNIT_ASSERT_EQUAL (expectedNos, actualNos);
+    CPPUNIT_ASSERT_EQUAL(expectedNos, actualNos);
     // Check if the result contains the expected string
-    CPPUNIT_ASSERT(std::find(licensesFound.begin(), licensesFound.end(), gplLicense) != licensesFound.end());
-    CPPUNIT_ASSERT(std::find(licensesFound.begin(), licensesFound.end(), lgplLicense) != licensesFound.end());
+    CPPUNIT_ASSERT(
+      std::find(licensesFound.begin(), licensesFound.end(), gplLicense)
+        != licensesFound.end());
+    CPPUNIT_ASSERT(
+      std::find(licensesFound.begin(), licensesFound.end(), lgplLicense)
+        != licensesFound.end());
+  };
+
+  /**
+   * \brief Test regex on a string with bad identifier
+   *
+   * \test
+   * -# Create a test SPDX identifier string with bad license identifier
+   * -# Load the regex patterns
+   * -# Run the regex on the string
+   * -# Check the actual number of matches against expected result
+   * -# Check the actual findings matches the expected licenses
+   */
+  void badNameTest (void) {
+
+    const std::string gplLicense = "GPL-2.0";
+    const std::string badLicense = "AB";
+    std::string content = "SPDX-License-Identifier: " + gplLicense + " AND "
+        + badLicense;
+    boost::regex listRegex(SPDX_LICENSE_LIST, boost::regex_constants::icase);
+    boost::regex nameRegex(SPDX_LICENSE_NAMES, boost::regex_constants::icase);
+
+    std::string::const_iterator begin = content.begin();
+    std::string::const_iterator end = content.end();
+    boost::match_results<std::string::const_iterator> what;
+
+    string licenseList;
+    boost::regex_search(begin, end, what, listRegex);
+    licenseList = what[1].str();
+
+    // Check if only correct license is found
+    CPPUNIT_ASSERT_EQUAL(gplLicense, licenseList);
+
+    // Find the actual license in the list
+    begin = licenseList.begin();
+    end = licenseList.end();
+    list<string> licensesFound;
+
+    while (begin != end)
+    {
+      boost::smatch res;
+      if (boost::regex_search(begin, end, res, nameRegex))
+      {
+        licensesFound.push_back(res[1].str());
+        begin = res[0].second;
+      }
+      else
+      {
+        break;
+      }
+    }
+
+    size_t expectedNos = 1;
+    size_t actualNos = licensesFound.size();
+    // Check if only 1 license is found
+    CPPUNIT_ASSERT_EQUAL(expectedNos, actualNos);
+    // Check if the result contains the expected string
+    CPPUNIT_ASSERT(
+      std::find(licensesFound.begin(), licensesFound.end(), gplLicense)
+        != licensesFound.end());
+    // Check if the result does not contain the bad string
+    CPPUNIT_ASSERT(
+      std::find(licensesFound.begin(), licensesFound.end(), badLicense)
+        == licensesFound.end());
   };
 
 };


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Remove the upper limit from license name as additions of new SPDX licenses will result in rewrite of code.

### Changes

1. Remove upper limit for license name (lower bound remains same).
1. Add `ojoregex.hpp` as dependency to `$(EXE)` to rebuild whenever regex changes.
1. Added **Dual-License** check in Functional test.
1. Added bad license name check in Unit test.

## How to test

1. Scan a file with license identifier more than 37 characters in length.
1. Modifying the `regex.hpp` file (using `touch`, or simple modification) should result in rebuild of agent when using `make`.
