### PR TITLE
feat(copyright): save deleted copyrights in copyright_event table

### DIFF
--- a/install/db/Makefile
+++ b/install/db/Makefile
@@ -36,6 +36,7 @@ install: all
 	$(INSTALL_DATA) dbmigrate_3.5-3.6.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.5-3.6.php
 	$(INSTALL_DATA) dbmigrate_3.6-3.7.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.6-3.7.php
 	$(INSTALL_DATA) dbmigrate_3.7-3.8.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.7-3.8.php
+	$(INSTALL_DATA) dbmigrate_copyright-event.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_copyright-event.php
 	$(INSTALL_DATA) dbmigrate_clearing-event.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_clearing-event.php
 	$(INSTALL_DATA) dbmigrate_real-parent.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_real-parent.php
 	$(INSTALL_DATA) dbmigrate_bulk_license.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_bulk_license.php
@@ -76,6 +77,7 @@ uninstall:
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.5-3.6.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.6-3.7.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.7-3.8.php
+	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_copyright-event.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_clearing-event.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_real-parent.php
 	rm -f $(DESTDIR)$(LIBEXECDIR)/dbmigrate_bulk_license.php

--- a/install/db/dbmigrate_copyright-event.php
+++ b/install/db/dbmigrate_copyright-event.php
@@ -1,0 +1,136 @@
+<?php
+/***********************************************************
+ Copyright (C) 2021 Siemens AG
+ Author: Shaheem Azmal M MD <shaheem.azmal@siemens.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***********************************************************/
+
+/**
+ * @file
+ * @brief Migrate DB for copyrights
+ */
+
+use Fossology\Lib\Db\DbManager;
+
+/**
+ * Maximum rows to process at once
+ * @var integer MAX_ROW_SIZE
+ */
+const MAX_SIZE_OF_ROW = 10000;
+
+/**
+ * Tables with is_enabled data
+ * @var array TABLE_NAMES
+ */
+const TABLE_NAMES = array(
+  "copyright" => "copyright_event",
+  "author" => "author_event",
+  "ecc" => "ecc_event",
+  "keyword" => "keyword_event"
+);
+
+/**
+ * Update the copyright_event table
+ * @param DbManager $dbManager
+ * @return int Count of updated rows
+ */
+function insertCopyrightEventTables($dbManager)
+{
+  if ($dbManager == NULL) {
+    echo "No connection object passed!\n";
+    return false;
+  }
+  foreach (TABLE_NAMES as $table => $tableEvent) {
+    $sql = "SELECT count(*) AS cnt FROM ";
+    $statement = __METHOD__ . ".getCountsFor";
+    $length = 0;
+    $row = $dbManager->getSingleRow($sql . $table ." WHERE is_enabled=false;", array(), $statement . $table);
+    $length = intval($row['cnt']);
+    if (!empty($length)) {
+      echo "*** Inserting $length records from $table to $tableEvent table ***\n";
+    }
+    $tablePk = $table."_pk";
+    $tableFk = $table."_fk";
+    $sql = "SELECT DISTINCT ON ($tablePk) $tablePk, uploadtree_pk, upload_fk 
+              FROM $table as cp
+            INNER JOIN uploadtree AS ut ON cp.pfile_fk = ut.pfile_fk
+              WHERE cp.is_enabled=false ORDER BY $tablePk
+                LIMIT $1;";
+    $i = 0;
+    $statement = __METHOD__ . ".updateContentFor.$tableEvent";
+    while ($i < $length) {
+      $rows = $dbManager->getRows($sql, array(MAX_SIZE_OF_ROW),
+        $statement);
+      $i += count($rows);
+      $dbManager->begin();
+      foreach ($rows as $key => $content) {
+        $sqlEvent = "INSERT INTO $tableEvent (upload_fk, $tableFk, uploadtree_fk) VALUES($content[upload_fk], $content[$tablePk], $content[uploadtree_pk])";
+        $dbManager->queryOnce($sqlEvent, $statement.$key."Insert");
+        
+        $sqlTable = "UPDATE $table SET is_enabled=true WHERE $tablePk = $content[$tablePk]";
+        $dbManager->queryOnce($sqlTable, $statement.$key."Update");
+      }
+      $dbManager->commit();
+      echo "Inserted $i out of $length rows in $tableEvent table\n";
+    }
+  }
+}
+
+/**
+ * Check if migration is Possible.
+ * @param DbManager $dbManager
+ * @return boolean True if migration is possible, false otherwise
+ */
+function checkIfMigratePossible($dbManager)
+{
+  if ($dbManager == NULL){
+    echo "No connection object passed!\n";
+    return false;
+  }
+
+  $migPossible = true;
+  foreach (TABLE_NAMES as $table => $tableEvent) {
+    if (DB_TableExists($table) != 1) {
+      $migPossible = false;
+      break;
+    }
+    if (DB_TableExists($tableEvent) != 1) {
+      $migPossible = false;
+      break;
+    }
+    if (DB_ColExists($table, 'is_enabled') != 1) {
+      $migPossible = false;
+      break;
+    }
+  }
+  return $migPossible;
+}
+
+/**
+ * @param DbManager $dbManager
+ */
+function createCopyrightMigrationForCopyrightEvents($dbManager)
+{
+  if (! checkIfMigratePossible($dbManager)) {
+    // Migration not possible
+    return;
+  }
+  try {
+    insertCopyrightEventTables($dbManager);
+  } catch (Exception $e) {
+    echo "Something went wrong. Try running postinstall again!\n";
+    $dbManager->rollback();
+  }
+}

--- a/install/fossinit.php
+++ b/install/fossinit.php
@@ -407,6 +407,10 @@ require_once("$LIBEXECDIR/instance_uuid.php");
 require_once("$LIBEXECDIR/dbmigrate_3.7-3.8.php");
 Migrate_37_38($dbManager, $MODDIR);
 
+// Migration script for copyright_event table
+require_once("$LIBEXECDIR/dbmigrate_copyright-event.php");
+createCopyrightMigrationForCopyrightEvents($dbManager);
+
 /* sanity check */
 require_once ("$LIBEXECDIR/sanity_check.php");
 $checker = new SanityChecker($dbManager,$Verbose);

--- a/src/cli/tests/test_fo_copyright_list.php
+++ b/src/cli/tests/test_fo_copyright_list.php
@@ -32,7 +32,7 @@ class test_fo_copyright_list extends \PHPUnit\Framework\TestCase
   protected function setUp()
   {
     $this->testDb = new TestPgDb("fossclitest");
-    $tables = array('users','upload','uploadtree_a','uploadtree','copyright','groups','group_user_member','agent','copyright_decision','copyright_ars','ars_master');
+    $tables = array('users','upload','uploadtree_a','uploadtree','copyright','groups','group_user_member','agent','copyright_decision','copyright_ars','ars_master','copyright_event');
     $this->testDb->createPlainTables($tables);
     $this->testDb->createInheritedTables(array('uploadtree_a'));
     $this->testDb->createInheritedArsTables(array('copyright'));

--- a/src/copyright/agent_tests/Functional/schedulerTest.php
+++ b/src/copyright/agent_tests/Functional/schedulerTest.php
@@ -167,7 +167,7 @@ class CopyrightScheduledTest extends \PHPUnit\Framework\TestCase
    */
   private function setUpTables()
   {
-    $this->testDb->createPlainTables(array('agent','uploadtree','upload','pfile','users','bucketpool','mimetype','ars_master','author'));
+    $this->testDb->createPlainTables(array('agent','uploadtree','upload','pfile','users','bucketpool','mimetype','ars_master','author','copyright_event'));
     $this->testDb->createSequences(array('agent_agent_pk_seq','upload_upload_pk_seq','pfile_pfile_pk_seq','users_user_pk_seq','nomos_ars_ars_pk_seq'));
     $this->testDb->createConstraints(array('agent_pkey','upload_pkey_idx','pfile_pkey','user_pkey'));
     $this->testDb->alterTables(array('agent','pfile','upload','ars_master','users'));

--- a/src/copyright/ui/ajax-copyright-hist.php
+++ b/src/copyright/ui/ajax-copyright-hist.php
@@ -258,7 +258,7 @@ class CopyrightHistogramProcessPost extends FO_Plugin
     $sql_upload = "";
     if ('uploadtree_a' == $uploadTreeTableName)
     {
-      $sql_upload = " AND UT.upload_fk=$upload_pk ";
+      $sql_upload = " AND UT.upload_fk=$5 ";
     }
 
     $join = "";
@@ -273,34 +273,40 @@ class CopyrightHistogramProcessPost extends FO_Plugin
     {
       // No filter, nothing to do
     }
-    $params = array($left, $right, $type, $agentId);
+    $params = array($left, $right, $type, $agentId, $upload_pk);
 
     $filterParms = $params;
     $searchFilter = $this->addSearchFilter($filterParms);
-    if (!$activated) {
-      $activatedClause = " AND CE.is_enabled=false and CE.upload_fk = $upload_pk ";
-    } else {
-      $activatedClause = " AND cp.".$tableName."_pk NOT IN (SELECT ".$tableName."_fk FROM $tableNameEvent WHERE upload_fk = $upload_pk AND is_enabled = false) ";
+
+    $activatedClause = "";
+    if ($activated) {
+      $activatedClause = "NOT";
     }
     $unorderedQuery = "FROM $tableName AS cp " .
         "INNER JOIN $uploadTreeTableName AS UT ON cp.pfile_fk = UT.pfile_fk " .
-        "LEFT JOIN $tableNameEvent AS CE ON CE.".$tableName."_fk = cp.".$tableName."_pk " .
+        "LEFT JOIN $tableNameEvent AS ce ON ce.".$tableName."_fk = cp.".$tableName."_pk " .
+        "AND ce.upload_fk = $5 " .
         $join .
         "WHERE cp.content!='' " .
         "AND ( UT.lft  BETWEEN  $1 AND  $2 ) " .
         "AND cp.type = $3 " .
         "AND cp.agent_fk= $4 " .
-        $activatedClause .
+        "AND cp." . $tableName . "_pk $activatedClause IN " .
+        "(SELECT " . $tableName . "_fk FROM $tableNameEvent WHERE upload_fk = $5 AND is_enabled = false)" .
         $sql_upload;
-    $totalFilter = $filterQuery . " " . $searchFilter;
-    $grouping = " GROUP BY cp.content ";
+    $grouping = " GROUP BY mcontent ";
 
-    $countQuery = "SELECT count(*) FROM (SELECT cp.content, count(*) $unorderedQuery $totalFilter $grouping) as K";
+    $countQuery = "SELECT count(*) FROM (
+  SELECT mcontent AS content FROM (SELECT
+    (CASE WHEN (ce.content IS NULL OR ce.content = '') THEN cp.content ELSE ce.content END) AS mcontent
+    $unorderedQuery $filterQuery $grouping) AS k $searchFilter) AS cx";
     $iTotalDisplayRecordsRow = $this->dbManager->getSingleRow($countQuery,
         $filterParms, __METHOD__.$tableName . ".count" . ($activated ? '' : '_deactivated'));
     $iTotalDisplayRecords = $iTotalDisplayRecordsRow['count'];
 
-    $countAllQuery = "SELECT count(*) FROM (SELECT cp.content, count(*) $unorderedQuery$grouping) as K";
+    $countAllQuery = "SELECT count(*) FROM (SELECT
+(CASE WHEN (ce.content IS NULL OR ce.content = '') THEN cp.content ELSE ce.content END) AS mcontent
+$unorderedQuery$grouping) as K";
     $iTotalRecordsRow = $this->dbManager->getSingleRow($countAllQuery, $params, __METHOD__,$tableName . "count.all" . ($activated ? '' : '_deactivated'));
     $iTotalRecords = $iTotalRecordsRow['count'];
 
@@ -310,19 +316,13 @@ class CopyrightHistogramProcessPost extends FO_Plugin
     $filterParms[] = $limit;
     $range .= ' LIMIT $' . count($filterParms);
 
-    $sql = "SELECT cp.content, cp.hash, CE.content AS contentedited, CE.hash AS hashedited, count(*) AS copyright_count  " .
-        $unorderedQuery . $totalFilter . " GROUP BY cp.content, cp.hash, CE.content, CE.hash " . $orderString . $range;
+    $sql = "SELECT mcontent AS content, mhash AS hash, copyright_count FROM (SELECT
+(CASE WHEN (ce.content IS NULL OR ce.content = '') THEN cp.content ELSE ce.content END) AS mcontent,
+(CASE WHEN (ce.hash IS NULL OR ce.hash = '') THEN cp.hash ELSE ce.hash END) AS mhash,
+count(*) AS copyright_count " .
+      "$unorderedQuery $filterQuery GROUP BY mcontent, mhash) AS k $searchFilter $orderString $range";
     $statement = __METHOD__ . $filter.$tableName . $uploadTreeTableName . ($activated ? '' : '_deactivated');
-    $this->dbManager->prepare($statement, $sql);
-    $result = $this->dbManager->execute($statement, $filterParms);
-    $rows = $this->dbManager->fetchAll($result);
-    foreach ($rows as $key => $row) {
-      if (!empty($row['contentedited'])) {
-        $rows[$key]['content'] = $rows[$key]['contentedited'];
-        $row[$key]['hash'] = $rows[$key]['hashedited'];
-      }
-    }
-    $this->dbManager->freeResult($result);
+    $rows = $this->dbManager->getRows($sql, $filterParms, $statement);
 
     return array($rows, $iTotalDisplayRecords, $iTotalRecords);
   }
