### PR TITLE
feat(reuse): Change data type of reuse_group from int to string.

### DIFF
--- a/src/www/ui/api/Controllers/JobController.php
+++ b/src/www/ui/api/Controllers/JobController.php
@@ -141,7 +141,7 @@ class JobController extends RestController
         $decider->setUsingArray($scanOptionsJSON["decider"]);
         $parametersSent = true;
       }
-      $reuser = new Reuser(0, 0, false, false);
+      $reuser = new Reuser(0, 'groupName', false, false);
       try {
         if (array_key_exists("reuse", $scanOptionsJSON) && ! empty($scanOptionsJSON["reuse"])) {
           $reuser->setUsingArray($scanOptionsJSON["reuse"]);

--- a/src/www/ui/api/Models/Reuser.php
+++ b/src/www/ui/api/Models/Reuser.php
@@ -33,7 +33,7 @@ class Reuser
    */
   private $reuseUpload;
   /**
-   * @var integer $reuseGroup
+   * @var string $reuseGroup
    * Group id to reuse from
    */
   private $reuseGroup;
@@ -52,7 +52,7 @@ class Reuser
    * Reuser constructor.
    *
    * @param integer $reuseUpload
-   * @param integer $reuseGroup
+   * @param string $reuseGroup
    * @param boolean $reuseMain
    * @param boolean $reuseEnhanced
    * @throws \UnexpectedValueException If reuse upload of reuse group are non
@@ -61,14 +61,14 @@ class Reuser
   public function __construct($reuseUpload, $reuseGroup, $reuseMain = false,
     $reuseEnhanced = false)
   {
-    if (is_numeric($reuseUpload) && is_numeric($reuseGroup)) {
+    if (is_numeric($reuseUpload)) {
       $this->reuseUpload = $reuseUpload;
       $this->reuseGroup = $reuseGroup;
       $this->reuseMain = $reuseMain;
       $this->reuseEnhanced = $reuseEnhanced;
     } else {
       throw new \UnexpectedValueException(
-        "reuse_upload and reuse_group should be integers", 400);
+        "reuse_upload should be integer", 400);
     }
   }
 
@@ -87,8 +87,7 @@ class Reuser
         FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
     }
     if (array_key_exists("reuse_group", $reuserArray)) {
-      $this->reuseGroup = filter_var($reuserArray["reuse_group"],
-        FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
+      $this->reuseGroup = $reuserArray["reuse_group"];
     }
     if (array_key_exists("reuse_main", $reuserArray)) {
       $this->reuseMain = filter_var($reuserArray["reuse_main"],
@@ -98,9 +97,13 @@ class Reuser
       $this->reuseEnhanced = filter_var($reuserArray["reuse_enhanced"],
         FILTER_VALIDATE_BOOLEAN);
     }
-    if ($this->reuseUpload === null || $this->reuseGroup === null) {
+    if ($this->reuseUpload === null) {
       throw new \UnexpectedValueException(
-        "reuse_upload and reuse_group should be integers", 400);
+        "reuse_upload should be integer", 400);
+    }
+    if ($this->reuseGroup === null) {
+      throw new \UnexpectedValueException(
+        "reuse_group should be a string", 400);
     }
     return $this;
   }
@@ -115,7 +118,7 @@ class Reuser
   }
 
   /**
-   * @return integer
+   * @return string
    */
   public function getReuseGroup()
   {
@@ -152,14 +155,13 @@ class Reuser
   }
 
   /**
-   * @param integer $reuseGroup
+   * @param string $reuseGroup
    */
   public function setReuseGroup($reuseGroup)
   {
-    $this->reuseGroup = filter_var($reuseGroup,
-      FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
+    $this->reuseGroup = $reuseGroup;
     if ($this->reuseGroup === null) {
-      throw new \UnexpectedValueException("Reuse group should be an integer!", 400);
+      throw new \UnexpectedValueException("Reuse group should be a string!", 400);
     }
   }
 

--- a/src/www/ui/api/Models/Reuser.php
+++ b/src/www/ui/api/Models/Reuser.php
@@ -34,7 +34,7 @@ class Reuser
   private $reuseUpload;
   /**
    * @var string $reuseGroup
-   * Group id to reuse from
+   * Group name to reuse from
    */
   private $reuseGroup;
   /**

--- a/src/www/ui/api/Models/ScanOptions.php
+++ b/src/www/ui/api/Models/ScanOptions.php
@@ -27,6 +27,7 @@ use Fossology\Reuser\ReuserAgentPlugin;
 use Fossology\UI\Api\Models\Info;
 use Fossology\UI\Api\Models\InfoType;
 use Symfony\Component\HttpFoundation\Request;
+use Fossology\Lib\Dao\UserDao;
 
 require_once dirname(dirname(__DIR__)) . "/agent-add.php";
 require_once dirname(dirname(dirname(dirname(__DIR__)))) . "/lib/php/common-folders.php";
@@ -149,7 +150,8 @@ class ScanOptions
     if ($this->reuse->getReuseEnhanced() === true) {
       $reuserRules[] = 'reuseEnhanced';
     }
-    $reuserSelector = $this->reuse->getReuseUpload() . "," . $this->reuse->getReuseGroup();
+    $userDao = $GLOBALS['container']->get("dao.user");
+    $reuserSelector = $this->reuse->getReuseUpload() . "," . $userDao->getGroupIdByName($this->reuse->getReuseGroup());
     $request->request->set(ReuserAgentPlugin::UPLOAD_TO_REUSE_SELECTOR_NAME, $reuserSelector);
     //global $SysConf;
     //$request->request->set('groupId', $SysConf['auth'][Auth::GROUP_ID]);

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -14,7 +14,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.1.3
+  version: 1.2.0
   contact:
     email: fossology@fossology.org
   license:
@@ -1264,7 +1264,7 @@ components:
           type: integer
           description: The UploadID to reuse.
         reuse_group:
-          type: integer
+          type: string
           description: The group of the reused upload
         reuse_main:
           type: boolean


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This PR changes the data type of reuse_group from int to string. Fixes #1801.

### Changes

The data type of reuse_group and reuseGroup is changed to string. The files affected are [Reuser.php](https://github.com/fossology/fossology/blob/master/src/www/ui/api/Models/Reuser.php), [openapi.yaml](https://github.com/fossology/fossology/blob/master/src/www/ui/api/documentation/openapi.yaml) and [JobController.php](https://github.com/fossology/fossology/blob/master/src/www/ui/api/Controllers/JobController.php).

## How to test

- Upload some files to scan and reuse a resource.
- There should be no console errors.
