### PR TITLE
feat(jobs): Show all running jobs

### DIFF
--- a/src/lib/php/Dao/ShowJobsDao.php
+++ b/src/lib/php/Dao/ShowJobsDao.php
@@ -372,4 +372,21 @@ class ShowJobsDao
       return array();
     }
   }
+
+  /**
+   * Get the status of all pending or running jobs.
+   * @return array Containing job name, number of jobs pending and running
+   */
+  public function getJobsForAll()
+  {
+    $sql = "SELECT jq_type AS job, jq_job_fk, job_upload_fk AS upload_fk, " .
+      "CASE WHEN (jq_endtext IS NULL AND jq_end_bits = 0) THEN 'pending' " .
+      "WHEN (jq_endtext = ANY('{Started,Restarted,Paused}')) THEN 'running' " .
+      "ELSE '' END AS status " .
+      "FROM jobqueue INNER JOIN job " .
+      "ON jq_job_fk = job_pk " .
+      "WHERE jq_endtime IS NULL;";
+    $statement = __METHOD__ . ".getAllUnFinishedJobs";
+    return $this->dbManager->getRows($sql, [], $statement);
+  }
 }

--- a/src/www/ui/async/AjaxAllJobStatus.php
+++ b/src/www/ui/async/AjaxAllJobStatus.php
@@ -1,0 +1,114 @@
+<?php
+/***********************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***********************************************************/
+namespace Fossology\UI\Ajax;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\Plugin\DefaultPlugin;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Fossology\Lib\Dao\ShowJobsDao;
+
+/**
+ * @class AjaxAllJobStatus
+ * Provides data for AllJobStatus page
+ */
+class AjaxAllJobStatus extends DefaultPlugin
+{
+
+  /** @var string NAME
+   * Mod name */
+  const NAME = "ajax_all_job_status";
+
+  /** @var DbManager $dbManager
+   * DB manager in use */
+  private $dbManager;
+
+  /** @var ShowJobsDao $showJobDao
+   * Dao to fetch job info */
+  private $showJobDao;
+
+  function __construct()
+  {
+    parent::__construct(self::NAME,
+      array(
+        self::PERMISSION => Auth::PERM_NONE,
+        self::REQUIRES_LOGIN => false
+      ));
+
+    $this->dbManager = $this->getObject('db.manager');
+    $this->showJobDao = $this->getObject('dao.show_jobs');
+  }
+
+  /**
+   * @param Request $request
+   * @return Response
+   */
+  protected function handle(Request $request)
+  {
+    $results = $this->showJobDao->getJobsForAll();
+    $uniqueTypes = array_unique(array_column($results, 'job'));
+    $data = array();
+
+    foreach ($uniqueTypes as $type) {
+      $data[$type] = [];
+      $data[$type]['running'] = 0;
+      $data[$type]['pending'] = 0;
+      $data[$type]['eta'] = 0;
+      foreach ($results as $row) {
+        if ($row['job'] != $type || empty($row['status'])) {
+          continue;
+        }
+        $data[$type][$row['status']] ++;
+        $newEta = $this->showJobDao->getEstimatedTime($row['jq_job_fk'],
+          $row['job'], 0, $row['upload_fk'], 1);
+        if (! empty($newEta)) {
+          $data[$type]['eta'] = ($newEta > $data[$type]['eta']) ? $newEta:$data[$type]['eta'];
+        }
+      }
+    }
+
+    $returnData = array();
+    foreach ($data as $agent => $row) {
+      $dataRow = [
+        "name" => $agent,
+        "running" => $row["running"],
+        "pending" => $row["pending"]
+      ];
+      if ($row['eta'] == 0) {
+        $dataRow['eta'] = "N/A";
+      } else {
+        $dataRow['eta'] = intval($row["eta"] / 3600) .
+          gmdate(":i:s", $row["eta"]);
+      }
+      $returnData[] = $dataRow;
+    }
+    $output = "";
+    $error_msg = "";
+    $schedStatus = "Running";
+    if (! fo_communicate_with_scheduler("status", $output, $error_msg)
+      && strstr($error_msg, "Connection refused") !== false) {
+      $schedStatus = "Stopped";
+    }
+    return new JsonResponse(["data" => $returnData, "scheduler" => $schedStatus]);
+  }
+}
+
+register_plugin(new AjaxAllJobStatus());

