### PR TITLE
feat(ununpack): standalone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,8 @@ src/spasht/agent/spasht
 src/spasht/agent/version.php
 src/ununpack/agent/departition
 src/ununpack/agent/ununpack
+src/ununpack/agent/departition-sa
+src/ununpack/agent/ununpack-sa
 src/wget_agent/agent/wget_agent
 variable.list
 /nbproject/private/

--- a/src/ununpack/agent/Makefile.sa
+++ b/src/ununpack/agent/Makefile.sa
@@ -1,0 +1,75 @@
+######################################################################
+# Copyright (C) 2020 Siemens AG
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+######################################################################
+
+TOP = ../../..
+VARS = $(TOP)/Makefile.conf
+DEPS = $(TOP)/Makefile.deps
+include $(VARS)
+LDFLAGS_LOCAL = -lmagic $(shell libgcrypt-config --libs)
+CFLAGS_LOCAL = -DSTANDALONE -Wall -D_FILE_OFFSET_BITS=64 $(shell libgcrypt-config --cflags) $(shell pkg-config --cflags --libs glib-2.0)
+EXE = departition-sa ununpack-sa
+
+CHKHDR = checksum.h
+CHKSRC = $(CHKHDR:%.h=%.c) traverse.c utils.c
+UUHDR = standalone.h ununpack.h ununpack-iso.h ununpack-disk.h ununpack-ar.h $(CHKHDR) ununpack_globals.h
+UUSRC = $(UUHDR:%.h=%.c)
+
+OBJECTS = standalone.o checksum.o traverse.o ununpack-iso.o ununpack-ar.o ununpack-disk.o utils.o
+COVERAGE = $(OBJECTS:%.o=%_cov.o)
+
+all: $(FOLIB) $(EXE)
+
+coverage: $(FOLIB) $(EXE:%=%-coverage)
+
+departition-sa: departition.c $(VARS)
+	$(CC) $< $(CFLAGS_LOCAL) $(FO_LDFLAGS) -o $@
+
+departition-coverage: departition.c $(VARS)
+	$(CC) $< $(CFLAGS_LOCAL) $(FO_LDFLAGS) $(FLAG_COV) -o $(@:%-coverage=%)
+
+ununpack-sa: ununpack.c libununpack.a $(VARS) $(DB) $(REPO) $(AGENTLIB) $(UUHDR)
+	$(CC) ununpack.c libununpack.a $(CFLAGS_LOCAL) $(LDFLAGS_LOCAL) $(DEFS) -o $@
+
+ununpack-coverage: ununpack.c libununpack_cov.a $(VARS) $(DB) $(REPO) $(AGENTLIB) $(UUHDR)
+	$(CC) ununpack.c libununpack_cov.a $(CFLAGS_LOCAL) $(LDFLAGS_LOCAL) $(FLAG_COV) $(DEFS) -o $(@:%-coverage=%)
+
+install: all $(VARS)
+	$(INSTALL_PROGRAM) departition-sa $(DESTDIR)$(MODDIR)/ununpack/agent/departition-sa
+	$(INSTALL_PROGRAM) ununpack-sa $(DESTDIR)$(MODDIR)/ununpack/agent/ununpack-sa
+
+uninstall: $(VARS)
+	rm -f $(DESTDIR)$(BINDIR)/departition-sa
+	rm -rf $(DESTDIR)$(MODDIR)/ununpack/agent
+
+$(OBJECTS): %.o: %.c $(UUHDR)
+	$(CC) -c $< $(CFLAGS_LOCAL)
+
+$(COVERAGE): %_cov.o: %.c
+	$(CC) -c $< $(CFLAGS_LOCAL) $(FLAG_COV) -o $@
+
+libununpack.a: $(OBJECTS)
+	ar cvr $@ $(OBJECTS)
+
+libununpack_cov.a: $(COVERAGE)
+	ar cvr $@ $(COVERAGE)
+
+clean:
+	rm -f $(EXE) *.o core *.a *.gc*
+
+.PHONY: all install uninstall clean
+
+include $(DEPS)

--- a/src/ununpack/agent/checksum.h
+++ b/src/ununpack/agent/checksum.h
@@ -31,7 +31,11 @@
 #include <fcntl.h>
 #include <dirent.h>
 
+#ifdef STANDALONE
+#include "standalone.h"
+#else
 #include "libfossology.h"
