### PR TITLE
fix(unifiedreport): Get department from config

### DIFF
--- a/src/unifiedreport/agent/reportSummary.php
+++ b/src/unifiedreport/agent/reportSummary.php
@@ -118,7 +118,7 @@ class ReportSummary
     $table->addRow($rowWidth);
     $table->addCell($cellFirstLen, $cellRowSpan)->addText(htmlspecialchars(" Clearing Information"), $firstRowStyle, "pStyle");
     $table->addCell($cellSecondLen)->addText(htmlspecialchars(" Department"), $firstRowStyle1, "pStyle");
-    $table->addCell($cellThirdLen)->addText(htmlspecialchars(" FOSSology Generation"), null, "pStyle");
+    $table->addCell($cellThirdLen)->addText(htmlspecialchars($otherStatement['ri_department']), null, "pStyle");
 
     $table->addRow($rowWidth);
     $table->addCell($cellFirstLen, $cellRowContinue);

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -1814,6 +1814,10 @@
   $Schema["TABLE"]["report_info"]["ri_excluded_obligations"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_excluded_obligations\" json";
   $Schema["TABLE"]["report_info"]["ri_excluded_obligations"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_excluded_obligations\" DROP NOT NULL";
 
+  $Schema["TABLE"]["report_info"]["ri_department"]["DESC"] = "";
+  $Schema["TABLE"]["report_info"]["ri_department"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_department\" text DEFAULT 'FOSSology Generation'::text";
+  $Schema["TABLE"]["report_info"]["ri_department"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_department\" SET NOT NULL, ALTER COLUMN \"ri_department\" SET DEFAULT 'FOSSology Generation'::text";
+
 
   $Schema["VIEW"]["license_file_ref"] = "CREATE VIEW \"license_file_ref\" AS SELECT license_ref.rf_fullname, license_ref.rf_shortname, license_ref.rf_pk, license_file.fl_end_byte, license_file.rf_match_pct, license_file.rf_timestamp, license_file.fl_start_byte, license_file.fl_ref_end_byte, license_file.fl_ref_start_byte, license_file.fl_pk, license_file.agent_fk, license_file.pfile_fk FROM (license_file JOIN license_ref ON ((license_file.rf_fk = license_ref.rf_pk)));";
 

--- a/src/www/ui/template/ui-report-conf.html.twig
+++ b/src/www/ui/template/ui-report-conf.html.twig
@@ -44,6 +44,14 @@
         </tr>
         <tr>
           <td align="left">
+            {{ "Department"|trans }}
+          </td>
+          <td align="left">
+            <input type="text" name="department" style="width:98%" value="{{ department|e }}" />
+          </td>
+        </tr>
+        <tr>
+          <td align="left">
             {{ "Report release date"|trans }}
           </td>
           <td align="left">
@@ -103,8 +111,8 @@
             {{ "Source / binary integration notes"|trans }}
           </td>
           <td align="left">
-            <input type="checkbox" name="nonCritical" {{ nonCritical }} />{{ "no critical files found, source code and binaries can be used as is"|trans }}<br />
-            <input type="checkbox" name="critical" {{ critical }} />{{ "critical files found, source code needs to be adapted and binaries possibly re-built"|trans }}
+            <label><input type="checkbox" name="nonCritical" {{ nonCritical }} />{{ "no critical files found, source code and binaries can be used as is"|trans }}</label><br />
+            <label><input type="checkbox" name="critical" {{ critical }} />{{ "critical files found, source code needs to be adapted and binaries possibly re-built"|trans }}</label>
           </td>
         </tr>
         <tr>
@@ -112,9 +120,9 @@
             {{ "Dependency notes"|trans }}
           </td>
           <td align="left">
-            <input type="checkbox" name="noDependency" {{ noDependency }} />{{ "no dependencies found, neither in source code nor in binaries"|trans }}<br />
-            <input type="checkbox" name="dependencySource" {{ dependencySource }} />{{ "dependencies found in source code (see obligations)"|trans }}<br />
-            <input type="checkbox" name="dependencyBinary" {{ dependencyBinary }} />{{ "dependencies found in binaries (see obligations)"|trans }}
+            <label><input type="checkbox" name="noDependency" {{ noDependency }} />{{ "no dependencies found, neither in source code nor in binaries"|trans }}</label><br />
+            <label><input type="checkbox" name="dependencySource" {{ dependencySource }} />{{ "dependencies found in source code (see obligations)"|trans }}</label><br />
+            <label><input type="checkbox" name="dependencyBinary" {{ dependencyBinary }} />{{ "dependencies found in binaries (see obligations)"|trans }}</label>
           </td>
         </tr>
         <tr>
@@ -122,8 +130,8 @@
             {{ "Export restrictions by copyright owner"|trans }}
           </td>
           <td align="left">
-            <input type="checkbox" name="noExportRestriction" {{ noExportRestriction }} />{{ "no export restrictions found"|trans }}<br />
-            <input type="checkbox" name="exportRestriction" {{ exportRestriction }} />{{ "export restrictions found (see obligations)"|trans }}
+            <label><input type="checkbox" name="noExportRestriction" {{ noExportRestriction }} />{{ "no export restrictions found"|trans }}</label><br />
+            <label><input type="checkbox" name="exportRestriction" {{ exportRestriction }} />{{ "export restrictions found (see obligations)"|trans }}</label>
           </td>
         </tr>
         <tr>
@@ -131,8 +139,8 @@
             {{ "Restrictions for use by copyright owner \n<br/> (e.g. not for Nuclear Power)"|trans }}
           </td>
           <td align="left">
-            <input type="checkbox" name="noRestriction" {{ noRestriction }} />{{ "no restrictions for use found"|trans }}<br />
-            <input type="checkbox" name="restrictionForUse" {{ restrictionForUse }} />{{ "restrictions for use found (see obligations)"|trans }}
+            <label><input type="checkbox" name="noRestriction" {{ noRestriction }} />{{ "no restrictions for use found"|trans }}</label><br />
+            <label><input type="checkbox" name="restrictionForUse" {{ restrictionForUse }} />{{ "restrictions for use found (see obligations)"|trans }}</label>
           </td>
         </tr>
         <tr>

--- a/src/www/ui/ui-report-conf.php
+++ b/src/www/ui/ui-report-conf.php
@@ -55,6 +55,7 @@ class ui_report_conf extends FO_Plugin
    */
   private $mapDBColumns = array(
     "reviewedBy" => "ri_reviewed",
+    "department" => "ri_department",
     "reportRel" => "ri_report_rel",
     "community" => "ri_community",
     "component" => "ri_component",
@@ -281,14 +282,21 @@ class ui_report_conf extends FO_Plugin
         $i++;
       }
       $parms[] = $this->getCheckBoxSelectionList($this->checkBoxListUR);
+      $checkBoxUrPos = count($parms);
       $parms[] = $this->getCheckBoxSelectionList($this->checkBoxListSPDX);
+      $checkBoxSpdxPos = count($parms);
       $parms[] = json_encode($obLicenses);
+      $excludeObligationPos = count($parms);
       $parms[] = $uploadId;
+      $uploadIdPos = count($parms);
 
       $SQL = "UPDATE report_info SET $columns" .
-               "ri_ga_checkbox_selection = $12, ri_spdx_selection = $13, ri_excluded_obligations = $14" .
-             "WHERE upload_fk = $15;";
-      $this->dbManager->getSingleRow($SQL, $parms, __METHOD__ . "updateReportInfoData");
+               "ri_ga_checkbox_selection = $$checkBoxUrPos, " .
+               "ri_spdx_selection = $$checkBoxSpdxPos, " .
+               "ri_excluded_obligations = $$excludeObligationPos" .
+               "WHERE upload_fk = $$uploadIdPos;";
+      $this->dbManager->getSingleRow($SQL, $parms,
+        __METHOD__ . "updateReportInfoData");
     }
     $this->vars += $this->allReportConfiguration($uploadId, $groupId);
   }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The unified report has a **Department** field under **Clearing Information** section. This field was hard coded with the value **FOSSology Generation** in the code and thus the user has to manually edit the file.

The commit adds a new column `ri_department` in `report_info` table to make this field editable from UI itself.

### Changes

1. Add a new column `ri_department` in `report_info`.
1. Add labels to check boxes in Report Config page.

## How to test

1. Check if the installation does not break reports in old uploads.
1. Check if updating the department in Report Conf page results in updated value in Unified Report.