### PR TITLE
chore(alljobs): Restrict to read

### DIFF
--- a/src/lib/php/Dao/ShowJobsDao.php
+++ b/src/lib/php/Dao/ShowJobsDao.php
@@ -374,7 +374,7 @@ class ShowJobsDao
   }
 
   /**
-   * Get the status of all pending or running jobs.
+   * Get the status of all recent pending or running jobs.
    * @return array Containing job name, number of jobs pending and running
    */
   public function getJobsForAll()
@@ -385,6 +385,7 @@ class ShowJobsDao
       "ELSE '' END AS status " .
       "FROM jobqueue INNER JOIN job " .
       "ON jq_job_fk = job_pk " .
+      "AND job_queued >= (now() - interval '" . $this->nhours . " hours') " .
       "WHERE jq_endtime IS NULL;";
     $statement = __METHOD__ . ".getAllUnFinishedJobs";
     return $this->dbManager->getRows($sql, [], $statement);

--- a/src/www/ui/async/AjaxAllJobStatus.php
+++ b/src/www/ui/async/AjaxAllJobStatus.php
@@ -49,7 +49,7 @@ class AjaxAllJobStatus extends DefaultPlugin
   {
     parent::__construct(self::NAME,
       array(
-        self::PERMISSION => Auth::PERM_NONE,
+        self::PERMISSION => Auth::PERM_READ,
         self::REQUIRES_LOGIN => false
       ));
 

--- a/src/www/ui/page/AllJobStatus.php
+++ b/src/www/ui/page/AllJobStatus.php
@@ -51,7 +51,7 @@ class AllJobStatus extends DefaultPlugin
         self::TITLE => "Status - all server jobs",
         self::MENU_LIST => "Admin::Dashboards::All Jobs",
         self::REQUIRES_LOGIN => false,
-        self::PERMISSION => Auth::PERM_NONE
+        self::PERMISSION => Auth::PERM_READ
       ));
   }
 


### PR DESCRIPTION
## Description

Restrict the All server jobs to read premissions. This will allow admin to configure to allow default user to read the page or not.

Also, restrict the jobs to recent jobs (4 weeks) to prevent processing irrelevant old jobs which do not matter anymore.

### Changes

1. Change the permission of `AllJobsStatus` and `AjaxAllJobStatus` to read.
1. Use the `nhours` in `ShowJobsDao` to list only recent jobs for `getJobsForAll()`.

## How to test

1. Check #1749
1. On an old instance, with old pending jobs, check if they do not show up in all jobs page.

Closes #1749