### PR TITLE
fix(globalDecision): fix global decision prevent adding history in ca…

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -643,6 +643,15 @@ INSERT INTO clearing_decision (
     return ($latestDec['decision_type'] == DecisionTypes::DO_NOT_USE);
   }
 
+  public function getClearingType($uploadTreeId, $groupId, $type)
+  {
+    $sql = "SELECT decision_type, scope FROM clearing_decision
+              WHERE uploadtree_fk=$1 AND group_fk = $2
+            ORDER BY clearing_decision_pk DESC LIMIT 1";
+    $latestDec = $this->dbManager->getSingleRow($sql,
+                 array($uploadTreeId, $groupId), $sqlLog = __METHOD__);
+    return $latestDec;
+  }
 
   public function isDecisionIrrelevant($uploadTreeId, $groupId)
   {


### PR DESCRIPTION
## Description

Do not add decisions in case of global decision if events wont change.

### Changes

* Make use of isDecisionWip function to check if decisions have been changed.

## How to test

* Upload a component X and make global clearing to few files.
* Create another user and Upload component X by new users login.
* Scroll through files which have global clearing decisions.
* Check the history so that new decisions should not be added.
* Do end to end clearing testing, So that other clearing areas shouldn't break.