### PR TITLE
feat(ci): Use FOSSology scanners CI

### DIFF
--- a/utils/automation/.gitlab-ci.sample.yml
+++ b/utils/automation/.gitlab-ci.sample.yml
@@ -1,0 +1,57 @@
+# Copyright Siemens AG 2020, anupam.ghosh@siemens.com, gaurav.mishra@siemens.com
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+stages:
+  - license
+
+license_check:
+  stage: license
+  image: fossology/fossology:scanner
+  script:
+    - /bin/fossologyscanner nomos ojo
+  only: [merge_requests]
+  artifacts:
+    paths:
+    - results
+    expire_in: 1 week
+    when: on_failure
+
+copyright_check:
+  stage: license
+  image: fossology/fossology:scanner
+  script:
+    - /bin/fossologyscanner copyright keyword
+  only: [merge_requests]
+  artifacts:
+    paths:
+    - results
+    expire_in: 1 week
+    when: on_failure
+
+repo_license_scan:
+  stage: license
+  image: fossology/fossology:scanner
+  script:
+    - /bin/fossologyscanner repo nomos ojo
+  only: [tags]
+  artifacts:
+    paths:
+    - results
+    expire_in: 1 week
+    when: on_failure
+
+repo_copyright_check:
+  stage: license
+  image: fossology/fossology:scanner
+  script:
+    - /bin/fossologyscanner copyright keyword repo
+  only: [tags]
+  artifacts:
+    paths:
+    - results
+    expire_in: 1 week
+    when: on_failure

--- a/utils/automation/.travis.sample.yml
+++ b/utils/automation/.travis.sample.yml
@@ -1,0 +1,41 @@
+# Copyright Siemens AG 2020, anupam.ghosh@siemens.com, gaurav.mishra@siemens.com
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+dist: bionic
+os: linux
+
+services:
+  - docker
+
+jobs:
+  include:
+    - stage: Compliance
+      name: Copyright
+      addons: {}
+      services: docker
+      script:
+        - >-
+          if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+          docker pull fossology/fossology:scanner
+          && docker run --name "fossologyscanner" -w "/opt/repo" -v ${PWD}:/opt/repo
+          -e TRAVIS=${TRAVIS} -e TRAVIS_REPO_SLUG=${TRAVIS_REPO_SLUG}
+          -e TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST}
+          fossology/fossology:scanner "/bin/fossologyscanner" copyright keyword ;
+          fi
+    - stage: Compliance
+      name: License
+      addons: {}
+      services: docker
+      script:
+        - >-
+          if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+          docker pull fossology/fossology:scanner
+          && docker run --name "fossologyscanner" -w "/opt/repo" -v ${PWD}:/opt/repo
+          -e TRAVIS=${TRAVIS} -e TRAVIS_REPO_SLUG=${TRAVIS_REPO_SLUG}
+          -e TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST}
+          fossology/fossology:scanner "/bin/fossologyscanner" nomos ojo ;
+          fi

