### PR TITLE
remove wrong 'extern "C"'

### DIFF
--- a/src/lib/c/libfossdbmanager.h
+++ b/src/lib/c/libfossdbmanager.h
@@ -23,6 +23,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <stdarg.h>
 #include <glib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct fo_dbmanager_preparedstatement fo_dbManager_PreparedStatement;
 typedef struct fo_dbmanager fo_dbManager;
 
@@ -92,5 +96,9 @@ int fo_dbManager_exists(fo_dbManager* dbManager, const char* type, const char* n
 // visible for testing
 int fo_dbManager_parseParamStr(const char* paramtypes, GArray** params);
 char* fo_dbManager_printStatement(fo_dbManager_PreparedStatement* preparedStatement);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* LIBFOSSDBMANAGER_H */

--- a/src/lib/cpp/libfossdbQueryResult.hpp
+++ b/src/lib/cpp/libfossdbQueryResult.hpp
@@ -19,9 +19,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #ifndef LIBFOSSDBQUERYRESULT_HPP_
 #define LIBFOSSDBQUERYRESULT_HPP_
 
-extern "C" {
 #include "libfossdbmanager.h"
-}
 
 #include "uniquePtr.hpp"
 

--- a/src/lib/cpp/libfossdbmanagerclass.hpp
+++ b/src/lib/cpp/libfossdbmanagerclass.hpp
@@ -19,9 +19,7 @@
 #ifndef LIBFOSSDBMANAGERCLASS_HPP_
 #define LIBFOSSDBMANAGERCLASS_HPP_
 
-extern "C" {
 #include "libfossdbmanager.h"
-}
 
 #include <cstdarg>
 #include <vector>


### PR DESCRIPTION
glib headers may use C++ for some constructs, and they provide 'extern "C"' around the needed sections of there code already. Otherwise compilation may fail like this:

```
  In file included from /usr/include/glib-2.0/glib/gatomic.h:31,
                   from /usr/include/glib-2.0/glib/gthread.h:32,
                   from /usr/include/glib-2.0/glib/gasyncqueue.h:32,
                   from /usr/include/glib-2.0/glib.h:32,
                   from ../../../src/lib/c/libfossdbmanager.h:24,
                   from libfossdbmanagerclass.hpp:23,
                   from libfossAgentDatabaseHandler.cc:18:
  /usr/include/c++/10/type_traits:56:3: error: template with C linkage
     56 |   template<typename _Tp, _Tp __v>
        |   ^~~~~~~~
```
