### PR TITLE
fix(spdx-rdf-report): Fix comments in export.

### DIFF
--- a/src/spdx2/agent/template/spdx2-file.xml.twig
+++ b/src/spdx2/agent/template/spdx2-file.xml.twig
@@ -43,7 +43,7 @@
 {% if licenseComment is empty %}
     <spdx:licenseComments rdf:resource="http://spdx.org/rdf/terms#noassertion" />
 {% else %}
-    <spdx:licenseComments><![CDATA[{{ licenseComment|e }}]]</spdx:licenseComments>
+    <spdx:licenseComments><![CDATA[{{ licenseComment|e }}]]></spdx:licenseComments>
 {% endif %}
 {% endif %}
 {% if scannerLicenses|default is empty %}


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix comments in SPDX RDF export by adding a closing `>` for `<![CDATA]`. Closes #1692. 

### Changes

Add a closing tag to the template file.

## How to test

Go to conf-page of an upload and enable "Show SPDX license comments" and export SPDX RDF of the upload. `<spdx:licenseComments>` for files should now be valid xml.


