### PR TITLE
fix(ClearingDao): Get uploadtree table name

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -343,6 +343,10 @@ class ClearingDao
     }
 
     $itemTreeBounds = $this->uploadDao->getItemTreeBounds($uploadTreeId);
+    $uploadId = $itemTreeBounds->getUploadId();
+    $uploadTreeTable = $this->uploadDao->getUploadtreeTableName($uploadId);
+    $itemTreeBounds = $this->uploadDao->getItemTreeBounds($uploadTreeId, $uploadTreeTable);
+
     if ($this->isDecisionIrrelevant($uploadTreeId, $groupId)) {
       $this->copyrightDao->updateTable($itemTreeBounds, '', '', $userId, 'copyright', 'rollback');
     } else if ($decType == DecisionTypes::IRRELEVANT) {

--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -462,7 +462,7 @@ class CopyrightDao
             INNER JOIN $itemTable AS ut ON cp.pfile_fk = ut.pfile_fk
             WHERE cpr.$cpTablePk = cp.$cpTablePk
               AND $withHash ( ut.lft BETWEEN $1 AND $2 )";
-    if ('uploadtree_a' == $item->getUploadTreeTableName()) {
+    if ('uploadtree_a' == $item->getUploadTreeTableName() || 'uploadtree' == $item->getUploadTreeTableName()) {
       $params[] = $item->getUploadId();
       $sql .= " AND ut.upload_fk=$".count($params);
       $stmt .= '.upload';


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

`getItemTreeBounds()` returned default `uploadtree` table causing wrong join with copyright table.

### Changes

1. Get the correct uploadtree table name and recreate the `$itemTreeBounds` to fix it.
1. As a fail safe, check for `uploadtree` in ClearingDao as well.