### PR TITLE
feat(rest): extend upload model with filesha1

### DIFF
--- a/src/www/ui/api/Helper/DbHelper.php
+++ b/src/www/ui/api/Helper/DbHelper.php
@@ -82,7 +82,7 @@ class DbHelper
     if ($uploadId == null) {
       $sql = "SELECT
 upload.upload_pk, upload.upload_desc, upload.upload_ts, upload.upload_filename,
-folder.folder_pk, folder.folder_name, pfile.pfile_size
+folder.folder_pk, folder.folder_name, pfile.pfile_size, pfile.pfile_sha1
 FROM upload
 INNER JOIN folderlist ON folderlist.upload_pk = upload.upload_pk
 INNER JOIN folder ON folder.folder_pk = folderlist.parent
@@ -94,7 +94,7 @@ ORDER BY upload.upload_pk;";
     } else {
       $sql = "SELECT
 upload.upload_pk, upload.upload_desc, upload.upload_ts, upload.upload_filename,
-folder.folder_pk, folder.folder_name, pfile.pfile_size
+folder.folder_pk, folder.folder_name, pfile.pfile_size, pfile.pfile_sha1
 FROM upload
 INNER JOIN folderlist ON folderlist.upload_pk = upload.upload_pk
 INNER JOIN folder ON folder.folder_pk = folderlist.parent
@@ -110,7 +110,7 @@ ORDER BY upload.upload_pk;";
     foreach ($result as $row) {
       $upload = new Upload($row["folder_pk"], $row["folder_name"],
         $row["upload_pk"], $row["upload_desc"], $row["upload_filename"],
-        $row["upload_ts"], $row["pfile_size"]);
+        $row["upload_ts"], $row["pfile_size"], $row["pfile_sha1"]);
       array_push($uploads, $upload->getArray());
     }
     return $uploads;

--- a/src/www/ui/api/Models/Upload.php
+++ b/src/www/ui/api/Models/Upload.php
@@ -63,6 +63,11 @@ class Upload
    */
   private $fileSize;
   /**
+   * @var string $fileSha1
+   * SHA1 checksum of the uploaded file
+   */
+  private $fileSha1;
+  /**
    * Upload constructor.
    * @param integer $folderId
    * @param string $folderName
@@ -71,9 +76,10 @@ class Upload
    * @param string $uploadName
    * @param string $uploadDate
    * @param integer $fileSize
+   * @param string $fileSha1
    * @param string $tag
    */
-  public function __construct($folderId, $folderName, $uploadId, $description, $uploadName, $uploadDate, $fileSize, $tag = NULL)
+  public function __construct($folderId, $folderName, $uploadId, $description, $uploadName, $uploadDate, $fileSize, $fileSha1, $tag = NULL)
   {
     $this->folderId = intval($folderId);
     $this->folderName = $folderName;
@@ -82,6 +88,7 @@ class Upload
     $this->uploadName = $uploadName;
     $this->uploadDate = $uploadDate;
     $this->fileSize = intval($fileSize);
+    $this->fileSha1 = $fileSha1;
   }
 
   /**
@@ -106,7 +113,8 @@ class Upload
       "description" => $this->description,
       "uploadname"  => $this->uploadName,
       "uploaddate"  => $this->uploadDate,
-      "filesize"    => $this->fileSize
+      "filesize"    => $this->fileSize,
+      "filesha1"    => $this->fileSha1,
     ];
   }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -14,7 +14,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.0.14
+  version: 1.0.15
   contact:
     email: fossology@fossology.org
   license:
@@ -963,6 +963,9 @@ components:
         filesize:
           type: integer
           description: Filesize in Bytes.
+        filesha1:
+          type: string
+          description: SHA1 digest of the file
     UploadSummary:
       type: object
       properties:


### PR DESCRIPTION
## Description

This patch extends the REST API model `Upoad` with the SHA1 sum of the uploaded file.

### Changes

A new fields is available in the `Upload` schema: `string filesha1`

## How to test

I tested the changes on a local docker-based instance performing a REST call on the `/uploads/` endpoints.

I couldn't find any unit tests for the REST API, are some available? 

Closing #1698
