### PR TITLE
feat(password): Create password policy

### DIFF
--- a/src/lib/php/Dao/UploadPermissionDao.php
+++ b/src/lib/php/Dao/UploadPermissionDao.php
@@ -60,7 +60,10 @@ class UploadPermissionDao
 
     $perm = $this->dbManager->getSingleRow('SELECT perm FROM perm_upload WHERE upload_fk=$1 AND group_fk=$2',
         array($uploadId, $groupId), __METHOD__);
-    return $perm['perm']>=Auth::PERM_WRITE;
+    if (! empty($perm) && array_key_exists('perm', $perm)) {
+      return $perm['perm']>=Auth::PERM_WRITE;
+    }
+    return false;
   }
 
   public function makeAccessibleToGroup($uploadId, $groupId, $perm=null)

--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -33,6 +33,8 @@ define("CONFIG_TYPE_TEXTAREA", 3);
 define("CONFIG_TYPE_PASSWORD", 4);
 /** Dropdown type config */
 define("CONFIG_TYPE_DROP", 5);
+/** Checkbox type config */
+define("CONFIG_TYPE_BOOL", 6);
 
 
 /**
@@ -376,19 +378,66 @@ function Populate_sysconfig()
   $smtpAuthPasswdPrompt = _('SMTP Login Password');
   $smtpAuthPasswdDesc = _('Password used for SMTP login.');
   $valueArray[$variable] = array("'$variable'", "null", "'$smtpAuthPasswdPrompt'",
-    strval(CONFIG_TYPE_PASSWORD), "'SMTP'", "5", "'$smtpAuthPasswdDesc'", "null", "null");
+    strval(CONFIG_TYPE_PASSWORD), "'SMTP'", "6", "'$smtpAuthPasswdDesc'", "null", "null");
 
   $variable = "SMTPSslVerify";
   $smtpSslPrompt = _('SMTP SSL Verify');
   $smtpSslDesc = _('The SSL verification for connection is required?');
   $valueArray[$variable] = array("'$variable'", "'S'", "'$smtpSslPrompt'",
-    strval(CONFIG_TYPE_DROP), "'SMTP'", "6", "'$smtpSslDesc'", "null", "'Ignore{I}|Strict{S}|Warn{W}'");
+    strval(CONFIG_TYPE_DROP), "'SMTP'", "7", "'$smtpSslDesc'", "null", "'Ignore{I}|Strict{S}|Warn{W}'");
 
   $variable = "SMTPStartTls";
   $smtpTlsPrompt = _('Start TLS');
   $smtpTlsDesc = _('Use TLS connection for SMTP?');
   $valueArray[$variable] = array("'$variable'", "'1'", "'$smtpTlsPrompt'",
-    strval(CONFIG_TYPE_DROP), "'SMTP'", "7", "'$smtpTlsDesc'", "null", "'Yes{1}|No{2}'");
+    strval(CONFIG_TYPE_DROP), "'SMTP'", "8", "'$smtpTlsDesc'", "null", "'Yes{1}|No{2}'");
+
+  /* Password policy config */
+  $variable = "PasswdPolicy";
+  $prompt = _('Enable password policy');
+  $desc = _('Enable password policy check');
+  $valueArray[$variable] = array("'$variable'", "false", "'$prompt'",
+    strval(CONFIG_TYPE_BOOL), "'PASSWD'", "1", "'$desc'",
+    "'check_boolean'", "null");
+
+  $variable = "PasswdPolicyMinChar";
+  $prompt = _('Minimum characters');
+  $desc = _('Blank for no limit');
+  $valueArray[$variable] = array("'$variable'", "8", "'$prompt'",
+    strval(CONFIG_TYPE_INT), "'PASSWD'", "2", "'$desc'", "null", "null");
+
+  $variable = "PasswdPolicyMaxChar";
+  $prompt = _('Maximum characters');
+  $desc = _('Blank for no limit');
+  $valueArray[$variable] = array("'$variable'", "16", "'$prompt'",
+    strval(CONFIG_TYPE_INT), "'PASSWD'", "3", "'$desc'", "null", "null");
+
+  $variable = "PasswdPolicyLower";
+  $prompt = _('Lowercase');
+  $desc = _('Minimum one lowercase character.');
+  $valueArray[$variable] = array("'$variable'", "true", "'$prompt'",
+    strval(CONFIG_TYPE_BOOL), "'PASSWD'", "4", "'$desc'",
+    "'check_boolean'", "null");
+
+  $variable = "PasswdPolicyUpper";
+  $prompt = _('Uppercase');
+  $desc = _('Minimum one uppercase character.');
+  $valueArray[$variable] = array("'$variable'", "true", "'$prompt'",
+    strval(CONFIG_TYPE_BOOL), "'PASSWD'", "5", "'$desc'",
+    "'check_boolean'", "null");
+
+  $variable = "PasswdPolicyDigit";
+  $prompt = _('Digit');
+  $desc = _('Minimum one digit.');
+  $valueArray[$variable] = array("'$variable'", "true", "'$prompt'",
+    strval(CONFIG_TYPE_BOOL), "'PASSWD'", "6", "'$desc'",
+    "'check_boolean'", "null");
+
+  $variable = "PasswdPolicySpecial";
+  $prompt = _('Allowed special characters');
+  $desc = _('Empty for do not care');
+  $valueArray[$variable] = array("'$variable'", "'@$!%*?&'", "'$prompt'",
+    strval(CONFIG_TYPE_TEXT), "'PASSWD'", "7", "'$desc'", "null", "null");
 
   $variable = "PATMaxExipre";
   $patTokenValidityPrompt = _('Max token validity');

