### PR TITLE
fix(make): Fix warnings in make for Ubuntu 20.04.2 LTS

### DIFF
--- a/src/nomos/agent/nomos.c
+++ b/src/nomos/agent/nomos.c
@@ -310,13 +310,13 @@ int main(int argc, char **argv)
   /* Record the progname name */
   if ((cp = strrchr(*argv, '/')) == NULL_STR)
   {
-    strncpy(gl.progName, *argv, sizeof(gl.progName));
+    strncpy(gl.progName, *argv, sizeof(gl.progName)-1);
   }
   else
   {
     while (*cp == '.' || *cp == '/')
       cp++;
-    strncpy(gl.progName, cp, sizeof(gl.progName));
+    strncpy(gl.progName, cp, sizeof(gl.progName)-1);
   }
 
   if (putenv("LANG=C") < 0)

--- a/src/wget_agent/agent/main.c
+++ b/src/wget_agent/agent/main.c
@@ -214,7 +214,7 @@ int main  (int argc, char *argv[])
   for(arg=optind; arg < argc; arg++)
   {
     memset(GlobalURL,'\0',sizeof(GlobalURL));
-    strncpy(GlobalURL,argv[arg],sizeof(GlobalURL));
+    strncpy(GlobalURL,argv[arg],sizeof(GlobalURL)-1);
     /* If the file contains "://" then assume it is a URL.
        Else, assume it is a file. */
     LOG_VERBOSE0("Command-line: %s",GlobalURL);

--- a/src/wget_agent/agent/wget_agent.c
+++ b/src/wget_agent/agent/wget_agent.c
@@ -1058,7 +1058,7 @@ void replace_url_with_auth()
       token = strtok(NULL, needle);
       index++;
     }
-    snprintf(GlobalURL, URLMAX, "%s%s:%s@%s", http, username, password, URI);
+    snprintf(GlobalURL, URLMAX-1, "%s%s:%s@%s", http, username, password, URI);
 
     if (strlen(additionalParams) > 0) {
       memmove(GlobalParam, additionalParams, strlen(additionalParams) +1);


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

There are many warning suppression mechanisms, I have used `_Pragma()` operator, it works for C99 and above and doesn't cause additional warnings.

See details here: https://nelkinda.com/blog/suppress-warnings-in-gcc-and-clang/#d11e435
Comparison: https://nelkinda.com/blog/suppress-warnings-in-gcc-and-clang/#d11e498

### Changes

List the changes done to fix a bug or introducing a new feature.
- Suppressed some warnings because theoretically, they won't turn into error. 
- Fixed some code to avoid error

## How to test

Describe the steps required to test the changes proposed in the pull request.
- Checkout this pull-request branch `git fetch upstream pull/1923/head:fix-warnings`
- `git checkout fix-warnings`
- Do a `make clean`
- Run `make`

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)
Fixes #1902 
Needs #1807 

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/1923"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

