### PR TITLE
fix(rest): Get upload summary without UI

### DIFF
--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -33,6 +33,7 @@ use Fossology\UI\Api\Helper\UploadHelper;
 use Fossology\Lib\Data\AgentRef;
 use Fossology\Lib\Dao\AgentDao;
 use Fossology\Lib\Proxy\ScanJobProxy;
+use Fossology\Lib\Proxy\UploadBrowseProxy;
 
 /**
  * @class UploadController
@@ -50,6 +51,16 @@ class UploadController extends RestController
    * Get query parameter name for container listing
    */
   const CONTAINER_PARAM = "containers";
+
+  public function __construct($container)
+  {
+    parent::__construct($container);
+    $groupId = $this->restHelper->getGroupId();
+    $dbManager = $this->dbHelper->getDbManager();
+    $uploadBrowseProxy = new UploadBrowseProxy($groupId, 0, $dbManager, false);
+    $uploadBrowseProxy->sanity();
+  }
+
   /**
    * Get list of uploads for current user
    *

--- a/src/www/ui/api/Helper/UploadHelper.php
+++ b/src/www/ui/api/Helper/UploadHelper.php
@@ -29,7 +29,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use Fossology\UI\Api\Helper\UploadHelper\HelperToUploadFilePage;
 use Fossology\UI\Api\Helper\UploadHelper\HelperToUploadVcsPage;
 use Fossology\UI\Api\Models\UploadSummary;
-use Fossology\UI\Page\BrowseLicense;
 use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Proxy\ScanJobProxy;
 use Fossology\Lib\Dao\AgentDao;
@@ -289,7 +288,7 @@ class UploadHelper
 
     $mainLicenses = $this->getMainLicenses($dbManager, $uploadId, $groupId);
 
-    $uiLicense = new BrowseLicense();
+    $uiLicense = $restHelper->getPlugin("license");
     $hist = $uiLicense->getUploadHist($itemTreeBounds);
 
     $summary = new UploadSummary();


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The entry for `upload_clearing` are missing for new uploads.

### Changes

Generate the entry for `upload_clearing` using `UploadBrowseProxy` class on every upload related endpoint.

## How to test

1. Upload a file using REST API or UI.
1. Fetch the `/uploads/<id>/summary` without opening `Browse` page in UI.
    1. Also, fetch from a different group from REST API.

Closes #1620