### PR TITLE
feat(auth): Add external authentification feature

### DIFF
--- a/install/defconf/fossology.conf.in
+++ b/install/defconf/fossology.conf.in
@@ -91,4 +91,29 @@ footer  = samplefooter.txt
 subject = FOSSology scan complete
 client  = /usr/bin/mailx
 
+[EXT_AUTH]
+; Use external Authentication
+CONF_EXT_AUTH_ENABLE=false
+
+; Environment variable where to find the User name
+CONF_EXT_AUTH_ENV_USER=
+
+; Environment variable where to find the User email
+CONF_EXT_AUTH_ENV_MAIL=
+
+; Environment variable where to find the User Description
+CONF_EXT_AUTH_ENV_DESC=
+
+; Set to true to force usernames to lowercase
+CONF_EXT_AUTH_LOWERCASE_USER="true"
+
+; Set to true to automatically create an account for users
+; logging in for the first time
+CONF_EXT_AUTH_NEW_USER_AUTO_CREATE="true"
+
+; List of agents attributed to newly created users
+; Example:
+; "agent_copyright,agent_keyword,agent_mimetype,agent_monk,agent_nomos,agent_ojo,agent_shagent"
+CONF_EXT_AUTH_NEW_USER_AGENT_LIST=
+
 

--- a/install/defconf/fossology.conf.in
+++ b/install/defconf/fossology.conf.in
@@ -105,15 +105,14 @@ CONF_EXT_AUTH_ENV_MAIL=
 CONF_EXT_AUTH_ENV_DESC=
 
 ; Set to true to force usernames to lowercase
-CONF_EXT_AUTH_LOWERCASE_USER="true"
+CONF_EXT_AUTH_LOWERCASE_USER=true
 
 ; Set to true to automatically create an account for users
 ; logging in for the first time
-CONF_EXT_AUTH_NEW_USER_AUTO_CREATE="true"
+CONF_EXT_AUTH_NEW_USER_AUTO_CREATE=true
 
 ; List of agents attributed to newly created users
 ; Example:
 ; "agent_copyright,agent_keyword,agent_mimetype,agent_monk,agent_nomos,agent_ojo,agent_shagent"
 CONF_EXT_AUTH_NEW_USER_AGENT_LIST=
-
 

--- a/src/lib/php/common-auth.php
+++ b/src/lib/php/common-auth.php
@@ -42,7 +42,41 @@ function siteminder_check()
 } // siteminder_check()
 
 /**
- * \brief Check if this account is correct
+ * \brief Check if the external HTTP authentication is enabled.
+ *  The mapping variables should be configured in fossology.conf
+ *  Usernames are forced lowercase.
+ * \return false if not enabled
+ */
+function auth_external_check()
+{
+  $EXT_AUTH_ENABLE = false;
+  if (array_key_exists('EXT_AUTH', $GLOBALS['SysConf'])) {
+    if (array_key_exists('CONF_EXT_AUTH_ENABLE', $GLOBALS['SysConf']['EXT_AUTH'])) {
+        $EXT_AUTH_ENABLE = $GLOBALS['SysConf']['EXT_AUTH']['CONF_EXT_AUTH_ENABLE'];
+    }
+  }
+  if ($EXT_AUTH_ENABLE) {
+    $EXT_AUTH_USER_KW = $GLOBALS['SysConf']['EXT_AUTH']['CONF_EXT_AUTH_ENV_USER'];
+    $EXT_AUTH_USER = $GLOBALS['_SERVER']["{$EXT_AUTH_USER_KW}"];
+    if (isset($EXT_AUTH_USER) && !empty($EXT_AUTH_USER)) {
+      if ($GLOBALS['SysConf']['EXT_AUTH']['CONF_EXT_AUTH_LOWERCASE_USER']) {
+          $EXT_AUTH_USER = strtolower($EXT_AUTH_USER);
+      }
+      $out['useAuthExternal']         = true;
+      $out['loginAuthExternal']       = $EXT_AUTH_USER;
+      $out['passwordAuthExternal']    = sha1($EXT_AUTH_USER);
+      $EXT_AUTH_MAIL_KW = $GLOBALS['SysConf']['EXT_AUTH']['CONF_EXT_AUTH_ENV_MAIL'];
+      $out['emailAuthExternal']       = $GLOBALS['_SERVER']["{$EXT_AUTH_MAIL_KW}"];
+      $EXT_AUTH_DESC_KW = $GLOBALS['SysConf']['EXT_AUTH']['CONF_EXT_AUTH_ENV_DESC'];
+      $out['descriptionAuthExternal'] = $GLOBALS['_SERVER']["{$EXT_AUTH_DESC_KW}"];
+      return $out;
+    }
+  }
+  return $out['useAuthExternal'] = false;
+}
+
+/**
+ * \brief check if this account is correct
  *
  * \param string &$user   User name, reference variable
  * \param string &$passwd Password, reference variable

--- a/src/www/ui/core-auth.php
+++ b/src/www/ui/core-auth.php
@@ -91,7 +91,7 @@ class core_auth extends FO_Plugin
     }
 
     //--------- Authentification external connection for auto-login-----------
-    if ($this->authExternal['useAuthExternal']) {
+    if ($this->authExternal !== false && $this->authExternal['useAuthExternal']) {
       $this->checkUsernameAndPassword($this->authExternal['loginAuthExternal'], $this->authExternal['passwordAuthExternal']);
     }
 
@@ -262,7 +262,7 @@ class core_auth extends FO_Plugin
   {
     $user_exists=true;
     /* Check the user for external authentication */
