### PR TITLE
fix(ui): Use default timezone if not set

### DIFF
--- a/src/lib/php/common-ui.php
+++ b/src/lib/php/common-ui.php
@@ -297,10 +297,12 @@ function Get1stUploadtreeID($upload)
  */
 function Convert2BrowserTime($server_time)
 {
-  $tz = $_SESSION["timezone"];
   $server_timezone = date_default_timezone_get();
   $browser_time = new \DateTime($server_time, new \DateTimeZone($server_timezone));
-  $browser_time->setTimeZone(new \DateTimeZone($tz));
+  if (array_key_exists("timezone", $_SESSION)) {
+    $tz = $_SESSION["timezone"];
+    $browser_time->setTimeZone(new \DateTimeZone($tz));
+  }
   $time = $browser_time->format('Y-m-d H:i:s');
   return $time;
 }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Under some circumstances, like if the user has old cookie or interacting with REST API, the `$_SESSION` will be missing timezone string. In such cases, use the server timezone instead, otherwise update the timezone as per the value stored in cookie.

### Changes

1. If the session contains timezone, update the timezone, otherwise leave it to server timezone.

## How to test

Check #1741

Also, check if the simple workflow of REST API is working.

Closes #1741