### PR TITLE
feat(upload): Add possibility to upload specific Git branch

### DIFF
--- a/src/wget_agent/agent/wget_agent.c
+++ b/src/wget_agent/agent/wget_agent.c
@@ -1058,6 +1058,7 @@ void replace_url_with_auth()
   char URI[FILEPATH] = "";
   char *token = NULL;
   char *temp = NULL;
+  char *additionalParams = NULL;
 
   if (strstr(GlobalParam, "password") && strstr(GlobalParam, "username"))
   {
@@ -1079,12 +1080,22 @@ void replace_url_with_auth()
     while( token != NULL )
     {
       if (1 == index) username = token;
-      if (3 == index) password = token;
+      if (3 == index) {
+        password = token;
+        additionalParams = token + strlen(token) + 1;
+        break;
+      }
       token = strtok(NULL, needle);
       index++;
     }
     snprintf(GlobalURL, URLMAX, "%s%s:%s@%s", http, username, password, URI);
-    memset(GlobalParam,'\0',STRMAX);
+
+    if (strlen(additionalParams) > 0) {
+      memmove(GlobalParam, additionalParams, strlen(additionalParams) +1);
+    } 
+    else {
+      memset(GlobalParam,'\0',STRMAX);
+    }
   }
 }
 

--- a/src/www/ui/api/Helper/UploadHelper.php
+++ b/src/www/ui/api/Helper/UploadHelper.php
@@ -174,6 +174,7 @@ class UploadHelper
     $vcsName = $vcsData["vcsName"];
     $vcsUsername = $vcsData["vcsUsername"];
     $vcsPasswd = $vcsData["vcsPassword"];
+    $vcsBranch = $vcsData["vcsBranch"];
 
     $symfonySession = $GLOBALS['container']->get('session');
     $symfonySession->set($this->uploadVcsPage::UPLOAD_FORM_BUILD_PARAMETER_NAME,
@@ -194,6 +195,7 @@ class UploadHelper
     $symfonyRequest->request->set('vcstype', $vcsType);
     $symfonyRequest->request->set('username', $vcsUsername);
     $symfonyRequest->request->set('passwd', $vcsPasswd);
+    $symfonyRequest->request->set('branch', $vcsBranch);
     $symfonyRequest->request->set('scm', $ignoreScm);
 
     return $this->uploadVcsPage->handleRequest($symfonyRequest);
@@ -243,6 +245,9 @@ class UploadHelper
     }
     if (! array_key_exists("vcsPassword", $vcsData)) {
       $vcsData["vcsPassword"] = "";
+    }
+    if (! array_key_exists("vcsBranch", $vcsData)) {
+      $vcsData["vcsBranch"] = "";
     }
     $vcsData["vcsType"] = $vcsType;
     if ($code !== 0) {

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -14,7 +14,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.0.13
+  version: 1.0.14
   contact:
     email: fossology@fossology.org
   license:
@@ -1192,6 +1192,9 @@ components:
             - git
         vcsUrl:
           description: URL of the repository
+          type: string
+        vcsBranch:
+          description: Branch to checkout for analysis (for Git only)
           type: string
         vcsName:
           description: Display name of the upload

--- a/src/www/ui/page/UploadVcsPage.php
+++ b/src/www/ui/page/UploadVcsPage.php
@@ -51,6 +51,7 @@ class UploadVcsPage extends UploadPageBase
     $vars['usernameField'] = 'username';
     $vars['passwdField'] = 'passwd';
     $vars['geturlField'] = self::GETURL_PARAM;
+    $vars['branchField'] = 'branch';
     $vars['nameField'] = 'name';
     $this->renderer->clearTemplateCache();
     $this->renderer->clearCacheFiles();
@@ -135,7 +136,12 @@ class UploadVcsPage extends UploadPageBase
     $Passwd = trim($request->get('passwd'));
     $Passwd = $this->basicShEscaping($Passwd);
     if (!empty($Passwd)) {
-      $jq_args .= "--password $Passwd";
+      $jq_args .= "--password $Passwd ";
+    }
+
+    $Branch = trim(explode(' ',trim($request->get('branch')))[0]);
+    if (!empty($Branch) && strcasecmp($VCSType,'git') == 0) {
+      $jq_args .= "--single-branch --branch '$Branch'";
     }
 
     $jobqueuepk = JobQueueAdd($jobpk, "wget_agent", $jq_args, NULL, NULL);

--- a/src/www/ui/template/upload_vcs.html.twig
+++ b/src/www/ui/template/upload_vcs.html.twig
@@ -32,6 +32,13 @@
   The URL can begin with HTTP://, HTTPS:// . When do git upload, if https url fails, please try http URL.
 </li>
 <li>
+  <label for="{{ branchField }}">
+    {{ '(Optional for Git) Branch name'| trans }}:
+  </label>
+  <br/>
+  <input name="{{ branchField }}" type="text" size="60"/><br/>
+</li>
+<li>
   <label for="{{ usernameField }}">
     {{ '(Optional) Username'| trans }}:
   </label>


### PR DESCRIPTION
### Description

Fixes #1390 

This change adds possibility to indicate specific git branch when uploading source code for analysis using both GUI and Rest API.
When no branch is passed, standard master branch clone is performed as before

### Changes

`src/wget_agent/agent/wget_agent.c `- changes in agent to pass additional argument to shell command

`src/www/ui/api/Helper/UploadHelper.php` - changes to handle additional parameter in RestApi call and pass it to agent

`src/www/ui/page/UploadVcsPage.php` - changes in upload agent to handle additional request parameter from restApi and GUI

`src/www/ui/template/upload_vcs.html.twig` - changes in twig template to acquire brach parameter from GUI user

## How to test

RestAPI - try to pass `vcsBranch` param in RestApi call to clone branch specified
GUI - pass (or not) specific branch when uploading source code for analysis from Git repository.

When no param passed, master branch should be cloned as before.
