### PR TITLE
fix(rest): fixed ignoreScm flag when value is false

### DIFF
--- a/src/www/ui/api/Helper/UploadHelper.php
+++ b/src/www/ui/api/Helper/UploadHelper.php
@@ -115,7 +115,7 @@ class UploadHelper
     $uploadedFile = $request->getUploadedFiles();
     $body = $request->getParsedBody();
 
-    if (! empty($ignoreScm) && ($ignoreScm == "true" || $ignoreScm)) {
+    if (! empty($ignoreScm) && ($ignoreScm == "true")) {
       // If SCM should be ignored
       $ignoreScm = 1;
     } else {


### PR DESCRIPTION
## Description

This pull request fixes Bug #1755 
Corrected if statement handling the ignoreScm flag during upload using the api.

### Changes

Removed "|| ignoreScm" in if statement to properly handle the case of value set to "false".

## How to test

Run the below Curl command and check the FOSSology UI for .git files in the upload. They should now be present in the files list.

curl -k -s -S -X POST http://localhost:8081/repo/api/v1/uploads
-H "folderId: 1"
-H 'uploadDescription: created by REST'
-H 'public: public' -H 'Content-Type: multipart/form-data'
-H 'ignoreScm: false'
-F 'fileInput=@"time-1.7.tar.gz";type=application/octet-stream'
-H "Authorization: Bearer eyJ0eXAi…"

Closes #1755