### PR TITLE
fix(decision): Create clearing events for irrelevant folder decisions

### DIFF
--- a/src/www/ui/scripts/change-license-browse.js
+++ b/src/www/ui/scripts/change-license-browse.js
@@ -88,7 +88,7 @@ function markDecisions(uploadTreeIdForMultiple) {
       "decisionMark": uploadTreeIdForMultiple
     };
   }
-  resultEntity = $('bulkIdResult');
+  resultEntity = $('#bulkIdResult');
   $.ajax({
     type: "POST",
     url: "?mod=change-license-processPost",
@@ -104,7 +104,7 @@ function deleteMarkedDecisions(decisionToBeRemoved) {
     "uploadTreeId": $('#uploadTreeId').val(),
     "decisionMark": decisionToBeRemoved
   };
-  resultEntity = $('bulkIdResult');
+  resultEntity = $('#bulkIdResult');
     var txt;
     var pleaseConfirm = confirm("You are about to delete recent decisions. Please confirm!");
   if (pleaseConfirm == true) {

--- a/src/www/ui/scripts/change-license-common.js
+++ b/src/www/ui/scripts/change-license-common.js
@@ -2,7 +2,7 @@
  Copyright (C) 2014-2020, Siemens AG
  Authors: Daniele Fognini, Johannes Najjar, Steffen Weber,
           Andreas J. Reichel, Shaheem Azmal M MD
- 
+
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
  version 2 as published by the Free Software Foundation.
@@ -105,7 +105,10 @@ function scheduledDeciderSuccess (data, resultEntity, callbackSuccess, callbackC
 }
 
 function scheduledDeciderError (responseobject, resultEntity) {
-  var error = responseobject.responseJSON.error;
+  var error = false;
+  if (responseobject.responseJSON !== undefined) {
+    error = responseobject.responseJSON.error;
+  }
   if (error) {
     resultEntity.text("error: " + error);
   } else {
@@ -146,7 +149,7 @@ function scheduleBulkScanCommon(resultEntity, callbackSuccess) {
   if(isUserError(bulkActions, refText)) {
     return;
   }
-  
+
   var post_data = {
     "bulkAction": bulkActions,
     "refText": refText,


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

When someone marked a whole folder as irrelevant, the `clearing_event`s for the files went missing. This causes data inconsistency while getting the license for those `clearing_decision`s.

### Changes

1. Use `ClearingDecisionProcessor::makeDecisionFromLastEvents()` to generate `clearing_decision` and `clearing_event`.
2. The functions `markDirectoryAsDecisionTypeIfScannerDetected()` and `markDirectoryAsDecisionTypeIfUserEdited()` were no longer required to be separate and thus replaced with `markDirectoryAsDecisionTypeRec()`.
3. Handle errors in UI script if AJAX call fails.

## How to test

1. On old branch, upload a package and mark a folder as irrelevant using either `[Edit]` under Actions column or use the checkbox.
2. Check the clearing history for the files inside the folder, the license name will be missing.
3. Generate the Unified report and check the Irrelevant files table, the licenses will be missing from there as well.

1. Install the branch and repeat the steps above.
2. The clearing history should be correct and the unified report as well.
3. Repeat the test with `Mark decisions as do not use` button.
4. Try removing the decisions and check the clearing history/report.