### PR TITLE
fix(lib): Check group on local decision only

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -79,6 +79,7 @@ class ClearingDao
     $statementName .= "." . $uploadTreeTable . ($onlyCurrent ? ".current": "");
 
     $globalScope = DecisionScopes::REPO;
+    $localScope = DecisionScopes::ITEM;
 
     return "WITH allDecs AS (
               SELECT
@@ -92,9 +93,11 @@ class ClearingDao
                 CASE cd.scope WHEN $globalScope THEN 1 ELSE 0 END AS scopesort
               FROM clearing_decision cd
                 INNER JOIN $uploadTreeTable ut
-                  ON (ut.pfile_fk = cd.pfile_fk AND cd.scope = $globalScope) OR ut.uploadtree_pk = cd.uploadtree_fk
+                  ON (ut.pfile_fk = cd.pfile_fk AND cd.scope = $globalScope)
+                    OR (ut.uploadtree_pk = cd.uploadtree_fk
+                      AND cd.scope = $localScope AND cd.group_fk = $p2)
               WHERE $sql_upload $condition
-                cd.decision_type!=$p1 AND cd.group_fk = $p2),
+                cd.decision_type!=$p1),
             decision AS (
               SELECT $filterClause *
               FROM allDecs

--- a/src/lib/php/Proxy/UploadTreeProxy.php
+++ b/src/lib/php/Proxy/UploadTreeProxy.php
@@ -183,9 +183,9 @@ class UploadTreeProxy extends DbViewProxy
   {
     return "NOT(SELECT (removed OR cd.decision_type=".DecisionTypes::IRRELEVANT.") excluded"
             . " FROM clearing_decision cd, clearing_decision_event cde, clearing_event ce"
-         . "    WHERE cd.group_fk=".$this->addParamAndGetExpr('groupId', $options[self::OPT_GROUP_ID])
-         . "      AND (cd.uploadtree_fk=$itemTable.uploadtree_pk"
-         . "        OR cd.scope=".DecisionScopes::REPO." AND cd.pfile_fk=$itemTable.pfile_fk)"
+         . "    WHERE ((cd.group_fk=".$this->addParamAndGetExpr('groupId', $options[self::OPT_GROUP_ID])
+         . "      AND cd.uploadtree_fk=$itemTable.uploadtree_pk)"
+         . "        OR (cd.scope=".DecisionScopes::REPO." AND cd.pfile_fk=$itemTable.pfile_fk))"
          . "      AND clearing_decision_pk=clearing_decision_fk"
          . "      AND clearing_event_fk=clearing_event_pk"
          . "      AND rf_fk=".$this->addParamAndGetExpr('conId',$options[self::OPT_CONCLUDE_REF])
@@ -287,9 +287,10 @@ SELECT decision_type, ROW_NUMBER() OVER (
 ) AS rnum
 FROM (
   SELECT * FROM clearing_decision cd
-  WHERE cd.group_fk = $groupId
-  AND (
-    ut.uploadtree_pk = cd.uploadtree_fk OR cd.pfile_fk = ut.pfile_fk AND cd.scope=".DecisionScopes::REPO."
+  WHERE (
+    ut.uploadtree_pk = cd.uploadtree_fk AND cd.group_fk = $groupId
+  ) OR (
+    cd.pfile_fk = ut.pfile_fk AND cd.scope=".DecisionScopes::REPO."
   )
 ) AS filtered_clearing_decision ORDER BY rnum DESC LIMIT 1";
         return " $conditionQueryHasLicense


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Clearing decisions were filtered based on user's group irrespective if it is global or not.

This PR changes the logic and checks for the group only for local decisions (per file).

### Changes

1. Fix the condition in `ClearingDao`.
1. Fix the condition in `UploadTreeProxy`.

## How to test

1. Create two users (User1 and User2) and 2 groups:
    a. User1 to Group1
    b. User2 to Group2
1. Perform some clearing on an upload with User1.
    - Add both local and global decisions.
1. Login from User2 and check following:
    a. Local decisions should not be visible to User2.
    b. Global decisions should be visible to User2.