### PR TITLE
fix(readmeoss): unescape contents

### DIFF
--- a/src/readmeoss/agent/readmeoss.php
+++ b/src/readmeoss/agent/readmeoss.php
@@ -206,7 +206,7 @@ class ReadmeOssAgent extends Agent
         $outData .= $addSeparator . $break;
       }
     }
-    return $outData;
+    return htmlspecialchars_decode($outData, ENT_DISALLOWED);
   }
 
   /**


### PR DESCRIPTION
## Description

Since the ReadMe_OSS report is a plain text file, it makes sense to unescape the contents. Otherwise the report will contain things like:

    Copyright (c) 2000 Contributor &lt;contributor@example.com&gt;

Instead of the desired:

    Copyright (c) 2000 Contributor <contributor@example.com>

This closes #1660.

## Changes

This is fixed by calling `htmlspecialchars_decode()` to reverse the encoding done elsewhere by `htmlspecialchar()`.

## How to test

1. Import code that contains a copyright statement with angle braces as shown above.
2. Scan code for copyrights.
3. Click the _ReadMe_OSS Generation_ button on the _Browse_ page.
4. View the report to see if it contains angle braces or html escape codes.

