### PR TITLE
chore(spdx): bump spdx version to 2.2

### DIFF
--- a/install/scripts/install-spdx-tools.sh
+++ b/install/scripts/install-spdx-tools.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-wget -nc https://github.com/spdx/tools/releases/download/V2.0.2/spdx-tools-2.0.2-jar-with-dependencies.jar -P $(dirname $0)/../../src/spdx2/agent_tests/Functional/
+wget -nc https://github.com/spdx/tools/releases/download/v2.2.2/spdx-tools-2.2.2-jar-with-dependencies.jar -P $(dirname $0)/../../src/spdx2/agent_tests/Functional/

--- a/src/spdx2/agent/template/spdx2-document.xml.twig
+++ b/src/spdx2/agent/template/spdx2-document.xml.twig
@@ -8,7 +8,7 @@
     xmlns:spdx="http://spdx.org/rdf/terms#"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
 <spdx:SpdxDocument rdf:about="{{ uri }}#SPDXRef-DOCUMENT">
-  <spdx:specVersion>SPDX-2.1</spdx:specVersion>
+  <spdx:specVersion>SPDX-2.2</spdx:specVersion>
   <spdx:dataLicense rdf:resource="http://spdx.org/licenses/CC0-1.0" />
   <spdx:creationInfo>
     <spdx:CreationInfo>

--- a/src/spdx2/agent/template/spdx2tv-document.twig
+++ b/src/spdx2/agent/template/spdx2tv-document.twig
@@ -4,7 +4,7 @@
    are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
    This file is offered as-is, without any warranty.
 #}
-SPDXVersion: SPDX-2.1
+SPDXVersion: SPDX-2.2
 DataLicense: CC0-1.0
 
 ##-------------------------

--- a/src/spdx2/agent_tests/Functional/schedulerTest.php
+++ b/src/spdx2/agent_tests/Functional/schedulerTest.php
@@ -256,15 +256,15 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
    * @brief Pull SPDX toolkit from github if not found
    *
    * -# Verify if Java is installed
-   * -# Pull version 2.1.0
-   * -# Store only spdx-tools-2.1.0-jar-with-dependencies.jar
+   * -# Pull version 2.2.2
+   * -# Store only spdx-tools-2.2.2-jar-with-dependencies.jar
    * @return string Jar file path
    */
   protected function pullSpdxTools()
   {
     $this-> verifyJavaIsInstalled();
 
-    $version='2.1.0';
+    $version='2.2.2';
     $tag='v'.$version;
 
     $jarFileBasename = 'spdx-tools-'.$version.'-jar-with-dependencies.jar';


### PR DESCRIPTION
Signed-off-by: Michael C. Jaeger <michael.c.jaeger@siemens.com>

## Description

Changing the spdx templates for SPDX file generation to version tag 2.2

### Changes

modified:   src/spdx2/agent/template/spdx2-document.xml.twig
modified:   src/spdx2/agent/template/spdx2tv-document.twig

## How to test

Generate SPDX documents and test them with the SPDx java tool (at version 2.2). Output:

```
lando:Downloads sam$ java -jar spdx-tools-2.2.2-jar-with-dependencies.jar Verify SPDX2_rigel-20190819-master.zip_1602710429-spdx.rdf.txt 
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
ERROR StatusLogger No log4j2 configuration file found. Using default configuration: logging only errors to the console. Set system property 'log4j2.debug' to show Log4j2 internal initialization logging.
This SPDX Document is valid.
lando:Downloads sam$ java -jar spdx-tools-2.2.2-jar-with-dependencies.jar Verify SPDX2TV_rigel-20190819-master.zip_1602710437.spdx.txt 
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
ERROR StatusLogger No log4j2 configuration file found. Using default configuration: logging only errors to the console. Set system property 'log4j2.debug' to show Log4j2 internal initialization logging.
This SPDX Document is valid.
lando:Downloads sam$ 
```
