### PR TITLE
feat(ui): Conversion of timestamps to browser timezone

### DIFF
--- a/src/lib/php/UI/template/components/login-form.html.twig
+++ b/src/lib/php/UI/template/components/login-form.html.twig
@@ -1,4 +1,5 @@
 {# Copyright 2014-2015 Siemens AG
+   Copyright 2020 Robert Bosch GmbH, Dineshkumar Devarajan <Devarajan.Dineshkumar@in.bosch.com>
 
    Copying and distribution of this file, with or without modification,
    are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
@@ -11,6 +12,7 @@
 {{ info }}
 <form method="post" action="{{ authUrl }}">
   <input type="hidden" name="HTTP_REFERER" value="{{ referrer }}"/>
+  <input type="hidden" name="timezone" id="timezone" value="" />
   <table border="0">
     <tr>
       <td>{{ 'Username'|trans }}:</td>
@@ -26,4 +28,5 @@
     </tr>
   </table>
   <script type="text/javascript">document.getElementById("unamein").focus();</script>
+  <script type="text/javascript">document.getElementById("timezone").value = Intl.DateTimeFormat().resolvedOptions().timeZone ;</script>
 </form>

--- a/src/lib/php/common-folders.php
+++ b/src/lib/php/common-folders.php
@@ -414,7 +414,7 @@ function FolderListUploads_perm($ParentFolder, $perm)
     $New = array();
     $New['upload_pk'] = $R['upload_pk'];
     $New['upload_desc'] = $R['upload_desc'];
-    $New['upload_ts'] = substr($R['upload_ts'], 0, 19);
+    $New['upload_ts'] = Convert2BrowserTime(substr($R['upload_ts'], 0, 19));
     $New['name'] = $R['upload_filename'];
     array_push($List,$New);
   }

--- a/src/lib/php/common-ui.php
+++ b/src/lib/php/common-ui.php
@@ -2,6 +2,7 @@
 /***********************************************************
  Copyright (C) 2009-2014 Hewlett-Packard Development Company, L.P.
  Copyright (C) 2017, Siemens AG
+ Copyright (C) 2020 Robert Bosch GmbH, Dineshkumar Devarajan <Devarajan.Dineshkumar@in.bosch.com>
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -288,4 +289,18 @@ function Get1stUploadtreeID($upload)
   $uploadtree_id = $row['max'];
   pg_free_result($result);
   return $uploadtree_id;
+}
+
+/**
+ * \brief Convert the server time to browser time
+ * \param time $server_time to be converted
+ */
+function Convert2BrowserTime($server_time)
+{
+  $tz = $_SESSION["timezone"];
+  $server_timezone = date_default_timezone_get();
+  $browser_time = new \DateTime($server_time, new \DateTimeZone($server_timezone));
+  $browser_time->setTimeZone(new \DateTimeZone($tz));
+  $time = $browser_time->format('Y-m-d H:i:s');
+  return $time;
 }

--- a/src/reportImport/ui/ReportImportPlugin.php
+++ b/src/reportImport/ui/ReportImportPlugin.php
@@ -92,7 +92,7 @@ class ReportImportPlugin extends DefaultPlugin
       if (!$this->uploadDao->isEditable($uploadProgress->getId(), $groupId)) {
         continue;
       }
-      $display = $uploadProgress->getFilename() . _(" from ") . date("Y-m-d H:i",$uploadProgress->getTimestamp());
+      $display = $uploadProgress->getFilename() . _(" from ") . Convert2BrowserTime(date("Y-m-d H:i:s",$uploadProgress->getTimestamp()));
       $uploadsById[$uploadProgress->getId()] = $display;
     }
     $vars['uploadList'] = $uploadsById;

