### PR TITLE
fix(delete): Do not remove upload_pk

### DIFF
--- a/src/delagent/agent/util.c
+++ b/src/delagent/agent/util.c
@@ -421,6 +421,11 @@ int deleteUpload (long uploadId, int userId, int userPerm)
   snprintf(SQL,MAXSQL,"DROP TABLE %s;",tempTable);
   PQexecCheckClear(NULL, SQL, __FILE__, __LINE__);
 
+  /* Mark upload deleted in upload table */
+  snprintf(SQL,MAXSQL,"UPDATE upload SET expire_action = 'd', "
+      "expire_date = now(), pfile_fk = NULL WHERE upload_pk = %ld;", uploadId);
+  PQexecCheckClear("Marking upload as deleted", SQL, __FILE__, __LINE__);
+
   PQexecCheckClear(NULL, "SET statement_timeout = 120000;", __FILE__, __LINE__);
 
   printfInCaseOfVerbosity("Deleted upload %ld from DB, now doing repository.\n",uploadId);

--- a/src/maintagent/agent/process.c
+++ b/src/maintagent/agent/process.c
@@ -171,7 +171,8 @@ FUNCTION void removeUploads()
 
   char *SQL = "DELETE FROM upload WHERE upload_pk  \
                IN (SELECT upload_fk FROM uploadtree WHERE parent IS NULL AND pfile_fk IS NULL)  \
-               OR upload_pk NOT IN (SELECT upload_fk FROM uploadtree)";
+               OR (upload_pk NOT IN (SELECT upload_fk FROM uploadtree) \
+                 AND expire_action != 'd' AND pfile_fk IS NOT NULL)";
 
   startTime = (long)time(0);
 

--- a/src/www/ui/async/AjaxShowJobs.php
+++ b/src/www/ui/async/AjaxShowJobs.php
@@ -293,7 +293,7 @@ class AjaxShowJobs extends \FO_Plugin
           'uploadName' => $jobs['upload']['upload_filename'],
           'uploadId' => $jobs['upload']['upload_pk'],
           'uploadDesc' => $jobs['upload']['upload_desc'],
-          'uploadItem' => $jobs['uploadtree']['uploadtree_pk'],
+          'uploadItem' => empty($jobs['uploadtree']) ? -1 : $jobs['uploadtree']['uploadtree_pk'],
           'uploadEta' => $this->showJobsDao->getEstimatedTime($jobs['job']['job_pk'], '', 0, $jobs['upload']['upload_pk'])
         );
       } else {

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -2085,7 +2085,6 @@
   $Schema["CONSTRAINT"]["tags_uploadtree_pkey"] = "ALTER TABLE \"tag_uploadtree\" ADD CONSTRAINT \"tags_uploadtree_pkey\" PRIMARY KEY (\"tag_uploadtree_pk\");";
   $Schema["CONSTRAINT"]["tags_uploadtree_tag_fk_fkey"] = "ALTER TABLE \"tag_uploadtree\" ADD CONSTRAINT \"tags_uploadtree_tag_fk_fkey\" FOREIGN KEY (\"tag_fk\") REFERENCES \"tag\" (\"tag_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["upload_pkey_idx"] = "ALTER TABLE \"upload\" ADD CONSTRAINT \"upload_pkey_idx\" PRIMARY KEY (\"upload_pk\");";
-  $Schema["CONSTRAINT"]["upload_pfile_fk_fkey"] = "ALTER TABLE \"upload\" ADD CONSTRAINT \"upload_pfile_fk_fkey\" FOREIGN KEY (\"pfile_fk\") REFERENCES \"pfile\" (\"pfile_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["upload_clearing_pkey"] = "ALTER TABLE \"upload_clearing\" ADD CONSTRAINT \"upload_clearing_pkey\" PRIMARY KEY (\"upload_fk\",\"group_fk\");";
   $Schema["CONSTRAINT"]["upload_clearing_license_upload_fk_fkey"] = "ALTER TABLE \"upload_clearing_license\" ADD CONSTRAINT \"upload_clearing_license_upload_fk_fkey\" FOREIGN KEY (\"upload_fk\") REFERENCES \"upload\" (\"upload_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["upload_packages_package_fk"] = "ALTER TABLE \"upload_packages\" ADD CONSTRAINT \"upload_packages_package_fk\" FOREIGN KEY (\"package_fk\") REFERENCES \"package\" (\"package_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";

--- a/src/www/ui/template/ui-showjobs.js.twig
+++ b/src/www/ui/template/ui-showjobs.js.twig
@@ -109,7 +109,7 @@ function createTableForJob(job) {
     border: "1"
   });
   var uploadLink = "";
-  if (job.upload !== null) {
+  if (job.upload !== null && job.upload.uploadItem != -1) {
     uploadLink = '<a title="{{ "Click to browse"|trans }}" ' +
     'href="?mod=browse&upload=' + job.upload.uploadId + '&item=' +
     job.upload.uploadItem + '">' + job.upload.uploadName + '</a>';

--- a/src/www/ui/ui-browse.php
+++ b/src/www/ui/ui-browse.php
@@ -265,7 +265,9 @@ class ui_browse extends FO_Plugin
     global $container;
     /* @var $dbManager DbManager */
     $dbManager = $container->get('db.manager');
-    $uploadExists = $dbManager->getSingleRow("SELECT count(*) cnt FROM upload WHERE upload_pk=$1",array($uploadId));
+    $uploadExists = $dbManager->getSingleRow(
+      "SELECT count(*) cnt FROM upload WHERE upload_pk=$1 " .
+      "AND expire_action!='d' AND pfile_fk IS NOT NULL", array($uploadId));
     if ($uploadExists['cnt']< 1) {
       throw new Exception("This upload no longer exists on this system.");
     }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

While deleting a upload, due to constraint `upload_pfile_fk_fkey`, the tuple from `upload` table also get dropped. This causes issues with the job table as they hold the `upload_fk` which causes issue for new uploads if the `upload_upload_pk_seq` is reset.

This commit drops that constraint, retaining the upload_pk and marks the upload as deleted using the `expire_action` and `expire_date` columns.
Since the upload link is removed from `foldercontents` table, no other changes were required. The commit also adds a filter to `removeUploads()` for maintenance agent so that it does not drop the tuple.

### Changes

1. Remove the `upload_pfile_fk_fkey` constraint.
1. Mark upload as deleted using `expire_action` and `expire_date` columns in delagent.
1. Update `removeUploads()` of maintagent so it does not drop the tuple.
1. Fix warnings in `AjaxShowJobs.php`.
1. Update `ui-browse.php` to detect deleted upload.

## How to test

1. Upload few packages and delete them.
    1. The row for the upload should not be deleted from `upload` table.
    1. `pfile_fk`, `expire_action` and `expire_date` columns should be updated for the upload.
1. Create a new folder and upload several packages to the folder.
    1. Deleting the folder should delete the uploads but not the respective tuple in `upload` table.

Closes #1684