### PR TITLE
feat(maintenance): Remove orphan log files

### DIFF
--- a/src/maintagent/agent/maintagent.h
+++ b/src/maintagent/agent/maintagent.h
@@ -36,6 +36,7 @@
 
 /* for DB */
 extern PGconn* pgConn;
+extern fo_dbManager* dbManager;
 
 /**
  * Maximum buffer to use
@@ -65,5 +66,6 @@ void deleteOrphanGold();
 void normalizeUploadPriorities();
 void reIndexAllTables();
 void removeOrphanedRows();
+void removeOrphanedLogFiles();
 
 #endif /* _MAINTAGENT_H */

--- a/src/maintagent/agent/process.c
+++ b/src/maintagent/agent/process.c
@@ -25,6 +25,7 @@
 
 /**********  Globals  *************/
 PGconn* pgConn = NULL;        ///< the connection to Database
+fo_dbManager* dbManager;      ///< fo_dbManager object
 
 /**
  * \brief simple wrapper which includes PQexec and fo_checkPQcommand
@@ -447,5 +448,79 @@ FUNCTION void removeOrphanedRows()
 
   printf("Time taken for removing orphaned rows from database : %ld seconds\n", endTime-startTime);
 
+  return;  // success
+}
+
+
+/**
+ * Remove orphan log files created to store the logs from agents on disk.
+ * @returns void but writes status to stdout
+ */
+FUNCTION void removeOrphanedLogFiles()
+{
+  PGresult* result;
+  PGresult* updateResult;
+  int row;
+  int countTuples;
+  int removedCount = 0;
+  int jobQueueId;
+  char* logPath;
+  long startTime, endTime;
+  fo_dbManager_PreparedStatement* updateStatement;
+  struct stat statbuf;
+
+  char *SQL = "SELECT jq_pk, jq_log FROM job ja "
+    "INNER JOIN job jb ON ja.job_upload_fk = jb.job_upload_fk "
+    "INNER JOIN jobqueue jq ON jb.job_pk = jq.jq_job_fk "
+    "WHERE ja.job_name = 'Delete' AND jq_log IS NOT NULL "
+    "AND jq_log != 'removed';";
+
+  startTime = (long)time(0);
+
+  result = PQexec(pgConn, SQL);
+  if (fo_checkPQresult(pgConn, result, SQL, __FILE__, __LINE__))
+  {
+    exitNow(-140);
+  }
+  countTuples = PQntuples(result);
+
+  updateStatement = fo_dbManager_PrepareStamement(dbManager,
+    "updateRemovedLogFromJobqueue",
+    "UPDATE jobqueue SET jq_log = 'removed' WHERE jq_pk = $1;", int);
+  /* Loop through the logs found and delete them. Also update the database */
+  for (row = 0; row < countTuples; row++)
+  {
+    fo_dbManager_begin(dbManager);
+    jobQueueId = atoi(PQgetvalue(result, row, 0));
+    logPath = PQgetvalue(result, row, 1);
+    if (stat(logPath, &statbuf) == -1)
+    {
+      LOG_NOTICE("Log file '%s' does not exists", logPath);
+    }
+    else
+    {
+      remove(logPath);
+      LOG_VERBOSE2("Removed file '%s'", logPath);
+    }
+    updateResult = fo_dbManager_ExecPrepared(updateStatement, jobQueueId);
+    if (updateResult)
+    {
+      free(updateResult);
+      removedCount++;
+    }
+    else
+    {
+      LOG_ERROR("Unable to update the value of jobqueue.jq_log to 'removed' "
+        "for jq_pk = %d", jobQueueId);
+    }
+    fo_dbManager_commit(dbManager);
+  }
+  PQclear(result);
+
+  endTime = (long)time(0);
+  printf("%d / %d Orphaned log files were removed "
+    "(%ld seconds)\n", removedCount, countTuples, endTime - startTime);
+
+  fo_scheduler_heart(1);  // Tell the scheduler that we are alive and update item count
   return;  // success
 }

--- a/src/maintagent/agent/usage.c
+++ b/src/maintagent/agent/usage.c
@@ -36,6 +36,7 @@ FUNCTION void usage(char *name)
   printf("  -F   :: Validate folder contents.\n");
   printf("  -g   :: Delete orphan gold files.\n");
   printf("  -h   :: Print help (usage).\n");
+  printf("  -L   :: Remove orphaned logs from file system.\n");
   printf("  -N   :: Normalize the (internal) priority numbers.\n");
   printf("  -p   :: Verify file permissions (report only).\n");
   printf("  -P   :: Verify and fix file permissions.\n");

--- a/src/maintagent/agent/utils.c
+++ b/src/maintagent/agent/utils.c
@@ -33,6 +33,7 @@
 FUNCTION void exitNow(int exitVal)
 {
   if (pgConn) PQfinish(pgConn);
+  if (dbManager) fo_dbManager_free(dbManager);
 
   if (exitVal) LOG_ERROR("Exiting with status %d", exitVal);
 

--- a/src/maintagent/ui/maintagent.php
+++ b/src/maintagent/ui/maintagent.php
@@ -87,6 +87,7 @@ class maintagent extends FO_Plugin {
                      "F"=>_("Validate folder contents."),
               //       "g"=>_("Remove orphaned gold files."),
                      "E"=>_("Remove orphaned rows from database."),
+                     "L"=>_("Remove orphaned log files from file system."),
                      "N"=>_("Normalize priority "),
               //       "p"=>_("Verify file permissions (report only)."),
               //       "P"=>_("Verify and fix file permissions."),

--- a/src/www/ui/async/AjaxShowJobs.php
+++ b/src/www/ui/async/AjaxShowJobs.php
@@ -154,7 +154,7 @@ class AjaxShowJobs extends \FO_Plugin
           }
           break;
         case 'jq_log':
-          if (empty($row[$field]) || !file_exists($row[$field])) {
+          if (empty($row[$field]) || $row[$field] == 'removed' || !file_exists($row[$field])) {
             break;
           }
           if (filesize($row[$field]) > self::MAX_LOG_OUTPUT) {


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Remove job log files created by agents for the uploads which were deleted.

### Changes

1. Added new function `removeOrphanedLogFiles()` with flag `-L`.
1. List the `jobqueue` entries for uploads where Delete action has been performed and remove all associated log files.
1. The removed file locations gets replaced with `removed`.

## How to test

1. Upload some package with binary files (images, etc.) which will cause monk to create log.
1. Delete the upload (`delagent` will also create a log file).
1. Save the `jobqueue.job_log` entries for the upload for verification.
1. Run the maintenance agent with relevant options.
1. Check if the `jobqueue.job_log` entries have been updated to `removed`.
1. Check if the previously saved files are removed from FS.

Closes #292