--- a/src/reuser/ui/reuser-plugin.php
+++ b/src/reuser/ui/reuser-plugin.php
@@ -186,7 +186,7 @@ class ReuserPlugin extends DefaultPlugin
     foreach ($folderUploads as $uploadProgress) {
       $key = $uploadProgress->getId().','.$uploadProgress->getGroupId();
       $display = $uploadProgress->getFilename() . _(" from ")
-               . date("Y-m-d H:i",$uploadProgress->getTimestamp())
+               . Convert2BrowserTime(date("Y-m-d H:i:s",$uploadProgress->getTimestamp()))
                . ' ('. $uploadProgress->getStatusString() . ')';
       $uploadsById[$key] = $display;
     }

--- a/src/www/ui/admin-dashboard-general.php
+++ b/src/www/ui/admin-dashboard-general.php
@@ -249,7 +249,7 @@ class dashboard extends FO_Plugin
         $V .= "<td class='dashboard'>$row[processid]</td>";
         $V .= "<td class='dashboard'>" . htmlspecialchars($row[$current_query]) .
           "</td>";
-        $StartTime = substr($row['query_start'], 0, 19);
+        $StartTime = Convert2BrowserTime(substr($row['query_start'], 0, 19));
         $V .= "<td class='dashboard'>$StartTime</td>";
         $V .= "<td class='dashboard'>$row[elapsed]</td>";
         $V .= "</tr>\n";

--- a/src/www/ui/admin-upload-edit.php
+++ b/src/www/ui/admin-upload-edit.php
@@ -139,7 +139,7 @@ class upload_properties extends FO_Plugin
       if (! $this->uploadDao->isEditable($uploadProgress->getId(), $groupId)) {
         continue;
       }
-      $display = $uploadProgress->getFilename() . _(" from ") . date("Y-m-d H:i",$uploadProgress->getTimestamp());
+      $display = $uploadProgress->getFilename() . _(" from ") . Convert2BrowserTime(date("Y-m-d H:i:s",$uploadProgress->getTimestamp()));
       $uploadsById[$uploadProgress->getId()] = $display;
     }
     $this->vars['uploadList'] = $uploadsById;

--- a/src/www/ui/async/AjaxBrowse.php
+++ b/src/www/ui/async/AjaxBrowse.php
@@ -196,7 +196,7 @@ class AjaxBrowse extends DefaultPlugin
       $nameColumn = '<input type="checkbox" name="uploads[]" class="browse-upload-checkbox" value="'.$uploadId.'"/>'.$nameColumn;
     }
 
