### PR TITLE
fix(ojo): New license as candidate

### DIFF
--- a/src/decider/agent/DeciderAgent.php
+++ b/src/decider/agent/DeciderAgent.php
@@ -281,7 +281,14 @@ class DeciderAgent extends Agent
     }
 
     if ($licenseMatchExists) {
-      $this->clearingDecisionProcessor->makeDecisionFromLastEvents($itemTreeBounds, $this->userId, $this->groupId, DecisionTypes::IDENTIFIED, $global=true);
+      try {
+        $this->clearingDecisionProcessor->makeDecisionFromLastEvents(
+          $itemTreeBounds, $this->userId, $this->groupId,
+          DecisionTypes::IDENTIFIED, true);
+      } catch (\Exception $e) {
+        echo "Can not auto decide global as file '" .
+          $itemTreeBounds->getItemId() . "' contains candidate license.\n";
+      }
     }
     return $licenseMatchExists;
   }

--- a/src/decider/agent/DeciderAgent.php
+++ b/src/decider/agent/DeciderAgent.php
@@ -284,9 +284,9 @@ class DeciderAgent extends Agent
       try {
         $this->clearingDecisionProcessor->makeDecisionFromLastEvents(
           $itemTreeBounds, $this->userId, $this->groupId,
-          DecisionTypes::IDENTIFIED, true);
+          DecisionTypes::IDENTIFIED, false);
       } catch (\Exception $e) {
-        echo "Can not auto decide global as file '" .
+        echo "Can not auto decide as file '" .
           $itemTreeBounds->getItemId() . "' contains candidate license.\n";
       }
     }

--- a/src/lib/cpp/libfossAgentDatabaseHandler.cc
+++ b/src/lib/cpp/libfossAgentDatabaseHandler.cc
@@ -107,6 +107,23 @@ std::vector<unsigned long> fo::AgentDatabaseHandler::queryFileIdsVectorForUpload
 }
 
 /**
+ * \brief Get pfile ids for a given upload id which agent has not scanned
+ * \param uploadId Upload id to fetch from
+ * \param agentId  Agent id to filter pfiles for
+ * \param ignoreFilesWithMimeType ignore files with particular mimetype
+ * \return Vector of pfile ids in given upload id
+ * \sa getSelectedPFiles()
+ */
+std::vector<unsigned long> fo::AgentDatabaseHandler::queryFileIdsVectorForUpload (
+    int uploadId, int agentId, bool ignoreFilesWithMimeType) const
+{
+  QueryResult queryResult(
+    getSelectedPFiles(dbManager.getConnection(), uploadId, agentId,
+                      ignoreFilesWithMimeType));
+  return queryResult.getSimpleResults(0, fo::stringToUnsignedLong);
+}
+
+/**
  * \brief Get the upload tree table name for a given upload id
  * \param uploadId Upload id to check
  * \return Name of the table holding the upload tree

--- a/src/lib/cpp/libfossAgentDatabaseHandler.hpp
+++ b/src/lib/cpp/libfossAgentDatabaseHandler.hpp
@@ -58,6 +58,8 @@ namespace fo
     char* getPFileNameForFileId(unsigned long pfileId) const;
     std::string queryUploadTreeTableName(int uploadId);
     std::vector<unsigned long> queryFileIdsVectorForUpload(int uploadId, bool ignoreFilesWithMimeType) const;
+    std::vector<unsigned long> queryFileIdsVectorForUpload(int uploadId,
+      int agentId, bool ignoreFilesWithMimeType) const;
   };
 }
 

--- a/src/lib/php/BusinessRules/LicenseMap.php
+++ b/src/lib/php/BusinessRules/LicenseMap.php
@@ -159,7 +159,7 @@ class LicenseMap
    */
   public static function getMappedLicenseRefView($usageExpr='$1')
   {
-    return "SELECT bot.rf_pk rf_origin, top.rf_pk, top.rf_shortname, top.rf_fullname FROM ONLY license_ref bot "
+    return "SELECT bot.rf_pk rf_origin, top.rf_pk, top.rf_shortname, top.rf_fullname FROM license_ref bot "
           ."LEFT JOIN license_map ON bot.rf_pk=rf_fk AND usage=$usageExpr "
           ."INNER JOIN license_ref top ON rf_parent=top.rf_pk OR rf_parent IS NULL AND bot.rf_pk=top.rf_pk";
   }