@@ -383,7 +383,7 @@ class CopyrightHistogramProcessPost extends FO_Plugin
       return '';
     }
     $filterParams[] = "%$searchPattern%";
-    return ' AND CP.content ilike $'.count($filterParams).' ';
+    return 'WHERE mcontent ilike $'.count($filterParams).' ';
   }
 
   /**

--- a/src/copyright/ui/ajax-copyright-hist.php
+++ b/src/copyright/ui/ajax-copyright-hist.php
@@ -245,6 +245,7 @@ class CopyrightHistogramProcessPost extends FO_Plugin
     $limit = GetParm('iDisplayLength', PARM_INTEGER);
 
     $tableName = $this->getTableName($type);
+    $tableNameEvent = $tableName.'_event';
     $orderString = $this->getOrderString();
 
     list($left, $right) = $this->uploadDao->getLeftAndRight($item, $uploadTreeTableName);
@@ -276,25 +277,30 @@ class CopyrightHistogramProcessPost extends FO_Plugin
 
     $filterParms = $params;
     $searchFilter = $this->addSearchFilter($filterParms);
+    if (!$activated) {
+      $activatedClause = " AND CE.is_enabled=false and CE.upload_fk = $upload_pk ";
+    } else {
+      $activatedClause = " AND cp.".$tableName."_pk NOT IN (SELECT ".$tableName."_fk FROM $tableNameEvent WHERE upload_fk = $upload_pk AND is_enabled = false) ";
+    }
     $unorderedQuery = "FROM $tableName AS cp " .
         "INNER JOIN $uploadTreeTableName AS UT ON cp.pfile_fk = UT.pfile_fk " .
+        "LEFT JOIN $tableNameEvent AS CE ON CE.".$tableName."_fk = cp.".$tableName."_pk " .
         $join .
         "WHERE cp.content!='' " .
         "AND ( UT.lft  BETWEEN  $1 AND  $2 ) " .
         "AND cp.type = $3 " .
         "AND cp.agent_fk= $4 " .
-        "AND cp.is_enabled=" . ($activated ? 'true' : 'false') .
+        $activatedClause .
         $sql_upload;
     $totalFilter = $filterQuery . " " . $searchFilter;
+    $grouping = " GROUP BY cp.content ";
 
-    $grouping = " GROUP BY content ";
-
-    $countQuery = "SELECT count(*) FROM (SELECT content, count(*) $unorderedQuery $totalFilter $grouping) as K";
+    $countQuery = "SELECT count(*) FROM (SELECT cp.content, count(*) $unorderedQuery $totalFilter $grouping) as K";
     $iTotalDisplayRecordsRow = $this->dbManager->getSingleRow($countQuery,
         $filterParms, __METHOD__.$tableName . ".count" . ($activated ? '' : '_deactivated'));
     $iTotalDisplayRecords = $iTotalDisplayRecordsRow['count'];
 
-    $countAllQuery = "SELECT count(*) FROM (SELECT content, count(*) $unorderedQuery$grouping) as K";
+    $countAllQuery = "SELECT count(*) FROM (SELECT cp.content, count(*) $unorderedQuery$grouping) as K";
     $iTotalRecordsRow = $this->dbManager->getSingleRow($countAllQuery, $params, __METHOD__,$tableName . "count.all" . ($activated ? '' : '_deactivated'));
     $iTotalRecords = $iTotalRecordsRow['count'];
 
@@ -304,12 +310,18 @@ class CopyrightHistogramProcessPost extends FO_Plugin
     $filterParms[] = $limit;
     $range .= ' LIMIT $' . count($filterParms);
 
-    $sql = "SELECT content, hash, count(*) as copyright_count  " .
-        $unorderedQuery . $totalFilter . " GROUP BY content, hash " . $orderString . $range;
+    $sql = "SELECT cp.content, cp.hash, CE.content AS contentedited, CE.hash AS hashedited, count(*) AS copyright_count  " .
+        $unorderedQuery . $totalFilter . " GROUP BY cp.content, cp.hash, CE.content, CE.hash " . $orderString . $range;
     $statement = __METHOD__ . $filter.$tableName . $uploadTreeTableName . ($activated ? '' : '_deactivated');
     $this->dbManager->prepare($statement, $sql);
     $result = $this->dbManager->execute($statement, $filterParms);
     $rows = $this->dbManager->fetchAll($result);
+    foreach ($rows as $key => $row) {
+      if (!empty($row['contentedited'])) {
+        $rows[$key]['content'] = $rows[$key]['contentedited'];
+        $row[$key]['hash'] = $rows[$key]['hashedited'];
+      }
+    }
     $this->dbManager->freeResult($result);
 
     return array($rows, $iTotalDisplayRecords, $iTotalRecords);

--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -351,7 +351,7 @@ class ClearingDao
     if ($this->isDecisionIrrelevant($uploadTreeId, $groupId)) {
       $this->copyrightDao->updateTable($itemTreeBounds, '', '', $userId, 'copyright', 'rollback');
     } else if ($decType == DecisionTypes::IRRELEVANT) {
-      $this->copyrightDao->updateTable($itemTreeBounds, '', '', $userId, 'copyright', 'delete');
+      $this->copyrightDao->updateTable($itemTreeBounds, '', '', $userId, 'copyright', 'delete', '2');
     }
 
     $this->dbManager->begin();
@@ -841,7 +841,7 @@ INSERT INTO clearing_decision (
                FROM UploadTreeView WHERE NOT EXISTS (
              SELECT uploadtree_fk FROM clearing_decision
               WHERE decision_type=$'.($a+2).' AND uploadtree_fk=UploadTreeView.uploadtree_pk)';
-       $this->copyrightDao->updateTable($itemTreeBounds, '', '', $userId, 'copyright', 'delete');
+       $this->copyrightDao->updateTable($itemTreeBounds, '', '', $userId, 'copyright', 'delete', '2');
     } else {
       $params[] = $decisionMark;
       $sql = $uploadTreeProxy->asCte()

--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -168,6 +168,29 @@ class CopyrightDao
   }
 
   /**
+   * @param $uploadFk
+   * @param $scope
+   * @return array $rows
+   */
+  public function getAllEventEntriesForUpload($uploadFk, $agentId, $scope=1)
+  {
+    $statementName = __METHOD__.$uploadFk;
+    $params[] = $uploadFk;
+    $params[] = $agentId;
+    $params[] = $scope;
+    $sql = "SELECT DISTINCT ON (copyright_pk) copyright_pk, C.content, c.hash, CE.content AS contentedited, CE.hash AS hashedited, CE.is_enabled As isEnabledEdited
+              FROM copyright_event CE INNER JOIN copyright C ON C.copyright_pk = CE.copyright_fk
+            WHERE CE.upload_fk=$1 AND scope=$3 AND C.agent_fk = $2";
+
+    $this->dbManager->prepare($statementName, $sql);
+    $sqlResult = $this->dbManager->execute($statementName, $params);
+    $rows = $this->dbManager->fetchAll($sqlResult);
+    $this->dbManager->freeResult($sqlResult);
+
+    return $rows;
+  }
+
+  /**
    * @param $tableName
    * @param $uploadTreeTableName
    * @param $uploadId
@@ -181,6 +204,7 @@ class CopyrightDao
     $statementName = __METHOD__.$tableName.$uploadTreeTableName;
     $params = array();
     $extendWClause = null;
+    $tableNameEvent = $tableName.'_event';
 
     if ($uploadTreeTableName === "uploadtree_a") {
       $params[]= $uploadId;
@@ -199,25 +223,35 @@ class CopyrightDao
       $statementName .= "._".$extrawhere."_";
     }
 
-    if ($enabled == 'false') {
+    if ($enabled != 'false') {
+      $activatedClause = " AND CE.is_enabled=false ";
       $statementName .= "._"."enabled";
+    } else {
+      $activatedClause = " AND C.".$tableName."_pk NOT IN (SELECT ".$tableName."_fk FROM $tableNameEvent WHERE upload_fk = $uploadId AND is_enabled = false) ";
     }
 
-    $sql = "SELECT UT.uploadtree_pk as uploadtree_pk, C.content AS content,
-              C.hash AS hash, C.agent_fk as agent_fk
+    $sql = "SELECT DISTINCT(copyright_pk), UT.uploadtree_pk as uploadtree_pk, C.content AS content,
+              C.hash AS hash, C.agent_fk as agent_fk, CE.content AS contentedited, CE.hash AS hashedited
               FROM $tableName C
              INNER JOIN $uploadTreeTableName UT ON C.pfile_fk = UT.pfile_fk
+             LEFT JOIN $tableNameEvent AS CE ON CE.".$tableName."_fk = C.".$tableName."_pk
              WHERE C.content IS NOT NULL
                AND C.content!=''
-               AND C.is_enabled='$enabled'
+               $activatedClause
                $extendWClause
              ORDER BY UT.uploadtree_pk, C.content DESC";
     $this->dbManager->prepare($statementName, $sql);
     $sqlResult = $this->dbManager->execute($statementName, $params);
-    $result = $this->dbManager->fetchAll($sqlResult);
+    $rows = $this->dbManager->fetchAll($sqlResult);
+    foreach ($rows as $key => $row) {
+      if (!empty($row['contentedited'])) {
+        $rows[$key]['content'] = $rows[$key]['contentedited'];
+        $row[$key]['hash'] = $rows[$key]['hashedited'];
+      }
+    }
     $this->dbManager->freeResult($sqlResult);
 
-    return $result;
+    return $rows;
   }
 
   /**
@@ -304,6 +338,7 @@ class CopyrightDao
   public function getAllEntries($tableName, $uploadId, $uploadTreeTableName, $type=null, $onlyCleared=false, $decisionType=null, $extrawhere=null)
   {
     $statementName = __METHOD__.$tableName.$uploadTreeTableName;
+    $tableNameEvent = $tableName.'_event';
 
     $params = array();
     $whereClause = "";
@@ -355,11 +390,13 @@ class CopyrightDao
             FROM $tableName C
             INNER JOIN $uploadTreeTableName UT
               ON C.pfile_fk = UT.pfile_fk
+            LEFT JOIN $tableNameEvent AS CE
+              ON CE.".$tableName."_fk = C.".$tableName."_pk
             $joinType JOIN (SELECT * FROM $tableNameDecision WHERE is_enabled='true') AS CD
               ON C.pfile_fk = CD.pfile_fk
             WHERE C.content IS NOT NULL
               AND C.content!=''
-              AND C.is_enabled='true'
+              AND C.".$tableName."_pk NOT IN (SELECT DISTINCT(".$tableName."_fk) FROM $tableNameEvent TE WHERE TE.upload_fk = $uploadId AND is_enabled = false)
               $whereClause
             ORDER BY CD.pfile_fk, UT.uploadtree_pk, C.content, CD.textfinding, CD.$decisionTableKey DESC";
 
@@ -436,43 +473,79 @@ class CopyrightDao
    * @param int $userId
    * @param string $cpTable
    */
