### PR TITLE
feat(cd): Build Focal packages on release

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -18,6 +18,7 @@ jobs:
           - 'debian:stretch'
           - 'ubuntu:bionic'
           - 'ubuntu:xenial'
+          - 'ubuntu:focal'
 
     runs-on: ubuntu-latest
     container: ${{ matrix.os }}


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Build the new Ubuntu version packages, Ubuntu Focal 20.04 while building release packages.

### Changes

Add `ubuntu:focal` to image list in GitHub workflow.