### PR TITLE
(feat) docker services healthchecks in the docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
     volumes:
       - database:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready --dbname $$POSTGRES_DB --username $$POSTGRES_USER"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,11 @@ services:
       - db
     volumes:
       - repository:/srv/fossology/repository/
+    healthcheck:
+      test: ["CMD-SHELL", "true"]
+      interval: 5s
+      timeout: 5s
+      retries: 2
   web:
     build:
       context: .
@@ -55,6 +60,11 @@ services:
       - scheduler
     volumes:
       - repository:/srv/fossology/repository/
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sSf localhost/repo/api/v1/version || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
   db:
     image: postgres:9.6
     restart: unless-stopped
@@ -65,6 +75,12 @@ services:
       - POSTGRES_INITDB_ARGS='-E SQL_ASCII'
     volumes:
       - database:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      # start-period: 10s
 
 volumes:
   database:


### PR DESCRIPTION
## Description

Use the [Health-check](https://github.com/compose-spec/compose-spec/blob/master/spec.md#healthcheck) feature inside `docker-compose` files to have a quick heath status of the containers when running `docker status`

### Changes

Proposed health tests are:
- *web* : `test: ["CMD-SHELL", "curl -sSf localhost/repo/api/v1/version || exit 1"]`
- *database* : `test: ["CMD-SHELL", "pg_isready"]`
- *scheduler* : `test: ["CMD-SHELL", "true"]`
   - **-> did not find a really useful check here since the container crashes as it becomes unhealthy!**

That's a first shot, tests can be improved in the future.

## How to test

1. Run Fossology using provided docker-compose file
2. Run `docker container ls -a`
![image](https://user-images.githubusercontent.com/22956329/102907850-e4c6de00-4476-11eb-8a73-8a709a6ab898.png)
