### PR TITLE
feat(copyright): add bulk undo for deactivated copyrights

### DIFF
--- a/src/copyright/ui/HistogramBase.php
+++ b/src/copyright/ui/HistogramBase.php
@@ -107,7 +107,11 @@ abstract class HistogramBase extends FO_Plugin {
   <br/><br/>
   <h4>Deactivated $typeDescriptor statements:</h4>
 </div>
-<div><table border=1 width='100%' id='copyright".$type."deactivated'></table></div>";
+<div><table border=1 width='100%' id='copyright".$type."deactivated'></table>
+  <br/><br/>
+  <a id='undoSelected".$type."' class='buttonLink'>Undo selected rows</a>
+  <br /><br />
+</div>";
 
     return array($output, $out);
   }

--- a/src/copyright/ui/TextFindingsAjax.php
+++ b/src/copyright/ui/TextFindingsAjax.php
@@ -325,7 +325,9 @@ class TextFindingsAjax
         "id='deleteBySelectfinding$hash' value='$hash,$upload," .
         $this->getDecisionTypeName($type) . "'>";
     } else {
-      $output['3'] = "";
+      $output['3'] = "<input type='checkbox' class='undoBySelect$type' " .
+        "id='undoBySelectfinding$hash' value='$hash,$upload," .
+        $this->getDecisionTypeName($type) . "'>";
     }
     return $output;
   }

--- a/src/copyright/ui/ajax-copyright-hist.php
+++ b/src/copyright/ui/ajax-copyright-hist.php
@@ -453,7 +453,7 @@ count(*) AS copyright_count " .
     }
     else
     {
-        $output['3'] = "";
+        $output['3'] = "<input type='checkbox' class='undoBySelect$type' id='undoBySelect$type$hash' value='".$upload.",".$uploadTreeId.",".$hash.",".$type."'>";
     }
     return $output;
   }

--- a/src/copyright/ui/template/histTable.js.twig
+++ b/src/copyright/ui/template/histTable.js.twig
@@ -24,7 +24,8 @@ function createTableBase{{ table.type }}(activated) {
     var id = '#copyright{{ table.type }}deactivated';
     var action = 'getDeactivatedData'
     aoColumns = aoColumns.concat([
-      { "sTitle": "", "sClass": "center read_only", "sWidth": "10%", "bSortable": false }
+      { "sTitle": "", "sClass": "center read_only", "sWidth": "10%", "bSortable": false },
+      { "sTitle": "<input type='checkbox' name='selectUndo{{ table.type }}' id='selectUndo{{ table.type }}' style='margin-left:11px'>", "sClass": "center read_only", "sWidth": "5%", "bSortable": false }
     ]);
   }
 
@@ -88,6 +89,18 @@ function createTable{{ table.type }}() {
     });
   });
 
