### PR TITLE
fix(report): Don't group results with custom text

### DIFF
--- a/src/lib/php/Report/ClearedGetterCommon.php
+++ b/src/lib/php/Report/ClearedGetterCommon.php
@@ -179,6 +179,7 @@ abstract class ClearedGetterCommon
         if ($extended) {
           $key = array_search($statement['textfinding'], array_column($findings, 'content'));
           $findings[$key]["comments"] = convertToUTF8($comments, false);
+          $findings[$key]["licenseId"] = $licenseId;
         }
       }
       //To keep the schedular alive for large files
@@ -188,7 +189,7 @@ abstract class ClearedGetterCommon
       }
     }
     arsort($statements);
-    if ($isUnifiedReport) {
+    if ($agentCall == "copyright" && $isUnifiedReport) {
       arsort($findings);
       if (!empty($objectAgent)) {
         $actualHeartbeat = (count($statements) + count($findings));

--- a/src/readmeoss/agent/readmeoss.php
+++ b/src/readmeoss/agent/readmeoss.php
@@ -125,11 +125,11 @@ class ReadmeOssAgent extends Agent
       if (!$this->uploadDao->isAccessible($addUploadId, $groupId)) {
         continue;
       }
-      $moreLicenses = $this->licenseClearedGetter->getCleared($addUploadId, $this, $groupId, true, null, false);
+      $moreLicenses = $this->licenseClearedGetter->getCleared($addUploadId, $this, $groupId, true, "license", false);
       $licenseStmts = array_merge($licenseStmts, $moreLicenses['statements']);
       $this->heartbeat(count($moreLicenses['statements']));
       $this->licenseClearedGetter->setOnlyAcknowledgements(true);
-      $moreAcknowledgements = $this->licenseClearedGetter->getCleared($addUploadId, $this, $groupId, true, null, false);
+      $moreAcknowledgements = $this->licenseClearedGetter->getCleared($addUploadId, $this, $groupId, true, "license", false);
       $licenseAcknowledgements = array_merge($licenseAcknowledgements, $moreAcknowledgements['statements']);
       $this->heartbeat(count($moreAcknowledgements['statements']));
       $moreCopyrights = $this->cpClearedGetter->getCleared($addUploadId, $this, $groupId, true, "copyright", false);

--- a/src/unifiedreport/agent/unifiedreport.php
+++ b/src/unifiedreport/agent/unifiedreport.php
@@ -264,7 +264,7 @@ class UnifiedReport extends Agent
 
     $this->heartbeat(0);
 
-    $licenses = $this->licenseClearedGetter->getCleared($uploadId, $this, $groupId, true, null, false);
+    $licenses = $this->licenseClearedGetter->getCleared($uploadId, $this, $groupId, true, "license", false);
     $this->heartbeat(empty($licenses) ? 0 : count($licenses["statements"]));
 
     $licensesMain = $this->licenseMainGetter->getCleared($uploadId, $this, $groupId, true, null, false);
@@ -277,7 +277,7 @@ class UnifiedReport extends Agent
     $this->heartbeat(empty($bulkLicenses) ? 0 : count($bulkLicenses["statements"]));
 
     $this->licenseClearedGetter->setOnlyAcknowledgements(true);
-    $licenseAcknowledgements = $this->licenseClearedGetter->getCleared($uploadId, $this, $groupId, true, null, false);
+    $licenseAcknowledgements = $this->licenseClearedGetter->getCleared($uploadId, $this, $groupId, true, "license", false);
     $this->heartbeat(empty($licenseAcknowledgements) ? 0 : count($licenseAcknowledgements["statements"]));
 
     $this->licenseClearedGetter->setOnlyComments(true);
@@ -297,7 +297,7 @@ class UnifiedReport extends Agent
     $this->heartbeat(empty($licensesDNUComment) ? 0 : count($licensesDNUComment["statements"]));
 
     $copyrights = $this->cpClearedGetter->getCleared($uploadId, $this, $groupId, true, "copyright", true);
-    $this->heartbeat(empty($copyrights["statements"]) ? 0 : count($copyrights["statements"]));
+    $this->heartbeat(empty($copyrights["scannerFindings"]) ? 0 : count($copyrights["scannerFindings"]) + count($copyrights["userFindings"]));
 
     $ecc = $this->eccClearedGetter->getCleared($uploadId, $this, $groupId, true, "ecc", false);
     $this->heartbeat(empty($ecc) ? 0 : count($ecc["statements"]));


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

### Description

In case a same license has been identified in different files with different license text, the report shows only one entry with only one license text.

### Changes

1. Add the missing `"license"` parameter to `getCleared()`.

## How to test

1. In a package, identify 3 files with same license (say Public-domain).
1. In all files, change the **License Text** with 3 different text.
1. Generate the Unified report and check for the license.
    - It should show 3 entries for all the 3 license texts with different files.