### PR TITLE
feat(maintagent): add job to remove expired tokens from database

### DIFF
--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -451,6 +451,12 @@ function Populate_sysconfig()
   $valueArray[$variable] = array("'$variable'", "30", "'$patTokenValidityPrompt'",
     strval(CONFIG_TYPE_INT), "'PAT'", "1", "'$patTokenValidityDesc'", "null", "null");
 
+  $variable = "PATMaxPostExpiryRetention";
+  $patTokenRetentionPrompt = _('Max expired token retention period');
+  $patTokenRetentionDesc = _('Maximum retention period of expired tokens (in days) for Maintagent');
+  $valueArray[$variable] = array("'$variable'", "30", "'$patTokenRetentionPrompt'",
+    strval(CONFIG_TYPE_INT), "'PAT'", "2", "'$patTokenRetentionDesc'", "null", "null");
+
   $variable = "SkipFiles";
   $mimeTypeToSkip = _("Skip MimeTypes from scanning");
   $mimeTypeDesc = _("add  comma (,) separated mimetype to exclude files from scanning");

--- a/src/maintagent/agent/maintagent.c
+++ b/src/maintagent/agent/maintagent.c
@@ -98,9 +98,11 @@ int main(int argc, char **argv)
   int reIndexAllTablesExe = 0;
   int removeOrphanedRowsExe = 0;
   int removeOrphanedLogs = 0;
+  int removeExpiredTokensExe = 0;
+  int tokenRetentionPeriod = 30;
 
   /* command line options */
-  while ((cmdopt = getopt(argc, argv, "aAc:DEFghiILNpPRTUvVZ")) != -1)
+  while ((cmdopt = getopt(argc, argv, "aAc:DEFghiILNpPRt:TUvVZ")) != -1)
   {
     switch (cmdopt)
     {
@@ -242,6 +244,14 @@ int main(int argc, char **argv)
           removeUploadsExe = 1;
         }
         break;
+      case 't': /* Remove expired personal access token */
+        if (removeExpiredTokensExe == 0)
+        {
+          tokenRetentionPeriod = atol(optarg);
+          removeExpiredTokens(tokenRetentionPeriod);
+          removeExpiredTokensExe = 1;
+        }
+        break;      
       case 'T': /* Remove orphaned temp tables */
         if (removeTempsExe == 0)
         {

--- a/src/maintagent/agent/maintagent.h
+++ b/src/maintagent/agent/maintagent.h
@@ -67,5 +67,6 @@ void normalizeUploadPriorities();
 void reIndexAllTables();
 void removeOrphanedRows();
 void removeOrphanedLogFiles();
+void removeExpiredTokens();
 
 #endif /* _MAINTAGENT_H */

--- a/src/maintagent/agent/usage.c
+++ b/src/maintagent/agent/usage.c
@@ -41,6 +41,7 @@ FUNCTION void usage(char *name)
   printf("  -p   :: Verify file permissions (report only).\n");
   printf("  -P   :: Verify and fix file permissions.\n");
   printf("  -R   :: Remove uploads with no pfiles.\n");
+  printf("  -t # :: Remove personal access tokens expired # days ago.\n");
   printf("  -T   :: Remove orphaned temp tables.\n");
   printf("  -U   :: Process expired uploads (slow).\n");
   printf("  -Z   :: Remove orphaned files from the repository (slow).\n");

--- a/src/maintagent/ui/maintagent.php
+++ b/src/maintagent/ui/maintagent.php
@@ -51,6 +51,10 @@ class maintagent extends FO_Plugin {
     foreach ($_REQUEST as $key => $value) {
       if ($key == $value) {
         $options .= $value;
+        if ($key == "t") {
+          $retentionPeriod = $SysConf['SYSCONFIG']['PATMaxPostExpiryRetention'];
+          $options .= $retentionPeriod;
+        }
       }
     }
 
@@ -92,6 +96,7 @@ class maintagent extends FO_Plugin {
               //       "p"=>_("Verify file permissions (report only)."),
               //       "P"=>_("Verify and fix file permissions."),
                      "R"=>_("Remove uploads with no pfiles."),
+                     "t"=>_("Remove expired personal access tokens."),
                      "T"=>_("Remove orphaned temp tables."),
                      "D"=>_("Vacuum Analyze the database."),
               //       "U"=>_("Process expired uploads (slow)."),
@@ -117,7 +122,7 @@ class maintagent extends FO_Plugin {
     $V.= "<p>";
     $V.= _("More information about these operations can be found ");
     $text = _("here.");
-    $V.= "<a href=http://www.fossology.org/projects/fossology/wiki/Maintagent> $text </a>";
+    $V.= "<a href=https://github.com/fossology/fossology/wiki/Maintenance-Agent> $text </a>";
 
     $V.= "<input type=hidden name=queue value=true>";
 


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Created a new job in maintenance agent to clean inactive tokens from database which are expired X days ago.
Closes: #1303 

### Changes

- Added option to edit Max expired token retention period in Admin > Customize page
- Created option to trigger the new job from CLI by passing an additional parameter
- Option to trigger the job from GUI
- Fixed the broken link of Maintenance agent documentation

## How to test

- Run the agent from CLI ` sudo src/maintagent/agent/maintagent -t 30 `
- Run the agent from GUI
