### PR TITLE
test(rest): Unit test cases for REST API

### DIFF
--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -17,6 +17,7 @@
     <testsuite name="Fossology PhpUnit Test Suite">
       <directory suffix="Test.php">lib/php</directory>
       <file>www/ui_tests/startUpTest.php</file>
+      <directory suffix="Test.php">www/ui_tests/api</directory>
       <file>cli/tests/test_fo_copyright_list.php</file>
     </testsuite>
 

--- a/src/www/ui/api/Controllers/FolderController.php
+++ b/src/www/ui/api/Controllers/FolderController.php
@@ -25,7 +25,6 @@ namespace Fossology\UI\Api\Controllers;
 
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Fossology\Lib\Auth\Auth;
 use Fossology\UI\Api\Models\Folder;
 use Fossology\UI\Api\Models\Info;
 use Fossology\UI\Api\Models\InfoType;
@@ -156,7 +155,7 @@ class FolderController extends RestController
       $folderParent = intval($folderArray[count($folderArray) - 2]['folder_pk']);
       $folderId = "$folderParent $folderId";
 
-      $rc = $folderDelete->Delete($folderId, Auth::getUserId());
+      $rc = $folderDelete->Delete($folderId, $this->restHelper->getUserId());
       if ($rc == "No access to delete this folder") {
         $info = new Info(403, $rc, InfoType::ERROR);
       } elseif ($rc !== null) {

--- a/src/www/ui/api/Controllers/ReportController.php
+++ b/src/www/ui/api/Controllers/ReportController.php
@@ -83,17 +83,17 @@ class ReportController extends RestController
         case $this->reportsAllowed[2]:
           $spdxGenerator = $this->restHelper->getPlugin('ui_spdx2');
           list ($jobId, $jobQueueId, $error) = $spdxGenerator->scheduleAgent(
-            Auth::getGroupId(), $upload, $reportFormat);
+            $this->restHelper->getGroupId(), $upload, $reportFormat);
           break;
         case $this->reportsAllowed[3]:
           $readmeGenerator = $this->restHelper->getPlugin('ui_readmeoss');
           list ($jobId, $jobQueueId, $error) = $readmeGenerator->scheduleAgent(
-            Auth::getGroupId(), $upload);
+            $this->restHelper->getGroupId(), $upload);
           break;
         case $this->reportsAllowed[4]:
           $unifiedGenerator = $this->restHelper->getPlugin('agent_founifiedreport');
           list ($jobId, $jobQueueId, $error) = $unifiedGenerator->scheduleAgent(
-            Auth::getGroupId(), $upload);
+            $this->restHelper->getGroupId(), $upload);
           break;
         default:
           $error = new Info(500, "Some error occured!", InfoType::ERROR);
@@ -166,7 +166,7 @@ class ReportController extends RestController
     if (array_key_exists("port", $url_parts)) {
       $download_path .= ':' . $url_parts["port"];
     }
