### PR TITLE
fix(licenseRef): Fix import of licenseRef.json

### DIFF
--- a/install/fossinit.php
+++ b/install/fossinit.php
@@ -383,7 +383,7 @@ if($isUpdating && (empty($sysconfig['Release']) || $sysconfig['Release'] == "3.1
 }
 
 $dbManager->begin();
-$dbManager->getSingleRow("DELETE FROM sysconfig WHERE variablename=$1",array('Release'),$sqlLog='drop.sysconfig.release');
+$dbManager->getSingleRow("DELETE FROM sysconfig WHERE variablename=$1",array('Release'),'drop.sysconfig.release');
 $dbManager->insertTableRow('sysconfig',
         array('variablename'=>'Release','conf_value'=>$sysconfig['Release'],'ui_label'=>'Release','vartype'=>2,'group_name'=>'Release','description'=>''));
 $dbManager->commit();
@@ -431,8 +431,10 @@ function insertInToLicenseRefTableUsingJson($tableName)
   }
   $dbManager->begin();
   if ($tableName === 'license_ref_2') {
-    $dbManager->queryOnce("DROP TABLE IF EXISTS license_ref_2", $statment = __METHOD__.'.dropAncientBackUp');
-    $dbManager->queryOnce("CREATE TABLE license_ref_2 AS SELECT * FROM license_ref WHERE 1=2", $statment = __METHOD__.'.backUpData');
+    $dbManager->queryOnce("DROP TABLE IF EXISTS license_ref_2",
+      __METHOD__.'.dropAncientBackUp');
+    $dbManager->queryOnce("CREATE TABLE license_ref_2 (LIKE license_ref INCLUDING DEFAULTS)",
+      __METHOD__.'.backUpData');
   }
   /** import licenseRef.json */
   $keysToBeChanged = array(
@@ -445,15 +447,20 @@ function insertInToLicenseRefTableUsingJson($tableName)
 
   $jsonData = json_decode(file_get_contents("$LIBEXECDIR/licenseRef.json"), true);
   $statementName = __METHOD__.'.insertInTo'.$tableName;
-  foreach($jsonData as $licenseArrayKey => $licenseArray) {
-    $keys = strtr(implode(",", array_keys($licenseArray)), $keysToBeChanged);
-    $valuePlaceHolders = "$" . join(",$",range(1, count(array_keys($licenseArray))));
-    $SQL = "INSERT INTO $tableName ( $keys ) VALUES ($valuePlaceHolders);";
+  foreach($jsonData as $licenseArray) {
+    $arrayKeys = array_keys($licenseArray);
+    $arrayValues = array_values($licenseArray);
+    $keys = strtr(implode(",", $arrayKeys), $keysToBeChanged);
+    $valuePlaceHolders = "$" . join(",$",range(1, count($arrayKeys)));
+    $md5PlaceHolder = "$". (count($arrayKeys) + 1);
+    $arrayValues[] = $licenseArray['rf_text'];
+    $SQL = "INSERT INTO $tableName ( $keys,rf_md5 ) " .
+      "VALUES ($valuePlaceHolders,md5($md5PlaceHolder));";
     $dbManager->prepare($statementName, $SQL);
-    $dbManager->execute($statementName, array_values($licenseArray));
+    $dbManager->execute($statementName, $arrayValues);
   }
   $dbManager->commit();
-  return;
+  return (0);
 }
 
 /**
@@ -468,24 +475,25 @@ function initLicenseRefTable($Verbose)
 {
   global $dbManager;
 
-  $dbManager->queryOnce("BEGIN");
+  $dbManager->begin();
   insertInToLicenseRefTableUsingJson('license_ref_2');
-  $dbManager->prepare(__METHOD__.".newLic", "select * from license_ref_2");
+  $dbManager->prepare(__METHOD__.".newLic", "SELECT * FROM license_ref_2");
   $result_new = $dbManager->execute(__METHOD__.".newLic");
 
-  $dbManager->prepare(__METHOD__.'.licenseRefByShortname','SELECT * from license_ref where rf_shortname=$1');
+  $dbManager->prepare(__METHOD__.'.licenseRefByShortname',
+    'SELECT *,md5(rf_text) AS hash FROM license_ref WHERE rf_shortname=$1');
   /** traverse all records in user's license_ref table, update or insert */
   while ($row = pg_fetch_assoc($result_new))
   {
     $rf_shortname = $row['rf_shortname'];
-    $escaped_name = pg_escape_string($rf_shortname);
-    $result_check = $dbManager->execute(__METHOD__.'.licenseRefByShortname',array($rf_shortname));
+    $result_check = $dbManager->execute(__METHOD__.'.licenseRefByShortname', array($rf_shortname));
     $count = pg_num_rows($result_check);
 
-    $rf_text = pg_escape_string($row['rf_text']);
-    $rf_url = pg_escape_string($row['rf_url']);
-    $rf_fullname = pg_escape_string($row['rf_fullname']);
-    $rf_notes = pg_escape_string($row['rf_notes']);
+    $rf_text = $row['rf_text'];
+    $rf_md5 = $row['rf_md5'];
+    $rf_url = $row['rf_url'];
+    $rf_fullname = $row['rf_fullname'];
+    $rf_notes = $row['rf_notes'];
     $rf_active = $row['rf_active'];
     $marydone = $row['marydone'];
     $rf_text_updatable = $row['rf_text_updatable'];
@@ -496,47 +504,193 @@ function initLicenseRefTable($Verbose)
     {
       $row_check = pg_fetch_assoc($result_check);
       pg_free_result($result_check);
-      $rf_text_check = pg_escape_string($row_check['rf_text']);
-      $rf_url_check = pg_escape_string($row_check['rf_url']);
-      $rf_fullname_check = pg_escape_string($row_check['rf_fullname']);
-      $rf_notes_check = pg_escape_string($row_check['rf_notes']);
+      $params = array();
+      $rf_text_check = $row_check['rf_text'];
+      $rf_md5_check = $row_check['rf_md5'];
+      $hash_check = $row_check['hash'];
+      $rf_url_check = $row_check['rf_url'];
+      $rf_fullname_check = $row_check['rf_fullname'];
+      $rf_notes_check = $row_check['rf_notes'];
       $rf_active_check = $row_check['rf_active'];
       $marydone_check = $row_check['marydone'];
       $rf_text_updatable_check = $row_check['rf_text_updatable'];
       $rf_detector_type_check = $row_check['rf_detector_type'];
       $rf_flag_check = $row_check['rf_flag'];
 
-      $sql = "UPDATE license_ref set ";
-      if ($rf_flag_check == 2 &&  $rf_flag == 1) {
-        $sql .= " rf_text='$rf_text_check',";
-      } else {
-        if ($rf_text_check != $rf_text && !empty($rf_text) && !(stristr($rf_text, 'License by Nomos')))  $sql .= " rf_text='$rf_text', rf_flag='1',";
+      $candidateLicense = isACandidateLicense($dbManager, $rf_shortname);
+      if ($candidateLicense) {
+        mergeCandidateLicense($dbManager, $candidateLicense);
       }
-      if ($rf_url_check != $rf_url && !empty($rf_url))  $sql .= " rf_url='$rf_url',";
-      if ($rf_fullname_check != $rf_fullname && !empty($rf_fullname))  $sql .= " rf_fullname ='$rf_fullname',";
-      if ($rf_notes_check != $rf_notes && !empty($rf_notes))  $sql .= " rf_notes ='$rf_notes',";
-      if ($rf_active_check != $rf_active && !empty($rf_active))  $sql .= " rf_active ='$rf_active',";
-      if ($marydone_check != $marydone && !empty($marydone))  $sql .= " marydone ='$marydone',";
-      if ($rf_text_updatable_check != $rf_text_updatable && !empty($rf_text_updatable))  $sql .= " rf_text_updatable ='$rf_text_updatable',";
-      if ($rf_detector_type_check != $rf_detector_type && !empty($rf_detector_type))  $sql .= " rf_detector_type = '$rf_detector_type',";
-      $sql = substr_replace($sql ,"",-1);
+
+      $statement = __METHOD__ . ".updateLicenseRef";
+      $sql = "UPDATE license_ref set ";
+      if (($rf_flag_check == 2 && $rf_flag == 1) ||
+        ($hash_check != $rf_md5_check)) {
+        $params[] = $rf_text_check;
+        $position = "$" . count($params);
+        $sql .= "rf_text=$position,rf_md5=md5($position),";
+        $statement .= ".text";
+      } else {
+        if ($rf_text_check != $rf_text && !empty($rf_text) &&
+          !(stristr($rf_text, 'License by Nomos'))) {
+          $params[] = $rf_text;
+          $position = "$" . count($params);
+          $sql .= "rf_text=$position,rf_md5=md5($position),rf_flag=1,";
+          $statement .= ".insertT";
+        }
+      }
+      if ($rf_url_check != $rf_url && !empty($rf_url)) {
+        $params[] = $rf_url;
+        $position = "$" . count($params);
+        $sql .= "rf_url=$position,";
+        $statement .= ".url";
+      }
+      if ($rf_fullname_check != $rf_fullname && !empty($rf_fullname)) {
+        $params[] = $rf_fullname;
+        $position = "$" . count($params);
+        $sql .= "rf_fullname=$position,";
+        $statement .= ".name";
+      }
+      if ($rf_notes_check != $rf_notes && !empty($rf_notes)) {
+        $params[] = $rf_notes;
+        $position = "$" . count($params);
+        $sql .= "rf_notes=$position,";
+        $statement .= ".notes";
+      }
+      if ($rf_active_check != $rf_active && !empty($rf_active)) {
+        $params[] = $rf_active;
+        $position = "$" . count($params);
+        $sql .= "rf_active=$position,";
+        $statement .= ".active";
+      }
+      if ($marydone_check != $marydone && !empty($marydone)) {
+        $params[] = $marydone;
+        $position = "$" . count($params);
+        $sql .= "marydone=$position,";
+        $statement .= ".marydone";
+      }
+      if ($rf_text_updatable_check != $rf_text_updatable && !empty($rf_text_updatable)) {
+        $params[] = $rf_text_updatable;
+        $position = "$" . count($params);
+        $sql .= "rf_text_updatable=$position,";
+        $statement .= ".tUpdate";
+      }
+      if ($rf_detector_type_check != $rf_detector_type && !empty($rf_detector_type)) {
+        $params[] = $rf_detector_type;
+        $position = "$" . count($params);
+        $sql .= "rf_detector_type=$position,";
+        $statement .= ".dType";
+      }
+      $sql = substr_replace($sql, "", -1);
 
       if ($sql != "UPDATE license_ref set") { // check if have something to update
-        $sql .= " where rf_shortname = '$escaped_name'";
-        $dbManager->queryOnce($sql);
+        $params[] = $rf_shortname;
+        $position = "$" . count($params);
+        $sql .= " WHERE rf_shortname=$position;";
+        $dbManager->getSingleRow($sql, $params, $statement);
       }
     } else {  // insert when it is new
       pg_free_result($result_check);
-      $sql = "INSERT INTO license_ref (rf_shortname, rf_text, rf_url, rf_fullname, rf_notes, rf_active, rf_text_updatable, rf_detector_type, marydone)"
-              . "VALUES ('$escaped_name', '$rf_text', '$rf_url', '$rf_fullname', '$rf_notes', '$rf_active', '$rf_text_updatable', '$rf_detector_type', '$marydone');";
-      $dbManager->queryOnce($sql);
+      $params = array();
+      $params['rf_shortname'] = $rf_shortname;
+      $params['rf_text'] = $rf_text;
+      $params['rf_url'] = $rf_url;
+      $params['rf_fullname'] = $rf_fullname;
+      $params['rf_notes'] = $rf_notes;
+      $params['rf_active'] = $rf_active;
+      $params['rf_text_updatable'] = $rf_text_updatable;
+      $params['rf_detector_type'] = $rf_detector_type;
+      $params['marydone'] = $marydone;
+      insertNewLicense($dbManager, $params);
     }
   }
   pg_free_result($result_new);
 
   $dbManager->queryOnce("DROP TABLE license_ref_2");
-  $dbManager->queryOnce("COMMIT");
+  $dbManager->commit();
 
   return (0);
 } // initLicenseRefTable()
 
+/**
+ * Check if the given shortname is a candidate license.
+ *
+ * @param DbManager $dbManager DbManager used
+ * @param string $rf_shortname Shortname of the license to check
+ * @returns False if the license is not candidate else DB row
+ */
+function isACandidateLicense($dbManager, $rf_shortname)
+{
+  $sql = "SELECT * FROM ONLY license_candidate WHERE rf_shortname = $1;";
+  $candidateRow = $dbManager->getSingleRow($sql, array($rf_shortname));
+  if (! empty($candidateRow) > 0) {
+    return $candidateRow;
+  } else {
+    return false;
+  }
+}
+
+/**
+ * Merge the candidate license to the main license_ref table.
+ *
+ * @param DbManager $dbManager    DbManager used
+ * @param array $candidateLicense Shortname of the license to check
+ * @return integer License ID
+ */
+function mergeCandidateLicense($dbManager, $candidateLicense)
+{
+  $dbManager->begin();
+  $deleteSql = "DELETE FROM license_candidate WHERE rf_pk = $1;";
+  $deleteStatement = __METHOD__ . ".deleteCandidte";
+  $dbManager->prepare($deleteStatement, $deleteSql);
+  $dbManager->execute($deleteStatement, array($candidateLicense['rf_pk']));
+  $licenseId = insertNewLicense($dbManager, $candidateLicense, true);
+  $dbManager->commit();
+  return $licenseId;
+}
+
+/**
+ * Insert new license to license_ref
+ *
+ * @param DbManager $dbManager  DbManager to be used
+ * @param array $license        License row to be added
+ * @param boolean $wasCandidate Was the new license already a candidate?
+ *        (required for rf_pk)
+ * @return integer New license ID
+ */
+function insertNewLicense($dbManager, $license, $wasCandidate = false)
+{
+  $insertStatement = __METHOD__ . ".insertNewLicense";
+  $sql = "INSERT INTO license_ref (";
+  if ($wasCandidate) {
+    $sql .= "rf_pk, ";
+    $insertStatement .= ".wasCandidate";
+  }
+  $sql .= "rf_shortname, rf_text, rf_url, rf_fullname, rf_notes, rf_active, " .
+    "rf_text_updatable, rf_detector_type, marydone, rf_md5, rf_add_date" .
+    ") VALUES (";
+  $params = array();
+  if ($wasCandidate) {
+    $params[] = $license['rf_pk'];
+  }
+  $params[] = $license['rf_shortname'];
+  $params[] = $license['rf_text'];
+  $params[] = $license['rf_url'];
+  $params[] = $license['rf_fullname'];
+  $params[] = $license['rf_notes'];
+  $params[] = $license['rf_active'];
+  $params[] = $license['rf_text_updatable'];
+  $params[] = $license['rf_detector_type'];
+  $params[] = $license['marydone'];
+
+  for ($i = 1; $i <= count($params); $i++) {
+    $sql .= "$" . $i . ",";
+  }
+
+  $params[] = $license['rf_text'];
+  $textPos = "$" . count($params);
+
+  $sql .= "md5($textPos),now())";
+  return $dbManager->insertPreparedAndReturn($insertStatement, $sql, $params,
+    "rf_pk");
+}

--- a/src/cli/exportLicenseRefUsingSPDX.php
+++ b/src/cli/exportLicenseRefUsingSPDX.php
@@ -44,7 +44,7 @@ class exportLicenseRef
     $newLicenseRefData = array();
     $usage = "Usage: " . basename($argv[0]) . " [options]
 
-      Create new licenseref.json file.  Options are: 
+      Create new licenseref.json file.  Options are:
         -E    Update all existing licenses and also add new licenses.
               (NOTE: there may be failure of test cases)
 
@@ -52,7 +52,7 @@ class exportLicenseRef
               (NOTE: there may be failure of test cases)
 
         -n    Only add new licenses.
- 
+
        --type Usually licenses/exceptions (optional)
               (ex: --type 'licenses')
 
@@ -179,9 +179,6 @@ class exportLicenseRef
       /* dump all the data from licenseRef.json file to a array */
       $existingLicenseRefData = (array) json_decode($getExistingLicenseRefData, true);
     }
