### PR TITLE
feat(copyright): reuse deactivated copyrights with reuser

### DIFF
--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -173,9 +173,10 @@ class CopyrightDao
    * @param $uploadId
    * @param $type
    * @param $extrawhere
+   * @param $enabled
    * @return array $result
    */
-  public function getScannerEntries($tableName, $uploadTreeTableName, $uploadId, $type, $extrawhere)
+  public function getScannerEntries($tableName, $uploadTreeTableName, $uploadId, $type, $extrawhere, $enabled='true')
   {
     $statementName = __METHOD__.$tableName.$uploadTreeTableName;
     $params = array();
@@ -198,12 +199,17 @@ class CopyrightDao
       $statementName .= "._".$extrawhere."_";
     }
 
-    $sql = "SELECT UT.uploadtree_pk as uploadtree_pk, C.content AS content
+    if ($enabled == 'false') {
+      $statementName .= "._"."enabled";
+    }
+
+    $sql = "SELECT UT.uploadtree_pk as uploadtree_pk, C.content AS content,
+              C.hash AS hash, C.agent_fk as agent_fk
               FROM $tableName C
              INNER JOIN $uploadTreeTableName UT ON C.pfile_fk = UT.pfile_fk
              WHERE C.content IS NOT NULL
                AND C.content!=''
-               AND C.is_enabled='true'
+               AND C.is_enabled='$enabled'
                $extendWClause
              ORDER BY UT.uploadtree_pk, C.content DESC";
     $this->dbManager->prepare($statementName, $sql);

--- a/src/lib/php/Dao/UploadDao.php
+++ b/src/lib/php/Dao/UploadDao.php
@@ -38,6 +38,7 @@ class UploadDao
   const REUSE_ENHANCED = 2;
   const REUSE_MAIN = 4;
   const REUSE_CONF = 16;
+  const REUSE_COPYRIGHT = 32;
 
   /** @var DbManager */
   private $dbManager;

--- a/src/reuser/agent_tests/Functional/SchedulerTestRunnerMock.php
+++ b/src/reuser/agent_tests/Functional/SchedulerTestRunnerMock.php
@@ -22,6 +22,7 @@ use Fossology\Lib\BusinessRules\ClearingDecisionFilter;
 use Fossology\Lib\BusinessRules\ClearingDecisionProcessor;
 use Fossology\Lib\Dao\AgentDao;
 use Fossology\Lib\Dao\ClearingDao;
+use Fossology\Lib\Dao\CopyrightDao;
 use Fossology\Lib\Dao\TreeDao;
 use Fossology\Lib\Dao\UploadDao;
 use Fossology\Lib\Data\DecisionTypes;
@@ -49,6 +50,10 @@ class SchedulerTestRunnerMock implements SchedulerTestRunner
    * ClearingDao object
    */
   private $clearingDao;
+  /** @var CopyrightDao $copyrightDao
+   * CopyrightDao object
+   */
+  private $copyrightDao;
   /** @var ClearingDecisionFilter $clearingDecisionFilter
    * ClearingDecisionFilter object
    */
@@ -70,9 +75,12 @@ class SchedulerTestRunnerMock implements SchedulerTestRunner
    */
   private $treeDao;
 
