### PR TITLE
fixed the grammatical errors in About Fossology page

### DIFF
--- a/src/www/ui/template/about.html.twig
+++ b/src/www/ui/template/about.html.twig
@@ -1,7 +1,7 @@
 {# Copyright 2014-2020 Siemens AG
 
    Copying and distribution of this file, with or without modification,
-   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
+   are permitted in any medium without royalty provided the copyright notice and this notice is preserved.
    This file is offered as-is, without any warranty.
 #}
 {% extends "include/base.html.twig" %}
@@ -53,8 +53,7 @@
    Copyright (C) 1989, 1991 Free Software Foundation, Inc.
    51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
-   Everyone is permitted to copy and distribute verbatim copies
-   of this license document, but changing it is not allowed.
+   Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
    </pre>
 
    <h3 id="preamble"><a id="SEC2">Preamble</a></h3>
@@ -88,7 +87,7 @@
    </p>
 
    <p>
-       The precise terms and conditions for copying, distribution and modification follow.
+       The precise terms and conditions for copying, distribution, and modification follow.
    </p>
 
    <h3 id="terms"><a id="SEC3">TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION</a></h3>
@@ -98,11 +97,11 @@
    </p>
 
    <p>
-       Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running the Program is not restricted, and the output from the Program is covered only if its contents constitute a work based on the Program (independent of having been made by running the Program). Whether that is true depends on what the Program does.
+       Activities other than copying, distribution, and modification are not covered by this License; they are outside its scope. The act of running the Program is not restricted, and the output from the Program is covered only if its contents constitute a work based on the Program (independent of having been made by running the Program). Whether that is true depends on what the Program does.
    </p>
 
    <p id="section1">
-       <strong>1.</strong> You may copy and distribute verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and give any other recipients of the Program a copy of this License along with the Program.
+       <strong>1.</strong> You may copy and distribute verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and the absence of any warranty, and give any other recipients of the Program a copy of this License along with the Program.
    </p>
 
    <p>
@@ -124,12 +123,12 @@
        </dd>
        <dt></dt>
        <dd>
-           <strong>c)</strong> If the modified program normally reads commands interactively when run, you must cause it, when started running for such interactive use in the most ordinary way, to print or display an announcement including an appropriate copyright notice and a notice that there is no warranty (or else, saying that you provide a warranty) and that users may redistribute the program under these conditions, and telling the user how to view a copy of this License. (Exception: if the Program itself is interactive but does not normally print such an announcement, your work based on the Program is not required to print an announcement.)
+           <strong>c)</strong> If the modified program normally reads commands interactively when run, you must cause it, when started running for such interactive use in the most ordinary way, to print or display an announcement including the appropriate copyright notice and a notice that there is no warranty (or else, saying that you provide a warranty) and that users may redistribute the program under these conditions, and telling the user how to view a copy of this License. (Exception: if the Program itself is interactive but does not normally print such an announcement, your work based on the Program is not required to print an announcement.)
        </dd>
    </dl>
 
    <p>
-       These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Program, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Program, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+       These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Program and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Program, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to every part regardless of who wrote it.
    </p>
 
    <p>
@@ -137,7 +136,7 @@
    </p>
 
    <p>
-       In addition, mere aggregation of another work not based on the Program with the Program (or with a work based on the Program) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+       Besides, mere aggregation of another work not based on the Program with the Program (or with a work based on the Program) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
    </p>
 
    <p id="section3">
@@ -175,7 +174,7 @@
    </p>
 
    <p id="section5">
-       <strong>5.</strong> You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Program or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Program (or any work based on the Program), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Program or works based on it.
+       <strong>5.</strong> You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Program or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Program (or any work based on the Program), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing, or modifying the Program or works based on it.
    </p>
 
    <p id="section6">
@@ -183,7 +182,7 @@
    </p>
 
    <p id="section7">
-       <strong>7.</strong> If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Program at all. For example, if a patent license would not permit royalty-free redistribution of the Program by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Program.
+       <strong>7.</strong> If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement, or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Program at all. For example, if a patent license would not permit royalty-free redistribution of the Program by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Program.
    </p>
 
    <p>
@@ -199,25 +198,25 @@
    </p>
 
    <p id="section8">
-       <strong>8.</strong> If the distribution and/or use of the Program is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Program under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+       <strong>8.</strong> If the distribution and/or use of the Program is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Program under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such a case, this License incorporates the limitation as if written in the body of this License.
    </p>
 
    <p id="section9">
-       <strong>9.</strong> The Free Software Foundation may publish revised and/or new versions of the General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+       <strong>9.</strong> The Free Software Foundation may publish revised and/or new versions of the General Public License from time to time. Such new versions will be similar in spirit to the present version but may differ in detail to address new problems or concerns.
    </p>
 
    <p>
-       Each version is given a distinguishing version number. If the Program specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of this License, you may choose any version ever published by the Free Software Foundation.
+       Each version is given a distinguishing version number. If the Program specifies a version number of this License that applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of this License, you may choose any version ever published by the Free Software Foundation.
    </p>
 
    <p id="section10">
-       <strong>10.</strong> If you wish to incorporate parts of the Program into other free programs whose distribution conditions are different, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+       <strong>10.</strong> If you wish to incorporate parts of the Program into other free programs whose distribution conditions are different, write to the author to ask for permission. For software that is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
    </p>
 
    <p id="section11"><strong>NO WARRANTY</strong></p>
 
    <p>
-       <strong>11.</strong> BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+       <strong>11.</strong> BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR, OR CORRECTION.
    </p>
 
    <p id="section12">
@@ -229,11 +228,11 @@
    <h3 id="howto"><a id="SEC4">How to Apply These Terms to Your New Programs</a></h3>
 
    <p>
