### PR TITLE
fix(travis): Fix page deploy stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -197,7 +197,8 @@ jobs:
         - bash utils/deploy-pages.sh
       deploy:
         provider: pages
-        cleanup: true
+        cleanup: false
+        skip_cleanup: true
         token: $GITHUB_TOKEN
         keep_history: false
         local_dir: ./code_docs


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

There was a syntax fix with #1656 for new travis.

The dpl v2 has few keyword changes from dpl v1 like `_` changed to `-`. Also, the tag `skip_cleanup` is replaced with `cleanup`.
This change was done 1:1 in #1656 but the logic of value is flipped with removal of `skip`.

### Changes

1. Change the value of `cleanup` to `false` as we want to keep the built docs by doxygen.
1. Keep the `skip_cleanup` tag since we've not explicitly opted in for dplv2.