### PR TITLE
fix(cd): Use published event to build release pkgs

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -3,7 +3,7 @@ name: Publish Release Packages
 on:
   release:
     types:
-      - created
+      - published
 
 env:
   DEBIAN_FRONTEND: noninteractive


### PR DESCRIPTION
## Description

The `created` event type works only if a release was done without making a draft. But `published` type event is raised when a release, pre-release or a draft of a release is published. This will make sure the pipeline runs irrespective of draft state.

For more, read: https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#release

### Changes

Change the trigger from `created` to `published`.