--- a/utils/automation/Dockerfile.ci
+++ b/utils/automation/Dockerfile.ci
@@ -1,0 +1,75 @@
+# FOSSologyNG CI Dockerfile
+# Copyright Siemens AG 2020, anupam.ghosh@siemens.com, gaurav.mishra@siemens.com
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Description: Gitlab CI runner image recipie
+# Using Debian 10
+
+FROM debian:buster-slim as builder
+
+WORKDIR /fossologyng
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    git \
+    lsb-release \
+    php-cli \
+    sudo \
+    dpkg-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY ./utils/fo-installdeps ./utils/fo-installdeps
+COPY ./utils/utils.sh ./utils/utils.sh
+COPY ./src/nomos/mod_deps ./src/nomos/
+COPY ./src/ojo/mod_deps ./src/ojo/
+COPY ./src/copyright/mod_deps ./src/copyright/
+
+RUN mkdir -p /fossologyng/dependencies-for-runtime \
+ && cp -R /fossologyng/src /fossologyng/utils /fossologyng/dependencies-for-runtime/
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+ && DEBIAN_FRONTEND=noninteractive /fossologyng/utils/fo-installdeps --build --offline -y \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+RUN chown $(whoami):$(whoami) -R .
+
+RUN make clean build-lib \
+ && make -C src/nomos/agent -f Makefile.sa all \
+ && make -C src/copyright/agent copyright \
+ && make -C src/copyright/agent keyword \
+ && make -C src/ojo/agent ojo
+
+RUN dpkg-shlibdeps -Orun-deps -esrc/nomos/agent/nomossa \
+                              -esrc/copyright/agent/copyright \
+                              -esrc/copyright/agent/keyword \
+                              -esrc/ojo/agent/ojo \
+ && sed -E -i -e 's/(shlibs:Depends=)|(\(>=?[ 0-9\:\.\~\-]*\))|(,)//g' run-deps
+
+FROM debian:buster-slim
+
+LABEL maintainer="Fossology <fossology@fossology.org>"
+
+COPY --from=builder /fossologyng/src/nomos/agent/nomossa /bin/nomossa
+COPY --from=builder /fossologyng/src/ojo/agent/ojo /bin/ojo
+COPY --from=builder /fossologyng/src/copyright/agent/copyright /bin/copyright
+COPY --from=builder /fossologyng/src/copyright/agent/copyright.conf /usr/local/share/fossology/copyright/agent/copyright.conf
+COPY --from=builder /fossologyng/src/copyright/agent/keyword /bin/keyword
+COPY --from=builder /fossologyng/src/copyright/agent/keyword.conf /usr/local/share/fossology/keyword/agent/keyword.conf
+COPY --from=builder /fossologyng/run-deps /opt/run-deps
+
+COPY ./utils/automation/fossologyscanner.py /bin/fossologyscanner
+
+RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' >> /etc/apt/apt.conf \
+ && DEBIAN_FRONTEND=noninteractive apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install --yes \
+ --no-install-recommends $(cat /opt/run-deps) python3 \
+ && DEBIAN_FRONTEND=noninteractive apt-get autoremove --yes \
+ && rm -rf /var/lib/apt/lists/* /opt/run-deps
+
+CMD ["bash"]

