### PR TITLE
feat(download): Limit source code download for admin users only

### DIFF
--- a/src/lib/php/common-license-file.php
+++ b/src/lib/php/common-license-file.php
@@ -285,6 +285,7 @@ function Level1WithLicense($agent_pk, $rf_shortname, $uploadtree_pk, $PkgsOnly=f
 function FileListLinks($upload_fk, $uploadtree_pk, $napk, $pfile_pk, $Recurse=True, &$UniqueTagArray = array(), $uploadtree_tablename = "uploadtree", $wantTags=true)
 {
   $LinkStr = "";
+  global $SysConf;
 
   if ($pfile_pk) {
     $text = _("View");
@@ -293,7 +294,10 @@ function FileListLinks($upload_fk, $uploadtree_pk, $napk, $pfile_pk, $Recurse=Tr
 
     $LinkStr .= "[<a href='" . Traceback_uri() . "?mod=view-license&upload=$upload_fk&item=$uploadtree_pk&napk=$napk' >$text</a>]";
     $LinkStr .= "[<a href='" . Traceback_uri() . "?mod=view_info&upload=$upload_fk&item=$uploadtree_pk&show=detail' >$text1</a>]";
-    $LinkStr .= "[<a href='" . Traceback_uri() . "?mod=download&upload=$upload_fk&item=$uploadtree_pk' >$text2</a>]";
+    if ($_SESSION['UserLevel'] >= $SysConf['SYSCONFIG']['SourceCodeDownloadRights']) {
+      $LinkStr .= "[<a href='" . Traceback_uri() . "?mod=download&upload=$upload_fk&item=$uploadtree_pk' >$text2</a>]";
+    }
+
   }
 
   /********  Tag  ********/

--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -16,6 +16,8 @@
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 ***********************************************************/
 
+use Fossology\Lib\Auth\Auth;
+
 /**
  * \file
  * \brief System configuration functions.
@@ -391,6 +393,14 @@ function Populate_sysconfig()
   $mimeTypeDesc = _("add  comma (,) separated mimetype to exclude files from scanning");
   $valueArray[$variable] = array("'$variable'", "null", "'$mimeTypeToSkip'",
     strval(CONFIG_TYPE_TEXT), "'Skip'", "1", "'$mimeTypeDesc'", "null", "null");
+
+  $perm_admin=Auth::PERM_ADMIN;
+  $perm_write=Auth::PERM_WRITE;
+  $variable = "SourceCodeDownloadRights";
+  $SourceDownloadRightsPrompt = _('Acces rights required to download source code');
+  $SourceDownloadRightsDesc = _('Choose which acces level will be required for user to be able to download source code.');
+  $valueArray[$variable] = array("'$variable'", "'$perm_write'", "'$SourceDownloadRightsPrompt'",
+  strval(CONFIG_TYPE_DROP), "'DOWNLOAD'", "1", "'$SourceDownloadRightsDesc'", "null", "'Administrator{{$perm_admin}}|Read_Write{{$perm_write}}'");
 
   /* Doing all the rows as a single insert will fail if any row is a dupe.
    So insert each one individually so that new variables get added.

--- a/src/www/ui/ui-download.php
+++ b/src/www/ui/ui-download.php
@@ -48,8 +48,12 @@ class ui_download extends FO_Plugin
    */
   function RegisterMenus()
   {
+    global $SysConf;
     $text = _("Download this file");
-    menu_insert("Browse-Pfile::Download",0,$this->Name,$text);
+    if ($_SESSION[Auth::USER_LEVEL] >= $SysConf['SYSCONFIG']['SourceCodeDownloadRights']) {
+      menu_insert("Browse-Pfile::Download",0,$this->Name,$text);
+    }
+
   } // RegisterMenus()
 
   /**
@@ -130,6 +134,7 @@ class ui_download extends FO_Plugin
       throw new Exception('Download plugin is not ready');
     }
 
+    global $SysConf;
     global $container;
     /** @var DbManager $dbManager */
     $dbManager = $container->get('db.manager');
@@ -160,6 +165,8 @@ class ui_download extends FO_Plugin
       $uploadId = $row['job_upload_fk'];
     } elseif (empty($item)) {
       throw new Exception("Invalid item parameter");
+    } elseif ($_SESSION[Auth::USER_LEVEL] < $SysConf['SYSCONFIG']['SourceCodeDownloadRights']) {
+      throw new Exception("User permissions not sufficient for source code download");
     } else {
       $path = RepPathItem($item);
       if (empty($path)) {


### PR DESCRIPTION
## Description

Fix proposal for #1304 

This PR is now in initial version, final solution should be confirmed

Now, all read/write users can download source code for uploads they have access to - it is not always desired situation.
Changing line below could not be the best solution as it will also prevent non-admin users from downloading anything else that uses this plugin - for example reports (and we do not want that)
https://github.com/fossology/fossology/blob/b5a389be8ef413fc488b56700ea23bdf3ff9c73a/src/www/ui/ui-download.php#L42

In this PR we simply do not show **Download** buttons when user is not an admin.
I'm aware that it isn't ready to be ths final solution, but I can see 2 options:

- add option in Customize to choose for which access right download button should be shown
- separate somehow (I don't know how yet) required permission level for:
    - downloading source code
    - everything else

### Changes (final version)

src/lib/php/common-sysconfig.php - additionl configuration option (Admin>Customize page) - possibility to choose which user level should be able to download source code

src/lib/php/common-license-file.php, src/www/ui/ui-download.php - showing Download buttons depending on user-level set on Admin>Customize page

### How to test

Depending on selected option:
![image](https://user-images.githubusercontent.com/12530337/80577095-97d55980-8a06-11ea-9bff-43672b3dfe98.png)

User with specified access rights (or higher) should see or not see Download button for source code


Closes #1304 