### PR TITLE
fix(test): Add new assignee attribute to REST

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -86,7 +86,7 @@ phpvendors:
 composer_install:
 	@echo "current dir: '$${PWD}'"
 	$(INSTALL_DATA) composer.json composer.lock $(DESTDIR)$(MODDIR)
-	(cd $(DESTDIR)$(MODDIR); export COMPOSER_HOME=/dev/null; $(COMPOSER_PHAR) install --no-plugins --no-scripts --no-dev)
+	(cd $(DESTDIR)$(MODDIR); export COMPOSER_HOME=/dev/null; export COMPOSER_ALLOW_SUPERUSER=1; $(COMPOSER_PHAR) install --no-plugins --no-scripts --no-dev)
 	if ! patch --reverse --silent --force --dry-run $(DESTDIR)$(MODDIR)/vendor/easyrdf/easyrdf/lib/EasyRdf/Parser/RdfXml.php $(TOP)/RdfXml.php.patch; then \
 		patch --silent --force $(DESTDIR)$(MODDIR)/vendor/easyrdf/easyrdf/lib/EasyRdf/Parser/RdfXml.php $(TOP)/RdfXml.php.patch; \
 	fi

--- a/src/www/ui_tests/api/Controllers/UploadControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadControllerTest.php
@@ -236,7 +236,7 @@ class UploadControllerTests extends \PHPUnit\Framework\TestCase
     }
     $hash = new Hash('sha1checksum', 'md5checksum', 'sha256checksum', $fileSize);
     return new Upload($folderId, $folderName, $id, $description,
-      $uploadName, $uploadDate, $hash);
+      $uploadName, $uploadDate, null, $hash);
   }
 
   /**

--- a/src/www/ui_tests/api/Models/SearchResultTest.php
+++ b/src/www/ui_tests/api/Models/SearchResultTest.php
@@ -40,7 +40,8 @@ class SearchResultTest extends \PHPUnit\Framework\TestCase
   public function testDataFormat()
   {
     $hash = new Hash('sha1checksum', 'md5checksum', 'sha256checksum', 123123);
-    $upload = new Upload(2, 'root', 3, '', 'my.tar.gz', '01-01-2020', $hash);
+    $upload = new Upload(2, 'root', 3, '', 'my.tar.gz', '01-01-2020', null,
+      $hash);
     $expectedResult = [
       'upload'        => $upload->getArray(),
       'uploadTreeId'  => 12,

--- a/src/www/ui_tests/api/Models/UploadSummaryTest.php
+++ b/src/www/ui_tests/api/Models/UploadSummaryTest.php
@@ -41,6 +41,7 @@ class UploadSummaryTest extends \PHPUnit\Framework\TestCase
     $expected = [
       "id"                      => 5,
       "uploadName"              => 'test.tar.gz',
+      "assignee"                => 3,
       "mainLicense"             => 'MIT',
       "uniqueLicenses"          => 5,
       "totalLicenses"           => 25,
@@ -55,6 +56,7 @@ class UploadSummaryTest extends \PHPUnit\Framework\TestCase
     $actual = new UploadSummary();
     $actual->setUploadId(5);
     $actual->setUploadName('test.tar.gz');
+    $actual->setAssignee(3);
     $actual->setMainLicense('MIT');
     $actual->setUniqueLicenses(5);
     $actual->setTotalLicenses(25);

--- a/src/www/ui_tests/api/Models/UploadTest.php
+++ b/src/www/ui_tests/api/Models/UploadTest.php
@@ -39,7 +39,7 @@ class UploadTest extends \PHPUnit\Framework\TestCase
   public function testDataFormat()
   {
     $hash = new Hash('sha1checksum', 'md5checksum', 'sha256checksum', 123123);
-    $upload = new Upload(2, 'root', 3, '', 'my.tar.gz', '01-01-2020', $hash);
+    $upload = new Upload(2, 'root', 3, '', 'my.tar.gz', '01-01-2020', 3, $hash);
     $expectedUpload = [
       "folderid"    => 2,
       "foldername"  => 'root',
@@ -47,10 +47,11 @@ class UploadTest extends \PHPUnit\Framework\TestCase
       "description" => '',
       "uploadname"  => 'my.tar.gz',
       "uploaddate"  => '01-01-2020',
+      "assignee"    => 3,
       "hash"        => $hash->getArray()
     ];
 
-    $actualUpload = new Upload(2, 'root', 3, '', 'my.tar.gz', '01-01-2020',
+    $actualUpload = new Upload(2, 'root', 3, '', 'my.tar.gz', '01-01-2020', 3,
       $hash);
 
     $this->assertEquals($expectedUpload, $actualUpload->getArray());


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add the new "assignee" attribute to "Upload" and "UploadSummary" objects in REST API test cases.

Added new envar `COMPOSER_ALLOW_SUPERUSER` to allow composer 2 to run under root user.

### Changes

1. Fix REST API test cases.
2. Add `COMPOSER_ALLOW_SUPERUSER` to `composer_install` make target allowing root user to run composer.

## How to test

Check travis test logs.