### PR TITLE
fix(lib): Correct non-default argument position

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -1033,6 +1033,7 @@ FROM (SELECT DISTINCT uploadtree_pk FROM allDecs) AS no_license_uploadtree;";
    */
   public function getCandidateLicenseCountForCurrentDecisions($uploadTreeId, $uploadId=0)
   {
+    $params = array();
     if (!empty($uploadId)) {
       $itemTreeBounds = $this->uploadDao->getParentItemBounds($uploadId, $uploadTreeTableName);
       $uploadTreeTableName = $this->uploadDao->getUploadtreeTableName($uploadId);
@@ -1049,7 +1050,7 @@ FROM (SELECT DISTINCT uploadtree_pk FROM allDecs) AS no_license_uploadtree;";
       SELECT rf_fk, date_added, removed FROM (
         SELECT rf_fk, date_added, removed, row_number()
           OVER (PARTITION BY rf_fk ORDER BY date_added DESC) AS ROWNUM
-        FROM clearing_event WHERE $uploadtreeStatement) SORTABLE 
+        FROM clearing_event WHERE $uploadtreeStatement) SORTABLE
           WHERE ROWNUM = 1 ORDER BY rf_fk)
       SELECT count(*) FROM license_candidate WHERE license_candidate.rf_pk IN
         (SELECT rf_fk FROM latestEvents WHERE removed=false);";

--- a/src/lib/php/Report/ClearedGetterCommon.php
+++ b/src/lib/php/Report/ClearedGetterCommon.php
@@ -212,7 +212,7 @@ abstract class ClearedGetterCommon
    */
   abstract protected function getStatements($uploadId, $uploadTreeTableName, $groupId=null);
 
-  public function getCleared($uploadId, $groupId=null, $extended=true, $agentcall=null, $isUnifiedReport=false, $objectAgent)
+  public function getCleared($uploadId, $objectAgent, $groupId=null, $extended=true, $agentcall=null, $isUnifiedReport=false)
   {
     $uploadTreeTableName = $this->uploadDao->getUploadtreeTableName($uploadId);
     $ungrupedStatements = $this->getStatements($uploadId, $uploadTreeTableName, $groupId);
@@ -231,7 +231,7 @@ abstract class ClearedGetterCommon
   {
     $escapeChars = array('\\f',"\\", "/", "\"");
     $withThisValue = array("","\\\\", "\\/", "\\\"");
-    $clearedString = str_replace($escapeChars, $withThisValue, $this->getCleared($uploadId, $groupId, false, null, false, null));
+    $clearedString = str_replace($escapeChars, $withThisValue, $this->getCleared($uploadId, null, $groupId, false, null, false));
     $json = json_encode($clearedString);
     return str_replace('\u001b','',$json);
   }

--- a/src/lib/php/Report/LicenseMainGetter.php
+++ b/src/lib/php/Report/LicenseMainGetter.php
@@ -60,7 +60,7 @@ class LicenseMainGetter extends ClearedGetterCommon
     return $allStatements;
   }
 
