### PR TITLE
feat(search) - possibility to search in selected upload only

### DIFF
--- a/src/lib/php/Dao/UploadDao.php
+++ b/src/lib/php/Dao/UploadDao.php
@@ -101,6 +101,20 @@ class UploadDao
     return $row ? Upload::createFromTable($row) : null;
   }
 
+  public function getActiveUploadsArray()
+  {
+    $stmt = __METHOD__;
+    $queryResult = $this->dbManager->getRows("SELECT * FROM upload where pfile_fk IS NOT NULL",
+        array(), $stmt);
+
+    $results = array();
+    foreach ($queryResult as $row) {
+      $results[] = Upload::createFromTable($row);
+    }
+
+    return $results;
+  }
+
   /**
    * @param $itemId
    * @param $uploadTreeTableName

--- a/src/www/ui/api/Controllers/SearchController.php
+++ b/src/www/ui/api/Controllers/SearchController.php
@@ -54,10 +54,16 @@ class SearchController extends RestController
     $filesizeMax = $request->getHeaderLine("filesizemax");
     $license = $request->getHeaderLine("license");
     $copyright = $request->getHeaderLine("copyright");
+    $uploadId = $request->getHeaderLine("uploadId");
 
     // set searchtype to search allfiles by default
     if (empty($searchType)) {
       $searchType = "allfiles";
+    }
+
+    // set uploadId to 0 - search in all files
+    if (empty($uploadId)) {
+      $uploadId = 0;
     }
 
     /*
@@ -83,7 +89,7 @@ class SearchController extends RestController
     }
 
     $item = GetParm("item", PARM_INTEGER);
-    $results = GetResults($item, $filename, $tag, 0,
+    $results = GetResults($item, $filename, $uploadId, $tag, 0,
       $filesizeMin, $filesizeMax, $searchType, $license, $copyright,
       $this->restHelper->getUploadDao(), $this->restHelper->getGroupId(),
       $GLOBALS['PG_CONN'])[0];

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -470,6 +470,12 @@ paths:
                 - containers
                 - allfiles
               default: allfiles
+          - name: uploadId
+            in: header
+            required: false
+            description: Id of the upload to search files into
+            schema:
+              type: integer    
           - name: filename
             description: Filename to find, can contain % as wild-card
             required: false

--- a/src/www/ui/search-helper.php
+++ b/src/www/ui/search-helper.php
@@ -36,7 +36,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
  *         contains uploadtree_pk, parent, upload_fk, pfile_fk, ufile_mode, and
  *         ufile_name
  */
-function GetResults($Item, $Filename, $tag, $Page, $SizeMin, $SizeMax, $searchtype,
+function GetResults($Item, $Filename, $Upload, $tag, $Page, $SizeMin, $SizeMax, $searchtype,
                     $License, $Copyright, $uploadDao, $groupID, $PG_CONN)
 {
   $MaxPerPage  = 100;  /* maximum number of result items per page */
@@ -163,6 +163,14 @@ function GetResults($Item, $Filename, $tag, $Page, $SizeMin, $SizeMax, $searchty
       $SQL .= " AND";
     }
     $SQL .= " ufile_name ilike '". pg_escape_string($Filename) . "'";
+    $NeedAnd=1;
+  }
+
+  if ($Upload != 0) {
+    if ($NeedAnd) {
+      $SQL .= " AND";
+    }
+    $SQL .= " upload_fk = ". pg_escape_string($Upload) . "";
     $NeedAnd=1;
   }
 

--- a/src/www/ui/template/ui-search.html.twig
+++ b/src/www/ui/template/ui-search.html.twig
@@ -45,6 +45,18 @@
         <ul>
             <li>
                 <b>
+                    {{ "Choose upload to search into: "|trans }}
+                </b>
+                <select id="scanFilter" name='upload'>
+                    <option value="0">-- {{ 'All uploads'|trans }} --</option>
+                    {% for uploadObj in uploadsArray %}
+                        <option value="{{ uploadObj.getId() }}"> {{ uploadObj.getFilename() }} from {{ uploadObj.getTimestamp() | date("Y-m-d H:i:s") }}</option>
+                    {% endfor %}
+                </select>
+                <br>
+            </li>
+            <li>
+                <b>
                     {{ "Enter the filename to find: " | trans }}
                 </b>
                 <INPUT type='text' name='filename' size='40' value='{{ Filename|e }}'>
@@ -125,5 +137,8 @@
             setReadonlyForFilters(true);
         });
         {% endif %}
+
+        document.getElementById('scanFilter').value = {{ Upload }};
+
     </script>
 {% endblock %}


### PR DESCRIPTION
This feature adds possibility to search only in specified upload while currently it is possible to do it in all available uploads

Closes: #1280 

## Description

Search option for all available uplads only is not very useful when there is more than 3-5 uploads user has access to.
This feature adds possibility to choose in which upload user wants to search in.
List od available uploads for user is dynamically loaded from DB.

### Changes

- Added option-field on template `src/www/ui/search-helper.php`  filled with all uploads user has access to (plus option to choose to search in All uploads)
- Added method for `src/lib/php/Dao/UploadDao.php` to retrieve all uploads 
- modified `src/www/ui/search-helper.php#GetResults` to filter search results only for selected upload

## How to test

Search results should be shown only for Upload selected from dropdown menu.
For --All uploads -- results from all uploads should be shown (as previously, before this feature)