### PR TITLE
fix(docker-compose): Revert container port to 8081

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - FOSSOLOGY_SCHEDULER_HOST=scheduler
     command: web
     ports:
-      - 8082:80
+      - 8081:80
     depends_on:
       - db
       - scheduler


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Revert the port binding of web container created by docker-compose to 8081 as documented in the README.

### Changes

Change the port mapping from 8082 to 8081 for web container.

## How to test

Do `docker-compose up` and check if `http://localhost:8081/repo` opens FOSSology.

Closes #1977