-  public function __construct(DbManager $dbManager, AgentDao $agentDao, ClearingDao $clearingDao, UploadDao $uploadDao, ClearingDecisionFilter $clearingDecisionFilter, TreeDao $treeDao)
+  public function __construct(DbManager $dbManager, AgentDao $agentDao, ClearingDao $clearingDao, UploadDao $uploadDao,
+                                                    ClearingDecisionFilter $clearingDecisionFilter, TreeDao $treeDao,
+                                                    CopyrightDao $copyrightDao)
   {
     $this->clearingDao = $clearingDao;
+    $this->copyrightDao = $copyrightDao;
     $this->uploadDao = $uploadDao;
     $this->agentDao = $agentDao;
     $this->dbManager = $dbManager;
@@ -97,6 +105,7 @@ class SchedulerTestRunnerMock implements SchedulerTestRunner
     $container->shouldReceive('get')->with('db.manager')->andReturn($this->dbManager);
     $container->shouldReceive('get')->with('dao.agent')->andReturn($this->agentDao);
     $container->shouldReceive('get')->with('dao.clearing')->andReturn($this->clearingDao);
+    $container->shouldReceive('get')->with('dao.copyright')->andReturn($this->copyrightDao);
     $container->shouldReceive('get')->with('dao.upload')->andReturn($this->uploadDao);
     $container->shouldReceive('get')->with('decision.types')->andReturn($this->decisionTypes);
     $container->shouldReceive('get')->with('businessrules.clearing_event_processor')->andReturn($this->clearingEventProcessor);

--- a/src/reuser/agent_tests/Functional/schedulerTest.php
+++ b/src/reuser/agent_tests/Functional/schedulerTest.php
@@ -30,6 +30,7 @@ namespace Fossology\Reuser\Test;
 use Fossology\Lib\BusinessRules\ClearingDecisionFilter;
 use Fossology\Lib\Dao\AgentDao;
 use Fossology\Lib\Dao\ClearingDao;
+use Fossology\Lib\Dao\CopyrightDao;
 use Fossology\Lib\Dao\HighlightDao;
 use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Dao\TreeDao;
@@ -84,6 +85,10 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
    * ClearingDao object
    */
   private $clearingDao;
+  /** @var CopyrightDao $copyrightDao
+   * CopyrightDao object
+   */
+  private $copyrightDao;
   /** @var ClearingDecisionFilter $clearingDecisionFilter
    * ClearingDecisionFilter object
    */
@@ -130,12 +135,14 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
     $this->highlightDao = new HighlightDao($this->dbManager);
     $this->clearingDecisionFilter = new ClearingDecisionFilter();
     $this->clearingDao = new ClearingDao($this->dbManager, $this->uploadDao);
+    $this->copyrightDao = new CopyrightDao($this->dbManager, $this->uploadDao);
     $this->treeDao = \Mockery::mock(TreeDao::class);
 
     $agentDao = new AgentDao($this->dbManager, $logger);
 
     $this->runnerMock = new SchedulerTestRunnerMock($this->dbManager, $agentDao,
-      $this->clearingDao, $this->uploadDao, $this->clearingDecisionFilter, $this->treeDao);
+                        $this->clearingDao, $this->uploadDao, $this->clearingDecisionFilter,
+                        $this->treeDao, $this->copyrightDao);
     $this->runnerCli = new SchedulerTestRunnerCli($this->testDb);
   }
 
@@ -150,6 +157,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
     $this->licenseDao = null;
     $this->highlightDao = null;
     $this->clearingDao = null;
+    $this->copyrightDao = null;
   }
 
   /**

--- a/src/reuser/ui/agent-reuser.php
+++ b/src/reuser/ui/agent-reuser.php
@@ -123,6 +123,9 @@ class ReuserAgentPlugin extends AgentPlugin
         case 'reuseConf':
           $reuseMode |= UploadDao::REUSE_CONF;
           break;
+        case 'reuseCopyright':
+          $reuseMode |= UploadDao::REUSE_COPYRIGHT;
+          break;
       }
     }
 
@@ -183,6 +186,9 @@ class ReuserAgentPlugin extends AgentPlugin
     }
     if ($request->get("Check_agent_ninka", false)) {
       $dependencies[] = "agent_ninka";
+    }
+    if ($request->get("Check_agent_copyright", false)) {
+      $dependencies[] = "agent_copyright";
     }
     return $dependencies;
   }

--- a/src/reuser/ui/template/agent_reuser.html.twig
+++ b/src/reuser/ui/template/agent_reuser.html.twig
@@ -8,6 +8,7 @@
   <input type="checkbox" name="reuseMode[]" value="reuseEnhanced"/> {{ 'Enhanced reuse (slower)'|trans }}<img src="images/info_16.png" title="{{'will copy a clearing decision if the two files differ by one line determined by a diff tool'|trans}}" alt="" class="info-bullet"/><br/>
   <input type="checkbox" name="reuseMode[]" value="reuseMain"/> {{ 'Reuse main license/s'|trans }}<img src="images/info_16.png" title="{{'will copy a main license decision(if any)'|trans}}" alt="" class="info-bullet"/><br/>
   <input type="checkbox" name="reuseMode[]" value="reuseConf"/> {{ 'Reuse report configuration settings'|trans }}<img src="images/info_16.png" title="{{'use to copy all the information from conf page(if any)'|trans}}" alt="" class="info-bullet"/><br/>
+  <input type="checkbox" name="reuseMode[]" value="reuseCopyright"/> {{ 'Reuse deactivated copyrights'|trans }}<img src="images/info_16.png" title="{{'use to copy only deactived copyright decisions from the reused package'|trans}}" alt="" class="info-bullet"/><br/>
   {{ 'Upload to reuse'|trans }}:<br/>
   {{ macro.select(uploadToReuseSelectorName, folderUploads, uploadToReuseSelectorName, reuseUploadId, 'style="min-width:420px;"', 5) }}
 </li>


### PR DESCRIPTION
Signed-off-by: Anupam Ghosh <anupam.ghosh@siemens.com>

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
Deactivated copyrights are not reused when the scanner version changes.

### Changes
Deactivated copyrights are now reused when `Reuse deactivated copyrights` is selected while uploading the package
or select the option from `Schedule Agents` page on an existing package.  


## How to test

* Install fossology 3.7.0 upload a package after with `copyright scanner` selection.
* Deactivate false positive copyrights. 
* Install this branch and reused the copyright on the same package or a different version of the package.
* Deactivated copyrights should get copied. 

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)
