### PR TITLE
fix(globaldecision): do not add decisions if the events have no change

### DIFF
--- a/src/www/ui/ui-clearing-view.php
+++ b/src/www/ui/ui-clearing-view.php
@@ -217,7 +217,7 @@ class ClearingView extends FO_Plugin
     $lastItem = GetParm("lastItem", PARM_INTEGER);
 
     if (!empty($lastItem)) {
-      $this->updateLastItem($userId, $groupId,$lastItem);
+      $this->updateLastItem($userId, $groupId, $lastItem, $uploadTreeId);
     }
 
     $uploadTreeTableName = $this->uploadDao->getUploadtreeTableName($uploadId);
@@ -344,13 +344,16 @@ class ClearingView extends FO_Plugin
    * @param int $lastItem
    * @return array
    */
-  protected function updateLastItem($userId, $groupId, $lastItem)
+  protected function updateLastItem($userId, $groupId, $lastItem, $currentUploadtreeId)
   {
     $type = GetParm("clearingTypes", PARM_INTEGER);
     $global = GetParm("globalDecision", PARM_STRING) === "on" ? 1 : 0;
     $uploadTreeTableName = $this->uploadDao->getUploadtreeTableName($lastItem);
     $itemBounds = $this->uploadDao->getItemTreeBounds($lastItem, $uploadTreeTableName);
-    $this->clearingDecisionEventProcessor->makeDecisionFromLastEvents($itemBounds, $userId, $groupId, $type, $global);
+    $isDecisionWip = $this->clearingDao->isDecisionWip($currentUploadtreeId, $groupId);
+    if ($isDecisionWip || !$global) {
+      $this->clearingDecisionEventProcessor->makeDecisionFromLastEvents($itemBounds, $userId, $groupId, $type, $global);
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Do not add decisions i case of global decision if events wont change.

### Changes

* Make use of isDecisionWip function to check if decisions have been changed.

## How to test

* Upload a component X and make global clearing to few files.
* Create another user and Upload component X by new users login.
* Scroll through files which have global clearing decisions.
* Check the history so that new decisions should not be added.
* Do end to end clearing testing, So that other clearing areas shouldn't break.