-  public function updateTable($item, $hash, $content, $userId, $cpTable='copyright', $action='')
+  public function updateTable($item, $hash, $content, $userId, $cpTable='copyright', $action='', $scope=1)
   {
+    $cpTablePk = $cpTable."_pk";
+    $cpTableEvent = $cpTable."_event";
+    $cpTableEventFk = $cpTable."_fk";
+    $paramEvent = array();
     $itemTable = $item->getUploadTreeTableName();
     $stmt = __METHOD__.".$cpTable.$itemTable";
-    $params = array($item->getLeft(),$item->getRight());
+    $uploadId = $item->getUploadId();
+    $params = array($item->getLeft(),$item->getRight(),$uploadId);
     $withHash = "";
 
     if (!empty($hash)) {
       $params[] = $hash;
-      $withHash = " cp.hash = $3 AND ";
+      $withHash = " cp.hash = $4 AND ";
       $stmt .= ".hash";
     }
-    if ($action == "delete") {
-      $setSql = "is_enabled='false'";
-      $stmt .= '.delete';
-    } else if ($action == "rollback") {
-      $setSql = "is_enabled='true'";
-      $stmt .= '.rollback';
-    } else {
-      $setSql = "content = $4, hash = md5($4), is_enabled='true'";
-      $params[] = StringOperation::replaceUnicodeControlChar($content);
+    // get latest agent id for copyright agent
+    $agentName = "copyright";
+    $scanJobProxy = new ScanJobProxy($GLOBALS['container']->get('dao.agent'),
+      $uploadId);
+    $scanJobProxy->createAgentStatus([$agentName]);
+    $selectedScanners = $scanJobProxy->getLatestSuccessfulAgentIds();
+    if (!array_key_exists($agentName, $selectedScanners)) {
+      return array();
+    }
+    $latestAgentId = $selectedScanners[$agentName];
+    $agentFilter = '';
+    if (!empty($latestAgentId)) {
+      $agentFilter = ' AND cp.agent_fk='.$latestAgentId;
     }
 
-    $cpTablePk = $cpTable."_pk";
-    $sql = "UPDATE $cpTable AS cpr SET $setSql
-            FROM $cpTable as cp
-            INNER JOIN $itemTable AS ut ON cp.pfile_fk = ut.pfile_fk
-            WHERE cpr.$cpTablePk = cp.$cpTablePk
-              AND $withHash ( ut.lft BETWEEN $1 AND $2 )";
-    if ('uploadtree_a' == $item->getUploadTreeTableName() || 'uploadtree' == $item->getUploadTreeTableName()) {
-      $params[] = $item->getUploadId();
-      $sql .= " AND ut.upload_fk=$".count($params);
-      $stmt .= '.upload';
-    }
+    $sql = "SELECT DISTINCT ON ($cpTablePk) $cpTablePk, uploadtree_pk, upload_fk FROM $cpTable as cp
+              INNER JOIN $itemTable AS ut ON cp.pfile_fk = ut.pfile_fk
+              AND $withHash ( ut.lft BETWEEN $1 AND $2 ) $agentFilter AND ut.upload_fk = $3";
 
     $this->dbManager->prepare($stmt, "$sql");
     $resource = $this->dbManager->execute($stmt, $params);
+    $rows = $this->dbManager->fetchAll($resource);
     $this->dbManager->freeResult($resource);
+
+    foreach ($rows as $row) {
+      $paramEvent[] = $row['upload_fk'];
+      $paramEvent[] = $row[$cpTablePk];
+      $paramEvent[] = $row['uploadtree_pk'];
+      if ($action == "delete") {
+        $paramEvent[] = $scope;
+        $sqlEvent = "INSERT INTO $cpTableEvent (upload_fk, $cpTableEventFk, uploadtree_fk, scope) VALUES($1, $2, $3, $4)";
+        $statement = "$stmt.delete";
+      } else if ($action == "rollback") {
+        $sqlEvent = "DELETE FROM $cpTableEvent WHERE upload_fk = $1 AND uploadtree_fk = $3 AND $cpTableEventFk = $2";
+        $statement = "$stmt.rollback";
+      } else {
+        $paramEvent[] = "true";
+        $paramEvent[] = StringOperation::replaceUnicodeControlChar($content);
+        $sqlExists = "SELECT exists(SELECT 1 FROM $cpTableEvent WHERE $cpTableEventFk = $1)::int";
+        $rowExists = $this->dbManager->getSingleRow($sqlExists, array($row[$cpTablePk]), $stmt.'Exists');
+
+        if ($rowExists['exists']) {
+          $sqlEvent = "UPDATE $cpTableEvent
+                        SET upload_fk = $1, uploadtree_fk = $3, is_enabled = $4, content = $5, hash = md5($5)
+                       WHERE $cpTableEventFk = $2";
+          $statement = "$stmt.update";
+        } else {
+          $sqlEvent = "INSERT INTO $cpTableEvent(upload_fk, uploadtree_fk, $cpTableEventFk, is_enabled, content, hash)
+                       VALUES($1, $3, $2, $4, $5, md5($5))";
+          $statement = "$stmt.insert";
+        }
+      }
+      $this->dbManager->prepare($statement, $sqlEvent);
+      $resourceEvent = $this->dbManager->execute($statement, $paramEvent);
+      $this->dbManager->freeResult($resourceEvent);
+      $paramEvent = array();
+    }
   }
 }

