### PR TITLE
fix(login): Do not set group_fk if empty

### DIFF
--- a/src/www/ui/user-edit.php
+++ b/src/www/ui/user-edit.php
@@ -93,7 +93,7 @@ class UserEditPage extends DefaultPlugin
 
     $vars = array('refreshUri' => Traceback_uri() . "?mod=" . self::NAME);
 
-      /*
+    /*
      * If this is a POST (the submit button was clicked), then process the
      * request.
      */
@@ -271,7 +271,7 @@ class UserEditPage extends DefaultPlugin
     /**** Update the users database record ****/
     /* First remove user_pass and user_seed if the password wasn't changed. */
     if (!empty($UserRec['_blank_pass']) ) {
-      $UserRec['user_seed'] = 'Seed';
+      $UserRec['user_seed'] = '';
       $options = array('cost' => 10);
       $UserRec['user_pass'] = password_hash("", PASSWORD_DEFAULT, $options);
     } else if (empty($UserRec['_pass1'])) { // password wasn't changed
@@ -351,15 +351,17 @@ class UserEditPage extends DefaultPlugin
       $UserRec = $this->GetUserRec($user_pk);
       $UserRec['_pass1'] = "";
       $UserRec['_pass2'] = "";
-      $options = array('cost' => 10);
-      $UserRec['_blank_pass'] = password_verify($UserRec['user_pass'], password_hash("", PASSWORD_DEFAULT, $options)) ? "on" : "";
+      $UserRec['_blank_pass'] = password_verify('', $UserRec['user_pass']) ? "on" : "";
     } else {
       $UserRec = array();
       $UserRec['user_pk'] = intval($request->get('user_pk'));
       $UserRec['user_name'] = stripslashes($request->get('user_name'));
       $UserRec['root_folder_fk'] = intval($request->get('root_folder_fk'));
       $UserRec['user_desc'] = stripslashes($request->get('user_desc'));
-      $UserRec['group_fk'] = intval($request->get('default_group_fk'));
+      $defaultGroup = $request->get('default_group_fk', null);
+      if ($defaultGroup !== null) {
+        $UserRec['group_fk'] = intval($defaultGroup);
+      }
 
       $UserRec['_pass1'] = stripslashes($request->get('_pass1'));
       $UserRec['_pass2'] = stripslashes($request->get('_pass2'));
@@ -374,7 +376,7 @@ class UserEditPage extends DefaultPlugin
         if (empty($UserRec['_blank_pass'])) { // check for blank password
           $StoredUserRec = $this->GetUserRec($UserRec['user_pk']);
           $options = array('cost' => 10);
-          $UserRec['_blank_pass'] = password_verify($UserRec['user_pass'], password_hash("", PASSWORD_DEFAULT, $options)) ? "on" : "";
+          $UserRec['_blank_pass'] = password_verify($StoredUserRec['user_pass'], password_hash("", PASSWORD_DEFAULT, $options)) ? "on" : "";
         }
       }
 


### PR DESCRIPTION
## Description

If the default group of a user was not updated in the form request, do not set the `group_fk` key which causes issue with DB update.

### Changes

Check if `default_group_fk` was sent before updating the `$UserRec['group_fk']` in `src/www/ui/user-edit.php`.

## How to test

1. Login as a non admin user.
2. Goto Admin > Users > Edit User Account and update a field. Submit the form and the update should be recorded.
3. Login as an admin user.
4. Goto Admin > Users > Edit User Account and update the default group of another user.