### PR TITLE
fix(ununpack): Correct the mimetype for deb files

### DIFF
--- a/src/ununpack/agent/ununpack.c
+++ b/src/ununpack/agent/ununpack.c
@@ -54,6 +54,7 @@
  * | application/x-rpm | rpm2cpio |
  * | application/x-archive | ar |
  * | application/x-debian-package | ar |
+ * | application/vnd.debian.binary-package | ar |
  * | application/x-iso | isoinfo |
  * | application/x-iso9660-image | isoinfo |
  * | application/x-fat | fat |

--- a/src/ununpack/agent/ununpack_globals.h
+++ b/src/ununpack/agent/ununpack_globals.h
@@ -105,7 +105,8 @@ cmdlist CMD[] =
 /* 30 */{ "application/jar","unzip","-q -P none -o","-x / >/dev/null 2>&1","unzip -Zhzv '%s' > '%s'",CMD_ARC,1,0177000,0177000, },
 /* 31 */{ "application/java-archive","unzip","-q -P none -o","-x / >/dev/null 2>&1","unzip -Zhzv '%s' > '%s'",CMD_ARC,1,0177000,0177000, },
 /* 32 */{ "application/x-dosexec","7z","x -y -pjunk",">/dev/null 2>&1","",CMD_ARC,1,0177000,0177000, },
-/* 33 */{ "","","",">/dev/null 2>&1","",CMD_DEFAULT,1,0177000,0177000, },
+/* 33 */{ "application/vnd.debian.binary-package","ar","x",">/dev/null 2>&1","dpkg -I '%s' > '%s'",CMD_AR,1,0177000,0177777, },
+/* 34 */{ "","","",">/dev/null 2>&1","",CMD_DEFAULT,1,0177000,0177000, },
   { NULL,NULL,NULL,NULL,NULL,-1,-1,0177000,0177000, },
 };
 #endif


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The mimetype for .deb Debian packages was wrong, added the new mimetype.

### Changes

Added the new mimetype for `.deb` files (`application/vnd.debian.binary-package`).

## How to test

Upload a `.deb` package, it should be unpacked.