### PR TITLE
feat(showjobs): Show delete file name

### DIFF
--- a/install/db/dbmigrate_3.7-3.8.php
+++ b/install/db/dbmigrate_3.7-3.8.php
@@ -36,6 +36,7 @@ const MAX_ROW_SIZE = 100;
  */
 const ENCODE_TABLES = array(
   "copyright",
+  "author",
   "ecc",
   "keyword"
 );

--- a/src/www/ui/ajax-uploads.php
+++ b/src/www/ui/ajax-uploads.php
@@ -61,7 +61,7 @@ class core_uploads extends FO_Plugin
         $V .= " (" . htmlentities($upload['upload_desc']) . ")";
       }
       if (! empty($upload['upload_ts'])) {
-        $V .= " :: " . htmlentities($upload['upload_ts']);
+        $V .= " :: " . htmlentities(Convert2BrowserTime($upload['upload_ts']));
       }
       $V .= "</option>\n";
     }

--- a/src/www/ui/async/AjaxShowJobs.php
+++ b/src/www/ui/async/AjaxShowJobs.php
@@ -136,7 +136,9 @@ class AjaxShowJobs extends \FO_Plugin
         case 'job_queued':
         case 'jq_starttime':
         case 'jq_endtime':
-          $value = Convert2BrowserTime($row[$field]);
+          if (! empty($row[$field])) {
+            $value = Convert2BrowserTime($row[$field]);
+          }
           break;
         case 'jq_itemsprocessed':
           $value = number_format($row[$field]);
@@ -230,8 +232,14 @@ class AjaxShowJobs extends \FO_Plugin
         'jobQueue' => $jobs['jobqueue']
       );
       foreach ($jobArr['jobQueue'] as $key => $singleJobQueue) {
-        $jobArr['jobQueue'][$key]['jq_starttime'] = Convert2BrowserTime($jobArr['jobQueue'][$key]['jq_starttime']);
-        $jobArr['jobQueue'][$key]['jq_endtime'] = Convert2BrowserTime($jobArr['jobQueue'][$key]['jq_endtime']) ;
+        if (! empty($jobArr['jobQueue'][$key]['jq_starttime'])) {
+          $jobArr['jobQueue'][$key]['jq_starttime'] = Convert2BrowserTime(
+            $jobArr['jobQueue'][$key]['jq_starttime']);
+        }
+        if (! empty($jobArr['jobQueue'][$key]['jq_endtime'])) {
+          $jobArr['jobQueue'][$key]['jq_endtime'] = Convert2BrowserTime(
+            $jobArr['jobQueue'][$key]['jq_endtime']) ;
+        }
         if (! empty($singleJobQueue["jq_endtime"])) {
           $numSecs = strtotime($singleJobQueue['jq_endtime']) -
             strtotime($singleJobQueue['jq_starttime']);

--- a/src/www/ui/template/ui-showjobs.js.twig
+++ b/src/www/ui/template/ui-showjobs.js.twig
@@ -113,6 +113,9 @@ function createTableForJob(job) {
     uploadLink = '<a title="{{ "Click to browse"|trans }}" ' +
     'href="?mod=browse&upload=' + job.upload.uploadId + '&item=' +
     job.upload.uploadItem + '">' + job.upload.uploadName + '</a>';
+  } else if (job.upload !== null && job.job.jobName == "Delete") {
+    uploadLink = '<span style="color:black">' + job.upload.uploadName +
+      ' (Deleted)</span>';
   } else {
     uploadLink = '<span style="color:black">' + job.job.jobName + '</span>';
   }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Show the filename of the deleted upload in Show Job pages and add the author table for UTF migration script.

Fix the color mismatch on show jobs.

### Changes

1. Show the uploadname if exists in `ui-showjobs.js.twig`
1. Add `author` table to `dbmigrate_3.7-3.8.php`
1. Do not fill job times if empty in `AjaxShowJobs.php`
1. Change the timezone in `ajax-uploads.php` as well.

## How to test

1. Upload a package and delete it.
    1. Under Show Jobs page, the package name should appear with a deleted message.
1. Run a maintenance job.
    1. Under Show Jobs page, the view should not break and show maintenance.
1. Kill the scheduler before uploading a package and check if the jobs appear with yellow background.

Closes #1753
Closes #1731