-       If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+       If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software that everyone can redistribute and change under these terms.
    </p>
 
    <p>
-       To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+       To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty, and each file should have at least the "copyright" line and a pointer to where the full notice is found.
    </p>
 
    <pre>
@@ -256,7 +255,7 @@
    </pre>
 
    <p>
-       Also add information on how to contact you by electronic and paper mail.
+       Also, add information on how to contact you by electronic and paper mail.
    </p>
 
    <p>
@@ -301,7 +300,7 @@
 
    <pre>
    Copyright (C) 1991, 1999 Free Software Foundation, Inc.
-   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 the USA
    Everyone is permitted to copy and distribute verbatim copies
    of this license document, but changing it is not allowed.
 
@@ -322,7 +321,7 @@
        When we speak of free software, we are referring to freedom of use, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish); that you receive source code or can get it if you want it; that you can change the software and use pieces of it in new free programs; and that you are informed that you can do these things.
    </p>
    <p>
-       To protect your rights, we need to make restrictions that forbid distributors to deny you these rights or to ask you to surrender these rights. These restrictions translate to certain responsibilities for you if you distribute copies of the library or if you modify it.
+       To protect your rights, we need to make restrictions that forbid distributors to deny you these rights or asking you to surrender these rights. These restrictions translate to certain responsibilities for you if you distribute copies of the library or if you modify them.
    </p>
    <p>
        For example, if you distribute copies of the library, whether gratis or for a fee, you must give the recipients all the rights that we gave you. You must make sure that they, too, receive or can get the source code. If you link other code with the library, you must provide complete object files to the recipients, so that they can relink them with the library after making changes to the library and recompiling it. And you must show them these terms so they know their rights.
@@ -337,13 +336,13 @@
        Finally, software patents pose a constant threat to the existence of any free program. We wish to make sure that a company cannot effectively restrict the users of a free program by obtaining a restrictive license from a patent holder. Therefore, we insist that any patent license obtained for a version of the library must be consistent with the full freedom of use specified in this license.
    </p>
    <p>
-       Most GNU software, including some libraries, is covered by the ordinary GNU General Public License. This license, the GNU Lesser General Public License, applies to certain designated libraries, and is quite different from the ordinary General Public License. We use this license for certain libraries in order to permit linking those libraries into non-free programs.
+       Most GNU software, including some libraries, is covered by the ordinary GNU General Public License. This license, the GNU Lesser General Public License, applies to certain designated libraries and is quite different from the ordinary General Public License. We use this license for certain libraries to permit linking those libraries into non-free programs.
    </p>
    <p>
-       When a program is linked with a library, whether statically or using a shared library, the combination of the two is legally speaking a combined work, a derivative of the original library. The ordinary General Public License therefore permits such linking only if the entire combination fits its criteria of freedom. The Lesser General Public License permits more lax criteria for linking other code with the library.
+       When a program is linked with a library, whether statically or using a shared library, the combination of the two is legally speaking a combined work, a derivative of the original library. The ordinary General Public License, therefore, permits such linking only if the entire combination fits its criteria of freedom. The Lesser General Public License permits more lax criteria for linking other codes with the library.
    </p>
    <p>
-       We call this license the "Lesser" General Public License because it does Less to protect the user's freedom than the ordinary General Public License. It also provides other free software developers Less of an advantage over competing non-free programs. These disadvantages are the reason we use the ordinary General Public License for many libraries. However, the Lesser license provides advantages in certain special circumstances.
+       We call this license the "Lesser" General Public License because it does Less to protect the user's freedom than the ordinary General Public License. It also provides other free software developers Less of an advantage over competing for non-free programs. These disadvantages are the reason we use the ordinary General Public License for many libraries. However, the Lesser license provides advantages in certain special circumstances.
    </p>
    <p>
        For example, on rare occasions, there may be a special need to encourage the widest possible use of a certain library, so that it becomes a de-facto standard. To achieve this, non-free programs must be allowed to use the library. A more frequent case is that a free library does the same job as widely used non-free libraries. In this case, there is little to gain by limiting the free library to free software only, so we use the Lesser General Public License.
@@ -355,7 +354,7 @@
        Although the Lesser General Public License is Less protective of the users' freedom, it does ensure that the user of a program that is linked with the Library has the freedom and the wherewithal to run that program using a modified version of the Library.
    </p>
    <p>
-       The precise terms and conditions for copying, distribution and modification follow. Pay close attention to the difference between a "work based on the library" and a "work that uses the library". The former contains code derived from the library, whereas the latter must be combined with the library in order to run.
+       The precise terms and conditions for copying, distribution, and modification follow. Pay close attention to the difference between a "work based on the library" and a "work that uses the library". The former contains code derived from the library, whereas the latter must be combined with the library to run.
    </p>
 
    <h3><a id="SEC3">TERMS AND CONDITIONS FOR COPYING,
@@ -365,7 +364,7 @@
        <strong>0.</strong> This License Agreement applies to any software library or other program which contains a notice placed by the copyright holder or other authorized party saying it may be distributed under the terms of this Lesser General Public License (also called "this License"). Each licensee is addressed as "you".
    </p>
    <p>
-       A "library" means a collection of software functions and/or data prepared so as to be conveniently linked with application programs (which use some of those functions and data) to form executables.
+       A "library" means a collection of software functions and/or data prepared to be conveniently linked with application programs (which use some of those functions and data) to form executables.
    </p>
    <p>
        The "Library", below, refers to any such software library or work which has been distributed under these terms. A "work based on the Library" means either the Library or any derivative work under copyright law: that is to say, a work containing the Library or a portion of it, either verbatim or with modifications and/or translated straightforwardly into another language. (Hereinafter, translation is included without limitation in the term "modification".)
@@ -374,10 +373,10 @@
        "Source code" for a work means the preferred form of the work for making modifications to it. For a library, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the library.
    </p>
    <p>
