### PR TITLE
feat(utils): Filter inputs for unicode ctrl chars

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -33,6 +33,7 @@ use Fossology\Lib\Proxy\UploadTreeProxy;
 use Fossology\Lib\Proxy\ScanJobProxy;
 use Monolog\Logger;
 use Fossology\Lib\Data\AgentRef;
+use Fossology\Lib\Util\StringOperation;
 
 class ClearingDao
 {
@@ -503,6 +504,10 @@ INSERT INTO clearing_decision (
   public function insertClearingEvent($uploadTreeId, $userId, $groupId, $licenseId, $isRemoved, $type = ClearingEventTypes::USER, $reportInfo = '', $comment = '', $acknowledgement = '', $jobId=0)
   {
     $insertIsRemoved = $this->dbManager->booleanToDb($isRemoved);
+
+    $reportInfo = StringOperation::replaceUnicodeControlChar($reportInfo);
+    $comment = StringOperation::replaceUnicodeControlChar($comment);
+    $acknowledgement = StringOperation::replaceUnicodeControlChar($acknowledgement);
 
     $stmt = __METHOD__;
     $params = array($uploadTreeId, $userId, $groupId, $type, $licenseId, $insertIsRemoved, $reportInfo, $comment, $acknowledgement);

--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -23,6 +23,7 @@ use Fossology\Lib\Data\Highlight;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
 use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Proxy\ScanJobProxy;
+use Fossology\Lib\Util\StringOperation;
 use Fossology\Lib\Data\AgentRef;
 use Monolog\Logger;
 
@@ -113,6 +114,7 @@ class CopyrightDao
   public function saveDecision($tableName, $pfileId, $userId , $clearingType,
                                $description, $textFinding, $comment, $decision_pk=-1)
   {
+    $textFinding = StringOperation::replaceUnicodeControlChar($textFinding);
     $primaryColumn = $tableName . '_pk';
     $assocParams = array(
       'user_fk' => $userId,
@@ -453,7 +455,7 @@ class CopyrightDao
       $stmt .= '.rollback';
     } else {
       $setSql = "content = $4, hash = md5($4), is_enabled='true'";
-      $params[] = $content;
+      $params[] = StringOperation::replaceUnicodeControlChar($content);
     }
 
     $cpTablePk = $cpTable."_pk";

--- a/src/lib/php/Dao/LicenseStdCommentDao.php
+++ b/src/lib/php/Dao/LicenseStdCommentDao.php
@@ -24,6 +24,7 @@ namespace Fossology\Lib\Dao;
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\Util\StringOperation;
 
 /**
  * @class LicenseStdCommentDao
@@ -81,7 +82,8 @@ class LicenseStdCommentDao
       "WHERE lsc_pk = $1 " .
       "RETURNING 1 AS updated;";
     $row = $this->dbManager->getSingleRow($sql,
-      [$commentPk, $newName, $newComment, $userFk]);
+      [$commentPk, $newName,
+        StringOperation::replaceUnicodeControlChar($newComment), $userFk]);
     return $row['updated'] == 1;
   }
 
@@ -112,7 +114,7 @@ class LicenseStdCommentDao
 
     $params = [
       'name' => $name,
-      'comment' => $comment,
+      'comment' => StringOperation::replaceUnicodeControlChar($comment),
       'user_fk' => $userFk
     ];
     $statement = __METHOD__ . ".insertNewLicStdComment";
@@ -164,7 +166,7 @@ class LicenseStdCommentDao
         $statement .= ".name";
       }
       if (array_key_exists("comment", $comment)) {
-        $params[] = $comment["comment"];
+        $params[] = StringOperation::replaceUnicodeControlChar($comment["comment"]);
         $updateStatement[] = "comment = $" . count($params);
         $statement .= ".comment";
       }

--- a/src/lib/php/Dao/SpashtDao.php
+++ b/src/lib/php/Dao/SpashtDao.php
@@ -23,6 +23,7 @@ use Fossology\Lib\Data\Spasht\Coordinate;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
 use Fossology\Lib\Db\DbManager;
 use Monolog\Logger;
+use Fossology\Lib\Util\StringOperation;
 
 /**
  * Class AgentDao
@@ -155,7 +156,7 @@ class SpashtDao
       $stmt .= '.rollback';
     } else {
       $setSql = "textfinding = $4, hash = md5($4), is_enabled='true'";
-      $params[] = $content;
+      $params[] = StringOperation::replaceUnicodeControlChar($content);
     }
 
     $sql = "UPDATE copyright_spasht AS cpr SET $setSql

--- a/src/lib/php/Util/StringOperation.php
+++ b/src/lib/php/Util/StringOperation.php
@@ -35,4 +35,18 @@ class StringOperation
     }
     return substr($a,0,$headLength);
   }
+
+  /**
+   * Replace any non-printable characters with a given character
+   * @param string $input   String to clean
+   * @param string $replace Replace control char with this
+   * @return string Input string with non-printable character removed
+   */
+  public static function replaceUnicodeControlChar($input, $replace="")
+  {
+    // 'Non-printable' is ASCII < 0x20 (excluding \r, \n and tab) and
+    // 0x7F - 0x9F.
+    return preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/u', $replace,
+      $input);
+  }
 }

--- a/src/lib/php/Util/test/StringOperationTest.php
+++ b/src/lib/php/Util/test/StringOperationTest.php
@@ -41,4 +41,35 @@ class StringOperationTest extends \PHPUnit\Framework\TestCase
     assertThat(StringOperation::getCommonHead('abc',''), equalTo(''));
     assertThat(StringOperation::getCommonHead('','abc'), equalTo(''));
   }
+
+  /**
+   * @test
+   * Test for StringOperation::replaceUnicodeControlChar
+   * -# Pass various valid and invalid unicode strings as input
+   * -# Pass various replace characters
+   * -# Check if the output is free of invalid unichars
+   */
+  public function testReplaceUnicodeControlChar()
+  {
+    assertThat(StringOperation::replaceUnicodeControlChar('Y', '?'),
+      equalTo('?Y'));
+    assertThat(StringOperation::replaceUnicodeControlChar('“IND'),
+      equalTo('“IND'));
+    assertThat(StringOperation::replaceUnicodeControlChar('y’©', 'a'),
+      equalTo('y’©'));
+    assertThat(StringOperation::replaceUnicodeControlChar('eys'),
+      equalTo('eys'));
+    assertThat(StringOperation::replaceUnicodeControlChar('नमस्ते', '.'),
+      equalTo('नमस्ते'));
+    assertThat(StringOperation::replaceUnicodeControlChar('abc', ''),
+      equalTo('abc'));
+    assertThat(StringOperation::replaceUnicodeControlChar('ab	c'),
+      equalTo('ab	c'));
+    assertThat(StringOperation::replaceUnicodeControlChar("abc\r\na", ''),
+      equalTo("abc\r\na"));
+    assertThat(StringOperation::replaceUnicodeControlChar("ab\tc"),
+      equalTo("ab\tc"));
+    assertThat(StringOperation::replaceUnicodeControlChar('', 'abc'),
+      equalTo(''));
+  }
 }

