### PR TITLE
fix(travis): Fix build config warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@
 
 language: php
 dist: xenial
+os: linux
 php: 7.0
 cache:
   ccache: true
@@ -153,7 +154,7 @@ jobs:
 #### PHPUnit tests ###########################
     - &phpunit-tests
       php: 5.6
-      addon: {}
+      addons: {}
       install: composer install --prefer-dist --working-dir=src
       before_script: ./utils/prepare-test -afty
       script:
@@ -196,12 +197,12 @@ jobs:
         - bash utils/deploy-pages.sh
       deploy:
         provider: pages
-        skip-cleanup: true
-        github-token: $GITHUB_TOKEN
-        keep-history: false
-        local-dir: ./code_docs
+        cleanup: true
+        token: $GITHUB_TOKEN
+        keep_history: false
+        local_dir: ./code_docs
         repo: $GH_REPO_REF
-        target-branch: master
+        target_branch: master
         on:
           branch: master
   allow_failures:


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix travis warnings.

``` console
$ travis lint
Warnings for .travis.yml:
[x] [warn] on jobs.include: key addon is not known, but addons is, using addons
[x] [warn] on jobs.include.deploy: deprecated key: skip_cleanup (not supported in dpl v2, use cleanup)
```

### Changes

1. Fix warnings given by travis.
1. Change deprecated keys for [dplv2](https://blog.travis-ci.com/2019-08-27-deployment-tooling-dpl-v2-preview-release)

## How to test

Check the travis logs.
https://travis-ci.org/fossology/fossology/builds/660574926/config