### PR TITLE
fix(clearingCount): do not add count as cleared in case of to be disc…

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -974,7 +974,7 @@ INSERT INTO clearing_decision (
       $statementName, $params);
 
     $statementName = __METHOD__ . $statementName;
-    $sql = "$cte SELECT COUNT(*) AS cnt FROM decision;";
+    $sql = "$cte SELECT COUNT(*) AS cnt FROM decision WHERE type_id <> ".DecisionTypes::TO_BE_DISCUSSED;
 
     $clearedCounter = $this->dbManager->getSingleRow($sql, $params,
       $statementName);

--- a/src/www/ui/async/AjaxExplorer.php
+++ b/src/www/ui/async/AjaxExplorer.php
@@ -399,14 +399,6 @@ class AjaxExplorer extends DefaultPlugin
 
     $img = ($filesCleared == $filesToBeCleared) ? 'green' : 'red';
 
-    // override green/red flag with yellow flag in case of single file with decision type "To Be Discussed"
-    $isDecisionTBD = $this->clearingDao->isDecisionTBD($childUploadTreeId, $groupId);
-    $img = $isDecisionTBD ? 'yellow' : $img;
-
-    // override green/red flag with greenRed flag in case of single file with decision type "Do Not Use"
-    $isDecisionDNU = $this->clearingDao->isDecisionDNU($childUploadTreeId, $groupId);
-    $img = $isDecisionDNU ? 'redGreen' : $img;
-
     // override green/red flag with grey flag in case of no_license_found scanner finding
     if (!empty($licenseList) && empty($editedLicenseList)) {
       $img = (
@@ -415,6 +407,14 @@ class AjaxExplorer extends DefaultPlugin
               (count(explode(",", $licenseList)) == 1)
              ) ? 'grey' : $img;
     }
+
+    // override green/red flag with yellow flag in case of single file with decision type "To Be Discussed"
+    $isDecisionTBD = $this->clearingDao->isDecisionTBD($childUploadTreeId, $groupId);
+    $img = $isDecisionTBD ? 'yellow' : $img;
+
+    // override green/red flag with greenRed flag in case of single file with decision type "Do Not Use"
+    $isDecisionDNU = $this->clearingDao->isDecisionDNU($childUploadTreeId, $groupId);
+    $img = $isDecisionDNU ? 'redGreen' : $img;
 
     return array($fileName, $licenseList, $editedLicenseList, $img, "$filesCleared/$filesToBeCleared", $fileListLinks);
   }


### PR DESCRIPTION

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

To be discussed files appearing as Grey in license browser. And count of cleared files varies in case of to be discussed.

### Changes

* fix count exclude to be discussed in single file view.

## How to test

* Single file view should have same count as tree-view in case of "To be discussed" decisions.

* For "no license found" files. if we have a decision as "To be discussed" in tree-view it should be with yellow dot.
