### PR TITLE
fix(globalDecision): make includesubfolders true in case of global to…

### DIFF
--- a/src/lib/php/BusinessRules/ClearingDecisionProcessor.php
+++ b/src/lib/php/BusinessRules/ClearingDecisionProcessor.php
@@ -164,8 +164,11 @@ class ClearingDecisionProcessor
     $this->dbManager->begin();
 
     $itemId = $itemBounds->getItemId();
-
-    $previousEvents = $this->clearingDao->getRelevantClearingEvents($itemBounds, $groupId, $includeSubFolders=false);
+    $includeSubFolders = false;
+    if (($global == DecisionScopes::REPO) && ($type != self::NO_LICENSE_KNOWN_DECISION_TYPE)) {
+      $includeSubFolders = true;
+    }
+    $previousEvents = $this->clearingDao->getRelevantClearingEvents($itemBounds, $groupId, $includeSubFolders);
     if ($type === self::NO_LICENSE_KNOWN_DECISION_TYPE) {
       $type = DecisionTypes::IDENTIFIED;
       $clearingEventIds = $this->insertClearingEventsForAgentFindings($itemBounds, $userId, $groupId, true, ClearingEventTypes::USER);

--- a/src/lib/php/BusinessRules/test/ClearingDecisionProcessorTest.php
+++ b/src/lib/php/BusinessRules/test/ClearingDecisionProcessorTest.php
@@ -100,7 +100,7 @@ class ClearingDecisionProcessorTest extends \PHPUnit\Framework\TestCase
 
   public function testMakeDecisionFromLastEvents()
   {
-    $isGlobal = DecisionScopes::REPO;
+    $isGlobal = DecisionScopes::ITEM;
     $addedEvent = $this->createClearingEvent(123, $this->timestamp, 13, "licA", "License A");
 
     $this->clearingDao->shouldReceive("getRelevantClearingEvents")


### PR DESCRIPTION
… capture previous decisions

## Description

* Include sub folders true in clearing decision processer to get the previous results 

## How to test

* Upload a package and add some global decisions with scanner findings and user findings.
* Re-upload the same package. and go to same files where the global decision was added.
* Use next and previous buttons to save the existing results.