### PR TITLE
fix(ununpack): Initialize gcrypt

### DIFF
--- a/src/ununpack/agent/ununpack.c
+++ b/src/ununpack/agent/ununpack.c
@@ -106,6 +106,7 @@
 #define _GNU_SOURCE
 #include "ununpack.h"
 #include "ununpack_globals.h"
+#include <gcrypt.h>
 
 #ifdef COMMIT_HASH_S
 char BuildVersion[]="ununpack build version: " VERSION_S " r(" COMMIT_HASH_S ").\n";
@@ -197,6 +198,11 @@ int	main(int argc, char *argv[])
         SafeExit(25);
     }
   }
+
+  /* Initialize gcrypt and disable security memory */
+  gcry_check_version(NULL);
+  gcry_control (GCRYCTL_DISABLE_SECMEM, 0);
+  gcry_control (GCRYCTL_INITIALIZATION_FINISHED, 0);
 
   /* Open DB and Initialize CMD table */
   if (UseRepository)

--- a/src/wget_agent/agent/main.c
+++ b/src/wget_agent/agent/main.c
@@ -24,6 +24,7 @@
 
 #define _GNU_SOURCE
 #include "wget_agent.h"
+#include <gcrypt.h>
 
 #ifdef COMMIT_HASH_S
 char BuildVersion[]="wget_agent build version: " VERSION_S " r(" COMMIT_HASH_S ").\n";
@@ -194,6 +195,11 @@ int main  (int argc, char *argv[])
     if (pgConn) PQfinish(pgConn);
     SafeExit(0);
   }
+
+  /* Initialize gcrypt and disable security memory */
+  gcry_check_version(NULL);
+  gcry_control (GCRYCTL_DISABLE_SECMEM, 0);
+  gcry_control (GCRYCTL_INITIALIZATION_FINISHED, 0);
 
   COMMIT_HASH = fo_sysconfig("wget_agent", "COMMIT_HASH");
   VERSION = fo_sysconfig("wget_agent", "VERSION");


### PR DESCRIPTION
## Description

While check `journalctl -xe`, saw
`ununpack[9125]: Libgcrypt warning: missing initialization - please fix the application`

The gcrypt needs to be initialized before using it which was missing from the agents. See https://www.gnupg.org/documentation/manuals/gcrypt/Initializing-the-library.html

### Changes

Initialize gcrypt in ununpack and wget using `gcry_check_version`.

## How to test

1. Install the agent, upload a package.
1. Upload a package using Upload from URL.
1. Check the `sudo journalctl -xe` and check if the above mentioned warning does not exists.