### PR TITLE
feat(export) : Consolidating results per file or directories

### DIFF
--- a/src/www/ui/template/ui-export-list.html.twig
+++ b/src/www/ui/template/ui-export-list.html.twig
@@ -1,4 +1,5 @@
 {# Copyright 2016-2017,2020 Siemens AG
+   Copyright (c) 2021 LG Electronics Inc.
 
    Copying and distribution of this file, with or without modification,
    are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
@@ -73,6 +74,31 @@
             Exclude files containing some substring in the path. 'mac' and it should
             exclude all files and directories containing the substring 'mac'.
           </label>
+        </li>
+        <li>
+          <span>
+            {{ "Consolidate Results?"|trans }}
+          </span>
+          <ul>
+            <li>
+              <lable>
+                <input type="radio" name="consolidate" value="rawResult" {% if rawResult %}checked{% endif %}>
+                Print raw result per file.
+              </lable>
+            </li>
+            <li>
+              <lable>
+                <input type="radio" name="consolidate" value="perFile" {% if perFile %}checked{% endif %}>
+                Print consolidated result per file.
+              </lable>
+            </li>
+            <li>
+              <lable>
+                <input type="radio" name="consolidate" value="perDirectory" {% if perDirectory %}checked{% endif %}>
+                Print consolidated result per directory.
+              </lable>
+            </li>
+          </ul>
         </li>
         <li>
           <label>


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

1) Consolidate findings of scanners into one.
2) Consolidate findings per file into per directory

### Changes

UI at Export Lists is slightly changed. There are three options. 1) raw, 2) per file, 3) per directory.
For 2) and 3), list of licenses at each row on the license list are merged into one.
For 3), list of files that has same result is merged into one row.

The result will be provided both on the browser and downloaded CSV file.

## How to test

Go to an upload > Export Lists
Select one of option at '5. Consolidate Results?'
Generate list. (You can print it on the browser or download the list.)
