### PR TITLE
feat(ci): Mark PRs with conflict with Actions

### DIFF
--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -1,0 +1,20 @@
+# Copyright 2021 Gaurav Mishra <mishra.gaurav@siemens.com>
+# SPDX-License-Identifier: GPL-2.0 AND LGPL-2.1
+
+name: Check PRs for conflicts
+
+on:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PRs are dirty
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        with:
+          dirtyLabel: "has merge conflicts"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: |
+            This pull request has conflicts, please rebase with master to resolve those before we can evaluate the pull request.


### PR DESCRIPTION
## Description

Use GitHub actions to mark PRs with merge conflicts with label "has merge conflicts".

### Changes

1. Create a new GitHub Action workflow which scans for dirty PRs when a merge to master happens.

## How to test

Check test runs on fork:
- When a PR becomes dirty (has conflict): https://github.com/GMishx/fossology/runs/2601394675?check_suite_focus=true#step:2:11
- When a PR is already dirty: https://github.com/GMishx/fossology/runs/2601483615?check_suite_focus=true#step:2:12
- Labeled PR: https://github.com/GMishx/fossology/pull/25