### PR TITLE
feat(copyright): save deleted copyrights in copyright_event table

### DIFF
--- a/install/db/Makefile
+++ b/install/db/Makefile
@@ -36,6 +36,7 @@ install: all
 	$(INSTALL_DATA) dbmigrate_3.5-3.6.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.5-3.6.php
 	$(INSTALL_DATA) dbmigrate_3.6-3.7.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.6-3.7.php
 	$(INSTALL_DATA) dbmigrate_3.7-3.8.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.7-3.8.php
+	$(INSTALL_DATA) dbmigrate_copyright-event.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_copyright-event.php
 	$(INSTALL_DATA) dbmigrate_clearing-event.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_clearing-event.php
 	$(INSTALL_DATA) dbmigrate_real-parent.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_real-parent.php
 	$(INSTALL_DATA) dbmigrate_bulk_license.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_bulk_license.php
@@ -76,6 +77,7 @@ uninstall:
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.5-3.6.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.6-3.7.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.7-3.8.php
+	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_copyright-event.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_clearing-event.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_real-parent.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_bulk_license.php

--- a/install/db/dbmigrate_copyright-event.php
+++ b/install/db/dbmigrate_copyright-event.php
@@ -1,0 +1,135 @@
+<?php
+/***********************************************************
+ Copyright (C) 2021 Siemens AG
+ Author: Shaheem Azmal M MD <shaheem.azmal@siemens.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***********************************************************/
+
+/**
+ * @file
+ * @brief Migrate DB for copyrights
+ */
+
+use Fossology\Lib\Db\DbManager;
+
+/**
+ * Maximum rows to process at once
+ * @var integer MAX_ROW_SIZE
+ */
+const MAX_SIZE_OF_ROW = 10000;
+
+/**
+ * Tables with is_enabled data
+ * @var array TABLE_NAMES
+ */
+const TABLE_NAMES = array(
+  "copyright" => "copyright_event",
+  "author" => "author_event",
+  "ecc" => "ecc_event",
+  "keyword" => "keyword_event"
+);
+
+/**
+ * Update the copyright_event table
+ * @param DbManager $dbManager
+ * @return int Count of updated rows
+ */
+function insertCopyrightEventTables($dbManager)
+{
+  if ($dbManager == NULL) {
+    echo "No connection object passed!\n";
+    return false;
+  }
+  foreach (TABLE_NAMES as $table => $tableEvent) {
+    $sql = "SELECT count(*) AS cnt FROM ";
+    $statement = __METHOD__ . ".getCountsFor";
+    $length = 0;
+    $row = $dbManager->getSingleRow($sql . $table ."WHERE is_enabled=false;", array(), $statement . $table);
+    $length = intval($row['cnt']);
+    
+    echo "*** Inserting $length records from $table to $tableEvent table ***\n";
+    
+    $tablePk = $table."_pk";
+    $sql = "SELECT DISTINCT ON ($tablePk) $tablePk, uploadtree_pk, upload_fk 
+              FROM $table as cp
+            INNER JOIN uploadtree AS ut ON cp.pfile_fk = ut.pfile_fk
+              WHERE cp.is_enabled=false ORDER BY $tablePk
+                LIMIT $1 OFFSET $2;";
+    $i = 0;
+    $statement = __METHOD__ . ".updateContentFor.$tableEvent";
+    while ($i <= $length) {
+      $rows = $dbManager->getRows($sql, array(MAX_SIZE_OF_ROW, $i),
+        $statement);
+      $i += count($rows);
+      $dbManager->begin();
+      foreach ($rows as $key => $content) {
+        $sqlEvent = "INSERT INTO $tableEvent (upload_fk, copyright_fk, uploadtree_fk) VALUES($content[upload_fk], $content[copyright_pk], $content[uploadtree_pk])";
+        $dbManager->queryOnce($sqlEvent, $statement.$key."Insert");
+        
+        $sqlTable = "UPDATE $table SET is_enabled=true WHERE copyright_pk = $content[copyright_pk]";
+        $dbManager->queryOnce($sqlTable, $statement.$key."Update");
+      }
+      $dbManager->commit();
+      echo "Inserted $i out of $length rows in $tableEvent table\n";
+    }
+  }
+}
+
+/**
+ * Check if migration is Possible.
+ * @param DbManager $dbManager
+ * @return boolean True if migration is possible, false otherwise
+ */
+function checkIfMigratePossible($dbManager)
+{
+  if ($dbManager == NULL){
+    echo "No connection object passed!\n";
+    return false;
+  }
+
+  $migPossible = true;
+  foreach (ENCODE_TABLES as $table => $tableEvent) {
+    if (DB_TableExists($table) != 1) {
+      $migPossible = false;
+      break;
+    }
+    if (DB_TableExists($tableEvent) != 1) {
+      $migPossible = false;
+      break;
+    }
+    if (DB_ColExists($table, 'is_enabled') != 1) {
+      $migPossible = false;
+      break;
+    }
+  }
+  return $migPossible;
+}
+
+/**
+ * @param DbManager $dbManager
+ */
+function createCopyrightMigrationForCopyrightEvents($dbManager)
+{
+  if (! checkIfMigratePossible($dbManager)) {
+    // Migration not possible
+    return;
+  }
+  try {
+    insertCopyrightEventTables($dbManager);
+  } catch (Exception $e) {
+    echo "Something went wrong. Try running postinstall again!\n";
+    $dbManager->rollback();
+  }
+}

