### PR TITLE
feat(gui): Add Bucket link for license view page

### DIFF
--- a/src/buckets/ui/ui-buckets.php
+++ b/src/buckets/ui/ui-buckets.php
@@ -118,6 +118,15 @@ class ui_buckets extends FO_Plugin
       $URI = $this->Name . Traceback_parm_keep(array("format","page","upload","item","bp"));
       $tooltipText = _("Browse by buckets");
       $this->microMenu->insert(array(MicroMenu::VIEW_META, MicroMenu::VIEW), $menuText, $menuPosition, $this->getName(), $URI, $tooltipText);
+      if (GetParm("mod",PARM_STRING) == $this->Name)
+      {
+        menu_insert("Browse::Bucket",0);
+        menu_insert("Browse::[BREAK]",100);
+      }
+      else
+      {
+        menu_insert("Browse::Bucket",0,$URI,$tooltipText);
+      }
     }
   } // RegisterMenus()
 


### PR DESCRIPTION
Problem described in #1366 
This PR adds Bucket menu entry for license view

### Changes

src/buckets/ui/ui-buckets.php - added menu entry insert

## How to test

Bucket link should be visible during browsing upload folders, not only files (mod=license)

Closes #1366