### PR TITLE
style(PHP): Upgrade fossology project from PHP 7 to PHP 8

### DIFF
--- a/src/lib/php/Util/StringOperation.php
+++ b/src/lib/php/Util/StringOperation.php
@@ -30,7 +30,7 @@ class StringOperation
     $headLength = 0;
     $maxNumberOfCharsToCompare = min(strlen($a), strlen($b));
     while ($headLength < $maxNumberOfCharsToCompare &&
-      $a{$headLength} === $b{$headLength}) {
+      $a[$headLength] === $b[$headLength]) {
       $headLength += 1;
     }
     return substr($a,0,$headLength);

--- a/src/nomos/agent_tests/testdata/NomosTestfiles/AGPL/JsonMapper.php
+++ b/src/nomos/agent_tests/testdata/NomosTestfiles/AGPL/JsonMapper.php
@@ -2,8 +2,6 @@
 /**
  * Part of JsonMapper
  *
- * PHP version 5
- *
  * @category Netresearch
  * @package  JsonMapper
  * @author   Christian Weiske <christian.weiske@netresearch.de>
@@ -106,7 +104,7 @@ class JsonMapper
         continue;
       }
 
-      if ($type{0} != '\\') {
+      if ($type[0] != '\\') {
         //create a full qualified namespace
         if ($strNs != '') {
           $type = '\\' . $strNs . '\\' . $type;
@@ -130,7 +128,7 @@ class JsonMapper
       }
 
       if ($array !== null) {
-        if ($subtype{0} != '\\') {
+        if ($subtype[0] != '\\') {
           //create a full qualified namespace
           if ($strNs != '') {
             $subtype = $strNs . '\\' . $subtype;

--- a/src/testing/syntax/syntaxtest.sh
+++ b/src/testing/syntax/syntaxtest.sh
@@ -83,7 +83,7 @@ then
 fi
 
 # scan each of the php files
-phpScanResults=$(find . -not \( -path ./vendor -prune \) -type f -name \*.php | xargs -L1 -P$threads -I {} sh -c "php --syntax-check {} || :")
+phpScanResults=$(find . -not \( -path ./vendor -prune \) -not \( -path ./nomos/agent_tests/testdata -prune \) -type f -name \*.php | xargs -L1 -P$threads -I {} sh -c "php --syntax-check {} || :")
 phpScanErrors=$(echo "$phpScanResults" | egrep -v '^No syntax errors detected in' | egrep -v '^$')
 
 if isVerbose


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The project currently uses PHP 7.x and is partially incompatible with PHP 8. It would be preferable to upgrade this project to PHP 8 for better compatibility with the latest technologies.

signed-off-by: Sarita Singh <saritasingh.0425@gmail.com>
fixes #1920 
## Changes

* In ./lib/php/Util/StringOperation.php on line 33
* In ./nomos/agent_tests/testdata/NomosTestfiles/AGPL/JsonMapper.php on line 109
   replaced curly braces with [ ].

## How to test

Run Syntax Checks for PHP8 using command: bash src/testing/syntax/syntaxtest.sh


