### PR TITLE
fix(fo-installdeps): Missing Fedora dependecies 

### DIFF
--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -197,7 +197,7 @@ if [[ $RUNTIME ]]; then
          esac
          ;;
       Fedora)
-         yum $YesOpt install postgresql-server httpd
+         yum $YesOpt install postgresql-server httpd chkconfig
          yum $YesOpt install \
             postgresql \
             php php-pear php-pgsql php-process php-xml php-mbstring\
@@ -209,9 +209,9 @@ if [[ $RUNTIME ]]; then
          # enable, possible init, and start postgresql
          /sbin/chkconfig postgresql on
          if [ ! -f /var/lib/pgsql/data/PG_VERSION ]; then
-            /sbin/service postgresql initdb
+            /usr/bin/postgresql-setup --initdb
          fi
-         /sbin/service postgresql start
+         /usr/bin/systemctl start postgresql
 
          echo "NOTE: unrar is not available in Fedora release $CODENAME,"
          echo "   please install from upstream sources."


### PR DESCRIPTION

## Description

There were few missing fedora dependencies that were missing.

## How to test

Pull fedora docker image and try executing fo-installdeps

Fixes: #1601 