### PR TITLE
fix(Nomos): Added a new License signature

### DIFF
--- a/src/nomos/agent/STRINGS.in
+++ b/src/nomos/agent/STRINGS.in
@@ -8735,7 +8735,7 @@ k
 #
 %ENTRY% _TITLE_PHP202
 %KEY% "licen[cs]"
-%STR% "the php licen[cs]e (v|version )2\.?0\.?2"
+%STR% "the php licen[cs]e (v|version )2\.?02"
 #
 %ENTRY% _TITLE_PUBUSE_V10
 %KEY% "licen[cs]"

--- a/src/nomos/agent/parse.c
+++ b/src/nomos/agent/parse.c
@@ -586,7 +586,7 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
       lmem[_mPHP] = 1;
     }
     else if (INFILE(_TITLE_PHP202)) {
-      INTERESTING(lDebug ? "PHP(v2.0.2#1)" : "PHP-2.0.2");
+      INTERESTING(lDebug ? "PHP(v2.02#1)" : "PHP-2.02");
       lmem[_mPHP] = 1;
     }
     else if (INFILE(_CR_VOVIDA) || INFILE(_TITLE_VOVIDA)) {
@@ -613,7 +613,7 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
       MEDINTEREST(lDebug ? "Sleepycat(1)" : "Sleepycat");
     }
     else if (INFILE(_TITLE_PHP202)) {
-      INTERESTING(lDebug ? "PHP(v2.0.2#2)" : "PHP-2.0.2");
+      INTERESTING(lDebug ? "PHP(v2.02#2)" : "PHP-2.02");
       lmem[_mPHP] = 1;
     }
     else if (INFILE(_TITLE_ZEND_V20)) {
@@ -1064,7 +1064,7 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
       INTERESTING(lDebug ? "PHP(v3.0#2)" : "PHP-3.0");
     }
     else if (INFILE(_TITLE_PHP202)) {
-      INTERESTING(lDebug ? "PHP(v2.0.2#3)" : "PHP-2.0.2");
+      INTERESTING(lDebug ? "PHP(v2.02#3)" : "PHP-2.02");
     }
     else if (INFILE(_CR_PHP)) {
       INTERESTING(lDebug ? "PHP(1)" : "PHP");

--- a/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan
+++ b/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan
@@ -122,6 +122,7 @@ File NomosTestfiles/PHP/PHP-3.0.txt contains license(s) PHP-3.0
 File NomosTestfiles/PHP/License3.01.php contains license(s) PHP-3.01
 File NomosTestfiles/PHP/PHP-3.01_ref_a.txt contains license(s) LGPL-2.0+,PHP-3.01
 File NomosTestfiles/PHP/PHP-3.0_ref_a.txt contains license(s) PHP-3.0
+File NomosTestfiles/PHP/PHP-2.02.txt contains license(s) PHP-2.02
 File NomosTestfiles/Apache/License-2.0.Apache_v2.0 contains license(s) Apache-2.0
 File NomosTestfiles/Apache/condor_blkng_full_disk_io.h contains license(s) Apache-2.0
 File NomosTestfiles/Apache/Apache-1.0.txt contains license(s) Apache-1.0

--- a/src/nomos/agent_tests/testdata/NomosTestfiles/PHP/PHP-2.02.txt
+++ b/src/nomos/agent_tests/testdata/NomosTestfiles/PHP/PHP-2.02.txt
@@ -1,0 +1,75 @@
+--------------------------------------------------------------------
+                  The PHP License, version 2.02
+Copyright (c) 1999 - 2002 The PHP Group. All rights reserved.
+--------------------------------------------------------------------
+
+Redistribution and use in source and binary forms, with or without
+modification, is permitted provided that the following conditions
+are met:
+
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+  3. The name "PHP" must not be used to endorse or promote products
+     derived from this software without prior permission from the
+     PHP Group.  This does not apply to add-on libraries or tools
+     that work in conjunction with PHP.  In such a case the PHP
+     name may be used to indicate that the product supports PHP.
+
+  4. The PHP Group may publish revised and/or new versions of the
+     license from time to time. Each version will be given a
+     distinguishing version number.
+     Once covered code has been published under a particular version
+     of the license, you may always continue to use it under the
+     terms of that version. You may also choose to use such covered
+     code under the terms of any subsequent version of the license
+     published by the PHP Group. No one other than the PHP Group has
+     the right to modify the terms applicable to covered code created
+     under this License.
+
+  5. Redistributions of any form whatsoever must retain the following
+     acknowledgment:
+     "This product includes PHP, freely available from
+     http://www.php.net/".
+
+  6. The software incorporates the Zend Engine, a product of Zend
+     Technologies, Ltd. ("Zend"). The Zend Engine is licensed to the
+     PHP Association (pursuant to a grant from Zend that can be
+     found at http://www.php.net/license/ZendGrant/) for
+     distribution to you under this license agreement, only as a
+     part of PHP.  In the event that you separate the Zend Engine
+     (or any portion thereof) from the rest of the software, or
+     modify the Zend Engine, or any portion thereof, your use of the
+     separated or modified Zend Engine software shall not be governed
+     by this license, and instead shall be governed by the license
+     set forth at http://www.zend.com/license/ZendLicense/.
+
+
+
+THIS SOFTWARE IS PROVIDED BY THE PHP DEVELOPMENT TEAM ``AS IS'' AND
+ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE PHP
+DEVELOPMENT TEAM OR ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------
+
+This software consists of voluntary contributions made by many
+individuals on behalf of the PHP Group.
+
+The PHP Group can be contacted via Email at group@php.net.
+
+For more information on the PHP Group and the PHP project,
+please see <http://www.php.net>.


### PR DESCRIPTION
## Description
Added a new regex to fix the wrong interpretation of PHP-2.02 license by nomos agent

## How to test

Try scanning the following file (http://www.php.net/license/2_02.txt) it should be identified as PHP 2.02.

fixes: #1213 

Signed-off-by: Sahil <sjha200000@gmail.com>

