### PR TITLE
fix(ui): License text editor

### DIFF
--- a/src/www/ui/scripts/change-license-common.js
+++ b/src/www/ui/scripts/change-license-common.js
@@ -240,6 +240,14 @@ function removeMainLicense(uploadId,licenseId) {
   }
 }
 
+function htmlDecode(value) {
+    if (value) {
+        return $('<div/>').html(value).text();
+    } else {
+        return '';
+    }
+}
+
 function openTextModel(uploadTreeId, licenseId, what, type) {
   var refTextId = "#referenceText"
 
@@ -256,7 +264,7 @@ function openTextModel(uploadTreeId, licenseId, what, type) {
     let clearingsForSingleFile = $("#clearingsForSingleFile"+licenseId+what).attr("title");
     idLicUploadTree = uploadTreeId+','+licenseId;
     whatCol = what;
-    $(refTextId).val(clearingsForSingleFile);
+    $(refTextId).val(htmlDecode(clearingsForSingleFile));
     if (what == 4 || what == "comment") {
       createDropDown($("#textModal > form > div"), $("#referenceText"));
     } else {
@@ -265,7 +273,7 @@ function openTextModel(uploadTreeId, licenseId, what, type) {
     }
     textModal.dialog('open');
   } else {
-    $(refTextId).val($("#"+licenseId+what+type).attr('title'));
+    $(refTextId).val(htmlDecode($("#"+licenseId+what+type).attr('title')));
     whatCol = what;
     whatLicId = licenseId;
     if (what == 4 || what == "comment") {


### PR DESCRIPTION
## Description

Since the license text is read from the "title" of the element, which is already [HTML encoded in PHP](https://github.com/fossology/fossology/blob/84a1897e32cc6556713f6efabd3c9ea3bd0dd4c7/src/www/ui/ajax-clearing-view.php#L282), the textarea should be decoded first.

### Changes

1. Use jQuery trickery to decode HTML with `htmlDecode()`.
2. Use the decoded value to fill textarea.

## How to test

1. Edit a license text and add some HTML characters like `&`, `"`, `'`, `<` or `>` in the license text.
2. Submit the decision and edit the same license text again.
    - In master branch, the special characters will be shows in HTML &amp; style.
    - In this branch, they should be shown in human readable format.
3. Check the above points for bulk license text as well.