### PR TITLE
feat(groups): Update default group for user

### DIFF
--- a/src/lib/php/UI/template/components/menu.html.twig
+++ b/src/lib/php/UI/template/components/menu.html.twig
@@ -37,7 +37,7 @@
             <td align='right'><small>{{ 'Group'|trans }}:</small></td>
             <td>
               {% if singleGroup %}{{ singleGroup }}
-              {%else%}       
+              {%else%}
                 <form action="{{ backtraceUri }}" method="post">
                   {% import "include/macros.html.twig" as macro %}
                   {{ macro.select('selectMemberGroup',allAssignedGroups,'selectMemberGroup',groupId,' class="ui-render-select2" onchange="this.form.submit()"') }}

--- a/src/www/ui/template/user_edit.html.twig
+++ b/src/www/ui/template/user_edit.html.twig
@@ -69,6 +69,14 @@
       <th width="25%">{{ "Default bucket pool"| trans }}</th>
       <td>{{ bucketPool }}</td>
     </tr>
+    {%  if isSessionAdmin %}
+      <tr class="classic">
+        <th width="25%">{{ "Select user's default group."|trans }}</th>
+        <td><select name="default_group_fk" class="ui-render-select2">
+          {{ defaultGroupOption }}
+        </select></td>
+      </tr>
+    {% endif %}
   </table>
   <input type="submit" name="UpdateBtn" value="{{ 'Update Account'|trans }}"/>
   </form>

--- a/src/www/ui/user-edit.php
+++ b/src/www/ui/user-edit.php
@@ -26,6 +26,7 @@ use Fossology\UI\Api\Models\Info;
 use Firebase\JWT\JWT;
 use Fossology\Lib\Exceptions\DuplicateTokenKeyException;
 use Fossology\Lib\Exceptions\DuplicateTokenNameException;