-    if ($this->authExternal['useAuthExternal']) {
+    if ($this->authExternal !== false && $this->authExternal['useAuthExternal']) {
       $username = $this->authExternal['loginAuthExternal'];
       /* checking if user exists */
       try {

--- a/src/www/ui/core-auth.php
+++ b/src/www/ui/core-auth.php
@@ -34,6 +34,8 @@ class core_auth extends FO_Plugin
   private $userDao;
   /** @var Session */
   private $session;
+  /** @var External Authentication */
+  private $authExternal;
 
   function __construct()
   {
@@ -47,6 +49,7 @@ class core_auth extends FO_Plugin
     $this->dbManager = $container->get("db.manager");
     $this->userDao = $container->get('dao.user');
     $this->session = $container->get('session');
+    $this->authExternal = auth_external_check();
   }
 
   /**
@@ -85,6 +88,11 @@ class core_auth extends FO_Plugin
     if (!$this->session->isStarted()) {
       $this->session->setName('Login');
       $this->session->start();
+    }
+
+    //--------- Authentification external connection for auto-login-----------
+    if ($this->authExternal['useAuthExternal']) {
+      $this->checkUsernameAndPassword($this->authExternal['loginAuthExternal'], $this->authExternal['passwordAuthExternal']);
     }
 
     if (array_key_exists('selectMemberGroup', $_POST)) {
@@ -252,6 +260,33 @@ class core_auth extends FO_Plugin
    */
   function checkUsernameAndPassword($userName, $password)
   {
+    $user_exists=true;
+    /* Check the user for external authentication */
+    if ($this->authExternal['useAuthExternal']) {
+      $username = $this->authExternal['loginAuthExternal'];
+      /* checking if user exists */
+      try {
+        $this->userDao->getUserAndDefaultGroupByUserName($username);
+      } catch (Exception $e) {
+          $user_exists=false;
+      }
+      if (! $user_exists && $GLOBALS['SysConf']['EXT_AUTH']['CONF_EXT_AUTH_NEW_USER_AUTO_CREATE']) {
+        /* If user does not exist then we create it */
+        $User = trim(str_replace("'", "''", $this->authExternal['loginAuthExternal']));
+        $Pass = $this->authExternal['passwordAuthExternal'] ;
+        $Seed = rand() . rand();
+        $Hash = sha1($Seed . $Pass);
+        $Desc = $this->authExternal['descriptionAuthExternal'];
+        $Perm = 3;
+        $Folder = 1;
+        $Email_notify = "y";
+        $Email = $this->authExternal['emailAuthExternal'];
+        /* Set default list of agents when a new user is created */
+        $agentList = $GLOBALS['SysConf']['EXT_AUTH']['CONF_EXT_AUTH_NEW_USER_AGENT_LIST'];
+        add_user($User, $Desc, $Seed, $Hash, $Perm, $Email, $Email_notify, $agentList, $Folder);
+      }
+    }
+
     if (empty($userName) || $userName == 'Default User') {
       return false;
     }


### PR DESCRIPTION
### Description
Partially fixes #1273 

This PR introduces external authentication, delegated to Apache.
Apache can be configured to perform any kind of authentication, and places relevent information (login, user name, email), etc. in environment variables.
- on first login, the user's account is automatically created
- then a session is opened for the user.

Optionally, all logins may be lower cased.

Further possible improvements:
1. Make the configuration available in the GUI
1. Configure the default list of agents for each newly created user
1. Add the 'logout' feature (logout is ineffective in this version)

### Changes

- Added configuration options in `fossology.conf.in`
- In `src/lib/php/common-auth.php` : new function to check external authentication validity
- In `src/www/ui/core-auth.php` : check authenticatino and create new account if needed

## How to test

Configure the Apache authentication, fossology.conf, and log in.

[Sample configurations](https://github.com/fossology/fossology/issues/1273#issuecomment-576890182)