-    $dateCol = substr($row['upload_ts'], 0, 19);
+    $dateCol = Convert2BrowserTime(substr($row['upload_ts'], 0, 19));
     $pairIdPrio = array($uploadId, floatval($row[UploadBrowseProxy::PRIO_COLUMN]));
     if (!$this->userPerm && 4 == $row['status_fk']) {
       $currentStatus = $this->statusTypes[4];

--- a/src/www/ui/async/AjaxFolderContents.php
+++ b/src/www/ui/async/AjaxFolderContents.php
@@ -51,7 +51,7 @@ class AjaxFolderContents extends DefaultPlugin
       $uploadStatus = new UploadStatus();
       $uploadDate = explode(".",$upload['upload_ts'])[0];
       $uploadStatus = " (" . $uploadStatus->getTypeName($upload['status_fk']) . ")";
-      $results[$upload['foldercontents_pk']] = $upload['upload_filename'] . _(" from ") . $uploadDate . $uploadStatus;
+      $results[$upload['foldercontents_pk']] = $upload['upload_filename'] . _(" from ") . Convert2BrowserTime($uploadDate) . $uploadStatus;
     }
 
     if (!$request->get('removable')) {

--- a/src/www/ui/async/AjaxShowJobs.php
+++ b/src/www/ui/async/AjaxShowJobs.php
@@ -3,6 +3,7 @@
  Copyright (C) 2015-2019, Siemens AG
  Author: Shaheem Azmal<shaheem.azmal@siemens.com>,
          Anupam Ghosh <anupam.ghosh@siemens.com>
+ Copyright (C) 2020 Robert Bosch GmbH, Dineshkumar Devarajan <Devarajan.Dineshkumar@in.bosch.com>
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -132,6 +133,11 @@ class AjaxShowJobs extends \FO_Plugin
       $value ="";
       $label = $labelKey;
       switch ($field) {
+        case 'job_queued':
+        case 'jq_starttime':
+        case 'jq_endtime':
+          $value = Convert2BrowserTime($row[$field]);
+          break;
         case 'jq_itemsprocessed':
           $value = number_format($row[$field]);
           break;
@@ -224,6 +230,8 @@ class AjaxShowJobs extends \FO_Plugin
         'jobQueue' => $jobs['jobqueue']
       );
       foreach ($jobArr['jobQueue'] as $key => $singleJobQueue) {
+        $jobArr['jobQueue'][$key]['jq_starttime'] = Convert2BrowserTime($jobArr['jobQueue'][$key]['jq_starttime']);
+        $jobArr['jobQueue'][$key]['jq_endtime'] = Convert2BrowserTime($jobArr['jobQueue'][$key]['jq_endtime']) ;
         if (! empty($singleJobQueue["jq_endtime"])) {
           $numSecs = strtotime($singleJobQueue['jq_endtime']) -
             strtotime($singleJobQueue['jq_starttime']);

--- a/src/www/ui/core-auth.php
+++ b/src/www/ui/core-auth.php
@@ -2,6 +2,7 @@
 /***********************************************************
  * Copyright (C) 2008-2013 Hewlett-Packard Development Company, L.P.
  * Copyright (C) 2015 Siemens AG
+ * Copyright (C) 2020 Robert Bosch GmbH, Dineshkumar Devarajan <Devarajan.Dineshkumar@in.bosch.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -201,6 +202,11 @@ class core_auth extends FO_Plugin
   {
     $userName = GetParm("username", PARM_TEXT);
     $password = GetParm("password", PARM_TEXT);
+    $timezone = GetParm("timezone", PARM_TEXT);
+    if (empty($timezone) || strpos($timezone,"Unknown") == true) {
+      $timezone = date_default_timezone_get();
+    }
+    $_SESSION['timezone'] = $timezone;
     $referrer = GetParm("HTTP_REFERER", PARM_TEXT);
     if (empty($referrer)) {
       $referrer = GetArrayVal('HTTP_REFERER', $_SERVER);

--- a/src/www/ui/template/upload_permissions.html.twig
+++ b/src/www/ui/template/upload_permissions.html.twig
@@ -1,4 +1,5 @@
 {# Copyright 2015,2020, Siemens AG
+   Copyright 2020 Robert Bosch GmbH, Dineshkumar Devarajan <Devarajan.Dineshkumar@in.bosch.com>
 
    Copying and distribution of this file, with or without modification,
    are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
@@ -21,7 +22,7 @@
     <select id="uploadselect" {% if allUploadsPerm %} disabled {% endif %} name="uploadselect" class="ui-render-select2">
     {% for upload in uploadList %}
       <option value="{{ upload.upload_pk }}"{% if upload.upload_pk==uploadId %} selected="selected"{% endif %}>{{ upload.name|e }},
-        {{ upload.upload_ts|date('Y-m-d h:i:s') }}</option>
+        {{ upload.upload_ts  }}</option>
     {% endfor %}
     </select>
     <br/><br/>


### PR DESCRIPTION
## Description

This pull request adds the capability to convert the timestamps shown in the FOSSology WebUI to the current timezone of the users browser. This makes it easier for the users to track when which action was executed without manually converting the time.

### Changes

**src/lib/php/UI/template/components/login-form.html.twig** - get the current users timezone during login
**src/lib/php/common-ui.php** - added function "Convert2BrowserTime" to be called wherever in the UI a timestamp is being displayed
**src/www/ui/core-auth.php** - if no timezone is provided by the browser it falls back to the server timezone

The remaining changed files are now calling the function "Convert2BrowserTime" for displaying the timestamps.

## How to test

After deployment of the application the user logging in to the application should see all timestamps in his current timezone instead of whichever timezone is currently configured on the server hosting FOSSology.