### PR TITLE
fix(rest) : Set job status as Failed when any one of the job is failed

### DIFF
--- a/src/www/ui/api/Controllers/JobController.php
+++ b/src/www/ui/api/Controllers/JobController.php
@@ -301,14 +301,14 @@ class JobController extends RestController
     }
 
     $jobStatusString = "";
-    if ($jobStatus & self::JOB_STARTED) {
+    if ($jobStatus & self::JOB_FAILED) {
+      /* If at least one job is failed, set status as failed */
+      $jobStatusString = "Failed";
+    } else if ($jobStatus & self::JOB_STARTED) {
       /* If at least one job is started, set status as processing */
       $jobStatusString = "Processing";
     } else if ($jobStatus & self::JOB_QUEUED) {
       $jobStatusString = "Queued";
-    } else if ($jobStatus & self::JOB_FAILED) {
-      /* If at least one job is failed, set status as failed */
-      $jobStatusString = "Failed";
     } else {
       /* If everything completed successfully, set status as completed */
       $jobStatusString = "Completed";


### PR DESCRIPTION
## Description

This pull request fixes bug #1805 .
Set the overall job status to Failed, if any one of the job is Failed.

### Changes

Corrected the order of job status verification in such a way that Failure status is validated first.

## How to test

` curl -k -s -S -X GET http://localhost/repo/api/v1/jobs?upload=<id> -H "Authorization: Bearer <TOKEN>"`


Response :

[
    {
        "id": 3,
        "name": "filename",
        "queueDate": "2020-10-06 12:17:51.458106+00",
        "uploadId": "3",
        "userId": "3",
        "groupId": "3",
        "eta": 0,
        "status": "Failed"   ->>>>>> Without this fix Job status is showing as Queued even when ununpack is failed.
    }
]

Fixes #1805