### PR TITLE
feat(rest): add license search based on short name

### DIFF
--- a/src/www/ui/api/Controllers/LicenseController.php
+++ b/src/www/ui/api/Controllers/LicenseController.php
@@ -1,0 +1,97 @@
+<?php
+
+/***************************************************************
+ Copyright (C) 2021 HH Partners
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Controller for licenses
+ */
+
+namespace Fossology\UI\Api\Controllers;
+
+use Fossology\Lib\Dao\LicenseDao;
+use Fossology\UI\Api\Models\License;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Psr\Container\ContainerInterface;
+use Slim\Http\Request;
+use Slim\Http\Response;
+
+/**
+ * @class LicenseController
+ * @brief Controller for licenses
+ */
+class LicenseController extends RestController
+{
+  /**
+   * @var LicenseDao $licenseDao
+   * License Dao object
+   */
+  private $licenseDao;
+
+  /**
+   * @param ContainerInterface $container
+   */
+  public function __construct($container)
+  {
+    parent::__construct($container);
+    $this->licenseDao = $this->container->get('dao.license');
+  }
+
+  /**
+   * Get the license information based on the provided parameters
+   *
+   * @param Request $request
+   * @param Response $response
+   * @param array $args
+   * @return Response
+   */
+  public function getLicense($request, $response, $args)
+  {
+    $shortName = $request->getHeaderLine("shortName");
+
+    if (empty($shortName)) {
+      $error = new Info(
+        400,
+        "'shortName' parameter missing from query.",
+        InfoType::ERROR
+      );
+      return $response->withJson($error->getArray(), $error->getCode());
+    }
+
+    $license = $this->licenseDao->getLicenseByShortName($shortName);
+
+    if ($license === NULL) {
+      $error = new Info(
+        404,
+        "No license found with short name '{$shortName}'.",
+        InfoType::ERROR
+      );
+      return $response->withJson($error->getArray(), $error->getCode());
+    }
+
+    $returnVal = new License(
+      $license->getId(),
+      $license->getShortName(),
+      $license->getFullName(),
+      $license->getText(),
+      $license->getRisk()
+    );
+
+    return $response->withJson($returnVal->getArray(), 200);
+  }
+}

--- a/src/www/ui/api/Models/License.php
+++ b/src/www/ui/api/Models/License.php
@@ -1,0 +1,185 @@
+<?php
+
+/***************************************************************
+Copyright (C) 2021 HH Partners
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief License
+ */
+
+namespace Fossology\UI\Api\Models;
+
+/**
+ * @class License
+ * @package Fossology\UI\Api\Models
+ * @brief License model to hold license related info
+ */
+class License
+{
+  /**
+   * @var integer $id
+   * License id
+   */
+  private $id;
+  /**
+   * @var string $shortName
+   * Short name of the license
+   */
+  private $shortName;
+  /**
+   * @var string $fullName
+   * Full name of the license
+   */
+  private $fullName;
+  /**
+   * @var string $text
+   * The text of the license
+   */
+  private $text;
+  /**
+   * @var integer|null $license
+   * The risk level of the license
+   */
+  private $risk;
+
+  /**
+   * License constructor.
+   *
+   * @param integer $id
+   * @param string $shortName
+   * @param string $fullName
+   * @param string $text
+   * @param integer|null $risk
+   */
+  public function __construct(
+    $id,
+    $shortName = "",
+    $fullName = "",
+    $text = "",
+    $risk = null
+  )
+  {
+    $this->id = intval($id);
+    $this->shortName = $shortName;
+    $this->fullName = $fullName;
+    $this->text = $text;
+
+    // invtval returns 0 for null, so check for nullness to preserve the
+    // difference in the response.
+    if (!is_null($risk)) {
+      $this->risk = intval($risk);
+    } else {
+      $this->risk = $risk;
+    }
+  }
+
+  /**
+   * JSON representation of the license
+   * @return string
+   */
+  public function getJSON()
+  {
+    return json_encode($this->getArray());
+  }
+
+  /**
+   * Get License element as associative array
+   * @return array
+   */
+  public function getArray()
+  {
+    return [
+      'id' => $this->id,
+      'shortName' => $this->shortName,
+      'fullName' => $this->fullName,
+      'text' => $this->text,
+      'risk' => $this->risk
+    ];
+  }
+
+  /**
+   * Get the license's short name
+   * @return string License's short name
+   */
+  public function getShortName()
+  {
+    return $this->shortName;
+  }
+
+  /**
+   * Get the license's full name
+   * @return string License's short name
+   */
+  public function getFullName()
+  {
+    return $this->fullName;
+  }
+
+  /**
+   * Get the license's text
+   * @return string License's text
+   */
+  public function getText()
+  {
+    return $this->text;
+  }
+
+  /**
+   * Get the license's risk level
+   * @return int|null License's risk level if set, null if not set
+   */
+  public function getRisk()
+  {
+    return $this->risk;
+  }
+
+  /**
+   * Set the license's short name
+   * @param string $shortName License's short name
+   */
+  public function setShortName($shortName)
+  {
+    $this->shortName = $shortName;
+  }
+
+  /**
+   * Set the license's full name
+   * @param string $fullName License's full name
+   */
+  public function setFullName($fullName)
+  {
+    $this->$fullName = $fullName;
+  }
+
+  /**
+   * Set the license's text
+   * @param string $text License's text
+   */
+  public function setText($text)
+  {
+    $this->$text = $text;
+  }
+
+  /**
+   * Set the license's risk level
+   * @param int|null $risk License's risk level or null
+   */
+  public function setRisk($risk)
+  {
+    $this->$risk = $risk;
+  }
+}

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -14,7 +14,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.1.2
+  version: 1.1.3
   contact:
     email: fossology@fossology.org
   license:
