### PR TITLE
chore(os): Drop xenial support for eol

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -17,7 +17,6 @@ jobs:
           - 'debian:buster'
           - 'debian:stretch'
           - 'ubuntu:bionic'
-          - 'ubuntu:xenial'
           - 'ubuntu:focal'
 
     runs-on: ubuntu-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,21 @@
-# Copyright Siemens AG, 2014-2019
-# SPDX-License-Identifier: GPL-2.0 LGPL-2.1
+# Copyright Siemens AG, 2014-2021
+# SPDX-License-Identifier: GPL-2.0 AND LGPL-2.1
 
 # build FOSSology on Travis CI - https://travis-ci.org/
 
 language: php
-dist: xenial
+dist: bionic
 os: linux
-php: 7.0
+php: 7.1
 cache:
   ccache: true
   directories:
     - $HOME/.composer
 env:
   global:
-    - PATH="/usr/lib/ccache/:$PATH"
+    - PATH="/usr/lib/ccache/:$TRAVIS_BUILD_DIR/src/ununpack/agent/:$PATH"
     - COMPOSER_HOME="$HOME/.composer/"
+    - PGPORT=5432
 
 addons:
   apt:
@@ -51,6 +52,7 @@ addons:
       - upx-ucl
       - libicu-dev
       - libgcrypt20-dev
+      - cppcheck
 
 services: postgresql
 
@@ -67,15 +69,15 @@ jobs:
         - src/testing/docker/test-standalone.sh
 #### C/C++ agent tests ###########################
     - &compiler-tests
-      env: CC=gcc-5 CXX=g++-5 CFLAGS='-Wall'
+      env: CC=gcc-6 CXX=g++-6 CFLAGS='-Wall'
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
           packages:
             - *default_packages
-            - gcc-5
-            - g++-5
+            - gcc-6
+            - g++-6
       install:
         - composer install --prefer-dist --working-dir=src
         - ./install/scripts/install-spdx-tools.sh
@@ -88,21 +90,11 @@ jobs:
       after_success:
         - ccache -s
     - <<: *compiler-tests
-      env: CC=gcc-6 CXX=g++-6 CFLAGS='-Wall'
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - *default_packages
-            - gcc-6
-            - g++-6
-    - <<: *compiler-tests
       env: CC=gcc-7 CXX=g++-7 CFLAGS='-Wall'
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
           packages:
             - *default_packages
             - gcc-7
@@ -112,7 +104,7 @@ jobs:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
           packages:
             - *default_packages
             - gcc-8
@@ -122,35 +114,45 @@ jobs:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
           packages:
             - *default_packages
             - gcc-9
             - g++-9
     - <<: *compiler-tests
-      env: CC=gcc-6 CXX=g++-6 CFLAGS='-Wall' PGPORT=5432
+      env: CC=gcc-10 CXX=g++-10 CFLAGS='-Wall'
       addons:
-        postgresql: "10"
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
           packages:
             - *default_packages
-            - gcc-6
-            - g++-6
-            - postgresql-10
-            - postgresql-client-10
+            - gcc-10
+            - g++-10
+    - <<: *compiler-tests
+      env: CC=gcc-10 CXX=g++-10 CFLAGS='-Wall'
+      addons:
+        postgresql: "13"
+        apt:
+          sources:
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
+          packages:
+            - *default_packages
+            - gcc-10
+            - g++-10
+            - postgresql-13
+            - postgresql-client-13
       before_script: &postgres-before-script
         # Use default port
-        - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/10/main/postgresql.conf
-        # Use 9.6 auth config:
-        - sudo cp /etc/postgresql/{9.5,10}/main/pg_hba.conf
+        - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/13/main/postgresql.conf
+        # Use 10 auth config:
+        - sudo cp /etc/postgresql/{10,13}/main/pg_hba.conf
         - sudo service postgresql restart
         - *default-before-script
 #### PHPUnit tests ###########################
     - &php7-phpunit-tests
       addons: {}
-      php: 7.0
+      php: 7.1
       install: composer update --ignore-platform-reqs --with-dependencies --prefer-dist --working-dir=src phpunit/phpunit
       before_script: ./utils/prepare-test -afty
       script:
@@ -158,21 +160,21 @@ jobs:
         - make build-lib VERSIONFILE build-cli
         - phpdbg -qrr src/vendor/bin/phpunit -csrc/phpunit.xml --testsuite="Fossology PhpUnit Test Suite" --colors=always | grep -v 'script>\|c.log'
       after_success: php src/vendor/bin/php-coveralls -vv -o coveralls.json -x clover.xml