--- a/src/www/ui/admin-license-file.php
+++ b/src/www/ui/admin-license-file.php
@@ -21,6 +21,7 @@ use Fossology\Lib\BusinessRules\LicenseMap;
 use Fossology\Lib\Db\DbManager;
 use Symfony\Component\HttpFoundation\Response;
 use Fossology\Lib\BusinessRules\ObligationMap;
+use Fossology\Lib\Util\StringOperation;
 
 define("TITLE_ADMIN_LICENSE_FILE", _("License Administration"));
 
@@ -392,11 +393,11 @@ class admin_license_file extends FO_Plugin
   function Updatedb()
   {
     $rfId = intval($_POST['rf_pk']);
-    $shortname = trim($_POST['rf_shortname']);
-    $fullname = trim($_POST['rf_fullname']);
+    $shortname = StringOperation::replaceUnicodeControlChar(trim($_POST['rf_shortname']));
+    $fullname = StringOperation::replaceUnicodeControlChar(trim($_POST['rf_fullname']));
     $url = $_POST['rf_url'];
     $notes = $_POST['rf_notes'];
-    $text = trim($_POST['rf_text']);
+    $text = StringOperation::replaceUnicodeControlChar(trim($_POST['rf_text']));
     $parent = $_POST['rf_parent'];
     $report = $_POST['rf_report'];
     $riskLvl = intval($_POST['risk_level']);
@@ -490,15 +491,16 @@ class admin_license_file extends FO_Plugin
    */
   function Adddb()
   {
-    $rf_shortname = trim($_POST['rf_shortname']);
-    $rf_fullname = trim($_POST['rf_fullname']);
+    $rf_shortname = StringOperation::replaceUnicodeControlChar(trim($_POST['rf_shortname']));
+    $rf_fullname = StringOperation::replaceUnicodeControlChar(trim($_POST['rf_fullname']));
     $rf_url = $_POST['rf_url'];
     $rf_notes = $_POST['rf_notes'];
-    $rf_text = trim($_POST['rf_text']);
+    $rf_text = StringOperation::replaceUnicodeControlChar(trim($_POST['rf_text']));
     $parent = $_POST['rf_parent'];
     $report = $_POST['rf_report'];
     $riskLvl = intval($_POST['risk_level']);
-    $selectedObligations = $_POST[$this->obligationSelectorName];
+    $selectedObligations = array_key_exists($this->obligationSelectorName,
+      $_POST) ? $_POST[$this->obligationSelectorName] : [];
 
     if (empty($rf_shortname)) {
       $text = _("ERROR: The license shortname is empty. License not added.");

--- a/src/www/ui/admin-obligation-file.php
+++ b/src/www/ui/admin-obligation-file.php
@@ -20,6 +20,7 @@
 use Fossology\Lib\BusinessRules\LicenseMap;
 use Fossology\Lib\BusinessRules\ObligationMap;
 use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\Util\StringOperation;
 
 define("TITLE_ADMIN_OBLIGATION_FILE", _("Obligations and Risks Administration"));
 
@@ -377,11 +378,11 @@ class admin_obligation_file extends FO_Plugin
   function Updatedb()
   {
     $obId = intval($_POST['ob_pk']);
-    $topic = trim($_POST['ob_topic']);
+    $topic = StringOperation::replaceUnicodeControlChar(trim($_POST['ob_topic']));
     $licnames = $_POST['licenseSelector'];
     $candidatenames = $_POST['candidateSelector'];
-    $text = trim($_POST['ob_text']);
-    $comment = trim($_POST['ob_comment']);
+    $text = StringOperation::replaceUnicodeControlChar(trim($_POST['ob_text']));
+    $comment = StringOperation::replaceUnicodeControlChar(trim($_POST['ob_comment']));
 
     if (empty($topic)) {
       $text = _("ERROR: The obligation topic is empty.");
@@ -438,11 +439,11 @@ class admin_obligation_file extends FO_Plugin
    */
   function Adddb()
   {
-    $topic = trim($_POST['ob_topic']);
+    $topic = StringOperation::replaceUnicodeControlChar(trim($_POST['ob_topic']));
     $licnames = empty($_POST['licenseSelector']) ? array() : $_POST['licenseSelector'];
     $candidatenames = empty($_POST['candidateSelector']) ? array() : $_POST['candidateSelector'];
-    $text = trim($_POST['ob_text']);
-    $comment = trim($_POST['ob_comment']);
+    $text = StringOperation::replaceUnicodeControlChar(trim($_POST['ob_text']));
+    $comment = StringOperation::replaceUnicodeControlChar(trim($_POST['ob_comment']));
     $message = "";
 
     if (empty($topic)) {
@@ -469,7 +470,15 @@ class admin_obligation_file extends FO_Plugin
     $stmt = __METHOD__.'.ob';
     $sql = "INSERT into obligation_ref (ob_active, ob_type, ob_modifications, ob_topic, ob_md5, ob_text, ob_classification, ob_text_updatable, ob_comment) VALUES ($1, $2, $3, $4, md5($5), $5, $6, $7, $8) RETURNING ob_pk";
     $this->dbManager->prepare($stmt,$sql);
-    $res = $this->dbManager->execute($stmt,array($_POST['ob_active'],$_POST['ob_type'],$_POST['ob_modifications'],$topic,$text, $_POST['ob_classification'],$_POST['ob_text_updatable'],$comment));
+    $res = $this->dbManager->execute($stmt,
+      array($_POST['ob_active'],
+        $_POST['ob_type'],
+        $_POST['ob_modifications'],
+        $topic,
+        $text,
+        $_POST['ob_classification'],
+        $_POST['ob_text_updatable'],
+        $comment));
     $row = $this->dbManager->fetchArray($res);
     $obId = $row['ob_pk'];
 


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

At every possible place where user input is taken as text and the input is written to a file (reports), remove non-printable unicode control characters.

### Changes

1. New function `replaceUnicodeControlChar` is added to `StringOperation` class.

## How to test

1. In an upload, add some license text and acknowledgements with invalid control characters.
1. Also, add some valid unicode characters like &copy; and text from languages with non-latin script.
1. Check if the invalid characters are removed before inserting the data in DB.
1. Perform same operation on License text update, new license creation, acknowledgement with bulk finding, etc.

Example of test strings:
```
4.	“IDENT”.  some text and it’s
copyrights ©
Agreement.

invals
```
```
There is something below this line.

Do copy with care.
```
```
नमस्ते
你好
こんにちは
```