### PR TITLE
feat(copyright): Search and replace with regex

### DIFF
--- a/src/copyright/ui/HistogramBase.php
+++ b/src/copyright/ui/HistogramBase.php
@@ -79,19 +79,35 @@ abstract class HistogramBase extends FO_Plugin {
       $typeDescriptor = $description;
     }
     $output = "<h4>Activated $typeDescriptor statements:</h4>
-               <div><table border=1 width='100%' id='copyright".$type."'></table></div>
-               <br/><br/>
-               <div>
-                 <span>
-                   Replace: <input type='text' id='replaceText".$type."' style='width:80%'>
-                 </span>
-               <br/><br/>
-               <a style='cursor: pointer; margin-left:10px;' id='replaceSelected".$type."' class='buttonLink'>Mark selected rows for replace</a>
-               <a style='cursor: pointer; margin-left:10px;' id='deleteSelected".$type."' class='buttonLink'>Mark selected rows for deletion</a>
-               <br/><br/>
-               <h4>Deactivated $typeDescriptor statements:</h4>
-               </div>
-               <div><table border=1 width='100%' id='copyright".$type."deactivated'></table></div>";
+<div><table border=1 width='100%' id='copyright".$type."'></table></div>
+<br/><br/>
+<div>
+  <table border=0 width='100%' id='searchReplaceTable".$type."'>
+  <tr>
+    <td>Advance search:</td>
+    <td style='width:80%'><input type='text' id='advSearchText".$type."' style='width:90%' class='advSearch'>
+      <img src='images/info_16.png' title='Use \"(*)\" to match any thing.\nExample: \"Copyright (*) All rights reserved(*)\" will match \"Copyright 2012-2020 Company ABC. All rights reserved {and some garbage here}\"' alt='' class='info-bullet'></td>
+    <td><a class='buttonLink' onClick='createReplacementText(\"".$type."\")' title='Create a replacement text with all placeholders.'>Create replacement text</a></td>
+  </tr>
+  <tr>
+    <td>Replace:</td>
+    <td style='width:80%'><input type='text' id='replaceText".$type."' style='width:90%'>
+      <img src='images/info_16.png' title='Use \"$1 $2\" as placeholder for corresponding (*) values.\nExample: \"Copyright $1 All rights reserved\" will result in \"Copyright 2012-2020 Company ABC. All rights reserved\" from example above' alt='' class='info-bullet'></td>
+    <td></td>
+  </tr></table>
+  <br/><br/>
+  <a style='cursor: pointer; margin-left:10px;' id='testReplacement".$type."' class='buttonLink'>Test replacement</a>
+  <a style='cursor: pointer; margin-left:10px;' id='replaceSelected".$type."' class='buttonLink'>Replace selected rows</a>
+  <a style='cursor: pointer; margin-left:10px;' id='deleteSelected".$type."' class='buttonLink'>Deactivate selected rows</a>
+  <br /><br />
+  <table border=1 id='testVal".$type."' style='display:none' class='dataTable'>
+    <tr><th style='width:50%'>From</th><th style='width:50%'>To</th></tr>
+    <tr><td id='testVal".$type."From'></td><td id='testVal".$type."To'></td></tr>
+  </table>
+  <br/><br/>
+  <h4>Deactivated $typeDescriptor statements:</h4>
+</div>
+<div><table border=1 width='100%' id='copyright".$type."deactivated'></table></div>";
 
     return array($output, $out);
   }