-    - &php71-phpunit-tests
-      <<: *php7-phpunit-tests
-      php: 7.1
     - <<: *php7-phpunit-tests
       php: 7.2
     - <<: *php7-phpunit-tests
       php: 7.3
     - <<: *php7-phpunit-tests
-      php: 7.2
-      env: PGPORT=5432
+      php: 7.4
       addons:
-        postgresql: "10"
+        postgresql: "13"
         apt:
           packages:
-            - postgresql-10
-            - postgresql-client-10
+            - postgresql-13
+            - postgresql-client-13
             - *default_packages
+      script:
+        - set -o pipefail
+        - make build-lib VERSIONFILE build-cli
+        - ./src/vendor/bin/phpunit -csrc/phpunit.xml --testsuite="Fossology PhpUnit Test Suite" --colors=always
       before_script: *postgres-before-script

--- a/Makefile.conf
+++ b/Makefile.conf
@@ -137,8 +137,8 @@ FO_CXXLDFLAGS = -lfossologyCPP -L$(CXXFOLIBDIR) -lstdc++ $(FO_LDFLAGS) \
                 $(shell pkg-config --libs icu-uc)
 
 # define VERSION and COMMIT_ID
-VERSION_PATTERN = '\([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+\)\(-?rc[[:digit:]]+\)?-\([[:digit:]]+\)-[[:alnum:]]*'
-VERSION = $(shell git describe --tags > /dev/null 2>&1 && git describe --tags | head -1 | sed -re 's/$(VERSION_PATTERN)/\1.\3\2/' || echo "unknown")
+VERSION_PATTERN = '\([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+\)\(-?rc[[:digit:]]+\)?-?\([[:digit:]]*\)-?[[:alnum:]]*'
+VERSION = $(shell git describe --tags > /dev/null 2>&1 && git describe --tags | head -1 | sed -re 's/$(VERSION_PATTERN)/\1.\3\2/' | sed -re 's/\.$$/.0/' || echo "unknown")
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD > /dev/null 2>&1 && git rev-parse --abbrev-ref HEAD | head -1 || echo "unknown")
 COMMIT_HASH=$(shell git show > /dev/null 2>&1 && git show | head -1 | awk '{print substr($$2,1,6)}' || echo "unknown")
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -62,7 +62,7 @@ sudo systemctl daemon-reload
 SCRIPT
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/focal64"
   config.vm.post_up_message = $post_up_message
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ".", "/fossology"

--- a/src/copyright/mod_deps
+++ b/src/copyright/mod_deps
@@ -101,8 +101,6 @@ if [[ $RUNTIME ]]; then
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.62.0;;
         buster|sid)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.67.0;;
-        xenial)
-          apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.58.0;;
         bionic)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.65.1;;
         focal)

--- a/src/lib/php/Dao/LicenseDao.php
+++ b/src/lib/php/Dao/LicenseDao.php
@@ -361,7 +361,7 @@ ORDER BY lft asc
     $pathStack = array($row['ufile_name']);
     $rgtStack = array($row['rgt']);
     $lastLft = $row['lft'];
-    $path = implode($pathStack,'/');
+    $path = implode('/', $pathStack);
     $this->addToLicensesPerFileName($licensesPerFileName, $path, $row, $ignore, $clearingDecisionsForLicList);
     while ($row = $this->dbManager->fetchArray($result)) {
       if (!empty($excluding) && false!==strpos("/$row[ufile_name]/", $excluding)) {
@@ -373,7 +373,7 @@ ORDER BY lft asc
       }
 
       $this->updateStackState($pathStack, $rgtStack, $lastLft, $row);
-      $path = implode($pathStack,'/');
+      $path = implode('/', $pathStack);
       $this->addToLicensesPerFileName($licensesPerFileName, $path, $row, $ignore, $clearingDecisionsForLicList);
     }
     $this->dbManager->freeResult($result);

--- a/src/lib/php/Util/StringOperation.php
+++ b/src/lib/php/Util/StringOperation.php
@@ -30,7 +30,7 @@ class StringOperation
     $headLength = 0;
     $maxNumberOfCharsToCompare = min(strlen($a), strlen($b));
     while ($headLength < $maxNumberOfCharsToCompare &&
-      $a{$headLength} === $b{$headLength}) {
+      $a[$headLength] === $b[$headLength]) {
       $headLength += 1;
     }
     return substr($a,0,$headLength);