-    /* get max rf_pk from existing licenseref.json file */
-    $maxkey = array_search(max($existingLicenseRefData), $existingLicenseRefData);
-    $newRfPk = $existingLicenseRefData[$maxkey]['rf_pk'] + 1;
     /* get license list and each license's URL */
     $getList = json_decode(file_get_contents($URL));
     foreach ($getList->$type as $listValue) {
@@ -191,8 +188,8 @@ class exportLicenseRef
       echo "INFO: search for license ".$getCurrentData[$this->mapArrayData[$type][0]]."\n";
       /* check if the licenseid of the current license exists in old license data */
       $licenseIdCheck = array_search($getCurrentData[$this->mapArrayData[$type][0]], array_column($existingLicenseRefData, 'rf_shortname'));
-      $currentMD5 = md5($getCurrentData[$this->mapArrayData[$type][1]]);
-      $MD5Check = array_search($currentMD5, array_column($existingLicenseRefData, 'rf_md5'));
+      $currentText = $getCurrentData[$this->mapArrayData[$type][1]];
+      $textCheck = array_search($currentText, array_column($existingLicenseRefData, 'rf_text'));
       if (!is_numeric($licenseIdCheck)) {
         /* if licenseid does'nt exists then remove the suffix if any and search again */
         $getCurrentData[$this->mapArrayData[$type][0]] = $this->getLicenseNameWithOutSuffix($getCurrentData[$this->mapArrayData[$type][0]]);
@@ -200,7 +197,7 @@ class exportLicenseRef
         $licenseIdCheck = array_search($getCurrentData[$this->mapArrayData[$type][0]], array_column($existingLicenseRefData, 'rf_shortname'));
       }
       if (is_numeric($licenseIdCheck) &&
-          !is_numeric($MD5Check) &&
+          !is_numeric($textCheck) &&
           (
             !empty($updateWithNew) ||
             !empty($updateExisting)
@@ -209,19 +206,17 @@ class exportLicenseRef
         $existingLicenseRefData[$licenseIdCheck]['rf_fullname'] = $getCurrentData[$this->mapArrayData[$type][2]];
         $existingLicenseRefData[$licenseIdCheck]['rf_text'] = $getCurrentData[$this->mapArrayData[$type][1]];
         $existingLicenseRefData[$licenseIdCheck]['rf_url'] = $getCurrentData['seeAlso'][0];
-        $existingLicenseRefData[$licenseIdCheck]['rf_md5'] = $currentMD5;
         $existingLicenseRefData[$licenseIdCheck]['rf_notes'] = (array_key_exists("licenseComments", $getCurrentData) ? $getCurrentData['licenseComments'] : $existingLicenseRefData[$licenseIdCheck]['rf_notes']);
         echo "INFO: license ".$getCurrentData[$this->mapArrayData[$type][0]]." updated\n\n";
       }
       if (!is_numeric($licenseIdCheck) &&
-          !is_numeric($MD5Check) &&
+          !is_numeric($textCheck) &&
           (
             !empty($updateWithNew) ||
             !empty($addNewLicense)
           )
          ) {
         $existingLicenseRefData[] = array(
-          'rf_pk' => "$newRfPk",
           'rf_shortname' => $getCurrentData[$this->mapArrayData[$type][0]],
           'rf_text' =>  $getCurrentData[$this->mapArrayData[$type][1]],
           'rf_url' =>  $getCurrentData['seeAlso'][0],
@@ -237,7 +232,6 @@ class exportLicenseRef
           'marydone' => "f",
           'rf_active' => "t",
           'rf_text_updatable' => "f",
-          'rf_md5' => $currentMD5,
           'rf_detector_type' => 1,
           'rf_source' => null,
           'rf_risk' => null,
@@ -245,7 +239,6 @@ class exportLicenseRef
           'rf_flag' => "1"
         );
         echo "INFO: new license ".$getCurrentData[$this->mapArrayData[$type][0]]." added\n\n";
-        $newRfPk++;
       }
     }
     return $existingLicenseRefData;

--- a/src/decider/agent_tests/Functional/schedulerTest.php
+++ b/src/decider/agent_tests/Functional/schedulerTest.php
@@ -156,7 +156,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
     $this->testDb->createViews(array('license_file_ref'),false);
     $this->testDb->createConstraints(array('agent_pkey','pfile_pkey','upload_pkey_idx','clearing_event_pkey','jobqueue_pkey'),false);
     $this->testDb->alterTables(array('agent','pfile','upload','ars_master','license_ref_bulk','license_set_bulk','clearing_event',
-      'clearing_decision','license_file','highlight','jobqueue','job'),false);
+      'clearing_decision','license_file', 'license_ref','highlight','jobqueue','job'),false);
     $this->testDb->createInheritedTables();
     $this->testDb->createInheritedArsTables(array('nomos','monk','copyright'));
 

