### PR TITLE
feat(build): Get build version number from git

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -60,14 +60,10 @@ jobs:
         echo PACKAGE_NAME=$(echo "FOSSology-${VERSION}-$(lsb_release -si | tr [:upper:] [:lower:])-$(lsb_release -sc | tr [:upper:] [:lower:]).tar.gz") >> $GITHUB_ENV
 
     - name: Build Debs
-      run: dpkg-buildpackage -I
+      run: ./utils/fo-debuild --no-sign
 
-    - name: Package
-      run: |
-        find .. -type f -name "*-dbgsym*" -exec rm -rf {} \;
-        mkdir packages
-        mv ../*.deb packages/
-        tar -czvf ${PACKAGE_NAME} ./packages
+    - name: Rename package
+      run: mv fossology_*.tar.gz ${PACKAGE_NAME}
 
     - name: Upload Release Asset
       id: upload-release-asset

--- a/Makefile.conf
+++ b/Makefile.conf
@@ -137,9 +137,10 @@ FO_CXXLDFLAGS = -lfossologyCPP -L$(CXXFOLIBDIR) -lstdc++ $(FO_LDFLAGS) \
                 $(shell pkg-config --libs icu-uc)
 
 # define VERSION and COMMIT_ID
-VERSION=`git describe --tags > /dev/null 2>&1 && git describe --tags | head -1 || echo "unknown"`
-BRANCH=`git rev-parse --abbrev-ref HEAD > /dev/null 2>&1 && git rev-parse --abbrev-ref HEAD | head -1 || echo "unknown"`
-COMMIT_HASH=`git show > /dev/null 2>&1 && git show | head -1 | awk '{print substr($$2,1,6)}' || echo "unknown"`
+VERSION_PATTERN = '\([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+\)\(-?rc[[:digit:]]+\)?-\([[:digit:]]+\)-[[:alnum:]]*'
+VERSION = $(shell git describe --tags > /dev/null 2>&1 && git describe --tags | head -1 | sed -re 's/$(VERSION_PATTERN)/\1.\3\2/' || echo "unknown")
+BRANCH=$(shell git rev-parse --abbrev-ref HEAD > /dev/null 2>&1 && git rev-parse --abbrev-ref HEAD | head -1 || echo "unknown")
+COMMIT_HASH=$(shell git show > /dev/null 2>&1 && git show | head -1 | awk '{print substr($$2,1,6)}' || echo "unknown")
 
 # Force the VERSION variable to be < 23 chars
 override VERSION:= $(shell echo ${VERSION} | cut -b1-23)

--- a/utils/fo-debuild
+++ b/utils/fo-debuild
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# This script builds the .deb packages by changing debian/changelog
+# Copyright (C) 2020 Siemens AG
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  version 2 as published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TOP="${SCRIPT_DIR}/.."
+
+show_help() {
+  cat <<EOF
+Usage: fo-debuild [options]
+  -s or --no-sign    : do not sign packages
+  -h or --help       : this help text
+EOF
+}
+
+NOSIGN=''
+
+. "${SCRIPT_DIR}/utils.sh"
+
+# Make sure we are in correct location
+pushd $TOP
+
+# make sure we're in a checked out git copy
+if [ ! -d .git ]; then
+   echo "ERROR: No Git information found. This script requires an git tree."
+   exit 0
+fi
+
+# Check if GIT is available. If not, then abort.
+which git >/dev/null 2>&1
+if [ $? != 0 ]; then
+   echo "ERROR: git command missing."
+   exit 1
+fi
+
+set -o errexit -o nounset -o pipefail
+
+## Options parsing and setup
+# parse options
+OPTS=$(getopt -o sh --long no-sign,help -n 'fo-debuild' -- "$@")
+
+if [[ $? -ne 0 ]]; then
+   OPTS="--help"
+fi
+
+eval set -- "$OPTS"
+
+while true; do
+   case "$1" in
+      -s|--no-sign)     NOSIGN="--no-sign"; shift;;
+      -h|--help)        show_help; exit;;
+      --)               shift; break;;
+      *)                echo "ERROR: option $1 not recognised"; exit 1;;
+   esac
+done
+
+# Get the version
+VERSION=$(eval ${VERSION_COMMAND})
+VERSION="${VERSION/-rc/~rc}-1"
+DISTRO=$(lsb_release --codename --short)
+
+# Update debian/changelog
+echo "Updating changelog with ${DISTRO} distro and ${VERSION} version."
+debchange --distribution ${DISTRO} \
+  --newversion ${VERSION} \
+  --urgency low --maintmaint "New patch build"
+
+utils/fo-mktar
+
+# Clean and build packages
+echo "Building packages..."
+make clean phpvendors
+dpkg-buildpackage ${NOSIGN}
+
+# Discard changelog changes
+git checkout -- debian/changelog
+
+# Package deb files
+echo "Packaging files as ${TOP}/fossology_${VERSION}.tar.gz"
+mkdir -p packages
+mv ../*.deb packages/
+mv ../fossology_${VERSION}_*.buildinfo packages/
+mv ../fossology_${VERSION}_*.changes packages/
+mv ../fossology_${VERSION}.dsc packages/
+tar -czvf fossology_${VERSION}.tar.gz packages
+rm -rf packages
+
+popd
+

--- a/utils/fo-debuild
+++ b/utils/fo-debuild
@@ -90,6 +90,7 @@ git checkout -- debian/changelog
 
 # Package deb files
 echo "Packaging files as ${TOP}/fossology_${VERSION}.tar.gz"
+find .. -type f -name "*-dbgsym*" -exec rm -rf {} \;
 mkdir -p packages
 mv ../*.deb packages/
 mv ../fossology_${VERSION}_*.buildinfo packages/

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -104,7 +104,7 @@ if [[ $BUILDTIME ]]; then
             libmxml-dev curl libxml2-dev libcunit1-dev libicu-dev \
             build-essential libtext-template-perl subversion rpm librpm-dev \
             libmagic-dev libglib2.0 libboost-regex-dev \
-            libboost-program-options-dev libpq-dev composer
+            libboost-program-options-dev libpq-dev composer devscripts libdistro-info-perl
          case "$CODENAME" in
            xenial|stretch)
              apt-get $YesOpt install php-mbstring php7.0-cli php7.0-xml php7.0-zip;;
@@ -115,7 +115,7 @@ if [[ $BUILDTIME ]]; then
            sid)
              apt-get $YesOpt install php-mbstring php-cli php-xml php-zip;;
            focal)
-             apt-get $YesOpt install php-mbstring php-cli php-xml php-zip;; 
+             apt-get $YesOpt install php-mbstring php-cli php-xml php-zip;;
          esac
          if ! dpkg --get-selections | grep -q postgresql-server-dev; then  ## if postgresql-server-dev is not installed
            case "$CODENAME" in

--- a/utils/fo-mktar
+++ b/utils/fo-mktar
@@ -1,16 +1,16 @@
 #!/bin/sh
 # This script packages the directory into a tar file.
 # Copyright (C) 2014 Hewlett-Packard Development Company, L.P.
-# 
+#
 #  This program is free software; you can redistribute it and/or
 #  modify it under the terms of the GNU General Public License
 #  version 2 as published by the Free Software Foundation.
-#  
+#
 #  This program is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
-#  
+#
 #  You should have received a copy of the GNU General Public License along
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -36,15 +36,19 @@ if [ ! -f "Makefile.conf" ]; then
    exit 1
 fi
 
-VERSION="`git describe --tags > /dev/null 2>&1 && git describe --tags | head -1`"
+. ./utils/utils.sh
+
+# define VERSION and COMMIT_ID
+VERSION=$(eval ${VERSION_COMMAND})
+VERSION="${VERSION/-rc/~rc}-1"
 
 # COMMIT_HASH is the last revision from git info.  This is used for packaging.
 COMMIT_HASH="`git show | head -1 | awk '{print substr($2,1,6)}'`"
 
-TARBASE="fossology-$VERSION"
+TARBASE="fossology_$VERSION"
 # Check for command-line for subversion
 if [ "$1" = "-s" ]; then
-   TARBASE="fossology-$VERSION-$COMMIT_HASH"
+   TARBASE="fossology_$VERSION-$COMMIT_HASH"
 fi
 
 echo "*** Packaging $VERSION (git $COMMIT_HASH) into $TARBASE ***"
@@ -61,7 +65,6 @@ fi
 echo "*** Exporting git version $COMMIT_HASH to ../$TARBASE ***"
 mkdir "../$TARBASE"
 cp -r . "../$TARBASE"
-find "../$TARBASE" | grep .git | xargs rm -rf
 if [ $? != 0 ]; then
    echo "ERROR: git export failed."
    exit 3
@@ -70,19 +73,19 @@ fi
 # Create the tar
 (
 cd ..
-if [ -f "$TARBASE.tar.gz" ]; then
-   echo "WARNING: ../$TARBASE.tar.gz exists, removing"
-   rm -f "$TARBASE.tar.gz"
-   if [ -f "$TARBASE.tar.gz" ]; then
-      echo "ERROR: unable to remove ../$TARBASE.tar.gz, exiting."
+if [ -f "$TARBASE.orig.tar.gz" ]; then
+   echo "WARNING: ../$TARBASE.orig.tar.gz exists, removing"
+   rm -f "$TARBASE.orig.tar.gz"
+   if [ -f "$TARBASE.orig.tar.gz" ]; then
+      echo "ERROR: unable to remove ../$TARBASE.orig.tar.gz, exiting."
       exit 4
    fi
 fi
 
 echo "*** Creating tar ***"
-tar --anchored --exclude=\*/debian -czf "$TARBASE.tar.gz" "$TARBASE"
+tar --anchored --exclude=\*/debian --exclude-vcs --exclude-vcs-ignores -czf "$TARBASE.orig.tar.gz" "$TARBASE"
 if [ $? != 0 ]; then