-  public function getCleared($uploadId, $groupId=null, $extended=true, $agentcall=null, $isUnifiedReport=false, $objectAgent)
+  public function getCleared($uploadId, $objectAgent, $groupId=null, $extended=true, $agentcall=null, $isUnifiedReport=false)
   {
     $uploadTreeTableName = $this->uploadDao->getUploadtreeTableName($uploadId);
     $statements = $this->getStatements($uploadId, $uploadTreeTableName, $groupId);

--- a/src/lib/php/Report/tests/ClearedGetterCommonTest.php
+++ b/src/lib/php/Report/tests/ClearedGetterCommonTest.php
@@ -53,7 +53,7 @@ class WeirdCharClearedGetter extends ClearedGetterCommon
   {
   }
 
-  public function getCleared($uploadId, $groupId = null, $extended = true, $agentcall = null, $isUnifiedReport = false, $objectAgent)
+  public function getCleared($uploadId, $objectAgent, $groupId = null, $extended = true, $agentcall = null, $isUnifiedReport = false)
   {
     return array(
       array("good" => "漢", "esc" => "escape", "uml" => ' ü ')
@@ -119,7 +119,7 @@ class ClearedComonReportTest extends \PHPUnit\Framework\TestCase
          ->with(3, $uploadTreeTableName, $parentId)
          ->andReturn("a/b/1");
 
-    $statements = $this->clearedGetterTest->getCleared($uploadId,null,true,null,false,null);
+    $statements = $this->clearedGetterTest->getCleared($uploadId, null);
     $expected = array(
       "statements" => array(
         array(
@@ -177,7 +177,7 @@ class ClearedComonReportTest extends \PHPUnit\Framework\TestCase
          ->andReturn("a/b/1");
 
     $tester = new TestClearedGetter("text");
-    $statements = $tester->getCleared($uploadId,null,true,null,false,null);
+    $statements = $tester->getCleared($uploadId, null);
     $expected = array(
       "statements" => array(
         array(

--- a/src/readmeoss/agent/readmeoss.php
+++ b/src/readmeoss/agent/readmeoss.php
@@ -125,17 +125,17 @@ class ReadmeOssAgent extends Agent
       if (!$this->uploadDao->isAccessible($addUploadId, $groupId)) {
         continue;
       }
-      $moreLicenses = $this->licenseClearedGetter->getCleared($addUploadId, $groupId, true, null, false, $this);
+      $moreLicenses = $this->licenseClearedGetter->getCleared($addUploadId, $this, $groupId, true, null, false);
       $licenseStmts = array_merge($licenseStmts, $moreLicenses['statements']);
       $this->heartbeat(count($moreLicenses['statements']));
       $this->licenseClearedGetter->setOnlyAcknowledgements(true);
-      $moreAcknowledgements = $this->licenseClearedGetter->getCleared($addUploadId, $groupId, true, null, false, $this);
+      $moreAcknowledgements = $this->licenseClearedGetter->getCleared($addUploadId, $this, $groupId, true, null, false);
       $licenseAcknowledgements = array_merge($licenseAcknowledgements, $moreAcknowledgements['statements']);
       $this->heartbeat(count($moreAcknowledgements['statements']));
-      $moreCopyrights = $this->cpClearedGetter->getCleared($addUploadId, $groupId, true, "copyright", false, $this);
+      $moreCopyrights = $this->cpClearedGetter->getCleared($addUploadId, $this, $groupId, true, "copyright", false);
       $copyrightStmts = array_merge($copyrightStmts, $moreCopyrights['statements']);
       $this->heartbeat(count($moreCopyrights['statements']));
-      $moreMainLicenses = $this->licenseMainGetter->getCleared($addUploadId, $groupId, true, null, false, $this);
+      $moreMainLicenses = $this->licenseMainGetter->getCleared($addUploadId, $this, $groupId, true, null, false);
       $licenseStmtsMain = array_merge($licenseStmtsMain, $moreMainLicenses['statements']);
       $this->heartbeat(count($moreMainLicenses['statements']));
     }

--- a/src/unifiedreport/agent/unifiedreport.php
+++ b/src/unifiedreport/agent/unifiedreport.php
@@ -264,42 +264,42 @@ class UnifiedReport extends Agent
 
     $this->heartbeat(0);
 
-    $licenses = $this->licenseClearedGetter->getCleared($uploadId, $groupId, true, null, false, $this);
+    $licenses = $this->licenseClearedGetter->getCleared($uploadId, $this, $groupId, true, null, false);
     $this->heartbeat(empty($licenses) ? 0 : count($licenses["statements"]));
 
-    $licensesMain = $this->licenseMainGetter->getCleared($uploadId, $groupId, true, null, false, $this);
+    $licensesMain = $this->licenseMainGetter->getCleared($uploadId, $this, $groupId, true, null, false);
     $this->heartbeat(empty($licensesMain) ? 0 : count($licensesMain["statements"]));
 
-    $licensesHist = $this->licenseClearedGetter->getLicenseHistogramForReport($uploadId, $groupId, true, null, false, $this);
+    $licensesHist = $this->licenseClearedGetter->getLicenseHistogramForReport($uploadId, $groupId);
     $this->heartbeat(empty($licensesHist) ? 0 : count($licensesHist["statements"]));
 
-    $bulkLicenses = $this->bulkMatchesGetter->getCleared($uploadId, $groupId, true, null, false, $this);
+    $bulkLicenses = $this->bulkMatchesGetter->getCleared($uploadId, $this, $groupId, true, null, false);
     $this->heartbeat(empty($bulkLicenses) ? 0 : count($bulkLicenses["statements"]));
 
     $this->licenseClearedGetter->setOnlyAcknowledgements(true);
-    $licenseAcknowledgements = $this->licenseClearedGetter->getCleared($uploadId, $groupId, true, null, false, $this);
+    $licenseAcknowledgements = $this->licenseClearedGetter->getCleared($uploadId, $this, $groupId, true, null, false);
     $this->heartbeat(empty($licenseAcknowledgements) ? 0 : count($licenseAcknowledgements["statements"]));
 
     $this->licenseClearedGetter->setOnlyComments(true);
-    $licenseComments = $this->licenseClearedGetter->getCleared($uploadId, $groupId, true, null, false, $this);
+    $licenseComments = $this->licenseClearedGetter->getCleared($uploadId, $this, $groupId, true, null, false);
     $this->heartbeat(empty($licenseComments) ? 0 : count($licenseComments["statements"]));
 
-    $licensesIrre = $this->licenseIrrelevantGetter->getCleared($uploadId, $groupId, true, null, false, $this);
+    $licensesIrre = $this->licenseIrrelevantGetter->getCleared($uploadId, $this, $groupId, true, null, false);
     $this->heartbeat(empty($licensesIrre) ? 0 : count($licensesIrre["statements"]));
 
-    $licensesIrreComment = $this->licenseIrrelevantCommentGetter->getCleared($uploadId, $groupId, true, null, false, $this);
+    $licensesIrreComment = $this->licenseIrrelevantCommentGetter->getCleared($uploadId, $this, $groupId, true, null, false);
     $this->heartbeat(empty($licensesIrreComment) ? 0 : count($licensesIrreComment["statements"]));
 
-    $licensesDNU = $this->licenseDNUGetter->getCleared($uploadId, $groupId, true, null, false, $this);
+    $licensesDNU = $this->licenseDNUGetter->getCleared($uploadId, $this, $groupId, true, null, false);
     $this->heartbeat(empty($licensesDNU) ? 0 : count($licensesDNU["statements"]));
 
-    $licensesDNUComment = $this->licenseDNUCommentGetter->getCleared($uploadId, $groupId, true, null, false, $this);
+    $licensesDNUComment = $this->licenseDNUCommentGetter->getCleared($uploadId, $this, $groupId, true, null, false);
     $this->heartbeat(empty($licensesDNUComment) ? 0 : count($licensesDNUComment["statements"]));
 
-    $copyrights = $this->cpClearedGetter->getCleared($uploadId, $groupId, true, "copyright", true, $this);
+    $copyrights = $this->cpClearedGetter->getCleared($uploadId, $this, $groupId, true, "copyright", true);
     $this->heartbeat(empty($copyrights["statements"]) ? 0 : count($copyrights["statements"]));
 
-    $ecc = $this->eccClearedGetter->getCleared($uploadId, $groupId, true, "ecc", false, $this);
+    $ecc = $this->eccClearedGetter->getCleared($uploadId, $this, $groupId, true, "ecc", false);
     $this->heartbeat(empty($ecc) ? 0 : count($ecc["statements"]));
 
     $otherStatement = $this->otherGetter->getReportData($uploadId);


### PR DESCRIPTION
## Description

Following fixes in library:
1. Default arguments in a function can not be followed by non-default arguments in PHP.
1. Variable not defined in `ClearingDao::getCandidateLicenseCountForCurrentDecisions()`.

### Changes

1. Define `$params` variable in `ClearingDao::getCandidateLicenseCountForCurrentDecisions()` before use.
1. Change the parameter arrangement in `ClearedGetterCommon::getCleared()`.

## How to test

Check if unified report and readme oss are working.