### PR TITLE
fix(ui): Show error message for invalid license id

### DIFF
--- a/src/www/ui/admin-license-file.php
+++ b/src/www/ui/admin-license-file.php
@@ -298,9 +298,9 @@ class admin_license_file extends FO_Plugin
         "SELECT * FROM ONLY license_ref WHERE rf_pk=$1", array($rf_pk),
         __METHOD__ . '.forUpdate');
       if ($row === false) {
-        $text = _("No licenses matching this key");
+        $text = _("ERROR: No licenses matching this key");
         $text1 = _("was found");
-        return "$text ($rf_pk) $text1.";
+        return ["error" => "$text ($rf_pk) $text1."];
       }
       $row['rf_parent'] = $parentMap->getProjectedId($rf_pk);
       $row['rf_report'] = $reportMap->getProjectedId($rf_pk);

--- a/src/www/ui/template/admin_license-upload_form.html.twig
+++ b/src/www/ui/template/admin_license-upload_form.html.twig
@@ -8,6 +8,7 @@
 
 {% block content %}
 
+{% if error is empty %}
 <form name="Updatefm" action="{{ actionUri }}" method="post">
   <input type="hidden" name="req_marydone" value="{{ req_marydone }}"/>
   <input type="hidden" name="req_shortname" value="{{ req_shortname }}"/>
@@ -84,6 +85,9 @@
   {% endif %}
   <input type="submit" value="{% if rfId %}{{ 'Update'|trans }}{% else %}{{ 'Add license'|trans }}{% endif %}"/>
 </form>
+{% else %}
+  {{ error }}
+{% endif %}
 {% endblock %}
 
 {% block foot %}


### PR DESCRIPTION
## Description

While trying to read wrong license from `?mod=admin_license&rf_pk=<wrong_rf_pk>`, PHP throws error and displays an empty page.
This PR fixes that by showing an error message when the license id is invalid.

### Changes

1. Add a new Twig variable `error` for license admin.
    - If it is empty, show the page normally.
    - If it is not empty, show the error message only.
2. Create the required `error` variable in case license ID is invalid.

## How to test

1. Open `?mod=admin_license&rf_pk=<wrong_rf_pk>`, should show an error message.
2. Edit a valid license, should work as expected.
3. Create a new license, should work as expected.