### PR TITLE
fix(nomos): Flush stdout in JSON writer

### DIFF
--- a/src/nomos/agent/json_writer.c
+++ b/src/nomos/agent/json_writer.c
@@ -62,6 +62,7 @@ void writeJson()
     *printcomma = true;
     printf("%s\n", prettyJson);
   }
+  fflush(stdout);
   sem_post(mutexJson);
   free(prettyJson);
   json_object_put(result);


### PR DESCRIPTION
## Description

Fix observed race condition in Nomos JSON output caused by `printf` buffering.

### Changes

Flush stdout after printing. When output is not a terminal, `printf` does not 
flush automatically and this results in overlapping output.

## How to test

1. Compile Nomos standalone
2. Run JSON output against a directory of files
3. Observe validity of JSON output

This closes #1903
