### PR TITLE
updated the documentation link

### DIFF
--- a/src/lib/php/UI/Component/Menu.php
+++ b/src/lib/php/UI/Component/Menu.php
@@ -35,7 +35,7 @@ class Menu
     menu_insert("Main::Jobs", 60);
     menu_insert("Main::Organize", 50);
     menu_insert("Main::Help", -1);
-    menu_insert("Main::Help::Documentation", 0, NULL, NULL, NULL, "<a href='http://www.fossology.org/projects/fossology/wiki/User_Documentation'>Documentation</a>");
+    menu_insert("Main::Help::Documentation", 0, NULL, NULL, NULL, "<a href='https://github.com/fossology/fossology/wiki'>Documentation</a>");
     $this->renderer = $renderer;
   }
 


### PR DESCRIPTION
## Description

Earlier the documentation page is giving proxy error but now the link has been updated

### Changes

Updated the link with `https://github.com/fossology/fossology/wiki` on line no 38 in
/src/lib/php/UI/Component/Menu.php

## How to test

Go to Help>Documentation

Issue Reference
#1941 