+#endif
 
 /**
  * \brief Store check sum of a file

--- a/src/ununpack/agent/standalone.c
+++ b/src/ununpack/agent/standalone.c
@@ -1,0 +1,64 @@
+/*
+Copyright (C) 2020 Siemens AG
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+/*
+**
+ * \file
+ * this is provide a dummy values for library function to make ununpack agent standalone
+ */
+#include "standalone.h"
+#include <sys/stat.h>
+#include <stdio.h>
+#include <glib.h>
+#include <errno.h>
+
+int result = 0;
+
+void  fo_scheduler_heart(int i){}
+void  fo_scheduler_connect(int* argc, char** argv, PGconn** db_conn){}
+void  fo_scheduler_disconnect(int retcode){}
+char* fo_scheduler_next(){return(0);}
+int   fo_scheduler_userID(){return(0);}
+void  fo_scheduler_set_special(int option, int value){}
+int   fo_scheduler_get_special(int option){return(0);}
+char* fo_sysconfig(const char* sectionname, const char* variablename){return(0);}
+int   fo_GetAgentKey   (PGconn *pgConn, const char *agent_name, long unused, const char *cpunused, const char *agent_desc){return(0);}
+int   fo_WriteARS(PGconn *pgConn, int ars_pk, int upload_pk, int agent_pk,
+                         const char *tableName, const char *ars_status, int ars_success){return(0);}
+int     fo_checkPQcommand(PGconn *pgConn, PGresult *result, char *sql, char *FileID, int LineNumb){return(0);}
+int     fo_checkPQresult(PGconn *pgConn, PGresult *result, char *sql, char *FileID, int LineNumb){return(0);}
+int     fo_tableExists(PGconn *pgConn, const char *tableName){return(0);}
+int     GetUploadPerm(PGconn *pgConn, long UploadPk, int user_pk){return(10);}
+int     fo_CreateARSTable(PGconn* pgConn, const char* tableName){return(0);}
+
+int   PQresultStatus(const PGresult *res){ return(PGRES_COMMAND_OK);}
+char* PQresultErrorMessage(const PGresult *res){return(0);}
+char* PQresultErrorField(const PGresult *res, int fieldcode){return(0);}
+int   PQntuples(const PGresult *res){return(1);}
+PGresult *PQexec(PGconn *conn, const char *query){return(0);}
+void  PQclear(PGresult *res){}
+char* PQgetvalue(const PGresult *res, int tup_num, int field_num){return("1");}
+size_t PQescapeStringConn(PGconn *conn,
+                   char *to, const char *from, size_t length, int *error){*error=0;return(0);}
+void  PQfinish(PGconn *conn){}
+
+void  PQsetNoticeProcessor(PGconn *pgConn, char *SQLNoticeProcessor, char *SQL){}
+
+char*   fo_RepMkPath (char *Type, char *Filename){return(0);}
+int   fo_RepExist(char* Type, char* Filename){return 1;}
+int   fo_RepExist2(char* Type, char* Filename){return 0;}
+int   fo_RepImport(char* Source, char* Type, char* Filename, int HardLink){return 0;}

