### PR TITLE
feat(monkbulk): Configurable irrelevant file scan

### DIFF
--- a/src/decider/agent/BulkReuser.php
+++ b/src/decider/agent/BulkReuser.php
@@ -68,8 +68,8 @@ class BulkReuser
      */
     $deciderPlugin = plugin_find("agent_deciderjob");
     $dependecies = array();
-    $sql = "INSERT INTO license_ref_bulk (user_fk,group_fk,rf_text,upload_fk,uploadtree_fk) "
-            . "SELECT $1 AS user_fk, $2 AS group_fk,rf_text,$3 AS upload_fk, $4 as uploadtree_fk
+    $sql = "INSERT INTO license_ref_bulk (user_fk,group_fk,rf_text,upload_fk,uploadtree_fk,ignore_irrelevant) "
+            . "SELECT $1 AS user_fk, $2 AS group_fk,rf_text,$3 AS upload_fk, $4 as uploadtree_fk, ignore_irrelevant
               FROM license_ref_bulk WHERE lrb_pk=$5 RETURNING lrb_pk, $5 as lrb_origin";
     $sqlLic = "INSERT INTO license_set_bulk (lrb_fk, rf_fk, removing, comment, reportinfo, acknowledgement) "
             ."SELECT $1 as lrb_fk, rf_fk, removing, comment, reportinfo, acknowledgement FROM license_set_bulk WHERE lrb_fk=$2";

--- a/src/lib/php/Dao/LicenseDao.php
+++ b/src/lib/php/Dao/LicenseDao.php
@@ -550,15 +550,17 @@ ORDER BY lft asc
    * @param int $uploadTreeId
    * @param bool[] $licenseRemovals
    * @param string $refText
+   * @param bool $ignoreIrrelevant Ignore irrelevant files while scanning
    * @return int lrp_pk on success or -1 on fail
    */
