### PR TITLE
fix(uuid-ossp): Create extension as postgres

### DIFF
--- a/install/db/dbcreate.in
+++ b/install/db/dbcreate.in
@@ -36,6 +36,17 @@ if [ $? = 0 ]; then
          echo "ERROR: failed to add plpgsql to fossology database"
       fi
    fi
+   echo "*** Checking for 'uuid-ossp' support ***"
+   su postgres -c 'echo "SELECT * FROM pg_extension;" | psql -t fossology' |grep -q uuid-ossp
+   if [ $? = 0 ]; then
+      echo "NOTE: 'uuid-ossp' already exists in fossology database, good"
+   else
+      echo "NOTE: 'uuid-ossp' doesn't exist, adding"
+      su postgres -c 'echo "CREATE EXTENSION \"uuid-ossp\";" | psql fossology'
+      if [ $? != 0 ]; then
+         echo "ERROR: failed to add 'uuid-ossp' to fossology database"
+      fi
+   fi
 else
    echo "*** Initializing database ***"
    su postgres -c "psql < {$LIBEXECDIR}/fossologyinit.sql"

--- a/install/db/fossologyinit.sql
+++ b/install/db/fossologyinit.sql
@@ -3,7 +3,7 @@ create role fossy with createdb login password 'fossy';
 -- PostgreSQL database dump
 --
 
-SET client_encoding = 'SQL_ASCII';
+SET client_encoding = 'UTF8';
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 
@@ -11,7 +11,7 @@ SET client_min_messages = warning;
 -- Name: fossology; Type: DATABASE; Schema: -; Owner: fossy
 --
 
-CREATE DATABASE fossology WITH TEMPLATE = template0 ENCODING = 'SQL_ASCII';
+CREATE DATABASE fossology WITH TEMPLATE = template1 ENCODING = 'UTF8';
 
 
 ALTER DATABASE fossology OWNER TO fossy;
@@ -19,7 +19,7 @@ ALTER DATABASE fossology OWNER TO fossy;
 \connect fossology
 CREATE LANGUAGE plpgsql;
 
-SET client_encoding = 'SQL_ASCII';
+SET client_encoding = 'UTF8';
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";

--- a/src/lib/php/Test/fosstestinit.sql
+++ b/src/lib/php/Test/fosstestinit.sql
@@ -13,7 +13,7 @@ $$
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 
-CREATE DATABASE fosstest WITH TEMPLATE = template0; -- ENCODING = 'SQL_ASCII';
+CREATE DATABASE fosstest WITH TEMPLATE = template1; -- ENCODING = 'UTF8';
 
 ALTER DATABASE fosstest OWNER TO fossy;
 

--- a/src/lib/php/libschema.php
+++ b/src/lib/php/libschema.php
@@ -131,6 +131,27 @@ class fo_libschema
       }
     }
 
+    $sql_statement = "select extname from pg_extension where extname = 'uuid-ossp'";
+
+    $result = pg_query($PG_CONN, $sql_statement);
+    if (!$result) {
+      throw new Exception("Could not check the database for uuid-ossp extension");
+    }
+
+    $uuid_already_installed = false;
+    if ( pg_fetch_row($result) ) {
+      $uuid_already_installed = true;
+    }
+
+    // then create extension uuid-ossp if not already created
+    if ( $uuid_already_installed == false ) {
+      $sql_statement = 'CREATE EXTENSION "uuid-ossp";';
+      $result = pg_query($PG_CONN, $sql_statement);
+      if (!$result) {
+        throw new Exception("Could not create uuid-ossp extension in the database");
+      }
+    }
+
     $this->debug = $debug;
     if (!file_exists($filename)) {
       $errMsg = "$filename does not exist.";

--- a/src/testing/db/TestDbFactory.php
+++ b/src/testing/db/TestDbFactory.php
@@ -64,6 +64,13 @@ class TestDbFactory
         if ($cmdRtn != 0)
           throw new \Exception("ERROR: failed to add plpgsql to $dbName database");
       }