@@ -1010,6 +1010,34 @@ paths:
         default:
             $ref: '#/components/responses/defaultResponse'
 
+  /license:
+    get:
+      tags:
+      - License
+      summary: Get license from the database
+      parameters:
+        - name: shortName
+          in: header
+          required: true
+          description: Short name of the license
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Requested license
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/License'
+        '404':
+          description: No license found with the given parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+            $ref: '#/components/responses/defaultResponse'
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1450,6 +1478,36 @@ components:
           example:
             - "Copyright (C) 2017-2020 Free Software Foundation, Inc."
             - "Copyright (C) 1991-2020 Free Software Foundation, Inc."
+    License:
+      description: License from the database
+      type: object
+      properties:
+        id:
+          description: Id key
+          type: integer
+          example:
+            126
+        shortName:
+          description: Short name
+          type: string
+          example:
+            "MIT"
+        fullName:
+          description: Full name
+          type: string
+          example:
+            "MIT License"
+        text:
+          description: License text
+          type: string
+          example:
+            "MIT License Copyright (c) <year> <copyright holders> ..."
+        risk:
+          description: Risk level
+          type: integer
+          nullable: true
+          example:
+            3
   responses:
     defaultResponse:
       description: Some error occured. Check the "message"

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -40,6 +40,7 @@ use Fossology\UI\Api\Controllers\SearchController;
 use Fossology\UI\Api\Controllers\UploadController;
 use Fossology\UI\Api\Controllers\UserController;
 use Fossology\UI\Api\Controllers\VersionController;
+use Fossology\UI\Api\Controllers\LicenseController;
 use Fossology\UI\Api\Middlewares\RestAuthMiddleware;
 use Fossology\UI\Api\Middlewares\FossologyInitMiddleware;
 use Fossology\UI\Api\Models\Info;
@@ -162,6 +163,13 @@ $app->group(VERSION_1 . 'version',
 $app->group(VERSION_1 . 'filesearch',
   function (){
     $this->post('', FileSearchController::class . ':getFiles');
+    $this->any('/{params:.*}', BadRequestController::class);
+  });
+
+/////////////////////////LICENSE SEARCH/////////////////
+$app->group(VERSION_1 . 'license',
+  function (){
+    $this->get('', LicenseController::class . ':getLicense');
     $this->any('/{params:.*}', BadRequestController::class);
   });
 


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add API endpoint `/license` to search for licenses based on their short name.

### Changes

Add the ability to search for licenses based on their short name. Returns the id, short name, full name and text.

## How to test

Query `/license` endpoint with header `shortName` set to a license's short name. Should return the license's id, short name, full name and text. Querying with non-existing short name should return a proper error. 