-       Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running a program using the Library is not restricted, and output from such a program is covered only if its contents constitute a work based on the Library (independent of the use of the Library in a tool for writing it). Whether that is true depends on what the Library does and what the program that uses the Library does.
+       Activities other than copying, distribution, and modification are not covered by this License; they are outside its scope. The act of running a program using the Library is not restricted, and output from such a program is covered only if its contents constitute a work based on the Library (independent of the use of the Library in a tool for writing it). Whether that is true depends on what the Library does and what the program that uses the Library does.
    </p>
    <p>
-       <strong>1.</strong> You may copy and distribute verbatim copies of the Library's complete source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and distribute a copy of this License along with the Library.
+       <strong>1.</strong> You may copy and distribute verbatim copies of the Library's complete source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and the absence of any warranty, and distribute a copy of this License along with the Library.
    </p>
    <p>
        You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
@@ -392,23 +391,23 @@
 
        <li><strong>c)</strong> You must cause the whole of the work to be licensed at no charge to all third parties under the terms of this License.</li>
 
-       <li><strong>d)</strong> If a facility in the modified Library refers to a function or a table of data to be supplied by an application program that uses the facility, other than as an argument passed when the facility is invoked, then you must make a good faith effort to ensure that, in the event an application does not supply such function or table, the facility still operates, and performs whatever part of its purpose remains meaningful.
+       <li><strong>d)</strong> If a facility in the modified Library refers to a function or a table of data to be supplied by an application program that uses the facility, other than as an argument passed when the facility is invoked, then you must make a good faith effort to ensure that, in the event, an application does not supply such function or table, the facility still operates, and performs whatever part of its purpose remains meaningful.
            <p>
                (For example, a function in a library to compute square roots has a purpose that is entirely well-defined independent of the application. Therefore, Subsection 2d requires that any application-supplied function or table used by this function must be optional: if the application does not supply it, the square root function must still compute square roots.)</p>
        </li>
    </ul>
 
    <p>
-       These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Library, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Library, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+       These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Library and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Library, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to every part regardless of who wrote it.
    </p>
    <p>
        Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Library.
    </p>
    <p>
-       In addition, mere aggregation of another work not based on the Library with the Library (or with a work based on the Library) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+       Besides, mere aggregation of another work not based on the Library with the Library (or with a work based on the Library) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
    </p>
    <p>
-       <strong>3.</strong> You may opt to apply the terms of the ordinary GNU General Public License instead of this License to a given copy of the Library. To do this, you must alter all the notices that refer to this License, so that they refer to the ordinary GNU General Public License, version 2, instead of to this License. (If a newer version than version 2 of the ordinary GNU General Public License has appeared, then you can specify that version instead if you wish.) Do not make any other change in these notices.
+       <strong>3.</strong> You may opt to apply the terms of the ordinary GNU General Public License instead of this License to a given copy of the Library. To do this, you must alter all the notices that refer to this License, so that they refer to the ordinary GNU General Public License, version 2, instead of to this License. (If a newer version than version 2 of the ordinary GNU General Public License has appeared, then you can specify that version instead if you wish.) Do not make any other changes to these notices.
    </p>
    <p>
        Once this change is made in a given copy, it is irreversible for that copy, so the ordinary GNU General Public License applies to all subsequent copies and derivative works made from that copy.
@@ -423,10 +422,10 @@
        If distribution of object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place satisfies the requirement to distribute the source code, even though third parties are not compelled to copy the source along with the object code.
    </p>
    <p>
-       <strong>5.</strong> A program that contains no derivative of any portion of the Library, but is designed to work with the Library by being compiled or linked with it, is called a "work that uses the Library". Such a work, in isolation, is not a derivative work of the Library, and therefore falls outside the scope of this License.
+       <strong>5.</strong> A program that contains no derivative of any portion of the Library, but is designed to work with the Library by being compiled or linked with it, is called a "work that uses the Library". Such a work, in isolation, is not a derivative work of the Library and therefore falls outside the scope of this License.
    </p>
    <p>
-       However, linking a "work that uses the Library" with the Library creates an executable that is a derivative of the Library (because it contains portions of the Library), rather than a "work that uses the library". The executable is therefore covered by this License. Section 6 states terms for distribution of such executables.
+       However, linking a "work that uses the Library" with the Library creates an executable that is a derivative of the Library (because it contains portions of the Library), rather than a "work that uses the library". The executable is therefore covered by this License. Section 6 states terms for the distribution of such executables.
    </p>
    <p>
        When a "work that uses the Library" uses material from a header file that is part of the Library, the object code for the work may be a derivative work of the Library even though the source code is not. Whether this is true is especially significant if the work can be linked without the Library, or if the work is itself a library. The threshold for this to be true is not precisely defined by law.
@@ -438,7 +437,7 @@
        Otherwise, if the work is a derivative of the Library, you may distribute the object code for the work under the terms of Section 6. Any executables containing that work also fall under Section 6, whether or not they are linked directly with the Library itself.
    </p>
    <p>
-       <strong>6.</strong> As an exception to the Sections above, you may also combine or link a "work that uses the Library" with the Library to produce a work containing portions of the Library, and distribute that work under terms of your choice, provided that the terms permit modification of the work for the customer's own use and reverse engineering for debugging such modifications.
+       <strong>6.</strong> As an exception to the Sections above, you may also combine or link a "work that uses the Library" with the Library to produce a work containing portions of the Library, and distribute that work under terms of your choice, provided that the terms permit modification of the work for the customer's use and reverse engineering for debugging such modifications.
    </p>
    <p>
        You must give prominent notice with each copy of the work that the Library is used in it and that the Library and its use are covered by this License. You must supply a copy of this License. If the work during execution displays copyright notices, you must include the copyright notice for the Library among them, as well as a reference directing the user to the copy of this License. Also, you must do one of these things:
@@ -448,11 +447,11 @@
        <li><strong>a)</strong> Accompany the work with the complete corresponding machine-readable source code for the Library including whatever changes were used in the work (which must be distributed under Sections 1 and 2 above); and, if the work is an executable linked with the Library, with the complete machine-readable "work that uses the Library", as object code and/or source code, so that the user can modify the Library and then relink to produce a modified executable containing the modified Library. (It is understood that the user who changes the contents of definitions files in the Library will not necessarily be able to recompile the application to use the modified definitions.)
        </li>
 
-       <li><strong>b)</strong> Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is one that (1) uses at run time a copy of the library already present on the user's computer system, rather than copying library functions into the executable, and (2) will operate properly with a modified version of the library, if the user installs one, as long as the modified version is interface-compatible with the version that the work was made with.</li>
+       <li><strong>b)</strong> Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is one that (1) uses at run time a copy of the Library already present on the user's computer system, rather than copying library functions into the executable, and (2) will operate properly with a modified version of the library, if the user installs one, as long as the modified version is interface-compatible with the version that the work was made with.</li>
 
        <li><strong>c)</strong> Accompany the work with a written offer, valid for at least three years, to give the same user the materials specified in Subsection 6a, above, for a charge no more than the cost of performing this distribution.</li>
 
-       <li><strong>d)</strong> If distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above specified materials from the same place.
+       <li><strong>d)</strong> If distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above-specified materials from the same place.
        </li>
 
        <li><strong>e)</strong> Verify that the user has already received a copy of these materials or that you have already sent this user a copy.</li>
@@ -462,7 +461,7 @@
        For an executable, the required form of the "work that uses the Library" must include any data and utility programs needed for reproducing the executable from it. However, as a special exception, the materials to be distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
    </p>
    <p>
-       It may happen that this requirement contradicts the license restrictions of other proprietary libraries that do not normally accompany the operating system. Such a contradiction means you cannot use both them and the Library together in an executable that you distribute.
+       This requirement may contradict the license restrictions of other proprietary libraries that do not normally accompany the operating system. Such a contradiction means you cannot use both them and the Library together in an executable that you distribute.
    </p>
    <p>
        <strong>7.</strong> You may place library facilities that are a work based on the Library side-by-side in a single library together with other library facilities not covered by this License, and distribute such a combined library, provided that the separate distribution of the work based on the Library and of the other library facilities is otherwise permitted, and provided that you do these two things:
@@ -471,20 +470,20 @@
    <ul>
        <li><strong>a)</strong> Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities. This must be distributed under the terms of the Sections above.</li>
 
-       <li><strong>b)</strong> Give prominent notice with the combined library of the fact that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.</li>
+       <li><strong>b)</strong> Give prominent notice with the combined library of the fact that part of it is a work based on the Library and explaining where to find the accompanying uncombined form of the same work.</li>
    </ul>
 
    <p>
        <strong>8.</strong> You may not copy, modify, sublicense, link with, or distribute the Library except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense, link with, or distribute the Library is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
    </p>
    <p>
-       <strong>9.</strong> You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Library or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Library (or any work based on the Library), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Library or works based on it.
+       <strong>9.</strong> You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Library or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Library (or any work based on the Library), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing, or modifying the Library or works based on it.
    </p>
    <p>
        <strong>10.</strong> Each time you redistribute the Library (or any work based on the Library), the recipient automatically receives a license from the original licensor to copy, distribute, link with or modify the Library subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties with this License.
    </p>
    <p>
-       <strong>11.</strong> If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Library at all. For example, if a patent license would not permit royalty-free redistribution of the Library by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Library.
+       <strong>11.</strong> If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement, or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Library at all. For example, if a patent license would not permit royalty-free redistribution of the Library by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Library.
    </p>
    <p>
        If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply, and the section as a whole is intended to apply in other circumstances.
@@ -496,22 +495,22 @@
        This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
    </p>
    <p>
-       <strong>12.</strong> If the distribution and/or use of the Library is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Library under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+       <strong>12.</strong> If the distribution and/or use of the Library is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Library under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such a case, this License incorporates the limitation as if written in the body of this License.
    </p>
    <p>
        <strong>13.</strong> The Free Software Foundation may publish revised and/or new versions of the Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
    </p>
    <p>
-       Each version is given a distinguishing version number. If the Library specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Library does not specify a license version number, you may choose any version ever published by the Free Software Foundation.
+       Each version is given a distinguishing version number. If the Library specifies a version number of this License that applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Library does not specify a license version number, you may choose any version ever published by the Free Software Foundation.
    </p>
    <p>
-       <strong>14.</strong> If you wish to incorporate parts of the Library into other free programs whose distribution conditions are incompatible with these, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+       <strong>14.</strong> If you wish to incorporate parts of the Library into other free programs whose distribution conditions are incompatible with these, write to the author to ask for permission. For software that is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
    </p>
    <p>
        <strong>NO WARRANTY</strong>
    </p>
    <p>
-       <strong>15.</strong> BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+       <strong>15.</strong> BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR, OR CORRECTION.
    </p>
    <p>
        <strong>16.</strong> IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
@@ -522,10 +521,10 @@
    <h3><a id="SEC4">How to Apply These Terms to Your New
    Libraries</a></h3>
    <p>
-       If you develop a new library, and you want it to be of the greatest possible use to the public, we recommend making it free software that everyone can redistribute and change. You can do so by permitting redistribution under these terms (or, alternatively, under the terms of the ordinary General Public License).
+       If you develop a new library, and you want it to be of the greatest possible use to the public, we recommend making it free software that everyone can redistribute and change. You can do so by permitting redistribution under these terms (or under the terms of the ordinary General Public License).
    </p>
    <p>
