### PR TITLE
feat(nomos): Optimize JSON output

### DIFF
--- a/src/nomos/agent/json_writer.h
+++ b/src/nomos/agent/json_writer.h
@@ -26,25 +26,9 @@
 #define _JSON_WRITER_H_
 
 /**
- * \brief Write the scan output to a temp file
- *
- * The function writes the output of a scan result to a temp file in append
- * mode which is read by parseTempJson() to create a single JSON output.
+ * \brief Write the scan output as a JSON
  */
-void writeToTemp();
-
-/**
- * \brief Write the scan result as JSON to STDOUT
- */
-void writeToStdOut();
-
-/**
- * \brief Read temp file and print a JSON to STDOUT
- *
- * Reads the temp file created by writeToTemp(), parse it and create a JSON.
- * Then writes this JSON to STDOUT.
- */
-void parseTempJson();
+void writeJson();
 
 /**
  * \brief Unescape the path separator from JSON
@@ -56,5 +40,16 @@ void parseTempJson();
  * @return The JSON with unescaped path separator.
  */
 char *unescapePathSeparator(const char* json);
+
+/**
+ * Initialize the semaphore and boolean to store flag for comma in JSON
+ */
+void initializeJson();
+
+/**
+ * Destory the semaphore the comma flag for JSON
+ */
+void destroyJson();
+
 
 #endif /* _JSON_WRITER_H_ */

--- a/src/nomos/agent/json_writer.h
+++ b/src/nomos/agent/json_writer.h
@@ -55,6 +55,6 @@ void parseTempJson();
  * @param json String to unescape
  * @return The JSON with unescaped path separator.
  */
-char *unescapePathSeparator(char* json);
+char *unescapePathSeparator(const char* json);
 
 #endif /* _JSON_WRITER_H_ */

--- a/src/nomos/agent/licenses.c
+++ b/src/nomos/agent/licenses.c
@@ -1228,14 +1228,7 @@ static void saveLicenseData(scanres_t *scores, int nCand, int nElem,
   {
     if (optionIsSet(OPTS_JSON_OUTPUT))
     {
-      if (optionIsSet(OPTS_SCANNING_DIRECTORY))
-      {
-        writeToTemp();
-      }
-      else
-      {
-        writeToStdOut();
-      }
+      writeJson();
     } else {
       if (optionIsSet(OPTS_LONG_CMD_OUTPUT) && realpath(cur.targetFile, realPathOfTarget))
         {

--- a/src/nomos/agent/nomos.c
+++ b/src/nomos/agent/nomos.c
@@ -253,7 +253,7 @@ void myFork(int proc_num, FILE **pFile) {
   {
     LOG_FATAL("fork failed\n");
   }
-  else if (pid == 0) { // chile process, every singe process runs on one temp path file
+  else if (pid == 0) { // Child process, every single process runs on one temp path file
     read_file_grab_license(proc_num, pFile); // grabbing licenses on /tmp/foss-XXXXXX
     return;
   }
@@ -427,18 +427,11 @@ int main(int argc, char **argv)
     /* when scanning_directory is real direcotry, scan license in parallel */
     if (scanning_directory) {
       if (process_count < 2) process_count = 2; // the least count is 2, at least has one child process
-
-      if (optionIsSet(OPTS_JSON_OUTPUT))
+      if (mutexJson == NULL && optionIsSet(OPTS_JSON_OUTPUT))
       {
-        char json_file_template[] = "/tmp/foss-nomos-json-XXXXXX";
-        int json_file_descriptor = mkstemp(json_file_template);
-        cur.tempJsonPath = fdopen(json_file_descriptor, "w+");
-        if (!cur.tempJsonPath)
-        {
-          LOG_FATAL("failed to open %s, %s\n", json_file_template,
-              strerror(errno));
-        }
-        sem_init(&cur.mutexTempJson, 1, 1);
+        initializeJson();
+        printf("{\n\"results\":[\n");
+        fflush(0);
       }
       pFile = malloc(process_count*(sizeof(FILE*)));
       pTempFileName = malloc(process_count*sizeof(char[50]));
@@ -497,10 +490,8 @@ int main(int argc, char **argv)
 
         if (optionIsSet(OPTS_JSON_OUTPUT))
         {
-          /* Print the JSON output and clean related variables */
-          parseTempJson();
-          sem_destroy(&cur.mutexTempJson);
-          fclose(cur.tempJsonPath);
+          printf("]\n}\n");
+          destroyJson();
         }
 
         /* free memeory */
@@ -513,11 +504,22 @@ int main(int argc, char **argv)
       {
         printf("Warning: -n {nprocs} ONLY works with -d {directory}.\n");
       }
+      if (optionIsSet(OPTS_JSON_OUTPUT))
+      {
+        initializeJson();
+        printf("{\n\"results\":[\n");
+        fflush(0);
+      }
       for (i = 0; i < file_count; i++) {
         initializeCurScan(&cur);
         processFile(files_to_be_scanned[i]);
         recordScanToDB(&cacheroot, &cur);
         freeAndClearScan(&cur);
+      }
+      if (optionIsSet(OPTS_JSON_OUTPUT))
+      {
+        printf("]\n}\n");
+        destroyJson();
       }
     }
   }

--- a/src/nomos/agent/nomos.h
+++ b/src/nomos/agent/nomos.h
@@ -430,9 +430,6 @@ struct curScan {
   GArray* keywordPositions; /**< List of matche positions */
   GArray* docBufferPositionsAndOffsets;
   int currentLicenceIndex;
-  FILE *tempJsonPath; /**< File descriptor for temporary file where
-                           intermediate outputs for json are stored */
-  sem_t mutexTempJson; /**< Mutex to handle writes to tempJsonPath */
 };
 
 /**

--- a/src/nomos/agent/nomos_utils.h
+++ b/src/nomos/agent/nomos_utils.h
@@ -33,6 +33,10 @@
 #define PG_ERRCODE_UNIQUE_VIOLATION "23505"
 #define FOSSY_EXIT( XY , XZ) printf(" %s %s,%d", XY , __FILE__, __LINE__);  Bail( XZ );
 #define LICENSE_REF_TABLE "ONLY license_ref"
+#define SEM_DEFAULT_VALUE 4
+
+sem_t* mutexJson;           ///< Mutex to handle JSON writes
+gboolean* printcomma;       ///< True to print comma while printing JSON object
 
 
 /** shortname cache very simple nonresizing hash table */


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Optimize the JSON output of directory scan for nomos by printing the result objects one by one instead of creating a huge chunk of single result object.

It helps in reducing the memory consumption while creating the JSON also the first output will appear much faster than earlier.

Also, fix a memory leak in `unescapePathSeparator()`.

Removed the use of additional temp file to store the scan results before being converted to JSON. This makes the output appear even faster.

### Changes

~1. Print JSON objects one by one in `parseTempJson()`.~
1. Fix the calculation of result string in `unescapePathSeparator()`.
1. Removed `writeToTemp()`, `writeToStdOut()` and `parseTempJson()`, replaced all with `writeJson()`.

## How to test

1. Run nomos with and without `-J` flag on a single file.
1. Run nomos with and without `-J` flag on multiple files.
1. Run nomos with `-J` and `-l` flag on a single file.
1. Run nomos with `-J` and `-d` on a directory.
1. Run nomos with `-J`, `-l` and `-d` on a directory.

~**Todo:** Try to remove the use of temporary file and directly print JSON reducing the time to first output even further.~