### PR TITLE
feat(conf): add textarea in conf page for notes

### DIFF
--- a/src/unifiedreport/agent/reportStatic.php
+++ b/src/unifiedreport/agent/reportStatic.php
@@ -217,6 +217,10 @@ class ReportStatic
     $this->addCheckBoxText($cell, $getCheckboxList[2], $nodependenciesfound);
     $this->addCheckBoxText($cell, $getCheckboxList[3], $dependenciesfoundinsourcecode);
     $this->addCheckBoxText($cell, $getCheckboxList[4], $dependenciesfoundinbinaries);
+    if ($otherStatement["ri_depnotes"] != 'NA' && !empty($otherStatement["ri_depnotes"])) {
+      $extraNotes = str_replace("\n", "<w:br/>", htmlspecialchars($otherStatement["ri_depnotes"], ENT_DISALLOWED));
+      $cell->addText($extraNotes, $rightColStyleBlue, "pStyle");
+    }
 
     $noexportrestrictionsfound = " no export restrictions found";
     $exportrestrictionsfound = " export restrictions found (see obligations)";
@@ -225,6 +229,10 @@ class ReportStatic
     $cell = $table->addCell($cellLen);
     $this->addCheckBoxText($cell, $getCheckboxList[5], $noexportrestrictionsfound);
     $this->addCheckBoxText($cell, $getCheckboxList[6], $exportrestrictionsfound);
+    if ($otherStatement["ri_exportnotes"] != 'NA' && !empty($otherStatement["ri_exportnotes"])) {
+      $extraNotes = str_replace("\n", "<w:br/>", htmlspecialchars($otherStatement["ri_exportnotes"], ENT_DISALLOWED));
+      $cell->addText($extraNotes, $rightColStyleBlue, "pStyle");
+    }
 
     $norestrictionsforusefound = " no restrictions for use found";
     $restrictionsforusefound = " restrictions for use found (see obligations)";
@@ -234,6 +242,10 @@ class ReportStatic
     $cell = $table->addCell($cellLen);
     $this->addCheckBoxText($cell, $getCheckboxList[7], $norestrictionsforusefound);
     $this->addCheckBoxText($cell, $getCheckboxList[8], $restrictionsforusefound);