-       To apply these terms, attach the following notices to the library. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+       To apply these terms, attach the following notices to the library. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty, and each file should have at least the "copyright" line and a pointer to where the full notice is found.
    </p>
 
    <pre>
@@ -544,11 +543,11 @@
 
    You should have received a copy of the GNU Lesser General Public
    License along with this library; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 the USA
    </pre>
 
    <p>
-       Also add information on how to contact you by electronic and paper mail.
+       Also, additional information on how to contact you by electronic and paper mail.
    </p>
    <p>
        You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the library, if necessary. Here is a sample; alter the names:
@@ -575,25 +574,25 @@
        The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
    </p>
    <p>
-       THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+       THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS, OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
    </p>
    <h3>
        Freeware-Fossology
    </h3>
    <p>
-       Copying and distribution of this file, with or without modification, are permitted in any medium without royalty provided the copyright notice and this notice are preserved. This file is offered as-is, without any warranty.
+       Copying and distribution of this file, with or without modification, are permitted in any medium without royalty provided the copyright notice and this notice is preserved. This file is offered as-is, without any warranty.
    </p>
    <h3>
        Freeware
    </h3>
    <p>
-       Software classified as freeware is licensed at no cost and is either fully functional for an unlimited time; or has only basic functions enabled with a fully functional version available commercially or as shareware.[8] In contrast to free software, the author usually restricts one or more rights of the user, including the rights to use, copy, distribute, modify and make derivative works of the software or extract the source code.[1][2][9][10] The software license may impose various additional restrictions on the type of use, e.g. only for personal use, private use, individual use, non-profit use, non-commercial use, academic use, educational use, use in charity or humanitarian organizations, non-military use, use by public authorities or various other combinations of these type of restrictions.[11] For instance, the license may be "free for private, non-commercial use". The software license may also impose various other restrictions, such as restricted use over a network, restricted use on a server, restricted use in a combination with some types of other software or with some hardware devices, prohibited distribution over the Internet other than linking to author's website, restricted distribution without author's consent, restricted number of copies, etc.
+       Software classified as freeware is licensed at no cost and is either fully functional for an unlimited time, or have only basic functions enabled with a fully functional version available commercially or as shareware.[8] In contrast to free software, the author usually restricts one or more rights of the user, including the rights to use, copy, distribute, modify and make derivative works of the software or extract the source code.[1][2][9][10] The software license may impose various additional restrictions on the type of use, e.g. only for personal use, private use, individual use, non-profit use, non-commercial use, academic use, educational use, use in charity or humanitarian organizations, non-military use, use by public authorities or various other combinations of these type of restrictions.[11] For instance, the license may be "free for private, non-commercial use". The software license may also impose various other restrictions, such as restricted use over a network, restricted use on a server, restricted use in a combination with some types of other software or with some hardware devices, prohibited distribution over the Internet other than linking to author's website, restricted distribution without author's consent, restricted number of copies, etc.
    </p>
    <h3>
        Freeware
    </h3>
    <p>
-       Copying and distribution of this file, with or without modification, are permitted in any medium without royalty provided the copyright notice and this notice are preserved. This file is offered as-is, without any warranty.
+       Copying and distribution of this file, with or without modification, are permitted in any medium without royalty provided the copyright notice and this notice is preserved. This file is offered as-is, without any warranty.
    </p>
    <h3>
        BSD-3-Clause
@@ -602,10 +601,10 @@
        Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
    </p>
    <p>
-       1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+       1. Redistributions of source code must retain the above copyright notice, this list of conditions, and the following disclaimer.
    </p>
    <p>
-       2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+       2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions, and the following disclaimer in the documentation and/or other materials provided with the distribution.
    </p>
    <p>
        3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
@@ -618,17 +617,15 @@
    </h3>
    <pre>
    © Skype – Last revised: August 2009