+  $('#selectUndo{{ table.type }}').change(function () {
+    $('.undoBySelect{{ table.type }}').prop('checked', $(this).prop("checked"));
+  });
+
+  $('#undoSelected{{ table.type }}').click(function () {
+    $("input:checkbox[class=undoBySelect{{ table.type }}]:checked").each(function () {
+      currentValue = $(this).val();
+      var currUploadData = currentValue.split(',');
+      undo{{ table.type }}(currUploadData[0], currUploadData[1], currUploadData[2], currUploadData[3]);
+    });
+  });
+
   $('#replaceSelected{{ table.type }}').click(function () {
     var replaceText = $('#replaceText{{ table.type }}').val().trim();
     var replaceIsValid = (replaceText) && !(/^\s*$/.test(replaceText));
@@ -134,6 +147,9 @@ function createPlaneTableBase{{ table.type }}(activated) {
   {
     var id = '#copyright{{ table.type }}deactivated';
     var action = 'getDeactivatedData'
+    aoColumns = aoColumns.concat([
+      { "sTitle": "<input type='checkbox' name='selectUndo{{ table.type }}' id='selectUndo{{ table.type }}' style='margin-left:11px'>", "sClass": "center read_only", "sWidth": "5%", "bSortable": false }
+    ]);
   }
 
   return $(id).dataTable({
@@ -173,6 +189,18 @@ function createPlainTable{{ table.type }}() {
       currentValue = $(this).val();
       var currUploadData = currentValue.split(',');
       deleteHashDecision(currUploadData[0], currUploadData[1], currUploadData[2]);
+    });
+  });
+
+  $('#selectUndo{{ table.type }}').change(function () {
+    $('.undoBySelect{{ table.type }}').prop('checked', $(this).prop("checked"));
+  });
+
+  $('#undoSelected{{ table.type }}').click(function () {
+    $("input:checkbox[class=undoBySelect{{ table.type }}]:checked").each(function () {
+      currentValue = $(this).val();
+      var currUploadData = currentValue.split(',');
+      undoHashDecision(currUploadData[0], currUploadData[1], currUploadData[2]);
     });
   });
 

--- a/src/spasht/ui/ajax-spasht-copyright-hist.php
+++ b/src/spasht/ui/ajax-spasht-copyright-hist.php
@@ -410,7 +410,7 @@ class SpashtCopyrightHistogramProcessPost extends FO_Plugin
     if ($rw && $activated) {
       $output['3'] = "<input type='checkbox' class='deleteBySelect$type' id='deleteBySelect$type$hash' value='".$upload.",".$uploadTreeId.",".$hash.",".$type."'>";
     } else {
-        $output['3'] = "";
+      $output['3'] = "<input type='checkbox' class='undoBySelect$type' id='undoBySelect$type$hash' value='".$upload.",".$uploadTreeId.",".$hash.",".$type."'>";
     }
     return $output;
   }

--- a/src/spasht/ui/template/agent_spasht_ui_tabs.html.twig
+++ b/src/spasht/ui/template/agent_spasht_ui_tabs.html.twig
@@ -42,9 +42,9 @@
               </span>
               <br/><br/>
               <a style='cursor:pointer;margin-left:10px;' id='replaceSelectedstatement'
-                class='buttonLink'>Mark selected rows for replace</a>
+                class='buttonLink'>Replace selected rows</a>
               <a style='cursor:pointer;margin-left:10px;' id='deleteSelectedstatement'
-                class='buttonLink'>Mark selected rows for deletion</a>
+                class='buttonLink'>Deactivate selected rows</a>
               <br />
             </div>
             <span style="font-weight:bold;display:block;padding:3em 0 1em;font-size:15pt;">Deactivated statements</span>
@@ -59,6 +59,12 @@
               </thead>
               <tbody></tbody>
             </table>
+            <br /><br />
+            <div>
+              <a id='undoSelectedstatement'
+                class='buttonLink'>Undo selected rows</a>
+              <br />
+            </div>
           </td>
           {% if fileList is not empty %}
           <td valign="top" style="width:15em">

--- a/src/spasht/ui/template/spasht_histTable.js.twig
+++ b/src/spasht/ui/template/spasht_histTable.js.twig
@@ -10,19 +10,24 @@ function createTableBase{{ table.type }}(activated) {
   var aoColumns = [
       { "sTitle": "{{ 'Count'| trans }}", "sClass": "right read_only", "sWidth": "5%" },
       { "sTitle": "{{ 'Copyright Content'| trans }}", "sClass": "left"},
-      { "sTitle": "", "sClass": "center read_only", "sWidth": "10%", "bSortable": false },
-      { "sTitle": "<input type='checkbox' name='selectDelete{{ table.type }}' id='selectDelete{{ table.type }}' style='margin-left:11px'>", "sClass": "center read_only", "sWidth": "5%", "bSortable": false }
+      { "sTitle": "", "sClass": "center read_only", "sWidth": "10%", "bSortable": false }
     ];
 
   if (activated)
   {
     var id = '#copyright_spasht_table';
     var action = 'getData';
+    aoColumns = aoColumns.concat([
+      { "sTitle": "<input type='checkbox' name='selectDelete{{ table.type }}' id='selectDelete{{ table.type }}' style='margin-left:11px'>", "sClass": "center read_only", "sWidth": "5%", "bSortable": false }
+    ]);
   }
   else
   {
     var id = '#copyright_spasht_table_deactivated';
     var action = 'getDeactivatedData';
+    aoColumns = aoColumns.concat([
+      { "sTitle": "<input type='checkbox' name='selectUndo{{ table.type }}' id='selectUndo{{ table.type }}' style='margin-left:11px'>", "sClass": "center read_only", "sWidth": "5%", "bSortable": false }
+    ]);
   }
 
   return $(id).dataTable({
@@ -81,6 +86,18 @@ function createTable{{ table.type }}() {
       currentValue = $(this).val();
       var currUploadData = currentValue.split(',');
       delete{{ table.type }}(currUploadData[0], currUploadData[1], currUploadData[2], currUploadData[3]);
+    });
+  });
+
+  $('#selectUndo{{ table.type }}').change(function () {
+    $('.undoBySelect{{ table.type }}').prop('checked', $(this).prop("checked"));
+  });
+
+  $('#undoSelected{{ table.type }}').click(function () {
+    $("input:checkbox[class=undoBySelect{{ table.type }}]:checked").each(function () {
+      currentValue = $(this).val();
+      var currUploadData = currentValue.split(',');
+      undo{{ table.type }}(currUploadData[0], currUploadData[1], currUploadData[2], currUploadData[3]);
     });
   });
 


### PR DESCRIPTION
## Description

Multiple undo option for deactivated copyrights. 

### Changes

* add a checkbox to select deleted.
* add a new button to submit.

## How to test

* Upload a package and deactivate some copyrights
* Go to deactivated statements and select multiple statements 
* Click on "Undo selected rows".

Closes #1928