### PR TITLE
feat(browser): total files in license browser view

### DIFF
--- a/src/www/ui/async/AjaxExplorer.php
+++ b/src/www/ui/async/AjaxExplorer.php
@@ -342,6 +342,7 @@ class AjaxExplorer extends DefaultPlugin
     /* show licenses under file name */
     $childItemTreeBounds =
         new ItemTreeBounds($childUploadTreeId, $this->uploadtree_tablename, $child['upload_fk'], $child['lft'], $child['rgt']);
+    $totalFilesCount = $this->uploadDao->countPlainFiles($childItemTreeBounds);
     if ($isContainer) {
       $agentFilter = $selectedAgentId ? array($selectedAgentId) : $latestSuccessfulAgentIds;
       $licenseEntries = $this->licenseDao->getLicenseShortnamesContained($childItemTreeBounds, $agentFilter, array());
@@ -419,8 +420,7 @@ class AjaxExplorer extends DefaultPlugin
     // override green/red flag with greenRed flag in case of single file with decision type "Do Not Use"
     $isDecisionDNU = $this->clearingDao->isDecisionDNU($childUploadTreeId, $groupId);
     $img = $isDecisionDNU ? 'redGreen' : $img;
-
-    return array($fileName, $licenseList, $editedLicenseList, $img, "$filesCleared/$filesToBeCleared", $fileListLinks);
+    return array($fileName, $licenseList, $editedLicenseList, $img, "$filesCleared / $filesToBeCleared / $totalFilesCount", $fileListLinks);
   }
 
   /**

--- a/src/www/ui/template/browse_file.js.twig
+++ b/src/www/ui/template/browse_file.js.twig
@@ -45,7 +45,7 @@ function createDirlistTable() {
             }
           }
         },
-        {"sTitle":"Files Cleared","sClass":"center","bSortable":false,"bSearchable":false},
+        {"sTitle":"Cleared / Open / Total","sClass":"center","bSortable":false,"bSearchable":false},
         {"sTitle":"Actions <input type='checkbox' id='selectMarkIrrelevant'>","sClass":"left","bSortable":false,"bSearchable":false,"sWidth":"13.6%"}],
     "sPaginationType": "listbox",
     "bProcessing": true,


### PR DESCRIPTION
Total files count added to Files Cleared column.

Column name changed to:
*Files Cleared/NotCleared/Total*
In context of a folder it gives the number of containing files.

Signed-off-by: Bartłomiej Dróżdż <bartlomiej.drozdz@orange.com>

## Description

Address the [comment point no 1](https://github.com/fossology/fossology/issues/1775#issuecomment-730518125) in #1775. 


The feature gives user a feedback in number of files in directories in the browser.

### Changes

src/www/ui/async/AjaxExplorer.php
src/www/ui/template/browse_file.js.twig

## How to test

Go to License Browser in your upload and you should see the number of files in the firectory in _Files Cleared/NotCleared/Total_ column.

![image](https://user-images.githubusercontent.com/702341/102358645-0a07a800-3fb0-11eb-9a97-240bb521b32a.png)