-   © 2007 Hugh Jackman
-   copyrighted work of Comtrol Corporation and or its suppliers.
-   copyrighted by, proprietary to and a trade secret of ADAPTEC.
-   copyrighted by the Regents of the University of California, Sun Microsystems, Inc., Scriptics Corporation, ActiveState Corporation and other parties.
+   © 2007 Hugh Jackman copyrighted work of Comtrol Corporation and or its suppliers.
+   copyrighted by, proprietary to, and a trade secret of ADAPTEC.
+   copyrighted by the Regents of the University of California, Sun Microsystems, Inc., Scriptics Corporation, ActiveState Corporation, and other parties.
    copyrighted by Open Market, Inc (\"Open Market\").
    copyrighted by Open Market, Inc ("Open Market"). The following terms apply to all files associated with the Software and Documentation unless explicitly disclaimed in individual files.
    copyrighted by Object Computing, Inc., St. Louis Missouri, Copyright (C) 2002, all rights reserved.
    copyrighted by Fedora Project
    copyrighted by Dr. Douglas C. Schmidt and the Center for Distributed Object Computing ('DOC' group) at Washington University, Copyright (C) 1993 - 2002, all rights reserved.
-   copyrighted by Dr. Douglas C. Schmidt and the Center for Distributed
-   copyrighted by Douglas C. Schmidt and his research group at Washington University, University of California, Irvine, and Vanderbilt University, Copyright (c) 1993-2009, all rights reserved.
+   copyrighted by Dr. Douglas C. Schmidt and the Center for Distributed copyrighted by Douglas C. Schmidt and his research group at Washington University, University of California, Irvine, and Vanderbilt University, Copyright (c) 1993-2009, all rights reserved.
    copyrighted by Douglas C. Schmidt
    copyrighted by Daniel Stenberg
    copyright, i.e., \"Copyright (c) 2001-2002 Python Software Foundation; All Rights Reserved
@@ -642,17 +639,15 @@
    copyright of CERN.
    copyright is written, it is Taro Muraoka.
    copyright has been retained by Great Circle Associates.
-   copyright by the Free Software Foundation
-   copyright Copyright Agent tableofcontents
-   copyright CERN.
+   copyright by the Free Software Foundation copyright Copyright Agent table of contents copyright CERN.
    copyright 3dfx interactive, inc. 1999, all rights reserved
    copyright 1999-2010 by Andrew Plotkin.
    copyright 1989-2000 by Norman Ramsey. All rights reserved.
    copyright 1988 Richard M. Stallman
-   copyright (c) aaron seigo <aseigo kde.org>
-   copyright (c) 2013-2014 hewlett-packard development company, l.p.
+   copyright (c) Aaron Seigo <aseigo kde.org>
+   copyright (c) 2013-2014 Hewlett-Packard development company, l.p.
    copyright (c) 2006 Mike Mintz and Robert Ekendahl. All rights reserved.
-   copyright (c) 2003, 2004 nexB Inc. All rights are reserved.
+   copyright (c) 2003, 2004 next Inc. All rights are reserved.
    copyright (c) 2000 The Apache Software Foundation. All rights reserved.
    copyright (C) 1996-2010 Julian R Seward. All rights reserved.
    copyright (C) 1996-2000 by David Turner, Robert Wilhelm, and Werner Lemberg. All rights reserved except as specified below.
@@ -689,7 +684,7 @@
    Copyright \u00a9 1991-2016 Unicode, Inc.
    Copyright \u00a9 1991-2015 Unicode, Inc.
    Copyright \u00a9 1991,1990,1989 Carnegie Mellon University
-   Copyright Treaty of 1996, the WIPO Performances and Phonograms Treaty of 1996 and the Universal Copyright Convention (as revised on July 24, 1971).
+   Copyright Treaty of 1996, the WIPO Performances and Phonograms Treaty of 1996, and the Universal Copyright Convention (as revised on July 24, 1971).
    Copyright Treaty of 1996, the WIPO Performances and Phonograms Treaty of 1996 and
    Copyright TNG Technology Consulting GmbH 2016-2017, maximilian.huber@tngtech.com
    Copyright TNG Technology Consulting GmbH 2016, maximilian.huber@tngtech.com
@@ -887,13 +882,13 @@
    Copyright (c) 1990, 1993, 1994, 1995 The Regents of the University of California. All rights reserved.
    Copyright (c) 1989-2001 by Lucent Technologies
    Copyright (c) 1989, 1993 The Regents of the University of California. All rights reserved.
-   Copyright (c) 1989, 1993 Really just one newline here! The Regents of the University of California. All rights reserved.
+   Copyright (c) 1989, 1993 just one newline here! The Regents of the University of California. All rights reserved.
    Copyright (c) 1988-1997 Sam Leffler Copyright (c) 1991-1997 Silicon Graphics, Inc.
    Copyright (c) 1986 by University of Toronto. Written by Henry Spencer.
    Copyright (c) 1985, 1987, 1989, 1990, 1991, 1992, 1993, 1997 Adobe Systems Incorporated. All Rights Reserved.
    Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
    Copyright (C) Siemens AG 2017
-   Copyright (C) May, 2000 The Open Group, Metro Link, Incorporated and others. All Rights Reserved
+   Copyright (C) May 2000 The Open Group, Metro Link, Incorporated and others. All Rights Reserved
    Copyright (C) Borland/Inprise. All Rights Reserved.
    Copyright (C) 205 Siemens AG
    Copyright (C) 2019, Siemens AG Author: Gaurav Mishra <mishra.gaurav@siemens.com>
@@ -908,7 +903,7 @@
    Copyright (C) 2017-2019 Bittium Wireless Ltd.
    Copyright (C) 2017-2018, Siemens AG
    Copyright (C) 2017-2018 Siemens AG
-   Copyright (C) 2017, Siemens AG Author: Anuapm Ghosh
+   Copyright (C) 2017, Siemens AG Author: Anupam Ghosh
    Copyright (C) 2017, Siemens AG
    Copyright (C) 2017 TNG Technology Consulting GmbH Authors: Andreas Würl, Steffen Weber, Maximilian Huber
    Copyright (C) 2017 TNG Technology Consulting GmbH Author: Steffen Weber, Johannes Najjar, Maximilian Huber
@@ -1148,8 +1143,8 @@
    (c) Copyright 1992 by Panagiotis Tsirigotis
    (c) 2006 Amazon Digital Services, Inc. or its affiliates.
    (c) 2005 - Peter Nederlof Peterned - http://www.xs4all.nl/~peterned/ License - http://creativecommons.org/licenses/LGPL/2.1/
-   (C) copyright 2007-2011, 2013 my favourite company Google
-   (C) THE FRAMEWORX COMPANY 2003 http://opensource.org/licenses/frameworx.php'
+   (C) copyright 2007-2011, 2013 my favorite company Google
+   (C) THE FRAMEWORK COMPANY 2003 http://opensource.org/licenses/frameworx.php'
    (C) HEWLETT-PACKARD COMPANY, 2004.
    (C) Copyright 2017-2019 Bittium Wireless Ltd.
    (C) Copyright 2006-2015 Hewlett-Packard Development Company, L.P.
@@ -1157,7 +1152,7 @@
    (C) 2017 Michael C. Jaeger, mcj@mcj.de
    (C) 2008-2012 HP Development Company
    (C) 2008, Matt Taggart <taggart@debian.org>
-   (C) 2007-2011, 2013 my favourite company Google
+   (C) 2007-2011, 2013 my favorite company Google
    (C) 1988, 1989 by Adobe Systems Incorporated. All rights reserved.
    </pre></p>
 {% endblock %}

--- a/src/www/ui/template/about.html.twig
+++ b/src/www/ui/template/about.html.twig
@@ -53,7 +53,8 @@
    Copyright (C) 1989, 1991 Free Software Foundation, Inc.
    51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
-   Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+   Everyone is permitted to copy and distribute verbatim copies
+   of this license document, but changing it is not allowed.
    </pre>
 
    <h3 id="preamble"><a id="SEC2">Preamble</a></h3>
@@ -300,7 +301,7 @@
 
    <pre>
    Copyright (C) 1991, 1999 Free Software Foundation, Inc.
-   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 the USA
+   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
    Everyone is permitted to copy and distribute verbatim copies
    of this license document, but changing it is not allowed.
 
@@ -321,7 +322,7 @@
        When we speak of free software, we are referring to freedom of use, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish); that you receive source code or can get it if you want it; that you can change the software and use pieces of it in new free programs; and that you are informed that you can do these things.
    </p>
    <p>
