### PR TITLE
fix(uploadDao): Fetch status based on group id

### DIFF
--- a/src/lib/php/Dao/UploadDao.php
+++ b/src/lib/php/Dao/UploadDao.php
@@ -226,14 +226,20 @@ class UploadDao
   }
 
   /**
-   * @brief unused function
+   * @brief Get the upload status.
+   * @param int $uploadId Upload to get status for
+   * @param int $groupId  Effective group
+   * @return integer Status fk or 1 if not found
+   * @throws Exception if upload not accessible.
    */
   public function getStatus($uploadId, $groupId)
   {
     if ($this->isAccessible($uploadId, $groupId)) {
-      $row = $this->dbManager->getSingleRow("SELECT status_fk FROM upload_clearing WHERE upload_fk = $1", array($uploadId));
+      $row = $this->dbManager->getSingleRow("SELECT status_fk " .
+        "FROM upload_clearing WHERE upload_fk=$1 AND group_fk=$2;",
+        array($uploadId, $groupId));
       if (false === $row) {
-        throw new \Exception("cannot find uploadId=$uploadId");
+        return 1;
       }
       return $row['status_fk'];
     } else {


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

`getStatus()` in `UploadDao` currently fetches a random entry. This causes confusion. Updated the function to match `getListOfUploadsOfFolder()` which fetches status based on upload id and group id.

### Changes

Update `UploadDao::getStatus()` to match the group id as well.
**Note**: Default status returned will be 1 (open).

## How to test

1. Upload a package from a user which has access to minimum 2 groups.
2. With group 1, change the upload status, to say rejected.
3. With group 2, change the upload status, to say closed.
4. The UI shows correct status to respective groups.
5. From the REST API, fetch the upload summary once with `groupName: group1` and once with `groupName: group2`. The `clearingStatus` should change based on group selected.
6. Fetch the upload summary from a third group with no status changes, the `clearingStatus` should say `Open`.