+use Fossology\Lib\Dao\UserDao;
 
 class UserEditPage extends DefaultPlugin
 {
@@ -39,6 +40,11 @@ class UserEditPage extends DefaultPlugin
    * Auth helper object */
   private $authHelper;
 
+  /**
+   * @var UserDao
+   * UserDao object */
+  private $userDao;
+
   function __construct()
   {
     parent::__construct(self::NAME, array(
@@ -50,6 +56,7 @@ class UserEditPage extends DefaultPlugin
 
     $this->dbManager = $this->getObject('db.manager');
     $this->authHelper = $this->getObject('helper.authHelper');
+    $this->userDao = $this->getObject('dao.user');
   }
 
   /**
@@ -172,6 +179,7 @@ class UserEditPage extends DefaultPlugin
     $vars['agentSelector'] = AgentCheckBoxMake(-1, array("agent_unpack",
       "agent_adj2nest", "wget_agent"), $UserRec['user_name']);
     $vars['bucketPool'] = SelectBucketPool($UserRec["default_bucketpool_fk"]);
+    $vars['defaultGroupOption'] = $this->getUserGroupSelect($UserRec);
 
     return $vars;
   }
@@ -191,34 +199,43 @@ class UserEditPage extends DefaultPlugin
     /**** Validations ****/
     /* Make sure we have a user_pk */
     if (empty($UserRec['user_pk'])) {
-      $Errors .= "<li>" . _("Consistency error (User_pk missing).  Please start over.");
+      $Errors .= "<li>" . _("Consistency error (User_pk missing).  Please start over.") . "</li>";
     }
 
     /* Make sure username looks valid */
     if (empty($UserRec['user_name'])) {
-      $Errors .= "<li>" . _("Username must be specified.");
+      $Errors .= "<li>" . _("Username must be specified.") . "</li>";
     }
 
     /* Verify the user_name is not a duplicate  */
     $CheckUserRec = GetSingleRec("users", "WHERE user_name='$UserRec[user_name]'");
     if ((!empty($CheckUserRec)) and ( $CheckUserRec['user_pk'] != $UserRec['user_pk'])) {
-      $Errors .= "<li>" . _("Username is not unique.");
+      $Errors .= "<li>" . _("Username is not unique.") . "</li>";
     }
 
     /* Make sure password matches */
     if ($UserRec['_pass1'] != $UserRec['_pass2']) {
-      $Errors .= "<li>" . _("Passwords do not match.");
+      $Errors .= "<li>" . _("Passwords do not match.") . "</li>";
     }
 
     /* Make sure email looks valid */
     $Check = preg_replace("/[^a-zA-Z0-9@_.+-]/", "", $UserRec['user_email']);
     if ($Check != $UserRec['user_email']) {
-      $Errors .= "<li>" . _("Invalid email address.");
+      $Errors .= "<li>" . _("Invalid email address.") . "</li>";
     }
 
     /* Did they specify a password and also request a blank password?  */
     if (!empty($UserRec['_blank_pass']) and ( !empty($UserRec['_pass1']) or ! empty($UserRec['_pass2']))) {
-      $Errors .= "<li>" . _("You cannot specify both a password and a blank password.");
+      $Errors .= "<li>" . _("You cannot specify both a password and a blank password.") . "</li>";
+    }
+
+    /* Check if the user is member of the group */
+    if (!empty($UserRec['group_fk'])) {
+      $group_map = $this->userDao->getUserGroupMap($UserRec['user_pk']);
+      if (array_search($UserRec['group_fk'], array_keys($group_map)) === false) {
+        $Errors .= "<li>" . _("User is not member of provided group.") .
+          "</li>";
+      }
     }
 
     /* If we have any errors, return them */
@@ -253,7 +270,7 @@ class UserEditPage extends DefaultPlugin
       $sql .= "$key='" . pg_escape_string($val) . "'";
       $first = false;
     }
-    $sql .= " where user_pk=$UserRec[user_pk]";
+    $sql .= " WHERE user_pk=$UserRec[user_pk]";
     $result = pg_query($PG_CONN, $sql);
     DBCheckResult($result, $sql, __FILE__, __LINE__);
     pg_free_result($result);
@@ -315,6 +332,7 @@ class UserEditPage extends DefaultPlugin
       $UserRec['user_name'] = stripslashes($request->get('user_name'));
       $UserRec['root_folder_fk'] = intval($request->get('root_folder_fk'));
       $UserRec['user_desc'] = stripslashes($request->get('user_desc'));
+      $UserRec['group_fk'] = intval($request->get('default_group_fk'));
 
       $UserRec['_pass1'] = stripslashes($request->get('_pass1'));
       $UserRec['_pass2'] = stripslashes($request->get('_pass2'));
@@ -460,6 +478,26 @@ class UserEditPage extends DefaultPlugin
     }
     array_multisort(array_column($response, "created"), SORT_ASC, $response);
     return $response;
+  }
+
+  /**
+   * Generate the HTML option list of groups for the user
+   * @param array $userRec User record being updated
+   * @return string HTML option list
+   */
+  private function getUserGroupSelect($userRec)
+  {
+    $groups = $this->userDao->getUserGroupMap($userRec['user_pk']);
+    $userDefaults = $this->userDao->getUserAndDefaultGroupByUserName($userRec['user_name']);
+    $options = "";
+    foreach ($groups as $groupId => $groupName) {
+      $options .= "<option value='$groupId' ";
+      if ($groupId == $userDefaults['group_fk']) {
+        $options .= "selected='selected'";
+      }
+      $options .= ">$groupName</option>";
+    }
+    return $options;
   }
 }
 


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add feature to update default group for a user from user edit form. This will be helpful while creating a new user.

Read #1353 for more info.

**Note:** Only admins will be able to update this value.

### Changes

1. Add new field `default_group_fk` to **Edit User Account** page.

## How to test

1. Create a new user.
2. Assign few groups to the newly created user.
3. Edit the new user and change the default group.
4. Login as the new user and check if the default group is updated for the user.
- Check if the non-admin users do not see the field.

Closes #1353