--- a/src/deciderjob/agent_tests/Functional/schedulerTest.php
+++ b/src/deciderjob/agent_tests/Functional/schedulerTest.php
@@ -143,7 +143,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
     $this->testDb->createSequences(array('agent_agent_pk_seq','pfile_pfile_pk_seq','upload_upload_pk_seq','nomos_ars_ars_pk_seq','license_file_fl_pk_seq','license_ref_rf_pk_seq','license_ref_bulk_lrb_pk_seq','clearing_decision_clearing_decision_pk_seq','clearing_event_clearing_event_pk_seq','FileLicense_pkey'),false);
     $this->testDb->createViews(array('license_file_ref'),false);
     $this->testDb->createConstraints(array('agent_pkey','pfile_pkey','upload_pkey_idx','clearing_event_pkey'),false);
-    $this->testDb->alterTables(array('agent','pfile','upload','ars_master','license_ref_bulk','clearing_event','clearing_decision','license_file','highlight'),false);
+    $this->testDb->alterTables(array('agent','pfile','upload','ars_master','license_ref_bulk','license_ref','clearing_event','clearing_decision','license_file','highlight'),false);
     $this->testDb->createInheritedTables();
     $this->testDb->createInheritedArsTables(array('nomos','monk'));
 

--- a/src/lib/php/Dao/test/LicenseDaoTest.php
+++ b/src/lib/php/Dao/test/LicenseDaoTest.php
@@ -46,9 +46,20 @@ class LicenseDaoTest extends \PHPUnit\Framework\TestCase
     $this->dbManager = null;
   }
 
