### PR TITLE
fix(postgresql): libschema to adopt Postgresql 12 changes

### DIFF
--- a/src/lib/php/Db/Driver.php
+++ b/src/lib/php/Db/Driver.php
@@ -49,6 +49,11 @@ interface Driver
   public function isConnected();
 
   /**
+   * @return int
+   */
+  public function version();
+  
+  /**
    * @return string
    */
   public function getLastError();

--- a/src/lib/php/Db/Driver/Postgres.php
+++ b/src/lib/php/Db/Driver/Postgres.php
@@ -88,6 +88,16 @@ class Postgres implements Driver
   }
 
   /**
+   * @return int
+  */
+  public function version()
+  {
+    $v = pg_version($this->dbConnection);
+    return (int)(explode(' ', $v['server'])[0]);
+  }
+
+
+  /**
    * @return string
    */
   public function getLastError()

--- a/src/lib/php/libschema.php
+++ b/src/lib/php/libschema.php
@@ -551,13 +551,15 @@ class fo_libschema
   {
     $referencedSequencesInTableColumns = array();
 
+    $ad_col_name = $this->dbman->getDriver()->version() < 12 ? "adsrc" : "adbin";
+
     $sql = "SELECT class.relname AS table,
         attr.attnum AS ordinal,
         attr.attname AS column_name,
         type.typname AS type,
         attr.atttypmod-4 AS modifier,
         attr.attnotnull AS notnull,
-        attrdef.adsrc AS default,
+        attrdef.".$ad_col_name." AS default,
         col_description(attr.attrelid, attr.attnum) AS description
       FROM pg_class AS class
       INNER JOIN pg_attribute AS attr ON attr.attrelid = class.oid AND attr.attnum > 0


### PR DESCRIPTION
Postgresql API interface changed after release 12 breaking ad column
name. Extended the Driver base class to provide db version.

Signed-off-by: Helio Chissini de Castro <helio.chissini-de-castro@bmw.de>

## Description

TEst postgres version and use the proper string for ad column.

### Changes

* Add version to Driver.php abstract class
* Add version to Postgres.php class
* Modified libschema.php to use the proper entrry

## How to test

Do fossology base installation with Postgresql release 12 or later