### PR TITLE
fix(conf): fix not able to save conf in case of brackets

### DIFF
--- a/src/www/ui/ui-report-conf.php
+++ b/src/www/ui/ui-report-conf.php
@@ -179,9 +179,9 @@ class ui_report_conf extends FO_Plugin
                      $obData['text'].'</textarea></td><td>';
       foreach ($obData['license'] as $value) {
         if (!empty($excludedObligations[$obTopic]) && in_array($value, $excludedObligations[$obTopic])) {
-          $tableRows .= '<input type="checkbox" name="obLicenses['.$obTopic.'][]" value="'.$value.'" checked> '.$value.'<br />';
+          $tableRows .= '<input type="checkbox" name="obLicenses['.urlencode($obTopic).'][]" value="'.$value.'" checked> '.$value.'<br />';
         } else {
-          $tableRows .= '<input type="checkbox" name="obLicenses['.$obTopic.'][]" value="'.$value.'"> '.$value.'<br />';
+          $tableRows .= '<input type="checkbox" name="obLicenses['.urlencode($obTopic).'][]" value="'.$value.'"> '.$value.'<br />';
         }
       }
       $tableRows .= '</td></tr>';
@@ -275,7 +275,14 @@ class ui_report_conf extends FO_Plugin
 
     if (isset($submitReportConf)) {
       $parms = array();
-      $obLicenses = @$_POST["obLicenses"];
+      $obLicensesEncoded = @$_POST["obLicenses"];
+      $obLicensesEncoded = !empty($obLicensesEncoded) ? $obLicensesEncoded : array();
+      $obLicenses = array();
+      array_walk($obLicensesEncoded,
+        function (&$licArray, $obTopic) use (&$obLicenses) {
+          $obLicenses[urldecode($obTopic)] = $licArray;
+        }
+      );
       $i = 1;
       $columns = "";
       foreach ($this->mapDBColumns as $key => $value) {


### PR DESCRIPTION
## Description

Use urlencode and decode for ObTopic in name, so that the brackets will not mix up with obligations.

## How to test

* Upload a component.
* Create a obligation with brackets '[]' Ex: obligation [Some name]
* Do clearing with license associated obligation.
* go to conf and select obligation and submit.
* check of the results have been stored in database.