### PR TITLE
feat(rest): get copyright info for file hash

### DIFF
--- a/src/lib/php/Dao/PfileDao.php
+++ b/src/lib/php/Dao/PfileDao.php
@@ -197,5 +197,31 @@ WHERE rnk = 1 AND removed = false AND decision_type = " .
     }
     return false;
   }
+
+  /**
+   * Get the list of copyrights for given pfile
+   * @param integer $pfileId Pfile to search
+   * @return array Array of copyrights found and not disabled
+   */
+  public function getCopyright($pfileId)
+  {
+    $statement = __METHOD__ . ".getCopyright";
+    $sql = "SELECT content " .
+      "FROM copyright " .
+      "WHERE (pfile_fk = $1) AND (is_enabled = TRUE) " .
+      "UNION " .
+      "SELECT textfinding " .
+      "FROM copyright_decision " .
+      "WHERE (pfile_fk = $1) AND (is_enabled = TRUE);";
+    $params = [$pfileId];
+    $rows = $this->dbManager->getRows($sql, $params, $statement);
+    if (!empty($rows) && array_key_exists('content', $rows[0])) {
+      $copyright = array_column($rows, 'content');
+      natcasesort($copyright);
+      return array_values($copyright);
+    } else {
+      return [];
+    }
+  }
 }
 

--- a/src/lib/php/Dao/test/PfileDaoTest.php
+++ b/src/lib/php/Dao/test/PfileDaoTest.php
@@ -223,4 +223,47 @@ class PfileDaoTest extends \PHPUnit\Framework\TestCase
     $this->assertEquals($expectedNoConclusion, $actualNoConclusions);
     $this->assertEquals($expectedAllRemoval, $actualAllRemoval);
   }
+
+  /**
+   * @test
+   * -# Test for PfileDao::getCopyright()
+   * -# Setup required tables and data
+   * -# Fetch results for different pfiles with 1 or 2 results
+   * -# Make sure the license list is sorted
+   * -# Not found results should be empty array
+   */
+  public function testGetCopyright()
+  {
+    $this->testDb->createPlainTables(['copyright', 'copyright_decision']);
+    $this->testDb->insertData(['copyright', 'copyright_decision']);
+
+    $expectedFirstFinding = [
+      'copyright (c) 2048',
+      'copyright (c) manual'
+    ];
+    $expectedSecondFinding = [
+      'copyright (c) 2002 lawrence e. rosen. all rights
+reserved. permission is hereby granted to copy and distribute this
+',
+      'copyright grant to the software. the
+    bsd and apache licenses are vague and incomplete in that respect.
+',
+      'copyright to the license will control changes. the apache
+'
+    ];
+    $expectedThirdFinding = [
+      'copyright (c) independent manual'
+    ];
+    $expectedNoFinding = [];
+
+    $actualFirstFinding = $this->pfileDao->getCopyright(9);
+    $actualSecondFinding = $this->pfileDao->getCopyright(6);
+    $actualThirdFinding = $this->pfileDao->getCopyright(14);
+    $actualNoFinding = $this->pfileDao->getCopyright(15);
+
+    $this->assertEquals($expectedFirstFinding, $actualFirstFinding);
+    $this->assertEquals($expectedSecondFinding, $actualSecondFinding);
+    $this->assertEquals($expectedThirdFinding, $actualThirdFinding);
+    $this->assertEquals($expectedNoFinding, $actualNoFinding);
+  }
 }

--- a/src/lib/php/Test/testdata.sql
+++ b/src/lib/php/Test/testdata.sql
@@ -110,6 +110,8 @@ you agree to indemnify, hold harmless and defend adobe systems incorporated from
 INSERT INTO copyright (copyright_pk, agent_fk, pfile_fk, content, hash, type, copy_startbyte, copy_endbyte, is_enabled) VALUES (16, 8, 9, 'copyright (c) 2048', '0x5c8f0370f2ab5d53', 'statement', 0, 18, 'true');
 INSERT INTO copyright_ars (ars_pk, agent_fk, upload_fk, ars_success, ars_status, ars_starttime, ars_endtime) VALUES (5, 8, 1, true, NULL, '2014-08-07 09:57:20.634464+00', '2014-08-07 09:57:20.642878+00');
 INSERT INTO copyright_ars (ars_pk, agent_fk, upload_fk, ars_success, ars_status, ars_starttime, ars_endtime) VALUES (11, 8, 2, true, NULL, '2014-08-07 09:57:27.86361+00', '2014-08-07 09:57:27.869927+00');
+INSERT INTO copyright_decision (copyright_decision_pk, user_fk, pfile_fk, clearing_decision_type_fk, description, textfinding, hash, comment, is_enabled) VALUES (1, 1, 9, 5, 'Manual copyright entry', 'copyright (c) manual', '3b6f7162caec7a85a34be604c5bb446fc34ed7e5ff2dacecaf1aaba3a782a23a', 'A friendly copyright comment', TRUE);
+INSERT INTO copyright_decision (copyright_decision_pk, user_fk, pfile_fk, clearing_decision_type_fk, description, textfinding, hash, comment, is_enabled) VALUES (1, 1, 14, 5, 'Manual copyright entry', 'copyright (c) independent manual', '3b6f7162caec7a85a34be604c5bb446fc34ed7e5ff2dacecaf1aaba3a782a23c', 'A friendly copyright comment', TRUE);
 INSERT INTO folder (folder_pk, folder_name, folder_desc, folder_perm) VALUES (1, 'Software Repository', 'Top Folder', NULL);
 INSERT INTO foldercontents (foldercontents_pk, parent_fk, foldercontents_mode, child_id) VALUES (1, 1, 0, 0);
 INSERT INTO foldercontents (foldercontents_pk, parent_fk, foldercontents_mode, child_id) VALUES (2, 1, 2, 1);