--- a/src/ununpack/agent/standalone.h
+++ b/src/ununpack/agent/standalone.h
@@ -1,0 +1,102 @@
+/*
+Copyright (C) 2020 Siemens AG
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+#ifndef _STANDALONE_H
+#define _STANDALONE_H 1
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef int PGconn;
+typedef int PGresult;
+
+#define PG_DIAG_SQLSTATE  0
+#define PGRES_COMMAND_OK 1
+#define PGRES_NONFATAL_ERROR 2
+
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+#ifndef TRUE
+#define TRUE 1
+#endif
+
+#define PERM_WRITE 2
+#define LOG_NOTICE(...) { \
+            fprintf(stdout, "FATAL %s.%d: ", __FILE__, __LINE__); \
+            fprintf(stdout, __VA_ARGS__); \
+            fprintf(stdout, "\n"); \
+            fflush(stdout); }
+#define LOG_FATAL(...) { \
+            fprintf(stdout, "FATAL %s.%d: ", __FILE__, __LINE__); \
+            fprintf(stdout, __VA_ARGS__); \
+            fprintf(stdout, "\n"); \
+            fflush(stdout); }
+#define LOG_ERROR(...) { \
+            fprintf(stdout, "ERROR %s.%d: ", __FILE__, __LINE__); \
+            fprintf(stdout, __VA_ARGS__); \
+            fprintf(stdout, "\n"); \
+            fflush(stdout); }
+#define LOG_WARNING(...) { \
+            fprintf(stdout, "WARNING %s.%d: ", __FILE__, __LINE__); \
+            fprintf(stdout, __VA_ARGS__); \
+            fprintf(stdout, "\n"); \
+            fflush(stdout); }
+
+#define LOG_DEBUG(...) { \
+            fprintf(stdout, "DEBUG %s.%d: ", __FILE__, __LINE__); \
+            fprintf(stdout, __VA_ARGS__); \
+            fprintf(stdout, "\n"); \
+            fflush(stdout); }
+
+extern void  fo_scheduler_heart(int i);
+extern void  fo_scheduler_connect(int* argc, char** argv, PGconn** db_conn);
+extern void  fo_scheduler_disconnect(int retcode);
+extern char* fo_scheduler_next();
+extern int   fo_scheduler_userID();
+extern void  fo_scheduler_set_special(int option, int value);
+extern int   fo_scheduler_get_special(int option);
+extern char* fo_sysconfig(const char* sectionname, const char* variablename);
+extern int   fo_GetAgentKey   (PGconn *pgConn,const char *agent_name, long unused, const char *cpunused, const char *agent_desc);
+extern int   fo_WriteARS(PGconn *pgConn, int ars_pk, int upload_pk, int agent_pk,
+                        const char *tableName, const char *ars_status, int ars_success);
+
+extern int   fo_checkPQcommand(PGconn *pgConn, PGresult *result, char *sql, char *FileID, int LineNumb);
+extern int   fo_checkPQresult(PGconn *pgConn, PGresult *result, char *sql, char *FileID, int LineNumb);
+extern int   fo_tableExists(PGconn *pgConn, const char *tableName);
+extern int   GetUploadPerm(PGconn *pgConn, long UploadPk, int user_pk);
+extern int   fo_CreateARSTable(PGconn* pgConn, const char* tableName);
+
+typedef struct {} fo_dbManager;
+
+extern int   PQresultStatus(const PGresult *res);
+extern char* PQresultErrorMessage(const PGresult *res);
+extern char* PQresultErrorField(const PGresult *res, int fieldcode);
+extern int   PQntuples(const PGresult *res);
+extern PGresult *PQexec(PGconn *conn, const char *query);
+extern void  PQclear(PGresult *res);
+extern char* PQgetvalue(const PGresult *res, int tup_num, int field_num);
+extern size_t PQescapeStringConn(PGconn *conn,
+                   char *to, const char *from, size_t length,
+                   int *error);
+extern void  PQfinish(PGconn *conn);
+
+extern char* fo_RepMkPath (char *Type, char *Filename);
+extern int   fo_RepExist(char* Type, char* Filename);
+extern int   fo_RepExist2(char* Type, char* Filename);
+extern int   fo_RepImport(char* Source, char* Type, char* Filename, int HardLink);
+#endif

--- a/src/ununpack/agent/ununpack.h
+++ b/src/ununpack/agent/ununpack.h
@@ -43,11 +43,16 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
-#include "libfossology.h"
 #include "checksum.h"
 #include "ununpack-ar.h"
 #include "ununpack-disk.h"
 #include "ununpack-iso.h"
+
+#ifdef STANDALONE
+#include "standalone.h"
+#else
+#include "libfossology.h"
+#endif
 
 #define Last(x)	(x)[strlen(x)-1]
 #define MAXCHILD        4096

--- a/src/ununpack/agent/utils.c
+++ b/src/ununpack/agent/utils.c
@@ -1705,7 +1705,7 @@ char *PathCheck(char *DirPath)
     free(NewPath);
     NewPath = strdup(TmpPath);
   }
-
+#ifndef STANDALONE
   if ((subs = strstr(NewPath, "%R")) )
   {
     /* repo location substitution */
@@ -1715,7 +1715,7 @@ char *PathCheck(char *DirPath)
     free(NewPath);
     NewPath = strdup(TmpPath);
   }
-
+#endif
   return(NewPath);
 }
 


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This PR makes unpack agent as standalone, so it can work independently.

### Changes
```
src/ununpack/agent/Makefile.sa
src/ununpack/agent/ununpack.c
src/ununpack/agent/ununpack.h
```
## How to test

1. go to `src/ununpack/agent` folder
2. Build ununpack-standalone : `make -f  Makefile.sa` (this will create ununpack-sa) 
3. `./ununpack-sa <file to unzip>`
4. other options can be used :
 -C     :: force continue when unpack tool fails.
  -d dir :: specify alternate extraction directory. %U substitutes a unique ID.
            Default is the same directory as file (usually not a good idea).
  -m #   :: number of CPUs to use (default: 1).
  -P     :: prune files: remove links, >1 hard links, zero files, etc.
  -R     :: recursively unpack (same as '-r -1')
  -r #   :: recurse to a specified depth (0=none/default, -1=infinite)
  -X     :: remove recursive sources after unpacking.
  -x     :: remove ALL unpacked files when done (clean up)