--- a/src/mimetype/agent_tests/Functional/cliParamsTest4Mimetype.php
+++ b/src/mimetype/agent_tests/Functional/cliParamsTest4Mimetype.php
@@ -101,7 +101,7 @@ class cliParamsTest4Mimetype extends \PHPUnit\Framework\TestCase {
     global $EXE_PATH;
     global $PG_CONN;
 
-    $mimeType1 = "application/x-executable";
+    $mimeType1 = "application/x-sharedlib";
     /* delete test data pre testing */
     $sql = "DELETE FROM mimetype where mimetype_name in ('$mimeType1');";
     $result = pg_query($PG_CONN, $sql);

--- a/src/nomos/mod_deps
+++ b/src/nomos/mod_deps
@@ -92,8 +92,6 @@ if [[ $RUNTIME ]]; then
   case "$DISTRO" in
     Debian|Ubuntu)
       case "$CODENAME" in
-        xenial)
-          apt-get $YesOpt install libjson-c2;;
         stretch|buster|sid|bionic|cosmic)
           apt-get $YesOpt install libjson-c3;;
         focal)

--- a/src/ojo/mod_deps
+++ b/src/ojo/mod_deps
@@ -102,8 +102,6 @@ if [[ $RUNTIME ]]; then
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.62.0 libboost-program-options1.62.0 libboost-regex1.62.0;;
         buster)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.67.0 libboost-program-options1.67.0 libboost-regex1.67.0;;
-        xenial)
-          apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.58.0 libboost-program-options1.58.0 libboost-regex1.58.0;;
         bionic)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.65.1 libboost-program-options1.65.1 libboost-regex1.65.1;;
         sid)

--- a/src/ununpack/agent_tests/Functional/cliParamsTest4UnunpackNormal.php
+++ b/src/ununpack/agent_tests/Functional/cliParamsTest4UnunpackNormal.php
@@ -476,15 +476,15 @@ class cliParamsTest4Ununpack extends \PHPUnit\Framework\TestCase
    * -# Check if the contents of file get unpacked
    * @todo Uncertain how the unpack results looks like
    */
-  function testNormalUpx(){
-    global $TEST_DATA_PATH;
-    global $TEST_RESULT_PATH;
+//   function testNormalUpx(){
+//     global $TEST_DATA_PATH;
+//     global $TEST_RESULT_PATH;
 
     //$command = "$this->UNUNPACK_PATH -qCR $TEST_DATA_PATH/".
     //            " -d $TEST_RESULT_PATH";
     //exec($command);
     //$this->assertFileExists("$TEST_RESULT_PATH/");
-  }
+//   }
 
   /**
    * @brief Check for disk images (file systems)
@@ -501,7 +501,7 @@ class cliParamsTest4Ununpack extends \PHPUnit\Framework\TestCase
                   "ext2file.fs -d $TEST_RESULT_PATH";
     exec($command);
     /* check if the result is ok? select one file to confirm */
-    $this->assertFileExists("$TEST_RESULT_PATH/ext2file.fs.dir/test.zip.dir/ununpack");
+    $this->assertFileExists("$TEST_RESULT_PATH/ext2file.fs.dir/testtwo.zip.dir/test.zip.dir/ununpack");
 
     // delete the directory ./test_result
     exec("/bin/rm -rf $TEST_RESULT_PATH");
@@ -512,7 +512,7 @@ class cliParamsTest4Ununpack extends \PHPUnit\Framework\TestCase
                   "ext3file.fs -d $TEST_RESULT_PATH";
     exec($command);
     /* check if the result is ok? select one file to confirm */
-    $this->assertFileExists("$TEST_RESULT_PATH/ext3file.fs.dir/test.zip.dir/ununpack");
+    $this->assertFileExists("$TEST_RESULT_PATH/ext3file.fs.dir/testtwo.zip.dir/test.zip.dir/ununpack");
 
     // delete the directory ./test_result
     exec("/bin/rm -rf $TEST_RESULT_PATH");
@@ -534,7 +534,7 @@ class cliParamsTest4Ununpack extends \PHPUnit\Framework\TestCase
                   "ntfsfile.fs -d $TEST_RESULT_PATH";
     exec($command);
     /* check if the result is ok? select one file to confirm */
