### PR TITLE
fix(username): update session variable on username change

### DIFF
--- a/src/www/ui/template/user_edit.html.twig
+++ b/src/www/ui/template/user_edit.html.twig
@@ -21,7 +21,7 @@
   <table style="border:1px solid black; border-collapse: collapse;" width="100%">
     <tr class="classic">
       <th width="25%">{{ "Username."|trans }}</th>
-      <td><input type="text" value="{{ userName|e }}" name="user_name" size="20"></td>
+      <td><input type="text" value="{{ userName|e }}" name="user_name" size="20" {% if not isSessionAdmin %}disabled="disabled"{% endif %}></td>
     </tr>
     <tr class="classic">
       <th width="25%">{{ "Description (name, contact, or other information)."|trans }} {{ "This may be blank."|trans }}</th>

--- a/src/www/ui/user-edit.php
+++ b/src/www/ui/user-edit.php
@@ -109,7 +109,13 @@ class UserEditPage extends DefaultPlugin
 
         /* Reread the user record as update verification */
         $UserRec = $this->CreateUserRec($request, $UserRec['user_pk']);
+        if ($user_pk == $user_pk_to_modify) {
+          $_SESSION['User'] = $UserRec['user_name'];
+        }
       } else {
+        if (empty($UserRec['user_name']) || $_SESSION['User'] != $UserRec['user_name']) {
+          $UserRec = $this->CreateUserRec($request, $UserRec['user_pk']);
+        }
         $vars['message'] = $rv;
       }
     } else {
@@ -261,6 +267,11 @@ class UserEditPage extends DefaultPlugin
         $Errors .= "<li>" . _("User is not member of provided group.") .
           "</li>";
       }
+    }
+
+    /* Make sure only admin can change the username */
+    if ((!Auth::isAdmin()) && ($UserRec['user_name'] != $_SESSION['User'])) {
+      $Errors .= "<li>" . _("Only admin can change the username.") . "</li>";
     }
 
     /* If we have any errors, return them */


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
* Update session variable on changing the username 
* Only allow the admin to change the username
* If the user provides an empty username then a blank white screen appears due to an internal server error

Closes #1112

### Changes

Updated `$_SESSION['User']` if `$UserRec['user_name']` does not match `$_SESSION['User']`

## How to test

1. Go to Admin->Users->Edit user account.
2. Change the value of the username for the current user (with active session).
3. Hit Update Account.
4. Goto Upload->(any page which allows selection of agents)