--- a/src/lib/php/tests/test_common_auth.php
+++ b/src/lib/php/tests/test_common_auth.php
@@ -24,6 +24,7 @@
 require_once(dirname(__FILE__) . '/../common-auth.php');
 
 /**
+ * @backupGlobals disabled
  * \class test_common_auth
  */
 class test_common_auth extends \PHPUnit\Framework\TestCase
@@ -47,12 +48,163 @@ class test_common_auth extends \PHPUnit\Framework\TestCase
     $this->assertEquals("Test Siteminder", $result);
   }
 
-
   /**
    * \brief clean the env
    */
   protected function tearDown()
   {
     print "Ending unit test for common-auth.php\n";
+  }
+
+  /**
+   * @brief Test for generate_password_policy()
+   * @test
+   * -# Setup SYSCONFIG
+   * -# Enable all policy settings
+   * -# Call generate_password_policy() and match expected regex
+   */
+  function test_generate_password_policy_all()
+  {
+    global $SysConf;
+    $SysConf = [];
+    $SysConf['SYSCONFIG'] = [];
+    $SysConf['SYSCONFIG']['PasswdPolicy'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicyMinChar'] = 8;
+    $SysConf['SYSCONFIG']['PasswdPolicyMaxChar'] = 16;
+    $SysConf['SYSCONFIG']['PasswdPolicyLower'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicyUpper'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicyDigit'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicySpecial'] = '#%@^!*()';
+    $expected = '(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[#%@^!*()])[a-zA-Z\\d#%@^!*()]{8,16}';
+    $actual = generate_password_policy();
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * @brief Test for generate_password_policy() when policy is disabled
+   * @test
+   * -# Setup SYSCONFIG
+   * -# Enable all policy settings
+   * -# Disable password policy
+   * -# generate_password_policy() should return regex to match all
+   */
+  function test_generate_password_policy_disable()
+  {
+    global $SysConf;
+    $SysConf = [];
+    $SysConf['SYSCONFIG'] = [];
+    $SysConf['SYSCONFIG']['PasswdPolicy'] = 'false';
+    $SysConf['SYSCONFIG']['PasswdPolicyMinChar'] = 8;
+    $SysConf['SYSCONFIG']['PasswdPolicyMaxChar'] = 16;
+    $SysConf['SYSCONFIG']['PasswdPolicyLower'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicyUpper'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicyDigit'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicySpecial'] = '#%@^!*()';
+    $expected = '.*';
+    $actual = generate_password_policy();
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * @brief Test for generate_password_policy() when no minimum limit is set
+   * @test
+   * -# Setup SYSCONFIG
+   * -# Enable all policy settings
+   * -# Set min limit to empty
+   * -# Call generate_password_policy() and match expected regex with min limit
+   *    as 0
+   */
+  function test_generate_password_policy_no_min()
+  {
+    global $SysConf;
+    $SysConf = [];
+    $SysConf['SYSCONFIG'] = [];
+    $SysConf['SYSCONFIG']['PasswdPolicy'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicyMinChar'] = '';
+    $SysConf['SYSCONFIG']['PasswdPolicyMaxChar'] = 16;
+    $SysConf['SYSCONFIG']['PasswdPolicyLower'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicyUpper'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicyDigit'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicySpecial'] = '#%@^!*()';
+    $expected = '(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[#%@^!*()])[a-zA-Z\\d#%@^!*()]{0,16}';
+    $actual = generate_password_policy();
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * @brief Test for generate_password_policy() when no max limit is set
+   * @test
+   * -# Setup SYSCONFIG
+   * -# Enable all policy settings
+   * -# Set max limit as empty
+   * -# Call generate_password_policy() and match expected regex without max
+   *    limit
+   */
+  function test_generate_password_policy_no_max()
+  {
+    global $SysConf;
+    $SysConf = [];
+    $SysConf['SYSCONFIG'] = [];
+    $SysConf['SYSCONFIG']['PasswdPolicy'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicyMinChar'] = 2;
+    $SysConf['SYSCONFIG']['PasswdPolicyMaxChar'] = '';
+    $SysConf['SYSCONFIG']['PasswdPolicyLower'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicyUpper'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicyDigit'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicySpecial'] = '#%@^!*()';
+    $expected = '(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[#%@^!*()])[a-zA-Z\\d#%@^!*()]{2,}';
+    $actual = generate_password_policy();
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * @brief Test for generate_password_policy()
+   * @test
+   * -# Setup SYSCONFIG
+   * -# Enable all policy settings
+   * -# Set min and max limits as empty
+   * -# Call generate_password_policy() and match expected regex with * limit
+   */
+  function test_generate_password_policy_no_limit()
+  {
+    global $SysConf;
+    $SysConf = [];
+    $SysConf['SYSCONFIG'] = [];
+    $SysConf['SYSCONFIG']['PasswdPolicy'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicyMinChar'] = '';
+    $SysConf['SYSCONFIG']['PasswdPolicyMaxChar'] = '';
+    $SysConf['SYSCONFIG']['PasswdPolicyLower'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicyUpper'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicyDigit'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicySpecial'] = '#%@^!*()';
+    $expected = '(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[#%@^!*()])[a-zA-Z\\d#%@^!*()]*';
+    $actual = generate_password_policy();
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * @brief Test for generate_password_policy()
+   * @test
+   * -# Setup SYSCONFIG
+   * -# Enable all policy settings
+   * -# Set special characters as empty
+   * -# Call generate_password_policy() and match expected regex to accept any
+   *    special character
+   */
+  function test_generate_password_policy_no_special()
+  {
+    global $SysConf;
+    $SysConf = [];
+    $SysConf['SYSCONFIG'] = [];
+    $SysConf['SYSCONFIG']['PasswdPolicy'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicyMinChar'] = '8';
+    $SysConf['SYSCONFIG']['PasswdPolicyMaxChar'] = '16';
+    $SysConf['SYSCONFIG']['PasswdPolicyLower'] = 'false';
+    $SysConf['SYSCONFIG']['PasswdPolicyUpper'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicyDigit'] = 'true';
+    $SysConf['SYSCONFIG']['PasswdPolicySpecial'] = '';
+    $expected = '(?=.*[A-Z])(?=.*\\d).{8,16}';
+    $actual = generate_password_policy();
+    $this->assertEquals($expected, $actual);
   }
 }

--- a/src/www/ui/css/fossology.css
+++ b/src/www/ui/css/fossology.css
@@ -115,7 +115,7 @@ html, body
 .semibordered
 {
   border:1px solid black;
-  border-collapse:collapse;    
+  border-collapse:collapse;
 }
 
 .semibordered td, .semibordered th
@@ -347,4 +347,23 @@ div.infoTable {
 
 .riskLevelBackgroud5 {
   background: #e95850;
+}
+
+.passPolicy {
+  font-size: .9em;
+  color: #FF666C;
+}
+
+.passFail {
+  box-shadow: 0 0 6px #FF2F4D;
+  margin: 4px;
+}
+
+.passPass {
+  box-shadow: 0 0 6px #2EFF57;
+  margin: 4px;
+}
+
+#passcheck, #pass2 {
+  margin: 4px;
 }

--- a/src/www/ui/template/password-policy-check.js.twig
+++ b/src/www/ui/template/password-policy-check.js.twig
@@ -1,0 +1,72 @@
+{# Copyright 2020 Siemens AG
+
+   Copying and distribution of this file, with or without modification,
+   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
+   This file is offered as-is, without any warranty.
+#}
+
+function checkpassword() {
+  var policyRegex = /^{{ policyRegex }}$/m;
+  var passField = $('#passcheck');
+  var pass = passField.val();
+  if (pass.match(policyRegex)) {
+    passField.removeClass('passFail');
+    passField.addClass('passPass');
+    return true;
+  }
+  passField.removeClass('passPass');
+  passField.addClass('passFail');
+  return false;
+}
+
+function checkpasswordmatch() {
+  var pass1 = $('#passcheck').val();
+  var pass2Field = $('#pass2');
+  if (checkpassword() && pass2Field.val() === pass1) {
+    pass2Field.removeClass('passFail');
+    pass2Field.addClass('passPass');
+    return true;
+  }
+  pass2Field.removeClass('passPass');
+  pass2Field.addClass('passFail');
+  return false;
+}
+
+$(document).ready(function () {
+  $('#passcheck').on('keyup', checkpassword);
+  if ($('#pass2').length) {
+    $('#pass2').on('keyup', checkpasswordmatch);
+  }
+  $("form[name={{ formName }}]").submit(function(e) {
+    if ({{ policyDisabled }} && $('#passcheck').val() == "") {
+      return true;
+    }
+    if (checkpassword() && checkpasswordmatch()) {
+      return true;
+    }
+    if ($('#passwdBanner').length == 0) {
+      var banner = $("<div id='passwdBanner' />").text("Please check password.");
+      $("body").append(banner);
+      $("#passwdBanner").dialog({
+        autoOpen: false,
+        height: "auto",
+        width: "auto",
+        title: "Password check fail",
+        modal: true,
+        buttons: [
+          {
+            text: "Ok",
+            click: function() {
+              $(this).dialog("close");
+            }
+          }
+        ],
+        close: function() {
+          $('#passcheck').focus();
+        }
+      });
+    }
+    $("#passwdBanner").dialog("open");
+    e.preventDefault();
+  });
+});

--- a/src/www/ui/template/user_edit.html.twig
+++ b/src/www/ui/template/user_edit.html.twig
@@ -10,14 +10,14 @@
 {% endblock %}
 
 {% block content %}
-  <form name="user_edit" method="POST">
+  <form name="{{ formName }}" method="POST">
   <input type="hidden" name="user_pk" value="{{ userId }}"/>
   {%  if isSessionAdmin %}
     {{ "Select the user to edit"|trans }}:
     {% import "include/macros.html.twig" as macro %}
     {{ macro.select('userid', allUsers, 'userid', userId, ' class="ui-render-select2" onchange="RefreshPage(this.value);"') }}
   {% endif %}
-    
+
   <table style="border:1px solid black; border-collapse: collapse;" width="100%">
     <tr class="classic">
       <th width="25%">{{ "Username."|trans }}</th>
@@ -35,8 +35,8 @@
       <th width="25%">{{ "E-mail notification on job completion"|trans }}</th>
       <td><input type="checkbox" name="email_notify" {% if eMailNotification %}checked{% endif %}></td>
     </tr>
-    
-    {%  if isSessionAdmin %}
+
+    {% if isSessionAdmin %}
       <tr class="classic">
         <th width="25%">{{ "Select the user's access level."|trans }}</th>
         <td>{{ macro.select('user_perm', allAccessLevels, 'user_perm', accessLevel) }}</td>
@@ -47,19 +47,23 @@
           {{ folderListOption }}
         </select></td>
       </tr>
+      {% if passwordPolicy is empty %}
       <tr class="classic">
         <th width="25%">{{ "Require no password."|trans }}</th>
         <td><input type="checkbox" name="_blank_pass" id="blank_pass" {% if isBlankPassword %}checked="checked" disabled="disabled"{% endif %}/></td>
       </tr>
+      {% endif %}
     {% endif %}
-    
+
     <tr class="classic">
       <th width="25%">{{ "Password."|trans }}</th>
-      <td><input type="password" name="_pass1" size="20" id="pass1"/></td>
+      <td><input type="password" name="_pass1" size="20" id="passcheck"/>{% if passwordPolicy is not empty %}
+      <br /><span class="passPolicy">{{ passwordPolicy }}</span>
+      {% endif %}</td>
     </tr>
     <tr class="classic">
       <th width='25%'>{{ "Re-enter password."|trans }}</th>
-      <td><input type="password" name="_pass2" size="20"/></td>
+      <td><input type="password" name="_pass2" size="20" id="pass2"/></td>
     </tr>
     <tr class="classic">
       <th width='25%'>{{ 'Default agents selected when uploading data.'|trans }}</th>
@@ -284,7 +288,7 @@
 
     {% if isBlankPassword %}
     $(document).ready(function(){
-      $("#pass1").keyup(function (){
+      $("#passcheck").keyup(function (){
         var isBlank = ($(this).val()==='');
         $("#blank_pass").prop("checked", isBlank);
       });
@@ -303,4 +307,5 @@
     });
   </script>
   <script src="scripts/user-edit.js" type="text/javascript"></script>
+  <script type="text/javascript">{% include "password-policy-check.js.twig" %}</script>
 {% endblock %}

--- a/src/www/ui/user-add.php
+++ b/src/www/ui/user-add.php
@@ -85,6 +85,15 @@ class user_add extends FO_Plugin
       return ($text);
     }
 
+    /* Make sure password matches policy */
+    $policyRegex = generate_password_policy();
+    $result = preg_match('/^' . $policyRegex . '$/m', $Pass);
+    if ($result !== 1) {
+      $text = _("Password does not match policy.");
+      $text .= "<br />" . generate_password_policy_string();
+      return ($text);
+    }
+
     if (empty($Email)) {
       $text = _("Email must be specified. Not added.");
       return ($text);
@@ -142,7 +151,7 @@ class user_add extends FO_Plugin
       }
     }
 
-    $V = "<form name='formy' method='POST'>\n";
+    $V = "<form name='user_add' method='POST'>\n";
     $V.= _("To create a new user, enter the following information:<P />\n");
     $Style = "<tr><td colspan=2 style='background:black;'></td></tr><tr>";
     $V.= "<table style='border:1px solid black; text-align:left; background:lightyellow;' width='75%'>";
@@ -184,10 +193,17 @@ class user_add extends FO_Plugin
     $V.= "</select></td>\n";
     $V.= "</tr>\n";
     $text = _("Password (optional)");
-    $V.= "$Style<th>$text</th><td><input type='password' name='pass1' size=20></td>\n";
-    $V.= "</tr>\n";
+    if (passwordPolicyEnabled()) {
+      $text = _("Password");
+    }
+    $V.= "$Style<th>$text</th><td><input type='password' name='pass1' id='passcheck' size=20>";
+    $policy = generate_password_policy_string();
+    if ($policy != "No policy defined.") {
+      $V.= "<br /><span class='passPolicy'>$policy</span>";
+    }
+    $V.= "</td>\n</tr>\n";
     $text = _("Re-enter password");
-    $V.= "$Style<th>$text</th><td><input type='password' name='pass2' size=20></td>\n";
+    $V.= "$Style<th>$text</th><td><input type='password' name='pass2' id='pass2' size=20 style='margin:4px'></td>\n";
     $V.= "</tr>\n";
     $text = _("E-mail Notification");
     $text1 = _("Check to enable email notification when upload scan completes .");
@@ -212,6 +228,14 @@ class user_add extends FO_Plugin
     $text = _("Add User");
     $V.= "<input type='submit' value='$text'>\n";
     $V.= "</form>\n";
+
+    $this->vars['formName'] = "user_add";
+    $this->vars['policyDisabled'] = passwordPolicyEnabled() ? "false" : "true";
+    $this->vars['policyRegex'] = generate_password_policy();
+    $passwordScript = $this->renderString("password-policy-check.js.twig");
+    $this->renderScripts('<script type="text/javascript">' . $passwordScript .
+      '</script>');
+
     return $V;
   }
 }

--- a/src/www/ui/user-del-helper.php
+++ b/src/www/ui/user-del-helper.php
@@ -78,9 +78,9 @@ function deleteUser($UserId, $dbManager)
 
   /* Make sure it was deleted */
   $result = $dbManager->execute($userCheckStatement, [$UserId]);
-  $rowCount = count($dbManager->fetchArray($result)['cnt']);
+  $rowEmpty = empty($dbManager->fetchArray($result)['cnt']);
   $dbManager->freeResult($result);
-  if ($rowCount != 0) {
+  if (! $rowEmpty) {
     $text = _("Failed to delete user.");
     return ($text);
   }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Allow admins to enforce password policies from Customize page. Following options can be chosen to generate policy:
1. Enable/disable policy check.
2. Fixing length of passwords (min and max).
3. Requiring minimum one of lowercase character.
4. Requiring minimum one of uppercase character.
5. Requiring minimum one digit.
6. Requiring minimum one of special characters from a predefined set.

This policy is used to generate RegEx and the password will be checked while creating a new user or editing a user.

The checks are added to the backend as well as frontend.

Also, if password policy is enabled, do not allow empty passwords for new users.

### Changes

1. `common-auth.php`: Two new functions `generate_password_policy()` and `generate_password_policy_string()` to generate policy regex and string respectively.
1. `admin-config.php`: New config type `CONFIG_TYPE_BOOL` to generate checkbox.
1. `password-policy-check.js.twig`: JS functions to handle checks in UI.
1. `user-add.php` and `user-edit.php`: Changes required for frontend checks.

### Screenshots

1. Configuration
![image](https://user-images.githubusercontent.com/18077542/95082988-81f85d00-0739-11eb-83cb-a3b3429623ee.png)
1. Check at frontend
![image](https://user-images.githubusercontent.com/18077542/95083059-99cfe100-0739-11eb-8470-d3d8a8d56089.png)

## How to test
1. Make changes to the policy from Customize page and check if the policy string and regex changes.
1. Disable policy and check if everything works.
1. While trying to submit non conformant password, UI should report error.
1. User edit page should work if password was not changed.