### PR TITLE
fix(ui): Show parent folder on *Browser views

### DIFF
--- a/src/lib/php/Dao/TreeDao.php
+++ b/src/lib/php/Dao/TreeDao.php
@@ -22,6 +22,7 @@ namespace Fossology\Lib\Dao;
 
 use Fossology\Lib\Db\DbManager;
 use Monolog\Logger;
+use Fossology\Lib\Data\Tree\ItemTreeBounds;
 
 class TreeDao
 {
@@ -143,5 +144,20 @@ class TreeDao
     $path = '';
     exec("$LIBEXECDIR/reppath $repo $hash", $path);
     return($path[0]);
+  }
+
+  /**
+   * Get the parent item of a given uploadtree item
+   * @param ItemTreeBounds $itemTreeBounds Item bounds to get parent for
+   * @return integer Item id of parent
+   */
+  public function getParentOfItem($itemTreeBounds)
+  {
+    $item = $itemTreeBounds->getItemId();
+    $tableName = $itemTreeBounds->getUploadTreeTableName();
+    $sql = "SELECT realparent FROM $tableName WHERE uploadtree_pk = $1;";
+    $statement = __METHOD__ . ".$tableName";
+    $row = $this->dbManager->getSingleRow($sql, [$item], $statement);
+    return $row['realparent'];
   }
 }

--- a/src/www/ui/page/BrowseLicense.php
+++ b/src/www/ui/page/BrowseLicense.php
@@ -26,6 +26,7 @@ use Fossology\Lib\Dao\AgentDao;
 use Fossology\Lib\Dao\ClearingDao;
 use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Dao\TreeDao;
 use Fossology\Lib\Data\ClearingDecision;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
 use Fossology\Lib\Plugin\DefaultPlugin;
@@ -90,9 +91,22 @@ class BrowseLicense extends DefaultPlugin
     if (empty($Item) || empty($Upload)) {
       return;
     }
-    $viewLicenseURI = "view-license" . Traceback_parm_keep(array("show", "format", "page", "upload", "item"));
+    $viewLicenseURI = $this->NAME . Traceback_parm_keep(array("show", "format", "page", "upload", "item"));
     $menuName = $this->Title;
-    if (GetParm("mod", PARM_STRING) == self::NAME) {
+
+    $uploadTreeTable = $this->uploadDao->getUploadtreeTableName($Upload);
+    $itemBounds = $this->uploadDao->getItemTreeBounds($Item, $uploadTreeTable);
+    if (! $itemBounds->containsFiles()) {
+      global $container;
+      /**
+       * @var TreeDao $treeDao Tree dao object
+       */
+      $treeDao = $container->get('dao.tree');
+      $parent = $treeDao->getParentOfItem($itemBounds);
+      $viewLicenseURI = $this->NAME . Traceback_parm_keep(array("show",
+        "format", "page", "upload")) . "&item=$parent";
+    }
+    if (GetParm("mod", PARM_STRING) == $this->NAME) {
       menu_insert("Browse::$menuName", 99);
       menu_insert("View::$menuName", 99);
       menu_insert("View-Meta::$menuName", 99);

--- a/src/www/ui/ui-file-browse.php
+++ b/src/www/ui/ui-file-browse.php
@@ -22,6 +22,7 @@ use Fossology\Lib\BusinessRules\LicenseMap;
 use Fossology\Lib\Dao\AgentDao;
 use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Dao\TreeDao;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
 use Fossology\Lib\Plugin\DefaultPlugin;
 use Fossology\Lib\Proxy\ScanJobProxy;
@@ -82,8 +83,21 @@ class ui_file_browse extends DefaultPlugin
     if (empty($Item) || empty($Upload)) {
       return;
     }
-    $viewLicenseURI = "view-license" . Traceback_parm_keep(array("show", "format", "page", "upload", "item"));
+    $viewLicenseURI = $this->Name . Traceback_parm_keep(array("show", "format", "page", "upload", "item"));
     $menuName = $this->Title;
+
+    $uploadTreeTable = $this->uploadDao->getUploadtreeTableName($Upload);
+    $itemBounds = $this->uploadDao->getItemTreeBounds($Item, $uploadTreeTable);
+    if (! $itemBounds->containsFiles()) {
+      global $container;
+      /**
+       * @var TreeDao $treeDao Tree dao object
+       */
+      $treeDao = $container->get('dao.tree');
+      $parent = $treeDao->getParentOfItem($itemBounds);
+      $viewLicenseURI = $this->NAME . Traceback_parm_keep(array("show",
+        "format", "page", "upload")) . "&item=$parent";
+    }
     if (GetParm("mod", PARM_STRING) == self::NAME) {
       menu_insert("Browse::$menuName", 98);
       menu_insert("View::$menuName", 98);


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Load parent folder while clicking on "License Browser" or "File Browser" from a file level view (Info, Conclusion, Copyright, etc.).

### Changes

1. Check if loaded on a single file while creating menu for "License Browser" and "File Browser".
  a. If yes, then find the parent item id and replace in the URL.
2. Added a new function `TreeDao::getParentOfItem()` to aid.

## How to test

1. From various views, check if link to "License Browser" and "File Browser" are working.
2. While viewing a single file, the link to "License Browser" and "File Browser" should take to the containing folder.