### PR TITLE
fix(reportImport): Read XML in chunks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
 
 COPY . .
 
-RUN /fossology/utils/install_composer.sh
-
-RUN make clean install clean
+RUN make clean install \
+ && make clean
 
 
 FROM debian:stretch-slim

--- a/RdfXml.php.patch
+++ b/RdfXml.php.patch
@@ -1,0 +1,38 @@
+# This patch is created from https://github.com/easyrdf/easyrdf/pull/370
+# It tries to improve the Report Import agent without updating the easyrdf
+# from 0.9.0 to latest version due to PHP version constraints.
+#
+# The copyrights are help by the respective authors (see
+# https://github.com/easyrdf/easyrdf/blob/master/LICENSE.md).
+
+--- vendor/easyrdf/easyrdf/lib/EasyRdf/Parser/RdfXml.php	2020-09-08 17:14:43.328912848 +0530
++++ vendor/easyrdf/easyrdf/lib/EasyRdf/Parser/RdfXml.php	2021-01-27 14:06:18.391440952 +0530
+@@ -795,14 +795,22 @@
+         /* xml parser */
+         $this->initXMLParser();
+ 
+-        /* parse */
+-        if (!xml_parse($this->xmlParser, $data, false)) {
++        /* split into 1MB chunks, so XML parser can cope */
++        $chunkSize = 1000000;
++        $length = strlen($data);
++        for ($pos=0; $pos < $length; $pos += $chunkSize) {
++          $chunk = substr($data, $pos, $chunkSize);
++          $isLast = ($pos + $chunkSize > $length);
++
++          /* Parse the chunk */
++          if (!xml_parse($this->xmlParser, $chunk, $isLast)) {
+             $message = xml_error_string(xml_get_error_code($this->xmlParser));
+             throw new EasyRdf_Parser_Exception(
+-                'XML error: "' . $message . '"',
+-                xml_get_current_line_number($this->xmlParser),
+-                xml_get_current_column_number($this->xmlParser)
+-            );
++              'XML error: "' . $message . '"',
++              xml_get_current_line_number($this->xmlParser),
++              xml_get_current_column_number($this->xmlParser)
++              );
++          }
+         }
+ 
+         xml_parser_free($this->xmlParser);

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,8 @@ Build-Depends: debhelper (>=9~), libglib2.0-dev, libmagic-dev, libxml2-dev,
  libssl-dev, postgresql-server-dev-all, libboost-regex-dev, libicu-dev,
  libboost-program-options-dev, libjsoncpp-dev, libjson-c-dev, libpq-dev,
  php7.0-cli|php7.2-cli|php7.3-cli|php7.4-cli, php-mbstring, php-zip,
- php-xml, libboost-system-dev, libboost-filesystem-dev, libgcrypt20-dev, composer
+ php-xml, libboost-system-dev, libboost-filesystem-dev, libgcrypt20-dev,
+ composer, patch
 Standards-Version: 3.9.1
 Homepage: https://fossology.org
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -87,6 +87,9 @@ composer_install:
 	@echo "current dir: '$${PWD}'"
 	$(INSTALL_DATA) composer.json composer.lock $(DESTDIR)$(MODDIR)
 	(cd $(DESTDIR)$(MODDIR); export COMPOSER_HOME=/dev/null; $(COMPOSER_PHAR) install --no-plugins --no-scripts --no-dev)
+	if ! patch --reverse --silent --force --dry-run $(DESTDIR)$(MODDIR)/vendor/easyrdf/easyrdf/lib/EasyRdf/Parser/RdfXml.php $(TOP)/RdfXml.php.patch; then \
+		patch --silent --force $(DESTDIR)$(MODDIR)/vendor/easyrdf/easyrdf/lib/EasyRdf/Parser/RdfXml.php $(TOP)/RdfXml.php.patch; \
+	fi
 
 .PHONY: subdirs $(BUILDDIRS)
 .PHONY: subdirs $(DIRS)

--- a/src/reportImport/reportImport.conf
+++ b/src/reportImport/reportImport.conf
@@ -4,16 +4,16 @@
 ; name: The name of the agent from the agent table
 name = reportImport
 
-; command: The command that the scheduler will use when creating an instance of this agent. 
+; command: The command that the scheduler will use when creating an instance of this agent.
 ; This will be parsed like a normal Unix command line.
 command = reportImport
 
-; max: The maximum number of this agent that is allowed to exist at any one time. 
+; max: The maximum number of this agent that is allowed to exist at any one time.
 ; This is set to -1 if there is no limit on the number of instances of the agent.
 max = -1
 
 ; special: Scheduler directive for special agent attributes.
 ; A comma separated list of values.
 ; Directives:
-;     EXCLUSIVE: the agent cannot run concurrently with any other agent. 
-special[] = 
+;     EXCLUSIVE: the agent cannot run concurrently with any other agent.
+special[] = NOKILL

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -104,7 +104,8 @@ if [[ $BUILDTIME ]]; then
             libmxml-dev curl libxml2-dev libcunit1-dev libicu-dev \
             build-essential libtext-template-perl subversion rpm librpm-dev \
             libmagic-dev libglib2.0 libboost-regex-dev \
-            libboost-program-options-dev libpq-dev composer devscripts libdistro-info-perl
+            libboost-program-options-dev libpq-dev composer patch devscripts \
+            libdistro-info-perl
          case "$CODENAME" in
            xenial|stretch)
              apt-get $YesOpt install php-mbstring php7.0-cli php7.0-xml php7.0-zip;;
@@ -141,14 +142,14 @@ if [[ $BUILDTIME ]]; then
             perl-Text-Template subversion \
             postgresql-devel file-devel \
             libxml2 \
-            boost-devel php-mbstring libicu-devel libpq-devel
+            boost-devel php-mbstring libicu-devel libpq-devel patch
          ;;
       RedHatEnterprise*|CentOS)
          yum $YesOpt install \
             postgresql-devel \
             gcc make file libxml2 \
             perl-Text-Template subversion \
-            boost-devel php-mbstring libicu-devel libpq-devel
+            boost-devel php-mbstring libicu-devel libpq-devel patch
          ;;
       *) echo "ERROR: distro not recognised, please fix and send a patch"; exit 1;;
    esac


### PR DESCRIPTION
# Note
This PR will make reportImport agent special with `NOKILL`!

## Description

1. Apply patch to `easyrdf` to read xml files in chunk of 1 Mb.
2. Since the majority of computation time is consumed by the **easyrdf** plugin (specifically `xml_parse()`) which can not controlled by FOSSology, adding special flag `NOKILL` to the _reportImport_ agent.

### Changes

1. Add patch for easyrdf plugin.
2. Add `NOKILL` to report import.

## How to test

1. Try to import a large RDF file.
2. Check if Debian package installation works.
3. Check if Docker installation works.

Closes #1136