### PR TITLE
fix(spasht): Fix advance search

### DIFF
--- a/src/spasht/ui/ui-spasht.php
+++ b/src/spasht/ui/ui-spasht.php
@@ -395,23 +395,29 @@ class ui_spasht extends FO_Plugin
 
   /**
    * @brief Check for Advance Search
+   * @param Coordinate $coord     Coordinates searched
+   * @param string $revisionName  Revision searched
+   * @param string $namespaceName Namespace searched
+   * @param string $typeName      Type searched
+   * @param string $providerName  Provider searched
    * @return boolean
    */
-  public function checkAdvanceSearch ($body, $revisionName, $namespaceName, $typeName, $providerName)
+  public function checkAdvanceSearch($coord, $revisionName, $namespaceName,
+    $typeName, $providerName)
   {
-    if (! empty($revisionName) && $body['revision'] != $revisionName) {
+    if (! empty($revisionName) && $coord->getRevision() != $revisionName) {
       return false;
     }
 
-    if (! empty($namespaceName) && $body['namespace'] != $namespaceName) {
+    if (! empty($namespaceName) && $coord->getNamespace() != $namespaceName) {
       return false;
     }
 
-    if (! empty($typeName) && $body['type'] != $typeName) {
+    if (! empty($typeName) && $coord->getType() != $typeName) {
       return false;
     }
 
-    if (! empty($providerName) && $body['provider'] != $providerName) {
+    if (! empty($providerName) && $coord->getProvider() != $providerName) {
       return false;
     }
 


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The data type used to store coordinates was changed from array to an object which was causing advance search to fail.

Check https://github.com/fossology/fossology/pull/1838#issuecomment-734678329 for logs.

### Changes

Change the data access in `checkAdvanceSearch()`.

## How to test

1. Search for a package in Spasht tab.
1. Do an advance search for a package in Spasht tab.
1. Schedule Spasht agent.