### PR TITLE
fix(logrotate): Send SIGHUP

### DIFF
--- a/debian/fossology-scheduler.logrotate
+++ b/debian/fossology-scheduler.logrotate
@@ -5,6 +5,10 @@
         compress
         delaycompress
         notifempty
+        su fossy fossy
         create 660 fossy fossy
         sharedscripts
+        postrotate
+                /usr/bin/killall -HUP fo_scheduler
+        endscript
 }

--- a/pbconf/fossology/deb/fossology-scheduler.logrotate
+++ b/pbconf/fossology/deb/fossology-scheduler.logrotate
@@ -5,6 +5,10 @@
         compress
         delaycompress
         notifempty
+        su fossy fossy
         create 660 fossy fossy
         sharedscripts
+        postrotate
+                /usr/bin/killall -HUP fo_scheduler
+        endscript
 }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Send the `SIGHUP` to scheduler after log rotation to reload config in-turn closing old log file and opening the new file created by `logrotate`.

The other option will be to use `copytruncate` flag which requires no signal generation but might cause loss of logs written during the rotation.

### Changes

1. Add `postrotate/endscript` to logrotate config to send `SIGHUP`.
1. Add `su fossy fossy` as the log files by default are generated under `fossy` user and not `root`.

## How to test

1. Install the logrotate file (or install fossology as deb package).
1. Wait for the log to rotate (or change the rotation condition and trigger manual rotation).
1. Check if scheduler works after rotation.
1. Check if scheduler writes to the new log file.

**Note:** Please check the behaviour of SIGHUP if there are some agents in running state and the scheduler receives the signal.