--- a/src/lib/php/Dao/UploadDao.php
+++ b/src/lib/php/Dao/UploadDao.php
@@ -38,7 +38,7 @@ class UploadDao
   const REUSE_ENHANCED = 2;
   const REUSE_MAIN = 4;
   const REUSE_CONF = 16;
-  const REUSE_COPYRIGHT = 32;
+  const REUSE_COPYRIGHT = 128;
   const UNIFIED_REPORT_HEADINGS = array(
     "assessment" => array("Assessment Summary" => true),
     "compliancetasks" => array("Required license compliance tasks" => true),
@@ -428,7 +428,7 @@ class UploadDao
     $statementName = __METHOD__;
 
     $this->dbManager->prepare($statementName,
-        "SELECT reused_upload_fk, reused_group_fk, reuse_mode FROM upload_reuse WHERE upload_fk = $1 AND group_fk=$2");
+        "SELECT reused_upload_fk, reused_group_fk, reuse_mode FROM upload_reuse WHERE upload_fk = $1 AND group_fk=$2 ORDER BY date_added DESC");
     $res = $this->dbManager->execute($statementName, array($uploadId, $groupId));
     $reusedPairs = $this->dbManager->fetchAll($res);
     $this->dbManager->freeResult($res);

--- a/src/reuser/agent/ReuserAgent.php
+++ b/src/reuser/agent/ReuserAgent.php
@@ -213,10 +213,11 @@ class ReuserAgent extends Agent
     }
     $uploadTreeTableName = $this->uploadDao->getUploadtreeTableName($uploadId);
     $extrawhere = ' agent_fk='.$agentId;
-    $allCopyrights = $this->copyrightDao->getScannerEntries('copyright', $uploadTreeTableName, $uploadId, $type=null,
-                                                            $extrawhere, $enabled='true');
+    $allCopyrights = $this->copyrightDao->getScannerEntries('copyright',
+      $uploadTreeTableName, $uploadId, null, $extrawhere);
 