-   echo "ERROR: unable to create ../$TARBASE.tar.gz, exiting."
+   echo "ERROR: unable to create ../$TARBASE.orig.tar.gz, exiting."
    exit 4
 fi
 )
@@ -95,4 +98,4 @@ if [ -d "../$TARBASE" ]; then
    exit 5
 fi
 
-echo "*** ../$TARBASE.tar.gz created successfully. ***"
+echo "*** ../$TARBASE.orig.tar.gz created successfully. ***"

--- a/utils/fo-mktar
+++ b/utils/fo-mktar
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This script packages the directory into a tar file.
 # Copyright (C) 2014 Hewlett-Packard Development Company, L.P.
 #

--- a/utils/utils.sh
+++ b/utils/utils.sh
@@ -51,3 +51,6 @@ Usage: mod_deps [options]
   -h or --help       : this help text
 EOF
 }
+
+VERSION_PATTERN='([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+)(-?rc[[:digit:]]+)?-([[:digit:]]+)-[[:alnum:]]*'
+VERSION_COMMAND="git describe --tags > /dev/null 2>&1 && git describe --tags | head -1 | sed -re 's/${VERSION_PATTERN}/\\1.\\3\\2/'"


### PR DESCRIPTION
## Description

Use the information provided by `git describe --tags` and generate the build version number.

The `git describe --tags` also displays the number of commits since last tags which is used here to get the build number. So let's say, last tag was 3.8.1 and there are 88 commits since then, the version now will be 3.8.1.88.
(See the **Example** in [man git-describe](https://linux.die.net/man/1/git-describe) for info on format)

Also, created a new script `utils/fo-debuild` to generate Debian packages and source tar with option to skip signing of packages with `--no-sign` flag.

### Changes

1. Get the no. of commits from `git describe --tags` using `sed` and generate build number using it.
1. Fix the `fo-mktar` to consider `.gitignore` and use new version.
1. New script `fo-debuild` to generate Debian packages.

## How to test

1. Check if `make VERSIONFILE` generates `VERSION` without errors and the version in `VERSION` file is correct.
1. Check if the script works even on tags (no commits since tag, no modification in version).
1. Check if `utils/fo-debuild` works with and without `--no-sign` option.