-  public function insertBulkLicense($userId, $groupId, $uploadTreeId, $licenseRemovals, $refText)
+  public function insertBulkLicense($userId, $groupId, $uploadTreeId, $licenseRemovals, $refText, $ignoreIrrelevant=true)
   {
     $licenseRefBulkIdResult = $this->dbManager->getSingleRow(
-        "INSERT INTO license_ref_bulk (user_fk, group_fk, uploadtree_fk, rf_text)
-      VALUES ($1,$2,$3,$4) RETURNING lrb_pk",
+        "INSERT INTO license_ref_bulk (user_fk, group_fk, uploadtree_fk, rf_text, ignore_irrelevant)
+      VALUES ($1,$2,$3,$4,$5) RETURNING lrb_pk",
         array($userId, $groupId, $uploadTreeId,
-          StringOperation::replaceUnicodeControlChar($refText)),
+          StringOperation::replaceUnicodeControlChar($refText),
+          $this->dbManager->booleanToDb($ignoreIrrelevant)),
         __METHOD__ . '.getLrb'
     );
     if ($licenseRefBulkIdResult === false) {

--- a/src/monk/agent/database.h
+++ b/src/monk/agent/database.h
@@ -22,7 +22,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <libfossology.h>
 #include "highlight.h"
 
-PGresult* queryFileIdsForUploadAndLimits(fo_dbManager* dbManager, int uploadId, long left, long right, long groupId);
+#define DECISION_TYPE_FOR_IRRELEVANT 4
+
+PGresult* queryFileIdsForUploadAndLimits(fo_dbManager* dbManager, int uploadId,
+                                         long left, long right, long groupId,
+                                         bool ignoreIrre);
 PGresult* queryAllLicenses(fo_dbManager* dbManager);
 char* getLicenseTextForLicenseRefId(fo_dbManager* dbManager, long refId);
 int hasAlreadyResultsFor(fo_dbManager* dbManager, int agentId, long pFileId);

--- a/src/monk/agent/monkbulk.h
+++ b/src/monk/agent/monkbulk.h
@@ -48,6 +48,7 @@ typedef struct {
   int userId;
   int groupId;
   char* refText;
+  bool ignoreIrre;
   BulkAction** actions;
 } BulkArguments;
 

--- a/src/www/ui/change-license-bulk.php
+++ b/src/www/ui/change-license-bulk.php
@@ -108,12 +108,14 @@ class ChangeLicenseBulk extends DefaultPlugin
 
     $refText = $request->get('refText');
     $actions = $request->get('bulkAction');
+    $ignoreIrrelevantFiles = (intval($request->get('ignoreIrre')) == 1);
 
     $licenseRemovals = array();
     foreach ($actions as $licenseAction) {
       $licenseRemovals[$licenseAction['licenseId']] = array(($licenseAction['action']=='Remove'), $licenseAction['comment'], $licenseAction['reportinfo'], $licenseAction['acknowledgement']);
     }
-    $bulkId = $this->licenseDao->insertBulkLicense($userId, $groupId, $uploadTreeId, $licenseRemovals, $refText);
+    $bulkId = $this->licenseDao->insertBulkLicense($userId, $groupId,
+      $uploadTreeId, $licenseRemovals, $refText, $ignoreIrrelevantFiles);
 
     if ($bulkId <= 0) {
       throw new Exception('cannot insert bulk reference');

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -1159,6 +1159,10 @@
   $Schema["TABLE"]["license_ref_bulk"]["uploadtree_fk"]["ADD"] = "ALTER TABLE \"license_ref_bulk\" ADD COLUMN \"uploadtree_fk\" int8";
   $Schema["TABLE"]["license_ref_bulk"]["uploadtree_fk"]["ALTER"] = "ALTER TABLE \"license_ref_bulk\" ALTER COLUMN \"uploadtree_fk\" SET NOT NULL";
 
+  $Schema["TABLE"]["license_ref_bulk"]["ignore_irrelevant"]["DESC"] = "COMMENT ON COLUMN \"license_ref_bulk\".\"ignore_irrelevant\" IS 'Should the irrelevant files be ignored during scan?'";
+  $Schema["TABLE"]["license_ref_bulk"]["ignore_irrelevant"]["ADD"] = "ALTER TABLE \"license_ref_bulk\" ADD COLUMN \"ignore_irrelevant\" bool DEFAULT true";
+  $Schema["TABLE"]["license_ref_bulk"]["ignore_irrelevant"]["ALTER"] = "ALTER TABLE \"license_ref_bulk\" ALTER COLUMN \"ignore_irrelevant\" SET NOT NULL, ALTER COLUMN \"ignore_irrelevant\" SET DEFAULT true";
+
 
   $Schema["TABLE"]["license_set_bulk"]["rf_fk"]["DESC"] = "COMMENT ON COLUMN \"license_set_bulk\".\"rf_fk\" IS 'reference to license_ref* (not only license_ref)'";
   $Schema["TABLE"]["license_set_bulk"]["rf_fk"]["ADD"] = "ALTER TABLE \"license_set_bulk\" ADD COLUMN \"rf_fk\" int8";

--- a/src/www/ui/scripts/change-license-common.js
+++ b/src/www/ui/scripts/change-license-common.js
@@ -2,7 +2,7 @@
  Copyright (C) 2014-2020, Siemens AG
  Authors: Daniele Fognini, Johannes Najjar, Steffen Weber,
           Andreas J. Reichel, Shaheem Azmal M MD
- 
+
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
  version 2 as published by the Free Software Foundation.
@@ -146,13 +146,14 @@ function scheduleBulkScanCommon(resultEntity, callbackSuccess) {
   if(isUserError(bulkActions, refText)) {
     return;
   }
-  
+
   var post_data = {
     "bulkAction": bulkActions,
     "refText": refText,
     "bulkScope": $('#bulkScope').val(),
     "uploadTreeId": $('#uploadTreeId').val(),
-    "forceDecision": $('#forceDecision').is(':checked')?1:0
+    "forceDecision": $('#forceDecision').is(':checked')?1:0,
+    "ignoreIrre": $('#bulkIgnoreIrre').is(':checked') ? 1 : 0
   };
 
   resultEntity.hide();

--- a/src/www/ui/template/ui-clearing-view_bulk.html.twig
+++ b/src/www/ui/template/ui-clearing-view_bulk.html.twig
@@ -83,7 +83,13 @@
       <option value="u">{{ 'scan whole Upload'| trans }}</option>
       <option value="f">{{ 'scan only current Folder'| trans }}</option>
     </select><img src="images/info_16.png" style="vertical-align:middle !important;" title="{{ 'Scan whole upload or this folder determines the scope of files where the text phrase is searched for. If “scan whole upload” is selected, the text phrase is searched in all files of the entire upload'|trans }}" alt="" class="info-bullet"/>
-    <input type="checkbox" style="vertical-align:bottom;" id="forceDecision"/>{{ 'ignoreConflicts'|trans }}<img src="images/info_16.png" style="vertical-align:middle !important;" title="{{ 'The bulk scan will create a clearing result, if the resulting list of licenses does not show conflicts. A conflict would be two different license ids for example. Imagine Nomos has found “Apache-1.0” and a bulk scan finds a text phrase with Apache-2.0 set, this represents a conflict. Otherwise if Nomos found Apache-2.0 and the bulk scan find a text phrase with “Apache-2.0” set, this is free from conflicts and a clearing result is set. Normally conflicts prevent clearing results. Checking the “ignore conflicts” will set a clearing decision in any case'|trans }}" alt="" class="info-bullet"/>
+    <input type="checkbox" style="vertical-align:bottom;" id="forceDecision"/><label for="forceDecision">{{ 'ignoreConflicts'|trans }}<img src="images/info_16.png" style="vertical-align:middle !important;" title="{{ 'The bulk scan will create a clearing result, if the resulting list of licenses does not show conflicts. A conflict would be two different license ids for example. Imagine Nomos has found “Apache-1.0” and a bulk scan finds a text phrase with Apache-2.0 set, this represents a conflict. Otherwise if Nomos found Apache-2.0 and the bulk scan find a text phrase with “Apache-2.0” set, this is free from conflicts and a clearing result is set. Normally conflicts prevent clearing results. Checking the “ignore conflicts” will set a clearing decision in any case'|trans }}" alt="" class="info-bullet"/></label>
+    <input type="checkbox" style="vertical-align:bottom;" id="bulkIgnoreIrre" checked="checked"/>
+    <label for="bulkIgnoreIrre">
+      {{ 'Ignore Irrelevant files'|trans }}<img src="images/info_16.png"
+      style="vertical-align:middle !important;"
+      title="{{ 'Do not include files marked as irrevelant for this scan.'|trans }}" alt="" class="info-bullet"/>
+    </label>
     <br>
       <button type="button" onclick='cleanText();'>Clean text</button>
       <img src="images/info_16.png" style="vertical-align:middle;" title="{{ 'The matching process ignores comment symbols, e.g. double-slashes. Hence, these symbols can be remove from bulk text.'|trans }}" alt="" class="info-bullet"/>


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Allow user to choose if they want to ignore irrelevant files while doing a monkbulk scan or not.

### Changes

The existing scanner ignores irrelevant files by default but works on pfile. While inserting the data back, this pfile needs to be translated into `uploadtree_pk`. During this translation, if a pfile occurs multiple times and is marked as irrelevant in some places but not in other, will include all `uploadtree_pk` which is undesirable.

This PR fixes that by checking `clearing_decision` while inserting new results as well.

Also, depending on the user's selection of **Ignore Irrelevant files** checkbox, the queries will consider or ignore the `clearing_decision`.

![image](https://user-images.githubusercontent.com/18077542/117398646-65651300-af1c-11eb-8ab2-4dec489f3bc3.png)

## How to test

1. Upload a package where same file is copied in multiple folders.
2. Do a normal scan on the upload and mark some of the folders with duplicate file as irrelevant.
3. In other files, run the monkbulk scan ignoring irrelevant files.
    - The files marked as irrelevant should not be effected by this scan.
4. Run the monkbulk again, this time not ignoring the irrelevant files.
    - The irrelevant files should get this new result as well.
5. Try to reuse this upload with **"... bulk phrases from reused packages"** on decider and see if the ignoring of irrelevant files work there too.