### PR TITLE
Feat(Copyright): Fixed the checking of config file in wrong folder

### DIFF
--- a/src/copyright/agent/regexConfProvider.cc
+++ b/src/copyright/agent/regexConfProvider.cc
@@ -62,7 +62,7 @@ string getRegexConfFile(const string& identity)
   string confRelativeToTestDir("../../agent/" + identity + ".conf");
 
   string confInInstallDir((sysconfigdir ? string(sysconfigdir) : "/usr/local/share/fossology/")
-                          + "/mods-enabled/" + identity +  "/agent/" + identity + ".conf");
+                          + identity +  "/agent/" + identity + ".conf");
 
   if(testIfFileExists( confInSameDir ))
   {


### PR DESCRIPTION
## Description
The copyright agent looks for the config file in the `following` directory 
` /usr/local/share/fossology//mods-enabled/copyright/agent/copyright.conf
`
which doesn't exists, it should look for the config file in:

`/usr/local/share/fossology/copyright
`


Fixes #1298 
