### PR TITLE
perf(license_candidate): Create PRIMARY KEY

### DIFF
--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -2042,6 +2042,7 @@
   $Schema["CONSTRAINT"]["keyword_decision_pfile_fk_fkey"] = "ALTER TABLE \"keyword_decision\" ADD CONSTRAINT \"keyword_decision_pfile_fk_fkey\" FOREIGN KEY (\"pfile_fk\") REFERENCES \"pfile\" (\"pfile_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["keyword_decision_pfile_hash_ukey"] = "ALTER TABLE \"keyword_decision\" ADD CONSTRAINT \"keyword_decision_pfile_hash_ukey\" UNIQUE (\"pfile_fk\",\"hash\");";
   $Schema["CONSTRAINT"]["license_candidate_fkey"] = "ALTER TABLE \"license_candidate\" ADD CONSTRAINT \"license_candidate_fkey\" FOREIGN KEY (\"group_fk\") REFERENCES \"groups\" (\"group_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
+  $Schema["CONSTRAINT"]["license_candidate_rf_pk_idk"] = "ALTER TABLE \"license_candidate\" ADD CONSTRAINT \"license_candidate_rf_pk_idk\" PRIMARY KEY (\"rf_pk\");";
   $Schema["CONSTRAINT"]["license_file_pkey"] = "ALTER TABLE \"license_file\" ADD CONSTRAINT \"license_file_pkey\" PRIMARY KEY (\"fl_pk\");";
   $Schema["CONSTRAINT"]["license_file_pfile_fk_fkey"] = "ALTER TABLE \"license_file\" ADD CONSTRAINT \"license_file_pfile_fk_fkey\" FOREIGN KEY (\"pfile_fk\") REFERENCES \"pfile\" (\"pfile_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["license_map_pkpk"] = "ALTER TABLE \"license_map\" ADD CONSTRAINT \"license_map_pkpk\" PRIMARY KEY (\"license_map_pk\");";


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Create a PRIMARY KEY index for `license_candidate` table. This will result in significant performance improvement for join of `license_file` table and `license_candidate` for calculating the license histogram in the left side of License Browser page.

### Changes

1. Create new index `license_candidate_rf_pk_idk` on `license_candidate` table.

## How to test

On a big FOSSology instance, check the load time of **License Browser** page for a big package before and after creating the index.

The following query is used to create license histogram by `LicenseDao::getLicenseHistogram()`:
```sql
SELECT rf_shortname AS license_shortname, rf_pk, count(*) AS count, count(distinct pfile_ref.pfile_fk) as unique
  FROM ( SELECT license_ref.rf_shortname, license_ref.rf_pk, license_file.fl_pk, license_file.agent_fk, license_file.pfile_fk
    FROM license_file
    JOIN license_ref ON license_file.rf_fk = license_ref.rf_pk) AS pfile_ref
    RIGHT JOIN uploadtree_a UT ON pfile_ref.pfile_fk = UT.pfile_fk AND agent_fk=ANY($4) WHERE (rf_shortname IS NULL OR rf_shortname NOT IN ('Void')) AND upload_fk=$1
  AND (UT.lft BETWEEN $2 AND $3) AND UT.ufile_mode&(3<<28)=0
GROUP BY license_shortname, rf_pk;
```

The query currently performs sequential join for `license_candidate` and `license_file`:
```
->  Append  (cost=0.28..1.64 rows=2 width=19) (actual time=0.001..0.002 rows=0 loops=1065)
       ->  Index Scan using rf_pkpk on license_ref  (cost=0.28..0.62 rows=1 width=19) (actual time=0.001..0.001 rows=0 loops=1065)
              Index Cond: (rf_pk = license_file.rf_fk)
       ->  Seq Scan on license_candidate  (cost=0.00..1.01 rows=1 width=29) (actual time=0.000..0.000 rows=0 loops=1065)
              Filter: (license_file.rf_fk = rf_pk)
              Rows Removed by Filter: 1
```

With the index, join will be performed by much faster index scan on SSD drives:
```
->  Append  (cost=0.28..0.77 rows=2 width=19) (actual time=0.001..0.001 rows=0 loops=1065)
       ->  Index Scan using rf_pkpk on license_ref  (cost=0.28..0.62 rows=1 width=19) (actual time=0.001..0.001 rows=0 loops=1065)
              Index Cond: (rf_pk = license_file.rf_fk)
       ->  Index Scan using license_candidate_rf_pk_idk on license_candidate  (cost=0.12..0.14 rows=1 width=29) (actual time=0.000..0.000 rows=0 loops=1065)
              Index Cond: (rf_pk = license_file.rf_fk)
```