+  /**
+   * Setup license_ref table and rf_pk sequence
+   */
+  private function setUpLicenseRefTable()
+  {
+    $this->testDb->createPlainTables(array('license_ref'));
+    $this->testDb->createSequences(array('license_ref_rf_pk_seq'));
+    $this->testDb->alterTables(array('license_ref'));
+  }
+
   public function testGetFileLicenseMatches()
   {
-    $this->testDb->createPlainTables(array('license_ref','uploadtree','license_file','agent'));
+    $this->testDb->createPlainTables(array('uploadtree','license_file','agent'));
+    $this->setUpLicenseRefTable();
     $this->testDb->insertData_license_ref();
 
     $lic0 = $this->dbManager->getSingleRow("Select * from license_ref limit 1");
@@ -89,7 +100,7 @@ class LicenseDaoTest extends \PHPUnit\Framework\TestCase
 
   public function testGetLicenseByShortName()
   {
-    $this->testDb->createPlainTables(array('license_ref'));
+    $this->setUpLicenseRefTable();
     $this->testDb->insertData_license_ref($limit=3);
     $licDao = new LicenseDao($this->dbManager);
     $lic0 = $this->dbManager->getSingleRow("Select rf_shortname from license_ref limit 1");
@@ -105,7 +116,7 @@ class LicenseDaoTest extends \PHPUnit\Framework\TestCase
 
   public function testGetLicenseId()
   {
-    $this->testDb->createPlainTables(array('license_ref'));
+    $this->setUpLicenseRefTable();
     $this->testDb->insertData_license_ref($limit=3);
     $licDao = new LicenseDao($this->dbManager);
     $lic0 = $this->dbManager->getSingleRow("Select rf_pk from license_ref limit 1");
@@ -121,7 +132,7 @@ class LicenseDaoTest extends \PHPUnit\Framework\TestCase
 
   public function testGetLicenseRefs()
   {
-    $this->testDb->createPlainTables(array('license_ref'));
+    $this->setUpLicenseRefTable();
     $this->testDb->insertData_license_ref();
     $licDao = new LicenseDao($this->dbManager);
     $licAll = $licDao->getLicenseRefs();
@@ -132,7 +143,8 @@ class LicenseDaoTest extends \PHPUnit\Framework\TestCase
 
   public function testGetLicenseShortnamesContained()
   {
-    $this->testDb->createPlainTables(array('license_ref','license_file','uploadtree'));
+    $this->testDb->createPlainTables(array('license_file','uploadtree'));
+    $this->setUpLicenseRefTable();
     $this->dbManager->queryOnce("CREATE TABLE \"uploadtree_a\" AS SELECT * FROM uploadtree");
     $this->testDb->createViews(array('license_file_ref'));
     $this->testDb->insertData(array('license_file','uploadtree_a'));
@@ -178,7 +190,8 @@ class LicenseDaoTest extends \PHPUnit\Framework\TestCase
 
   public function testGetLicenseIdPerPfileForAgentId()
   {
-    $this->testDb->createPlainTables(array('license_ref','license_file','uploadtree','agent'));
+    $this->testDb->createPlainTables(array('license_file','uploadtree','agent'));
+    $this->setUpLicenseRefTable();
     $this->testDb->insertData(array('agent'));
     $this->testDb->createViews(array('license_file_ref'));
     $this->testDb->insertData_license_ref($limit=3);
@@ -225,7 +238,8 @@ class LicenseDaoTest extends \PHPUnit\Framework\TestCase
 
   public function testGetLicensesPerFileNameForAgentId()
   {
-    $this->testDb->createPlainTables(array('license_ref','license_file','uploadtree','agent'));
+    $this->testDb->createPlainTables(array('license_file','uploadtree','agent'));
+    $this->setUpLicenseRefTable();
     $this->testDb->insertData(array('agent'));
     $this->testDb->createViews(array('license_file_ref'));
     $this->testDb->insertData_license_ref($limit=3);
@@ -357,7 +371,7 @@ class LicenseDaoTest extends \PHPUnit\Framework\TestCase
   public function testIsNewLicense()
   {
     $groupId = 401;
-    $this->testDb->createPlainTables(array('license_ref'));
+    $this->setUpLicenseRefTable();
     $this->testDb->insertData_license_ref();
     $this->dbManager->queryOnce("CREATE TABLE license_candidate AS SELECT *,$groupId group_fk FROM license_ref LIMIT 1");
     $licCandi = $this->dbManager->getSingleRow("SELECT * FROM license_candidate",array(),__METHOD__.'.candi');
@@ -385,7 +399,8 @@ class LicenseDaoTest extends \PHPUnit\Framework\TestCase
 
   public function testGetAgentFileLicenseMatchesWithLicenseMapping()
   {
-    $this->testDb->createPlainTables(array('license_ref','uploadtree','license_file','agent','license_map'));
+    $this->testDb->createPlainTables(array('uploadtree','license_file','agent','license_map'));
+    $this->setUpLicenseRefTable();
     $this->testDb->insertData_license_ref();
 
     $lic0 = $this->dbManager->getSingleRow("Select * from license_ref limit 1",array(),__METHOD__.'.anyLicense');

--- a/src/lib/php/Data/Highlight.php
+++ b/src/lib/php/Data/Highlight.php
@@ -125,7 +125,7 @@ class Highlight
    */
   public function setLicenseId($licenseId)
   {
-    $this->licenseId = $licenseId;
+    $this->licenseId = intval($licenseId);
   }
 
   /**

--- a/src/lib/php/Test/TestAbstractDb.php
+++ b/src/lib/php/Test/TestAbstractDb.php
@@ -95,11 +95,16 @@ abstract class TestAbstractDb
     $jsonData = json_decode(file_get_contents("$LIBEXECDIR/licenseRef.json"), true);
     $statementName = __METHOD__.'.insertInToLicenseRef';
     foreach ($jsonData as $licenseArrayKey => $licenseArray) {
-      $keys = strtr(implode(",", array_keys($licenseArray)), $keysToBeChanged);
-      $valuePlaceHolders = "$" . join(",$",range(1, count(array_keys($licenseArray))));
-      $SQL = "INSERT INTO license_ref ( $keys ) VALUES ($valuePlaceHolders);";
+      $arrayKeys = array_keys($licenseArray);
+      $arrayValues = array_values($licenseArray);
+      $keys = strtr(implode(",", $arrayKeys), $keysToBeChanged);
+      $valuePlaceHolders = "$" . join(",$",range(1, count($arrayKeys)));
+      $md5PlaceHolder = "$". (count($arrayKeys) + 1);
+      $arrayValues[] = $licenseArray['rf_text'];
+      $SQL = "INSERT INTO license_ref ( $keys,rf_md5 ) " .
+      "VALUES ($valuePlaceHolders,md5($md5PlaceHolder));";
       $this->dbManager->prepare($statementName, $SQL);
-      $this->dbManager->execute($statementName, array_values($licenseArray));
+      $this->dbManager->execute($statementName, $arrayValues);
       if ($licenseArrayKey >= $limit) {
         break;
       }

--- a/src/monk/agent_tests/Functional/bulkTest.php
+++ b/src/monk/agent_tests/Functional/bulkTest.php
@@ -121,7 +121,7 @@ class MonkBulkTest extends \PHPUnit\Framework\TestCase
     $this->testDb->createSequences(array('agent_agent_pk_seq','pfile_pfile_pk_seq','upload_upload_pk_seq','nomos_ars_ars_pk_seq','license_file_fl_pk_seq','license_ref_rf_pk_seq','license_ref_bulk_lrb_pk_seq','clearing_event_clearing_event_pk_seq'),false);
     $this->testDb->createViews(array('license_file_ref'),false);
     $this->testDb->createConstraints(array('agent_pkey','pfile_pkey','upload_pkey_idx','FileLicense_pkey','clearing_event_pkey', 'license_ref_bulk_pkey', 'license_set_bulk_fkey'),false);
-    $this->testDb->alterTables(array('agent','pfile','upload','ars_master','license_ref_bulk','license_set_bulk','clearing_event','license_file','highlight'),false);
+    $this->testDb->alterTables(array('agent','pfile','upload','ars_master','license_ref_bulk','license_ref','license_set_bulk','clearing_event','license_file','highlight'),false);
     $this->testDb->createInheritedTables();
     $this->testDb->insertData(array('pfile','upload','uploadtree_a','users'), false);
     $this->testDb->insertData_license_ref();
@@ -161,7 +161,8 @@ class MonkBulkTest extends \PHPUnit\Framework\TestCase
     $removing = false;
     $refText = "The GNU General Public License is a free, copyleft license for software and other kinds of works.";
 
-    $bulkId = $this->licenseDao->insertBulkLicense($userId, $groupId, $uploadTreeId, array($licenseId => $removing), $refText);
+    $bulkId = $this->licenseDao->insertBulkLicense($userId, $groupId, $uploadTreeId,
+      array($licenseId => array($removing,"","","")), $refText);
 
     $this->assertGreaterThan($expected=0, $bulkId);
 
@@ -181,7 +182,8 @@ class MonkBulkTest extends \PHPUnit\Framework\TestCase
     $refSecondText = "Our General Public Licenses are designed to make sure that you " .
                "have the freedom to distribute copies of free software";
     $licenseSecondId = 215;
-    $bulkSecondId = $this->licenseDao->insertBulkLicense($userId, $groupId, $uploadTreeId, array($licenseSecondId => $removing), $refSecondText);
+    $bulkSecondId = $this->licenseDao->insertBulkLicense($userId, $groupId, $uploadTreeId,
+      array($licenseSecondId => array($removing,"","","")), $refSecondText);
 
     $jobId++;
     list($output,$retCode) = $this->runBulkMonk($userId, $groupId, $jobId, $bulkSecondId);
@@ -190,7 +192,7 @@ class MonkBulkTest extends \PHPUnit\Framework\TestCase
     $relevantDecisionsItemPfile3 = $this->clearingDao->getRelevantClearingEvents($bounds6, $groupId);
     $relevantDecisionsItemPfile4 = $this->clearingDao->getRelevantClearingEvents($bounds7, $groupId);
     assertThat(count($relevantDecisionsItemPfile3), is(equalTo(1)));
-    
+
     assertThat(count($relevantDecisionsItemPfile4), is(equalTo(2)));
     assertThat($relevantDecisionsItemPfile4, hasKeyInArray($licenseSecondId));
 
@@ -214,7 +216,8 @@ class MonkBulkTest extends \PHPUnit\Framework\TestCase
     $refText = "The GNU General Public License is a free, copyleft license for software and other kinds of works.";
 
     $bulkId = $this->licenseDao->insertBulkLicense($userId, $groupId, $uploadTreeId,
-      array($licenseId1 => $removing1, $licenseId2 => $removing2), $refText);
+      array($licenseId1 => array($removing1,"","",""),
+        $licenseId2 => array($removing2,"","","")), $refText);
 
     $this->assertGreaterThan($expected=0, $bulkId);
 
@@ -283,7 +286,8 @@ class MonkBulkTest extends \PHPUnit\Framework\TestCase
     $removing = false;
     $refText = "The GNU General Public License is a free, copyleft license for software and other kinds of works.";
 
-    $bulkId = $this->licenseDao->insertBulkLicense($userId, $groupId, $uploadTreeId, array($licenseId => $removing), $refText);
+    $bulkId = $this->licenseDao->insertBulkLicense($userId, $groupId, $uploadTreeId,
+      array($licenseId => array($removing,"","","")), $refText);
 
     $this->assertGreaterThan($expected = 0, $bulkId);
 
@@ -338,7 +342,8 @@ class MonkBulkTest extends \PHPUnit\Framework\TestCase
 
     $jobId = 64;
 
-    $bulkId = $this->licenseDao->insertBulkLicense($userId, $groupId, $uploadTreeId, array($licenseId => $removing), $refText);
+    $bulkId = $this->licenseDao->insertBulkLicense($userId, $groupId, $uploadTreeId,
+      array($licenseId => array($removing,"","","")), $refText);
 
     $this->assertGreaterThan($expected=0, $bulkId);
 
@@ -370,7 +375,8 @@ class MonkBulkTest extends \PHPUnit\Framework\TestCase
     $removing = false;
     $refText = "The GNU";
 
-    $bulkId = $this->licenseDao->insertBulkLicense($userId, $groupId, $uploadTreeId, array($licenseId => $removing), $refText);
+    $bulkId = $this->licenseDao->insertBulkLicense($userId, $groupId, $uploadTreeId,
+      array($licenseId => array($removing,"","","")), $refText);
 
     $this->assertGreaterThan($expected=0, $bulkId);
 
@@ -423,7 +429,8 @@ class MonkBulkTest extends \PHPUnit\Framework\TestCase
     $removing = false;
     $refText = "";
 
-    $bulkId = $this->licenseDao->insertBulkLicense($userId, $groupId, $uploadTreeId, array($licenseId => $removing), $refText);
+    $bulkId = $this->licenseDao->insertBulkLicense($userId, $groupId, $uploadTreeId,
+      array($licenseId => array($removing,"","","")), $refText);
 
     $this->assertGreaterThan($expected=0, $bulkId);
 

--- a/src/monk/agent_tests/Functional/cliTest.php
+++ b/src/monk/agent_tests/Functional/cliTest.php
@@ -100,6 +100,7 @@ class MonkCliTest extends \PHPUnit\Framework\TestCase
   {
     $this->testDb->createPlainTables(array('license_ref'),false);
     $this->testDb->createSequences(array('license_ref_rf_pk_seq'),false);
+    $this->testDb->alterTables(array('license_ref'),false);
 
     $this->testDb->insertData_license_ref(1<<10);
   }

--- a/src/monk/agent_tests/Functional/schedulerTest.php
+++ b/src/monk/agent_tests/Functional/schedulerTest.php
@@ -117,7 +117,7 @@ class MonkScheduledTest extends \PHPUnit\Framework\TestCase
     $this->testDb->createSequences(array('agent_agent_pk_seq','pfile_pfile_pk_seq','upload_upload_pk_seq','nomos_ars_ars_pk_seq','license_file_fl_pk_seq','license_ref_rf_pk_seq','license_ref_bulk_lrb_pk_seq','clearing_event_clearing_event_pk_seq','clearing_decision_clearing_decision_pk_seq'),false);
     $this->testDb->createViews(array('license_file_ref'),false);
     $this->testDb->createConstraints(array('agent_pkey','pfile_pkey','upload_pkey_idx','FileLicense_pkey','clearing_event_pkey','clearing_decision_pkey'),false);
-    $this->testDb->alterTables(array('agent','pfile','upload','ars_master','license_ref_bulk','license_set_bulk','clearing_event','license_file','highlight','clearing_decision'),false);
+    $this->testDb->alterTables(array('agent','pfile','upload','ars_master','license_ref_bulk','license_ref','license_set_bulk','clearing_event','license_file','highlight','clearing_decision'),false);
     $this->testDb->createInheritedTables();
     $this->testDb->insertData(array('pfile','upload','uploadtree_a','users'), false);
     $this->testDb->insertData_license_ref(200);
@@ -167,7 +167,7 @@ class MonkScheduledTest extends \PHPUnit\Framework\TestCase
 
     $highlights = $this->highlightDao->getHighlightDiffs($this->uploadDao->getItemTreeBounds(7));
 
-    $expectedHighlight = new Highlight(18, 35825, Highlight::MATCH, 20, 35819);
+    $expectedHighlight = new Highlight(18, 35825, Highlight::MATCH, 20, 35146);
     $expectedHighlight->setLicenseId($matchedLicense->getId());
 
     $this->assertEquals(array($expectedHighlight), $highlights);
@@ -175,9 +175,9 @@ class MonkScheduledTest extends \PHPUnit\Framework\TestCase
     $highlights = $this->highlightDao->getHighlightDiffs($this->uploadDao->getItemTreeBounds(11));
 
     $expectedHighlights = array();
-    $expectedHighlights[] = new Highlight(18, 339, Highlight::MATCH, 20, 350);
-    $expectedHighlights[] = new Highlight(340, 347, Highlight::CHANGED, 351, 357);
-    $expectedHighlights[] = new Highlight(348, 35149, Highlight::MATCH, 358, 35819);
+    $expectedHighlights[] = new Highlight(18, 339, Highlight::MATCH, 20, 341);
+    $expectedHighlights[] = new Highlight(340, 347, Highlight::CHANGED, 342, 348);
+    $expectedHighlights[] = new Highlight(348, 35149, Highlight::MATCH, 349, 35146);
     foreach($expectedHighlights as $expectedHighlight) {
       $expectedHighlight->setLicenseId($matchedLicense->getId());
     }

--- a/src/reuser/agent_tests/Functional/schedulerTest.php
+++ b/src/reuser/agent_tests/Functional/schedulerTest.php
@@ -191,7 +191,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
     $this->testDb->createConstraints(array('agent_pkey','pfile_pkey',
       'upload_pkey_idx','FileLicense_pkey','clearing_event_pkey'),false);
     $this->testDb->alterTables(array('agent','pfile','upload','ars_master',
-      'license_ref_bulk','clearing_event','clearing_decision','license_file','highlight'),false);
+      'license_ref_bulk','license_ref','clearing_event','clearing_decision','license_file','highlight'),false);
     $this->testDb->createInheritedTables();
     $this->testDb->createInheritedArsTables(array('monk'));
 

--- a/src/spdx2/agent_tests/Functional/schedulerTest.php
+++ b/src/spdx2/agent_tests/Functional/schedulerTest.php
@@ -129,7 +129,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
     $this->testDb->createConstraints(array('agent_pkey','pfile_pkey','upload_pkey_idx',
       'FileLicense_pkey','clearing_event_pkey'));
     $this->testDb->alterTables(array('agent','pfile','upload','ars_master','license_ref_bulk','license_set_bulk',
-      'clearing_event','clearing_decision','license_file','highlight'));
+      'clearing_event','clearing_decision','license_file','license_ref','highlight'));
 
     $this->testDb->insertData(array('mimetype_ars','pkgagent_ars','ununpack_ars','decider_ars'),true,__DIR__.'/fo_report.sql');
     $this->testDb->resetSequenceAsMaxOf('agent_agent_pk_seq', 'agent', 'agent_pk');

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -892,8 +892,8 @@
   $Schema["TABLE"]["license_ref"]["rf_url"]["ALTER"] = "ALTER TABLE \"license_ref\" ALTER COLUMN \"rf_url\" DROP NOT NULL";
 
   $Schema["TABLE"]["license_ref"]["rf_add_date"]["DESC"] = "COMMENT ON COLUMN \"license_ref\".\"rf_add_date\" IS 'Date License added to this table'";
-  $Schema["TABLE"]["license_ref"]["rf_add_date"]["ADD"] = "ALTER TABLE \"license_ref\" ADD COLUMN \"rf_add_date\" date";
-  $Schema["TABLE"]["license_ref"]["rf_add_date"]["ALTER"] = "ALTER TABLE \"license_ref\" ALTER COLUMN \"rf_add_date\" DROP NOT NULL";
+  $Schema["TABLE"]["license_ref"]["rf_add_date"]["ADD"] = "ALTER TABLE \"license_ref\" ADD COLUMN \"rf_add_date\" date DEFAULT now()";
+  $Schema["TABLE"]["license_ref"]["rf_add_date"]["ALTER"] = "ALTER TABLE \"license_ref\" ALTER COLUMN \"rf_add_date\" DROP NOT NULL, ALTER COLUMN \"rf_add_date\" SET DEFAULT now()";
 
   $Schema["TABLE"]["license_ref"]["rf_copyleft"]["DESC"] = "COMMENT ON COLUMN \"license_ref\".\"rf_copyleft\" IS 'Is license copyleft?'";
   $Schema["TABLE"]["license_ref"]["rf_copyleft"]["ADD"] = "ALTER TABLE \"license_ref\" ADD COLUMN \"rf_copyleft\" bit(1)";


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

### Changes

1. Remove `rf_md5` from `licenseRef.json` as it can be derived from `rf_text`.
2. Remove `rf_pk` from `licenseRef.json` as `rf_shortname` is the correct way to reference a license from DB.
3. Update `rf_md5` whenever `rf_text` updates.
4. Insert `rf_add_date` for new licenses.
5. If a license already exists as candidate, merge it with main `license_ref` before updating.

## How to test

- On an existing DB:
    1. Install the branch and check if the license texts are updated
    1. The `rf_md5` is correct (`SELECT rf_shortname, rf_md5, md5(rf_text) AS hash FROM license_ref WHERE rf_md5 != md5(rf_text);`)
    1. Check if `license_ref.rf_pk` has not been changed.
- On new DB:
    1. Check if all the licenses are updated.
    1. The `rf_md5` is correct (`SELECT rf_shortname, rf_md5, md5(rf_text) AS hash FROM license_ref WHERE rf_md5 != md5(rf_text);`)
- On existing DB with candidates:
    1. Insert a candidate license.
    1. Insert the same license to `licenseRef.json`.
    1. After installing, check if candidate license got merged with the `license_ref` and the `rf_pk` for the license has not changed.