### PR TITLE
fix(ui): Add scroll to NOTICE file modal

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -464,6 +464,7 @@ INSERT INTO clearing_decision (
       $row['acknowledgement'] = "";
     }
 
+    $changeTo = StringOperation::replaceUnicodeControlChar($changeTo, false);
     if ($what == 'reportinfo') {
       $reportInfo = $changeTo;
       $comment = $row['comment'];

--- a/src/www/ui/ajax-clearing-view.php
+++ b/src/www/ui/ajax-clearing-view.php
@@ -277,9 +277,9 @@ class AjaxClearingView extends FO_Plugin
     }
 
     if (!empty($forValue)) {
-      $value = substr(ltrim($forValue, " \t\n"), 0, 15)."...";
+      $value = convertToUTF8(substr(ltrim($forValue, " \t\n"), 0, 15)."...");
     }
-    return "<a href=\"javascript:;\" style='$classAttr' id='clearingsForSingleFile$licenseId$what' onclick=\"openTextModel($uploadTreeId, $licenseId, $what);\" title='".htmlspecialchars($forValue, ENT_QUOTES)."'>$value</a>";
+    return "<a href=\"javascript:;\" style='$classAttr' id='clearingsForSingleFile$licenseId$what' onclick=\"openTextModel($uploadTreeId, $licenseId, $what);\" title='".convertToUTF8(htmlspecialchars($forValue, ENT_QUOTES), true)."'>$value</a>";
   }
 
   /**

--- a/src/www/ui/css/fossology.css
+++ b/src/www/ui/css/fossology.css
@@ -146,6 +146,11 @@ html, body
   background-color: #E6E6E6;
   border-radius: 10px;
   display: none;
+  box-sizing: border-box;
+  max-height: 70vh;
+  min-height: 20vh;
+  max-width: 70vw;
+  min-width: 20vw;
 }
 
 .icon-small {

--- a/src/www/ui/scripts/change-license-common.js
+++ b/src/www/ui/scripts/change-license-common.js
@@ -308,15 +308,16 @@ function UseThisNoticeButton(idx, text)
 }
 
 function doHandleNoticeFiles(response) {
-   noticeSelectTable.clear();
+  noticeSelectTable.clear();
 
   $.each(response, function(idx, el) {
     if (el.ufile_name !== undefined && el.contents_short !== undefined
         && el.contents !== undefined) {
       noticeSelectTable.row.add([el.ufile_name, el.contents_short, UseThisNoticeButton(idx, el.contents) ]);
-      noticeSelectTable.draw();
     }
   });
+  noticeSelectTable.draw();
+  textAckInputModal.dialog("option", "position", {my: "center", at: "center", of: window });
 }
 
 function selectNoticeFile() {
@@ -399,10 +400,13 @@ function doOnSuccess(textModal) {
 }
 
 $(document).ready(function () {
-  textAckInputModal = $('#textAckInputModal').dialog({autoOpen:false, width:"auto",height:"auto", modal:true,open:function(){$(".ui-widget-overlay").addClass("grey-overlay");}});
-  $('#textAckInputModal').draggable({
-    stop: function(){
-      $(this).css({'width':'','height':''});
+  textAckInputModal = $('#textAckInputModal').dialog({
+    autoOpen:false, width:"auto", height:"auto", modal:true, resizable: false,
+    open: function() {
+      $(".ui-widget-overlay").addClass("grey-overlay");
+      $(this).css("box-sizing", "border-box").css("max-height", "70vh")
+        .css("min-height", "20vh").css("max-width", "70vw")
+        .css("min-width", "20vw");
     }
   });
 
@@ -412,10 +416,12 @@ $(document).ready(function () {
     data: []
   });
 
-  textModal = $('#textModal').dialog({autoOpen:false, width:"auto",height:"auto"});
-  $('#textModal').draggable({
-    stop: function(){
-      $(this).css({'width':'','height':''});
+  textModal = $('#textModal').dialog({
+    autoOpen:false, width:"auto",height:"auto",
+    open: function() {
+      $(this).css("box-sizing", "border-box").css("max-height", "70vh")
+        .css("min-height", "20vh").css("max-width", "70vw")
+        .css("min-width", "20vw");
     }
   });
 });


### PR DESCRIPTION
## Description

The Modal dialog to select a notice file for acknowledgement does not had max-height. Thus, if an upload contains many NOTICE files, it becomes very hard to scroll. Also, the inner elements of the dialog were draggable, which is not required.

### Changes

1. Add a scroll bar to notice file selection modal for acknowledgement, done by setting setting the max-height of the dialog to 70% of the viewport.
2. Remove the unnecessary draggable for the inner elements of modal.
3. Add additional UTF-8 checks to license browser.

## How to test

1. Upload a file with many NOTICE files.
2. Goto license browser and add an acknowledgement.
3. Click on "Select from Notice file".

- The modal dialog should not exceed 70% height of the page.
- The inner elements of the dialog should move with the modal, not separately.