+    if ($otherStatement["ri_copyrightnotes"] != 'NA' && !empty($otherStatement["ri_copyrightnotes"])) {
+      $extraNotes = str_replace("\n", "<w:br/>", htmlspecialchars($otherStatement["ri_copyrightnotes"], ENT_DISALLOWED));
+      $cell->addText($extraNotes, $rightColStyleBlue, "pStyle");
+    }
 
     $table->addRow($rowWidth, "pStyle");
     $table->addCell($cellFirstLen)->addText(htmlspecialchars(" Additional notes"), $leftColStyle, "pStyle");

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -1884,6 +1884,18 @@
   $Schema["TABLE"]["report_info"]["ri_department"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_department\" text DEFAULT 'FOSSology Generation'::text";
   $Schema["TABLE"]["report_info"]["ri_department"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_department\" SET NOT NULL, ALTER COLUMN \"ri_department\" SET DEFAULT 'FOSSology Generation'::text";
 
+  $Schema["TABLE"]["report_info"]["ri_depnotes"]["DESC"] = "";
+  $Schema["TABLE"]["report_info"]["ri_depnotes"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_depnotes\" text DEFAULT 'NA'::text";
+  $Schema["TABLE"]["report_info"]["ri_depnotes"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_depnotes\" SET NOT NULL, ALTER COLUMN \"ri_depnotes\" SET DEFAULT 'NA'::text";
+
+  $Schema["TABLE"]["report_info"]["ri_exportnotes"]["DESC"] = "";
+  $Schema["TABLE"]["report_info"]["ri_exportnotes"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_exportnotes\" text DEFAULT 'NA'::text";
+  $Schema["TABLE"]["report_info"]["ri_exportnotes"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_exportnotes\" SET NOT NULL, ALTER COLUMN \"ri_exportnotes\" SET DEFAULT 'NA'::text";
+
+  $Schema["TABLE"]["report_info"]["ri_copyrightnotes"]["DESC"] = "";
+  $Schema["TABLE"]["report_info"]["ri_copyrightnotes"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_copyrightnotes\" text DEFAULT 'NA'::text";
+  $Schema["TABLE"]["report_info"]["ri_copyrightnotes"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_copyrightnotes\" SET NOT NULL, ALTER COLUMN \"ri_copyrightnotes\" SET DEFAULT 'NA'::text";
+
 
   $Schema["VIEW"]["license_file_ref"] = "CREATE VIEW \"license_file_ref\" AS SELECT license_ref.rf_fullname, license_ref.rf_shortname, license_ref.rf_pk, license_file.fl_end_byte, license_file.rf_match_pct, license_file.rf_timestamp, license_file.fl_start_byte, license_file.fl_ref_end_byte, license_file.fl_ref_start_byte, license_file.fl_pk, license_file.agent_fk, license_file.pfile_fk FROM (license_file JOIN license_ref ON ((license_file.rf_fk = license_ref.rf_pk)));";
 

--- a/src/www/ui/template/ui-report-conf.html.twig
+++ b/src/www/ui/template/ui-report-conf.html.twig
@@ -114,8 +114,8 @@
             {{ "Source / binary integration notes"|trans }}
           </td>
           <td align="left">
-            <label><input type="checkbox" name="nonCritical" {{ nonCritical }} />{{ "no critical files found, source code and binaries can be used as is"|trans }}</label><br />
-            <label><input type="checkbox" name="critical" {{ critical }} />{{ "critical files found, source code needs to be adapted and binaries possibly re-built"|trans }}</label>
+            <label><input type="radio" name="critical" value="nonCritical" {{ nonCritical }} />{{ "no critical files found, source code and binaries can be used as is"|trans }}</label><br />
+            <label><input type="radio" name="critical" value="critical" {{ critical }} />{{ "critical files found, source code needs to be adapted and binaries possibly re-built"|trans }}</label>
           </td>
         </tr>
         <tr>
@@ -123,9 +123,10 @@
             {{ "Dependency notes"|trans }}
           </td>
           <td align="left">
-            <label><input type="checkbox" name="noDependency" {{ noDependency }} />{{ "no dependencies found, neither in source code nor in binaries"|trans }}</label><br />
-            <label><input type="checkbox" name="dependencySource" {{ dependencySource }} />{{ "dependencies found in source code (see obligations)"|trans }}</label><br />
-            <label><input type="checkbox" name="dependencyBinary" {{ dependencyBinary }} />{{ "dependencies found in binaries (see obligations)"|trans }}</label>
+            <label><input type="radio" name="dependencySourceBinary" value="noDependency" {{ noDependency }} />{{ "no dependencies found, neither in source code nor in binaries"|trans }}</label><br />
+            <label><input type="radio" name="dependencySourceBinary" {{ dependencySource }} value="dependencySource" />{{ "dependencies found in source code (see obligations)"|trans }}</label><br />
+            <label><input type="radio" name="dependencySourceBinary" {{ dependencyBinary }} value="dependencyBinary" />{{ "dependencies found in binaries (see obligations)"|trans }}</label>
+            <label><textarea {{ styleDependencyTA }} id="dependencyBinarySource" name="dependencyBinarySource">{{ dependencyBinarySource|e }}</textarea></label>
           </td>
         </tr>
         <tr>
@@ -133,8 +134,9 @@
             {{ "Export restrictions by copyright owner"|trans }}
           </td>
           <td align="left">
-            <label><input type="checkbox" name="noExportRestriction" {{ noExportRestriction }} />{{ "no export restrictions found"|trans }}</label><br />
-            <label><input type="checkbox" name="exportRestriction" {{ exportRestriction }} />{{ "export restrictions found (see obligations)"|trans }}</label>
+            <label><input type="radio" name="exportRestriction" value="noExportRestriction" {{ noExportRestriction }} />{{ "no export restrictions found"|trans }}</label><br />
+            <label><input type="radio" name="exportRestriction" value="exportRestriction" {{ exportRestriction }} />{{ "export restrictions found (see obligations)"|trans }}</label>
+            <label><textarea {{ styleExportTA }} id="exportRestrictionText" name="exportRestrictionText">{{ exportRestrictionText|e }}</textarea></label>
           </td>
         </tr>
         <tr>
@@ -142,8 +144,9 @@
             {{ "Restrictions for use by copyright owner \n<br/> (e.g. not for Nuclear Power)"|trans }}
           </td>
           <td align="left">
-            <label><input type="checkbox" name="noRestriction" {{ noRestriction }} />{{ "no restrictions for use found"|trans }}</label><br />
-            <label><input type="checkbox" name="restrictionForUse" {{ restrictionForUse }} />{{ "restrictions for use found (see obligations)"|trans }}</label>
+            <label><input type="radio" name="restrictionForUse" value="noRestriction" {{ noRestriction }} />{{ "no restrictions for use found"|trans }}</label><br />
+            <label><input type="radio" name="restrictionForUse" value="restrictionForUse" {{ restrictionForUse }} />{{ "restrictions for use found (see obligations)"|trans }}</label>
+            <label><textarea {{ styleRestrictionTA }} id="copyrightRestrictionText" name="copyrightRestrictionText">{{ copyrightRestrictionText|e }}</textarea></label>
           </td>
         </tr>
         <tr>
@@ -197,7 +200,7 @@
             {{ "Show SPDX license comments"|trans }}
           </td>
           <td align="left">
-            <input type="checkbox" name="spdxLicenseComment" {{ spdxLicenseComment }} />
+            <input type="checkbox" name="spdxLicenseComment" value="spdxLicenseComment" {{ spdxLicenseComment }} />
          </td>
         </tr>
         <tr>
@@ -205,7 +208,7 @@
             {{ "Ignore files with no info in SPDX"|trans }}
           </td>
           <td align="left">
-            <input type="checkbox" name="ignoreFilesWOInfo" {{ ignoreFilesWOInfo }} />
+            <input type="checkbox" name="ignoreFilesWOInfo" value="ignoreFilesWOInfo" {{ ignoreFilesWOInfo }} />
           </td>
         </tr>
       </table>

--- a/src/www/ui/ui-report-conf.php
+++ b/src/www/ui/ui-report-conf.php
@@ -65,30 +65,33 @@ class ui_report_conf extends FO_Plugin
     "footerNote" => "ri_footer",
     "generalAssesment" => "ri_general_assesment",
     "gaAdditional" => "ri_ga_additional",
-    "gaRisk" => "ri_ga_risk"
+    "gaRisk" => "ri_ga_risk",
+    "dependencyBinarySource" => "ri_depnotes",
+    "exportRestrictionText" => "ri_exportnotes",
+    "copyrightRestrictionText" => "ri_copyrightnotes"
   );
 
   /**
-   * @var checkBoxListUR $checkBoxListUR
+   * @var radioListUR $radioListUR
    */
-  private $checkBoxListUR = array(
-    "nonCritical",
-    "critical",
-    "noDependency",
-    "dependencySource",
-    "dependencyBinary",
-    "noExportRestriction",
-    "exportRestriction",
-    "noRestriction",
-    "restrictionForUse"
+  private $radioListUR = array(
+    "nonCritical" => "critical",
+    "critical" => "critical",
+    "noDependency" => "dependencySourceBinary",
+    "dependencySource" => "dependencySourceBinary",
+    "dependencyBinary" => "dependencySourceBinary",
+    "noExportRestriction" => "exportRestriction",
+    "exportRestriction" => "exportRestriction",
+    "noRestriction" => "restrictionForUse",
+    "restrictionForUse" => "restrictionForUse"
   );
 
   /**
    * @var checkBoxListSPDX $checkBoxListSPDX
    */
   private $checkBoxListSPDX = array(
-    "spdxLicenseComment",
-    "ignoreFilesWOInfo"
+    "spdxLicenseComment" => "spdxLicenseComment",
+    "ignoreFilesWOInfo" => "ignoreFilesWOInfo"
   );
 
 
@@ -155,17 +158,31 @@ class ui_report_conf extends FO_Plugin
     foreach ($this->mapDBColumns as $key => $value) {
       $vars[$key] = $row[$value];
     }
+    $textAreaNoneStyle = ' style="display:none;overflow:auto;width:98%;height:80px;"';
+    $textAreaStyle = ' style="overflow:auto;width:98%;height:80px;"';
+    $vars['styleDependencyTA'] = $vars['styleExportTA'] = $vars['styleRestrictionTA'] = $textAreaStyle;
+    if ($row['ri_depnotes'] == 'NA' || empty($row['ri_depnotes'])) {
+       $vars['styleDependencyTA'] = $textAreaNoneStyle;
+    }
+
+    if ($row['ri_exportnotes'] == 'NA' || empty($row['ri_exportnotes'])) {
+       $vars['styleExportTA'] = $textAreaNoneStyle;
+    }
+
+    if ($row['ri_copyrightnotes'] == 'NA' || empty($row['ri_copyrightnotes'])) {
+       $vars['styleRestrictionTA'] = $textAreaNoneStyle;
+    }
 
     if (!empty($row['ri_ga_checkbox_selection'])) {
       $listURCheckbox = explode(',', $row['ri_ga_checkbox_selection']);
-      foreach ($this->checkBoxListUR as $key => $value) {
+      foreach (array_keys($this->radioListUR) as $key => $value) {
         $vars[$value] = $listURCheckbox[$key];
       }
     }
 
     if (!empty($row['ri_spdx_selection'])) {
       $listSPDXCheckbox = explode(',', $row['ri_spdx_selection']);
-      foreach ($this->checkBoxListSPDX as $key => $value) {
+      foreach (array_keys($this->checkBoxListSPDX) as $key => $value) {
         $vars[$value] = $listSPDXCheckbox[$key];
       }
     }
@@ -240,14 +257,14 @@ class ui_report_conf extends FO_Plugin
   }
 
   /**
-   * @param array $checkBoxListParams
+   * @param array $listParams
    * @return $cbSelectionList
    */
-  protected function getCheckBoxSelectionList($checkBoxListParams)
+  protected function getCheckBoxSelectionList($listParams)
   {
-    foreach ($checkBoxListParams as $checkBoxListParam) {
-      $ret = GetParm($checkBoxListParam, PARM_STRING);
-      if (empty($ret)) {
+    foreach ($listParams as $listkey => $listValue) {
+      $ret = GetParm($listValue, PARM_STRING);
+      if ($ret != $listkey) {
         $cbList[] = "unchecked";
       } else {
         $cbList[] = "checked";
@@ -283,7 +300,7 @@ class ui_report_conf extends FO_Plugin
         $parms[] = GetParm($key, PARM_TEXT);
         $i++;
       }
-      $parms[] = $this->getCheckBoxSelectionList($this->checkBoxListUR);
+      $parms[] = $this->getCheckBoxSelectionList($this->radioListUR);
       $checkBoxUrPos = count($parms);
       $parms[] = $this->getCheckBoxSelectionList($this->checkBoxListSPDX);
       $checkBoxSpdxPos = count($parms);
@@ -342,6 +359,33 @@ class ui_report_conf extends FO_Plugin
           var idString = $(e.currentTarget).attr('id');
           idString = parseInt(idString.slice(-1)) - 1;
           $.cookie(reportTabCookie, idString);
+        }
+      });
+      $(\"input[name='dependencySourceBinary']\").change(function(){
+        var val = $(\"input[name='dependencySourceBinary']:checked\").val();
+        if (val == 'noDependency') {
+          $('#dependencyBinarySource').hide();
+          $('#dependencyBinarySource').val('');
+        } else {
+          $('#dependencyBinarySource').css('display', 'block');
+        }
+      });
+      $(\"input[name='exportRestriction']\").change(function(){
+        var val = $(\"input[name='exportRestriction']:checked\").val();
+        if (val == 'noExportRestriction') {
+          $('#exportRestrictionText').hide();
+          $('#exportRestrictionText').val('');
+        } else {
+          $('#exportRestrictionText').css('display', 'block');
+        }
+      });
+      $(\"input[name='restrictionForUse']\").change(function(){
+        var val = $(\"input[name='restrictionForUse']:checked\").val();
+        if (val == 'noRestriction') {
+          $('#copyrightRestrictionText').hide();
+          $('#copyrightRestrictionText').val('');
+        } else {
+          $('#copyrightRestrictionText').css('display', 'block');
         }
       });
     });


### PR DESCRIPTION
## Description

Add text boxes for three columns in report conf page, to-write extra notes if needed. 

Columns where the text-area is added.

* Dependency notes.
* Export restrictions by copyright owner.
* Restrictions for use by copyright owner. 

## How to test

* Generate a unified report after filling the above mentioned columns and check if the extra note added gets displayed.