-    if ($url_parts["path"][-1] !== '/') {
+    if (substr($url_parts["path"], -1) !== '/') {
       $url_parts["path"] .= '/';
     }
     $download_path .= $url_parts["path"] . $jobId;

--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -449,7 +449,7 @@ class UploadController extends RestController
         $response = $response->withJson($error->getArray(), $error->getCode());
       } else if (array_key_exists('isAgentRunning', $agent) &&
         $agent['isAgentRunning']) {
-        $error = new Info(503, "Agent $agent is running. " .
+        $error = new Info(503, "Agent " . $agent["agentName"] . " is running. " .
           "Please check job status at /api/v1/jobs?upload=" . $uploadId,
           InfoType::INFO);
         $response = $response->withHeader('Retry-After', '60')

--- a/src/www/ui_tests/Makefile
+++ b/src/www/ui_tests/Makefile
@@ -21,16 +21,16 @@ TOP = ../../..
 VARS = $(TOP)/Makefile.conf
 include $(VARS)
 
-DIRS =  ui_tests
+DIRS =  api
 TESTDIR = ui_tests
 
 dirloop=for dir in $(DIRS); do $(MAKE) -s -C $$dir $(1);  done
 
 all:
-	echo "all: Nothing to do for ui_tests"
+	$(call dirloop, )
 
 test:
-	echo "test: Place holder for launching UI functional tests"
+	$(call dirloop,test)
 
 coverage:
 	echo "No make coverage for ui_tests"

--- a/src/www/ui_tests/api/Controllers/AuthControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/AuthControllerTest.php
@@ -1,0 +1,298 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @dir
+ * @brief Unit test cases for API controllers
+ * @file
+ * @brief Unit tests for AuthController
+ */
+
+/**
+ * @namespace Fossology::UI::Api::Test::Controllers
+ *            Unit tests for controllers
+ */
+namespace Fossology\UI\Api\Test\Controllers;
+
+use Mockery as M;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Fossology\UI\Api\Controllers\AuthController;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\AuthHelper;
+use Slim\Http\Request;
+use Slim\Http\Response;
+use Slim\Http\Body;
+use Slim\Http\Uri;
+use Slim\Http\Headers;
+
+/**
+ * @class AuthControllerTest
+ * @brief Test for AtuhController
+ */
+class AuthControllerTest extends \PHPUnit\Framework\TestCase
+{
+
+  /**
+   * @var DbHelper $dbHelper
+   * DB Helper mock
+   */
+  private $dbHelper;
+
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+
+  /**
+   * @var AuthController $authController
+   * Test object
+   */
+  private $authController;
+
+  /**
+   * @var integer $assertCountBefore
+   * Assertions before running tests
+   */
+  private $assertCountBefore;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp()
+  {
+    global $container;
+    $container = M::mock('ContainerBuilder');
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->restHelper = M::mock(RestHelper::class);
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+    $this->authController = new AuthController($container);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+  }
+
+  /**
+   * @brief Remove test objects
+   * @see PHPUnit_Framework_TestCase::tearDown()
+   */
+  protected function tearDown()
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  /**
+   * @test
+   * Test is getAuthHeaders always return deprecation notice
+   */
+  public function testGetAuthHeaders()
+  {
+    $request = M::mock(Request::class);
+    $response = new Response();
+    $response = $this->authController->getAuthHeaders($request, $response,
+      array());
+
+    $warningMessage = "The resource is deprecated. Use /tokens";
+    $returnVal = new Info(406, $warningMessage, InfoType::ERROR);
+
+    $response->getBody()->seek(0);
+    $this->assertEquals($warningMessage, $response->getHeaderLine('Warning'));
+    $this->assertEquals($returnVal->getArray(),
+      json_decode($response->getBody()->getContents(), true));
+    $this->assertEquals($returnVal->getCode(), $response->getStatusCode());
+  }
+
+  /**
+   * @test
+   * -# Mock the request to get a new token
+   * -# Call AuthController::createNewJwtToken()
+   * -# Check if response contains a new JWT token
+   */
+  public function testCreateNewJwtToken()
+  {
+    global $container;
+    $authHelper = M::mock(AuthHelper::class);
+    $authHelper->shouldReceive('checkUsernameAndPassword')->withArgs([
+      'foss','foss'])->andReturn(true);
+    $authHelper->shouldReceive('generateJwtToken')->withArgs([
+      '2020-01-01', '2020-01-01', '2.2', 'read', M::any()])
+      ->andReturn("sometoken");
+    $this->dbHelper->shouldReceive('insertNewTokenKey')->withArgs(array(
+      2, '2020-01-01', 'r', 'test_token', M::any()))->andReturn([
+      "jti" => "2.2",
+      "created_on" => '2020-01-01'
+    ]);
+    $this->restHelper->shouldReceive('validateTokenRequest')->withArgs(array(
+      '2020-01-01', 'test_token', 'read'))->andReturn(true);
+    $this->restHelper->shouldReceive('getAuthHelper')->andReturn($authHelper);
+    $this->restHelper->shouldReceive('getUserId')->andReturn(2);
+    $container->shouldReceive('get')->withArgs(array('helper.restHelper'))
+      ->andReturn($this->restHelper);
+
+    $body = new Body(fopen('php://temp', 'r+'));
+    $body->write(json_encode([
+        "username" => "foss",
+        "password" => "foss",
+        "token_name" => "test_token",
+        "token_scope" => "read",
+        "token_expire" => "2020-01-01"
+      ]));
+    $requestHeaders = new Headers();
+    $requestHeaders->set('Content-Type', 'application/json');
+    $request = new Request("POST", new Uri("HTTP", "localhost"), $requestHeaders,
+      [], [], $body);
+    $response = new Response();
+    $response = $this->authController->createNewJwtToken($request, $response,
+      []);
+    $response->getBody()->seek(0);
+    $this->assertEquals(["Authorization" => "Bearer sometoken"],
+      json_decode($response->getBody()->getContents(), true));
+    $this->assertEquals(201, $response->getStatusCode());
+  }
+
+  /**
+   * @test
+   * -# Mock the request to get a new token
+   * -# Mock a failed response of RestHelper::validateTokenRequest()
+   * -# Call AuthController::createNewJwtToken()
+   * -# Check if failed response if returned
+   */
+  public function testCreateNewJwtTokenExpiredToken()
+  {
+    global $container;
+    $authHelper = M::mock(AuthHelper::class);
+    $authHelper->shouldReceive('checkUsernameAndPassword')->withArgs([
+      'foss', 'foss'])->andReturn(true);
+    $authHelper->shouldReceive('generateJwtToken')->withArgs([
+      '2020-01-02', '2020-01-01', '2.2', 'read', M::any()])
+      ->andReturn("sometoken");
+    $this->dbHelper->shouldReceive('insertNewTokenKey')->withArgs(array(
+      2, '2020-01-02', 'r', 'test_token', M::any()))->andReturn([
+      "jti" => "2.2",
+      "created_on" => '2020-01-01'
+    ]);
+    $failedResponse = new Info(400, "error text", InfoType::ERROR);
+    $this->restHelper->shouldReceive('validateTokenRequest') ->withArgs(array(
+      '2020-01-02', 'test_token', 'read'))->andReturn($failedResponse);
+    $this->restHelper->shouldReceive('getAuthHelper')->andReturn($authHelper);
+    $this->restHelper->shouldReceive('getUserId')->andReturn(2);
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+
+    $body = new Body(fopen('php://temp', 'r+'));
+    $body->write(json_encode([
+        "username" => "foss",
+        "password" => "foss",
+        "token_name" => "test_token",
+        "token_scope" => "read",
+        "token_expire" => "2020-01-02"
+      ]));
+    $requestHeaders = new Headers();
+    $requestHeaders->set('Content-Type', 'application/json');
+    $request = new Request("POST", new Uri("HTTP", "localhost"), $requestHeaders,
+      [], [], $body);
+    $response = new Response();
+    $response = $this->authController->createNewJwtToken($request, $response,
+      []);
+    $response->getBody()->seek(0);
+    $this->assertEquals($failedResponse->getArray(),
+      json_decode($response->getBody()->getContents(), true));
+    $this->assertEquals($failedResponse->getCode(), $response->getStatusCode());
+  }
+
+  /**
+   * @test
+   * -# Mock the request to get a new token
+   * -# Mock a failed response of AuthHelper::checkUsernameAndPassword()
+   * -# Call AuthController::createNewJwtToken()
+   * -# Check if failed response if returned
+   */
+  public function testCreateNewJwtTokenInvalidPassword()
+  {
+    global $container;
+    $authHelper = M::mock(AuthHelper::class);
+    $authHelper->shouldReceive('checkUsernameAndPassword')->withArgs([
+      'foss', 'foss'])->andReturn(false);
+    $this->restHelper->shouldReceive('validateTokenRequest')->withArgs(array(
+      '2020-01-03', 'test_token', 'read'))->andReturn(true);
+    $this->restHelper->shouldReceive('getAuthHelper')->andReturn($authHelper);
+    $this->restHelper->shouldReceive('getUserId')->andReturn(2);
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+
+    $body = new Body(fopen('php://temp', 'r+'));
+    $body->write(json_encode([
+        "username" => "foss",
+        "password" => "foss",
+        "token_name" => "test_token",
+        "token_scope" => "read",
+        "token_expire" => "2020-01-03"
+      ]));
+    $requestHeaders = new Headers();
+    $requestHeaders->set('Content-Type', 'application/json');
+    $request = new Request("POST", new Uri("HTTP", "localhost"), $requestHeaders,
+      [], [], $body);
+    $response = new Response();
+    $failedResponse = new Info(404, "Username or password incorrect.",
+      InfoType::ERROR);
+    $response = $this->authController->createNewJwtToken($request, $response,
+      []);
+    $response->getBody()->seek(0);
+    $this->assertEquals($failedResponse->getArray(),
+      json_decode($response->getBody()->getContents(), true));
+    $this->assertEquals($failedResponse->getCode(), $response->getStatusCode());
+  }
+
+  /**
+   * @test
+   * -# Test if the function AuthController::arrayKeyExists returns true for
+   * request where all key exists
+   * -# Test if the function AuthController::arrayKeyExists returns true for
+   * request with one extra key
+   * -# Test if the function AuthController::arrayKeyExists returns false for
+   * request with missing keys
+   */
+  public function testArrayKeysExists()
+  {
+    $reflection = new \ReflectionClass(get_class($this->authController));
+    $method = $reflection->getMethod('arrayKeysExists');
+    $method->setAccessible(true);
+    $result = $method->invokeArgs($this->authController, [
+        ["key1" => "value1", "key2" => "value2"],
+        ["key1", "key2"]
+      ]);
+    $this->assertTrue($result);
+    $result = $method->invokeArgs($this->authController, [
+        ["key1" => "value1", "key2" => "value2"],
+        ["key1"]
+      ]);
+    $this->assertTrue($result);
+    $result = $method->invokeArgs($this->authController, [
+        ["key1" => "value1", "key2" => "value2"],
+        ["key1", "key2", "key3"]
+      ]);
+    $this->assertFalse($result);
+  }
+}

--- a/src/www/ui_tests/api/Controllers/FolderControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/FolderControllerTest.php
@@ -1,0 +1,834 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Controller for folder queries
+ */
+
+namespace
+{
+
+  /**
+   * Override to common-folder function GetFolderArray
+   */
+  function GetFolderArray($a, &$b)
+  {
+    if ($a == 2) {
+      $b[2] = "root";
+      $b[3] = "root-child1";
+      $b[4] = "root-child2";
+    } else {
+      $b[$a] = "singlefolder";
+    }
+  }
+
+  /**
+   * Override to common-folder function FolderGetName
+   */
+  function FolderGetName($folderId)
+  {
+    return "$folderId-folder";
+  }
+
+  /**
+   * Override to common-folder function Folder2Path
+   */
+  function Folder2Path($folderId)
+  {
+    $folderList = array();
+    $folderList[] = ["folder_pk" => 2, "folder_name" => FolderGetName(2)];
+    $folderList[] = ["folder_pk" => 3, "folder_name" => FolderGetName(3)];
+    return $folderList;
+  }
+}
+
+namespace Fossology\UI\Api\Test\Controllers
+{
+
+  use Mockery as M;
+  use Fossology\UI\Api\Helper\DbHelper;
+  use Fossology\UI\Api\Helper\RestHelper;
+  use Fossology\UI\Api\Controllers\FolderController;
+  use Fossology\Lib\Dao\FolderDao;
+  use Fossology\Lib\Data\Folder\Folder;
+  use Slim\Http\Response;
+  use Fossology\UI\Api\Models\Info;
+  use Fossology\UI\Api\Models\InfoType;
+  use Slim\Http\Headers;
+  use Slim\Http\Request;
+  use Slim\Http\Uri;
+  use Slim\Http\Body;
+
+  /**
+   * @class FolderControllerTest
+   * @brief Test for FolderController
+   */
+  class FolderControllerTest extends \PHPUnit\Framework\TestCase
+  {
+
+    /**
+     * @var DbHelper $dbHelper
+     * DbHelper mock
+     */
+    private $dbHelper;
+    /**
+     * @var FolderDao $folderDao
+     * FolderDao mock
+     */
+    private $folderDao;
+    /**
+     * @var RestHelper $restHelper
+     * RestHelper mock
+     */
+    private $restHelper;
+    /**
+     * @var FolderController $folderController
+     * FolderController object to test
+     */
+    private $folderController;
+    /**
+     * @var integer $userId
+     * Current user ID to test
+     */
+    private $userId;
+    /**
+     * @var folder_create $folderPlugin
+     * Folder plugin object to mock
+     */
+    private $folderPlugin;
+    /**
+     * @var admin_folder_delete $deletePlugin
+     * Delagent folder delete object to mock
+     */
+    private $deletePlugin;
+    /**
+     * @var folder_properties $folderPropertiesPlugin
+     * Folder properties plugin to mock
+     */
+    private $folderPropertiesPlugin;
+    /**
+     * @var AdminContentMove $folderContentPlugin
+     * Folder copy/move plugin object to mock
+     */
+    private $folderContentPlugin;
+
+    /**
+     * @var integer $assertCountBefore
+     * Assertions before running tests
+     */
+    private $assertCountBefore;
+
+    /**
+     * @brief Setup test objects
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    protected function setUp()
+    {
+      global $container;
+      $this->userId = 2;
+      $container = M::mock('ContainerBuilder');
+      $this->dbHelper = M::mock(DbHelper::class);
+      $this->restHelper = M::mock(RestHelper::class);
+      $this->folderDao = M::mock(FolderDao::class);
+      $this->folderPlugin = M::mock('folder_create');
+      $this->deletePlugin = M::mock('admin_folder_delete');
+      $this->folderPropertiesPlugin = M::mock('folder_properties');
+      $this->folderContentPlugin = M::mock('content_move');
+
+      $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+      $this->restHelper->shouldReceive('getFolderDao')->andReturn($this->folderDao);
+      $this->restHelper->shouldReceive('getUserId')->andReturn($this->userId);
+      $this->restHelper->shouldReceive('getPlugin')
+        ->withArgs(array('folder_create'))->andReturn($this->folderPlugin);
+      $this->restHelper->shouldReceive('getPlugin')
+        ->withArgs(array('admin_folder_delete'))->andReturn($this->deletePlugin);
+      $this->restHelper->shouldReceive('getPlugin')
+        ->withArgs(array('folder_properties'))
+        ->andReturn($this->folderPropertiesPlugin);
+      $this->restHelper->shouldReceive('getPlugin')
+        ->withArgs(array('content_move'))
+        ->andReturn($this->folderContentPlugin);
+
+      $container->shouldReceive('get')->withArgs(array(
+        'helper.restHelper'))->andReturn($this->restHelper);
+      $this->folderController = new FolderController($container);
+      $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+    }
+
+    /**
+     * @brief Remove test objects
+     * @see PHPUnit_Framework_TestCase::tearDown()
+     */
+    protected function tearDown()
+    {
+      $this->addToAssertionCount(
+        \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+      M::close();
+    }
+
+    /**
+     * Helper function to generate pseudo Folder objects
+     *
+     * @param integer $id Folder ID to generate
+     * @return NULL|\Fossology\Lib\Data\Folder\Folder
+     */
+    public function getFolder($id)
+    {
+      $name = "";
+      switch ($id) {
+        case 2: $name = "root";break;
+        case 3: $name = "root-child1";break;
+        case 4: $name = "root-child2";break;
+        case -1: return null;
+        default: $name = "singlefolder";
+      }
+      return new Folder($id, $name, "", 1);
+    }
+
+    /**
+     * Helper function to get pseudo parent id of given folder
+     *
+     * @param integer $id Folder id to get parent
+     * @return NULL|number
+     */
+    public function getFolderParent($id)
+    {
+      $pid = null;
+      if ($id == 3 || $id == 4) {
+        $pid = 2;
+      } elseif ($id > 4) {
+        $pid = $id - 1;
+      }
+      return $pid;
+    }
+
+    /**
+     * Helper function to get JSON array from response
+     *
+     * @param Response $response
+     * @return array Decoded response
+     */
+    private function getResponseJson($response)
+    {
+      $response->getBody()->seek(0);
+      return json_decode($response->getBody()->getContents(), true);
+    }
+
+    /**
+     * @test
+     * -# Test to get all folders accessible by user by calling
+     *    FolderController::getFolders()
+     * -# Check if the response is array of folders
+     */
+    public function testGetAllFolders()
+    {
+      $rootFolder = new Folder(2, "root", "", 2);
+      $this->folderDao->shouldReceive('getRootFolder')->withArgs(array(2))
+        ->andReturn($rootFolder);
+      $this->folderDao->shouldReceive('getFolder')
+        ->andReturnUsing([$this, 'getFolder']);
+      $this->folderDao->shouldReceive('getFolderParentId')
+        ->andReturnUsing([$this, 'getFolderParent']);
+      $expectedFoldersList = [];
+      for ($i = 2; $i <= 4; $i ++) {
+        $folder = $this->getFolder($i);
+        $parentId = $this->getFolderParent($i);
+        $folderModel = new \Fossology\UI\Api\Models\Folder($folder->getId(),
+          $folder->getName(), $folder->getDescription(), $parentId);
+        $expectedFoldersList[] = $folderModel->getArray();
+      }
+      $actualResponse = $this->folderController->getFolders(null,
+        new Response(), []);
+      $this->assertEquals(200, $actualResponse->getStatusCode());
+      $this->assertEquals($expectedFoldersList,
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test to get specific folder from FolderController::getFolders()
+     * -# Check if the response is a single object of Folder
+     */
+    public function testGetSpecificFolders()
+    {
+      $folderId = 3;
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array($folderId))->andReturn(true);
+      $this->folderDao->shouldReceive('getFolder')
+        ->andReturnUsing([$this, 'getFolder']);
+      $this->folderDao->shouldReceive('getFolderParentId')
+        ->andReturnUsing([$this, 'getFolderParent']);
+      $folder = $this->getFolder($folderId);
+      $parentId = $this->getFolderParent($folderId);
+      $folderModel = new \Fossology\UI\Api\Models\Folder($folder->getId(),
+        $folder->getName(), $folder->getDescription(), $parentId);
+      $expectedFoldersList = $folderModel->getArray();
+      $actualResponse = $this->folderController->getFolders(null,
+        new Response(), ['id' => $folderId]);
+      $this->assertEquals(200, $actualResponse->getStatusCode());
+      $this->assertEquals($expectedFoldersList,
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test to check a 404 response of invalid folder
+     * -# Call FolderController::getFolders() for invalid folder
+     * -# Check for a 404 response
+     */
+    public function testGetInvalidFolder()
+    {
+      $folderId = -1;
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array($folderId))->andReturn(false);
+      $this->folderDao->shouldReceive('getFolder')
+        ->andReturnUsing([$this, 'getFolder']);
+      $expectedResponse = new Info(404, "Folder id $folderId does not exists",
+        InfoType::ERROR);
+      $actualResponse = $this->folderController->getFolders(null,
+        new Response(), ['id' => $folderId]);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test to check inaccessible folder's response on
+     *    FolderController::getFolders()
+     * -# Check for 403 response
+     */
+    public function testGetInAccessibleFolder()
+    {
+      $folderId = 3;
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array($folderId))->andReturn(false);
+      $this->folderDao->shouldReceive('getFolder')
+        ->andReturnUsing([$this, 'getFolder']);
+      $expectedResponse = new Info(403, "Folder id $folderId is not accessible",
+        InfoType::ERROR);
+      $actualResponse = $this->folderController->getFolders(null,
+        new Response(), ['id' => $folderId]);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Check for FolderController::createFolder()
+     * -# Check for 201 response with folder id
+     */
+    public function testCreateFolder()
+    {
+      $parentFolder = 2;
+      $folderName = "root-child1";
+      $folderDescription = "Description";
+      $folderId = 5;
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array($parentFolder, $this->userId))->andReturn(true);
+      $this->folderPlugin->shouldReceive('create')
+        ->withArgs(array($parentFolder, $folderName, $folderDescription))
+        ->andReturn(1);
+      $this->folderDao->shouldReceive('getFolderId')
+        ->withArgs(array($folderName, $parentFolder))->andReturn($folderId);
+      $requestHeaders = new Headers();
+      $requestHeaders->set('parentFolder', $parentFolder);
+      $requestHeaders->set('folderName', $folderName);
+      $requestHeaders->set('folderDescription', $folderDescription);
+      $body = new Body(fopen('php://temp', 'r+'));
+      $request = new Request("POST", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $body);
+      $response = new Response();
+      $actualResponse = $this->folderController->createFolder($request,
+        $response, []);
+      $expectedResponse = new Info(201, $folderId, InfoType::INFO);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Check for inaccessible parent on FolderController::createFolder()
+     * -# Check for 403 response
+     */
+    public function testCreateFolderParentNotAccessible()
+    {
+      $parentFolder = 2;
+      $folderName = "root-child1";
+      $folderDescription = "Description";
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array($parentFolder, $this->userId))->andReturn(false);
+      $requestHeaders = new Headers();
+      $requestHeaders->set('parentFolder', $parentFolder);
+      $requestHeaders->set('folderName', $folderName);
+      $requestHeaders->set('folderDescription', $folderDescription);
+      $body = new Body(fopen('php://temp', 'r+'));
+      $request = new Request("POST", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $body);
+      $response = new Response();
+      $actualResponse = $this->folderController->createFolder($request,
+        $response, []);
+      $expectedResponse = new Info(403, "Parent folder can not be accessed!",
+        InfoType::ERROR);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Check for duplicate folder response from
+     *    FolderController::createFolder()
+     * -# Check for 200 response
+     */
+    public function testCreateFolderDuplicateNames()
+    {
+      $parentFolder = 2;
+      $folderName = "root-child1";
+      $folderDescription = "Description";
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array($parentFolder, $this->userId))->andReturn(true);
+      $this->folderPlugin->shouldReceive('create')
+        ->withArgs(array($parentFolder, $folderName, $folderDescription))
+        ->andReturn(4);
+      $requestHeaders = new Headers();
+      $requestHeaders->set('parentFolder', $parentFolder);
+      $requestHeaders->set('folderName', $folderName);
+      $requestHeaders->set('folderDescription', $folderDescription);
+      $body = new Body(fopen('php://temp', 'r+'));
+      $request = new Request("POST", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $body);
+      $response = new Response();
+      $actualResponse = $this->folderController->createFolder($request,
+        $response, []);
+      $expectedResponse = new Info(200, "Folder $folderName already exists!",
+        InfoType::INFO);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test for FolderController::deleteFolder()
+     * -# Check for 202 response
+     */
+    public function testDeleteFolder()
+    {
+      $folderId = 3;
+      $folderName = FolderGetName($folderId);
+      $this->folderDao->shouldReceive('getFolder')
+        ->withArgs(array($folderId))->andReturn($this->getFolder($folderId));
+      $this->deletePlugin->shouldReceive('Delete')
+        ->withArgs(array("2 $folderId", $this->userId))->andReturnNull();
+      $actualResponse = $this->folderController->deleteFolder(null,
+        new Response(), ["id" => $folderId]);
+      $expectedResponse = new Info(202, "Folder, \"$folderName\" deleted.",
+        InfoType::INFO);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test if folder is invalid on FolderController::deleteFolder()
+     * -# Check for 404 response
+     */
+    public function testDeleteFolderInvalidFolder()
+    {
+      $folderId = 0;
+      $this->folderDao->shouldReceive('getFolder')
+        ->withArgs(array($folderId))->andReturnNull();
+      $actualResponse = $this->folderController->deleteFolder(null,
+        new Response(), ["id" => $folderId]);
+      $expectedResponse = new Info(404, "Folder id not found!",
+        InfoType::ERROR);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test to delete inaccessible folder on FolderController::deleteFolder()
+     * -# Check for 403 response
+     */
+    public function testDeleteFolderNoAccess()
+    {
+      $folderId = 3;
+      $errorText = "No access to delete this folder";
+      $this->folderDao->shouldReceive('getFolder')
+        ->withArgs(array($folderId))->andReturn($this->getFolder($folderId));
+      $this->deletePlugin->shouldReceive('Delete')
+        ->withArgs(array("2 $folderId", $this->userId))
+        ->andReturn($errorText);
+      $actualResponse = $this->folderController->deleteFolder(null,
+        new Response(), ["id" => $folderId]);
+      $expectedResponse = new Info(403, $errorText, InfoType::ERROR);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test for FolderController::editFolder()
+     * -# Check for 200 reponse
+     */
+    public function testEditFolder()
+    {
+      $folderId = 3;
+      $folderName = "new name";
+      $folderDescription = "new description";
+      $this->folderDao->shouldReceive('getFolder')
+        ->andReturnUsing([$this, 'getFolder']);
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array($folderId, $this->userId))->andReturn(true);
+      $this->folderPropertiesPlugin->shouldReceive('Edit')
+        ->withArgs(array($folderId, $folderName, $folderDescription));
+      $requestHeaders = new Headers();
+      $requestHeaders->set('name', $folderName);
+      $requestHeaders->set('description', $folderDescription);
+      $body = new Body(fopen('php://temp', 'r+'));
+      $request = new Request("PATCH", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $body);
+      $response = new Response();
+      $actualResponse = $this->folderController->editFolder($request,
+        $response, ["id" => $folderId]);
+      $expectedResponse = new Info(200, 'Folder "' . FolderGetName($folderId) .
+        '" updated.', InfoType::INFO);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Check FolderController::editFolder() on non-existing folder
+     * -# Check for 404 response
+     */
+    public function testEditFolderNotExists()
+    {
+      $folderId = 8;
+      $folderName = "new name";
+      $folderDescription = "new description";
+      $this->folderDao->shouldReceive('getFolder')->andReturnNull();
+      $requestHeaders = new Headers();
+      $requestHeaders->set('name', $folderName);
+      $requestHeaders->set('description', $folderDescription);
+      $body = new Body(fopen('php://temp', 'r+'));
+      $request = new Request("PATCH", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $body);
+      $response = new Response();
+      $actualResponse = $this->folderController->editFolder($request,
+        $response, ["id" => $folderId]);
+      $expectedResponse = new Info(404, "Folder id not found!", InfoType::ERROR);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test for inaccessible folder on FolderController::editFolder()
+     * -# Check for 403 response
+     */
+    public function testEditFolderNotAccessible()
+    {
+      $folderId = 3;
+      $folderName = "new name";
+      $folderDescription = "new description";
+      $this->folderDao->shouldReceive('getFolder')
+        ->andReturnUsing([$this, 'getFolder']);
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array($folderId, $this->userId))->andReturn(false);
+      $requestHeaders = new Headers();
+      $requestHeaders->set('name', $folderName);
+      $requestHeaders->set('description', $folderDescription);
+      $body = new Body(fopen('php://temp', 'r+'));
+      $request = new Request("PATCH", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $body);
+      $response = new Response();
+      $actualResponse = $this->folderController->editFolder($request,
+        $response, ["id" => $folderId]);
+      $expectedResponse = new Info(403, "Folder is not accessible!",
+        InfoType::ERROR);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test for copy action on FolderController::copyFolder()
+     * -# Check for 202 response
+     */
+    public function testCopyFolder()
+    {
+      $folderId = 3;
+      $parentId = 2;
+      $folderContentPk = 5;
+      $folderName = FolderGetName($folderId);
+      $parentFolderName = FolderGetName($parentId);
+
+      $this->folderDao->shouldReceive('getFolder')
+        ->andReturnUsing([$this, 'getFolder']);
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array(M::anyOf($folderId, "$parentId"),
+          $this->userId))->andReturn(true);
+      $this->folderDao->shouldReceive('getFolderContentsId')
+        ->withArgs(array($folderId, 1))->andReturn($folderContentPk);
+      $this->folderContentPlugin->shouldReceive('copyContent')
+        ->withArgs(array([$folderContentPk], $parentId, true))->andReturn("");
+      $requestHeaders = new Headers();
+      $requestHeaders->set('parent', $parentId);
+      $requestHeaders->set('action', "copy");
+      $body = new Body(fopen('php://temp', 'r+'));
+      $request = new Request("PUT", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $body);
+      $response = new Response();
+
+      $actualResponse = $this->folderController->copyFolder($request,
+        $response, ["id" => $folderId]);
+      $expectedResponse = new Info(202,
+        "Folder \"$folderName\" copy(ed) under \"$parentFolderName\".",
+        InfoType::INFO);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test for move action on FolderController::copyFolder()
+     * -# Check for 202 response
+     */
+    public function testMoveFolder()
+    {
+      $folderId = 3;
+      $parentId = 2;
+      $folderContentPk = 5;
+      $folderName = FolderGetName($folderId);
+      $parentFolderName = FolderGetName($parentId);
+
+      $this->folderDao->shouldReceive('getFolder')
+        ->andReturnUsing([$this, 'getFolder']);
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array(M::anyOf($folderId, "$parentId"),
+          $this->userId))->andReturn(true);
+      $this->folderDao->shouldReceive('getFolderContentsId')
+        ->withArgs(array($folderId, 1))->andReturn($folderContentPk);
+      $this->folderContentPlugin->shouldReceive('copyContent')
+        ->withArgs(array([$folderContentPk], $parentId, false))->andReturn("");
+      $requestHeaders = new Headers();
+      $requestHeaders->set('parent', $parentId);
+      $requestHeaders->set('action', "move");
+      $body = new Body(fopen('php://temp', 'r+'));
+      $request = new Request("PUT", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $body);
+      $response = new Response();
+
+      $actualResponse = $this->folderController->copyFolder($request,
+        $response, ["id" => $folderId]);
+      $expectedResponse = new Info(202,
+        "Folder \"$folderName\" move(ed) under \"$parentFolderName\".",
+        InfoType::INFO);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test for invalid folder copy on FolderController::copyFolder()
+     * -# Check for 404 response
+     */
+    public function testCopyFolderNotFound()
+    {
+      $folderId = 3;
+      $parentId = 2;
+
+      $this->folderDao->shouldReceive('getFolder')->withArgs(array($folderId))
+        ->andReturnNull();
+      $requestHeaders = new Headers();
+      $requestHeaders->set('parent', $parentId);
+      $requestHeaders->set('action', "copy");
+      $body = new Body(fopen('php://temp', 'r+'));
+      $request = new Request("PUT", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $body);
+      $response = new Response();
+
+      $actualResponse = $this->folderController->copyFolder($request,
+        $response, ["id" => $folderId]);
+      $expectedResponse = new Info(404, "Folder id not found!",
+        InfoType::ERROR);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test for invalid parent copy on FolderController::copyFolder()
+     * -# Check for 404 response
+     */
+    public function testCopyParentFolderNotFound()
+    {
+      $folderId = 3;
+      $parentId = 2;
+
+      $this->folderDao->shouldReceive('getFolder')->withArgs(array($folderId))
+        ->andReturn($this->getFolder($folderId));
+      $this->folderDao->shouldReceive('getFolder')->withArgs(array($parentId))
+        ->andReturnNull();
+      $requestHeaders = new Headers();
+      $requestHeaders->set('parent', $parentId);
+      $requestHeaders->set('action', "copy");
+      $body = new Body(fopen('php://temp', 'r+'));
+      $request = new Request("PUT", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $body);
+      $response = new Response();
+
+      $actualResponse = $this->folderController->copyFolder($request,
+        $response, ["id" => $folderId]);
+      $expectedResponse = new Info(404, "Parent folder not found!",
+        InfoType::ERROR);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test for inaccessible folder on FolderController::copyFolder()
+     * -# Check for 403 response
+     */
+    public function testCopyFolderNotAccessible()
+    {
+      $folderId = 3;
+      $parentId = 2;
+
+      $this->folderDao->shouldReceive('getFolder')
+        ->andReturnUsing([$this, 'getFolder']);
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array($folderId, $this->userId))->andReturn(false);
+      $requestHeaders = new Headers();
+      $requestHeaders->set('parent', $parentId);
+      $requestHeaders->set('action', "copy");
+      $body = new Body(fopen('php://temp', 'r+'));
+      $request = new Request("PUT", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $body);
+      $response = new Response();
+
+      $actualResponse = $this->folderController->copyFolder($request,
+        $response, ["id" => $folderId]);
+      $expectedResponse = new Info(403, "Folder is not accessible!",
+        InfoType::ERROR);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test for inaccessible parent folder on FolderController::copyFolder()
+     * -# Check for 403 response
+     */
+    public function testCopyParentFolderNotAccessible()
+    {
+      $folderId = 3;
+      $parentId = 2;
+
+      $this->folderDao->shouldReceive('getFolder')
+        ->andReturnUsing([$this, 'getFolder']);
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array($folderId, $this->userId))->andReturn(true);
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array("$parentId", $this->userId))->andReturn(false);
+      $requestHeaders = new Headers();
+      $requestHeaders->set('parent', $parentId);
+      $requestHeaders->set('action', "copy");
+      $body = new Body(fopen('php://temp', 'r+'));
+      $request = new Request("PUT", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $body);
+      $response = new Response();
+
+      $actualResponse = $this->folderController->copyFolder($request,
+        $response, ["id" => $folderId]);
+      $expectedResponse = new Info(403, "Parent folder is not accessible!",
+        InfoType::ERROR);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test for invalid action on FolderController::copyFolder()
+     * -# Check for 400 response
+     */
+    public function testCopyFolderInvalidAction()
+    {
+      $folderId = 3;
+      $parentId = 2;
+
+      $this->folderDao->shouldReceive('getFolder')
+        ->andReturnUsing([$this, 'getFolder']);
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array(M::anyOf($folderId, "$parentId"),
+          $this->userId))->andReturn(true);
+      $requestHeaders = new Headers();
+      $requestHeaders->set('parent', $parentId);
+      $requestHeaders->set('action', "somethingrandom");
+      $body = new Body(fopen('php://temp', 'r+'));
+      $request = new Request("PUT", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $body);
+      $response = new Response();
+
+      $actualResponse = $this->folderController->copyFolder($request,
+        $response, ["id" => $folderId]);
+      $expectedResponse = new Info(400, "Action can be one of [copy,move]!",
+        InfoType::ERROR);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+  }
+}

--- a/src/www/ui_tests/api/Controllers/JobControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/JobControllerTest.php
@@ -1,0 +1,358 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Unit tests for JobController
+ */
+
+namespace Fossology\UI\Api\Test\Controllers;
+
+use Mockery as M;
+use Fossology\UI\Api\Controllers\JobController;
+use Slim\Http\Headers;
+use Slim\Http\Body;
+use Slim\Http\Request;
+use Slim\Http\Response;
+use Fossology\UI\Api\Models\Job;
+use Slim\Http\Uri;
+use Fossology\Lib\Dao\JobDao;
+use Fossology\Lib\Dao\ShowJobsDao;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+
+/**
+ * @class JobControllerTest
+ * @brief Tests for JobController
+ */
+class JobControllerTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @var DbHelper $dbHelper
+   * DB Helper mock
+   */
+  private $dbHelper;
+
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+
+  /**
+   * @var JobDao $jobDao
+   * JobDao mock
+   */
+  private $jobDao;
+
+  /**
+   * @var ShowJobsDao $showJobsDao
+   * ShowJobsDao mock
+   */
+  private $showJobsDao;
+
+  /**
+   * @var JobController $jobController
+   * JobController object to test
+   */
+  private $jobController;
+
+  /**
+   * @var integer $assertCountBefore
+   * Assertions before running tests
+   */
+  private $assertCountBefore;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp()
+  {
+    global $container;
+    $container = M::mock('ContainerBuilder');
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->restHelper = M::mock(RestHelper::class);
+    $this->jobDao = M::mock(JobDao::class);
+    $this->showJobsDao = M::mock(ShowJobsDao::class);
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+    $this->restHelper->shouldReceive('getJobDao')->andReturn($this->jobDao);
+    $this->restHelper->shouldReceive('getShowJobDao')->andReturn($this->showJobsDao);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+    $this->jobController = new JobController($container);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+  }
+
+  /**
+   * @brief Remove test objects
+   * @see PHPUnit_Framework_TestCase::tearDown()
+   */
+  protected function tearDown()
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+
+  /**
+   * Helper function to get JSON array from response
+   *
+   * @param Response $response
+   * @return array Decoded response
+   */
+  private function getResponseJson($response)
+  {
+    $response->getBody()->seek(0);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+
+  /**
+   * @test
+   * -# Test JobController::getJobs() for all jobs
+   * -# Check if response is 200
+   */
+  public function testGetJobs()
+  {
+    $job = new Job(11, "job_name", "01-01-2020", 4, 2, 2, 0, "Completed");
+    $this->dbHelper->shouldReceive('getJobs')->withArgs(array(null, 0, 1))
+      ->andReturn([[$job], 1]);
+    $this->jobDao->shouldReceive('getAllJobStatus')->withArgs(array(4, 2, 2))
+      ->andReturn(['11' => 0]);
+    $this->showJobsDao->shouldReceive('getEstimatedTime')
+      ->withArgs(array(11, '', 0, 4))->andReturn("0");
+    $this->showJobsDao->shouldReceive('getDataForASingleJob')
+      ->withArgs(array(11))->andReturn(["jq_endtext"=>'Completed']);
+
+    $requestHeaders = new Headers();
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("GET", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+    $response = new Response();
+    $actualResponse = $this->jobController->getJobs($request, $response, []);
+    $expectedResponse = $job->getArray();
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse,
+      $this->getResponseJson($actualResponse)[0]);
+    $this->assertEquals('1',
+      $actualResponse->getHeaderLine('X-Total-Pages'));
+  }
+
+  /**
+   * @test
+   * -# Test JobController::getJobs() with limit and page set
+   * -# Check if response is 200 and have correct total pages header
+   */
+  public function testGetJobsLimitPage()
+  {
+    $jobTwo = new Job(12, "job_two", "01-01-2020", 5, 2, 2, 0, "Completed");
+    $this->dbHelper->shouldReceive('getJobs')->withArgs(array(null, 1, 2))
+      ->andReturn([[$jobTwo], 2]);
+    $this->jobDao->shouldReceive('getAllJobStatus')->withArgs(array(4, 2, 2))
+      ->andReturn(['11' => 0]);
+    $this->jobDao->shouldReceive('getAllJobStatus')->withArgs(array(5, 2, 2))
+      ->andReturn(['12' => 0]);
+    $this->showJobsDao->shouldReceive('getEstimatedTime')
+      ->withArgs(array(M::anyOf(11, 12), '', 0, M::anyOf(4, 5)))->andReturn("0");
+    $this->showJobsDao->shouldReceive('getDataForASingleJob')
+      ->withArgs([M::anyOf(11, 12)])->andReturn(["jq_endtext"=>'Completed']);
+
+    $requestHeaders = new Headers();
+    $requestHeaders->set('limit', '1');
+    $requestHeaders->set('page', '2');
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("GET", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+    $response = new Response();
+    $actualResponse = $this->jobController->getJobs($request, $response, []);
+    $expectedResponse = $jobTwo->getArray();
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse,
+      $this->getResponseJson($actualResponse)[0]);
+    $this->assertEquals('2',
+      $actualResponse->getHeaderLine('X-Total-Pages'));
+  }
+
+  /**
+   * @test
+   * -# Test JobController::getJobs() with invalid job id
+   * -# Check if response is 404
+   */
+  public function testGetInvalidJob()
+  {
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["job", "job_pk", 2])->andReturn(false);
+
+    $requestHeaders = new Headers();
+    $requestHeaders->set('limit', '1');
+    $requestHeaders->set('page', '2');
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("GET", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+    $response = new Response();
+    $actualResponse = $this->jobController->getJobs($request, $response, [
+      "id" => 2]);
+    $expectedResponse = new Info(404, "Job id 2 doesn't exist", InfoType::ERROR);
+    $this->assertEquals($expectedResponse->getCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse->getArray(),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test JobController::getJobs() with single job id
+   * -# Check if response is 200
+   */
+  public function testGetJobFromId()
+  {
+    $job = new Job(12, "job_two", "01-01-2020", 5, 2, 2, 0, "Completed");
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["job", "job_pk", 12])->andReturn(true);
+    $this->dbHelper->shouldReceive('getJobs')->withArgs(array(12, 0, 1))
+      ->andReturn([[$job], 1]);
+    $this->jobDao->shouldReceive('getAllJobStatus')->withArgs(array(5, 2, 2))
+      ->andReturn(['12' => 0]);
+    $this->showJobsDao->shouldReceive('getEstimatedTime')
+      ->withArgs(array(12, '', 0, 5))->andReturn("0");
+    $this->showJobsDao->shouldReceive('getDataForASingleJob')
+      ->withArgs([12])->andReturn(["jq_endtext"=>'Completed']);
+
+    $requestHeaders = new Headers();
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("GET", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+    $response = new Response();
+    $actualResponse = $this->jobController->getJobs($request, $response, [
+      "id" => 12]);
+    $expectedResponse = $job->getArray();
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse,
+      $this->getResponseJson($actualResponse));
+    $this->assertEquals('1',
+      $actualResponse->getHeaderLine('X-Total-Pages'));
+  }
+
+  /**
+   * @test
+   * -# Test JobController::getJobs() with single upload
+   * -# Check if response is 200
+   */
+  public function testGetJobsFromUpload()
+  {
+    $job = new Job(12, "job_two", "01-01-2020", 5, 2, 2, 0, "Completed");
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", 5])->andReturn(true);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(['job', 'job_pk', 12])->andReturn(true);
+    $this->dbHelper->shouldReceive('getJobs')->withArgs(array(null, 0, 1, 5))
+      ->andReturn([[$job], 1]);
+    $this->jobDao->shouldReceive('getAllJobStatus')->withArgs(array(5, 2, 2))
+      ->andReturn(['12' => 0]);
+    $this->showJobsDao->shouldReceive('getEstimatedTime')
+      ->withArgs(array(12, '', 0, 5))->andReturn("0");
+    $this->showJobsDao->shouldReceive('getDataForASingleJob')
+      ->withArgs([12])->andReturn(["jq_endtext"=>'Completed']);
+
+    $requestHeaders = new Headers();
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("GET", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+    $request = $request->withQueryParams([JobController::UPLOAD_PARAM => 5]);
+    $response = new Response();
+    $actualResponse = $this->jobController->getJobs($request, $response, []);
+    $expectedResponse = $job->getArray();
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse,
+      $this->getResponseJson($actualResponse)[0]);
+    $this->assertEquals('1',
+      $actualResponse->getHeaderLine('X-Total-Pages'));
+  }
+
+  /**
+   * @test
+   * -# Test JobController::getUploadEtaInSeconds()
+   * -# Test if HH:MM:SS can be translated to seconds
+   * -# Test if empty response results in 0
+   */
+  public function testGetUploadEtaInSeconds()
+  {
+    $jobId = 11;
+    $uploadId = 5;
+    $completedJob = 5;
+    $completedUpload = 3;
+    $this->showJobsDao->shouldReceive('getEstimatedTime')
+      ->withArgs([$jobId, '', 0, $uploadId])
+      ->andReturn("3:10:23");
+    $this->showJobsDao->shouldReceive('getEstimatedTime')
+      ->withArgs([$completedJob, '', 0, $completedUpload])
+      ->andReturn("0");
+    $reflection = new \ReflectionClass(get_class($this->jobController));
+    $method = $reflection->getMethod('getUploadEtaInSeconds');
+    $method->setAccessible(true);
+
+    $result = $method->invokeArgs($this->jobController, [$jobId, $uploadId]);
+    $this->assertEquals((3 * 3600) + (10 * 60) + 23, $result);
+
+    $result = $method->invokeArgs($this->jobController,
+      [$completedJob, $completedUpload]);
+    $this->assertEquals(0, $result);
+  }
+
+  /**
+   * @test
+   * -# Test JobController::getJobStatus()
+   * -# Setup one job with two complete children => result Completed
+   * -# Setup one job with one child processing and other in queue => result
+   *    Processing
+   * -# Setup one job with one child completed and one failed => result Failed
+   */
+  public function testGetJobStatus()
+  {
+    $jobCompleted = [1, 2];
+    $jobQueued = [3, 4];
+    $jobFailed = [5, 6];
+    $this->showJobsDao->shouldReceive('getDataForASingleJob')
+      ->withArgs([M::anyof(1, 2, 5)])
+      ->andReturn(["jq_endtext" => "Completed"]);
+    $this->showJobsDao->shouldReceive('getDataForASingleJob')
+      ->withArgs([3])->andReturn(["jq_endtext" => "Started"]);
+    $this->showJobsDao->shouldReceive('getDataForASingleJob')
+      ->withArgs([4])->andReturn(["jq_endtext" => "Processing",
+        "jq_endtime" => ""]);
+    $this->showJobsDao->shouldReceive('getDataForASingleJob')
+      ->withArgs([6])->andReturn(["jq_endtext" => "Failed",
+        "jq_endtime" => "01-01-2020 00:00:00"]);
+
+    $reflection = new \ReflectionClass(get_class($this->jobController));
+    $method = $reflection->getMethod('getJobStatus');
+    $method->setAccessible(true);
+
+    $result = $method->invokeArgs($this->jobController, [$jobCompleted]);
+    $this->assertEquals("Completed", $result);
+
+    $result = $method->invokeArgs($this->jobController, [$jobQueued]);
+    $this->assertEquals("Processing", $result);
+
+    $result = $method->invokeArgs($this->jobController, [$jobFailed]);
+    $this->assertEquals("Failed", $result);
+  }
+}

--- a/src/www/ui_tests/api/Controllers/ReportControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/ReportControllerTest.php
@@ -1,0 +1,503 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for ReportController
+ */
+
+namespace Fossology\UI\Api\Test\Controllers;
+
+use Mockery as M;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Data\Upload\Upload;
+use Fossology\Lib\Db\DbManager;
+use Fossology\UI\Api\Controllers\ReportController;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Slim\Http\Body;
+use Slim\Http\Headers;
+use Slim\Http\Request;
+use Slim\Http\Response;
+use Slim\Http\Uri;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+
+/**
+ * @class ReportControllerTest
+ * @brief Tests for ReportController
+ */
+class ReportControllerTest extends \PHPUnit\Framework\TestCase
+{
+
+  /**
+   * @var array $reportsAllowed
+   * Allowed agent names to create report
+   */
+  private $reportsAllowed = array(
+    'dep5',
+    'spdx2',
+    'spdx2tv',
+    'readmeoss',
+    'unifiedreport'
+  );
+
+  /**
+   * @var ReportController $reportController
+   * ReportController object to test
+   */
+  private $reportController;
+
+  /**
+   * @var UploadDao $uploadDao
+   * UploadDao mock
+   */
+  private $uploadDao;
+
+  /**
+   * @var integer $userId
+   * User id
+   */
+  private $userId;
+
+  /**
+   * @var integer $groupId
+   * Group id
+   */
+  private $groupId;
+
+  /**
+   * @var SpdxTwoGeneratorUi $spdxPlugin
+   * SPDX generator mock
+   */
+  private $spdxPlugin;
+
+  /**
+   * @var M\MockInterface $readmeossPlugin
+   * ReadMeOssPlugin mock
+   */
+  private $readmeossPlugin;
+
+  /**
+   * @var M\MockInterface $unifiedPlugin
+   * FoUnifiedReportGenerator mock
+   */
+  private $unifiedPlugin;
+
+  /**
+   * @var M\MockInterface $downloadPlugin
+   * ui_download mock
+   */
+  private $downloadPlugin;
+
+  /**
+   * @var DbManager $dbManager
+   * DbManager mock
+   */
+  private $dbManager;
+
+  /**
+   * @var integer $assertCountBefore
+   * Assertions before running tests
+   */
+  private $assertCountBefore;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp()
+  {
+    global $container;
+    $this->userId = 2;
+    $this->groupId = 2;
+    $container = M::mock('ContainerBuilder');
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->dbManager = M::mock(DbManager::class);
+    $this->restHelper = M::mock(RestHelper::class);
+    $this->uploadDao = M::mock(UploadDao::class);
+    $this->spdxPlugin = M::mock(SpdxTwoGeneratorUi::class);
+    $this->readmeossPlugin = M::mock('ReadMeOssPlugin');
+    $this->unifiedPlugin = M::mock('FoUnifiedReportGenerator');
+    $this->downloadPlugin = M::mock('ui_download');
+
+    $this->dbHelper->shouldReceive('getDbManager')->andReturn($this->dbManager);
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+    $this->restHelper->shouldReceive('getUploadDao')
+      ->andReturn($this->uploadDao);
+    $this->restHelper->shouldReceive('getGroupId')->andReturn($this->groupId);
+    $this->restHelper->shouldReceive('getPlugin')
+      ->withArgs(array('ui_spdx2'))->andReturn($this->spdxPlugin);
+    $this->restHelper->shouldReceive('getPlugin')
+      ->withArgs(array('ui_readmeoss'))->andReturn($this->readmeossPlugin);
+    $this->restHelper->shouldReceive('getPlugin')
+      ->withArgs(array('download'))->andReturn($this->downloadPlugin);
+    $this->restHelper->shouldReceive('getPlugin')
+      ->withArgs(array('agent_founifiedreport'))
+      ->andReturn($this->unifiedPlugin);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+    $this->reportController = new ReportController($container);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+  }
+
+  /**
+   * @brief Remove test objects
+   * @see PHPUnit_Framework_TestCase::tearDown()
+   */
+  protected function tearDown()
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  /**
+   * Helper function to get JSON array from response
+   *
+   * @param Response $response
+   * @return array Decoded response
+   */
+  private function getResponseJson($response)
+  {
+    $response->getBody()->seek(0);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+
+  /**
+   * Helper function to generate uploads
+   * @param integer $id Upload id (if > 4, return NULL)
+   * @return NULL|\Fossology\Lib\Data\Upload\Upload
+   */
+  private function getUpload($id)
+  {
+    $filename = "";
+    $description = "";
+    $treeTableName = "uploadtree_a";
+    $timestamp = "";
+    switch ($id) {
+      case 2:
+        $filename = "top$id";
+        $timestamp = "01-01-2020";
+        break;
+      case 3:
+        $filename = "child$id";
+        $timestamp = "02-01-2020";
+        break;
+      case 4:
+        $filename = "child$id";
+        $timestamp = "03-01-2020";
+        break;
+      default:
+        return null;
+    }
+    return new Upload($id, $filename, $description, $treeTableName, $timestamp);
+  }
+
+  /**
+   * Helper function to call ReportController::getReport() and return response
+   * @param integer $uploadId
+   * @param string  $reportFormat
+   * @return Response
+   */
+  private function getResponseForReport($uploadId, $reportFormat)
+  {
+    $requestHeaders = new Headers();
+    $requestHeaders->set('uploadId', $uploadId);
+    $requestHeaders->set('reportFormat', $reportFormat);
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("GET", new Uri("HTTP", "localhost", 80,
+      "/api/v1/report"), $requestHeaders, [], [], $body);
+    $response = new Response();
+    return $this->reportController->getReport($request, $response, []);
+  }
+
+  /**
+   * @test
+   * -# Test ReportController::getReport() for all available report types
+   * -# Check the response for 201
+   */
+  public function testGetReportAllFormats()
+  {
+    $uploadId = 3;
+    $upload = $this->getUpload($uploadId);
+
+    $this->uploadDao->shouldReceive('isAccessible')->withArgs([$uploadId,
+      $this->groupId])->andReturn(true);
+    $this->uploadDao->shouldReceive('getUpload')->withArgs([$uploadId])
+      ->andReturn($upload);
+    $this->spdxPlugin->shouldReceive('scheduleAgent')
+      ->withArgs([$this->groupId, $upload, M::anyOf($this->reportsAllowed[0],
+        $this->reportsAllowed[1], $this->reportsAllowed[2])])
+      ->andReturn([32, 33, ""]);
+    $this->readmeossPlugin->shouldReceive('scheduleAgent')
+      ->withArgs([$this->groupId, $upload])->andReturn([32, 33, ""]);
+    $this->unifiedPlugin->shouldReceive('scheduleAgent')
+      ->withArgs([$this->groupId, $upload])->andReturn([32, 33, ""]);
+
+    $expectedResponse = new Info(201, "localhost/api/v1/report/32",
+      InfoType::INFO);
+
+    foreach ($this->reportsAllowed as $reportFormat) {
+      $actualResponse = $this->getResponseForReport($uploadId, $reportFormat);
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+    }
+  }
+
+  /**
+   * @test
+   * -# Test ReportController::getReport() for invalid report type
+   * -# Test for 400 response
+   */
+  public function testGetReportInvalidFormat()
+  {
+    $uploadId = 3;
+    $reportFormat = 'report';
+
+    $expectedResponse = new Info(400,
+      "reportFormat must be from [" . implode(",", $this->reportsAllowed) . "]",
+      InfoType::ERROR);
+
+    $actualResponse = $this->getResponseForReport($uploadId, $reportFormat);
+
+    $this->assertEquals($expectedResponse->getCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse->getArray(),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test ReportController::getReport() for inaccessible upload
+   * -# Check for 403 response
+   */
+  public function testGetReportInaccessibleUpload()
+  {
+    $uploadId = 4;
+    $reportFormat = $this->reportsAllowed[1];
+
+    $this->uploadDao->shouldReceive('isAccessible')->withArgs([$uploadId,
+      $this->groupId])->andReturn(false);
+
+    $expectedResponse = new Info(403, "Upload is not accessible!",
+      InfoType::ERROR);
+
+    $actualResponse = $this->getResponseForReport($uploadId, $reportFormat);
+
+    $this->assertEquals($expectedResponse->getCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse->getArray(),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test ReportController::getReport() for invalid upload
+   * -# Check for 404 response
+   */
+  public function testGetReportInvalidUpload()
+  {
+    $uploadId = 10;
+    $reportFormat = $this->reportsAllowed[1];
+    $upload = $this->getUpload($uploadId);
+
+    $this->uploadDao->shouldReceive('isAccessible')->withArgs([$uploadId,
+      $this->groupId])->andReturn(true);
+    $this->uploadDao->shouldReceive('getUpload')->withArgs([$uploadId])
+      ->andReturn($upload);
+
+    $expectedResponse = new Info(404, "Upload does not exists!",
+      InfoType::ERROR);
+
+    $actualResponse = $this->getResponseForReport($uploadId, $reportFormat);
+
+    $this->assertEquals($expectedResponse->getCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse->getArray(),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test ReportController::downloadReport()
+   * -# Generate all mock objects
+   * -# Generate a temporary file to be downloaded
+   * -# Replicate expected headers
+   * -# Check for acutal headers
+   * -# Check for actual file content
+   */
+  public function testDownloadReport()
+  {
+    $reportId = 43;
+    $uploadId = 3;
+
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs(['SELECT jq_type FROM jobqueue WHERE jq_job_fk = $1',
+        [$reportId], "reportValidity"])
+      ->andReturn(["jq_type" => $this->reportsAllowed[1]]);
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs(['SELECT job_upload_fk FROM job WHERE job_pk = $1',
+        [$reportId], "reportFileUpload"])
+      ->andReturn(["job_upload_fk" => $uploadId]);
+    $this->uploadDao->shouldReceive('isAccessible')->withArgs([$uploadId,
+      $this->groupId])->andReturn(true);
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs(['SELECT * FROM reportgen WHERE job_fk = $1',
+        [$reportId], "reportFileName"])
+      ->andReturn(["job_upload_fk" => $uploadId]);
+
+    $tmpfile = tempnam(sys_get_temp_dir(), "FOO");
+
+    $handle = fopen($tmpfile, "w");
+    fwrite($handle, "writing to tempfile");
+    fclose($handle);
+
+    $fileResponse = new BinaryFileResponse($tmpfile);
+    $fileResponse->headers->set('Content-Type', 'text/plain');
+    $fileResponse->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT);
+    $fileContent = $fileResponse->getFile();
+    $this->downloadPlugin->shouldReceive('getReport')->andReturn($fileResponse);
+
+    $expectedResponse = new Response();
+    $expectedResponse = $expectedResponse->withHeader('Content-Description',
+        'File Transfer')
+      ->withHeader('Content-Type', $fileResponse->headers->get('Content-Type'))
+      ->withHeader('Content-Disposition',
+        $fileResponse->headers->get('Content-Disposition'))
+      ->withHeader('Cache-Control', 'must-revalidate')
+      ->withHeader('Pragma', 'private')
+      ->withHeader('Content-Length', filesize($fileContent));
+
+    ob_start();
+    $actualResponse = $this->reportController->downloadReport(null,
+      new Response(), ["id" => $reportId]);
+    $output = ob_get_clean();
+
+    $expectedResponse->getBody()->seek(0);
+    $this->assertEquals($expectedResponse->getBody()->getContents(),
+      $actualResponse->getBody()->getContents());
+    $this->assertEquals($expectedResponse->getHeaders(),
+      $actualResponse->getHeaders());
+    $this->assertEquals(file_get_contents($tmpfile), $output);
+    unlink($tmpfile);
+  }
+
+  /**
+   * @test
+   * -# Test ReportController::downloadReport() for inaccessible upload
+   * -# Check for 403 response
+   */
+  public function testDownloadReportInAccessibleUpload()
+  {
+    $reportId = 43;
+    $uploadId = 3;
+
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs(['SELECT jq_type FROM jobqueue WHERE jq_job_fk = $1',
+        [$reportId], "reportValidity"])
+      ->andReturn(["jq_type" => $this->reportsAllowed[1]]);
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs(['SELECT job_upload_fk FROM job WHERE job_pk = $1',
+        [$reportId], "reportFileUpload"])
+      ->andReturn(["job_upload_fk" => $uploadId]);
+    $this->uploadDao->shouldReceive('isAccessible')->withArgs([$uploadId,
+      $this->groupId])->andReturn(false);
+
+    $expectedResponse = new Info(403, "Report is not accessible.",
+      InfoType::INFO);
+
+    $actualResponse = $this->reportController->downloadReport(null,
+      new Response(), ["id" => $reportId]);
+
+    $this->assertEquals($expectedResponse->getCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse->getArray(),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test ReportController::downloadReport() for invalid upload
+   * -# Check for 404 response
+   */
+  public function testDownloadReportInvalidUpload()
+  {
+    $reportId = 43;
+
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs(['SELECT jq_type FROM jobqueue WHERE jq_job_fk = $1',
+        [$reportId], "reportValidity"])
+      ->andReturn(["jq_type" => ""]);
+
+    $expectedResponse = new Info(404, "No report scheduled with given job id.",
+            InfoType::ERROR);
+
+    $actualResponse = $this->reportController->downloadReport(null,
+      new Response(), ["id" => $reportId]);
+
+    $this->assertEquals($expectedResponse->getCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse->getArray(),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test ReportController::downloadReport() for early download
+   * -# Check for 503 response with `Retry-After` headers.
+   */
+  public function testDownloadReportTryLater()
+  {
+    $reportId = 43;
+    $uploadId = 3;
+
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs(['SELECT jq_type FROM jobqueue WHERE jq_job_fk = $1',
+        [$reportId], "reportValidity"])
+      ->andReturn(["jq_type" => $this->reportsAllowed[1]]);
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs(['SELECT job_upload_fk FROM job WHERE job_pk = $1',
+        [$reportId], "reportFileUpload"])
+      ->andReturn(["job_upload_fk" => $uploadId]);
+    $this->uploadDao->shouldReceive('isAccessible')->withArgs([$uploadId,
+      $this->groupId])->andReturn(true);
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs(['SELECT * FROM reportgen WHERE job_fk = $1',
+        [$reportId], "reportFileName"])
+      ->andReturn(false);
+
+    $expectedResponse = new Info(503, "Report is not ready. Retry after 10s.",
+      InfoType::INFO);
+
+    $actualResponse = $this->reportController->downloadReport(null,
+      new Response(), ["id" => $reportId]);
+
+    $this->assertEquals($expectedResponse->getCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse->getArray(),
+      $this->getResponseJson($actualResponse));
+    $this->assertEquals('10', $actualResponse->getHeaderLine('Retry-After'));
+  }
+}

--- a/src/www/ui_tests/api/Controllers/UploadControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadControllerTest.php
@@ -1,0 +1,690 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for UploadController
+ */
+
+namespace Fossology\UI\Api\Test\Controllers;
+
+use Mockery as M;
+use Fossology\UI\Api\Controllers\UploadController;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\Lib\Db\DbManager;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\Lib\Data\UploadStatus;
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Data\Tree\ItemTreeBounds;
+use Fossology\UI\Api\Models\Upload;
+use Slim\Http\Response;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Fossology\DelAgent\UI\DeleteResponse;
+use Fossology\DelAgent\UI\DeleteMessages;
+use Slim\Http\Request;
+use Slim\Http\Headers;
+use Slim\Http\Body;
+use Slim\Http\Uri;
+use Fossology\Lib\Dao\FolderDao;
+use Fossology\Lib\Dao\AgentDao;
+use Fossology\UI\Api\Models\Hash;
+
+function TryToDelete($uploadpk, $user_pk, $group_pk, $uploadDao)
+{
+  return UploadControllerTests::$function->TryToDelete($uploadpk, $user_pk,
+    $group_pk, $uploadDao);
+}
+
+/**
+ * @class UploadControllerTest
+ * @brief Unit tests for UploadController
+ */
+class UploadControllerTests extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @var \Mockery\MockInterface $functions
+   * Public function mock
+   */
+  public static $functions;
+
+  /**
+   * @var integer $assertCountBefore
+   * Assertions before running tests
+   */
+  private $assertCountBefore;
+
+  /**
+   * @var integer $userId
+   * User ID to mock
+   */
+  private $userId;
+
+  /**
+   * @var integer $groupId
+   * Group ID to mock
+   */
+  private $groupId;
+
+  /**
+   * @var DbHelper $dbHelper
+   * DbHelper mock
+   */
+  private $dbHelper;
+
+  /**
+   * @var DbManager $dbManager
+   * Dbmanager mock
+   */
+  private $dbManager;
+
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+
+  /**
+   * @var UploadController $uploadController
+   * UploadController mock
+   */
+  private $uploadController;
+
+  /**
+   * @var UploadDao $uploadDao
+   * UploadDao mock
+   */
+  private $uploadDao;
+
+  /**
+   * @var FolderDao $folderDao
+   * FolderDao mock
+   */
+  private $folderDao;
+
+  /**
+   * @var AgentDao $agentDao
+   * AgentDao mock
+   */
+  private $agentDao;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp()
+  {
+    global $container;
+    $this->userId = 2;
+    $this->groupId = 2;
+    $container = M::mock('ContainerBuilder');
+    self::$functions = M::mock();
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->dbManager = M::mock(DbManager::class);
+    $this->restHelper = M::mock(RestHelper::class);
+    $this->uploadDao = M::mock(UploadDao::class);
+    $this->folderDao = M::mock(FolderDao::class);
+    $this->agentDao = M::mock(AgentDao::class);
+
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs([M::any(), [$this->groupId, UploadStatus::OPEN,
+        Auth::PERM_READ]]);
+    $this->dbHelper->shouldReceive('getDbManager')->andReturn($this->dbManager);
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+    $this->restHelper->shouldReceive('getGroupId')->andReturn($this->groupId);
+    $this->restHelper->shouldReceive('getUserId')->andReturn($this->userId);
+    $this->restHelper->shouldReceive('getUploadDao')
+      ->andReturn($this->uploadDao);
+    $this->restHelper->shouldReceive('getFolderDao')
+      ->andReturn($this->folderDao);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+    $container->shouldReceive('get')->withArgs(array(
+      'dao.agent'))->andReturn($this->agentDao);
+    $this->uploadController = new UploadController($container);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+  }
+
+  /**
+   * @brief Remove test objects
+   * @see PHPUnit_Framework_TestCase::tearDown()
+   */
+  protected function tearDown()
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  /**
+   * Helper function to get JSON array from response
+   *
+   * @param Response $response
+   * @return array Decoded response
+   */
+  private function getResponseJson($response)
+  {
+    $response->getBody()->seek(0);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+
+  /**
+   * Helper function to generate uploads bounds
+   * @param integer $id Upload id (if > 4, return false)
+   * @return false|ItemTreeBounds
+   */
+  private function getUploadBounds($id)
+  {
+    if ($id > 4) {
+      return false;
+    }
+    $itemId = ($id * 100) + 1;
+    $left = ($id * 100) + 2;
+    $right = ($id * 100) + 50;
+    return new ItemTreeBounds($itemId, 'uploadtree_a', $id, $left, $right);
+  }
+
+  /**
+   * Helper function to generate uploads
+   * @param integer $id Upload id (if > 4, return NULL)
+   * @return NULL|Upload
+   */
+  private function getUpload($id)
+  {
+    $uploadName = "";
+    $description = "";
+    $uploadDate = "";
+    $folderId = 2;
+    $folderName = "SR";
+    $fileSize = 0;
+    switch ($id) {
+      case 2:
+        $uploadName = "top$id";
+        $uploadDate = "01-01-2020";
+        $fileSize = 123;
+        break;
+      case 3:
+        $uploadName = "child$id";
+        $uploadDate = "02-01-2020";
+        $fileSize = 133;
+        break;
+      case 4:
+        $uploadName = "child$id";
+        $uploadDate = "03-01-2020";
+        $fileSize = 153;
+        break;
+      default:
+        return null;
+    }
+    $hash = new Hash('sha1checksum', 'md5checksum', 'sha256checksum', $fileSize);
+    return new Upload($folderId, $folderName, $id, $description,
+      $uploadName, $uploadDate, $hash);
+  }
+
+  /**
+   * @test
+   * -# Test for UploadController::getUploads() to fetch single upload
+   * -# Check if response is 200
+   */
+  public function testGetSingleUpload()
+  {
+    $uploadId = 3;
+    $upload = $this->getUpload($uploadId);
+    $requestHeaders = new Headers();
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("GET", new Uri("HTTP", "localhost", 80,
+      "/uploads/$uploadId"), $requestHeaders, [], [], $body);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([$uploadId, $this->groupId])->andReturn(true);
+    $this->uploadDao->shouldReceive('getParentItemBounds')
+      ->withArgs([$uploadId])->andReturn($this->getUploadBounds($uploadId));
+    $this->dbHelper->shouldReceive('getUploads')
+      ->withArgs([$this->userId, $this->groupId, 100, 1, $uploadId, null, true])
+      ->andReturn([1, [$upload->getArray()]]);
+    $expectedResponse = (new Response())->withJson($upload->getArray(), 200);
+    $actualResponse = $this->uploadController->getUploads($request,
+      new Response(), ['id' => $uploadId]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for UploadController::getUploads() for inaccessible upload
+   * -# Check if response status is 403
+   */
+  public function testGetSingleUploadInAccessible()
+  {
+    $uploadId = 3;
+    $requestHeaders = new Headers();
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("GET", new Uri("HTTP", "localhost", 80,
+      "/uploads/$uploadId"), $requestHeaders, [], [], $body);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([$uploadId, $this->groupId])->andReturn(false);
+    $expectedResponse = new Info(403, "Upload is not accessible",
+      InfoType::ERROR);
+    $actualResponse = $this->uploadController->getUploads($request,
+      new Response(), ['id' => $uploadId]);
+    $this->assertEquals($expectedResponse->getCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse->getArray(),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test UploadController::getUploads() for all uploads
+   * -# Check if the response is array with status 200
+   */
+  public function testGetUploads()
+  {
+    $uploads = [
+      $this->getUpload(2)->getArray(),
+      $this->getUpload(3)->getArray(),
+      $this->getUpload(4)->getArray()
+    ];
+    $requestHeaders = new Headers();
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("GET", new Uri("HTTP", "localhost", 80,
+      "/uploads/"), $requestHeaders, [], [], $body);
+    $this->dbHelper->shouldReceive('getUploads')
+      ->withArgs([$this->userId, $this->groupId, 100, 1, null, null, true])
+      ->andReturn([1, $uploads]);
+    $expectedResponse = (new Response())->withJson($uploads, 200);
+    $actualResponse = $this->uploadController->getUploads($request,
+      new Response(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for UploadController::getUploads() where ununpack not finished
+   * -# Check if the response status is 503
+   * -# Check if the response has headers `Retry-After` and `Look-at` set
+   */
+  public function testGetSingleUploadNotUnpacked()
+  {
+    $uploadId = 3;
+    $requestHeaders = new Headers();
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("GET", new Uri("HTTP", "localhost", 80,
+      "/uploads/"), $requestHeaders, [], [], $body);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([$uploadId, $this->groupId])->andReturn(true);
+    $this->uploadDao->shouldReceive('getParentItemBounds')
+      ->withArgs([$uploadId])->andReturn(false);
+
+    $expectedResponse = new Response();
+    $returnVal = new Info(503,
+      "Ununpack job not started. Please check job status at " .
+      "/api/v1/jobs?upload=" . $uploadId, InfoType::INFO);
+    $expectedResponse = $expectedResponse->withHeader('Retry-After', '60')
+      ->withHeader('Look-at', "/api/v1/jobs?upload=" . $uploadId)
+      ->withJson($returnVal->getArray(), $returnVal->getCode());
+    $actualResponse = $this->uploadController->getUploads($request,
+      new Response(), ['id' => $uploadId]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+    $this->assertEquals($expectedResponse->getHeaders(),
+      $actualResponse->getHeaders());
+  }
+
+  /**
+   * @test
+   * -# Test for UploadController::copyUpload()
+   * -# Check if response status is 202
+   */
+  public function testCopyUpload()
+  {
+    $uploadId = 3;
+    $folderId = 5;
+    $info = new Info(202, "Upload $uploadId will be copied to folder $folderId",
+      InfoType::INFO);
+
+    $this->restHelper->shouldReceive('copyUpload')
+      ->withArgs([$uploadId, $folderId, true])->andReturn($info);
+    $expectedResponse = (new Response())->withJson($info->getArray(),
+      $info->getCode());
+
+    $requestHeaders = new Headers();
+    $requestHeaders->set('folderId', $folderId);
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("PUT", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+    $actualResponse = $this->uploadController->copyUpload($request,
+      new Response(), ['id' => $uploadId]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for UploadController::moveUpload() with invalid folder id
+   * -# Check if response status is 400
+   */
+  public function testMoveUploadInvalidFolder()
+  {
+    $uploadId = 3;
+    $info = new Info(400, "folderId header should be an integer!",
+      InfoType::ERROR);
+
+    $expectedResponse = (new Response())->withJson($info->getArray(),
+      $info->getCode());
+
+    $requestHeaders = new Headers();
+    $requestHeaders->set('folderId', 'alpha');
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("PATCH", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+
+    $actualResponse = $this->uploadController->moveUpload($request,
+      new Response(), ['id' => $uploadId]);
+
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test for UploadController::postUpload()
+   * -# Check if response status is 201 with upload id
+   */
+  public function testPostUpload()
+  {
+    $folderId = 2;
+    $uploadDescription = "Test Upload";
+
+    $requestHeaders = new Headers();
+    $requestHeaders->set('folderId', $folderId);
+    $requestHeaders->set('uploadDescription', $uploadDescription);
+    $requestHeaders->set('ignoreScm', true);
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("POST", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+
+    $uploadHelper = M::mock('overload:Fossology\UI\Api\Helper\UploadHelper');
+    $uploadHelper->shouldReceive('createNewUpload')
+      ->withArgs([$request, $folderId, $uploadDescription, 'protected', true,
+        'vcs'])
+      ->andReturn([true, '', '', 20]);
+
+    $this->folderDao->shouldReceive('getAllFolderIds')->andReturn([2,3,4]);
+    $this->folderDao->shouldReceive('isFolderAccessible')
+      ->withArgs([$folderId])->andReturn(true);
+
+    $info = new Info(201, intval(20), InfoType::INFO);
+    $expectedResponse = (new Response())->withJson($info->getArray(),
+      $info->getCode());
+    $actualResponse = $this->uploadController->postUpload($request,
+      new Response(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test for UploadController::postUpload() with inaccessible folder
+   * -# Check if response status is 403
+   */
+  public function testPostUploadFolderNotAccessible()
+  {
+    $folderId = 2;
+    $uploadDescription = "Test Upload";
+
+    $requestHeaders = new Headers();
+    $requestHeaders->set('folderId', $folderId);
+    $requestHeaders->set('uploadDescription', $uploadDescription);
+    $requestHeaders->set('ignoreScm', true);
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("POST", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+
+    $uploadHelper = M::mock('overload:Fossology\UI\Api\Helper\UploadHelper');
+
+    $this->folderDao->shouldReceive('getAllFolderIds')->andReturn([2,3,4]);
+    $this->folderDao->shouldReceive('isFolderAccessible')
+      ->withArgs([$folderId])->andReturn(false);
+
+    $info = new Info(403, "folderId $folderId is not accessible!",
+      InfoType::ERROR);
+    $expectedResponse = (new Response())->withJson($info->getArray(),
+      $info->getCode());
+    $actualResponse = $this->uploadController->postUpload($request,
+      new Response(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test for UploadController::postUpload() with invalid folder id
+   * -# Check if response status is 404
+   */
+  public function testPostUploadFolderNotFound()
+  {
+    $folderId = 8;
+    $uploadDescription = "Test Upload";
+
+    $requestHeaders = new Headers();
+    $requestHeaders->set('folderId', $folderId);
+    $requestHeaders->set('uploadDescription', $uploadDescription);
+    $requestHeaders->set('ignoreScm', true);
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("POST", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+
+    $uploadHelper = M::mock('overload:Fossology\UI\Api\Helper\UploadHelper');
+
+    $this->folderDao->shouldReceive('getAllFolderIds')->andReturn([2,3,4]);
+
+    $info = new Info(404, "folderId $folderId does not exists!",
+      InfoType::ERROR);
+    $expectedResponse = (new Response())->withJson($info->getArray(),
+      $info->getCode());
+    $actualResponse = $this->uploadController->postUpload($request,
+      new Response(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test for UploadController::postUpload() with internal error
+   * -# Check if response status is 500 with error messages set
+   */
+  public function testPostUploadInternalError()
+  {
+    $folderId = 3;
+    $uploadDescription = "Test Upload";
+    $errorMessage = "Failed to insert upload record";
+    $errorDesc = "";
+
+    $requestHeaders = new Headers();
+    $requestHeaders->set('folderId', $folderId);
+    $requestHeaders->set('uploadDescription', $uploadDescription);
+    $requestHeaders->set('ignoreScm', true);
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("POST", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+
+    $uploadHelper = M::mock('overload:Fossology\UI\Api\Helper\UploadHelper');
+    $uploadHelper->shouldReceive('createNewUpload')
+      ->withArgs([$request, $folderId, $uploadDescription, 'protected', true,
+        'vcs'])
+      ->andReturn([false, $errorMessage, $errorDesc, -1]);
+
+    $this->folderDao->shouldReceive('getAllFolderIds')->andReturn([2,3,4]);
+    $this->folderDao->shouldReceive('isFolderAccessible')
+    ->withArgs([$folderId])->andReturn(true);
+
+    $info = new Info(500, $errorMessage . "\n" . $errorDesc, InfoType::ERROR);
+    $expectedResponse = (new Response())->withJson($info->getArray(),
+      $info->getCode());
+    $actualResponse = $this->uploadController->postUpload($request,
+      new Response(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test for UploadController::getUploadLicenses()
+   * -# Check if the response status is 200 with correct information
+   */
+  public function testGetUploadLicenses()
+  {
+    $uploadId = 3;
+    $agentsRun = [
+      ['agentName' => 'nomos', 'currentAgentId' => 2, 'isAgentRunning' => false],
+      ['agentName' => 'monk', 'currentAgentId' => 3, 'isAgentRunning' => false]
+    ];
+    $licenseResponse = [
+      ['filePath' => 'filea', 'agentFindings' => 'MIT', 'conclusions' => 'MIT'],
+      ['filePath' => 'fileb', 'agentFindings' => 'MIT',
+        'conclusions' => 'No_license_found']
+    ];
+
+    $requestHeaders = new Headers();
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("POST", new Uri("HTTP", "localhost", 80,
+        "/uploads/$uploadId/licenses", UploadController::AGENT_PARAM .
+        "=nomos,monk&containers=false"),
+      $requestHeaders, [], [], $body);
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([$uploadId, $this->groupId])->andReturn(true);
+    $this->uploadDao->shouldReceive('getParentItemBounds')
+      ->withArgs([$uploadId])->andReturn($this->getUploadBounds($uploadId));
+    $this->agentDao->shouldReceive('arsTableExists')
+      ->withArgs([M::anyOf('nomos', 'monk')])->andReturn(true);
+
+    $scanJobProxy = M::mock('overload:Fossology\Lib\Proxy\ScanJobProxy');
+    $scanJobProxy->shouldReceive('createAgentStatus')
+      ->withArgs([['nomos', 'monk']])
+      ->andReturn($agentsRun);
+
+    $uploadHelper = M::mock('overload:Fossology\UI\Api\Helper\UploadHelper');
+    $uploadHelper->shouldReceive('getUploadLicenseList')
+      ->withArgs([$uploadId, ['nomos', 'monk'], false])
+      ->andReturn($licenseResponse);
+
+    $expectedResponse = (new Response())->withJson($licenseResponse, 200);
+
+    $actualResponse = $this->uploadController->getUploadLicenses($request,
+      new Response(), ['id' => $uploadId]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test for UploadController::getUploadLicenses() when agents pending
+   * -# Check if response status is 503
+   * -# Check if response headers `Retry-After` and `Look-at` set
+   */
+  public function testGetUploadLicensesPendingScan()
+  {
+    $uploadId = 3;
+    $agentsRun = [
+      ['agentName' => 'nomos', 'currentAgentId' => 2, 'isAgentRunning' => true],
+      ['agentName' => 'monk', 'currentAgentId' => 3, 'isAgentRunning' => false]
+    ];
+
+    $requestHeaders = new Headers();
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("POST", new Uri("HTTP", "localhost", 80,
+        "/uploads/$uploadId/licenses", UploadController::AGENT_PARAM .
+        "=nomos,monk&containers=false"),
+      $requestHeaders, [], [], $body);
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([$uploadId, $this->groupId])->andReturn(true);
+    $this->uploadDao->shouldReceive('getParentItemBounds')
+      ->withArgs([$uploadId])->andReturn($this->getUploadBounds($uploadId));
+    $this->agentDao->shouldReceive('arsTableExists')
+      ->withArgs([M::anyOf('nomos', 'monk')])->andReturn(true);
+
+    $scanJobProxy = M::mock('overload:Fossology\Lib\Proxy\ScanJobProxy');
+    $scanJobProxy->shouldReceive('createAgentStatus')
+      ->withArgs([['nomos', 'monk']])
+      ->andReturn($agentsRun);
+
+    $info = new Info(503, "Agent nomos is running. " .
+      "Please check job status at /api/v1/jobs?upload=" . $uploadId,
+      InfoType::INFO);
+    $expectedResponse = (new Response())->withHeader('Retry-After', '60')
+      ->withHeader('Look-at', "/api/v1/jobs?upload=" . $uploadId)
+      ->withJson($info->getArray(), $info->getCode());
+
+    $actualResponse = $this->uploadController->getUploadLicenses($request,
+      new Response(), ['id' => $uploadId]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+    $this->assertEquals($expectedResponse->getHeaders(),
+      $actualResponse->getHeaders());
+  }
+}

--- a/src/www/ui_tests/api/Controllers/UserControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UserControllerTest.php
@@ -1,0 +1,233 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for UserController
+ */
+
+namespace Fossology\UI\Api\Test\Controllers;
+
+require_once dirname(dirname(dirname(dirname(__DIR__)))) .
+  '/lib/php/Plugin/FO_Plugin.php';
+
+use Mockery as M;
+use Slim\Http\Response;
+use Fossology\UI\Api\Controllers\UserController;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Models\User;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+
+/**
+ * @class UserControllerTest
+ * @brief Test cases for UserController
+ */
+class UserControllerTest extends \PHPUnit\Framework\TestCase
+{
+
+  /**
+   * @var integer $assertCountBefore
+   * Assertions before running tests
+   */
+  private $assertCountBefore;
+
+  /**
+   * @var DbHelper $dbHelper
+   * DbHelper mock
+   */
+  private $dbHelper;
+
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp()
+  {
+    global $container;
+    $container = M::mock('ContainerBuilder');
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->restHelper = M::mock(RestHelper::class);
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+    $this->userController = new UserController($container);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+  }
+
+  /**
+   * @brief Remove test objects
+   * @see PHPUnit_Framework_TestCase::tearDown()
+   */
+  protected function tearDown()
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  /**
+   * Helper function to get JSON array from response
+   *
+   * @param Response $response
+   * @return array Decoded response
+   */
+  private function getResponseJson($response)
+  {
+    $response->getBody()->seek(0);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+
+  /**
+   * Generate array of users
+   * @param array $userIds User ids to be generated
+   * @return array[]
+   */
+  private function getUsers($userIds)
+  {
+    $userArray = array();
+    foreach ($userIds as $userId) {
+      if ($userId == 2) {
+        $accessLevel = PLUGIN_DB_ADMIN;
+      } elseif ($userId > 2 && $userId <= 4) {
+        $accessLevel = PLUGIN_DB_WRITE;
+      } elseif ($userId == 5) {
+        $accessLevel = PLUGIN_DB_READ;
+      } else {
+        continue;
+      }
+      $user = new User($userId, "user$userId", "User $userId",
+        "user$userId@example.com", $accessLevel, 2, 4, "");
+      $userArray[] = $user->getArray();
+    }
+    return $userArray;
+  }
+
+  /**
+   * @test
+   * -# Test UserController::getUsers() for specific user id
+   * -# Check if response contains only one user info
+   */
+  public function testGetSpecificUser()
+  {
+    $userId = 2;
+    $user = $this->getUsers([$userId]);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["users", "user_pk", $userId])->andReturn(true);
+    $this->dbHelper->shouldReceive('getUsers')->withArgs([$userId])
+      ->andReturn($user);
+    $expectedResponse = (new Response())->withJson($user[0], 200);
+    $actualResponse = $this->userController->getUsers(null, new Response(),
+      ['id' => $userId]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test UserController::getUsers() for invalid user id
+   * -# Check if response status is 404
+   */
+  public function testGetSpecificUserNotFound()
+  {
+    $userId = 6;
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["users", "user_pk", $userId])->andReturn(false);
+    $error = new Info(404, "UserId doesn't exist", InfoType::ERROR);
+    $expectedResponse = (new Response())->withJson($error->getArray(),
+      $error->getCode());
+    $actualResponse = $this->userController->getUsers(null, new Response(),
+      ['id' => $userId]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test UserController::getUsers() for all users
+   * -# Check if the response is list of user info
+   */
+  public function testGetAllUsers()
+  {
+    $users = $this->getUsers([2, 3, 4]);
+    $this->dbHelper->shouldReceive('getUsers')->withArgs([null])
+      ->andReturn($users);
+    $expectedResponse = (new Response())->withJson($users, 200);
+    $actualResponse = $this->userController->getUsers(null, new Response(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test UserController::deleteUser() for valid delete request
+   * -# Check if response status is 202
+   */
+  public function testDeleteUser()
+  {
+    $userId = 4;
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["users", "user_pk", $userId])->andReturn(true);
+    $this->dbHelper->shouldReceive('deleteUser')->withArgs([$userId]);
+    $info = new Info(202, "User will be deleted", InfoType::INFO);
+    $expectedResponse = (new Response())->withJson($info->getArray(),
+      $info->getCode());
+    $actualResponse = $this->userController->deleteUser(null, new Response(),
+      ['id' => $userId]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test UserController::deleteUser() for invalid user id
+   * -# Check if response status is 404
+   */
+  public function testDeleteUserDoesNotExists()
+  {
+    $userId = 8;
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["users", "user_pk", $userId])->andReturn(false);
+    $info = new Info(404, "UserId doesn't exist", InfoType::ERROR);
+    $expectedResponse = (new Response())->withJson($info->getArray(),
+      $info->getCode());
+    $actualResponse = $this->userController->deleteUser(null, new Response(),
+      ['id' => $userId]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+}

--- a/src/www/ui_tests/api/Controllers/VersionControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/VersionControllerTest.php
@@ -1,0 +1,130 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for VersionController
+ */
+
+namespace Fossology\UI\Api\Test\Controllers;
+
+use Mockery as M;
+use Symfony\Component\Yaml\Parser;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\RestHelper;
+use Slim\Http\Response;
+use Fossology\UI\Api\Controllers\VersionController;
+
+/**
+ * @class VersionControllerTest
+ * @brief Test cases for VersionController
+ */
+class VersionControllerTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @var string YAML_LOC
+   * Location of openapi.yaml file
+   */
+  const YAML_LOC = __DIR__ . '/../../../ui/api/documentation/openapi.yaml';
+
+  /**
+   * @var integer $assertCountBefore
+   * Assertions before running tests
+   */
+  private $assertCountBefore;
+
+  /**
+   * @var DbHelper $dbHelper
+   * DbHelper mock
+   */
+  private $dbHelper;
+
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp()
+  {
+    global $container;
+    $container = M::mock('ContainerBuilder');
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->restHelper = M::mock(RestHelper::class);
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+    $this->versionController = new VersionController($container);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+  }
+
+  /**
+   * @brief Remove test objects
+   * @see PHPUnit_Framework_TestCase::tearDown()
+   */
+  protected function tearDown()
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  /**
+   * Helper function to get JSON array from response
+   *
+   * @param Response $response
+   * @return array Decoded response
+   */
+  private function getResponseJson($response)
+  {
+    $response->getBody()->seek(0);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+
+  public function testGetVersion()
+  {
+    try {
+      $yaml = new Parser();
+      $yamlDocArray = $yaml->parseFile(self::YAML_LOC);
+    } catch (ParseException $exception) {
+      printf("Unable to parse the YAML string: %s", $exception->getMessage());
+    }
+    $apiVersion = $yamlDocArray["info"]["version"];
+    $security = array();
+    foreach ($yamlDocArray["security"] as $secMethod) {
+      $security[] = key($secMethod);
+    }
+    $expectedResponse = (new Response())->withJson(array(
+        "version" => $apiVersion,
+        "security" => $security
+      ), 200);
+    $actualResponse = $this->versionController->getVersion(null, new Response(),
+      []);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+}

--- a/src/www/ui_tests/api/Helper/AuthHelperTest.php
+++ b/src/www/ui_tests/api/Helper/AuthHelperTest.php
@@ -1,0 +1,252 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @dir
+ * @brief Unit test cases for API helpers
+ * @file
+ * @brief Tests for AuthHelper
+ */
+
+/**
+ * @namespace Fossology::UI::Api::Test::Helper
+ *            Unit tests for API helpers
+ */
+namespace Fossology\UI\Api\Test\Helper;
+
+use Mockery as M;
+use Fossology\UI\Api\Helper\AuthHelper;
+use Fossology\Lib\Dao\UserDao;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Fossology\UI\Api\Helper\DbHelper;
+use Firebase\JWT\JWT;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+
+/**
+ * @class AuthHelperTest
+ * @brief Test cases for AuthHelper
+ */
+class AuthHelperTest extends \PHPUnit\Framework\TestCase
+{
+
+  /**
+   * @var integer $assertCountBefore
+   * Assertions before running tests
+   */
+  private $assertCountBefore;
+
+  /**
+   * @var AuthHelper $authHelper
+   * AuthHelper object to test
+   */
+  private $authHelper;
+
+  /**
+   * @var UserDao $userDao
+   * UserDao mock
+   */
+  private $userDao;
+
+  /**
+   * @var Session $session
+   * Session mock
+   */
+  private $session;
+
+  /**
+   * @var DbHelper $dbHelper
+   * DbHelper mock
+   */
+  private $dbHelper;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp()
+  {
+    $this->userDao = M::mock(UserDao::class);
+    $this->session = M::mock(Session::class);
+    $this->dbHelper = M::mock(DbHelper::class);
+
+    $this->session->shouldReceive('isStarted')->andReturn(true);
+
+    $this->authHelper = new AuthHelper($this->userDao, $this->session,
+      $this->dbHelper);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+  }
+
+  /**
+   * @brief Remove test objects
+   * @see PHPUnit_Framework_TestCase::tearDown()
+   */
+  protected function tearDown()
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  /**
+   * @test
+   * -# Test for AuthHelper::verifyAuthToken(), AuthHelper::generateJwtToken()
+   *    and AuthHelper::isTokenActive()
+   * -# Generate a JWT token using AuthHelper::generateJwtToken()
+   * -# Call AuthHelper::verifyAuthToken()
+   * -# Check if the function says token is active
+   * -# Check if the function updates user id and token scope.
+   */
+  public function testVerifyAuthToken()
+  {
+    $userId = null;
+    $tokenScope = null;
+    $jti = "4.2";
+    $key = "mysecretkey";
+    $createdOn = strftime('%Y-%m-%d');
+    $expire = strftime('%Y-%m-%d', strtotime('+3 day'));
+    $authToken = $this->authHelper->generateJwtToken($expire, $createdOn, $jti,
+      "write", $key);
+    $authHeader = "Bearer " . $authToken;
+    $tokenRow = [
+      "token_key" => $key,
+      "created_on" => $createdOn,
+      "expire_on" => $expire,
+      "user_fk" => 2,
+      "active" => 't',
+      "token_scope" => "w"
+    ];
+
+    $this->dbHelper->shouldReceive('getTokenKey')
+      ->withArgs(["4"])
+      ->andReturn($tokenRow);
+
+    $expectedReturn = true;
+
+    $actualReturn = $this->authHelper->verifyAuthToken($authHeader, $userId,
+      $tokenScope);
+
+    $this->assertEquals($expectedReturn, $actualReturn);
+    $this->assertEquals(2, $userId);
+    $this->assertEquals("write", $tokenScope);
+  }
+
+  /**
+   * @test
+   * -# Test for AuthHelper::isTokenActive()
+   * -# Generate two DB rows with active and inactive tokens
+   * -# Call AuthHelper::isTokenActive() on both rows and check for results
+   */
+  public function testIsTokenActive()
+  {
+    $key = "mysecretkey";
+    $createdOn = strftime('%Y-%m-%d');
+    $expire = strftime('%Y-%m-%d', strtotime('+3 day'));
+    $tokenId = 4;
+    $activeTokenRow = [
+      "token_key" => $key,
+      "created_on" => $createdOn,
+      "expire_on" => $expire,
+      "user_fk" => 2,
+      "active" => 't',
+      "token_scope" => "w"
+    ];
+    $expireTokenRow = [
+      "token_key" => $key,
+      "created_on" => $createdOn,
+      "expire_on" => $expire,
+      "user_fk" => 2,
+      "active" => 'f',
+      "token_scope" => "w"
+    ];
+
+    $this->assertEquals(true, $this->authHelper->isTokenActive($activeTokenRow,
+      $tokenId));
+
+    $expectedResponse = new Info(403, "Token expired.", InfoType::ERROR);
+    $actualResponse = $this->authHelper->isTokenActive($expireTokenRow,
+      $tokenId);
+    $this->assertEquals($expectedResponse, $actualResponse);
+  }
+
+  /**
+   * @test
+   * -# Test for AuthHelper::isTokenActive()
+   * -# Generate DB row with expired token
+   * -# Check if AuthHelper::isTokenActive() calls DbHelper::invalidateToken()
+   * -# Check if the result contains 403 status
+   */
+  public function testIsTokenActiveExpireOldToken()
+  {
+    $key = "mysecretkey";
+    $createdOn = strftime('%Y-%m-%d', strtotime('-3 day'));
+    $expire = strftime('%Y-%m-%d', strtotime('-1 day'));
+    $tokenId = 4;
+    $tokenRow = [
+      "token_key" => $key,
+      "created_on" => $createdOn,
+      "expire_on" => $expire,
+      "user_fk" => 2,
+      "active" => 't',
+      "token_scope" => "w"
+    ];
+
+    $this->dbHelper->shouldReceive('invalidateToken')
+      ->withArgs([$tokenId])->once();
+
+    $expectedResponse = new Info(403, "Token expired.", InfoType::ERROR);
+    $actualResponse = $this->authHelper->isTokenActive($tokenRow, $tokenId);
+    $this->assertEquals($expectedResponse->getArray(),
+      $actualResponse->getArray());
+  }
+
+  /**
+   * @test
+   * -# Test for AuthHelper::userHasGroupAccess()
+   * -# Check if the function accepts correct group
+   * -# Check if the function returns 403 for inaccessible group
+   */
+  public function testUserHasGroupAccess()
+  {
+    $userId = 3;
+    $groupName = 'fossy';
+    $groupMap = [
+      2 => 'fossy',
+      3 => 'read',
+      4 => 'write'
+    ];
+
+    $this->userDao->shouldReceive('getGroupIdByName')
+      ->withArgs([$groupName])->andReturn(['group_pk' => 2])->once();
+    $this->userDao->shouldReceive('getUserGroupMap')
+      ->withArgs([$userId])->andReturn($groupMap)->twice();
+
+    $this->assertEquals(true, $this->authHelper->userHasGroupAccess($userId,
+      $groupName));
+
+    $groupName = 'random';
+    $this->userDao->shouldReceive('getGroupIdByName')
+      ->withArgs([$groupName])->andReturn(['group_pk' => 6])->once();
+
+    $expectedResponse = new Info(403, "User has no access to $groupName group",
+      InfoType::ERROR);
+    $actualResponse = $this->authHelper->userHasGroupAccess($userId,
+      $groupName);
+    $this->assertEquals($expectedResponse, $actualResponse);
+  }
+}

--- a/src/www/ui_tests/api/Helper/DbHelperTest.php
+++ b/src/www/ui_tests/api/Helper/DbHelperTest.php
@@ -1,0 +1,266 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for DbHelper
+ */
+
+namespace Fossology\UI\Api\Test\Helper;
+
+if (session_status() == PHP_SESSION_NONE) {
+  session_start();
+}
+
+require_once dirname(dirname(dirname(dirname(__DIR__)))) .
+  '/lib/php/Plugin/FO_Plugin.php';
+
+use Mockery as M;
+use Fossology\Lib\Db\ModernDbManager;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\Lib\Auth\Auth;
+use Fossology\UI\Api\Models\User;
+use Fossology\Lib\Dao\FolderDao;
+
+/**
+ * @class DbHelperTest
+ * @brief Tests for DbHelper
+ */
+class DbHelperTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @var integer $assertCountBefore
+   * Assertions before running tests
+   */
+  private $assertCountBefore;
+
+  /**
+   * @var ModernDbManager $dbManager
+   * ModernDbManager mock
+   */
+  private $dbManager;
+
+  /**
+   * @var DbHelper $dbHelper
+   * DbHelper object to test
+   */
+  private $dbHelper;
+
+  /**
+   * @var FolderDao $folderDao
+   * FolderDao object to test
+   */
+  private $folderDao;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp()
+  {
+    $this->dbManager = M::mock(ModernDbManager::class);
+    $this->folderDao = M::mock(FolderDao::class);
+
+    $this->dbHelper = new DbHelper($this->dbManager, $this->folderDao);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+  }
+
+  /**
+   * @brief Remove test objects
+   * @see PHPUnit_Framework_TestCase::tearDown()
+   */
+  protected function tearDown()
+  {
+    $GLOBALS['SysConf']['auth'][Auth::USER_ID] = -1;
+    $_SESSION[Auth::USER_LEVEL] = -1;
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  /**
+   * Generate user row data to match database
+   * @return array
+   */
+  private function generateUserRow()
+  {
+    $agent_list = [];
+    $agent_list[2] = 'nomos,monk';
+    $agent_list[3] = 'nomos,ojo';
+    $agent_list[4] = 'copyright,ecc';
+
+    $perm_list = [];
+    $perm_list[2] = PLUGIN_DB_ADMIN;
+    $perm_list[3] = PLUGIN_DB_WRITE;
+    $perm_list[4] = PLUGIN_DB_READ;
+
+    $userRows = [];
+    for ($i = 2; $i <= 4; $i++) {
+      $row = [
+        'user_pk' => $i, 'user_name' => "user$i", 'user_desc' => "user $i",
+        'user_email' => "user$i@local", 'email_notify' => 'y',
+        'root_folder_fk' => 2, 'user_perm' => $perm_list[$i],
+        'user_agent_list' => $agent_list[$i]
+      ];
+      $userRows[$i] = $row;
+    }
+    return $userRows;
+  }
+
+  /**
+   * Generate User object array from DB array
+   * @param array $rows
+   * @param integer $currentUser If set, returns complete object of user with
+   *                             provided id, others will be masked
+   * @return array
+   */
+  private function generateUserFromRow($rows, $currentUser = null)
+  {
+    $users = [];
+    foreach ($rows as $row) {
+      if ($currentUser === null || $row['user_pk'] == $currentUser) {
+        $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
+            $row["user_email"], $row["user_perm"], $row["root_folder_fk"],
+          $row["email_notify"], $row["user_agent_list"]);
+      } else {
+        $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
+          null, null, null, null, null);
+      }
+      $users[$row["user_pk"]] = $user->getArray();
+    }
+    return $users;
+  }
+
+  /**
+   * @test
+   * -# Test for DbHelper::getUsers()
+   * -# Check if all users are returned for admin user
+   */
+  public function testGetUsersAll()
+  {
+    $userId = 2;
+
+    $GLOBALS['SysConf']['auth'][Auth::USER_ID] = $userId;
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+
+    $sql = 'SELECT user_pk, user_name, user_desc, user_email,
+                  email_notify, root_folder_fk, user_perm, user_agent_list ' .
+      'FROM users;';
+    $statement = DbHelper::class . "::getUsers.getAllUsers";
+    $userRows = $this->generateUserRow();
+
+    $this->dbManager->shouldReceive('getRows')
+      ->withArgs([$sql, [], $statement])
+      ->once()
+      ->andReturn($userRows);
+
+    $expectedUsers = array_values($this->generateUserFromRow($userRows));
+    $actualUsers = $this->dbHelper->getUsers();
+
+    $this->assertEquals($expectedUsers, $actualUsers);
+  }
+
+  /**
+   * @test
+   * -# Test for DbHelper::getUsers()
+   * -# Check if all users are returned, masking other users for non-admin users
+   */
+  public function testGetUsersAllNonAdmin()
+  {
+    $userId = 3;
+
+    $GLOBALS['SysConf']['auth'][Auth::USER_ID] = $userId;
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+
+    $sql = 'SELECT user_pk, user_name, user_desc, user_email,
+                  email_notify, root_folder_fk, user_perm, user_agent_list ' .
+      'FROM users;';
+    $statement = DbHelper::class . "::getUsers.getAllUsers";
+    $userRows = $this->generateUserRow();
+
+    $this->dbManager->shouldReceive('getRows')
+      ->withArgs([$sql, [], $statement])
+      ->once()
+      ->andReturn($userRows);
+
+    $expectedUsers = array_values($this->generateUserFromRow($userRows,
+      $userId));
+    $actualUsers = $this->dbHelper->getUsers();
+
+    $this->assertEquals($expectedUsers, $actualUsers);
+  }
+
+  /**
+   * @test
+   * -# Test for DbHelper::getUsers() fetching specific user
+   * -# Check if complete object is returned
+   */
+  public function testGetUsersSingleUserAdmin()
+  {
+    $userId = 2;
+
+    $GLOBALS['SysConf']['auth'][Auth::USER_ID] = $userId;
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+
+    $sql = "SELECT user_pk, user_name, user_desc, user_email,
+                email_notify, root_folder_fk, user_perm, user_agent_list FROM users
+                WHERE user_pk = $1;";
+    $statement = DbHelper::class . "::getUsers.getSpecificUser";
+    $userRows = $this->generateUserRow();
+
+    $this->dbManager->shouldReceive('getRows')
+      ->withArgs([$sql, [$userId], $statement])
+      ->once()
+      ->andReturn([$userRows[$userId]]);
+
+    $expectedUsers = $this->generateUserFromRow($userRows, $userId);
+    $actualUsers = $this->dbHelper->getUsers($userId);
+
+    $this->assertEquals([$expectedUsers[$userId]], $actualUsers);
+  }
+
+  /**
+   * @test
+   * -# Test for DbHelper::getUsers() fetching single user by non-admin user
+   * -# Check if masked user is returned
+   */
+  public function testGetUsersSingleUserNonAdmin()
+  {
+    $userId = 3;
+    $fetchId = 4;
+
+    $GLOBALS['SysConf']['auth'][Auth::USER_ID] = $userId;
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+
+    $sql = "SELECT user_pk, user_name, user_desc, user_email,
+                email_notify, root_folder_fk, user_perm, user_agent_list FROM users
+                WHERE user_pk = $1;";
+    $statement = DbHelper::class . "::getUsers.getSpecificUser";
+    $userRows = $this->generateUserRow();
+
+    $this->dbManager->shouldReceive('getRows')
+      ->withArgs([$sql, [$fetchId], $statement])
+      ->once()
+      ->andReturn([$userRows[$fetchId]]);
+
+    $expectedUsers = $this->generateUserFromRow($userRows, $userId);
+    $actualUsers = $this->dbHelper->getUsers($fetchId);
+
+    $this->assertEquals([$expectedUsers[$fetchId]], $actualUsers);
+  }
+}

--- a/src/www/ui_tests/api/Helper/RestHelperTest.php
+++ b/src/www/ui_tests/api/Helper/RestHelperTest.php
@@ -1,0 +1,307 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for RestHelper
+ */
+
+namespace Fossology\UI\Api\Helper;
+
+
+use Mockery as M;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\Lib\Dao\UploadPermissionDao;
+use Fossology\Lib\Dao\FolderDao;
+use Fossology\Lib\Dao\UserDao;
+use Fossology\Lib\Dao\JobDao;
+use Fossology\Lib\Dao\ShowJobsDao;
+use Fossology\UI\Api\Helper\AuthHelper;
+use Fossology\UI\Api\Helper\RestHelper;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Fossology\Lib\Auth\Auth;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+
+$GLOBALS['globalSession'] = new Session();
+$GLOBALS['globalSession']->set('t','t');
+
+function plugin_find($plugin)
+{
+  return RestHelperTest::$functions->plugin_find($plugin);
+}
+
+/**
+ * @class RestHelperTest
+ * @brief Test cases for RestHelper
+ */
+class RestHelperTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @var \Mockery\MockInterface $functions
+   * Mock of public functions
+   */
+  public static $functions;
+  /**
+   * @var UploadDao $uploadDao
+   * UploadDao mock
+   */
+  private $uploadDao;
+  /**
+   * @var DbHelper $dbHelper
+   * DbHelper mock
+   */
+  private $dbHelper;
+  /**
+   * @var UploadPermissionDao $uploadPermissionDao
+   * UploadPermissionDao mock
+   */
+  private $uploadPermissionDao;
+  /**
+   * @var FolderDao $folderDao
+   * FolderDao mock
+   */
+  private $folderDao;
+  /**
+   * @var UserDao $userDao
+   * UserDao mock
+   */
+  private $userDao;
+  /**
+   * @var JobDao $jobDao
+   * JobDao mock
+   */
+  private $jobDao;
+  /**
+   * @var ShowJobsDao $showJobDao
+   * ShowJobsDao mock
+   */
+  private $showJobDao;
+  /**
+   * @var AuthHelper $authHelper
+   * AuthHelper mock
+   */
+  private $authHelper;
+  /**
+   * @var Session $session
+   * Session mock
+   */
+  private $session;
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+  /**
+   * @var integer $userId
+   * User id
+   */
+  private $userId;
+  /**
+   * @var integer $groupId
+   * Group id
+   */
+  private $groupId;
+  /**
+   * @var \Mockery\MockInterface $contentMovePlugin
+   * content_move plugin mock
+   */
+  private $contentMovePlugin;
+  /**
+   * @var integer $assertCountBefore
+   * Assertions before running tests
+   */
+  private $assertCountBefore;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp()
+  {
+    $this->uploadPermissionDao = M::mock(UploadPermissionDao::class);
+    $this->uploadDao  = M::mock(UploadDao::class);
+    $this->userDao    = M::mock(UserDao::class);
+    $this->folderDao  = M::mock(FolderDao::class);
+    $this->dbHelper   = M::mock(DbHelper::class);
+    $this->authHelper = M::mock(AuthHelper::class);
+    $this->jobDao     = M::mock(JobDao::class);
+    $this->showJobDao = M::mock(ShowJobsDao::class);
+    $this->session    = $GLOBALS['globalSession'];
+    $this->userId     = 2;
+    $this->groupId    = 2;
+    self::$functions = M::mock();
+    $this->contentMovePlugin = M::mock('AdminContentMove');
+
+    $this->session->set(Auth::USER_ID, $this->userId);
+    $this->session->set(Auth::GROUP_ID, $this->groupId);
+    $this->authHelper->shouldReceive('getSession')->andReturn($this->session);
+
+    self::$functions->shouldReceive('plugin_find')
+      ->withArgs(['content_move'])
+      ->andReturn($this->contentMovePlugin);
+
+    $this->restHelper = new RestHelper(
+      $this->uploadPermissionDao,
+      $this->uploadDao,
+      $this->userDao,
+      $this->folderDao,
+      $this->dbHelper,
+      $this->authHelper,
+      $this->jobDao,
+      $this->showJobDao);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+  }
+
+  /**
+   * @brief Remove test objects
+   * @see PHPUnit_Framework_TestCase::tearDown()
+   */
+  protected function tearDown()
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  /**
+   * @test
+   * -# Test for RestHelper::copyUpload()
+   * -# Check if the response for RestHelper::copyUpload() is 202
+   */
+  public function testCopyUpload()
+  {
+    $uploadId = 5;
+    $newFolderId = 10;
+    $isCopy = true;
+    $uploadContentId = 44;
+
+    $this->folderDao->shouldReceive('isFolderAccessible')
+      ->withArgs([$newFolderId, $this->userId])
+      ->once()
+      ->andReturn(true);
+    $this->uploadPermissionDao->shouldReceive('isAccessible')
+      ->withArgs([$uploadId, $this->groupId])
+      ->once()
+      ->andReturn(true);
+    $this->folderDao->shouldReceive('getFolderContentsId')
+      ->withArgs([$uploadId, 2])
+      ->once()
+      ->andReturn($uploadContentId);
+    $this->contentMovePlugin->shouldReceive('copyContent')
+      ->withArgs([[$uploadContentId], $newFolderId, $isCopy])
+      ->once()
+      ->andReturn("");
+
+    $expected = new Info(202, "Upload $uploadId will be copied to folder " .
+      $newFolderId, InfoType::INFO);
+    $actual = $this->restHelper->copyUpload($uploadId, $newFolderId, $isCopy);
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * @test
+   * -# Test for RestHelper::validateTokenRequest()
+   * -# Check if RestHelper::validateTokenRequest() accepts valid requests
+   */
+  public function testValidateTokenRequest()
+  {
+    $tokenExpire = strftime('%Y-%m-%d', strtotime('+3 day'));
+    $tokenName = "myTok";
+    $tokenScope = "read";
+    $tokenValidity = 30;
+
+    $this->authHelper->shouldReceive('getMaxTokenValidity')
+      ->andReturn($tokenValidity);
+    $this->assertTrue($this->restHelper->validateTokenRequest($tokenExpire,
+      $tokenName, $tokenScope));
+  }
+
+  /**
+   * @test
+   * -# Test for RestHelper::validateTokenRequest() with expire > max valid
+   * -# Check if response is 400 with valid message.
+   */
+  public function testValidateTokenRequestMaxExpire()
+  {
+    $tokenExpire = strftime('%Y-%m-%d', strtotime('+10 day'));
+    $tokenName = "myTok";
+    $tokenScope = "read";
+    $tokenValidity = 3;
+
+    $this->authHelper->shouldReceive('getMaxTokenValidity')
+      ->andReturn($tokenValidity);
+
+    $expected = new Info(400,
+      "The token should have at least 1 day and max $tokenValidity days " .
+      "of validity and should follow YYYY-MM-DD format.", InfoType::ERROR);
+    $actual = $this->restHelper->validateTokenRequest($tokenExpire, $tokenName,
+      $tokenScope);
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * @test
+   * -# Test for RestHelper::validateTokenRequest() with invalid date format
+   * -# Check if response is 400 with valid message.
+   */
+  public function testValidateTokenRequestInvalidExpire()
+  {
+    $tokenExpire = strftime('%d-%m-%Y', strtotime('+10 day'));
+    $tokenName = "myTok";
+    $tokenScope = "read";
+    $tokenValidity = 30;
+
+    $this->authHelper->shouldReceive('getMaxTokenValidity')
+      ->andReturn($tokenValidity);
+
+    $expected = new Info(400,
+      "The token should have at least 1 day and max $tokenValidity days " .
+      "of validity and should follow YYYY-MM-DD format.", InfoType::ERROR);
+    $actual = $this->restHelper->validateTokenRequest($tokenExpire, $tokenName,
+      $tokenScope);
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * @test
+   * -# Test RestHelper::validateTokenRequest() with invalid scope
+   * -# Check if the response is 400 with valid message.
+   */
+  public function testValidateTokenRequestInvalidScope()
+  {
+    $tokenExpire = strftime('%Y-%m-%d', strtotime('+10 day'));
+    $tokenName = "myTok";
+    $tokenScope = "r";
+    $tokenValidity = 30;
+
+    $this->authHelper->shouldReceive('getMaxTokenValidity')
+      ->andReturn($tokenValidity);
+
+    $expected = new Info(400, "Invalid token scope, allowed only " .
+      join(",", RestHelper::VALID_SCOPES), InfoType::ERROR);
+    $actual = $this->restHelper->validateTokenRequest($tokenExpire, $tokenName,
+      $tokenScope);
+
+    $this->assertEquals($expected, $actual);
+  }
+}

--- a/src/www/ui_tests/api/Makefile
+++ b/src/www/ui_tests/api/Makefile
@@ -1,0 +1,26 @@
+# Copyright Siemens AG 2017
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+TOP = ../../../..
+VARS = $(TOP)/Makefile.conf
+include $(VARS)
+
+LOCALAGENTDIR = ../../agent
+
+all:
+	@echo "No action to make api tests"
+
+test: all
+	$(PHPUNIT) --bootstrap $(PHPUNIT_BOOT) --configuration tests.xml
+
+coverage: all
+	$(PHPUNIT) --bootstrap $(PHPUNIT_BOOT) --coverage-html ./results --configuration tests.xml
+
+clean:
+	@echo "nothing to do"
+
+.PHONY: all test coverage clean

--- a/src/www/ui_tests/api/Models/AnalysisTest.php
+++ b/src/www/ui_tests/api/Models/AnalysisTest.php
@@ -1,0 +1,125 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @dir
+ * @brief Unit test cases for API models
+ * @file
+ * @brief Tests for Analysis
+ */
+
+/**
+ * @namespace Fossology::UI::Api::Test::Models
+ *            Unit tests for models
+ */
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\Analysis;
+
+/**
+ * @class AnalysisTest
+ * @brief Tests for Analysis model
+ */
+class AnalysisTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @test
+   * -# Test for Analysis::setUsingArray()
+   * -# Check if the Analysis object is updated with actual array values
+   */
+  public function testSetUsingArray()
+  {
+    $analysisArray = [
+      "bucket" => true,
+      "copyright_email_author" => "true",
+      "ecc" => 1,
+      "keyword" => (1==1),
+      "mime" => false,
+      "monk" => "false",
+      "nomos" => 0,
+      "ojo" => (1==2)
+    ];
+
+    $expectedObject = new Analysis(true, true, true, true);
+
+    $actualObject = new Analysis();
+    $actualObject->setUsingArray($analysisArray);
+
+    $this->assertEquals($expectedObject, $actualObject);
+  }
+
+  /**
+   * @test
+   * -# Test for Analysis::setUsingString()
+   * -# Create two strings with different delimiters
+   * -# Check if the created Analysis objects hold expected values
+   */
+  public function testSetUsingString()
+  {
+    $analysisStringComma = "bucket, ecc, keyword";
+    $analysisStringSemi = "bucket;ecc;monk";
+
+    $expectedObjectComma = new Analysis();
+    $expectedObjectComma->setBucket(true);
+    $expectedObjectComma->setEcc(true);
+    $expectedObjectComma->setKeyword(true);
+
+    $expectedObjectSemi = new Analysis();
+    $expectedObjectSemi->setBucket(true);
+    $expectedObjectSemi->setEcc(true);
+    $expectedObjectSemi->setMonk(true);
+
+    $actualObjectComma = new Analysis();
+    $actualObjectComma->setUsingString($analysisStringComma);
+    $actualObjectSemi = new Analysis();
+    $actualObjectSemi->setUsingString($analysisStringSemi);
+
+    $this->assertEquals($expectedObjectComma, $actualObjectComma);
+    $this->assertEquals($expectedObjectSemi, $actualObjectSemi);
+  }
+
+  /**
+   * @test
+   * -# Test for Analysis::getArray()
+   * -# Create expected array
+   * -# Create test object and set the values
+   * -# Get the array from object and match with expected array
+   */
+  public function testDataFormat()
+  {
+    $expectedArray = [
+      "bucket"    => true,
+      "copyright_email_author" => true,
+      "ecc"       => false,
+      "keyword"   => false,
+      "mimetype"  => true,
+      "monk"      => false,
+      "nomos"     => true,
+      "ojo"       => true,
+      "package"   => false
+    ];
+    $actualObject = new Analysis();
+    $actualObject->setBucket(true);
+    $actualObject->setCopyright(true);
+    $actualObject->setMime(true);
+    $actualObject->setNomos(true);
+    $actualObject->setOjo(true);
+
+    $this->assertEquals($expectedArray, $actualObject->getArray());
+  }
+}

--- a/src/www/ui_tests/api/Models/DeciderTest.php
+++ b/src/www/ui_tests/api/Models/DeciderTest.php
@@ -1,0 +1,78 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for Decider
+ */
+
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\Decider;
+
+/**
+ * @class DeciderTest
+ * @brief Tests for Decider model
+ */
+class DeciderTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @test
+   * -# Test for Decider::setUsingArray()
+   * -# Create a test array and pass to setUsingArray() on test object
+   * -# Check if the object is updated
+   */
+  public function testSetUsingArray()
+  {
+    $deciderArray = [
+      "nomos_monk" => true,
+      "bulk_reused" => false,
+      "ojo_decider" => (1==1)
+    ];
+
+    $expectedObject = new Decider(true, false, false, true);
+
+    $actualObject = new Decider();
+    $actualObject->setUsingArray($deciderArray);
+
+    $this->assertEquals($expectedObject, $actualObject);
+  }
+
+  /**
+   * @test
+   * -# Test for Decider::getArray()
+   * -# Create expected array and update test object to match it
+   * -# Check if the response of getArray() on test object matches expected
+   *    array
+   */
+  public function testDataFormat()
+  {
+    $expectedArray = [
+      "nomos_monk"  => true,
+      "bulk_reused" => false,
+      "new_scanner" => false,
+      "ojo_decider" => true
+    ];
+
+    $actualObject = new Decider();
+    $actualObject->setNomosMonk(true);
+    $actualObject->setOjoDecider(true);
+
+    $this->assertEquals($expectedArray, $actualObject->getArray());
+  }
+}

--- a/src/www/ui_tests/api/Models/FileTest.php
+++ b/src/www/ui_tests/api/Models/FileTest.php
@@ -1,0 +1,69 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for File model
+ */
+
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\File;
+use Fossology\UI\Api\Models\Hash;
+use Fossology\UI\Api\Models\Findings;
+
+/**
+ * @class FileTest
+ * @brief Tests for File model
+ */
+class FileTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @test
+   * -# Test for keys in File model
+   */
+  public function testDataFormat()
+  {
+    $expectedArray = [
+      "hash" => [
+        "sha1" => "sha1checksum",
+        "md5" => "md5checksum",
+        "sha256" => "sha256checksum",
+        "size" => 123
+      ],
+      "findings"=> [
+        "scanner" => [
+          "License1"
+        ],
+        "conclusion" => [
+          "License2"
+        ],
+        "copyright" => []
+      ],
+      "uploads" => []
+    ];
+
+    $hash = new Hash('sha1checksum', 'md5checksum', 'sha256checksum', 123);
+    $findings = new Findings("License1", "License2", []);
+    $object = new File($hash);
+    $object->setFindings($findings);
+    $object->setUploads([]);
+
+    $this->assertEquals($expectedArray, $object->getArray());
+  }
+}

--- a/src/www/ui_tests/api/Models/FolderTest.php
+++ b/src/www/ui_tests/api/Models/FolderTest.php
@@ -1,0 +1,59 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for Folder model
+ */
+
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\Folder;
+
+/**
+ * @class FolderTest
+ * @brief Tests for Folder model
+ */
+class FolderTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @test
+   * -# Test for keys in Folder model
+   */
+  public function testDataFormat()
+  {
+    $expectedParent = [
+      'id' => 2,
+      'name' => 'parent',
+      'description' => 'Root folder',
+      'parent' => null
+    ];
+    $expectedChild = [
+      'id' => 3,
+      'name' => 'folder-1',
+      'description' => 'Folder 1',
+      'parent' => 2
+    ];
+
+    $parentFolder = new Folder('2', 'parent', 'Root folder', null);
+    $childFolder = new Folder('3', 'folder-1', 'Folder 1', '2');
+
+    $this->assertEquals($expectedParent, $parentFolder->getArray());
+    $this->assertEquals($expectedChild, $childFolder->getArray());
+  }
+}

--- a/src/www/ui_tests/api/Models/InfoTest.php
+++ b/src/www/ui_tests/api/Models/InfoTest.php
@@ -1,0 +1,58 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for Info model
+ */
+
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+
+/**
+ * @class InfoTest
+ * @brief Tests for Info model
+ */
+class InfoTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @test
+   * -# Test the data format returned by Info::getArray() model
+   */
+  public function testDataFormat()
+  {
+    $expectedInfo = [
+      'code' => 200,
+      'message' => "All good",
+      'type' => "INFO"
+    ];
+    $expectedError = [
+      'code' => 500,
+      'message' => "Something bad",
+      'type' => "ERROR"
+    ];
+
+    $actualInfo = new Info(200, "All good", InfoType::INFO);
+    $actualError = new Info(500, "Something bad", InfoType::ERROR);
+
+    $this->assertEquals($expectedInfo, $actualInfo->getArray());
+    $this->assertEquals($expectedError, $actualError->getArray());
+  }
+}

--- a/src/www/ui_tests/api/Models/JobTest.php
+++ b/src/www/ui_tests/api/Models/JobTest.php
@@ -1,0 +1,55 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for Job model
+ */
+
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\Job;
+
+/**
+ * @class JobTest
+ * @brief Test for Job model
+ */
+class JobTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @test
+   * -# Test data model returned by Job::getArray() is correct
+   */
+  public function testDataFormat()
+  {
+    $expectedStatus = [
+      'id'        => 22,
+      'name'      => 'ojo',
+      'queueDate' => '01-01-2020',
+      'uploadId'  => 4,
+      'userId'    => 2,
+      'groupId'   => 2,
+      'eta'       => 3,
+      'status'    => 'Processing'
+    ];
+
+    $actualJob = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+
+    $this->assertEquals($expectedStatus, $actualJob->getArray());
+  }
+}

--- a/src/www/ui_tests/api/Models/ReuserTest.php
+++ b/src/www/ui_tests/api/Models/ReuserTest.php
@@ -1,0 +1,104 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for Reueser model
+ */
+
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\Reuser;
+
+/**
+ * @class ReuserTest
+ * @brief Tests for Reuser model
+ */
+class ReuserTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @test
+   * -# Test constructor and Reuser::getArray()
+   */
+  public function testReuserConst()
+  {
+    $expectedArray = [
+      "reuse_upload"   => 2,
+      "reuse_group"    => 'fossy',
+      "reuse_main"     => true,
+      "reuse_enhanced" => false
+    ];
+
+    $actualReuser = new Reuser(2, 'fossy', true);
+
+    $this->assertEquals($expectedArray, $actualReuser->getArray());
+  }
+
+  /**
+   * @test
+   * -# Test if UnexpectedValueException is thrown for invalid upload and group
+   *    id by constructor
+   */
+  public function testReuserException()
+  {
+    $this->expectException(\UnexpectedValueException::class);
+    $this->expectExceptionMessage("reuse_upload should be integer");
+    $object = new Reuser('alpha', 2);
+  }
+
+  /**
+   * @test
+   * -# Test for Reuser::setUsingArray()
+   */
+  public function testSetUsingArray()
+  {
+    $expectedArray = [
+      "reuse_upload"   => 2,
+      "reuse_group"    => 'fossy',
+      "reuse_main"     => 'true',
+      "reuse_enhanced" => false
+    ];
+
+    $actualReuser = new Reuser(1, 'fossy');
+    $actualReuser->setUsingArray($expectedArray);
+
+    $expectedArray["reuse_main"] = true;
+    $this->assertEquals($expectedArray, $actualReuser->getArray());
+  }
+
+  /**
+   * @test
+   * -# Test if UnexpectedValueException is thrown for invalid upload and group
+   *    id by Reuser::setUsingArray()
+   */
+  public function testSetUsingArrayException()
+  {
+    $expectedArray = [
+      "reuse_upload"   => 'alpha',
+      "reuse_group"    => 'fossy',
+      "reuse_main"     => 'true',
+      "reuse_enhanced" => false
+    ];
+
+    $this->expectException(\UnexpectedValueException::class);
+    $this->expectExceptionMessage("reuse_upload should be integer");
+
+    $actualReuser = new Reuser(1, 'fossy');
+    $actualReuser->setUsingArray($expectedArray);
+  }
+}

--- a/src/www/ui_tests/api/Models/SearchResultTest.php
+++ b/src/www/ui_tests/api/Models/SearchResultTest.php
@@ -1,0 +1,55 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for SearchResult model
+ */
+
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\Upload;
+use Fossology\UI\Api\Models\SearchResult;
+use Fossology\UI\Api\Models\Hash;
+
+/**
+ * @class SearchResultTest
+ * @brief Test for SearchResult model
+ */
+class SearchResultTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @test
+   * -# Test the data format returned by SearchResult::getArray() model
+   */
+  public function testDataFormat()
+  {
+    $hash = new Hash('sha1checksum', 'md5checksum', 'sha256checksum', 123123);
+    $upload = new Upload(2, 'root', 3, '', 'my.tar.gz', '01-01-2020', $hash);
+    $expectedResult = [
+      'upload'        => $upload->getArray(),
+      'uploadTreeId'  => 12,
+      'filename'      => 'fileinupload.txt'
+    ];
+
+    $actualResult = new SearchResult($upload->getArray(), '12',
+      'fileinupload.txt');
+
+    $this->assertEquals($expectedResult, $actualResult->getArray());
+  }
+}

--- a/src/www/ui_tests/api/Models/UploadSummaryTest.php
+++ b/src/www/ui_tests/api/Models/UploadSummaryTest.php
@@ -1,0 +1,98 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for UploadSummary model
+ */
+
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\UploadSummary;
+use Fossology\Lib\Data\UploadStatus;
+
+/**
+ * @class UploadSummaryTest
+ * @brief Test cases for UploadSummary model
+ */
+class UploadSummaryTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @test
+   * -# Test the data format returned by UploadSummary::getArray() model
+   */
+  public function testDataFormat()
+  {
+    $expected = [
+      "id"                      => 5,
+      "uploadName"              => 'test.tar.gz',
+      "mainLicense"             => 'MIT',
+      "uniqueLicenses"          => 5,
+      "totalLicenses"           => 25,
+      "uniqueConcludedLicenses" => 1,
+      "totalConcludedLicenses"  => 25,
+      "filesToBeCleared"        => 0,
+      "filesCleared"            => 25,
+      "clearingStatus"          => "Closed",
+      "copyrightCount"          => 10
+    ];
+
+    $actual = new UploadSummary();
+    $actual->setUploadId(5);
+    $actual->setUploadName('test.tar.gz');
+    $actual->setMainLicense('MIT');
+    $actual->setUniqueLicenses(5);
+    $actual->setTotalLicenses(25);
+    $actual->setUniqueConcludedLicenses(1);
+    $actual->setTotalConcludedLicenses(25);
+    $actual->setFilesToBeCleared(0);
+    $actual->setFilesCleared(25);
+    $actual->setClearingStatus(UploadStatus::CLOSED);
+    $actual->setCopyrightCount(10);
+
+    $this->assertEquals($expected, $actual->getArray());
+  }
+
+  /**
+   * @test
+   * -# Test for UploadSummary::statusToString()
+   * -# Check if the function responds correct string for each UploadStatus
+   *    member.
+   * -# Also check if the function handles invalid values.
+   */
+  public function testStatusToString()
+  {
+    $expectedOpen = "Open";
+    $expectedProgress = "InProgress";
+    $expectedClosed = "Closed";
+    $expectedRejected = "Rejected";
+    $expectedDefault = "NA";
+
+    $this->assertEquals($expectedOpen,
+      UploadSummary::statusToString(UploadStatus::OPEN));
+    $this->assertEquals($expectedProgress,
+      UploadSummary::statusToString(UploadStatus::IN_PROGRESS));
+    $this->assertEquals($expectedClosed,
+      UploadSummary::statusToString(UploadStatus::CLOSED));
+    $this->assertEquals($expectedRejected,
+      UploadSummary::statusToString(UploadStatus::REJECTED));
+    $this->assertEquals($expectedDefault, UploadSummary::statusToString(null));
+    $this->assertEquals($expectedDefault,
+      UploadSummary::statusToString('garbage'));
+  }
+}

--- a/src/www/ui_tests/api/Models/UploadTest.php
+++ b/src/www/ui_tests/api/Models/UploadTest.php
@@ -1,0 +1,58 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for Upload model
+ */
+
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\Upload;
+use Fossology\UI\Api\Models\Hash;
+
+/**
+ * @class UploadTest
+ * @brief Test for Upload model
+ */
+class UploadTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @test
+   * -# Test the data format returned by Upload::getArray() model
+   */
+  public function testDataFormat()
+  {
+    $hash = new Hash('sha1checksum', 'md5checksum', 'sha256checksum', 123123);
+    $upload = new Upload(2, 'root', 3, '', 'my.tar.gz', '01-01-2020', $hash);
+    $expectedUpload = [
+      "folderid"    => 2,
+      "foldername"  => 'root',
+      "id"          => 3,
+      "description" => '',
+      "uploadname"  => 'my.tar.gz',
+      "uploaddate"  => '01-01-2020',
+      "hash"        => $hash->getArray()
+    ];
+
+    $actualUpload = new Upload(2, 'root', 3, '', 'my.tar.gz', '01-01-2020',
+      $hash);
+
+    $this->assertEquals($expectedUpload, $actualUpload->getArray());
+  }
+}

--- a/src/www/ui_tests/api/Models/UserTest.php
+++ b/src/www/ui_tests/api/Models/UserTest.php
@@ -1,0 +1,77 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2020 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for User model
+ */
+
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\User;
+
+require_once dirname(dirname(dirname(dirname(__DIR__)))) .
+  '/lib/php/Plugin/FO_Plugin.php';
+
+/**
+ * @class UserTest
+ * @brief Tests for User model
+ */
+class UserTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @test
+   * -# Test the data format returned by User::getArray() model
+   */
+  public function testDataFormat()
+  {
+    $expectedCurrentUser = [
+      "id"           => 2,
+      "name"         => 'fossy',
+      "description"  => 'super user',
+      "email"        => 'fossy@localhost',
+      "accessLevel"  => 'admin',
+      "rootFolderId" => 2,
+      "emailNotification" => true,
+      "agents"       => [
+        "bucket"    => true,
+        "copyright_email_author" => true,
+        "ecc"       => false,
+        "keyword"   => false,
+        "mimetype"  => false,
+        "monk"      => false,
+        "nomos"     => true,
+        "ojo"       => true,
+        "package"   => false
+      ]
+    ];
+    $expectedNonAdminUser = [
+      "id"           => 8,
+      "name"         => 'userii',
+      "description"  => 'very useri',
+    ];
+
+    $actualCurrentUser = new User(2, 'fossy', 'super user', 'fossy@localhost',
+      PLUGIN_DB_ADMIN, 2, true, "bucket,copyright,nomos,ojo");
+    $actualNonAdminUser = new User(8, 'userii', 'very useri', null, null, null,
+      null, null);
+
+    $this->assertEquals($expectedCurrentUser, $actualCurrentUser->getArray());
+    $this->assertEquals($expectedNonAdminUser, $actualNonAdminUser->getArray());
+  }
+}

--- a/src/www/ui_tests/api/tests.xml
+++ b/src/www/ui_tests/api/tests.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<phpunit
+  bootstrap="../../../phpunit-bootstrap.php" colors="true"
+  backupGlobals="true"
+  beStrictAboutTestsThatDoNotTestAnything="false"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="false"
+  stopOnFailure="false">
+
+  <testsuites>
+    <testsuite name="Fossology PhpUnit REST API">
+      <directory suffix="Test.php">Controllers</directory>
+      <directory suffix="Test.php">Helper</directory>
+      <directory suffix="Test.php">Models</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Adding unit test cases for REST API.

### Changes

1. Some changes are done in `Contollers` to use Helper class to get userID and groupID.
1. Created new folder `src/www/ui_tests/api/` containing all the test cases.
1. Added test suite for REST API to `src/phpunit.xml`.

## How to test

1. Run `make test-www` or `src/vendor/bin/phpunit -csrc/phpunit.xml --testsuite="Fossology PhpUnit Test Suite"` or check the Travis log.

Partial work on #1590