### PR TITLE
fix(spdxReport): add missing artifact to file path in spdx reporting

### DIFF
--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -443,7 +443,7 @@ class SpdxTwoAgent extends Agent
       if (($filesProceeded&2047)==0) {
         $this->heartbeat(0);
       }
-      $fullPath = $treeDao->getFullPath($fileId,$treeTableName,0,true);
+      $fullPath = $treeDao->getFullPath($fileId,$treeTableName,0);
       if (!empty($licenses['concluded']) && count($licenses['concluded'])>0) {
         $this->toLicensesWithFilesAdder($licensesWithFiles,$licenses['concluded'],$licenses['copyrights'],$fileId,$fullPath);
       } else {
@@ -689,7 +689,7 @@ class SpdxTwoAgent extends Agent
         $lastValue = $filesProceeded;
       }
       $hashes = $treeDao->getItemHashes($fileId);
-      $fileName = $treeDao->getFullPath($fileId, $treeTableName, 0, true);
+      $fileName = $treeDao->getFullPath($fileId, $treeTableName, 0);
       if (!is_array($licenses['concluded'])) {
         $licenses['concluded'] = array();
       }


### PR DESCRIPTION
closes #1703 

## Description

Path in SPDX files is getting chopped because of which there are few files missing in the report in rare cases.

### Changes

add parent and enable file path with artifacts.

## How to test

Please see #1703 