--- a/utils/automation/fossologyscanner.py
+++ b/utils/automation/fossologyscanner.py
@@ -1,0 +1,575 @@
+#!/usr/bin/env python3
+
+# Copyright Siemens AG 2020, anupam.ghosh@siemens.com, gaurav.mishra@siemens.com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from subprocess import PIPE, Popen
+import multiprocessing
+import urllib.request
+import tempfile
+import fnmatch
+import json
+import ssl
+import sys
+import re
+import os
+
+RUNNING_ON = None
+TRAVIS_REPO_SLUG = None
+TRAVIS_PULL_REQUEST = None
+API_URL = None
+PROJECT_ID = None
+MR_IID = None
+API_TOKEN = None
+
+
+def get_ci_name():
+  '''
+  Set the environment variables based on CI the job is running on
+  '''
+  global RUNNING_ON
+  global TRAVIS_REPO_SLUG
+  global TRAVIS_PULL_REQUEST
+  global API_URL
+  global PROJECT_ID
+  global MR_IID
+  global API_TOKEN
+
+  if 'GITLAB_CI' in os.environ:
+    RUNNING_ON = 'GITLAB'
+    API_URL = os.environ['CI_API_V4_URL'] if 'CI_API_V4_URL' in os.environ else ''
+    PROJECT_ID = os.environ['CI_PROJECT_ID'] if 'CI_PROJECT_ID' in os.environ else ''
+    MR_IID = os.environ['CI_MERGE_REQUEST_IID'] if 'CI_MERGE_REQUEST_IID' in os.environ else ''
+    API_TOKEN = os.environ['API_TOKEN'] if 'API_TOKEN' in os.environ else ''
+  elif 'TRAVIS' in os.environ and os.environ['TRAVIS'] == 'true':
+    RUNNING_ON = 'TRAVIS'
+    TRAVIS_REPO_SLUG = os.environ['TRAVIS_REPO_SLUG']
+    TRAVIS_PULL_REQUEST = os.environ['TRAVIS_PULL_REQUEST']
+
+class CliOptions(object):
+  '''
+  Hold the various shared flags and data
+
+  :ivar nomos: run nomos scanner
+  :ivar ojo: run ojo scanner
+  :ivar copyright: run copyright scanner
+  :ivar keyword: run keyword scanner
+  :ivar repo: scan whole repo or just diff
+  :ivar diff_dir: directory to scan
+  :ivar whitelist: information from whitelist.json
+  '''
+  nomos = False
+  ojo = False
+  copyright = False
+  keyword = False
+  repo = False
+  diff_dir = os.getcwd()
+  whitelist = {
+    'licenses': [],
+    'exclude': []
+  }
+
+
+def get_white_list():
+  """
+  Decode json from `whitelist.json`
+
+  :return: whilte list dictionary
+  :rtype: dict()
+  """
+  with open('whitelist.json') as f:
+    data = json.load(f)
+  return data
+
+
+class RepoSetup:
+  """
+  Setup temp_dir using the diff or current MR
+  """
+
+  def __init__(self, cli_options):
+    """
+    Create a temp dir
+
+    :param cli_options: CliOptions object to get whitelist from
+    :type cli_options: CliOptions
+    """
+    self.temp_dir = tempfile.TemporaryDirectory()
+    self.whitelist = cli_options.whitelist
+
+  def __del__(self):
+    """
+    Clean the created temp dir
+    """
+    self.temp_dir.cleanup()
+
+  def __is_excluded_path(self, path):
+    """
+    Check if the path is whitelisted
+
+    The function used fnmatch to check if the path is in whiltelist or not.
+
+    :param path: path to check
+    :type path: string
+
+    :return: True if the path is in white list, False otherwise
+    :rtype: boolean
+    """
+    path_is_excluded = False
+    for pattern in self.whitelist['exclude']:
+      if fnmatch.fnmatchcase(path, pattern):
+        path_is_excluded = True
+        break
+    return path_is_excluded
+
+  def get_diff_dir(self):
+    """
+    Populate temp dir using the gitlab API `merge_requests`
+
+    :return: temp dir path
+    :rtype: string
+    """
+    change_response = None
+    path_key = None
+    change_key = None
+
+    if RUNNING_ON == "GITLAB":
+      api_req_url = f"{API_URL}/projects/{PROJECT_ID}/merge_requests" + \
+        f"/{MR_IID}/changes"
+      headers = {'Private-Token': API_TOKEN}
+      path_key = "new_path"
+      change_key = "diff"
+    else:
+      api_req_url = f"https://api.github.com/repos/{TRAVIS_REPO_SLUG}" + \
+        f"/pulls/{TRAVIS_PULL_REQUEST}/files"
+      headers = {}
+      path_key = "filename"
+      change_key = "patch"
+
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+
+    req = urllib.request.Request(api_req_url, headers=headers)
+    try:
+      with urllib.request.urlopen(req, context=context) as response:
+        change_response = response.read()
+    except Exception as e:
+      print(f"Unable to get URL {api_req_url}")
+      raise e
+
+    change_response = json.loads(change_response)
+    if RUNNING_ON == "GITLAB":
+      changes = change_response['changes']
+    else:
+      changes = change_response
+
+    remove_diff_regex = re.compile(r"^([ +-])(.*)$", re.MULTILINE)
+
+    for change in changes:
+      if change[path_key] is not None:
+        path_to_be_excluded = self.__is_excluded_path(change[path_key])
+        if path_to_be_excluded == False:
+          curr_file = os.path.join(self.temp_dir.name, change[path_key])
+          curr_dir = os.path.dirname(curr_file)
+          if curr_dir != self.temp_dir.name:
+            os.makedirs(name=curr_dir, exist_ok=True)
+          curr_file = open(file=curr_file, mode='w+', encoding='UTF-8')
+          print(re.sub(remove_diff_regex, r"\2", change[change_key]),
+                file=curr_file)
+
+    return self.temp_dir.name
+
+
+class Scanners:
+  """
+  Handle all the data from different scanners
+
+  :ivar nomos_path: path to nomos bin
+  :ivar copyright_path: path to copyright bin
+  :ivar keywrod_path: path to keyword bin
+  :ivar ojo_path: path to ojo bin
+  :ivar cli_options: CliOptions object
+  """
+  nomos_path = '/bin/nomossa'
+  copyright_path = '/bin/copyright'
+  keyword_path = '/bin/keyword'
+  ojo_path = '/bin/ojo'
+
+  def __init__(self, cli_options):
+    """
+    Initialize the cli_options
+
+    :param cli_options: CliOptions object to use
+    :type cli_options: CliOptions
+    """
+    self.cli_options = cli_options
+
+  def __is_excluded_path(self, path):
+    """
+    Check if the path is whitelisted
+
+    The function used fnmatch to check if the path is in whiltelist or not.
+
+    :param path: path to check
+    :type path: string
+
+    :return: True if the path is in white list, False otherwise
+    :rtype: boolean
+    """
+    path_is_excluded = False
+    for pattern in self.cli_options.whitelist['exclude']:
+      if fnmatch.fnmatchcase(path, pattern):
+        path_is_excluded = True
+        break
+    return path_is_excluded
+
+  def __normalize_path(self, path):
+    """
+    Noramalize the given path to repository root
+
+    :param path: path to normalize
+    :type path: string
+
+    :return: False if the path is white listed, normalized path otherwise
+    :rtype: string
+    """
+    path = path.replace(f"{self.cli_options.diff_dir}/", '')
+    if self.cli_options.repo == True:
+      path_is_excluded = self.__is_excluded_path(path)
+      if path_is_excluded == True:
+        return False
+    return path
+
+  def __get_nomos_result(self):
+    """
+    Get the raw results from nomos scanner
+
+    :return: raw json from nomos
+    :rtype: dict()
+    """
+    nomossa_process = Popen([self.nomos_path, "-J", "-l", "-d",
+                             self.cli_options.diff_dir, "-n",
+                             str(multiprocessing.cpu_count() - 1)], stdout=PIPE)
+    result = nomossa_process.communicate()[0]
+    return json.loads(result.decode('UTF-8').strip())
+
+  def __get_ojo_result(self):
+    """
+    Get the raw results from ojo scanner
+
+    :return: raw json from ojo
+    :rtype: dict()
+    """
+    ojo_process = Popen([self.ojo_path, "-J", "-d", self.cli_options.diff_dir],
+                        stdout=PIPE)
+    result = ojo_process.communicate()[0]
+    return json.loads(result.decode('UTF-8').strip())
+
+  def __get_copyright_results(self):
+    """
+    Get the raw results from copyright scanner
+
+    :return: raw json from copyright
+    :rtype: dict()
+    """
+    copyright_process = Popen([self.copyright_path, "-J", "-d",
+                               self.cli_options.diff_dir], stdout=PIPE)
+    result = copyright_process.communicate()[0]
+    return json.loads(result.decode('UTF-8').strip())
+
+  def __get_keyword_results(self):
+    """
+    Get the raw results from keyword scanner
+
+    :return: raw json from keyword
+    :rtype: dict()
+    """
+    keyword_process = Popen([self.keyword_path, "-J", "-d",
+                             self.cli_options.diff_dir], stdout=PIPE)
+    result = keyword_process.communicate()[0]
+    return json.loads(result.decode('UTF-8').strip())
+
+  def get_copyright_list(self):
+    """
+    Get the formated results from copyright scanner
+
+    :return: list of findings
+    :rtype: list()
+    """
+    copyright_results = self.__get_copyright_results()
+    copyright_list = list()
+    for result in copyright_results:
+      path = self.__normalize_path(result['file'])
+      if path == False:
+        continue
+      if result['results'] != None and result['results'] != "Unable to read file":
+        contents = list()
+        for finding in result['results']:
+          if finding is not None and finding['type'] == "statement":
+            content = finding['content'].strip()
+            if content != "":
+              contents.append(content)
+        if len(contents) > 0:
+          copyright_list.append({
+            'file': path,
+            'result': contents
+          })
+    if len(copyright_list) > 0:
+      return copyright_list
+    return False
+
+  def get_keyword_list(self):
+    """
+    Get the formated results from keyword scanner
+
+    :return: list of findings
+    :rtype: list()
+    """
+    keyword_results = self.__get_keyword_results()
+    keyword_list = list()
+    for result in keyword_results:
+      path = self.__normalize_path(result['file'])
+      if path == False:
+        continue
+      if result['results'] != None and result['results'] != "Unable to read file":
+        contents = list()
+        for finding in result['results']:
+          if finding is not None:
+            content = finding['content'].strip()
+            if content != "":
+              contents.append(content)
+        if len(contents) > 0:
+          keyword_list.append({
+            'file': path,
+            'result': contents
+          })
+    if len(keyword_list) > 0:
+      return keyword_list
+    return False
+
+  def __get_non_whitelisted_license_nomos(self):
+    """
+    Get the formated results from nomos scanner
+
+    :return: list of findings
+    :rtype: list()
+    """
+    nomos_result = self.__get_nomos_result()
+    failed_licenses = list()
+    for result in nomos_result['results']:
+      path = self.__normalize_path(result['file'])
+      if path == False:
+        continue
+      if result['licenses'] != None and result['licenses'][0] != 'No_license_found':
+        licenses = set()
+        for license in result['licenses']:
+          if license not in self.cli_options.whitelist['licenses'] and license != 'No_license_found':
+            licenses.add(license.strip())
+        if len(licenses) > 0:
+          failed_licenses.append({
+            'file': path,
+            'result': licenses
+          })
+    return failed_licenses
+
+  def __get_non_whitelisted_license_ojo(self):
+    """
+    Get the formated results from ojo scanner
+
+    :return: list of findings
+    :rtype: list()
+    """
+    ojo_result = self.__get_ojo_result()
+    failed_licenses = list()
+    for result in ojo_result:
+      path = self.__normalize_path(result['file'])
+      if path == False:
+        continue
+      if result['results'] != None and result['results'] != 'Unable to read file':
+        licenses = set()
+        for finding in result['results']:
+          if finding['license'] not in self.cli_options.whitelist['licenses'] and finding['license'] != None:
+            licenses.add(finding['license'].strip())
+        if len(licenses) > 0:
+          failed_licenses.append({
+            'file': path,
+            'result': licenses
+          })
+    return failed_licenses
+
+  def __merge_nomos_ojo(self, nomos_licenses, ojo_licenses):
+    """
+    Merge the results from nomos and ojo based on file name
+
+    :param nomos_licenses: formatted result form nomos
+    :type nomos_licenses: list()
+    :param ojo_licenses: formatted result form ojo
+    :type ojo_licenses: list()
+
+    :return: merged list of scanner findings
+    :rtype: list()
+    """
+    for ojo_entry in ojo_licenses:
+      for nomos_entry in nomos_licenses:
+        if ojo_entry['file'] == nomos_entry['file']:
+          nomos_entry['result'].update(ojo_entry['result'])
+          break
+      else:
+        nomos_licenses.append(ojo_entry)
+    return nomos_licenses
+
+  def results_are_whitelisted(self):
+    """
+    Get the formatted list of license scanner findings
+
+    The list contains the merged result of nomos/ojo scanner based on
+    cli_options passed
+
+    :return: merged list of scanner findings
+    :rtype: list()
+    """
+    failed_licenses = None
+    if self.cli_options.nomos:
+      nomos_licenses = self.__get_non_whitelisted_license_nomos()
+      if self.cli_options.ojo == False:
+        failed_licenses = nomos_licenses
+    if self.cli_options.ojo:
+      ojo_licenses = self.__get_non_whitelisted_license_ojo()
+      if self.cli_options.nomos == False:
+        failed_licenses = ojo_licenses
+      else:
+        failed_licenses = self.__merge_nomos_ojo(nomos_licenses,
+                             ojo_licenses)
+    if len(failed_licenses) > 0:
+      return failed_licenses
+    return True
+
+
+def parse_argv(argv):
+  """
+  Parse the arguments passed and translate them to CliOptions object
+
+  :return: CliOptions object
+  :rtype: CliOptions
+  """
+  cli_options = CliOptions
+  if "nomos" in argv:
+    cli_options.nomos = True
+  if "copyright" in argv:
+    cli_options.copyright = True
+  if "keyword" in argv:
+    cli_options.keyword = True
+  if "ojo" in argv:
+    cli_options.ojo = True
+  if "repo" in argv:
+    cli_options.repo = True
+  if cli_options.nomos == False and cli_options.ojo == False and cli_options.copyright == False and cli_options.keyword == False:
+    cli_options.nomos = True
+    cli_options.ojo = True
+    cli_options.copyright = True
+    cli_options.keyword = True
+  return cli_options
+
+
+def print_results(name, failed_results, result_file):
+  """
+  Print the formatted scanner results
+
+  :param name: Name of the scanner
+  :type name: string
+  :param failed_results: formatted scanner results to be printed
+  :type failed_results: list()
+  :param result_file: File to write results to
+  :type result_file: TextIOWrapper
+  """
+  for files in failed_results:
+    print(f"File: {files['file']}")
+    result_file.write(f"File: {files['file']}\n")
+    plural = ""
+    if len(files['result']) > 1:
+      plural = "s"
+    print(f"{name}{plural}:")
+    result_file.write(f"{name}{plural}:\n")
+    for result in files['result']:
+      print("\t" + result)
+      result_file.write("\t" + result + "\n")
+
+
+def main(argv):
+  get_ci_name()
+  cli_options = parse_argv(argv)
+
+  try:
+    cli_options.whitelist = get_white_list()
+  except FileNotFoundError:
+    print("Unable to find whitelist.json in current dir\n" +
+          "Continuing without it.", file=sys.stderr)
+
+  repo_setup = RepoSetup(cli_options)
+  if cli_options.repo == False:
+    cli_options.diff_dir = repo_setup.get_diff_dir()
+
+  scanner = Scanners(cli_options)
+  return_val = 0
+
+  # Create result dir
+  result_dir = "results"
+  os.makedirs(name=result_dir, exist_ok=True)
+
+  if cli_options.nomos or cli_options.ojo:
+    license_file = open(f"{result_dir}/licenses.txt", 'w')
+    failed_licenses = scanner.results_are_whitelisted()
+    if failed_licenses != True:
+      print("\u2718 Following licenses found which are not whitelisted:")
+      license_file.write("Following licenses found which are not whitelisted:\n")
+      print_results("License", failed_licenses, license_file)
+      return_val = return_val | 2
+    else:
+      print("\u2714 No license violation found")
+      license_file.write("No license violation found")
+    print()
+    license_file.close()
+  if cli_options.copyright:
+    copyright_file = open(f"{result_dir}/copyrights.txt", 'w')
+    copyright_results = scanner.get_copyright_list()
+    if copyright_results != False:
+      print("\u2718 Following copyrights found:")
+      copyright_file.write("Following copyrights found:\n")
+      print_results("Copyright", copyright_results, copyright_file)
+      return_val = return_val | 4
+    else:
+      print("\u2714 No copyright violation found")
+      copyright_file.write("No copyright violation found")
+    print()
+    copyright_file.close()
+  if cli_options.keyword:
+    keyword_file = open(f"{result_dir}/keywords.txt", 'w')
+    keyword_results = scanner.get_keyword_list()
+    if keyword_results != False:
+      print("\u2718 Following keywords found:")
+      keyword_file.write("Following keywords found:\n")
+      print_results("Keyword", keyword_results, keyword_file)
+      return_val = return_val | 8
+    else:
+      print("\u2714 No keyword violation found")
+      keyword_file.write("No keyword violation found")
+    print()
+    keyword_file.close()
+  return return_val
+
+
+if __name__ == "__main__":
+   sys.exit(main(sys.argv))

