### PR TITLE
fix(email): Update email command for s-nail

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -79,7 +79,7 @@ Description: architecture for analyzing software, web interface
 
 Package: fossology-scheduler
 Architecture: any
-Depends: fossology-common, heirloom-mailx | s-nail, ${shlibs:Depends},
+Depends: fossology-common, s-nail, ${shlibs:Depends},
  ${misc:Depends}
 Conflicts: fossology-scheduler-single
 Description: architecture for analyzing software, scheduler

--- a/install/defconf/fossology.conf.in
+++ b/install/defconf/fossology.conf.in
@@ -89,7 +89,7 @@ LOGDIR=/var/log/$PROJECT
 header  = sampleheader.txt
 footer  = samplefooter.txt
 subject = FOSSology scan complete
-client  = /usr/bin/mailx
+client  = /usr/bin/s-nail
 
 [EXT_AUTH]
 ; Use external Authentication


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

For sending email in Ubuntu 20.04, s-nail is used as a dependency by fossology (#1614 ). 
In [S-nail v14.9.6](http://manpages.ubuntu.com/manpages/bionic/man1/s-nail.1.html) `smtp-auth-user` and `smtp-auth-password` flag is replaced by `mta`. Also `-S v15-compat` flag should be added for forward compatibility with s-nail v15

### Changes

Updated the email command for [s-nail](http://manpages.ubuntu.com/manpages/bionic/man1/s-nail.1.html)

## How to test

- Pull this branch
- Start PostgreSQL and apache 2
- Build and install from src in ubuntu 20.04
- Upload a file 
- Check if email notification for completion of fossology scan is received

