### PR TITLE
feat(dbcreate): retry psql check while starting

### DIFF
--- a/install/db/dbcreate.in
+++ b/install/db/dbcreate.in
@@ -15,6 +15,17 @@ echo "*** Setting up the FOSSology database ***"
 # At some point this is where we could dynamically set the db password
 
 # first check that postgres is running
+psqln=0
+until [ "$psqln" -ge 10 ]; do
+   su postgres -c 'echo \\q|psql'
+   if [ $? = 0 ]; then
+      break
+   fi
+   echo "WARNING: postgresql isn't running. Retrying..."
+   sleep 15
+   psqln=$((psqln+1))
+done
+
 su postgres -c 'echo \\q|psql'
 if [ $? != 0 ]; then
    echo "ERROR: postgresql isn't running"


### PR DESCRIPTION
Sometimes when we stop and start the docker instance.
We get the following error message:
psql: FATAL:  the database system is starting up
ERROR: postgresql isn't running

It doesn't mean that the postgresql is not running.
It means postgresql is preparing to start.
So we might need to check for a while and wait.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

When we stop and start an instance of docker. We sometimes got the following log: 
```
*****************************************************
WARNING: No database host was set and therefore the
internal database without persistency will be used.
THIS IS NOT RECOMENDED FOR PRODUCTIVE USE!
*****************************************************
Starting PostgreSQL 9.6 database server: main.
*** Running postinstall for common actions***
*** Creating user and group ***
NOTE: group 'fossy' already exists, good.
NOTE: user 'fossy' already exists, good.
*** Making sure needed dirs exist with right ownership/permissions ***
*** clearing file cache ***
NOTE: Repository already exists at /srv/fossology/repository
NOTE: Running the PostgreSQL vacuum and analyze command can result in a large database performance improvement.
      We suggest that you either configure postgres to run its autovacuum and autoanalyze daemons, or maintagent -D in a cron job, or run Admin > Maintenance on a regular basis.
      Admin > Dashboard will show you the last time vacuum and analyze have been run.
*** Setting up the FOSSology database ***
psql: FATAL:  the database system is starting up
ERROR: postgresql isn't running
```


### Changes

We use psql check and if it fails, we will retry it with some delay several times.


## How to test

docker run -p 8081:80 fossology/fossology
docker stop <instance id>
docker start <instance id>