--- a/utils/automation/whitelist.sample.json
+++ b/utils/automation/whitelist.sample.json
@@ -1,0 +1,11 @@
+{
+  "licenses": [
+    "GPL-2.0+",
+    "GPL-2.0",
+    "LGPL-2.0+"
+  ],
+  "exclude": [
+    "*/agent_tests/*",
+    "src/vendor/*"
+  ]
+}


### PR DESCRIPTION
## Description

An idea to provide FOSSology scanners as GitLab runner to do license scanning in a GitLab CI pipeline.

Sample files are provided for .gitlab-ci.yml and whitelist.json under the same folder.

### Changes

1. A new folder created named `utils/automation` to hold all the relevant files.
1. File `Dockerfile.ci` creates a slim docker image which can then be used by GitLab runners to scan the code.
1. The file `fossologyscanner.py` can be used as an entry point which in turns call other scanners and collect the output from them.

## How to test
### Building the image
```shell
docker build -t fossology/fossology:scanner -f utils/automation/Dockerfile.ci .
```

### Testing on GitLab runners
Please check the provided `.gitlab-ci.sample.yml` file.

### Testing on Travis
Please check the provided `.travis.sample.yml` file.

### Testing on Docker container
```shell
docker run -it -v <path/to/scan>:/project fossology/fossology:runner
cd /project
/bin/fossologyscanner [copyright|nomos|ojo|keyword] repo
```

## Todo
- [x] Write a wiki explaining the working of runner. [FOSSology scanners in CI](https://github.com/fossology/fossology/wiki/FOSSology-scanners-in-CI)
- [ ] Setup docker hub triggers once PR gets merged.