-    $this->assertFileExists("$TEST_RESULT_PATH/ntfsfile.fs.dir/test.zip.dir/ununpack");
+    $this->assertFileExists("$TEST_RESULT_PATH/ntfsfile.fs.dir/testtwo.zip.dir/test.zip.dir/ununpack");
   }
 
   /* unpack boot x-x86_boot image, to-do, do not confirm

--- a/utils/fo-debuild
+++ b/utils/fo-debuild
@@ -62,7 +62,7 @@ eval set -- "$OPTS"
 
 while true; do
    case "$1" in
-      -s|--no-sign)     NOSIGN="-us -uc"; shift;;
+      -s|--no-sign)     NOSIGN="--no-sign" shift;;
       -h|--help)        show_help; exit;;
       -t|--no-tar)      NOTAR="1"; shift;;
       --)               shift; break;;

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -107,7 +107,7 @@ if [[ $BUILDTIME ]]; then
             libboost-program-options-dev libpq-dev composer patch devscripts \
             libdistro-info-perl
          case "$CODENAME" in
-           xenial|stretch)
+           stretch)
              apt-get $YesOpt install php-mbstring php7.0-cli php7.0-xml php7.0-zip php7.0-gd;;
            buster)
              apt-get $YesOpt install php-mbstring php7.3-cli php7.3-xml php7.3-zip php7.3-gd;;
@@ -120,8 +120,6 @@ if [[ $BUILDTIME ]]; then
          esac
          if ! dpkg --get-selections | grep -q postgresql-server-dev; then  ## if postgresql-server-dev is not installed
            case "$CODENAME" in
-              xenial)
-                apt-get $YesOpt install postgresql-server-dev-9.5;;
               stretch)
                 apt-get $YesOpt install postgresql-server-dev-9.6;;
               buster)
@@ -175,10 +173,6 @@ if [[ $RUNTIME ]]; then
             subversion git \
             dpkg-dev
          case "$CODENAME" in
-            xenial)
-               apt-get $YesOpt install postgresql-9.5 php7.0 php7.0-pgsql libapache2-mod-php7.0 php7.0-pgsql \
-                 php7.0-cli php7.0-curl php7.0-mbstring php7.0-zip php-gettext s-nail libboost-program-options1.58.0 \
-                 libboost-regex1.58.0 libicu55;;
             stretch)
                apt-get $YesOpt install postgresql-9.6 php7.0 php7.0-pgsql libapache2-mod-php7.0 php7.0-pgsql \
                  php7.0-cli php7.0-curl php7.0-xml php7.0-zip php7.0-mbstring php-gettext s-nail libboost-program-options1.62.0 \

--- a/utils/utils.sh
+++ b/utils/utils.sh
@@ -52,5 +52,5 @@ Usage: mod_deps [options]
 EOF
 }
 
-VERSION_PATTERN='([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+)(-?rc[[:digit:]]+)?-([[:digit:]]+)-[[:alnum:]]*'
-VERSION_COMMAND="git describe --tags > /dev/null 2>&1 && git describe --tags | head -1 | sed -re 's/${VERSION_PATTERN}/\\1.\\3\\2/'"
+VERSION_PATTERN='([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+)(-?rc[[:digit:]]+)?-?([[:digit:]]*)-?[[:alnum:]]*'
+VERSION_COMMAND="git describe --tags > /dev/null 2>&1 && git describe --tags | head -1 | sed -re 's/${VERSION_PATTERN}/\\1.\\3\\2/' | sed -re 's/\.$/.0/'"


### PR DESCRIPTION
## Description

Drop support for Ubuntu Xenial as it [reached its EOL](https://help.ubuntu.com/community/EOL#Ubuntu_16.04_Xenial_Xerus). This means upgrading Travis jobs and Vagrant box too.

Also, there is an interesting observation that git does not print tag information in the format introduced in #1768 if the tag is on current commit. This causes Debian builds to fail.
The solution is to make format more flexible and add additional 0 revision.

# Note
This PR also updates the Vagrant box from Ubuntu Xenial to Ubuntu Focal!

### Changes

1. Drop support for Ubuntu Xenial.
2. Update Travis jobs from Xenial to Bionic
    - Not update to Focal due to limited PHP support.
    - See supported versions for Bionic: https://docs.travis-ci.com/user/reference/bionic/#php-support
    - See supported versions for Focal: https://docs.travis-ci.com/user/reference/focal/#php-support
3. Add test cases for GCC-10 and Postgres-13.
4. Remove `phpdbg` from PHP7.4 due to strict resource checks.
5. Handle case where building package for a tag (see description).
6. Revert changes from #1888 to remove signing from other build artifacts.
7. Other testcase fixes.

## How to test

Check the Travis logs.