### PR TITLE
feat(licenseExport): include obligation topic in exported CSV

### DIFF
--- a/src/lib/php/Application/LicenseCsvExport.php
+++ b/src/lib/php/Application/LicenseCsvExport.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Copyright (C) 2015, Siemens AG
+Copyright (C) 2015,2021, Siemens AG
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -76,6 +76,7 @@ class LicenseCsvExport
    */
   public function createCsv($rf=0)
   {
+    $forGroupBy = " GROUP BY rf.rf_shortname, rf.rf_fullname, rf.rf_text, rc.rf_shortname, rr.rf_shortname, rf.rf_url, rf.rf_notes, rf.rf_source, rf.rf_risk, gp.group_name";
     $sql = "WITH marydoneCand AS (
   SELECT * FROM license_candidate
   WHERE marydone = true
@@ -86,35 +87,37 @@ SELECT DISTINCT ON(rf_pk) * FROM
 SELECT
   rf.rf_shortname, rf.rf_fullname, rf.rf_text, rc.rf_shortname parent_shortname,
   rr.rf_shortname report_shortname, rf.rf_url, rf.rf_notes, rf.rf_source,
-  rf.rf_risk, gp.group_name
+  rf.rf_risk, gp.group_name, string_agg(ob_topic, ', ') obligations
 FROM allLicenses AS rf
+  LEFT OUTER JOIN obligation_map om ON om.rf_fk = rf.rf_pk
+  LEFT OUTER JOIN obligation_ref ON ob_fk = ob_pk
   FULL JOIN groups AS gp ON gp.group_pk = rf.group_fk
   LEFT JOIN license_map mc ON mc.rf_fk=rf.rf_pk AND mc.usage=$2
   LEFT JOIN license_ref rc ON mc.rf_parent=rc.rf_pk
   LEFT JOIN license_map mr ON mr.rf_fk=rf.rf_pk AND mr.usage=$3
   LEFT JOIN license_ref rr ON mr.rf_parent=rr.rf_pk
 WHERE rf.rf_detector_type=$1";
+
     $param = array(1, LicenseMap::CONCLUSION, LicenseMap::REPORT);
     if ($rf > 0) {
       $stmt = __METHOD__ . '.rf';
       $param[] = $rf;
-      $sql .= ' AND rf.rf_pk = $'.count($param);
+      $sql .= ' AND rf.rf_pk = $'.count($param).$forGroupBy;
       $row = $this->dbManager->getSingleRow($sql,$param,$stmt);
       $vars = $row ? array( $row ) : array();
     } else {
       $stmt = __METHOD__;
-      $sql .= ' ORDER BY rf.rf_pk';
+      $sql .= $forGroupBy . ', rf.rf_pk ORDER BY rf.rf_pk';
       $this->dbManager->prepare($stmt,$sql);
       $res = $this->dbManager->execute($stmt,$param);
       $vars = $this->dbManager->fetchAll( $res );
       $this->dbManager->freeResult($res);
     }
-
     $out = fopen('php://output', 'w');
     ob_start();
     $head = array(
       'shortname', 'fullname', 'text', 'parent_shortname', 'report_shortname',
-      'url', 'notes', 'source', 'risk', 'group');
+      'url', 'notes', 'source', 'risk', 'group', 'obligations');
     fputcsv($out, $head, $this->delimiter, $this->enclosure);
     foreach ($vars as $row) {
       fputcsv($out, $row, $this->delimiter, $this->enclosure);

--- a/src/lib/php/Application/LicenseCsvImport.php
+++ b/src/lib/php/Application/LicenseCsvImport.php
@@ -67,7 +67,8 @@ class LicenseCsvImport
       'notes'=>array('notes'),
       'source'=>array('source','Foreign ID'),
       'risk'=>array('risk','risk_level'),
-      'group'=>array('group','License group')
+      'group'=>array('group','License group'),
+      'obligations'=>array('obligations','License obligations')
       );
 
   /**

--- a/src/lib/php/Application/test/LicenseCsvExportTest.php
+++ b/src/lib/php/Application/test/LicenseCsvExportTest.php
@@ -59,7 +59,7 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
   public function testCreateCsv()
   {
     $testDb = new TestPgDb("licenseCsvExport");
-    $testDb->createPlainTables(array('license_ref','license_map','groups'));
+    $testDb->createPlainTables(array('license_ref','license_map','groups','obligation_ref','obligation_map'));
     $testDb->createInheritedTables(array('license_candidate'));
     $dbManager = $testDb->getDbManager();
     $licenses = array();
@@ -105,7 +105,7 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
     $dbManager->insertTableRow('license_map', array('rf_fk'=>3,'rf_parent'=>2,'usage'=>LicenseMap::REPORT));
 
     $licenseCsvExport = new LicenseCsvExport($dbManager);
-    $head = array('shortname','fullname','text','parent_shortname','report_shortname','url','notes','source','risk','group');
+    $head = array('shortname','fullname','text','parent_shortname','report_shortname','url','notes','source','risk','group', 'obligations');
     $out = fopen('php://output', 'w');
 
     $csv = $licenseCsvExport->createCsv();
@@ -120,7 +120,7 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
         $licenses[1]['rf_notes'],
         $licenses[1]['rf_source'],
         $licenses[1]['rf_risk'],
-        null));
+        null, null));
 
     fputcsv($out, array($licenses[2]['rf_shortname'],
         $licenses[2]['rf_fullname'],
@@ -131,7 +131,7 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
         $licenses[2]['rf_notes'],
         $licenses[2]['rf_source'],
         $licenses[2]['rf_risk'],
-        null));
+        null, null));
 
     fputcsv($out, array($licenses[3]['rf_shortname'],
         $licenses[3]['rf_fullname'],
@@ -142,7 +142,7 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
         $licenses[3]['rf_notes'],
         $licenses[3]['rf_source'],
         $licenses[3]['rf_risk'],
-        null));
+        null, null));
 
     fputcsv($out, array($candLicenses[2]['rf_shortname'],
       $candLicenses[2]['rf_fullname'],
@@ -153,7 +153,7 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
       $candLicenses[2]['rf_notes'],
       $candLicenses[2]['rf_source'],
       $candLicenses[2]['rf_risk'],
-      "test"));
+      "test", null));
 
     fputcsv($out, array($candLicenses[4]['rf_shortname'],
       $candLicenses[4]['rf_fullname'],
@@ -164,7 +164,7 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
       $candLicenses[4]['rf_notes'],
       $candLicenses[4]['rf_source'],
       $candLicenses[4]['rf_risk'],
-      "test"));
+      "test", null));
     $expected = ob_get_contents();
     ob_end_clean();
 
@@ -184,7 +184,7 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
           $licenses[3]['rf_notes'],
           $licenses[3]['rf_source'],
           $licenses[3]['rf_risk'],
-          null
+          null, null
         ),
         $delimiter);
     $expected3 = ob_get_contents();

--- a/src/www/ui/template/admin_license_from_csv.html.twig
+++ b/src/www/ui/template/admin_license_from_csv.html.twig
@@ -22,6 +22,10 @@
     <br/>
     <p>&nbsp;&nbsp;&nbsp;&nbsp;<input type="submit" value="{{ 'Upload'| trans }}"/>
     </p>
+    <p>
+      {{ 'NOTE: Obligations will not get imported, To import go to Admin -> Obligation Admin -> CSV Import'| trans }} <br/>
+    </p>
+
   </form>
 
 {% endblock %}


### PR DESCRIPTION
## Description

Include obligation topic as obligations in exported license CSv file.

### Changes

Change query accordingly to add the obligation topic.

## How to test

* Go to Admin -> License Admin -> Select license.
* Click on any license edit where obligations are there.
* Export CSV and check if the CSV have obligations column.
* Do the same for multiple license export.
* Check the license import from newly downloaded CSV.