+      exec($cmd = "echo 'SELECT * FROM pg_extension;' | psql -Ufossy -h localhost -t $dbName | grep -q uuid-ossp", $cmdOut, $cmdRtn);
+      if ($cmdRtn != 0)
+      {
+        exec($cmd = "echo 'CREATE EXTENSION \"uuid-ossp\";' | psql -Ufossy -h localhost $dbName", $cmdOut, $cmdRtn);
+        if ($cmdRtn != 0)
+          throw new \Exception("ERROR: failed to add 'uuid-ossp' to $dbName database");
+      }
     } else
     {
       $fosstestSql = file_get_contents(dirname(__FILE__) . '/../../lib/php/Test/fosstestinit.sql');

--- a/src/testing/db/create_test_database.php
+++ b/src/testing/db/create_test_database.php
@@ -280,11 +280,7 @@ $test_db_name = "fossologytest_$testing_timestamp";
 $test_pg_conn = @pg_connect($initial_postgres_params)
     or die("FAIL: Could not connect to Postgres server!");
 
-// note: normal 'mortal' users cannot choose 'SQL_ASCII' encoding
-// unless the LC_CTYPE environment variable is set correctly
-//$sql_statement="CREATE DATABASE $test_db_name ENCODING='SQL_ASCII'";
-// In the long run, FOSSology should be using a UTF8 encoding for text
-$sql_statement="CREATE DATABASE $test_db_name ENCODING='UTF8' TEMPLATE template0";
+$sql_statement="CREATE DATABASE $test_db_name ENCODING='UTF8' TEMPLATE template1";
 $result = pg_query($test_pg_conn, $sql_statement)
     or die("FAIL: Could not create test database!\n");
 
@@ -327,6 +323,23 @@ if ( $plpgsql_already_installed == FALSE ) {
     $sql_statement = "CREATE LANGUAGE plpgsql";
     $result = pg_query($test_db_conn, $sql_statement)
         or die("Could not create plpgsql language in the database\n");
+}
+
+$sql_statement = "select extname from pg_extension where extname = 'uuid-ossp'";
+
+$result = pg_query($test_db_conn, $sql_statement)
+    or die("Could not check the database for uuid-ossp extension\n");
+
+$uuid_already_installed = FALSE;
+if ( $row = pg_fetch_row($result) ) {
+    $uuid_already_installed = TRUE;
+}
+
+// then create extension uuid-ossp if not already created
+if ( $uuid_already_installed == FALSE ) {
+    $sql_statement = 'CREATE EXTENSION "uuid-ossp";';
+    $result = pg_query($test_db_conn, $sql_statement)
+        or die("Could not create uuid-ossp extension in the database\n");
 }
 
 

--- a/src/testing/db/fosstestinit.sql
+++ b/src/testing/db/fosstestinit.sql
@@ -19,7 +19,7 @@ $$
 -- PostgreSQL database dump
 --
 
-SET client_encoding = 'SQL_ASCII';
+SET client_encoding = 'UTF8';
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 
@@ -27,7 +27,7 @@ SET client_min_messages = warning;
 -- Name: fosstest; Type: DATABASE; Schema: -; Owner: fossy
 --
 
-CREATE DATABASE fosstest WITH TEMPLATE = template0 ENCODING = 'SQL_ASCII';
+CREATE DATABASE fosstest WITH TEMPLATE = template1 ENCODING = 'UTF8';
 
 
 ALTER DATABASE fosstest OWNER TO fossy;
@@ -35,7 +35,7 @@ ALTER DATABASE fosstest OWNER TO fossy;
 \connect fosstest
 CREATE OR REPLACE LANGUAGE plpgsql;
 
-SET client_encoding = 'SQL_ASCII';
+SET client_encoding = 'UTF8';
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 

--- a/src/testing/db/ftdbcreate.sh
+++ b/src/testing/db/ftdbcreate.sh
@@ -42,12 +42,23 @@ if [ $? = 0 ]; then
          echo "ERROR: failed to add plpgsql to $dbname database"
       fi
    fi
+   echo "*** Checking for 'uuid-ossp' support ***"
+   su postgres -c "echo 'SELECT * FROM pg_extension;' | psql -t $dbname" |grep -q uuid-ossp
+   if [ $? = 0 ]; then
+      echo "NOTE: 'uuid-ossp' already exists in $dbname database, good"
+   else
+      echo "NOTE: 'uuid-ossp' doesn't exist, adding"
+      su postgres -c "echo 'CREATE EXTENSION \"uuid-ossp\";' | psql $dbname"
+      if [ $? != 0 ]; then
+         echo "ERROR: failed to add 'uuid-ossp' to $dbname database"
+      fi
+   fi
 else
    echo "sysconfdir from env is -> $SYSCONFDIR"
    echo "*** Initializing database ***"
    echo "testroot is->$TESTROOT"
    if [ -z $TESTROOT ]
-   then 
+   then
      TESTROOT=`pwd`;
      #echo "TESTROOT IS:$TESTROOT";
    #else
@@ -64,7 +75,7 @@ else
    else
        fossSql='fosstestinit.sql'
    fi
-  
+
    echo "DB: before su to postgres"
    su postgres -c "psql < ./$fossSql"
    if [ $? != 0 ] ; then

--- a/src/testing/utils/dbcreate
+++ b/src/testing/utils/dbcreate
@@ -31,6 +31,17 @@ if [ $? = 0 ]; then
          echo "ERROR: failed to add plpgsql to fosstest database"
       fi
    fi
+   echo "*** Checking for 'uuid-ossp' support ***"
+   su postgres -c 'echo "SELECT * FROM pg_extension;" | psql -t fosstest' |grep -q uuid-ossp
+   if [ $? = 0 ]; then
+      echo "NOTE: 'uuid-ossp' already exists in fossology database, good"
+   else
+      echo "NOTE: 'uuid-ossp' doesn't exist, adding"
+      su postgres -c 'echo "CREATE EXTENSION \"uuid-ossp\";" | psql fosstest'
+      if [ $? != 0 ]; then
+         echo "ERROR: failed to add 'uuid-ossp' to fossology database"
+      fi
+   fi
 else
    echo "*** Initializing database ***"
    su postgres -c "psql < testDBinit.sql"

--- a/src/testing/utils/testDBinit.sql
+++ b/src/testing/utils/testDBinit.sql
@@ -3,7 +3,7 @@ create role fossy with createdb login password 'fossy';
 -- PostgreSQL database dump
 --
 
-SET client_encoding = 'SQL_ASCII';
+SET client_encoding = 'UTF8';
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 
@@ -11,7 +11,7 @@ SET client_min_messages = warning;
 -- Name: fosstest; Type: DATABASE; Schema: -; Owner: fossy
 --
 
-CREATE DATABASE fosstest WITH TEMPLATE = template0 ENCODING = 'SQL_ASCII';
+CREATE DATABASE fosstest WITH TEMPLATE = template1 ENCODING = 'UTF8';
 
 
 ALTER DATABASE fosstest OWNER TO fossy;
@@ -19,9 +19,10 @@ ALTER DATABASE fosstest OWNER TO fossy;
 \connect fosstest
 CREATE LANGUAGE plpgsql;
 
-SET client_encoding = 'SQL_ASCII';
+SET client_encoding = 'UTF8';
 SET check_function_bodies = false;
 SET client_min_messages = warning;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 --
 -- Name: SCHEMA public; Type: COMMENT; Schema: -; Owner: postgres

--- a/utils/prepare-test
+++ b/utils/prepare-test
@@ -96,6 +96,7 @@ if echo ${WarnAccept} | grep -q -e "^[yY]$" ; then
   sudo chown "$(whoami)" /var/local/cache/fossology
   sudo mkdir -p /srv/fossologyTestRepo
   sudo chown "$(whoami)" /srv/fossologyTestRepo
+  sudo su postgres -c "echo 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";'|psql -d template1" || true
   if [[ "${CreateFossy}" == "Y" ]]; then
     sudo su postgres -c "echo \"CREATE USER fossy WITH PASSWORD 'fossy' CREATEDB;\"|psql" || true >/dev/null
     echo "localhost:*:*:fossy:fossy" >> ~/.pgpass


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Create the `uuid-ossp` extension as `postgres` user instead of `fossy`.

### Changes

Create he extension where the `plpgsql` was created as `postgres` user.

## How to test

On database without `uuid-ossp` extension (< 3.9.0 release).
Install fossology and run fo-postinstall.

The installation should finish without errors and extension `uuid-ossp` should be created.