### PR TITLE
feat(rest): Upload from URL and server

### DIFF
--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -224,13 +224,20 @@ class UploadController extends RestController
       $public = $request->getHeaderLine('public');
       $public = empty($public) ? 'protected' : $public;
       $ignoreScm = $request->getHeaderLine('ignoreScm');
-      list ($status, $message, $statusDescription, $uploadId) = $uploadHelper->createNewUpload(
-        $request, $folderId, $description, $public, $ignoreScm);
+      $uploadType = $request->getHeaderLine('uploadType');
+      if (empty($uploadType)) {
+        $uploadType = "vcs";
+      }
+      $uploadResponse = $uploadHelper->createNewUpload($request, $folderId,
+        $description, $public, $ignoreScm, $uploadType);
+      $status = $uploadResponse[0];
+      $message = $uploadResponse[1];
+      $statusDescription = $uploadResponse[2];
       if (! $status) {
-        $info = new Info($uploadId != -1 ? $uploadId : 500,
-          $message . "\n" . $statusDescription,
+        $info = new Info(500, $message . "\n" . $statusDescription,
           InfoType::ERROR);
       } else {
+        $uploadId = $uploadResponse[3];
         $info = new Info(201, intval($uploadId), InfoType::INFO);
       }
       return $response->withJson($info->getArray(), $info->getCode());

--- a/src/www/ui/api/Helper/UploadHelper/HelperToUploadSrvPage.php
+++ b/src/www/ui/api/Helper/UploadHelper/HelperToUploadSrvPage.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * *************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *************************************************************
+ */
+
+/**
+ * @file
+ * @brief  Helper to handle server uploads via REST API
+ */
+
+namespace Fossology\UI\Api\Helper\UploadHelper;
+
+use Fossology\UI\Page\UploadSrvPage;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @class HelperToUploadSrvPage
+ * Child class helper to access protected methods of UploadSrvPage
+ */
+class HelperToUploadSrvPage extends UploadSrvPage
+{
+
+  /**
+   * Handles the Symfony Request object and pass it to handleUpload() of
+   * UploadVcsPage.
+   *
+   * @param Request $request Symfony Request object holding information about
+   *        the upload
+   */
+  public function handleRequest(Request $request)
+  {
+    return $this->handleUpload($request);
+  }
+}

--- a/src/www/ui/api/Helper/UploadHelper/HelperToUploadUrlPage.php
+++ b/src/www/ui/api/Helper/UploadHelper/HelperToUploadUrlPage.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * *************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *************************************************************
+ */
+
+/**
+ * @file
+ * @brief  Helper to handle URL uploads via REST API
+ */
+
+namespace Fossology\UI\Api\Helper\UploadHelper;
+
+use Fossology\UI\Page\UploadUrlPage;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @class HelperToUploadUrlPage
+ * Child class helper to access protected methods of UploadUrlPage
+ */
+class HelperToUploadUrlPage extends UploadUrlPage
+{
+
+  /**
+   * Handles the Symfony Request object and pass it to handleUpload() of
+   * UploadVcsPage.
+   *
+   * @param Request $request Symfony Request object holding information about
+   *        the upload
+   */
+  public function handleRequest(Request $request)
+  {
+    return $this->handleUpload($request);
+  }
+}

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -14,7 +14,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.0.15
+  version: 1.0.16
   contact:
     email: fossology@fossology.org
   license:
@@ -244,7 +244,7 @@ paths:
       tags:
         - Upload
       summary: Uploads
-      description: |
+      description: >
         The uploads endpoint returns all uploads
       responses:
         '200':
@@ -261,13 +261,16 @@ paths:
       tags:
         - Upload
       summary: Post new upload to FOSSology
-      description: |
+      description: >
         Endpoint to create a new upload in FOSSology
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VcsUpload'
+              oneOf:
+                - $ref: '#/components/schemas/VcsUpload'
+                - $ref: '#/components/schemas/UrlUpload'
+                - $ref: '#/components/schemas/ServerUpload'
           multipart/form-data:
             schema:
               type: object
@@ -300,7 +303,8 @@ paths:
               - public
             default: protected
         - name: ignoreScm
-          description: Ignore SCM files (Git, SVN, TFS)
+          description: >
+            Ignore SCM files (Git, SVN, TFS) and files with particular Mimetype
           in: header
           required: false
           schema:
@@ -313,6 +317,18 @@ paths:
           schema:
             type: string
             description: Group name, from last login if not provided    
+        - name: uploadType
+          description: >
+            Type of upload done. Required for VCS, URL and server uploads
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - vcs
+              - url
+              - server
+            default: vcs
       responses:
         '201':
           description: Upload is created
@@ -1238,6 +1254,41 @@ components:
             example:
               - "MIT"
               - "No_license_found"
+    UrlUpload:
+      description: To create an upload from a URL
+      type: object
+      properties:
+        url:
+          description: URL for file/folder to be uploaded
+          type: string
+        name:
+          description: Viewable name for this file or directory
+          type: string
+        accept:
+          description: >
+            Comma-separated lists of file name suffixes or patterns to accpet
+          type: string
+        reject:
+          description: >
+            Comma-separated lists of file name suffixes or patterns to reject
+          type: string
+        maxRecursionDepth:
+          description: Maximum recursion depth for folders (0 for infinite)
+          type: integer
+      required:
+        - url
+    ServerUpload:
+      description: To create an upload from a server
+      type: object
+      properties:
+        path:
+          description: File path to be uploaded (reccursive, support *)
+          type: string
+        name:
+          description: Viewable name for this file or directory
+          type: string
+      required:
+        - path
   responses:
     defaultResponse:
           description: Some error occured. Check the "message"

--- a/src/www/ui/page/UploadSrvPage.php
+++ b/src/www/ui/page/UploadSrvPage.php
@@ -282,7 +282,7 @@ class UploadSrvPage extends UploadPageBase
     $Url = Traceback_uri() . "?mod=showjobs&upload=$uploadId";
     $message .= "The file $sourceFiles has been uploaded. ";
     $keep = "It is <a href='$Url'>upload #" . $uploadId . "</a>.\n";
-    return array(true, $message.$keep, $description);
+    return array(true, $message.$keep, $description, $uploadId);
   }
 }
 register_plugin(new UploadSrvPage());

--- a/src/www/ui/page/UploadUrlPage.php
+++ b/src/www/ui/page/UploadUrlPage.php
@@ -110,7 +110,7 @@ class UploadUrlPage extends UploadPageBase
     }
 
     $message = $this->postUploadAddJobs($request, $shortName, $uploadId, $jobId, true);
-    return array(true, $message, $description);
+    return array(true, $message, $description, $uploadId);
   }
 
   protected function handleView(Request $request, $vars)


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Provided option to allow user to upload from URL or server from REST API.

### Changes

1. New parameter `uploadType` to define uploading from URL/VCS/Server.
1. Two new schema `components/schemas/UrlUpload` and `components/schemas/ServerUpload`

## How to test

1. Check if upload from URL works with all parameters.
1. Check if upload from Server works with all parameters.
1. Check if upload from File works.
1. Check if upload from VCS works even when `uploadType` is not provided (for backward compatibility).
1. Check if an error is thrown for invalid value in `uploadType`.

Depends on #1699 for API version.

Closes #1562