-    $reusedCopyrights = $this->copyrightDao->getAllEventEntriesForUpload($reusedUploadId, $reusedAgentId);
+    $reusedCopyrights = $this->copyrightDao->getAllEventEntriesForUpload(
+      $reusedUploadId, $reusedAgentId, false);
 
     if (!empty($reusedCopyrights) && !empty($allCopyrights)) {
       foreach ($reusedCopyrights as $reusedCopyright) {
@@ -224,17 +225,11 @@ class ReuserAgent extends Agent
           if (strcmp($copyright['hash'], $reusedCopyright['hash']) == 0) {
             $action = "delete";
             $content = "";
-            $hash = $reusedCopyright['hash'];
-            if ($reusedCopyright['isEnabledEdited']
-              && !empty($reusedCopyright['hashedited'])
-               ) {
-              $action = "";
-              $content = $reusedCopyright['contentedited'];
-            }
+            $hash = $copyright['hash'];
             $item = $this->uploadDao->getItemTreeBounds(intval($copyright['uploadtree_pk']),
                       $uploadTreeTableName);
-            $this->copyrightDao->updateTable($item, $hash, $content, $this->userId,
-                      'copyright', $action);
+            $this->copyrightDao->updateTable($item, $hash, $content,
+              $this->userId, 'copyright', $action);
             unset($allCopyrights[$copyrightKey]);
             $this->heartbeat(1);
           }

--- a/src/reuser/agent/ReuserAgent.php
+++ b/src/reuser/agent/ReuserAgent.php
@@ -217,7 +217,7 @@ class ReuserAgent extends Agent
       $uploadTreeTableName, $uploadId, null, $extrawhere);
 
     $reusedCopyrights = $this->copyrightDao->getAllEventEntriesForUpload(
-      $reusedUploadId, $reusedAgentId, false);
+      $reusedUploadId, $reusedAgentId);
 
     if (!empty($reusedCopyrights) && !empty($allCopyrights)) {
       foreach ($reusedCopyrights as $reusedCopyright) {

--- a/src/reuser/agent/ReuserAgent.php
+++ b/src/reuser/agent/ReuserAgent.php
@@ -208,24 +208,34 @@ class ReuserAgent extends Agent
   {
     $agentId = $this->getAgentId($uploadId);
     $reusedAgentId = $this->getAgentId($reusedUploadId);
-    if ($agentId == $reusedAgentId || $agentId == null || $reusedAgentId == null) {
+    if ($agentId == null || $reusedAgentId == null) {
       return true;
     }
     $uploadTreeTableName = $this->uploadDao->getUploadtreeTableName($uploadId);
     $extrawhere = ' agent_fk='.$agentId;
     $allCopyrights = $this->copyrightDao->getScannerEntries('copyright', $uploadTreeTableName, $uploadId, $type=null,
                                                             $extrawhere, $enabled='true');
-    $reusedUploadtreeTableName = $this->uploadDao->getUploadtreeTableName($reusedUploadId);
-    $extrawhere = ' agent_fk='.$reusedAgentId;
-    $reusedCopyrights = $this->copyrightDao->getScannerEntries('copyright', $reusedUploadtreeTableName, $reusedUploadId,
-                                                                $type=null, $extrawhere, $enabled='false');
+
+    $reusedCopyrights = $this->copyrightDao->getAllEventEntriesForUpload($reusedUploadId, $reusedAgentId);
+
     if (!empty($reusedCopyrights) && !empty($allCopyrights)) {
       foreach ($reusedCopyrights as $reusedCopyright) {
-        foreach ($allCopyrights as $copyright) {
-          if ($copyright['hash'] == $reusedCopyright['hash']) {
-            $item = $this->uploadDao->getItemTreeBounds(intval($copyright['uploadtree_pk']), $uploadTreeTableName);
-            $this->copyrightDao->updateTable($item, $copyright['hash'], $copyright['content'], $this->userId,
-                                             $cpTable='copyright', $action='delete');
+        foreach ($allCopyrights as $copyrightKey => $copyright) {
+          if (strcmp($copyright['hash'], $reusedCopyright['hash']) == 0) {
+            $action = "delete";
+            $content = "";
+            $hash = $reusedCopyright['hash'];
+            if ($reusedCopyright['isEnabledEdited']
+              && !empty($reusedCopyright['hashedited'])
+               ) {
+              $action = "";
+              $content = $reusedCopyright['contentedited'];
+            }
+            $item = $this->uploadDao->getItemTreeBounds(intval($copyright['uploadtree_pk']),
+                      $uploadTreeTableName);
+            $this->copyrightDao->updateTable($item, $hash, $content, $this->userId,
+                      'copyright', $action);
+            unset($allCopyrights[$copyrightKey]);
             $this->heartbeat(1);
           }
         }

--- a/src/reuser/ui/template/agent_reuser.html.twig
+++ b/src/reuser/ui/template/agent_reuser.html.twig
@@ -8,7 +8,7 @@
   <input type="checkbox" name="reuseMode[]" value="reuseEnhanced"/> {{ 'Enhanced reuse (slower)'|trans }}<img src="images/info_16.png" title="{{'will copy a clearing decision if the two files differ by one line determined by a diff tool'|trans}}" alt="" class="info-bullet"/><br/>
   <input type="checkbox" name="reuseMode[]" value="reuseMain"/> {{ 'Reuse main license/s'|trans }}<img src="images/info_16.png" title="{{'will copy a main license decision(if any)'|trans}}" alt="" class="info-bullet"/><br/>
   <input type="checkbox" name="reuseMode[]" value="reuseConf"/> {{ 'Reuse report configuration settings'|trans }}<img src="images/info_16.png" title="{{'use to copy all the information from conf page(if any)'|trans}}" alt="" class="info-bullet"/><br/>
-  <input type="checkbox" name="reuseMode[]" value="reuseCopyright"/> {{ 'Reuse deactivated copyright when agent version changes'|trans }}<img src="images/info_16.png" title="{{'Use to copy only deactivated copyright decisions from the reused package only if the agent version changes between uploads'|trans}}" alt="" class="info-bullet"/><br/>
+  <input type="checkbox" name="reuseMode[]" value="reuseCopyright"/> {{ 'Reuse edited and deactivated copyrights'|trans }}<img src="images/info_16.png" title="{{'Use to copy edited and deactivated copyrights from the reused package'|trans}}" alt="" class="info-bullet"/><br/>
   {{ 'Upload to reuse'|trans }}:<br/>
   {{ macro.select(uploadToReuseSelectorName, folderUploads, uploadToReuseSelectorName, reuseUploadId, 'style="min-width:420px;"', 5) }}
 </li>

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -411,7 +411,7 @@
   $Schema["TABLE"]["copyright_event"]["is_enabled"]["ADD"] = "ALTER TABLE \"copyright_event\" ADD COLUMN \"is_enabled\" bool DEFAULT false";
   $Schema["TABLE"]["copyright_event"]["is_enabled"]["ALTER"] = "ALTER TABLE \"copyright_event\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT false";
 
-  $Schema["TABLE"]["copyright_event"]["scope"]["DESC"] = "COMMENT ON COLUMN \"copyright_event\".\"scope\" IS 'to differentiate disabled copyrights 1 for normal'";
+  $Schema["TABLE"]["copyright_event"]["scope"]["DESC"] = "COMMENT ON COLUMN \"copyright_event\".\"scope\" IS '1 for normal and 2 for deactivation from license page ex: irrelevent'";
   $Schema["TABLE"]["copyright_event"]["scope"]["ADD"] = "ALTER TABLE \"copyright_event\" ADD COLUMN \"scope\" int4 DEFAULT 1";
   $Schema["TABLE"]["copyright_event"]["scope"]["ALTER"] = "ALTER TABLE \"copyright_event\" ALTER COLUMN \"scope\" SET NOT NULL, ALTER COLUMN \"scope\" SET DEFAULT 1";
 
@@ -518,7 +518,7 @@
   $Schema["TABLE"]["author_event"]["is_enabled"]["ADD"] = "ALTER TABLE \"author_event\" ADD COLUMN \"is_enabled\" bool DEFAULT false";
   $Schema["TABLE"]["author_event"]["is_enabled"]["ALTER"] = "ALTER TABLE \"author_event\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT false";
 
-  $Schema["TABLE"]["author_event"]["scope"]["DESC"] = "COMMENT ON COLUMN \"author_event\".\"scope\" IS 'to differentiate disabled copyrights 1 for normal'";
+  $Schema["TABLE"]["author_event"]["scope"]["DESC"] = "COMMENT ON COLUMN \"author_event\".\"scope\" IS '1 for normal and 2 for deactivation from license page ex: irrelevent'";
   $Schema["TABLE"]["author_event"]["scope"]["ADD"] = "ALTER TABLE \"author_event\" ADD COLUMN \"scope\" int4 DEFAULT 1";
   $Schema["TABLE"]["author_event"]["scope"]["ALTER"] = "ALTER TABLE \"author_event\" ALTER COLUMN \"scope\" SET NOT NULL, ALTER COLUMN \"scope\" SET DEFAULT 1";
 
@@ -625,7 +625,7 @@
   $Schema["TABLE"]["ecc_event"]["is_enabled"]["ADD"] = "ALTER TABLE \"ecc_event\" ADD COLUMN \"is_enabled\" bool DEFAULT false";
   $Schema["TABLE"]["ecc_event"]["is_enabled"]["ALTER"] = "ALTER TABLE \"ecc_event\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT false";
 
-  $Schema["TABLE"]["ecc_event"]["scope"]["DESC"] = "COMMENT ON COLUMN \"ecc_event\".\"scope\" IS 'to differentiate disabled copyrights 1 for normal'";
+  $Schema["TABLE"]["ecc_event"]["scope"]["DESC"] = "COMMENT ON COLUMN \"ecc_event\".\"scope\" IS '1 for normal and 2 for deactivation from license page ex: irrelevent'";
   $Schema["TABLE"]["ecc_event"]["scope"]["ADD"] = "ALTER TABLE \"ecc_event\" ADD COLUMN \"scope\" int4 DEFAULT 1";
   $Schema["TABLE"]["ecc_event"]["scope"]["ALTER"] = "ALTER TABLE \"ecc_event\" ALTER COLUMN \"scope\" SET NOT NULL, ALTER COLUMN \"scope\" SET DEFAULT 1";
 
@@ -2157,7 +2157,7 @@
 
   $Schema["SEQUENCE"]["license_ref_rf_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"license_ref_rf_pk_seq\"";
   $Schema["SEQUENCE"]["license_ref_rf_pk_seq"]["UPDATE"] = "SELECT setval('license_ref_rf_pk_seq',(SELECT greatest(1,max(rf_pk)) val FROM license_ref))";
-  
+
   $Schema["SEQUENCE"]["copyright_decision_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"copyright_decision_pk_seq\"";
   $Schema["SEQUENCE"]["copyright_decision_pk_seq"]["UPDATE"] = "SELECT setval('copyright_decision_pk_seq',(SELECT greatest(1,max(copyright_decision_pk)) val FROM copyright_decision))";
 

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -383,6 +383,39 @@
   $Schema["TABLE"]["copyright_decision"]["is_enabled"]["ALTER"] = "ALTER TABLE \"copyright_decision\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT true";
 
 
+  $Schema["TABLE"]["copyright_event"]["copyright_event_pk"]["DESC"] = "";
+  $Schema["TABLE"]["copyright_event"]["copyright_event_pk"]["ADD"] = "ALTER TABLE \"copyright_event\" ADD COLUMN \"copyright_event_pk\" int8 DEFAULT nextval('copyright_event_pk_seq'::regclass)";
+  $Schema["TABLE"]["copyright_event"]["copyright_event_pk"]["ALTER"] = "ALTER TABLE \"copyright_event\" ALTER COLUMN \"copyright_event_pk\" SET NOT NULL, ALTER COLUMN \"copyright_event_pk\" SET DEFAULT nextval('copyright_event_pk_seq'::regclass)";
+
+  $Schema["TABLE"]["copyright_event"]["upload_fk"]["DESC"] = "";
+  $Schema["TABLE"]["copyright_event"]["upload_fk"]["ADD"] = "ALTER TABLE \"copyright_event\" ADD COLUMN \"upload_fk\" int8";
+  $Schema["TABLE"]["copyright_event"]["upload_fk"]["ALTER"] = "ALTER TABLE \"copyright_event\" ALTER COLUMN \"upload_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["copyright_event"]["uploadtree_fk"]["DESC"] = "";
+  $Schema["TABLE"]["copyright_event"]["uploadtree_fk"]["ADD"] = "ALTER TABLE \"copyright_event\" ADD COLUMN \"uploadtree_fk\" int4";
+  $Schema["TABLE"]["copyright_event"]["uploadtree_fk"]["ALTER"] = "ALTER TABLE \"copyright_event\" ALTER COLUMN \"uploadtree_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["copyright_event"]["copyright_fk"]["DESC"] = "";
+  $Schema["TABLE"]["copyright_event"]["copyright_fk"]["ADD"] = "ALTER TABLE \"copyright_event\" ADD COLUMN \"copyright_fk\" int8";
+  $Schema["TABLE"]["copyright_event"]["copyright_fk"]["ALTER"] = "ALTER TABLE \"copyright_event\" ALTER COLUMN \"copyright_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["copyright_event"]["content"]["DESC"] = "";
+  $Schema["TABLE"]["copyright_event"]["content"]["ADD"] = "ALTER TABLE \"copyright_event\" ADD COLUMN \"content\" text";
+  $Schema["TABLE"]["copyright_event"]["content"]["ALTER"] = "ALTER TABLE \"copyright_event\" ALTER COLUMN \"content\" DROP NOT NULL";
+
+  $Schema["TABLE"]["copyright_event"]["hash"]["DESC"] = "";
+  $Schema["TABLE"]["copyright_event"]["hash"]["ADD"] = "ALTER TABLE \"copyright_event\" ADD COLUMN \"hash\" text";
+  $Schema["TABLE"]["copyright_event"]["hash"]["ALTER"] = "ALTER TABLE \"copyright_event\" ALTER COLUMN \"hash\" DROP NOT NULL";
+
+  $Schema["TABLE"]["copyright_event"]["is_enabled"]["DESC"] = "COMMENT ON COLUMN \"copyright_event\".\"is_enabled\" IS 'true to enabled with edited, false to disable'";
+  $Schema["TABLE"]["copyright_event"]["is_enabled"]["ADD"] = "ALTER TABLE \"copyright_event\" ADD COLUMN \"is_enabled\" bool DEFAULT false";
+  $Schema["TABLE"]["copyright_event"]["is_enabled"]["ALTER"] = "ALTER TABLE \"copyright_event\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT false";
+
+  $Schema["TABLE"]["copyright_event"]["scope"]["DESC"] = "COMMENT ON COLUMN \"copyright_event\".\"scope\" IS 'to differentiate disabled copyrights 1 for normal'";
+  $Schema["TABLE"]["copyright_event"]["scope"]["ADD"] = "ALTER TABLE \"copyright_event\" ADD COLUMN \"scope\" int4 DEFAULT 1";
+  $Schema["TABLE"]["copyright_event"]["scope"]["ALTER"] = "ALTER TABLE \"copyright_event\" ALTER COLUMN \"scope\" SET NOT NULL, ALTER COLUMN \"scope\" SET DEFAULT 1";
+
+
   $Schema["TABLE"]["copyright_spasht"]["copyright_spasht_pk"]["DESC"] = "";
   $Schema["TABLE"]["copyright_spasht"]["copyright_spasht_pk"]["ADD"] = "ALTER TABLE \"copyright_spasht\" ADD COLUMN \"copyright_spasht_pk\" int8 DEFAULT nextval('copyright_spasht_pk_seq'::regclass)";
   $Schema["TABLE"]["copyright_spasht"]["copyright_spasht_pk"]["ALTER"] = "ALTER TABLE \"copyright_spasht\" ALTER COLUMN \"copyright_spasht_pk\" SET NOT NULL, ALTER COLUMN \"copyright_spasht_pk\" SET DEFAULT nextval('copyright_spasht_pk_seq'::regclass)";
@@ -455,6 +488,39 @@
   $Schema["TABLE"]["author"]["is_enabled"]["DESC"] = "COMMENT ON COLUMN \"author\".\"is_enabled\" IS 'true to enable, false to disable'";
   $Schema["TABLE"]["author"]["is_enabled"]["ADD"] = "ALTER TABLE \"author\" ADD COLUMN \"is_enabled\" bool DEFAULT true";
   $Schema["TABLE"]["author"]["is_enabled"]["ALTER"] = "ALTER TABLE \"author\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT true";
+
+
+  $Schema["TABLE"]["author_event"]["author_event_pk"]["DESC"] = "";
+  $Schema["TABLE"]["author_event"]["author_event_pk"]["ADD"] = "ALTER TABLE \"author_event\" ADD COLUMN \"author_event_pk\" int8 DEFAULT nextval('author_event_pk_seq'::regclass)";
+  $Schema["TABLE"]["author_event"]["author_event_pk"]["ALTER"] = "ALTER TABLE \"author_event\" ALTER COLUMN \"author_event_pk\" SET NOT NULL, ALTER COLUMN \"author_event_pk\" SET DEFAULT nextval('author_event_pk_seq'::regclass)";
+
+  $Schema["TABLE"]["author_event"]["upload_fk"]["DESC"] = "";
+  $Schema["TABLE"]["author_event"]["upload_fk"]["ADD"] = "ALTER TABLE \"author_event\" ADD COLUMN \"upload_fk\" int8";
+  $Schema["TABLE"]["author_event"]["upload_fk"]["ALTER"] = "ALTER TABLE \"author_event\" ALTER COLUMN \"upload_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["author_event"]["uploadtree_fk"]["DESC"] = "";
+  $Schema["TABLE"]["author_event"]["uploadtree_fk"]["ADD"] = "ALTER TABLE \"author_event\" ADD COLUMN \"uploadtree_fk\" int4";
+  $Schema["TABLE"]["author_event"]["uploadtree_fk"]["ALTER"] = "ALTER TABLE \"author_event\" ALTER COLUMN \"uploadtree_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["author_event"]["author_fk"]["DESC"] = "";
+  $Schema["TABLE"]["author_event"]["author_fk"]["ADD"] = "ALTER TABLE \"author_event\" ADD COLUMN \"author_fk\" int8";
+  $Schema["TABLE"]["author_event"]["author_fk"]["ALTER"] = "ALTER TABLE \"author_event\" ALTER COLUMN \"author_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["author_event"]["content"]["DESC"] = "";
+  $Schema["TABLE"]["author_event"]["content"]["ADD"] = "ALTER TABLE \"author_event\" ADD COLUMN \"content\" text";
+  $Schema["TABLE"]["author_event"]["content"]["ALTER"] = "ALTER TABLE \"author_event\" ALTER COLUMN \"content\" DROP NOT NULL";
+
+  $Schema["TABLE"]["author_event"]["hash"]["DESC"] = "";
+  $Schema["TABLE"]["author_event"]["hash"]["ADD"] = "ALTER TABLE \"author_event\" ADD COLUMN \"hash\" text";
+  $Schema["TABLE"]["author_event"]["hash"]["ALTER"] = "ALTER TABLE \"author_event\" ALTER COLUMN \"hash\" DROP NOT NULL";
+
+  $Schema["TABLE"]["author_event"]["is_enabled"]["DESC"] = "COMMENT ON COLUMN \"author_event\".\"is_enabled\" IS 'true to enabled with edited, false to disable'";
+  $Schema["TABLE"]["author_event"]["is_enabled"]["ADD"] = "ALTER TABLE \"author_event\" ADD COLUMN \"is_enabled\" bool DEFAULT false";
+  $Schema["TABLE"]["author_event"]["is_enabled"]["ALTER"] = "ALTER TABLE \"author_event\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT false";
+
+  $Schema["TABLE"]["author_event"]["scope"]["DESC"] = "COMMENT ON COLUMN \"author_event\".\"scope\" IS 'to differentiate disabled copyrights 1 for normal'";
+  $Schema["TABLE"]["author_event"]["scope"]["ADD"] = "ALTER TABLE \"author_event\" ADD COLUMN \"scope\" int4 DEFAULT 1";
+  $Schema["TABLE"]["author_event"]["scope"]["ALTER"] = "ALTER TABLE \"author_event\" ALTER COLUMN \"scope\" SET NOT NULL, ALTER COLUMN \"scope\" SET DEFAULT 1";
 
 
   $Schema["TABLE"]["ecc"]["ecc_pk"]["DESC"] = "";
@@ -531,6 +597,39 @@
   $Schema["TABLE"]["ecc_decision"]["is_enabled"]["ALTER"] = "ALTER TABLE \"ecc_decision\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT true";
 
 
+  $Schema["TABLE"]["ecc_event"]["ecc_event_pk"]["DESC"] = "";
+  $Schema["TABLE"]["ecc_event"]["ecc_event_pk"]["ADD"] = "ALTER TABLE \"ecc_event\" ADD COLUMN \"ecc_event_pk\" int8 DEFAULT nextval('ecc_event_pk_seq'::regclass)";
+  $Schema["TABLE"]["ecc_event"]["ecc_event_pk"]["ALTER"] = "ALTER TABLE \"ecc_event\" ALTER COLUMN \"ecc_event_pk\" SET NOT NULL, ALTER COLUMN \"ecc_event_pk\" SET DEFAULT nextval('ecc_event_pk_seq'::regclass)";
+
+  $Schema["TABLE"]["ecc_event"]["upload_fk"]["DESC"] = "";
+  $Schema["TABLE"]["ecc_event"]["upload_fk"]["ADD"] = "ALTER TABLE \"ecc_event\" ADD COLUMN \"upload_fk\" int8";
+  $Schema["TABLE"]["ecc_event"]["upload_fk"]["ALTER"] = "ALTER TABLE \"ecc_event\" ALTER COLUMN \"upload_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["ecc_event"]["uploadtree_fk"]["DESC"] = "";
+  $Schema["TABLE"]["ecc_event"]["uploadtree_fk"]["ADD"] = "ALTER TABLE \"ecc_event\" ADD COLUMN \"uploadtree_fk\" int4";
+  $Schema["TABLE"]["ecc_event"]["uploadtree_fk"]["ALTER"] = "ALTER TABLE \"ecc_event\" ALTER COLUMN \"uploadtree_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["ecc_event"]["ecc_fk"]["DESC"] = "";
+  $Schema["TABLE"]["ecc_event"]["ecc_fk"]["ADD"] = "ALTER TABLE \"ecc_event\" ADD COLUMN \"ecc_fk\" int8";
+  $Schema["TABLE"]["ecc_event"]["ecc_fk"]["ALTER"] = "ALTER TABLE \"ecc_event\" ALTER COLUMN \"ecc_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["ecc_event"]["content"]["DESC"] = "";
+  $Schema["TABLE"]["ecc_event"]["content"]["ADD"] = "ALTER TABLE \"ecc_event\" ADD COLUMN \"content\" text";
+  $Schema["TABLE"]["ecc_event"]["content"]["ALTER"] = "ALTER TABLE \"ecc_event\" ALTER COLUMN \"content\" DROP NOT NULL";
+
+  $Schema["TABLE"]["ecc_event"]["hash"]["DESC"] = "";
+  $Schema["TABLE"]["ecc_event"]["hash"]["ADD"] = "ALTER TABLE \"ecc_event\" ADD COLUMN \"hash\" text";
+  $Schema["TABLE"]["ecc_event"]["hash"]["ALTER"] = "ALTER TABLE \"ecc_event\" ALTER COLUMN \"hash\" DROP NOT NULL";
+
+  $Schema["TABLE"]["ecc_event"]["is_enabled"]["DESC"] = "COMMENT ON COLUMN \"ecc_event\".\"is_enabled\" IS 'true to enabled with edited, false to disable'";
+  $Schema["TABLE"]["ecc_event"]["is_enabled"]["ADD"] = "ALTER TABLE \"ecc_event\" ADD COLUMN \"is_enabled\" bool DEFAULT false";
+  $Schema["TABLE"]["ecc_event"]["is_enabled"]["ALTER"] = "ALTER TABLE \"ecc_event\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT false";
+
+  $Schema["TABLE"]["ecc_event"]["scope"]["DESC"] = "COMMENT ON COLUMN \"ecc_event\".\"scope\" IS 'to differentiate disabled copyrights 1 for normal'";
+  $Schema["TABLE"]["ecc_event"]["scope"]["ADD"] = "ALTER TABLE \"ecc_event\" ADD COLUMN \"scope\" int4 DEFAULT 1";
+  $Schema["TABLE"]["ecc_event"]["scope"]["ALTER"] = "ALTER TABLE \"ecc_event\" ALTER COLUMN \"scope\" SET NOT NULL, ALTER COLUMN \"scope\" SET DEFAULT 1";
+
+
   $Schema["TABLE"]["keyword"]["keyword_pk"]["DESC"] = "";
   $Schema["TABLE"]["keyword"]["keyword_pk"]["ADD"] = "ALTER TABLE \"keyword\" ADD COLUMN \"keyword_pk\" int8 DEFAULT nextval('keyword_pk_seq'::regclass)";
   $Schema["TABLE"]["keyword"]["keyword_pk"]["ALTER"] = "ALTER TABLE \"keyword\" ALTER COLUMN \"keyword_pk\" SET NOT NULL, ALTER COLUMN \"keyword_pk\" SET DEFAULT nextval('keyword_pk_seq'::regclass)";
@@ -603,6 +702,39 @@
   $Schema["TABLE"]["keyword_decision"]["is_enabled"]["DESC"] = "COMMENT ON COLUMN \"keyword_decision\".\"is_enabled\" IS 'true to enable, false to disable'";
   $Schema["TABLE"]["keyword_decision"]["is_enabled"]["ADD"] = "ALTER TABLE \"keyword_decision\" ADD COLUMN \"is_enabled\" bool DEFAULT true";
   $Schema["TABLE"]["keyword_decision"]["is_enabled"]["ALTER"] = "ALTER TABLE \"keyword_decision\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT true";
+
+
+  $Schema["TABLE"]["keyword_event"]["keyword_event_pk"]["DESC"] = "";
+  $Schema["TABLE"]["keyword_event"]["keyword_event_pk"]["ADD"] = "ALTER TABLE \"keyword_event\" ADD COLUMN \"keyword_event_pk\" int8 DEFAULT nextval('keyword_event_pk_seq'::regclass)";
+  $Schema["TABLE"]["keyword_event"]["keyword_event_pk"]["ALTER"] = "ALTER TABLE \"keyword_event\" ALTER COLUMN \"keyword_event_pk\" SET NOT NULL, ALTER COLUMN \"keyword_event_pk\" SET DEFAULT nextval('keyword_event_pk_seq'::regclass)";
+
+  $Schema["TABLE"]["keyword_event"]["upload_fk"]["DESC"] = "";
+  $Schema["TABLE"]["keyword_event"]["upload_fk"]["ADD"] = "ALTER TABLE \"keyword_event\" ADD COLUMN \"upload_fk\" int8";
+  $Schema["TABLE"]["keyword_event"]["upload_fk"]["ALTER"] = "ALTER TABLE \"keyword_event\" ALTER COLUMN \"upload_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["keyword_event"]["uploadtree_fk"]["DESC"] = "";
+  $Schema["TABLE"]["keyword_event"]["uploadtree_fk"]["ADD"] = "ALTER TABLE \"keyword_event\" ADD COLUMN \"uploadtree_fk\" int4";
+  $Schema["TABLE"]["keyword_event"]["uploadtree_fk"]["ALTER"] = "ALTER TABLE \"keyword_event\" ALTER COLUMN \"uploadtree_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["keyword_event"]["keyword_fk"]["DESC"] = "";
+  $Schema["TABLE"]["keyword_event"]["keyword_fk"]["ADD"] = "ALTER TABLE \"keyword_event\" ADD COLUMN \"keyword_fk\" int8";
+  $Schema["TABLE"]["keyword_event"]["keyword_fk"]["ALTER"] = "ALTER TABLE \"keyword_event\" ALTER COLUMN \"keyword_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["keyword_event"]["content"]["DESC"] = "";
+  $Schema["TABLE"]["keyword_event"]["content"]["ADD"] = "ALTER TABLE \"keyword_event\" ADD COLUMN \"content\" text";
+  $Schema["TABLE"]["keyword_event"]["content"]["ALTER"] = "ALTER TABLE \"keyword_event\" ALTER COLUMN \"content\" DROP NOT NULL";
+
+  $Schema["TABLE"]["keyword_event"]["hash"]["DESC"] = "";
+  $Schema["TABLE"]["keyword_event"]["hash"]["ADD"] = "ALTER TABLE \"keyword_event\" ADD COLUMN \"hash\" text";
+  $Schema["TABLE"]["keyword_event"]["hash"]["ALTER"] = "ALTER TABLE \"keyword_event\" ALTER COLUMN \"hash\" DROP NOT NULL";
+
+  $Schema["TABLE"]["keyword_event"]["is_enabled"]["DESC"] = "COMMENT ON COLUMN \"keyword_event\".\"is_enabled\" IS 'true to enabled with edited, false to disable'";
+  $Schema["TABLE"]["keyword_event"]["is_enabled"]["ADD"] = "ALTER TABLE \"keyword_event\" ADD COLUMN \"is_enabled\" bool DEFAULT false";
+  $Schema["TABLE"]["keyword_event"]["is_enabled"]["ALTER"] = "ALTER TABLE \"keyword_event\" ALTER COLUMN \"is_enabled\" DROP NOT NULL, ALTER COLUMN \"is_enabled\" SET DEFAULT false";
+
+  $Schema["TABLE"]["keyword_event"]["scope"]["DESC"] = "COMMENT ON COLUMN \"keyword_event\".\"scope\" IS '1 for normal and 2 for deactivation from license page ex: irrelevent'";
+  $Schema["TABLE"]["keyword_event"]["scope"]["ADD"] = "ALTER TABLE \"keyword_event\" ADD COLUMN \"scope\" int4 DEFAULT 1";
+  $Schema["TABLE"]["keyword_event"]["scope"]["ALTER"] = "ALTER TABLE \"keyword_event\" ALTER COLUMN \"scope\" SET NOT NULL, ALTER COLUMN \"scope\" SET DEFAULT 1";
 
 
   $Schema["TABLE"]["file_picker"]["file_picker_pk"]["DESC"] = "";
@@ -1984,6 +2116,18 @@
   $Schema["SEQUENCE"]["copyright_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"copyright_pk_seq\"";
   $Schema["SEQUENCE"]["copyright_pk_seq"]["UPDATE"] = "SELECT setval('copyright_pk_seq',(SELECT greatest(1,max(copyright_pk)) val FROM copyright))";
 
+  $Schema["SEQUENCE"]["copyright_event_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"copyright_event_pk_seq\"";
+  $Schema["SEQUENCE"]["copyright_event_pk_seq"]["UPDATE"] = "SELECT setval('copyright_event_pk_seq',(SELECT greatest(1,max(copyright_event_pk)) val FROM copyright_event))";
+
+  $Schema["SEQUENCE"]["author_event_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"author_event_pk_seq\"";
+  $Schema["SEQUENCE"]["author_event_pk_seq"]["UPDATE"] = "SELECT setval('author_event_pk_seq',(SELECT greatest(1,max(author_event_pk)) val FROM author_event))";
+
+  $Schema["SEQUENCE"]["ecc_event_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"ecc_event_pk_seq\"";
+  $Schema["SEQUENCE"]["ecc_event_pk_seq"]["UPDATE"] = "SELECT setval('ecc_event_pk_seq',(SELECT greatest(1,max(ecc_event_pk)) val FROM ecc_event))";
+
+  $Schema["SEQUENCE"]["keyword_event_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"keyword_event_pk_seq\"";
+  $Schema["SEQUENCE"]["keyword_event_pk_seq"]["UPDATE"] = "SELECT setval('keyword_event_pk_seq',(SELECT greatest(1,max(keyword_event_pk)) val FROM keyword_event))";
+
   $Schema["SEQUENCE"]["license_file_fl_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"license_file_fl_pk_seq\"";
   $Schema["SEQUENCE"]["license_file_fl_pk_seq"]["UPDATE"] = "SELECT setval('license_file_fl_pk_seq',(SELECT greatest(1,max(fl_pk)) val FROM license_file))";
 
@@ -2243,6 +2387,19 @@
   $Schema["CONSTRAINT"]["users_default_bucketpool_pk_fkey"] = "ALTER TABLE \"users\" ADD CONSTRAINT \"users_default_bucketpool_pk_fkey\" FOREIGN KEY (\"default_bucketpool_fk\") REFERENCES \"bucketpool\" (\"bucketpool_pk\") ON UPDATE NO ACTION ON DELETE NO ACTION;";
   $Schema["CONSTRAINT"]["users_group_id_fkey"] = "ALTER TABLE \"users\" ADD CONSTRAINT \"users_group_id_fkey\" FOREIGN KEY (\"group_fk\") REFERENCES \"groups\" (\"group_pk\") ON UPDATE NO ACTION ON DELETE NO ACTION;";
   $Schema["CONSTRAINT"]["users_new_upload_group_fk_fkey"] = "ALTER TABLE \"users\" ADD CONSTRAINT \"users_new_upload_group_fk_fkey\" FOREIGN KEY (\"new_upload_group_fk\") REFERENCES \"groups\" (\"group_pk\") ON UPDATE CASCADE ON DELETE RESTRICT;";
+  $Schema["CONSTRAINT"]["copyright_event_pkey"] = "ALTER TABLE \"copyright_event\" ADD CONSTRAINT \"copyright_event_pkey\" PRIMARY KEY (\"copyright_event_pk\");";
+  $Schema["CONSTRAINT"]["copyright_event_upload_fk_fkey"] = "ALTER TABLE \"copyright_event\" ADD CONSTRAINT \"copyright_event_upload_fk_fkey\" FOREIGN KEY (\"upload_fk\") REFERENCES \"upload\" (\"upload_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
+  $Schema["CONSTRAINT"]["copyright_event_copyright_fk_fkey"] = "ALTER TABLE \"copyright_event\" ADD CONSTRAINT \"copyright_event_copyright_fk_fkey\" FOREIGN KEY (\"copyright_fk\") REFERENCES \"copyright\" (\"copyright_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
+    $Schema["CONSTRAINT"]["author_event_pkey"] = "ALTER TABLE \"author_event\" ADD CONSTRAINT \"author_event_pkey\" PRIMARY KEY (\"author_event_pk\");";
+  $Schema["CONSTRAINT"]["author_event_upload_fk_fkey"] = "ALTER TABLE \"author_event\" ADD CONSTRAINT \"author_event_upload_fk_fkey\" FOREIGN KEY (\"upload_fk\") REFERENCES \"upload\" (\"upload_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
+  $Schema["CONSTRAINT"]["author_event_author_fk_fkey"] = "ALTER TABLE \"author_event\" ADD CONSTRAINT \"author_event_author_fk_fkey\" FOREIGN KEY (\"author_fk\") REFERENCES \"author\" (\"author_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
+    $Schema["CONSTRAINT"]["ecc_event_pkey"] = "ALTER TABLE \"ecc_event\" ADD CONSTRAINT \"ecc_event_pkey\" PRIMARY KEY (\"ecc_event_pk\");";
+  $Schema["CONSTRAINT"]["ecc_event_upload_fk_fkey"] = "ALTER TABLE \"ecc_event\" ADD CONSTRAINT \"ecc_event_upload_fk_fkey\" FOREIGN KEY (\"upload_fk\") REFERENCES \"upload\" (\"upload_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
+  $Schema["CONSTRAINT"]["ecc_event_ecc_fk_fkey"] = "ALTER TABLE \"ecc_event\" ADD CONSTRAINT \"ecc_event_ecc_fk_fkey\" FOREIGN KEY (\"ecc_fk\") REFERENCES \"ecc\" (\"ecc_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
+  $Schema["CONSTRAINT"]["keyword_event_pkey"] = "ALTER TABLE \"keyword_event\" ADD CONSTRAINT \"keyword_event_pkey\" PRIMARY KEY (\"keyword_event_pk\");";
+  $Schema["CONSTRAINT"]["keyword_event_upload_fk_fkey"] = "ALTER TABLE \"keyword_event\" ADD CONSTRAINT \"keyword_event_upload_fk_fkey\" FOREIGN KEY (\"upload_fk\") REFERENCES \"upload\" (\"upload_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
+  $Schema["CONSTRAINT"]["keyword_event_keyword_fk_fkey"] = "ALTER TABLE \"keyword_event\" ADD CONSTRAINT \"keyword_event_keyword_fk_fkey\" FOREIGN KEY (\"keyword_fk\") REFERENCES \"keyword\" (\"keyword_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
+
 
   $Schema["INDEX"]["bucket_container"]["bucketcontainer_uploadtree"] = "CREATE INDEX bucketcontainer_uploadtree ON bucket_container USING btree (uploadtree_fk);";
 
@@ -2342,6 +2499,22 @@
   $Schema["INDEX"]["uploadtree_a"]["uploadtree_a_upload_fk_lft_idx"] = "CREATE INDEX uploadtree_a_upload_fk_lft_idx ON uploadtree_a USING btree (upload_fk, lft);";
   $Schema["INDEX"]["uploadtree_a"]["uploadtree_a_upload_lft_ufilemode_pfile_idx"] = "CREATE INDEX uploadtree_a_upload_lft_ufilemode_pfile_idx ON uploadtree_a USING btree (upload_fk, lft, ufile_mode, pfile_fk);";
   $Schema["INDEX"]["upload_clearing_license"]["upload_clearing_license_upload_group_idx"] = "CREATE INDEX upload_clearing_license_upload_group_idx ON upload_clearing_license USING btree (upload_fk, group_fk);";
+
+  $Schema["INDEX"]["copyright_event"]["copyright_event_upload_fk_index"] = "CREATE INDEX copyright_event_upload_fk_index ON copyright_event USING btree (upload_fk);";
+  $Schema["INDEX"]["copyright_event"]["copyright_event_uploadtree_fk_index"] = "CREATE INDEX copyright_event_uploadtree_fk_index ON copyright_event USING btree (uploadtree_fk);";
+  $Schema["INDEX"]["copyright_event"]["copyright_event_copyright_fk_index"] = "CREATE INDEX copyright_event_copyright_fk_index ON copyright_event USING btree (copyright_fk);";
+
+  $Schema["INDEX"]["author_event"]["author_event_upload_fk_index"] = "CREATE INDEX author_event_upload_fk_index ON author_event USING btree (upload_fk);";
+  $Schema["INDEX"]["author_event"]["author_event_uploadtree_fk_index"] = "CREATE INDEX author_event_uploadtree_fk_index ON author_event USING btree (uploadtree_fk);";
+  $Schema["INDEX"]["author_event"]["author_event_author_fk_index"] = "CREATE INDEX author_event_author_fk_index ON author_event USING btree (author_fk);";
+
+  $Schema["INDEX"]["keyword_event"]["keyword_event_upload_fk_index"] = "CREATE INDEX keyword_event_upload_fk_index ON keyword_event USING btree (upload_fk);";
+  $Schema["INDEX"]["keyword_event"]["keyword_event_uploadtree_fk_index"] = "CREATE INDEX keyword_event_uploadtree_fk_index ON keyword_event USING btree (uploadtree_fk);";
+  $Schema["INDEX"]["keyword_event"]["keyword_event_keyword_fk_index"] = "CREATE INDEX keyword_event_keyword_fk_index ON keyword_event USING btree (keyword_fk);";
+
+  $Schema["INDEX"]["ecc_event"]["ecc_event_upload_fk_index"] = "CREATE INDEX ecc_event_upload_fk_index ON ecc_event USING btree (upload_fk);";
+  $Schema["INDEX"]["ecc_event"]["ecc_event_uploadtree_fk_index"] = "CREATE INDEX ecc_event_uploadtree_fk_index ON ecc_event USING btree (uploadtree_fk);";
+  $Schema["INDEX"]["ecc_event"]["ecc_event_ecc_fk_index"] = "CREATE INDEX ecc_event_ecc_fk_index ON ecc_event USING btree (ecc_fk);";
 
   $Schema["CLUSTER"]["upload_pkey_idx"] = "ALTER TABLE \"upload\" CLUSTER ON \"upload_pkey_idx\";";
   $Schema["CLUSTER"]["ufile_rel_pkey"] = "ALTER TABLE \"uploadtree\" CLUSTER ON \"ufile_rel_pkey\";";

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -1887,6 +1887,10 @@
   $Schema["TABLE"]["upload_reuse"]["reuse_mode"]["ADD"] = "ALTER TABLE \"upload_reuse\" ADD COLUMN \"reuse_mode\" int4 DEFAULT 0";
   $Schema["TABLE"]["upload_reuse"]["reuse_mode"]["ALTER"] = "ALTER TABLE \"upload_reuse\" ALTER COLUMN \"reuse_mode\" SET NOT NULL, ALTER COLUMN \"reuse_mode\" SET DEFAULT 0";
 
+  $Schema["TABLE"]["upload_reuse"]["date_added"]["DESC"] = "";
+  $Schema["TABLE"]["upload_reuse"]["date_added"]["ADD"] = "ALTER TABLE \"upload_reuse\" ADD COLUMN \"date_added\" timestamptz DEFAULT now()";
+  $Schema["TABLE"]["upload_reuse"]["date_added"]["ALTER"] = "ALTER TABLE \"upload_reuse\" ALTER COLUMN \"date_added\" SET NOT NULL, ALTER COLUMN \"date_added\" SET DEFAULT now()";
+
 
   $Schema["TABLE"]["uploadtree"]["uploadtree_pk"]["DESC"] = "";
   $Schema["TABLE"]["uploadtree"]["uploadtree_pk"]["ADD"] = "ALTER TABLE \"uploadtree\" ADD COLUMN \"uploadtree_pk\" int4 DEFAULT nextval('uploadtree_uploadtree_pk_seq'::regclass)";

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -2421,6 +2421,7 @@
   $Schema["INDEX"]["clearing_event"]["clearing_event_uploadtree_group_fk_idx"] = "CREATE INDEX clearing_event_uploadtree_group_fk_idx ON clearing_event USING btree (uploadtree_fk, group_fk, date_added);";
   $Schema["INDEX"]["clearing_event"]["clearing_event_pk_removed_idx"] = "CREATE INDEX clearing_event_pk_removed_idx ON clearing_event USING btree(clearing_event_pk, removed, rf_fk) WHERE NOT removed;";
 
+  $Schema["INDEX"]["copyright"]["copyright_pfile_fk_is_enabled_false_idx"] = "CREATE INDEX copyright_pfile_fk_is_enabled_false_idx ON copyright USING btree (pfile_fk, is_enabled) WHERE is_enabled = false;";
   $Schema["INDEX"]["copyright"]["copyright_agent_fk_idx"] = "CREATE INDEX copyright_agent_fk_idx ON copyright USING btree (agent_fk);";
   $Schema["INDEX"]["copyright"]["copyright_pfile_fk_index"] = "CREATE INDEX copyright_pfile_fk_index ON copyright USING btree (pfile_fk);";
   $Schema["INDEX"]["copyright"]["copyright_pfile_hash_idx"] = "CREATE INDEX copyright_pfile_hash_idx ON copyright USING btree (hash, pfile_fk);";
@@ -2434,10 +2435,12 @@
   $Schema["INDEX"]["copyright_spasht"]["copyright_spasht_pfile_fk_index"] = "CREATE INDEX copyright_spasht_pfile_fk_index ON copyright_spasht USING btree (pfile_fk);";
   $Schema["INDEX"]["copyright_spasht"]["copyright_spasht_pfile_hash_index"] = "CREATE INDEX copyright_spasht_pfile_hash_index ON copyright_spasht USING btree (hash, pfile_fk);";
 
+  $Schema["INDEX"]["author"]["author_pfile_fk_is_enabled_false_idx"] = "CREATE INDEX author_pfile_fk_is_enabled_false_idx ON author USING btree (pfile_fk, is_enabled) WHERE is_enabled = false;";
   $Schema["INDEX"]["author"]["author_agent_fk_idx"] = "CREATE INDEX author_agent_fk_idx ON author USING btree (agent_fk);";
   $Schema["INDEX"]["author"]["author_pfile_fk_index"] = "CREATE INDEX author_pfile_fk_index ON author USING btree (pfile_fk);";
   $Schema["INDEX"]["author"]["author_pfile_hash_idx"] = "CREATE INDEX author_pfile_hash_idx ON author USING btree (hash, pfile_fk);";
 
+  $Schema["INDEX"]["ecc"]["ecc_pfile_fk_is_enabled_false_idx"] = "CREATE INDEX ecc_pfile_fk_is_enabled_false_idx ON ecc USING btree (pfile_fk, is_enabled) WHERE is_enabled = false;";
   $Schema["INDEX"]["ecc"]["ecc_agent_fk_index"] = "CREATE INDEX ecc_agent_fk_index ON ecc USING btree (agent_fk);";
   $Schema["INDEX"]["ecc"]["ecc_hash_index"] = "CREATE INDEX ecc_hash_index ON ecc USING btree (hash);";
   $Schema["INDEX"]["ecc"]["ecc_pfile_fk_index"] = "CREATE INDEX ecc_pfile_fk_index ON ecc USING btree (pfile_fk);";
@@ -2448,6 +2451,7 @@
   $Schema["INDEX"]["ecc_decision"]["ecc_decision_user_fk_index"] = "CREATE INDEX ecc_decision_user_fk_index ON ecc_decision USING btree (user_fk);";
   $Schema["INDEX"]["ecc_decision"]["ecc_decision_pfile_hash_index"] = "CREATE INDEX ecc_decision_pfile_hash_index ON ecc_decision USING btree (hash, pfile_fk);";
 
+  $Schema["INDEX"]["keyword"]["keyword_pfile_fk_is_enabled_false_idx"] = "CREATE INDEX keyword_pfile_fk_is_enabled_false_idx ON keyword USING btree (pfile_fk, is_enabled) WHERE is_enabled = false;";
   $Schema["INDEX"]["keyword"]["keyword_agent_fk_index"] = "CREATE INDEX keyword_agent_fk_index ON keyword USING btree (agent_fk);";
   $Schema["INDEX"]["keyword"]["keyword_hash_index"] = "CREATE INDEX keyword_hash_index ON keyword USING btree (hash);";
   $Schema["INDEX"]["keyword"]["keyword_pfile_fk_index"] = "CREATE INDEX keyword_pfile_fk_index ON keyword USING btree (pfile_fk);";


### PR DESCRIPTION
## Description

Separate copyright, author, ecc and keyword edits to another "tableName_event" table. for better reuse.  

### Changes

* Script to migrate old data.
* Create new _event table.
* Changes to save new data in new event table.

## How to test

* End-to-end testing of copyright and sister tables with reuse.
