### PR TITLE
fix(copyrightDao): Change statement in updateTable

### DIFF
--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -444,6 +444,7 @@ class CopyrightDao
     if (!empty($hash)) {
       $params[] = $hash;
       $withHash = " cp.hash = $3 AND ";
+      $stmt .= ".hash";
     }
     if ($action == "delete") {
       $setSql = "is_enabled='false'";


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The `CopyrightDao::updateTable()` can be called by Copyright UI, Reuser (when reusing copyrights) or Clearing Dao (when **irrelevant** decision sent).

The ClearingDao does not send the hash of copyright resulting in a different SQL query. Whereas other methods send the hash and a different SQL query is generated. This causes issue with `prepare()` as the statement name is not updated.

### Changes

Update statement name in `CopyrightDao::updateTable()` if hash is sent.

## How to test

1. In an upload, mark some files as **irrelevant**
    - It will call `CopyrightDao::updateTable()` without hash and a statement will be prepared.
1. Perform some copyright clearing
    - It will call `CopyrightDao::updateTable()` with hash.
1. Upload the same package again and Reuse the older package with **Reuse deactivated copyrights**.
    - It will call `CopyrightDao::updateTable()` with hash.