-       To protect your rights, we need to make restrictions that forbid distributors to deny you these rights or asking you to surrender these rights. These restrictions translate to certain responsibilities for you if you distribute copies of the library or if you modify them.
+       To protect your rights, we need to make restrictions that forbid distributors to deny you these rights or to ask you to surrender these rights. These restrictions translate to certain responsibilities for you if you distribute copies of the library or if you modify it.
    </p>
    <p>
        For example, if you distribute copies of the library, whether gratis or for a fee, you must give the recipients all the rights that we gave you. You must make sure that they, too, receive or can get the source code. If you link other code with the library, you must provide complete object files to the recipients, so that they can relink them with the library after making changes to the library and recompiling it. And you must show them these terms so they know their rights.
@@ -447,11 +448,11 @@
        <li><strong>a)</strong> Accompany the work with the complete corresponding machine-readable source code for the Library including whatever changes were used in the work (which must be distributed under Sections 1 and 2 above); and, if the work is an executable linked with the Library, with the complete machine-readable "work that uses the Library", as object code and/or source code, so that the user can modify the Library and then relink to produce a modified executable containing the modified Library. (It is understood that the user who changes the contents of definitions files in the Library will not necessarily be able to recompile the application to use the modified definitions.)
        </li>
 
-       <li><strong>b)</strong> Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is one that (1) uses at run time a copy of the Library already present on the user's computer system, rather than copying library functions into the executable, and (2) will operate properly with a modified version of the library, if the user installs one, as long as the modified version is interface-compatible with the version that the work was made with.</li>
+       <li><strong>b)</strong> Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is one that (1) uses at run time a copy of the library already present on the user's computer system, rather than copying library functions into the executable, and (2) will operate properly with a modified version of the library, if the user installs one, as long as the modified version is interface-compatible with the version that the work was made with.</li>
 
        <li><strong>c)</strong> Accompany the work with a written offer, valid for at least three years, to give the same user the materials specified in Subsection 6a, above, for a charge no more than the cost of performing this distribution.</li>
 
-       <li><strong>d)</strong> If distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above-specified materials from the same place.
+       <li><strong>d)</strong> If distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above specified materials from the same place.
        </li>
 
        <li><strong>e)</strong> Verify that the user has already received a copy of these materials or that you have already sent this user a copy.</li>
@@ -543,7 +544,7 @@
 
    You should have received a copy of the GNU Lesser General Public
    License along with this library; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 the USA
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
    </pre>
 
    <p>
@@ -574,7 +575,7 @@
        The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
    </p>
    <p>
-       THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS, OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+       THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
    </p>
    <h3>
        Freeware-Fossology
@@ -617,15 +618,17 @@
    </h3>
    <pre>
    © Skype – Last revised: August 2009
