### PR TITLE
fix(lib): Remove extra parameters

### DIFF
--- a/src/lib/c/libfossagent.c
+++ b/src/lib/c/libfossagent.c
@@ -115,9 +115,7 @@ PGresult* queryFileIdsForUpload(fo_dbManager* dbManager, int uploadId, bool igno
       fo_dbManager_PrepareStamement(
         dbManager,
         queryName,
-        SQL,
-        int),
-      uploadId
+        SQL)
     );
     g_free(queryName);
   }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

There was extra parameter for `queryFileIdsForUpload()` even if the upload tree table is not `uploadtree_a`.

### Changes

Remove extra parameters from `queryFileIdsForUpload()` if `uploadtreeTableName != uploadtree_a`.

## How to test

1. Upload a file larger than 500mb (provided in #1737)
1. Reduce the size of uploadtree split from https://github.com/fossology/fossology/blob/b4e3a379a83a3402f0b75bf5198f772b42cd2f7f/src/ununpack/agent/ununpack.c#L272 and upload any file.

Closes #1737 