### PR TITLE
fix(upload): Fix the check for expire_action

### DIFF
--- a/src/maintagent/agent/process.c
+++ b/src/maintagent/agent/process.c
@@ -172,7 +172,7 @@ FUNCTION void removeUploads()
   char *SQL = "DELETE FROM upload WHERE upload_pk  \
                IN (SELECT upload_fk FROM uploadtree WHERE parent IS NULL AND pfile_fk IS NULL)  \
                OR (upload_pk NOT IN (SELECT upload_fk FROM uploadtree) \
-                 AND expire_action != 'd' AND pfile_fk IS NOT NULL)";
+                 AND (expire_action IS NULL OR expire_action != 'd') AND pfile_fk IS NOT NULL)";
 
   startTime = (long)time(0);
 

--- a/src/www/ui/ui-browse.php
+++ b/src/www/ui/ui-browse.php
@@ -267,7 +267,7 @@ class ui_browse extends FO_Plugin
     $dbManager = $container->get('db.manager');
     $uploadExists = $dbManager->getSingleRow(
       "SELECT count(*) cnt FROM upload WHERE upload_pk=$1 " .
-      "AND expire_action!='d' AND pfile_fk IS NOT NULL", array($uploadId));
+      "AND (expire_action IS NULL OR expire_action!='d') AND pfile_fk IS NOT NULL", array($uploadId));
     if ($uploadExists['cnt']< 1) {
       throw new Exception("This upload no longer exists on this system.");
     }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The PR #1707 included changes which changed the behavior of `expire_action` column of `upload` table. A new check was added to check if the upload was deleted. The check looks for `'d'` in expire_action column of upload table. The default value for the column in NULL which fails the check of `!= 'd'` in Postgres.

This commits fixes the check by additional check of column being NULL.

### Changes

Change the check of `expire_action` being not equal to `d` to `expire_action IS NULL OR expire_action != 'd'`.

## How to test

1. Check if you can open **Browse** page (`?mod=browse`) for an upload.
1. Check if you can open **Browse** page for a deleted upload.