-   © 2007 Hugh Jackman copyrighted work of Comtrol Corporation and or its suppliers.
-   copyrighted by, proprietary to, and a trade secret of ADAPTEC.
-   copyrighted by the Regents of the University of California, Sun Microsystems, Inc., Scriptics Corporation, ActiveState Corporation, and other parties.
+   © 2007 Hugh Jackman
+   copyrighted work of Comtrol Corporation and or its suppliers.
+   copyrighted by, proprietary to and a trade secret of ADAPTEC.
+   copyrighted by the Regents of the University of California, Sun Microsystems, Inc., Scriptics Corporation, ActiveState Corporation and other parties.
    copyrighted by Open Market, Inc (\"Open Market\").
    copyrighted by Open Market, Inc ("Open Market"). The following terms apply to all files associated with the Software and Documentation unless explicitly disclaimed in individual files.
    copyrighted by Object Computing, Inc., St. Louis Missouri, Copyright (C) 2002, all rights reserved.
    copyrighted by Fedora Project
    copyrighted by Dr. Douglas C. Schmidt and the Center for Distributed Object Computing ('DOC' group) at Washington University, Copyright (C) 1993 - 2002, all rights reserved.
-   copyrighted by Dr. Douglas C. Schmidt and the Center for Distributed copyrighted by Douglas C. Schmidt and his research group at Washington University, University of California, Irvine, and Vanderbilt University, Copyright (c) 1993-2009, all rights reserved.
+   copyrighted by Dr. Douglas C. Schmidt and the Center for Distributed
+   copyrighted by Douglas C. Schmidt and his research group at Washington University, University of California, Irvine, and Vanderbilt University, Copyright (c) 1993-2009, all rights reserved.
    copyrighted by Douglas C. Schmidt
    copyrighted by Daniel Stenberg
    copyright, i.e., \"Copyright (c) 2001-2002 Python Software Foundation; All Rights Reserved
@@ -639,15 +642,17 @@
    copyright of CERN.
    copyright is written, it is Taro Muraoka.
    copyright has been retained by Great Circle Associates.
-   copyright by the Free Software Foundation copyright Copyright Agent table of contents copyright CERN.
+   copyright by the Free Software Foundation
+   copyright Copyright Agent tableofcontents
+   copyright CERN.
    copyright 3dfx interactive, inc. 1999, all rights reserved
    copyright 1999-2010 by Andrew Plotkin.
    copyright 1989-2000 by Norman Ramsey. All rights reserved.
    copyright 1988 Richard M. Stallman
-   copyright (c) Aaron Seigo <aseigo kde.org>
-   copyright (c) 2013-2014 Hewlett-Packard development company, l.p.
+   copyright (c) aaron seigo <aseigo kde.org>
+   copyright (c) 2013-2014 hewlett-packard development company, l.p.
    copyright (c) 2006 Mike Mintz and Robert Ekendahl. All rights reserved.
-   copyright (c) 2003, 2004 next Inc. All rights are reserved.
+   copyright (c) 2003, 2004 nexB Inc. All rights are reserved.
    copyright (c) 2000 The Apache Software Foundation. All rights reserved.
    copyright (C) 1996-2010 Julian R Seward. All rights reserved.
    copyright (C) 1996-2000 by David Turner, Robert Wilhelm, and Werner Lemberg. All rights reserved except as specified below.
@@ -684,7 +689,7 @@
    Copyright \u00a9 1991-2016 Unicode, Inc.
    Copyright \u00a9 1991-2015 Unicode, Inc.
    Copyright \u00a9 1991,1990,1989 Carnegie Mellon University
-   Copyright Treaty of 1996, the WIPO Performances and Phonograms Treaty of 1996, and the Universal Copyright Convention (as revised on July 24, 1971).
+   Copyright Treaty of 1996, the WIPO Performances and Phonograms Treaty of 1996 and the Universal Copyright Convention (as revised on July 24, 1971).
    Copyright Treaty of 1996, the WIPO Performances and Phonograms Treaty of 1996 and
    Copyright TNG Technology Consulting GmbH 2016-2017, maximilian.huber@tngtech.com
    Copyright TNG Technology Consulting GmbH 2016, maximilian.huber@tngtech.com
@@ -882,13 +887,13 @@
    Copyright (c) 1990, 1993, 1994, 1995 The Regents of the University of California. All rights reserved.
    Copyright (c) 1989-2001 by Lucent Technologies
    Copyright (c) 1989, 1993 The Regents of the University of California. All rights reserved.
-   Copyright (c) 1989, 1993 just one newline here! The Regents of the University of California. All rights reserved.
+   Copyright (c) 1989, 1993 Really just one newline here! The Regents of the University of California. All rights reserved.
    Copyright (c) 1988-1997 Sam Leffler Copyright (c) 1991-1997 Silicon Graphics, Inc.
    Copyright (c) 1986 by University of Toronto. Written by Henry Spencer.
    Copyright (c) 1985, 1987, 1989, 1990, 1991, 1992, 1993, 1997 Adobe Systems Incorporated. All Rights Reserved.
    Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
    Copyright (C) Siemens AG 2017
-   Copyright (C) May 2000 The Open Group, Metro Link, Incorporated and others. All Rights Reserved
+   Copyright (C) May, 2000 The Open Group, Metro Link, Incorporated and others. All Rights Reserved
    Copyright (C) Borland/Inprise. All Rights Reserved.
    Copyright (C) 205 Siemens AG
    Copyright (C) 2019, Siemens AG Author: Gaurav Mishra <mishra.gaurav@siemens.com>
@@ -903,7 +908,7 @@
    Copyright (C) 2017-2019 Bittium Wireless Ltd.
    Copyright (C) 2017-2018, Siemens AG
    Copyright (C) 2017-2018 Siemens AG
-   Copyright (C) 2017, Siemens AG Author: Anupam Ghosh
+   Copyright (C) 2017, Siemens AG Author: Anuapm Ghosh
    Copyright (C) 2017, Siemens AG
    Copyright (C) 2017 TNG Technology Consulting GmbH Authors: Andreas Würl, Steffen Weber, Maximilian Huber
    Copyright (C) 2017 TNG Technology Consulting GmbH Author: Steffen Weber, Johannes Najjar, Maximilian Huber
@@ -1143,8 +1148,8 @@
    (c) Copyright 1992 by Panagiotis Tsirigotis
    (c) 2006 Amazon Digital Services, Inc. or its affiliates.
    (c) 2005 - Peter Nederlof Peterned - http://www.xs4all.nl/~peterned/ License - http://creativecommons.org/licenses/LGPL/2.1/
-   (C) copyright 2007-2011, 2013 my favorite company Google
-   (C) THE FRAMEWORK COMPANY 2003 http://opensource.org/licenses/frameworx.php'
+   (C) copyright 2007-2011, 2013 my favourite company Google
+   (C) THE FRAMEWORX COMPANY 2003 http://opensource.org/licenses/frameworx.php'
    (C) HEWLETT-PACKARD COMPANY, 2004.
    (C) Copyright 2017-2019 Bittium Wireless Ltd.
    (C) Copyright 2006-2015 Hewlett-Packard Development Company, L.P.
@@ -1152,7 +1157,7 @@
    (C) 2017 Michael C. Jaeger, mcj@mcj.de
    (C) 2008-2012 HP Development Company
    (C) 2008, Matt Taggart <taggart@debian.org>
-   (C) 2007-2011, 2013 my favorite company Google
+   (C) 2007-2011, 2013 my favourite company Google
    (C) 1988, 1989 by Adobe Systems Incorporated. All rights reserved.
    </pre></p>
 {% endblock %}


### PR DESCRIPTION
## Description

Fixed the grammatical error in the documentation of about fossology.

### Changes

Updated the file src/www/ui/template/about.html.twig

## How to test
http://localhost/repo/?mod=about
Check the updated document on this.

Issue
#1935 