--- a/install/fossinit.php
+++ b/install/fossinit.php
@@ -407,6 +407,10 @@ require_once("$LIBEXECDIR/instance_uuid.php");
 require_once("$LIBEXECDIR/dbmigrate_3.7-3.8.php");
 Migrate_37_38($dbManager, $MODDIR);
 
+// Migration script for copyright_event table
+require_once("$LIBEXECDIR/dbmigrate_copyright-event.php");
+createCopyrightMigrationForCopyrightEvents($dbManager);
+
 /* sanity check */
 require_once ("$LIBEXECDIR/sanity_check.php");
 $checker = new SanityChecker($dbManager,$Verbose);

--- a/src/cli/tests/test_fo_copyright_list.php
+++ b/src/cli/tests/test_fo_copyright_list.php
@@ -32,7 +32,7 @@ class test_fo_copyright_list extends \PHPUnit\Framework\TestCase
   protected function setUp()
   {
     $this->testDb = new TestPgDb("fossclitest");
-    $tables = array('users','upload','uploadtree_a','uploadtree','copyright','groups','group_user_member','agent','copyright_decision','copyright_ars','ars_master');
+    $tables = array('users','upload','uploadtree_a','uploadtree','copyright','groups','group_user_member','agent','copyright_decision','copyright_ars','ars_master','copyright_event');
     $this->testDb->createPlainTables($tables);
     $this->testDb->createInheritedTables(array('uploadtree_a'));
     $this->testDb->createInheritedArsTables(array('copyright'));

--- a/src/copyright/agent_tests/Functional/schedulerTest.php
+++ b/src/copyright/agent_tests/Functional/schedulerTest.php
@@ -167,7 +167,7 @@ class CopyrightScheduledTest extends \PHPUnit\Framework\TestCase
    */
   private function setUpTables()
   {
-    $this->testDb->createPlainTables(array('agent','uploadtree','upload','pfile','users','bucketpool','mimetype','ars_master','author'));
+    $this->testDb->createPlainTables(array('agent','uploadtree','upload','pfile','users','bucketpool','mimetype','ars_master','author','copyright_event'));
     $this->testDb->createSequences(array('agent_agent_pk_seq','upload_upload_pk_seq','pfile_pfile_pk_seq','users_user_pk_seq','nomos_ars_ars_pk_seq'));
     $this->testDb->createConstraints(array('agent_pkey','upload_pkey_idx','pfile_pkey','user_pkey'));
     $this->testDb->alterTables(array('agent','pfile','upload','ars_master','users'));

--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -351,7 +351,7 @@ class ClearingDao
     if ($this->isDecisionIrrelevant($uploadTreeId, $groupId)) {
       $this->copyrightDao->updateTable($itemTreeBounds, '', '', $userId, 'copyright', 'rollback');
     } else if ($decType == DecisionTypes::IRRELEVANT) {
-      $this->copyrightDao->updateTable($itemTreeBounds, '', '', $userId, 'copyright', 'delete');
+      $this->copyrightDao->updateTable($itemTreeBounds, '', '', $userId, 'copyright', 'delete', '2');
     }
 
     $this->dbManager->begin();
@@ -841,7 +841,7 @@ INSERT INTO clearing_decision (
                FROM UploadTreeView WHERE NOT EXISTS (
              SELECT uploadtree_fk FROM clearing_decision
               WHERE decision_type=$'.($a+2).' AND uploadtree_fk=UploadTreeView.uploadtree_pk)';
-       $this->copyrightDao->updateTable($itemTreeBounds, '', '', $userId, 'copyright', 'delete');
+       $this->copyrightDao->updateTable($itemTreeBounds, '', '', $userId, 'copyright', 'delete', '2');
     } else {
       $params[] = $decisionMark;
       $sql = $uploadTreeProxy->asCte()

--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -168,6 +168,29 @@ class CopyrightDao
   }
 
   /**
+   * @param $uploadFk
+   * @param $scope
+   * @return array $rows
+   */
+  public function getAllEventEntriesForUpload($uploadFk, $agentId, $scope=1)
+  {
+    $statementName = __METHOD__.$uploadFk;
+    $params[] = $uploadFk;
+    $params[] = $agentId;
+    $params[] = $scope;
+    $sql = "SELECT C.content, c.hash, CE.content AS contentedited, CE.hash AS hashedited, CE.is_enabled
+              FROM copyright_event CE INNER JOIN copyright C ON C.copyright_pk = CE.copyright_fk
+            WHERE CE.upload_fk=$1 AND scope=$3 AND C.agent_fk = $2";
+
+    $this->dbManager->prepare($statementName, $sql);
+    $sqlResult = $this->dbManager->execute($statementName, $params);
+    $rows = $this->dbManager->fetchAll($sqlResult);
+    $this->dbManager->freeResult($sqlResult);
+
+    return $rows;
+  }
+
+  /**
    * @param $tableName
    * @param $uploadTreeTableName
    * @param $uploadId
@@ -181,6 +204,7 @@ class CopyrightDao
     $statementName = __METHOD__.$tableName.$uploadTreeTableName;
     $params = array();
     $extendWClause = null;
+    $tableNameEvent = $tableName.'_event';
 
     if ($uploadTreeTableName === "uploadtree_a") {
       $params[]= $uploadId;
@@ -199,25 +223,35 @@ class CopyrightDao
       $statementName .= "._".$extrawhere."_";
     }
 
-    if ($enabled == 'false') {
+    if (!$enabled == 'false') {
+      $activatedClause = " AND CE.is_enabled=false ";
       $statementName .= "._"."enabled";
+    } else {
+      $activatedClause = " AND C.".$tableName."_pk NOT IN (SELECT ".$tableName."_fk FROM $tableNameEvent WHERE upload_fk = $uploadId AND is_enabled = false) ";
     }
 
     $sql = "SELECT UT.uploadtree_pk as uploadtree_pk, C.content AS content,
-              C.hash AS hash, C.agent_fk as agent_fk
+              C.hash AS hash, C.agent_fk as agent_fk, CE.content AS contentedited, CE.hash AS hashedited
               FROM $tableName C
              INNER JOIN $uploadTreeTableName UT ON C.pfile_fk = UT.pfile_fk
+             LEFT JOIN $tableNameEvent AS CE ON CE.".$tableName."_fk = C.".$tableName."_pk
              WHERE C.content IS NOT NULL
                AND C.content!=''
-               AND C.is_enabled='$enabled'
+               $activatedClause
                $extendWClause
              ORDER BY UT.uploadtree_pk, C.content DESC";
     $this->dbManager->prepare($statementName, $sql);
     $sqlResult = $this->dbManager->execute($statementName, $params);
-    $result = $this->dbManager->fetchAll($sqlResult);
+    $rows = $this->dbManager->fetchAll($sqlResult);
+    foreach ($rows as $key => $row) {
+      if (!empty($row['contentedited'])) {
+        $rows[$key]['content'] = $rows[$key]['contentedited'];
+        $row[$key]['hash'] = $rows[$key]['hashedited'];
+      }
+    }
     $this->dbManager->freeResult($sqlResult);
 
-    return $result;
+    return $rows;
   }
 
   /**
@@ -436,43 +470,73 @@ class CopyrightDao
    * @param int $userId
    * @param string $cpTable
    */
-  public function updateTable($item, $hash, $content, $userId, $cpTable='copyright', $action='')
+  public function updateTable($item, $hash, $content, $userId, $cpTable='copyright', $action='', $scope=1)
   {
     $itemTable = $item->getUploadTreeTableName();
     $stmt = __METHOD__.".$cpTable.$itemTable";
-    $params = array($item->getLeft(),$item->getRight());
+    $uploadId = $item->getUploadId();
+    $params = array($item->getLeft(),$item->getRight(),$uploadId);
     $withHash = "";
 
     if (!empty($hash)) {
       $params[] = $hash;
-      $withHash = " cp.hash = $3 AND ";
+      $withHash = " cp.hash = $4 AND ";
       $stmt .= ".hash";
     }
-    if ($action == "delete") {
-      $setSql = "is_enabled='false'";
-      $stmt .= '.delete';
-    } else if ($action == "rollback") {
-      $setSql = "is_enabled='true'";
-      $stmt .= '.rollback';
-    } else {
-      $setSql = "content = $4, hash = md5($4), is_enabled='true'";
-      $params[] = StringOperation::replaceUnicodeControlChar($content);
+
+    $agentName = "copyright";
+    $scanJobProxy = new ScanJobProxy($GLOBALS['container']->get('dao.agent'),
+      $uploadId);
+    $scanJobProxy->createAgentStatus([$agentName]);
+    $selectedScanners = $scanJobProxy->getLatestSuccessfulAgentIds();
+    if (!array_key_exists($agentName, $selectedScanners)) {
+      return array();
     }
+    $latestAgentId = $selectedScanners[$agentName];
+    $agentFilter = ' AND cp.agent_fk='.$latestAgentId;
 
     $cpTablePk = $cpTable."_pk";
-    $sql = "UPDATE $cpTable AS cpr SET $setSql
-            FROM $cpTable as cp
-            INNER JOIN $itemTable AS ut ON cp.pfile_fk = ut.pfile_fk
-            WHERE cpr.$cpTablePk = cp.$cpTablePk
-              AND $withHash ( ut.lft BETWEEN $1 AND $2 )";
-    if ('uploadtree_a' == $item->getUploadTreeTableName() || 'uploadtree' == $item->getUploadTreeTableName()) {
-      $params[] = $item->getUploadId();
-      $sql .= " AND ut.upload_fk=$".count($params);
-      $stmt .= '.upload';
-    }
+    $sql = "SELECT DISTINCT ON ($cpTablePk) $cpTablePk, uploadtree_pk FROM $cpTable as cp
+              INNER JOIN $itemTable AS ut ON cp.pfile_fk = ut.pfile_fk
+              AND $withHash ( ut.lft BETWEEN $1 AND $2 ) $agentFilter AND ut.upload_fk = $3";
 
     $this->dbManager->prepare($stmt, "$sql");
     $resource = $this->dbManager->execute($stmt, $params);
+    $rows = $this->dbManager->fetchAll($resource);
+
+    foreach ($rows as $row) {
+      $paramEvent[] = $uploadId;
+      $paramEvent[] = $row[$cpTablePk];
+      $paramEvent[] = $row['uploadtree_pk'];
+      if ($action == "delete") {
+        $paramEvent[] = $scope;
+        $sqlEvent = "INSERT INTO copyright_event(upload_fk, copyright_fk, uploadtree_fk, scope) VALUES($1, $2, $3, $4)";
+        $stmt .= '.delete';
+      } else if ($action == "rollback") {
+        $sqlEvent = "DELETE FROM copyright_event WHERE upload_fk = $1 AND uploadtree_fk = $3 AND copyright_fk = $2";
+        $stmt .= '.rollback';
+      } else {
+        $paramEvent[] = "true";
+        $paramEvent[] = StringOperation::replaceUnicodeControlChar($content);
+        $sqlExists = "SELECT exists(SELECT 1 FROM copyright_event WHERE copyright_fk = $1)::int";
+        $rowExists = $this->dbManager->getSingleRow($sqlExists, array($row[$cpTablePk]), $stmt.'Exists');
+
+        if ($rowExists['exists']) {
+          $sqlEvent = "UPDATE copyright_event
+                        SET upload_fk = $1, uploadtree_fk = $3, is_enabled = $4, content = $5, hash = md5($5)
+                       WHERE copyright_fk = $2";
+          $stmt .= '.update';
+        } else {
+          $sqlEvent = "INSERT INTO copyright_event(upload_fk, uploadtree_fk, copyright_fk, is_enabled, content, hash)
+                       VALUES($1, $3, $2, $4, $5, md5($5))";
+          $stmt .= '.insert';
+        }
+      }
+      $this->dbManager->prepare($stmt, "$sqlEvent");
+      $resourceEvent = $this->dbManager->execute($stmt, $paramEvent);
+      $this->dbManager->freeResult($resourceEvent);
+      $paramEvent = array();
+    }
     $this->dbManager->freeResult($resource);
   }
 }

--- a/src/reuser/agent/ReuserAgent.php
+++ b/src/reuser/agent/ReuserAgent.php
@@ -208,24 +208,32 @@ class ReuserAgent extends Agent
   {
     $agentId = $this->getAgentId($uploadId);
     $reusedAgentId = $this->getAgentId($reusedUploadId);
-    if ($agentId == $reusedAgentId || $agentId == null || $reusedAgentId == null) {
+    if ($agentId == null || $reusedAgentId == null) {
       return true;
     }
     $uploadTreeTableName = $this->uploadDao->getUploadtreeTableName($uploadId);
     $extrawhere = ' agent_fk='.$agentId;
     $allCopyrights = $this->copyrightDao->getScannerEntries('copyright', $uploadTreeTableName, $uploadId, $type=null,
                                                             $extrawhere, $enabled='true');
-    $reusedUploadtreeTableName = $this->uploadDao->getUploadtreeTableName($reusedUploadId);
-    $extrawhere = ' agent_fk='.$reusedAgentId;
-    $reusedCopyrights = $this->copyrightDao->getScannerEntries('copyright', $reusedUploadtreeTableName, $reusedUploadId,
-                                                                $type=null, $extrawhere, $enabled='false');
+
+    $reusedCopyrights = $this->copyrightDao->getAllEventEntriesForUpload($reusedUploadId, $reusedAgentId);
+
     if (!empty($reusedCopyrights) && !empty($allCopyrights)) {
       foreach ($reusedCopyrights as $reusedCopyright) {
         foreach ($allCopyrights as $copyright) {
-          if ($copyright['hash'] == $reusedCopyright['hash']) {
-            $item = $this->uploadDao->getItemTreeBounds(intval($copyright['uploadtree_pk']), $uploadTreeTableName);
-            $this->copyrightDao->updateTable($item, $copyright['hash'], $copyright['content'], $this->userId,
-                                             $cpTable='copyright', $action='delete');
+          if (strcmp($copyright['hash'], $reusedCopyright['hash']) == 0) {
+            $action = "delete";
+            $content = "";
+            $hash = "";
+            if ($reusedCopyright['is_enabled']) {
+              $action = "";
+              $content = $reusedCopyright['content'];
+              $hash = $copyright['hash'];
+            }
+            $item = $this->uploadDao->getItemTreeBounds(intval($copyright['uploadtree_pk']),
+                      $uploadTreeTableName);
+            $this->copyrightDao->updateTable($item, $hash, $content, $this->userId,
+                      'copyright', $action);
             $this->heartbeat(1);
           }
         }

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -383,6 +383,39 @@
   $Schema["TABLE"]["copyright_decision"]["is_enabled"]["ALTER"] = "ALTER TABLE \"copyright_decision\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT true";
 
 
+  $Schema["TABLE"]["copyright_event"]["copyright_event_pk"]["DESC"] = "";
+  $Schema["TABLE"]["copyright_event"]["copyright_event_pk"]["ADD"] = "ALTER TABLE \"copyright_event\" ADD COLUMN \"copyright_event_pk\" int8 DEFAULT nextval('copyright_event_pk_seq'::regclass)";
+  $Schema["TABLE"]["copyright_event"]["copyright_event_pk"]["ALTER"] = "ALTER TABLE \"copyright_event\" ALTER COLUMN \"copyright_event_pk\" SET NOT NULL, ALTER COLUMN \"copyright_event_pk\" SET DEFAULT nextval('copyright_event_pk_seq'::regclass)";
+
+  $Schema["TABLE"]["copyright_event"]["upload_fk"]["DESC"] = "";
+  $Schema["TABLE"]["copyright_event"]["upload_fk"]["ADD"] = "ALTER TABLE \"copyright_event\" ADD COLUMN \"upload_fk\" int8";
+  $Schema["TABLE"]["copyright_event"]["upload_fk"]["ALTER"] = "ALTER TABLE \"copyright_event\" ALTER COLUMN \"upload_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["copyright_event"]["uploadtree_fk"]["DESC"] = "";
+  $Schema["TABLE"]["copyright_event"]["uploadtree_fk"]["ADD"] = "ALTER TABLE \"copyright_event\" ADD COLUMN \"uploadtree_fk\" int4";
+  $Schema["TABLE"]["copyright_event"]["uploadtree_fk"]["ALTER"] = "ALTER TABLE \"copyright_event\" ALTER COLUMN \"uploadtree_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["copyright_event"]["copyright_fk"]["DESC"] = "";
+  $Schema["TABLE"]["copyright_event"]["copyright_fk"]["ADD"] = "ALTER TABLE \"copyright_event\" ADD COLUMN \"copyright_fk\" int8";
+  $Schema["TABLE"]["copyright_event"]["copyright_fk"]["ALTER"] = "ALTER TABLE \"copyright_event\" ALTER COLUMN \"copyright_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["copyright_event"]["content"]["DESC"] = "";
+  $Schema["TABLE"]["copyright_event"]["content"]["ADD"] = "ALTER TABLE \"copyright_event\" ADD COLUMN \"content\" text";
+  $Schema["TABLE"]["copyright_event"]["content"]["ALTER"] = "ALTER TABLE \"copyright_event\" ALTER COLUMN \"content\" DROP NOT NULL";
+
+  $Schema["TABLE"]["copyright_event"]["hash"]["DESC"] = "";
+  $Schema["TABLE"]["copyright_event"]["hash"]["ADD"] = "ALTER TABLE \"copyright_event\" ADD COLUMN \"hash\" text";
+  $Schema["TABLE"]["copyright_event"]["hash"]["ALTER"] = "ALTER TABLE \"copyright_event\" ALTER COLUMN \"hash\" DROP NOT NULL";
+
+  $Schema["TABLE"]["copyright_event"]["is_enabled"]["DESC"] = "COMMENT ON COLUMN \"copyright_event\".\"is_enabled\" IS 'true to enabled with edited, false to disable'";
+  $Schema["TABLE"]["copyright_event"]["is_enabled"]["ADD"] = "ALTER TABLE \"copyright_event\" ADD COLUMN \"is_enabled\" bool DEFAULT false";
+  $Schema["TABLE"]["copyright_event"]["is_enabled"]["ALTER"] = "ALTER TABLE \"copyright_event\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT false";
+
+  $Schema["TABLE"]["copyright_event"]["scope"]["DESC"] = "COMMENT ON COLUMN \"copyright_event\".\"scope\" IS 'to differentiate disabled copyrights 1 for normal'";
+  $Schema["TABLE"]["copyright_event"]["scope"]["ADD"] = "ALTER TABLE \"copyright_event\" ADD COLUMN \"scope\" int4 DEFAULT 1";
+  $Schema["TABLE"]["copyright_event"]["scope"]["ALTER"] = "ALTER TABLE \"copyright_event\" ALTER COLUMN \"scope\" SET NOT NULL, ALTER COLUMN \"scope\" SET DEFAULT 1";
+
+
   $Schema["TABLE"]["copyright_spasht"]["copyright_spasht_pk"]["DESC"] = "";
   $Schema["TABLE"]["copyright_spasht"]["copyright_spasht_pk"]["ADD"] = "ALTER TABLE \"copyright_spasht\" ADD COLUMN \"copyright_spasht_pk\" int8 DEFAULT nextval('copyright_spasht_pk_seq'::regclass)";
   $Schema["TABLE"]["copyright_spasht"]["copyright_spasht_pk"]["ALTER"] = "ALTER TABLE \"copyright_spasht\" ALTER COLUMN \"copyright_spasht_pk\" SET NOT NULL, ALTER COLUMN \"copyright_spasht_pk\" SET DEFAULT nextval('copyright_spasht_pk_seq'::regclass)";
@@ -455,6 +488,39 @@
   $Schema["TABLE"]["author"]["is_enabled"]["DESC"] = "COMMENT ON COLUMN \"author\".\"is_enabled\" IS 'true to enable, false to disable'";
   $Schema["TABLE"]["author"]["is_enabled"]["ADD"] = "ALTER TABLE \"author\" ADD COLUMN \"is_enabled\" bool DEFAULT true";
   $Schema["TABLE"]["author"]["is_enabled"]["ALTER"] = "ALTER TABLE \"author\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT true";
+
+
+  $Schema["TABLE"]["author_event"]["author_event_pk"]["DESC"] = "";
+  $Schema["TABLE"]["author_event"]["author_event_pk"]["ADD"] = "ALTER TABLE \"author_event\" ADD COLUMN \"author_event_pk\" int8 DEFAULT nextval('author_event_pk_seq'::regclass)";
+  $Schema["TABLE"]["author_event"]["author_event_pk"]["ALTER"] = "ALTER TABLE \"author_event\" ALTER COLUMN \"author_event_pk\" SET NOT NULL, ALTER COLUMN \"author_event_pk\" SET DEFAULT nextval('author_event_pk_seq'::regclass)";
+
+  $Schema["TABLE"]["author_event"]["upload_fk"]["DESC"] = "";
+  $Schema["TABLE"]["author_event"]["upload_fk"]["ADD"] = "ALTER TABLE \"author_event\" ADD COLUMN \"upload_fk\" int8";
+  $Schema["TABLE"]["author_event"]["upload_fk"]["ALTER"] = "ALTER TABLE \"author_event\" ALTER COLUMN \"upload_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["author_event"]["uploadtree_fk"]["DESC"] = "";
+  $Schema["TABLE"]["author_event"]["uploadtree_fk"]["ADD"] = "ALTER TABLE \"author_event\" ADD COLUMN \"uploadtree_fk\" int4";
+  $Schema["TABLE"]["author_event"]["uploadtree_fk"]["ALTER"] = "ALTER TABLE \"author_event\" ALTER COLUMN \"uploadtree_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["author_event"]["copyright_fk"]["DESC"] = "";
+  $Schema["TABLE"]["author_event"]["copyright_fk"]["ADD"] = "ALTER TABLE \"author_event\" ADD COLUMN \"copyright_fk\" int8";
+  $Schema["TABLE"]["author_event"]["copyright_fk"]["ALTER"] = "ALTER TABLE \"author_event\" ALTER COLUMN \"copyright_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["author_event"]["content"]["DESC"] = "";
+  $Schema["TABLE"]["author_event"]["content"]["ADD"] = "ALTER TABLE \"author_event\" ADD COLUMN \"content\" text";
+  $Schema["TABLE"]["author_event"]["content"]["ALTER"] = "ALTER TABLE \"author_event\" ALTER COLUMN \"content\" DROP NOT NULL";
+
+  $Schema["TABLE"]["author_event"]["hash"]["DESC"] = "";
+  $Schema["TABLE"]["author_event"]["hash"]["ADD"] = "ALTER TABLE \"author_event\" ADD COLUMN \"hash\" text";
+  $Schema["TABLE"]["author_event"]["hash"]["ALTER"] = "ALTER TABLE \"author_event\" ALTER COLUMN \"hash\" DROP NOT NULL";
+
+  $Schema["TABLE"]["author_event"]["is_enabled"]["DESC"] = "COMMENT ON COLUMN \"author_event\".\"is_enabled\" IS 'true to enabled with edited, false to disable'";
+  $Schema["TABLE"]["author_event"]["is_enabled"]["ADD"] = "ALTER TABLE \"author_event\" ADD COLUMN \"is_enabled\" bool DEFAULT false";
+  $Schema["TABLE"]["author_event"]["is_enabled"]["ALTER"] = "ALTER TABLE \"author_event\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT false";
+
+  $Schema["TABLE"]["author_event"]["scope"]["DESC"] = "COMMENT ON COLUMN \"author_event\".\"scope\" IS 'to differentiate disabled copyrights 1 for normal'";
+  $Schema["TABLE"]["author_event"]["scope"]["ADD"] = "ALTER TABLE \"author_event\" ADD COLUMN \"scope\" int4 DEFAULT 1";
+  $Schema["TABLE"]["author_event"]["scope"]["ALTER"] = "ALTER TABLE \"author_event\" ALTER COLUMN \"scope\" SET NOT NULL, ALTER COLUMN \"scope\" SET DEFAULT 1";
 
 
   $Schema["TABLE"]["ecc"]["ecc_pk"]["DESC"] = "";
@@ -531,6 +597,39 @@
   $Schema["TABLE"]["ecc_decision"]["is_enabled"]["ALTER"] = "ALTER TABLE \"ecc_decision\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT true";
 
 
+  $Schema["TABLE"]["ecc_event"]["ecc_event_pk"]["DESC"] = "";
+  $Schema["TABLE"]["ecc_event"]["ecc_event_pk"]["ADD"] = "ALTER TABLE \"ecc_event\" ADD COLUMN \"ecc_event_pk\" int8 DEFAULT nextval('ecc_event_pk_seq'::regclass)";
+  $Schema["TABLE"]["ecc_event"]["ecc_event_pk"]["ALTER"] = "ALTER TABLE \"ecc_event\" ALTER COLUMN \"ecc_event_pk\" SET NOT NULL, ALTER COLUMN \"ecc_event_pk\" SET DEFAULT nextval('ecc_event_pk_seq'::regclass)";
+
+  $Schema["TABLE"]["ecc_event"]["upload_fk"]["DESC"] = "";
+  $Schema["TABLE"]["ecc_event"]["upload_fk"]["ADD"] = "ALTER TABLE \"ecc_event\" ADD COLUMN \"upload_fk\" int8";
+  $Schema["TABLE"]["ecc_event"]["upload_fk"]["ALTER"] = "ALTER TABLE \"ecc_event\" ALTER COLUMN \"upload_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["ecc_event"]["uploadtree_fk"]["DESC"] = "";
+  $Schema["TABLE"]["ecc_event"]["uploadtree_fk"]["ADD"] = "ALTER TABLE \"ecc_event\" ADD COLUMN \"uploadtree_fk\" int4";
+  $Schema["TABLE"]["ecc_event"]["uploadtree_fk"]["ALTER"] = "ALTER TABLE \"ecc_event\" ALTER COLUMN \"uploadtree_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["ecc_event"]["copyright_fk"]["DESC"] = "";
+  $Schema["TABLE"]["ecc_event"]["copyright_fk"]["ADD"] = "ALTER TABLE \"ecc_event\" ADD COLUMN \"copyright_fk\" int8";
+  $Schema["TABLE"]["ecc_event"]["copyright_fk"]["ALTER"] = "ALTER TABLE \"ecc_event\" ALTER COLUMN \"copyright_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["ecc_event"]["content"]["DESC"] = "";
+  $Schema["TABLE"]["ecc_event"]["content"]["ADD"] = "ALTER TABLE \"ecc_event\" ADD COLUMN \"content\" text";
+  $Schema["TABLE"]["ecc_event"]["content"]["ALTER"] = "ALTER TABLE \"ecc_event\" ALTER COLUMN \"content\" DROP NOT NULL";
+
+  $Schema["TABLE"]["ecc_event"]["hash"]["DESC"] = "";
+  $Schema["TABLE"]["ecc_event"]["hash"]["ADD"] = "ALTER TABLE \"ecc_event\" ADD COLUMN \"hash\" text";
+  $Schema["TABLE"]["ecc_event"]["hash"]["ALTER"] = "ALTER TABLE \"ecc_event\" ALTER COLUMN \"hash\" DROP NOT NULL";
+
+  $Schema["TABLE"]["ecc_event"]["is_enabled"]["DESC"] = "COMMENT ON COLUMN \"ecc_event\".\"is_enabled\" IS 'true to enabled with edited, false to disable'";
+  $Schema["TABLE"]["ecc_event"]["is_enabled"]["ADD"] = "ALTER TABLE \"ecc_event\" ADD COLUMN \"is_enabled\" bool DEFAULT false";
+  $Schema["TABLE"]["ecc_event"]["is_enabled"]["ALTER"] = "ALTER TABLE \"ecc_event\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT false";
+
+  $Schema["TABLE"]["ecc_event"]["scope"]["DESC"] = "COMMENT ON COLUMN \"ecc_event\".\"scope\" IS 'to differentiate disabled copyrights 1 for normal'";
+  $Schema["TABLE"]["ecc_event"]["scope"]["ADD"] = "ALTER TABLE \"ecc_event\" ADD COLUMN \"scope\" int4 DEFAULT 1";
+  $Schema["TABLE"]["ecc_event"]["scope"]["ALTER"] = "ALTER TABLE \"ecc_event\" ALTER COLUMN \"scope\" SET NOT NULL, ALTER COLUMN \"scope\" SET DEFAULT 1";
+
+
   $Schema["TABLE"]["keyword"]["keyword_pk"]["DESC"] = "";
   $Schema["TABLE"]["keyword"]["keyword_pk"]["ADD"] = "ALTER TABLE \"keyword\" ADD COLUMN \"keyword_pk\" int8 DEFAULT nextval('keyword_pk_seq'::regclass)";
   $Schema["TABLE"]["keyword"]["keyword_pk"]["ALTER"] = "ALTER TABLE \"keyword\" ALTER COLUMN \"keyword_pk\" SET NOT NULL, ALTER COLUMN \"keyword_pk\" SET DEFAULT nextval('keyword_pk_seq'::regclass)";
@@ -603,6 +702,39 @@
   $Schema["TABLE"]["keyword_decision"]["is_enabled"]["DESC"] = "COMMENT ON COLUMN \"keyword_decision\".\"is_enabled\" IS 'true to enable, false to disable'";
   $Schema["TABLE"]["keyword_decision"]["is_enabled"]["ADD"] = "ALTER TABLE \"keyword_decision\" ADD COLUMN \"is_enabled\" bool DEFAULT true";
   $Schema["TABLE"]["keyword_decision"]["is_enabled"]["ALTER"] = "ALTER TABLE \"keyword_decision\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT true";
+
+
+  $Schema["TABLE"]["keyword_event"]["keyword_event_pk"]["DESC"] = "";
+  $Schema["TABLE"]["keyword_event"]["keyword_event_pk"]["ADD"] = "ALTER TABLE \"keyword_event\" ADD COLUMN \"keyword_event_pk\" int8 DEFAULT nextval('keyword_event_pk_seq'::regclass)";
+  $Schema["TABLE"]["keyword_event"]["keyword_event_pk"]["ALTER"] = "ALTER TABLE \"keyword_event\" ALTER COLUMN \"keyword_event_pk\" SET NOT NULL, ALTER COLUMN \"keyword_event_pk\" SET DEFAULT nextval('keyword_event_pk_seq'::regclass)";
+
+  $Schema["TABLE"]["keyword_event"]["upload_fk"]["DESC"] = "";
+  $Schema["TABLE"]["keyword_event"]["upload_fk"]["ADD"] = "ALTER TABLE \"keyword_event\" ADD COLUMN \"upload_fk\" int8";
+  $Schema["TABLE"]["keyword_event"]["upload_fk"]["ALTER"] = "ALTER TABLE \"keyword_event\" ALTER COLUMN \"upload_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["keyword_event"]["uploadtree_fk"]["DESC"] = "";
+  $Schema["TABLE"]["keyword_event"]["uploadtree_fk"]["ADD"] = "ALTER TABLE \"keyword_event\" ADD COLUMN \"uploadtree_fk\" int4";
+  $Schema["TABLE"]["keyword_event"]["uploadtree_fk"]["ALTER"] = "ALTER TABLE \"keyword_event\" ALTER COLUMN \"uploadtree_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["keyword_event"]["copyright_fk"]["DESC"] = "";
+  $Schema["TABLE"]["keyword_event"]["copyright_fk"]["ADD"] = "ALTER TABLE \"keyword_event\" ADD COLUMN \"copyright_fk\" int8";
+  $Schema["TABLE"]["keyword_event"]["copyright_fk"]["ALTER"] = "ALTER TABLE \"keyword_event\" ALTER COLUMN \"copyright_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["keyword_event"]["content"]["DESC"] = "";
+  $Schema["TABLE"]["keyword_event"]["content"]["ADD"] = "ALTER TABLE \"keyword_event\" ADD COLUMN \"content\" text";
+  $Schema["TABLE"]["keyword_event"]["content"]["ALTER"] = "ALTER TABLE \"keyword_event\" ALTER COLUMN \"content\" DROP NOT NULL";
+
+  $Schema["TABLE"]["keyword_event"]["hash"]["DESC"] = "";
+  $Schema["TABLE"]["keyword_event"]["hash"]["ADD"] = "ALTER TABLE \"keyword_event\" ADD COLUMN \"hash\" text";
+  $Schema["TABLE"]["keyword_event"]["hash"]["ALTER"] = "ALTER TABLE \"keyword_event\" ALTER COLUMN \"hash\" DROP NOT NULL";
+
+  $Schema["TABLE"]["keyword_event"]["is_enabled"]["DESC"] = "COMMENT ON COLUMN \"keyword_event\".\"is_enabled\" IS 'true to enabled with edited, false to disable'";
+  $Schema["TABLE"]["keyword_event"]["is_enabled"]["ADD"] = "ALTER TABLE \"keyword_event\" ADD COLUMN \"is_enabled\" bool DEFAULT false";
+  $Schema["TABLE"]["keyword_event"]["is_enabled"]["ALTER"] = "ALTER TABLE \"keyword_event\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT false";
+
+  $Schema["TABLE"]["keyword_event"]["scope"]["DESC"] = "COMMENT ON COLUMN \"keyword_event\".\"scope\" IS 'to differentiate disabled copyrights 1 for normal'";
+  $Schema["TABLE"]["keyword_event"]["scope"]["ADD"] = "ALTER TABLE \"keyword_event\" ADD COLUMN \"scope\" int4 DEFAULT 1";
+  $Schema["TABLE"]["keyword_event"]["scope"]["ALTER"] = "ALTER TABLE \"keyword_event\" ALTER COLUMN \"scope\" SET NOT NULL, ALTER COLUMN \"scope\" SET DEFAULT 1";
 
 
   $Schema["TABLE"]["file_picker"]["file_picker_pk"]["DESC"] = "";
@@ -1983,6 +2115,18 @@
 
   $Schema["SEQUENCE"]["copyright_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"copyright_pk_seq\"";
   $Schema["SEQUENCE"]["copyright_pk_seq"]["UPDATE"] = "SELECT setval('copyright_pk_seq',(SELECT greatest(1,max(copyright_pk)) val FROM copyright))";
+
+  $Schema["SEQUENCE"]["copyright_event_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"copyright_event_pk_seq\"";
+  $Schema["SEQUENCE"]["copyright_event_pk_seq"]["UPDATE"] = "SELECT setval('copyright_event_pk_seq',(SELECT greatest(1,max(copyright_event_pk)) val FROM copyright_event))";
+
+  $Schema["SEQUENCE"]["author_event_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"author_event_pk_seq\"";
+  $Schema["SEQUENCE"]["author_event_pk_seq"]["UPDATE"] = "SELECT setval('author_event_pk_seq',(SELECT greatest(1,max(author_event_pk)) val FROM author_event))";
+
+  $Schema["SEQUENCE"]["ecc_event_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"ecc_event_pk_seq\"";
+  $Schema["SEQUENCE"]["ecc_event_pk_seq"]["UPDATE"] = "SELECT setval('ecc_event_pk_seq',(SELECT greatest(1,max(ecc_event_pk)) val FROM ecc_event))";
+
+  $Schema["SEQUENCE"]["keyword_event_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"keyword_event_pk_seq\"";
+  $Schema["SEQUENCE"]["keyword_event_pk_seq"]["UPDATE"] = "SELECT setval('keyword_event_pk_seq',(SELECT greatest(1,max(keyword_event_pk)) val FROM keyword_event))";
 
   $Schema["SEQUENCE"]["license_file_fl_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"license_file_fl_pk_seq\"";
   $Schema["SEQUENCE"]["license_file_fl_pk_seq"]["UPDATE"] = "SELECT setval('license_file_fl_pk_seq',(SELECT greatest(1,max(fl_pk)) val FROM license_file))";


### PR DESCRIPTION

## Description

Separate copyright status to another table. for better reuse.  

### Changes

* Script to migrate old data.
* Create new _event table 

## How to test

* End-to-end testing of copyrights with reuse.