--- a/src/www/ui/page/AllJobStatus.php
+++ b/src/www/ui/page/AllJobStatus.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * *********************************************************
+ * Copyright (C) 2020 Siemens AG
+ *
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *********************************************************
+ */
+
+/**
+ * @file
+ * Report general job status of the server to user.
+ */
+namespace Fossology\UI\Page;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Plugin\DefaultPlugin;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @class AllJobStatus
+ * Page to show all scheduled/running jobs on server to users.
+ */
+class AllJobStatus extends DefaultPlugin
+{
+
+  /**
+   * @var string NAME
+   *      Mod name
+   */
+  const NAME = "all_job_status";
+
+  function __construct()
+  {
+    parent::__construct(self::NAME,
+      array(
+        self::TITLE => "Status - all server jobs",
+        self::MENU_LIST => "Admin::Dashboards::All Jobs",
+        self::REQUIRES_LOGIN => false,
+        self::PERMISSION => Auth::PERM_NONE
+      ));
+  }
+
+  /**
+   * @param Request $request
+   * @return Response
+   */
+  protected function handle(Request $request)
+  {
+    global $SysConf;
+    $vars = array();
+    $vars['clockTime'] = $SysConf['SYSCONFIG']['ShowJobsAutoRefresh'];
+    return $this->render('all_job_status.html.twig',
+      $this->mergeWithDefault($vars));
+  }
+}
+
+register_plugin(new AllJobStatus());

--- a/src/www/ui/template/all_job_status.html.twig
+++ b/src/www/ui/template/all_job_status.html.twig
@@ -1,0 +1,85 @@
+{# Copyright 2020 Siemens AG
+
+   Copying and distribution of this file, with or without modification,
+   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
+   This file is offered as-is, without any warranty.
+#}
+{% extends "include/base.html.twig" %}
+
+{% block content %}
+  <table border="0">
+    <tr>
+      <th style="padding:3px 10px">{{ 'Scheduler'|trans }}</th>
+      <td style="padding:3px 10px" id="scheduler_status"></td>
+    </tr>
+  </table><br />
+  <table border="1" style="width:auto !important;margin:unset !important;"
+    id="alljobstatustable">
+    <thead>
+      <tr>
+        <th>{{ 'Agent name'|trans }}</th>
+        <th>{{ 'Running'|trans }}</th>
+        <th>{{ 'Pending'|trans }}</th>
+        <th>{{ 'ETA'|trans }}</th>
+      </tr>
+    </thead>
+    <tfoot>
+      <tr>
+        <td style="font-weight:bold;text-align:right">{{ 'Total'|trans }}</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+    </tfoot>
+  </table>
+{% endblock %}
+
+{% block foot %}
+  {{ parent() }}
+  <script type="text/javascript" src="scripts/jquery.dataTables.min.js"></script>
+  <script type="text/javascript" src="scripts/jquery.dataTables.select.js"></script>
+  <script type="text/javascript">
+    $(document).ready(function() {
+	  var t = $("#alljobstatustable").DataTable({
+	    processing: true,
+	    searching: false,
+	    paging: false,
+	    info: false,
+	    autoWidth: false,
+	    ajax: {
+          url: "?mod=ajax_all_job_status",
+          dataSrc: function (json) {
+            var returnval = [];
+            for (var i = 0; i < json.data.length; i++) {
+              var newrow = [];
+              newrow.push(json.data[i].name);
+              newrow.push(json.data[i].running);
+              newrow.push(json.data[i].pending);
+              newrow.push(json.data[i].eta);
+              returnval.push(newrow);
+            }
+            $("#scheduler_status").html(json.scheduler);
+            return returnval;
+          }
+        },
+        footerCallback: function (row, data, start, end, display) {
+          var api = this.api(), data;
+          var totalRunning = api.column(1).data().reduce(function (a, b) {
+            return parseInt(a) + parseInt(b);
+          }, 0);
+          var totalPending = api.column(2).data().reduce(function (a, b) {
+            return parseInt(a) + parseInt(b);
+          }, 0);
+          $(api.column(1).footer()).html(totalRunning);
+          $(api.column(2).footer()).html(totalPending);
+        }
+	  });
+	  var clockTime = {{ clockTime }};
+	  if (clockTime != "0") {
+	    setInterval(function(){
+	      t.ajax.reload();
+	    }, clockTime * 1000);
+	  }
+	});
+  </script>
+{% endblock %}


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add a new page to show all running/pending jobs on server.
The page also shows current status of scheduler (Running/Stopped).

This will help users to understand the reason if their jobs are stuck.

### Changes

1. Add new function in `ShowJobsDao.php` to get running and pending jobs per agent.
1. Change the default port on `common-scheduler.php` to `24693` (as per the `fossology.conf`).
1. New async page `AjaxAllJobStatus.php` to get job status and scheduler status.
1. New page `AllJobStatus.php` and template `all_job_status.html.twig` to show the data from `AjaxAllJobStatus.php`.

**Note:**
1. The page is added under Admin >> Dashboards >> All Jobs
1. The page will work **without login** (as no sensitive information is displayed).

## How to test

1. Check if the new page appears under Admin >> Dashboards >> All Jobs
1. Check if the page reloads in the time intervals defined by **ShowJobs Auto Refresh Time** in **Customize** page.
1. Disable/Enable the scheduler to check the scheduler status updates on page.