### PR TITLE
fix(rest): missing Group component in API documentation

### DIFF
--- a/src/www/ui/api/Models/Group.php
+++ b/src/www/ui/api/Models/Group.php
@@ -18,7 +18,7 @@
  ***************************************************************/
 /**
  * @file
- * @brief Folder model
+ * @brief Group model
  */
 
 namespace Fossology\UI\Api\Models;
@@ -37,7 +37,7 @@ class Group
   private $name;
 
   /**
-   * Folder constructor.
+   * Group constructor.
    *
    * @param int $id
    * @param string $name

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1560,6 +1560,20 @@ components:
           nullable: true
           example:
             3
+    Group:
+      description: Group object
+      type: object
+      properties:
+        id:
+          description: Id key
+          type: integer
+          example:
+            126
+        name:
+          description: Name of a group
+          type: string
+          example:
+            "Main group"    
   responses:
     defaultResponse:
       description: Some error occured. Check the "message"


### PR DESCRIPTION
Signed-off-by: Piotr Pszczola <piotr.pszczola@orange.com>

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fixes #1900 

### Changes

Added Group component to src/www/ui/api/documentation/openapi.yaml
Few naming fixes in src/www/ui/api/Models/Group.php

## How to test

Swagger integration verification should not show any errors
