### PR TITLE
fix(AdviceLicense):show error message on failed merge

### DIFF
--- a/src/www/ui/page/AdminLicenseCandidate.php
+++ b/src/www/ui/page/AdminLicenseCandidate.php
@@ -134,7 +134,12 @@ class AdminLicenseCandidate extends DefaultPlugin
         $vars['message'] = 'Short name must be unique';
         break;
       case 'merge':
-        $ok = $this->mergeCandidate($rf,$suggest,$vars);
+        try {
+          $ok = $this->mergeCandidate($rf,$suggest,$vars);
+        } catch (\Throwable $th) {
+          $vars['message'] = 'The license text already exists.';
+          break;
+        }
         if ($ok) {
           $vars = array(
               'aaData' => json_encode($this->getArrayArrayData()),

--- a/src/www/ui/page/AdminLicenseCandidate.php
+++ b/src/www/ui/page/AdminLicenseCandidate.php
@@ -245,7 +245,7 @@ class AdminLicenseCandidate extends DefaultPlugin
     /** @var DbManager */
     $dbManager = $this->getObject('db.manager');
     $tableColumnMap = array("license_file"=>"rf_fk",
-        "license_ref_bulk"=>"rf_fk",
+        "license_set_bulk"=>"rf_fk",
         "clearing_event"=>"rf_fk");
     foreach ($tableColumnMap as $table=>$column) {
       $dbManager->prepare($stmt=__METHOD__.".$table","UPDATE $table SET $column=$1 WHERE $column=$2");


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix white page showing when **merge** is clicked, when advice license and a main license have the same license text.

## Changes

An error message stating `the license text already exists` is shown if the above case occurs.
