### PR TITLE
feat(copyright): Enable agent to read authors from ROS catkin package manifest files as per spec

### DIFF
--- a/src/copyright/agent/copyright.conf
+++ b/src/copyright/agent/copyright.conf
@@ -25,6 +25,7 @@ author=(?:(?:author|contributor|maintainer)s?)
 author=__author__|(?:(?:written|contribut(?:ed|ions?)|maintained|modifi(?:ed|cations?)|put__SPACES__together)__SPACES__by)
 author=(?:__author__)[:]?
 author=__author____SPACESALL____NAMESLIST__\.?
+author=__author__|(?<=<author>)(.*?)(?=<\/author>)
 #
 COPYSYM=(?:\(c\)|&copy;|\xA9|\xC2\xA9|\$\xB8|\xE2\x92\xB8|\$\xD2|\xE2\x93\x92|\$\x9E|\xE2\x92\x9E)
 REG_COPYRIGHT=copyright(?:ed|s)?[[:space:]:]*|__COPYSYM__[ \t]+([[:alnum:] ][^\0]{0,2}){5,}

--- a/src/copyright/agent_tests/Unit/test_scanners.cc
+++ b/src/copyright/agent_tests/Unit/test_scanners.cc
@@ -51,6 +51,10 @@ const char testContent[] = "© 2007 Hugh Jackman\n\n"
   "if (c) { return -1 } \n\n"
   "Written by: me, myself and Irene.\n\n"
   "Authors all the people at ABC\n\n"
+  "<author>Author1</author>"
+  "<head>All the people</head>"
+  "<author>Author1 Author2 Author3</author>"
+  "<author>Author4</author><b>example</b>"
   "Apache\n\n"
   "This file is protected under pants 1 , 2 ,3\n\n"
   "Do not modify this document\n\n"
@@ -135,6 +139,9 @@ protected:
     scannerTest(sc, testContent, "author", {
       "Written by: me, myself and Irene.",
       "Authors all the people at ABC",
+      "Author1",
+      "Author1 Author2 Author3",
+      "Author4",
       "maintained by benjamin drieu <benj@debian.org>"
     });
   }


### PR DESCRIPTION
## Description
Allow Fossology's copyright agent to detect authors from ROS catkin package manifest files as per [official spec](http://wiki.ros.org/catkin/package.xml)

### Changes

1. Add new regex for detecting authors from <author> tags to the file:
 `src/copyright/agent/copyright.conf`
2. Add new test data to check the above regex to the file : 
`src/copyright/agent_tests/Unit/test_scanners.cc`

## How to test

### Running the unittests
Build and run the unittests for the copyright agent in `src/copyright/agent_tests/Unit`

```
src/copyright/agent_tests/Unit$ make
src/copyright/agent_tests/Unit$ ./test_copyright 
```
**Result** : all tests should pass


### Confirming manually
1. Use the following contents as "package.xml"

```xml
<package format="2">
  <name>foo_core</name>
  <version>1.2.4</version>
  <description>
  This package provides foo capability.
  </description>
  <license>BSD</license>
  <author>foo bar</author>
</package>
```

2. Execute the copyright agent from the commandline

`src/copyright/agent $ ./copyright --files /tmp/package.xml`

**Result**
The agent should detect author from within the `<author>` tags:

```
/tmp/package.xml ::
        [180:187:author] 'foo bar'
```


Implements #1689 