### PR TITLE
refactor(login): updated password hashing algorithm

### DIFF
--- a/src/cli/fo_usergroup.php
+++ b/src/cli/fo_usergroup.php
@@ -72,8 +72,8 @@ if ($user !== false) {
 
 if ($uName && !$user) {
   $pass = array_key_exists('upasswd', $opts) ? $opts['upasswd'] : '';
-  $seed = rand() . rand();
-  $hash = sha1($seed . $pass);
+  $options = array('cost' => 10);
+  $hash = password_hash($pass, PASSWORD_DEFAULT, $options);
   $desc = 'created via cli';
   $perm = array_key_exists('accesslvl', $opts) ? intval($opts['accesslvl']) : 0;
   if (array_key_exists('folder', $opts)) {
@@ -89,7 +89,7 @@ if ($uName && !$user) {
   }
   $agentList = userAgents();
   $email = $emailNotify = '';
-  add_user($uName, $desc, $seed, $hash, $perm, $email, $emailNotify, $agentList, $folderid);
+  add_user($uName, $desc, $hash, $perm, $email, $emailNotify, $agentList, $folderid);
   $user = $userDao->getUserByName($uName);
   print "added user $uName\n";
 }

--- a/src/cli/tests/test_common.php
+++ b/src/cli/tests/test_common.php
@@ -155,8 +155,8 @@ function add_user($user='fossy', $password='fossy')
 {
   global $PG_CONN;
   /* User does not exist.  Create it. */
-  $Seed = rand() . rand();
-  $Hash = sha1($Seed . $password);
+  $options = array('cost' => 10);
+  $Hash = password_hash($password, PASSWORD_DEFAULT, $options);
   $sql = "SELECT * FROM users WHERE user_name = '$user';";
   $result = pg_query($PG_CONN, $sql);
   $row0 = pg_fetch_assoc($result);
@@ -165,7 +165,7 @@ function add_user($user='fossy', $password='fossy')
     /* User does not exist.  Create it. */
     $SQL = "INSERT INTO users (user_name,user_desc,user_seed,user_pass," .
       "user_perm,user_email,email_notify,root_folder_fk)
-        VALUES ('$user','Default Administrator','$Seed','$Hash',10,'$password','y',1);";
+        VALUES ('$user','Default Administrator','Seed','$Hash',10,'$password','y',1);";
     // $text = _("*** Created default administrator: '$user' with password '$password'.");
     $result = pg_query($PG_CONN, $SQL);
     pg_free_result($result);

--- a/src/lib/php/common-users.php
+++ b/src/lib/php/common-users.php
@@ -30,7 +30,6 @@
  * Parameters are the user table fields:
  * \param string $User  user_name
  * \param string $Desc  user_desc
- * \param string $Seed  user_seed
  * \param string $Hash  user_pass
  * \param int    $Perm  user_perm
  * \param string $Email user_email
@@ -41,7 +40,7 @@
  *
  * \return error: exit (1)
  */
-function add_user($User, $Desc, $Seed, $Hash, $Perm, $Email, $Email_notify,
+function add_user($User, $Desc, $Hash, $Perm, $Email, $Email_notify,
                   $agentList, $Folder, $default_bucketpool_fk='')
 {
   global $container;
@@ -54,7 +53,7 @@ function add_user($User, $Desc, $Seed, $Hash, $Perm, $Email, $Email_notify,
   $dbManager->prepare($stmt='users.insert',$sql="INSERT INTO users
          (user_name,user_desc,user_seed,user_pass,user_perm,user_email,
           email_notify,user_agent_list,root_folder_fk) VALUES ($1,$2,$3,$4,$5,$6,  $7,$8,$9)");
-  $dbManager->execute($stmt,array ($User,$Desc,$Seed,$Hash,$Perm,$Email,  $Email_notify,$agentList,$Folder));
+  $dbManager->execute($stmt,array ($User,$Desc,'Seed',$Hash,$Perm,$Email,  $Email_notify,$agentList,$Folder));
 
   /* Make sure it was added */
   $row = $dbManager->getSingleRow("SELECT * FROM users WHERE user_name = $1",array($User),$stmt='users.get');
@@ -84,5 +83,30 @@ function add_user($User, $Desc, $Seed, $Hash, $Perm, $Email, $Email_notify,
   // set active group = own group
   $dbManager->prepare($stmt='users.update', $sql = "update users SET group_fk=$1, default_bucketpool_fk=$3 WHERE user_pk=$2");
   $dbManager->execute($stmt,array($group_pk,$user_pk,$default_bucketpool_fk));
+  return ('');
+}
+
+/**
+ * \brief Update user password hash
+ *
+ * \param string $User  user_name
+ * \param string $Hash  user_pass
+ *
+ * \return error: exit (1)
+ */
+function update_password_hash($User, $Hash)
+{
+  global $container;
+  $dbManager = $container->get('db.manager');
+
+  // Check if user exist
+  $row = $dbManager->getSingleRow("SELECT * FROM users WHERE user_name = $1",array($User),$stmt='users.get');
+  if (empty($row['user_name'])) {
+    $text = _("User does not exist.");
+    return ($text);
+  }
+
+  $dbManager->prepare($stmt = 'users.update_hash', $sql = "UPDATE users SET user_seed = $1, user_pass = $2  WHERE user_name = $3");
+  $dbManager->execute($stmt,array ('Seed', $Hash, $User));
   return ('');
 }

--- a/src/testing/db/create_test_database.php
+++ b/src/testing/db/create_test_database.php
@@ -512,8 +512,9 @@ debug("Elapsed Time = $elapsed");
 
 // insert the 'fossy' user into the test database
 // this is the FOSSology user 'fossy' (not a Postgres user, or a system user)
-$random_seed = rand().rand();
-$hash = sha1($random_seed . "fossy");
+$random_seed = 'Seed';
+$options = array('cost' => 10);
+$hash = password_hash("fossy", PASSWORD_DEFAULT, $options);
 $user_sql = "INSERT INTO users (user_pk, user_name, user_desc, user_seed, user_pass, user_perm, user_email, email_notify, root_folder_fk) VALUES (1, 'fossy', 'Default Administrator', '$random_seed', '$hash', 10, 'fossy', 'n', 1);";
 pg_query($test_db_conn, $user_sql)
     or die("FAIL: could not insert default user into user table\n");

--- a/src/testing/install/test4migrationinstall/test_common.php
+++ b/src/testing/install/test4migrationinstall/test_common.php
@@ -119,8 +119,8 @@
   function add_user($user='fossy', $password='fossy') {
     global $PG_CONN;
     /* User does not exist.  Create it. */
-    $Seed = rand() . rand();
-    $Hash = sha1($Seed . $password);
+    $options = array('cost' => 10);
+    $Hash = password_hash($password, PASSWORD_DEFAULT, $options);
     $sql = "SELECT * FROM users WHERE user_name = '$user';";
     $result = pg_query($PG_CONN, $sql);
     $row0 = pg_fetch_assoc($result);
@@ -129,7 +129,7 @@
       /* User does not exist.  Create it. */
       $SQL = "INSERT INTO users (user_name,user_desc,user_seed,user_pass," .
         "user_perm,user_email,email_notify,root_folder_fk)
-        VALUES ('$user','Default Administrator','$Seed','$Hash',10,'$password','y',1);";
+        VALUES ('$user','Default Administrator','Seed','$Hash',10,'$password','y',1);";
       // $text = _("*** Created default administrator: '$user' with password '$password'.");
       $result = pg_query($PG_CONN, $SQL);
       pg_free_result($result);

--- a/src/testing/install/test4packageinstall/test_common.php
+++ b/src/testing/install/test4packageinstall/test_common.php
@@ -142,8 +142,8 @@
   function add_user($user='fossy', $password='fossy') {
     global $PG_CONN;
     /* User does not exist.  Create it. */
-    $Seed = rand() . rand();
-    $Hash = sha1($Seed . $password);
+    $options = array('cost' => 10);
+    $Hash = password_hash($password, PASSWORD_DEFAULT, $options);
     $sql = "SELECT * FROM users WHERE user_name = '$user';";
     $result = pg_query($PG_CONN, $sql);
     $row0 = pg_fetch_assoc($result);
@@ -152,7 +152,7 @@
       /* User does not exist.  Create it. */
       $SQL = "INSERT INTO users (user_name,user_desc,user_seed,user_pass," .
         "user_perm,user_email,email_notify,root_folder_fk)
-        VALUES ('$user','Default Administrator','$Seed','$Hash',10,'$password','y',1);";
+        VALUES ('$user','Default Administrator','Seed','$Hash',10,'$password','y',1);";
       // $text = _("*** Created default administrator: '$user' with password '$password'.");
       $result = pg_query($PG_CONN, $SQL);
       pg_free_result($result);

--- a/src/www/ui/user-add.php
+++ b/src/www/ui/user-add.php
@@ -59,8 +59,8 @@ class user_add extends FO_Plugin
     $User = trim($User);
     $Pass = GetParm('pass1', PARM_TEXT);
     $Pass2 = GetParm('pass2', PARM_TEXT);
-    $Seed = rand() . rand();
-    $Hash = sha1($Seed . $Pass);
+    $options = array('cost' => 10);
+    $Hash = password_hash($Pass, PASSWORD_DEFAULT, $options);
     $Desc = str_replace("'", "''", GetParm('description', PARM_TEXT));
     $Perm = GetParm('permission', PARM_INTEGER);
     $Folder = GetParm('folder', PARM_INTEGER);
@@ -120,7 +120,7 @@ class user_add extends FO_Plugin
       $Email_notify = '';
     }
 
-    $ErrMsg = add_user($User, $Desc, $Seed, $Hash, $Perm, $Email, $Email_notify,
+    $ErrMsg = add_user($User, $Desc, $Hash, $Perm, $Email, $Email_notify,
       $agentList, $Folder, $default_bucketpool_fk);
 
     return ($ErrMsg);

--- a/src/www/ui/user-edit.php
+++ b/src/www/ui/user-edit.php
@@ -247,8 +247,9 @@ class UserEditPage extends DefaultPlugin
     /**** Update the users database record ****/
     /* First remove user_pass and user_seed if the password wasn't changed. */
     if (!empty($UserRec['_blank_pass']) ) {
-      $UserRec['user_seed'] = rand() . rand();
-      $UserRec['user_pass'] = sha1($UserRec['user_seed'] . "");
+      $UserRec['user_seed'] = 'Seed';
+      $options = array('cost' => 10);
+      $UserRec['user_pass'] = password_hash("", PASSWORD_DEFAULT, $options);
     } else if (empty($UserRec['_pass1'])) { // password wasn't changed
       unset( $UserRec['user_pass']);
       unset( $UserRec['user_seed']);
@@ -326,7 +327,8 @@ class UserEditPage extends DefaultPlugin
       $UserRec = $this->GetUserRec($user_pk);
       $UserRec['_pass1'] = "";
       $UserRec['_pass2'] = "";
-      $UserRec['_blank_pass'] = ($UserRec['user_pass'] == sha1($UserRec['user_seed'] . "")) ? "on" : "";
+      $options = array('cost' => 10);
+      $UserRec['_blank_pass'] = password_verify($UserRec['user_pass'], password_hash("", PASSWORD_DEFAULT, $options)) ? "on" : "";
     } else {
       $UserRec = array();
       $UserRec['user_pk'] = intval($request->get('user_pk'));
@@ -338,16 +340,17 @@ class UserEditPage extends DefaultPlugin
       $UserRec['_pass1'] = stripslashes($request->get('_pass1'));
       $UserRec['_pass2'] = stripslashes($request->get('_pass2'));
       if (!empty($UserRec['_pass1'])) {
-        $UserRec['user_seed'] = rand() . rand();
-        $UserRec['user_pass'] = sha1($UserRec['user_seed'] . $UserRec['_pass1']);
+        $UserRec['user_seed'] = 'Seed';
+        $options = array('cost' => 10);
+        $UserRec['user_pass'] = password_hash($UserRec['_pass1'], PASSWORD_DEFAULT, $options);
         $UserRec['_blank_pass'] = "";
       } else {
         $UserRec['user_pass'] = "";
         $UserRec['_blank_pass'] = stripslashes($request->get("_blank_pass"));
         if (empty($UserRec['_blank_pass'])) { // check for blank password
-          // get the stored seed
           $StoredUserRec = $this->GetUserRec($UserRec['user_pk']);
-          $UserRec['_blank_pass'] = ($UserRec['user_pass'] == sha1($StoredUserRec['user_seed'] . "")) ? "on" : "";
+          $options = array('cost' => 10);
+          $UserRec['_blank_pass'] = password_verify($UserRec['user_pass'], password_hash("", PASSWORD_DEFAULT, $options)) ? "on" : "";
         }
       }
 


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Currently fossology uses SHA-1 which is now officially deprecated. 
Also as per the [official website](https://www.php.net/manual/en/function.password-hash.php), the salt option of PASSWORD_BCRYPT has been deprecated as of PHP 7.0.0

### Changes

Updated password hashing algorithm from SHA1 to PASSWORD_DEFAULT (Use the bcrypt algorithm)

Closes #841