--- a/src/www/ui/api/Controllers/FileSearchController.php
+++ b/src/www/ui/api/Controllers/FileSearchController.php
@@ -141,14 +141,17 @@ class FileSearchController extends RestController
       $uploads = $this->getPackageUpload($pfileId);
       if (! empty($uploads)) {
         $scannerFindings = [];
+        $copyright = [];
         $conclusions = $this->getMainLicenses($uploads);
       } else {
         $scannerFindings = $this->getFileFindings($pfileId);
         $conclusions = $this->getFileConclusions($pfileId);
+        $copyright = $this->getFileCopyright($pfileId);
       }
       $findings = new Findings();
       $findings->setScanner($scannerFindings);
       $findings->setConclusion($conclusions);
+      $findings->setCopyright($copyright);
       $inputFileList[$pfileId]->setFindings($findings);
       $inputFileList[$pfileId]->setUploads($uploads);
     }
@@ -173,6 +176,16 @@ class FileSearchController extends RestController
   {
     return $this->fileHelper->pfileConclusions($this->restHelper->getGroupId(),
       $pfileId);
+  }
+
+  /**
+   * Get the copyright for given pfile id
+   * @param integer $pfileId
+   * @sa Fossology::UI::Api::Helper::FileHelper::pfileCopyright()
+   */
+  private function getFileCopyright($pfileId)
+  {
+    return $this->fileHelper->pfileCopyright($pfileId);
   }
 
   /**

--- a/src/www/ui/api/Helper/FileHelper.php
+++ b/src/www/ui/api/Helper/FileHelper.php
@@ -99,4 +99,16 @@ class FileHelper
   {
     return $this->pfileDao->getUploadForPackage($pfileId);
   }
+
+  /**
+   * Get the copyright for given pfile
+   *
+   * @param integer $pfileId PfileId to get copyright for
+   * @return array List of copyrights found
+   * @sa Fossology::Lib::Dao::PfileDao::getCopyright()
+   */
+  public function pfileCopyright($pfileId)
+  {
+    return $this->pfileDao->getCopyright($pfileId);
+  }
 }

--- a/src/www/ui/api/Models/Findings.php
+++ b/src/www/ui/api/Models/Findings.php
@@ -41,15 +41,23 @@ class Findings
   private $conclusion;
 
   /**
+   * @var array $copyright
+   * List of copyright
+   */
+  private $copyright;
+
+  /**
    * Findings constructor.
    *
    * @param array $scanner    Licenses found by scanners
    * @param array $conclusion Licenses concluded by users
+   * @param array $copyright  Copyright for the file
    */
-  public function __construct($scanner = null, $conclusion = null)
+  public function __construct($scanner = null, $conclusion = null, $copyright = null)
   {
     $this->setScanner($scanner);
     $this->setConclusion($conclusion);
+    $this->setCopyright($copyright);
   }
 
   /**
@@ -66,6 +74,14 @@ class Findings
   public function getConclusion()
   {
     return $this->conclusion;
+  }
+
+  /**
+   * @return array
+   */
+  public function getCopyright()
+  {
+    return $this->copyright;
   }
 
   /**
@@ -97,6 +113,20 @@ class Findings
   }
 
   /**
+   * @param array $copyrights
+   */
+  public function setCopyright($copyright)
+  {
+    if (is_array($copyright)) {
+      $this->copyright = $copyright;
+    } elseif (is_string($copyright)) {
+      $this->copyright = [$copyright];
+    } elseif ($copyright === null && empty($this->copyright)) {
+      $this->copyright = null;
+    }
+  }
+
+  /**
    * Get the object as associative array
    *
    * @return array
@@ -105,7 +135,8 @@ class Findings
   {
     return [
       'scanner'     => $this->getScanner(),
-      'conclusion'  => $this->getConclusion()
+      'conclusion'  => $this->getConclusion(),
+      'copyright'  => $this->getCopyright()
     ];
   }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -14,7 +14,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.1.1
+  version: 1.1.2
   contact:
     email: fossology@fossology.org
   license:
@@ -1439,6 +1439,17 @@ components:
           example:
             - "MIT"
             - "GPL-2.0"
+        copyright:
+          description: >
+            Copyright findings for the file
+          type: array
+          items:
+            type: string
+            description: Copyright finding
+            nullable: true
+          example:
+            - "Copyright (C) 2017-2020 Free Software Foundation, Inc."
+            - "Copyright (C) 1991-2020 Free Software Foundation, Inc."
   responses:
     defaultResponse:
       description: Some error occured. Check the "message"


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Modify REST API's `/filesearch` endpoint to export copyright information in addition to license data. 

### Changes

Added list of copyright statements to the findings object returned by the API. I'm not super familiar with the copyright aspects of Fossology, so would any feedback on the draft would be very welcome. I'm only querying the `copyright` table, should `copyright_decision` also be queried? 

## How to test

Query `/filesearch` endpoint with a hash of a source file uploaded. Should return the copyright statements of the file.
