### PR TITLE
fix(reuser): removed agent log

### DIFF
--- a/src/reuser/agent/ReuserAgent.php
+++ b/src/reuser/agent/ReuserAgent.php
@@ -344,7 +344,7 @@ class ReuserAgent extends Agent
    */
   protected function copyClearingDecisionIfDifferenceIsSmall($reusedPath,$newPath,$clearingDecision,$itemId)
   {
-    $diffLevel = system("diff $reusedPath $newPath | wc -l");
+    $diffLevel = exec("diff $reusedPath $newPath | wc -l");
     if ($diffLevel === false) {
       throw new \Exception('cannot use diff tool');
     }


### PR DESCRIPTION

## Description
Closes #1884

When reusing a component, the agent log was getting printed which is not required.

## Changes

Used the **exec** command instead of **system**
In the **copyClearingDecisionIfDifferenceIsSmall** function previously the system() command was used. While system executed the task fine it also displayed the output immediately(agent-log) which was unnecessary. I have used the exec function instead which executed the task but does not display the output.

## How to test

1. Upload a file.
2. Do some clearing.
3. Upload the same file with a higher version and select the enhanced reuse feature which will compare with the previous file.

Previously when a file was uploaded, after doing some clearing uploading the same file with a higher version and using the **reuse** feature was printing the agent logs which are not required. After making the above-mentioned change if the method is followed the logs will no longer be printed.