### PR TITLE
fix(db): add indexes to pfile on sha1 and sha256

### DIFF
--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -2281,6 +2281,8 @@
   $Schema["INDEX"]["personal_access_tokens"]["user_fk_active_idx"] = "CREATE INDEX user_fk_active_idx ON personal_access_tokens USING btree (user_fk, active);";
 
   $Schema["INDEX"]["pfile"]["pfile_mimetypefk_idx"] = "CREATE INDEX pfile_mimetypefk_idx ON pfile USING btree (pfile_mimetypefk);";
+  $Schema["INDEX"]["pfile"]["pfile_sha1_idx"] = "CREATE INDEX pfile_sha1_idx ON pfile USING btree (pfile_sha1);";
+  $Schema["INDEX"]["pfile"]["pfile_sha256_idx"] = "CREATE INDEX pfile_sha256_idx ON pfile USING btree (pfile_sha256);";
 
   $Schema["INDEX"]["report_cache"]["report_cache_createdts"] = "CREATE INDEX report_cache_createdts ON report_cache USING btree (report_cache_tla);";
 


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Create indexes for columns `pfile_sha1` and `pfile_sha256` on table `pfile`.

## How to test

Run and analyze `SELECT * FROM pfile WHERE pfile_sha1 = 'ABC'` and `SELECT * FROM pfile WHERE pfile_sha256 = 'ABC'`. The queries should utilize the indexes.

Closes #1859 