--- a/src/copyright/ui/copyright-hist.php
+++ b/src/copyright/ui/copyright-hist.php
@@ -120,6 +120,9 @@ class CopyrightHistogram extends HistogramBase {
     $(document).ready(function() {
       tableCopyright =  createTablestatement();
       tableFindings = createPlainTablecopyFindings();
+      $('#testReplacementstatement').click(function() {
+        testReplacement(tableCopyright, 'statement');
+      });
       $('#copyrightFindingsTabs').tabs({
         active: ($.cookie(copyrightTabCookie) || 0),
         activate: function(e, ui){

--- a/src/copyright/ui/ecc-hist.php
+++ b/src/copyright/ui/ecc-hist.php
@@ -63,7 +63,7 @@ class EccHistogram  extends HistogramBase {
     list($VEcc, $tableVars) = $this->getTableContent($upload_pk, $Uploadtree_pk, $filter, $agentId);
 
     $V = "<table border=0 width='100%'>\n";
-    $V .= "<tr><td valign='top' width='50%'>$VEcc</td><td valign='top'>$VF</td></tr>\n";
+    $V .= "<tr><td valign='top'>$VEcc</td><td valign='top'>$VF</td></tr>\n";
     $V .= "</table>\n";
     $V .= "<hr />\n";
     return array($V,$tableVars);
@@ -104,7 +104,10 @@ class EccHistogram  extends HistogramBase {
 
     $(document).ready(function() {
       tableEcc =  createTableecc();
-    } );
+      $('#testReplacementecc').click(function() {
+        testReplacement(tableEcc, 'ecc');
+      });
+    });
 
     ";
 

--- a/src/copyright/ui/email-hist.php
+++ b/src/copyright/ui/email-hist.php
@@ -113,6 +113,15 @@ class EmailHistogram extends HistogramBase {
       tableEmail = createTableemail();
       tableUrl = createTableurl();
       tableAuthor = createTableauthor();
+      $('#testReplacementemail').click(function() {
+        testReplacement(tableEmail, 'email');
+      });
+      $('#testReplacementurl').click(function() {
+        testReplacement(tableUrl, 'url');
+      });
+      $('#testReplacementauthor').click(function() {
+        testReplacement(tableAuthor, 'author');
+      });
       $(\"#EmailUrlAuthorTabs\").tabs({
         active: ($.cookie(emailTabCookie) || 0),
         activate: function(e, ui){

--- a/src/copyright/ui/keyword-hist.php
+++ b/src/copyright/ui/keyword-hist.php
@@ -29,7 +29,7 @@ class KeywordHistogram  extends HistogramBase {
     $this->agentName = "keyword";
     parent::__construct();
   }
-  
+
   /**
    * @param $upload_pk
    * @param $Uploadtree_pk
@@ -61,7 +61,7 @@ class KeywordHistogram  extends HistogramBase {
     list($VKeyword, $tableVars) = $this->getTableContent($upload_pk, $Uploadtree_pk, $filter, $agentId);
 
     $V = "<table border=0 width='100%'>\n";
-    $V .= "<tr><td valign='top' width='50%'>$VKeyword</td><td valign='top'>$VF</td></tr>\n";
+    $V .= "<tr><td valign='top'>$VKeyword</td><td valign='top'>$VF</td></tr>\n";
     $V .= "</table>\n";
     $V .= "<hr />\n";
     return array($V,$tableVars);
@@ -93,8 +93,11 @@ class KeywordHistogram  extends HistogramBase {
     return "
 
     $(document).ready(function() {
-      tableKeyword =  createTablekeyword();
-    } );
+      tableKeyword = createTablekeyword();
+      $('#testReplacementkeyword').click(function() {
+        testReplacement(tableKeyword, 'keyword');
+      });
+    });
 
     ";
 

--- a/src/copyright/ui/template/copyrighthist_scripts.html.twig
+++ b/src/copyright/ui/template/copyrighthist_scripts.html.twig
@@ -39,5 +39,45 @@
     });
   }
 
+  function advanceSearchToRegex(search) {
+    var val = $.fn.dataTable.util.escapeRegex(search.trim());
+    return val.replace(/\\\(\\\*\\\)/g, "(.*)");
+  }
+
+  function testReplacement(table, type) {
+    var checkBoxes = $("input:checkbox[class=deleteBySelect" + type + "]:checked");
+    var toVal = $('#replaceText' + type).val();
+    if (checkBoxes.length == 0 || /^\s*$/.test(toVal)) {
+      return;
+    }
+    var idPrefix = '#testVal' + type;
+
+    var firstRow = checkBoxes.first();
+    var testVal = table.api().row($(firstRow).parent().parent()[0]).data()[1];
+    testVal = $("<textarea/>").html(testVal).text();  // Decode HTML &lt; &gt;
+    var regex = advanceSearchToRegex($('#advSearchText' + type).val());
+    var finalVal = toVal;
+    if (!/^\s*$/.test(regex)) {
+      finalVal = testVal.replace(new RegExp(regex, "gi"), toVal);
+    }
+
+    $(idPrefix + 'From').text(testVal);
+    $(idPrefix + 'To').text(finalVal);
+    $(idPrefix).show();
+  }
+
+  function createReplacementText(type) {
+    var searchRegex = $('#advSearchText' + type).val();
+    var i = 1;
+    var replaceText = searchRegex.replace(/\(\*\)/g, function(match) {
+      return "$" + (i++);
+    });
+    $('#replaceText' + type).val(replaceText);
+  }
+
+  $(document).ready(function() {
+    $('img').tooltip();
+  });
+
   {{ scriptBlock }}
 </script>

--- a/src/copyright/ui/template/histTable.js.twig
+++ b/src/copyright/ui/template/histTable.js.twig
@@ -92,12 +92,19 @@ function createTable{{ table.type }}() {
     var replaceText = $('#replaceText{{ table.type }}').val().trim();
     var replaceIsValid = (replaceText) && !(/^\s*$/.test(replaceText));
     var ajaxList = new Array();
-    if(replaceIsValid){
+    if (replaceIsValid) {
+      var regex = advanceSearchToRegex($('#advSearchText{{ table.type }}').val().trim());
       $("input:checkbox[class=deleteBySelect{{ table.type }}]:checked").each(function () {
-        currentValue = $(this).val();
-        var currUploadData = currentValue.split(',');
+        var currentId = $(this).val();
+        var currUploadData = currentId.split(',');
+        var currentValue = enabledTable.api().row($(this).parent().parent()[0]).data()[1];
+        currentValue = $("<textarea/>").html(currentValue).text();  // Decode HTML &lt; &gt;
+        var newValue = replaceText;
+        if (!/^\s*$/.test(regex)) {
+          newValue = currentValue.replace(new RegExp(regex, "gi"), replaceText);
+        }
         ajaxList.push(updateRows{{ table.type }}(currUploadData[0],
-          currUploadData[1], currUploadData[2], currUploadData[3], replaceText));
+          currUploadData[1], currUploadData[2], currUploadData[3], newValue));
       });
       // Wait for all ajax calls to resolve
       $.when.apply($, ajaxList).done(function(){
@@ -169,7 +176,9 @@ function createPlainTable{{ table.type }}() {
     });
   });
 
-  $('#replaceText{{ table.type }}').parent().remove();
+  $('#searchReplaceTable{{ table.type }}').remove();
+  $('#testVal{{ table.type }}').remove();
+  $('#testReplacement{{ table.type }}').remove();
   $('#replaceSelected{{ table.type }}').remove();
 
   return enabledTable;
@@ -214,7 +223,7 @@ function undo{{ table.type }}(upload, item, hash, kind) {
     dataType: 'text',
     url: '?mod=ajax-copyright-hist&action=undo',
     data: { id : upload + ',' + item + ',' + hash + ',' + kind },
-      success: function(data) { 
+      success: function(data) {
         $("#delete{{ table.type }}" + hash).show();
         $("#update{{ table.type }}" + hash).hide();
         $("#deleteBySelect{{ table.type }}" + hash).prop('checked', false);


### PR DESCRIPTION
## Description

Add feature to search using regex, create placeholders and replace in Copyright and sister UIs. Same feature can be used to search for specific terms and replace.
A test table has been added as well where user can see sample results before comiting to it.

For example, you can search for `Copyright(*) rights reserved(*)` which can match anything like:
```
Copyright 2012-2016 Example Inc, All rights reserved
Copyright 2018 Example Inc, All rights reserved some small text snipit
Copyright 2014-2019 Example Inc, All rights reserved and some random text picked up by the agent
```

And replacement can be done with `Copyright$1 rights reserved` (notice the `$1` placeholder) which will transform all text to:
```
Copyright 2012-2016 Example Inc, All rights reserved
Copyright 2018 Example Inc, All rights reserved
Copyright 2014-2019 Example Inc, All rights reserved
```

Also, another simple search like `Example Inc` and replacement to `Example Incorporation` will transform text to:
```
Copyright 2012-2016 Example Incorporation, All rights reserved
Copyright 2018 Example Incorporation, All rights reserved some small text snipit
Copyright 2014-2019 Example Incorporation, All rights reserved and some random text picked up by the agent
```

### Changes

1. Add new buttons to `HistogramBase.php`
1. Add JS calls to `*-hist.php`
1. Add helper functions to `copyrighthist_scripts.html.twig`
1. Add corresponding calls to `histTable.js.twig`

## How to test

1. On an upload, search for a small set of copyrights which needs to be fixed.
1. Create a regex in Advance search box and get the corresponding sample replace text using `Create replacement text` button.
1. Check results with `Test replacement` button.
1. Submit the result and check if everything works as expected.
1. Any other regex symbols should not have any effect in Advance search box.