### PR TITLE
feat(rest): Filter uploads by folder id

### DIFF
--- a/src/lib/php/Dao/FolderDao.php
+++ b/src/lib/php/Dao/FolderDao.php
@@ -296,7 +296,7 @@ WHERE fc.parent_fk = $1 AND fc.foldercontents_mode = " . self::MODE_UPLOAD . " A
     return !empty($cycle);
   }
 
-  protected function getContent($folderContentId)
+  public function getContent($folderContentId)
   {
     $content = $this->dbManager->getSingleRow('SELECT * FROM foldercontents WHERE foldercontents_pk=$1',
       array($folderContentId),
@@ -444,13 +444,14 @@ WHERE fc.parent_fk = $1 AND fc.foldercontents_mode = " . self::MODE_UPLOAD . " A
   /**
    * Get the folder contents id for a given child id
    * @param integer $childId Id of the child
+   * @param integer $mode    Mode of child
    * @return NULL|integer Folder content id if success, NULL otherwise
    */
-  public function getFolderContentsId($childId)
+  public function getFolderContentsId($childId, $mode)
   {
     $folderContentsRow = $this->dbManager->getSingleRow(
       'SELECT foldercontents_pk FROM foldercontents '.
-      'WHERE child_id = $1', [$childId]);
+      'WHERE child_id = $1 AND foldercontents_mode = $2', [$childId, $mode]);
     if (!$folderContentsRow) {
       return null;
     }

--- a/src/lib/php/Proxy/UploadBrowseProxy.php
+++ b/src/lib/php/Proxy/UploadBrowseProxy.php
@@ -131,12 +131,16 @@ class UploadBrowseProxy
     if (count($params)!=1) {
       throw new \Exception('expected argument to be array with exactly one element for folderId');
     }
+    if (! is_array($params[0])) {
+      $params[0] = [$params[0]];
+    }
+    $params[0] = '{' . implode(',', $params[0]) . '}';
     $params[] = $this->groupId;
     $params[] = Auth::PERM_READ;
     $partQuery = 'upload
         INNER JOIN upload_clearing ON upload_pk = upload_clearing.upload_fk AND group_fk=$2
         INNER JOIN uploadtree ON upload_pk = uploadtree.upload_fk AND upload.pfile_fk = uploadtree.pfile_fk
-        WHERE upload_pk IN (SELECT child_id FROM foldercontents WHERE foldercontents_mode&2 != 0 AND parent_fk = $1 )
+        WHERE upload_pk IN (SELECT child_id FROM foldercontents WHERE foldercontents_mode&2 != 0 AND parent_fk = ANY($1::int[]) )
          AND (public_perm>=$3
               OR EXISTS(SELECT * FROM perm_upload WHERE perm_upload.upload_fk = upload_pk AND group_fk=$2))
          AND parent IS NULL

--- a/src/lib/php/services.xml.in
+++ b/src/lib/php/services.xml.in
@@ -193,6 +193,7 @@ without any warranty.
 
         <service id="helper.dbHelper" class="Fossology\UI\Api\Helper\DbHelper">
             <argument type="service" id="db.manager"/>
+            <argument type="service" id="dao.folder"/>
         </service>
         <service id="helper.fileHelper" class="Fossology\UI\Api\Helper\FileHelper">
             <argument type="service" id="dao.pfile"/>

--- a/src/www/ui/api/Controllers/FolderController.php
+++ b/src/www/ui/api/Controllers/FolderController.php
@@ -235,7 +235,7 @@ class FolderController extends RestController
       $isCopy = (strcmp($action, "copy") == 0);
       $message = $folderMove->copyContent(
         [
-          $folderDao->getFolderContentsId($folderId)
+          $folderDao->getFolderContentsId($folderId, $folderDao::MODE_FOLDER)
         ], $newParent, $isCopy);
       if (empty($message)) {
         $info = new Info(202,

--- a/src/www/ui/api/Controllers/SearchController.php
+++ b/src/www/ui/api/Controllers/SearchController.php
@@ -98,7 +98,13 @@ class SearchController extends RestController
     // rewrite it and add additional information about it's parent upload
     for ($i = 0; $i < sizeof($results); $i ++) {
       $currentUpload = $this->dbHelper->getUploads(
-        $this->restHelper->getUserId(), $results[$i]["upload_fk"])[0];
+        $this->restHelper->getUserId(), $this->restHelper->getGroupId(), 1, 1,
+        $results[$i]["upload_fk"], null, true)[1];
+      if (! empty($currentUpload)) {
+        $currentUpload = $currentUpload[0];
+      } else {
+        continue;
+      }
       $uploadTreePk = $results[$i]["uploadtree_pk"];
       $filename = $this->dbHelper->getFilenameFromUploadTree($uploadTreePk);
       $currentResult = new SearchResult($currentUpload, $uploadTreePk, $filename);

--- a/src/www/ui/api/Helper/RestHelper.php
+++ b/src/www/ui/api/Helper/RestHelper.php
@@ -215,7 +215,8 @@ class RestHelper
         return new Info(403, "Upload is not accessible.",
           InfoType::ERROR);
       }
-      $uploadContentId = $this->folderDao->getFolderContentsId($uploadId);
+      $uploadContentId = $this->folderDao->getFolderContentsId($uploadId,
+        $this->folderDao::MODE_UPLOAD);
       $contentMove = $this->getPlugin('content_move');
 
       $errors = $contentMove->copyContent([$uploadContentId], $newFolderId, $isCopy);

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -14,7 +14,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.1.0
+  version: 1.1.1
   contact:
     email: fossology@fossology.org
   license:
@@ -138,6 +138,13 @@ paths:
         in: path
         schema:
           type: integer
+      - name: groupName
+        description: The group name to chose while accessing the package
+        in: header
+        required: false
+        schema:
+          type: string
+          description: Group name, from last login if not provided
     get:
       tags:
         - Upload
@@ -172,14 +179,6 @@ paths:
         - Upload
         - Organize
       summary: Delete upload by id
-      parameters:
-        - name: groupName
-          description: The group name to chose while deleting the package
-          in: header
-          required: false
-          schema:
-            type: string
-            description: Group name, from last login if not provided
       responses:
         '202':
           description: Upload will be deleted
@@ -201,13 +200,6 @@ paths:
           required: true
           schema:
             type: integer
-        - name: groupName
-          description: The group name to chose while changing the package
-          in: header
-          required: false
-          schema:
-            type: string
-            description: Group name, from last login if not provided
       responses:
         '202':
           description: Upload will be moved
@@ -240,15 +232,57 @@ paths:
           $ref: '#/components/responses/defaultResponse'
 
   /uploads:
+    parameters:
+      - name: groupName
+        description: The group name to chose while accessing the package
+        in: header
+        required: false
+        schema:
+          type: string
+          description: Group name, from last login if not provided
     get:
       tags:
         - Upload
       summary: Uploads
+      parameters:
+        - name: folderId
+          description: Folder ID to limit the uploads to
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: recursive
+          description: Load uploads from child folders as well
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: true
+        - name: page
+          description: Page number to fetch
+          in: header
+          required: false
+          schema:
+            type: integer
+            default: 1
+        - name: limit
+          description: Limits of responses per request
+          in: header
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 100
       description: >
         The uploads endpoint returns all uploads
       responses:
         '200':
           description: An array of uploads
+          headers:
+            X-Total-Pages:
+              description: Total number of pages which can be fetched
+              schema:
+                type: integer
           content:
             application/json:
               schema:
@@ -310,13 +344,6 @@ paths:
           schema:
             type: boolean
             default: false
-        - name: groupName
-          description: The group name to chose while uploading the package
-          in: header
-          required: false
-          schema:
-            type: string
-            description: Group name, from last login if not provided
         - name: uploadType
           description: >
             Type of upload done. Required for VCS, URL and server uploads
@@ -347,6 +374,13 @@ paths:
         in: path
         schema:
           type: integer
+      - name: groupName
+        description: The group name to chose while accessing the package
+        in: header
+        required: false
+        schema:
+          type: string
+          description: Group name, from last login if not provided
     get:
       tags:
         - Upload
@@ -408,6 +442,13 @@ paths:
         schema:
           type: boolean
           default: true
+      - name: groupName
+        description: The group name to chose while accessing the package
+        in: header
+        required: false
+        schema:
+          type: string
+          description: Group name, from last login if not provided
     get:
       tags:
         - Upload
@@ -446,85 +487,85 @@ paths:
           $ref: '#/components/responses/defaultResponse'
 
   /search:
-      get:
-        tags:
-          - Search
-        description: Search the FOSSology for a specific file
-        parameters:
-          - name: groupName
-            description: The group name to chose while performing search
-            in: header
-            required: false
-            schema:
-              type: string
-              description: Group name, from last login if not provided
-          - name: searchType
-            # use 'allfiles', if not given
-            required: false
-            description: Limit search to
-            in: header
-            schema:
-              type: string
-              enum:
-                - directory
-                - containers
-                - allfiles
-              default: allfiles
-          - name: uploadId
-            in: header
-            required: false
-            description: Id of the upload to search files into
-            schema:
-              type: integer    
-          - name: filename
-            description: Filename to find, can contain % as wild-card
-            required: false
-            in: header
-            schema:
-              type: string
-          - name: tag
-            description: Tag to find
-            required: false
-            in: header
-            schema:
-              type: string
-          - name: filesizemin
-            description: Min filesize in bytes
-            required: false
-            in: header
-            schema:
-              type: integer
-              minimum: 0
-          - name: filesizemax
-            description: Max filesize in bytes
-            required: false
-            in: header
-            schema:
-              type: integer
-              minimum: 0
-          - name: license
-            description: License search filter
-            required: false
-            in: header
-            schema:
-              type: string
-          - name: copyright
-            description: Copyright search filter
-            required: false
-            in: header
-            schema:
-              type: string
-        responses:
-          '200':
-            description: OK
-            content:
-              application/json:
-                schema:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/SearchResults'
-          default:
-            $ref: '#/components/responses/defaultResponse'
+    get:
+      tags:
+        - Search
+      description: Search the FOSSology for a specific file
+      parameters:
+        - name: groupName
+          description: The group name to chose while performing search
+          in: header
+          required: false
+          schema:
+            type: string
+            description: Group name, from last login if not provided
+        - name: searchType
+          # use 'allfiles', if not given
+          required: false
+          description: Limit search to
+          in: header
+          schema:
+            type: string
+            enum:
+              - directory
+              - containers
+              - allfiles
+            default: allfiles
+        - name: uploadId
+          in: header
+          required: false
+          description: Id of the upload to search files into
+          schema:
+            type: integer
+        - name: filename
+          description: Filename to find, can contain % as wild-card
+          required: false
+          in: header
+          schema:
+            type: string
+        - name: tag
+          description: Tag to find
+          required: false
+          in: header
+          schema:
+            type: string
+        - name: filesizemin
+          description: Min filesize in bytes
+          required: false
+          in: header
+          schema:
+            type: integer
+            minimum: 0
+        - name: filesizemax
+          description: Max filesize in bytes
+          required: false
+          in: header
+          schema:
+            type: integer
+            minimum: 0
+        - name: license
+          description: License search filter
+          required: false
+          in: header
+          schema:
+            type: string
+        - name: copyright
+          description: Copyright search filter
+          required: false
+          in: header
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SearchResults'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /users:
       get:
         tags:
@@ -544,11 +585,11 @@ paths:
             $ref: '#/components/responses/defaultResponse'
   /users/{id}:
     parameters:
-        - name: id
-          required: true
-          in: path
-          schema:
-            type: integer
+      - name: id
+        required: true
+        in: path
+        schema:
+          type: integer
     get:
       tags:
         - User
@@ -578,86 +619,87 @@ paths:
         default:
             $ref: '#/components/responses/defaultResponse'
   /jobs:
-      get:
-        tags:
-        - Job
-        summary: Gets all jobs
-        description: Returns all jobs with their status
-        parameters:
-          - name: limit
-            required: false
-            schema:
-              type: integer
-              minimum: 1
-            in: header
-          - name: page
-            required: false
-            schema:
-              type: integer
-              minimum: 1
-            in: header
-          - name: upload
-            required: false
-            schema:
-              type: integer
-            in: query
-            description: Return jobs for the given upload id only
-        responses:
-          '200':
-            description: OK
-            headers:
-              X-Total-Pages:
-                description: Total number of pages which can be generated based on limit
-                schema:
-                  type: integer
-            content:
-              application/json:
-                schema:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/Job'
-          default:
-            $ref: '#/components/responses/defaultResponse'
-      post:
-        tags:
-          - Job
-        summary: Schedule an Analysis
-        description:  Schedule an Analysis of an existing upload
-        parameters:
-          # This could also be omitted, because there are no real folders
-          - name: folderId
-            in: header
-            required: true
-            schema:
-              type: integer
-          - name: uploadId
-            in: header
-            required: true
-            schema:
-              type: integer
-          - name: groupName
-            description: The group name to chose while scheduling jobs
-            in: header
-            required: false
-            schema:
-              type: string
-              description: Group name, from last login if not provided
-        requestBody:
-          description: Agents to be scheduled with the job
-          required: true
+    parameters:
+      - name: groupName
+        description: The group name to chose while accessing jobs
+        in: header
+        required: false
+        schema:
+          type: string
+          description: Group name, from last login if not provided
+    get:
+      tags:
+      - Job
+      summary: Gets all jobs
+      description: Returns all jobs with their status
+      parameters:
+        - name: limit
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+          in: header
+        - name: page
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+          in: header
+        - name: upload
+          required: false
+          schema:
+            type: integer
+          in: query
+          description: Return jobs for the given upload id only
+      responses:
+        '200':
+          description: OK
+          headers:
+            X-Total-Pages:
+              description: Total number of pages which can be generated based on limit
+              schema:
+                type: integer
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ScanOptions'
-        responses:
-          '201':
-            description: Job Scheduled with job id in message
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/Info'
-          default:
-            $ref: '#/components/responses/defaultResponse'
+                type: array
+                items:
+                  $ref: '#/components/schemas/Job'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+    post:
+      tags:
+        - Job
+      summary: Schedule an Analysis
+      description:  Schedule an Analysis of an existing upload
+      parameters:
+        # This could also be omitted, because there are no real folders
+        - name: folderId
+          in: header
+          required: true
+          schema:
+            type: integer
+        - name: uploadId
+          in: header
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        description: Agents to be scheduled with the job
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanOptions'
+      responses:
+        '201':
+          description: Job Scheduled with job id in message
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /jobs/{id}:
     parameters:
       - name: id
@@ -682,6 +724,14 @@ paths:
             $ref: '#/components/responses/defaultResponse'
 
   /folders:
+    parameters:
+      - name: groupName
+        description: The group name to chose while accessing folders
+        in: header
+        required: false
+        schema:
+          type: string
+          description: Group name, from last login if not provided
     get:
       tags:
       - Organize
@@ -745,6 +795,13 @@ paths:
         description: ID of the folder
         schema:
           type: integer
+      - name: groupName
+        description: The group name to chose while accessing the folder
+        in: header
+        required: false
+        schema:
+          type: string
+          description: Group name, from last login if not provided
     get:
       tags:
       - Organize


### PR DESCRIPTION
## Description

This PR allows user to limit uploads results to given folder id, provide an option to list uploads recursively, paginate the results if more than 100 uploads exists (can be controlled with `limit` parameter in header).

The default folder id is the user's root folder id and recursive is set to true.

In the earlier implementation, the uploads listing was limited to the user accessing the endpoint meaning that you can list only the uploads done by you. However, the UI lists the uploads based on group id. The REST API now reflects the same behavior.

The listing of `groupName` parameter is updated in the `openapi.yaml` to reduce the redundancy and add the endpoints which were missing it.

### Changes

1. Add new parameters `folderId`, `recursive` and `page` to `/uploads` endpoint.
1. List uploads based on groupId, not userId in `/uploads`.
1. `/uploads` response is paginated and can be controlled with `page` and `limit` parameters in headers.
1. Refactor `openapi.yaml` for `groupName`.

## How to test

1. Check if you can list uploads with `/uploads`.
1. Check if you can limit the responses with `folderId` and `recursive` parameters.
    - Also, bad values for the parameters should not break the code.
1. Check if `/folders` endpoint and `/search` endpoints are working.
1. Check if general UI of FOSSology is working.

Closes #1720