### PR TITLE
fix(delagent): Remove clearing_decision and license_ref_bulk

### DIFF
--- a/src/delagent/agent/delagent.h
+++ b/src/delagent/agent/delagent.h
@@ -52,7 +52,7 @@ extern PGconn* pgConn;
  * \def MAXSQL
  * Maximum length of SQL commands
  */
-#define MAXSQL  1024
+#define MAXSQL  2048
 /**
  * \def MAXSQLFolder
  * Maximum length of folder address


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

While deleting an upload, the entries from `clearing_decision` and `license_ref_bulk` were not deleted from delagent leaving the DB in inconsistent state until someone runs maintenance agent.

This PR will remove all the corresponding entries from mentioned tables bellow.

### Changes

1. Remove local clearing entries from `clearing_decision`, `clearing_event` and `clearing_decision_event` tables.
    - The global entries will not be removed as they are referenced by pfile.
    - And if the pfile is deleted (not referred by any other upload), they will be removed by `clearing_decision_pfile_fk_fkey` constraint.
1. Remove entries from `license_ref_bulk` for deleted `uploadtree_pk`.

## How to test

#### On current master branch
1. Upload a package, do some clearing ad then delete the upload.
1. Run `fo_postinstall` simulating a new version install.
1. Upload a new package.
1. Entries from cleared package will appear for the new upload.

#### With the fix
1. Upload a package, do some clearing and then delete the upload.
    - All the clearing entries should be removed.
1. Upload a package which have some shared pfiles with other upload. Do some clearing with global decisions and delete any one upload.
    - All the local entries from the deleted upload should be removed.
    - The global entries should be preserved.