--- a/src/lib/php/BusinessRules/test/LicenseMapTest.php
+++ b/src/lib/php/BusinessRules/test/LicenseMapTest.php
@@ -162,10 +162,11 @@ class LicenseMapTest extends \PHPUnit\Framework\TestCase
     $res = $this->dbManager->execute($stmt);
     $map = $this->dbManager->fetchAll($res);
     $this->dbManager->freeResult($res);
-    assertThat($map,is(arrayWithSize(2)));
+    assertThat($map,is(arrayWithSize(3)));
     $expected = array(
         array('rf_origin'=>1, 'rf_pk'=>1,'rf_shortname'=>'One','rf_fullname'=>'One-1'),
-        array('rf_origin'=>2, 'rf_pk'=>1,'rf_shortname'=>'One','rf_fullname'=>'One-1')
+        array('rf_origin'=>2, 'rf_pk'=>1,'rf_shortname'=>'One','rf_fullname'=>'One-1'),
+        array('rf_origin'=>3, 'rf_pk'=>3,'rf_shortname'=>'Three','rf_fullname'=>'Three-3')
     );
     assertThat($map,containsInAnyOrder($expected));
   }

--- a/src/lib/php/Dao/LicenseDao.php
+++ b/src/lib/php/Dao/LicenseDao.php
@@ -60,7 +60,7 @@ class LicenseDao
     $statementName = __METHOD__ . ".$uploadTreeTableName.$usageId";
     $params = array($itemTreeBounds->getUploadId(), $itemTreeBounds->getLeft(), $itemTreeBounds->getRight());
     if ($usageId==LicenseMap::TRIVIAL) {
-      $licenseJoin = "ONLY license_ref mlr ON license_file.rf_fk = mlr.rf_pk";
+      $licenseJoin = "license_ref mlr ON license_file.rf_fk = mlr.rf_pk";
     } else {
       $params[] = $usageId;
       $licenseMapCte = LicenseMap::getMappedLicenseRefView('$4');

--- a/src/lib/php/Proxy/test/UploadTreeProxyTest.php
+++ b/src/lib/php/Proxy/test/UploadTreeProxyTest.php
@@ -312,6 +312,7 @@ class UploadTreeProxyTest extends \PHPUnit\Framework\TestCase
   public function testOptionSkipAlreadyClearedRanged()
   {
     $this->testDb->createPlainTables( array('license_file','clearing_decision','clearing_decision_event','clearing_event','license_ref') );
+    $this->testDb->createInheritedTables( array('license_candidate') );
 
     $rfId = 201;
     $groupId = 301;
@@ -346,6 +347,7 @@ class UploadTreeProxyTest extends \PHPUnit\Framework\TestCase
   public function testOptionSkipAlreadyClearedParented()
   {
     $this->testDb->createPlainTables( array('license_file','clearing_decision','clearing_decision_event','clearing_event','license_ref') );
+    $this->testDb->createInheritedTables( array('license_candidate') );
 
     $rfId = 201;
     $groupId = 301;
@@ -379,6 +381,7 @@ class UploadTreeProxyTest extends \PHPUnit\Framework\TestCase
   public function testOptionSkipTheseThatAreAlreadyCleared()
   {
     $this->testDb->createPlainTables( array('license_file','clearing_decision','clearing_decision_event','clearing_event','license_ref') );
+    $this->testDb->createInheritedTables( array('license_candidate') );
 
     $rfId = 201;
     $groupId = 301;
@@ -412,6 +415,7 @@ class UploadTreeProxyTest extends \PHPUnit\Framework\TestCase
   public function testOptionSkipAlreadyClearedButScanRanged()
   {
     $this->testDb->createPlainTables( array('license_file','clearing_decision','clearing_decision_event','clearing_event','license_ref','license_map') );
+    $this->testDb->createInheritedTables( array('license_candidate') );
 
     $rfId = 201;
     $groupId = 301;

--- a/src/ojo/agent/OjoAgent.cc
+++ b/src/ojo/agent/OjoAgent.cc
@@ -38,6 +38,7 @@ OjoAgent::OjoAgent() :
  * Scan a single file (when running from scheduler).
  * @param filePath        The file to be scanned.
  * @param databaseHandler Database handler to be used.
+ * @param groupId         Group running the scan
  * @return List of matches found.
  * @sa OjoAgent::scanString()
  * @sa OjoAgent::filterMatches()
@@ -46,7 +47,7 @@ OjoAgent::OjoAgent() :
  * read with the file path in description.
  */
 vector<ojomatch> OjoAgent::processFile(const string &filePath,
-  OjosDatabaseHandler &databaseHandler)
+  OjosDatabaseHandler &databaseHandler, const int groupId)
 {
   ifstream stream(filePath);
   std::stringstream sstr;
@@ -67,7 +68,7 @@ vector<ojomatch> OjoAgent::processFile(const string &filePath,
     scanString(m.content, regDualLicense, licenseNames, m.start, true);
   }
 
-  findLicenseId(licenseNames, databaseHandler);
+  findLicenseId(licenseNames, databaseHandler, groupId);
   filterMatches(licenseNames);
 
   return licenseNames;
@@ -167,14 +168,15 @@ void OjoAgent::filterMatches(vector<ojomatch> &matches)
  * Update the license id for each match entry
  * @param[in,out] matches List of matches to be updated
  * @param databaseHandler Database handler to be used
+ * @param groupId         Group running the scan
  */
 void OjoAgent::findLicenseId(vector<ojomatch> &matches,
-  OjosDatabaseHandler &databaseHandler)
+  OjosDatabaseHandler &databaseHandler, const int groupId)
 {
   // Update license_fk
   for (size_t i = 0; i < matches.size(); ++i)
   {
     matches[i].license_fk = databaseHandler.getLicenseIdForName(
-      matches[i].content);
+      matches[i].content, groupId);
   }
 }

--- a/src/ojo/agent/OjoAgent.hpp
+++ b/src/ojo/agent/OjoAgent.hpp
@@ -37,7 +37,7 @@ class OjoAgent
   public:
     OjoAgent();
     std::vector<ojomatch> processFile(const std::string &filePath,
-      OjosDatabaseHandler &databaseHandler);
+      OjosDatabaseHandler &databaseHandler, const int groupId);
     std::vector<ojomatch> processFile(const std::string &filePath);
   private:
     /**
@@ -53,7 +53,7 @@ class OjoAgent
         std::vector<ojomatch> &result, unsigned int offset, bool isDualTest);
     void filterMatches(std::vector<ojomatch> &matches);
     void findLicenseId(std::vector<ojomatch> &matches,
-      OjosDatabaseHandler &databaseHandler);
+      OjosDatabaseHandler &databaseHandler, const int groupId);
 };
 
 #endif /* SRC_OJO_AGENT_OJOAGENT_HPP_ */

--- a/src/ojo/agent/OjoState.cc
+++ b/src/ojo/agent/OjoState.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019, Siemens AG
+ * Copyright (C) 2019,2021 Siemens AG
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -61,7 +61,8 @@ const OjoAgent& OjoState::getOjoAgent() const
  * @param ignoreFilesWithMimeType To ignore files with particular mimetype
  */
 OjoCliOptions::OjoCliOptions(int verbosity, bool json, bool ignoreFilesWithMimeType) :
-    verbosity(verbosity), json(json), ignoreFilesWithMimeType(ignoreFilesWithMimeType)
+    verbosity(verbosity), json(json), ignoreFilesWithMimeType(ignoreFilesWithMimeType),
+    userId(-1), groupId(-1)
 {
 }
 
@@ -69,7 +70,8 @@ OjoCliOptions::OjoCliOptions(int verbosity, bool json, bool ignoreFilesWithMimeT
  * @brief Default constructor for OjoCliOptions
  */
 OjoCliOptions::OjoCliOptions() :
-    verbosity(0), json(false), ignoreFilesWithMimeType(false)
+    verbosity(0), json(false), ignoreFilesWithMimeType(false), userId(-1),
+    groupId(-1)
 {
 }
 
@@ -109,3 +111,38 @@ bool OjoCliOptions::doignoreFilesWithMimeType() const
   return ignoreFilesWithMimeType;
 }
 
+/**
+ * @brief Set the user id
+ * @param userId User id
+ */
+void OjoCliOptions::setUserId(const int userId)
+{
+  this->userId = userId;
+}
+
+/**
+ * @brief Set the group id
+ * @param groupId Group id
+ */
+void OjoCliOptions::setGroupId(const int groupId)
+{
+  this->groupId = groupId;
+}
+
+/**
+ * @brief Get the user running the agent
+ * @return User id if available, -1 otherwise
+ */
+int OjoCliOptions::getUserId() const
+{
+  return userId;
+}
+
+/**
+ * @brief Get the group running the agent
+ * @return Group id if available, -1 otherwise
+ */
+int OjoCliOptions::getGroupId() const
+{
+  return groupId;
+}

--- a/src/ojo/agent/OjoState.hpp
+++ b/src/ojo/agent/OjoState.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019, Siemens AG
+ * Copyright (C) 2019,2021 Siemens AG
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -37,11 +37,18 @@ class OjoCliOptions
     int verbosity;  /**< The verbosity level */
     bool json;      /**< Whether to generate JSON output */
     bool ignoreFilesWithMimeType; /**< Ignore files with particular mimetype */
+    int userId;     /**< User running the agent */
+    int groupId;    /**< Group running the agent */
 
   public:
+    void setUserId(const int);
+    void setGroupId(const int);
+
     bool isVerbosityDebug() const;
     bool doJsonOutput() const;
     bool doignoreFilesWithMimeType() const;
+    int getUserId() const;
+    int getGroupId() const;
 
     OjoCliOptions(int verbosity, bool json, bool ignoreFilesWithMimeType);
     OjoCliOptions();

--- a/src/ojo/agent/OjoUtils.cc
+++ b/src/ojo/agent/OjoUtils.cc
@@ -114,7 +114,7 @@ bool processUploadId(const OjoState &state, int uploadId,
     OjosDatabaseHandler &databaseHandler, bool ignoreFilesWithMimeType)
 {
   vector<unsigned long> fileIds = databaseHandler.queryFileIdsForUpload(
-      uploadId, ignoreFilesWithMimeType);
+      uploadId, state.getAgentId(), ignoreFilesWithMimeType);
   char const *repoArea = "files";
 
   bool errors = false;
@@ -152,7 +152,8 @@ bool processUploadId(const OjoState &state, int uploadId,
       vector<ojomatch> identified;
       try
       {
-        identified = agentObj.processFile(filePath, threadLocalDatabaseHandler);
+        identified = agentObj.processFile(filePath, threadLocalDatabaseHandler,
+                                          state.getCliOptions().getGroupId());
       }
       catch (std::runtime_error &e)
       {
@@ -315,6 +316,16 @@ bool parseCliOptions(int argc, char **argv, OjoCliOptions &dest,
     bool  ignoreFilesWithMimeType = vm.count("ignoreFilesWithMimeType") > 0 ?  true : false;
 
     dest = OjoCliOptions(verbosity, json, ignoreFilesWithMimeType);
+
+    if (vm.count("userID") > 0)
+    {
+      dest.setUserId(vm["userID"].as<int>());
+    }
+
+    if (vm.count("groupID") > 0)
+    {
+      dest.setGroupId(vm["groupID"].as<int>());
+    }
 
     if (vm.count("directory"))
     {

--- a/src/ojo/agent/OjosDatabaseHandler.hpp
+++ b/src/ojo/agent/OjosDatabaseHandler.hpp
@@ -79,19 +79,21 @@ class OjosDatabaseHandler: public fo::AgentDatabaseHandler
     ;
     OjosDatabaseHandler spawn() const;
 
-    std::vector<unsigned long> queryFileIdsForUpload(int uploadId, bool ignoreFilesWithMimeType);
-    std::vector<unsigned long> queryFileIdsForScan(int uploadId, int agentId, bool ignoreFilesWithMimeType);
+    std::vector<unsigned long> queryFileIdsForUpload(int uploadId, int agentId,
+                                                     bool ignoreFilesWithMimeType);
     unsigned long saveLicenseToDatabase(OjoDatabaseEntry &entry) const;
     bool insertNoResultInDatabase(OjoDatabaseEntry &entry) const;
     bool saveHighlightToDatabase(const ojomatch &match,
       const unsigned long fl_fk) const;
 
-    unsigned long getLicenseIdForName(std::string const &rfShortName);
+    unsigned long getLicenseIdForName(std::string const &rfShortName,
+                                      const int groupId);
 
   private:
-    unsigned long getCachedLicenseIdForName(
+    unsigned long getCachedLicenseIdForName (
       std::string const &rfShortName) const;
-    unsigned long selectOrInsertLicenseIdForName(std::string rfShortname);
+    unsigned long selectOrInsertLicenseIdForName (std::string rfShortname,
+                                                  const int groupId);
     /**
      * Cached license pairs
      */

--- a/src/ojo/agent_tests/Functional/schedulerTest.php
+++ b/src/ojo/agent_tests/Functional/schedulerTest.php
@@ -140,10 +140,15 @@ class OjoScheduledTest extends \PHPUnit\Framework\TestCase
         'upload',
         'pfile',
         'users',
+        'groups',
         'ars_master',
         'license_ref',
         'license_file',
         'highlight'
+      ));
+    $this->testDb->createInheritedTables(
+      array(
+        'license_candidate'
       ));
     $this->testDb->createSequences(
       array(
@@ -151,6 +156,7 @@ class OjoScheduledTest extends \PHPUnit\Framework\TestCase
         'upload_upload_pk_seq',
         'pfile_pfile_pk_seq',
         'users_user_pk_seq',
+        'group_group_pk_seq',
         'nomos_ars_ars_pk_seq',
         'license_ref_rf_pk_seq',
         'license_file_fl_pk_seq',
@@ -171,6 +177,7 @@ class OjoScheduledTest extends \PHPUnit\Framework\TestCase
         'upload',
         'ars_master',
         'users',
+        'groups',
         'license_ref',
         'license_file'
       ));

--- a/src/reportImport/ui/template/ReportImportPlugin.html.twig
+++ b/src/reportImport/ui/template/ReportImportPlugin.html.twig
@@ -36,9 +36,6 @@ This file is offered as-is, without any warranty.
                 <input type="radio" id="addNewLicensesAs-candidate" name="addNewLicensesAs" value="candidate" checked="checked">
                 <label for="addNewLicensesAs-candidate">license candidate</label>
                 <br/>
-                <span>
-                  Note: license candidates as scanner findings are currently not handled correctly in the UI
-                </span>
               </li>
               {% if userIsAdmin %}
               <li>

--- a/src/www/ui/async/AjaxExplorer.php
+++ b/src/www/ui/async/AjaxExplorer.php
@@ -461,8 +461,7 @@ class AjaxExplorer extends DefaultPlugin
           UploadTreeProxy::OPT_SKIP_THESE => UploadTreeProxy::OPT_SKIP_ALREADY_CLEARED,
           UploadTreeProxy::OPT_ITEM_FILTER => "AND (lft BETWEEN " .
           $itemTreeBounds->getLeft() . " AND " . $itemTreeBounds->getRight() . ")",
-          UploadTreeProxy::OPT_GROUP_ID => $groupId,
-          UploadTreeProxy::OPT_ONLY_MAIN_LICENSE => true
+          UploadTreeProxy::OPT_GROUP_ID => $groupId
         ), $itemTreeBounds->getUploadTreeTableName(),
         $viewName = 'already_cleared_uploadtree' . $itemTreeBounds->getUploadId());
 
@@ -477,8 +476,7 @@ class AjaxExplorer extends DefaultPlugin
           UploadTreeProxy::OPT_SKIP_THESE => "noLicense",
           UploadTreeProxy::OPT_ITEM_FILTER => "AND (lft BETWEEN " .
           $itemTreeBounds->getLeft() . " AND " . $itemTreeBounds->getRight() . ")",
-          UploadTreeProxy::OPT_GROUP_ID => $groupId,
-          UploadTreeProxy::OPT_ONLY_MAIN_LICENSE => true
+          UploadTreeProxy::OPT_GROUP_ID => $groupId
         ), $itemTreeBounds->getUploadTreeTableName(),
         $viewName = 'no_license_uploadtree' . $itemTreeBounds->getUploadId());
       $this->noLicenseUploadTreeView->materialize();


### PR DESCRIPTION
## Description

Create new OJO licenses as candidate licenses rather than main license as ojo looks for regex and can insert malicious licenses in DB.
Also, the auto decision of ojo findings was set to global which was causing some troubles, this PR also sets it back to local decisions only.

### Changes

1. Insert new licenses by ojo in candidate table.
2. **Do not make ojo auto decisions as global.**
3. Fix UI and Unified report to show candidate licenses.
4. Fix ojo to not rescan files.

## How to test

1. Create a sample file with `SPDX-License-Identifier` of a new license.
2. Check if the new license was detected my OJO but ends-up in candidate list.
3. Check if the reported license is shown in all UI views.
4. Check if the reported license is shown in reports.
5. Check if reuser can understand this new candidate license.
6. Check if running decider on upload does not mark decisions as global.