### PR TITLE
fix(bulk): add class to show text highlighted for matched page

### DIFF
--- a/src/www/ui/template/bulk-history.html.twig
+++ b/src/www/ui/template/bulk-history.html.twig
@@ -28,13 +28,15 @@
             {% endif %}
           </table>
       </td>
-      <td>
       {% if bulkHistoryHighlightUri and row.id > 0 and row.matched %}
+      <td class="hi-bulk">
       <a href="{{ bulkHistoryHighlightUri }}&item={{ itemId }}&clearingId={{ row.id }}#highlight">{{ row.text|e }}<a>
-      {% else %}
-      {{ row.text|e }}
-      {% endif %}
       </td>
+      {% else %}
+      <td>
+      {{ row.text|e }}
+      </td>
+      {% endif %}
     </tr>
   {% endfor %}
   {% else %}


### PR DESCRIPTION


<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

* Add missing class to highlight text for bulk. in case of matched file.

## How to test

* Upload a package and run bulk for multiple files with different text phrases.
* Check if in each file in bulk history if the matched text is highlighted. 
