### PR TITLE
feat(rest): Add POST/PATCH license endpoints

### DIFF
--- a/src/lib/php/Dao/LicenseDao.php
+++ b/src/lib/php/Dao/LicenseDao.php
@@ -679,6 +679,7 @@ ORDER BY lft asc
       if ($candidate) {
         $tableName='obligation_candidate_map';
         $sql = "SELECT ob_pk, ob_topic, ob_text, ob_active, rf_fk, " .
+          "ob_type, ob_classification, ob_comment, " .
           "rf_shortname FROM obligation_ref " .
           "JOIN $tableName ON $tableName.ob_fk = obligation_ref.ob_pk " .
           "JOIN license_ref ON $tableName.rf_fk = license_ref.rf_pk " .
@@ -688,6 +689,7 @@ ORDER BY lft asc
         $conclusionmapCte = LicenseMap::getMappedLicenseRefView('$2');
         $sql = "WITH conclusionmap AS (" . $conclusionmapCte . ") " .
           "SELECT ob_pk, ob_topic, ob_text, ob_active, rf_origin AS rf_fk, " .
+          "ob_type, ob_classification, ob_comment, " .
           "lr.rf_shortname FROM obligation_ref " .
           "JOIN $tableName ON $tableName.ob_fk = obligation_ref.ob_pk " .
           "JOIN conclusionmap ON $tableName.rf_fk = conclusionmap.rf_pk " .

--- a/src/phpunit-bootstrap.php
+++ b/src/phpunit-bootstrap.php
@@ -12,5 +12,6 @@ without any warranty.
 namespace TestSupport;
 
 require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/lib/php/common-string.php';
 
 \Hamcrest\Util::registerGlobalFunctions();

--- a/src/www/ui/api/Controllers/LicenseController.php
+++ b/src/www/ui/api/Controllers/LicenseController.php
@@ -23,8 +23,11 @@
 
 namespace Fossology\UI\Api\Controllers;
 
+use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\LicenseDao;
+use Fossology\Lib\Util\StringOperation;
 use Fossology\UI\Api\Models\License;
+use Fossology\UI\Api\Models\Obligation;
 use Fossology\UI\Api\Models\Info;
 use Fossology\UI\Api\Models\InfoType;
 use Psr\Container\ContainerInterface;
@@ -37,6 +40,22 @@ use Slim\Http\Response;
  */
 class LicenseController extends RestController
 {
+  /**
+   * Get header parameter name for page listing
+   */
+  const PAGE_PARAM = "page";
+  /**
+   * Get header parameter name for limiting listing
+   */
+  const LIMIT_PARAM = "limit";
+  /**
+   * Get header parameter name for active licenses
+   */
+  const ACTIVE_PARAM = "active";
+  /**
+   * Limit of licenses in get query
+   */
+  const LICENSE_FETCH_LIMIT = 100;
   /**
    * @var LicenseDao $licenseDao
    * License Dao object
@@ -62,20 +81,21 @@ class LicenseController extends RestController
    */
   public function getLicense($request, $response, $args)
   {
-    $shortName = $request->getHeaderLine("shortName");
+    $shortName = $args["shortname"];
 
     if (empty($shortName)) {
       $error = new Info(
         400,
-        "'shortName' parameter missing from query.",
+        "Short name missing from request.",
         InfoType::ERROR
       );
       return $response->withJson($error->getArray(), $error->getCode());
     }
 
-    $license = $this->licenseDao->getLicenseByShortName($shortName);
+    $license = $this->licenseDao->getLicenseByShortName($shortName,
+      $this->restHelper->getGroupId());
 
-    if ($license === NULL) {
+    if ($license === null) {
       $error = new Info(
         404,
         "No license found with short name '{$shortName}'.",
@@ -84,14 +104,227 @@ class LicenseController extends RestController
       return $response->withJson($error->getArray(), $error->getCode());
     }
 
+    $obligations = $this->licenseDao->getLicenseObligations([$license->getId()],
+      false);
+    $obligations = array_merge($obligations,
+      $this->licenseDao->getLicenseObligations([$license->getId()], true));
+    $obligationList = [];
+    foreach ($obligations as $obligation) {
+      $obligationList[] = new Obligation(
+        $obligation['ob_pk'],
+        $obligation['ob_topic'],
+        $obligation['ob_type'],
+        $obligation['ob_text'],
+        $obligation['ob_classification'],
+        $obligation['ob_comment']
+      );
+    }
+
     $returnVal = new License(
       $license->getId(),
       $license->getShortName(),
       $license->getFullName(),
       $license->getText(),
+      $license->getUrl(),
+      $obligationList,
       $license->getRisk()
     );
 
     return $response->withJson($returnVal->getArray(), 200);
+  }
+
+  /**
+   * Get list of all licenses, paginated upon request params
+   *
+   * @param Request $request
+   * @param Response $response
+   * @param array $args
+   * @return Response
+   */
+  public function getAllLicenses($request, $response, $args)
+  {
+    $retVal = null;
+    $limit = $request->getHeaderLine(self::LIMIT_PARAM);
+    if (! empty($limit)) {
+      $limit = filter_var($limit, FILTER_VALIDATE_INT);
+      if ($limit < 1) {
+        $info = new Info(400, "limit should be positive integer > 1",
+          InfoType::ERROR);
+        $retVal = $response->withJson($info->getArray(), $info->getCode());
+      }
+    } else {
+      $limit = self::LICENSE_FETCH_LIMIT;
+    }
+
+    $totalPages = $this->dbHelper->getLicenseCount(
+      $this->restHelper->getGroupId());
+    $totalPages = intval(ceil($totalPages / $limit));
+
+    $page = $request->getHeaderLine(self::PAGE_PARAM);
+    if (! empty($page)) {
+      $page = filter_var($page, FILTER_VALIDATE_INT);
+      if ($page <= 0) {
+        $info = new Info(400, "page should be positive integer > 0",
+          InfoType::ERROR);
+        $retVal = $response->withJson($info->getArray(), $info->getCode());
+      }
+      if ($page > $totalPages) {
+        $info = new Info(400, "Can not exceed total pages: $totalPages",
+          InfoType::ERROR);
+        $retVal = $response->withHeader("X-Total-Pages", $totalPages)
+          ->withJson($info->getArray(), $info->getCode());
+      }
+    } else {
+      $page = 1;
+    }
+    if ($retVal !== null) {
+      return $retVal;
+    }
+    $onlyActive = $request->getHeaderLine(self::ACTIVE_PARAM);
+    if (! empty($onlyActive)) {
+      $onlyActive = filter_var($onlyActive, FILTER_VALIDATE_BOOLEAN);
+    } else {
+      $onlyActive = false;
+    }
+
+    $licenses = $this->dbHelper->getLicensesPaginated($page, $limit,
+      $this->restHelper->getGroupId(), $onlyActive);
+    $licenseList = [];
+
+    foreach ($licenses as $license) {
+      $newRow = new License(
+        $license['rf_pk'],
+        $license['rf_shortname'],
+        $license['rf_fullname'],
+        $license['rf_text'],
+        $license['rf_url'],
+        null,
+        $license['rf_risk'],
+        $license['group_fk'] != 0
+      );
+      $licenseList[] = $newRow->getArray();
+    }
+
+    return $response->withHeader("X-Total-Pages", $totalPages)
+      ->withJson($licenseList, 200);
+  }
+
+  /**
+   * Create a new license
+   *
+   * @param Request $request
+   * @param Response $response
+   * @param array $args
+   * @return Response
+   */
+  public function createLicense($request, $response, $args)
+  {
+    $newLicense = $request->getParsedBody();
+    $newLicense = License::parseFromArray($newLicense);
+    $newInfo = null;
+    if ($newLicense === -1) {
+      $newInfo = new Info(400, "Input contains additional properties.",
+        InfoType::ERROR);
+    } elseif ($newLicense === -2) {
+      $newInfo = new Info(400, "Property 'shortName' is required.",
+        InfoType::ERROR);
+    } elseif (! $newLicense->getIsCandidate() && ! Auth::isAdmin()) {
+      $newInfo = new Info(403, "Need to be admin to create non-candidate " .
+        "license.", InfoType::ERROR);
+    }
+    if ($newInfo !== null) {
+      return $response->withJson($newInfo->getArray(), $newInfo->getCode());
+    }
+    $tableName = "license_ref";
+    $assocData = [
+      "rf_shortname" => $newLicense->getShortName(),
+      "rf_fullname" => $newLicense->getFullName(),
+      "rf_text" => $newLicense->getText(),
+      "rf_risk" => $newLicense->getRisk(),
+      "rf_url" => $newLicense->getUrl(),
+      "rf_detector_type" => 1
+    ];
+    if ($newLicense->getIsCandidate()) {
+      $tableName = "license_candidate";
+      $assocData["group_fk"] = $this->restHelper->getGroupId();
+      $assocData["rf_user_fk_created"] = $this->restHelper->getUserId();
+      $assocData["rf_user_fk_modified"] = $this->restHelper->getUserId();
+      $assocData["marydone"] = $newLicense->getMergeRequest();
+    }
+    $rfPk = $this->dbHelper->getDbManager()->insertTableRow($tableName,
+      $assocData, __METHOD__ . ".newLicense", "rf_pk");
+    $newInfo = new Info(201, "License " . $newLicense->getShortName() .
+      " added with id '$rfPk'.", InfoType::INFO);
+    return $response->withJson($newInfo->getArray(), $newInfo->getCode());
+  }
+
+  /**
+   * Update a license
+   *
+   * @param Request $request
+   * @param Response $response
+   * @param array $args
+   * @return Response
+   */
+  public function updateLicense($request, $response, $args)
+  {
+    $newParams = $request->getParsedBody();
+    $shortName = $args["shortname"];
+    $newInfo = null;
+    if (empty($shortName)) {
+      $newInfo = new Info(400, "Short name missing from request.",
+        InfoType::ERROR);
+      return $response->withJson($newInfo->getArray(), $newInfo->getCode());
+    }
+
+    $license = $this->licenseDao->getLicenseByShortName($shortName,
+      $this->restHelper->getGroupId());
+
+    if ($license === null) {
+      $newInfo = new Info(404, "No license found with short name '$shortName'.",
+        InfoType::ERROR);
+      return $response->withJson($newInfo->getArray(), $newInfo->getCode());
+    }
+    $isCandidate = $this->restHelper->getDbHelper()->doesIdExist(
+      "license_candidate", "rf_pk", $license->getId());
+
+    $assocData = [];
+    if (array_key_exists('fullName', $newParams)) {
+      $assocData['rf_fullname'] = StringOperation::replaceUnicodeControlChar($newParams['fullName']);
+    }
+    if (array_key_exists('text', $newParams)) {
+      $assocData['rf_text'] = StringOperation::replaceUnicodeControlChar($newParams['text']);
+    }
+    if (array_key_exists('url', $newParams)) {
+      $assocData['rf_url'] = StringOperation::replaceUnicodeControlChar($newParams['url']);
+    }
+    if (array_key_exists('risk', $newParams)) {
+      $assocData['rf_risk'] = intval($newParams['risk']);
+    }
+    do {
+      if (empty($assocData)) {
+        $newInfo = new Info(400, "Empty body sent.", InfoType::ERROR);
+        break;
+      }
+      if ($isCandidate && ! $this->restHelper->getUserDao()->isAdvisorOrAdmin(
+          $this->restHelper->getUserId(), $this->restHelper->getGroupId())) {
+        $newInfo = new Info(403, "Operation not permitted for this group.",
+          InfoType::ERROR);
+        break;
+      } elseif (!$isCandidate && !Auth::isAdmin()) {
+        $newInfo = new Info(403, "Only admin can edit main licenses.",
+          InfoType::ERROR);
+        break;
+      }
+      $tableName = "license_ref";
+      if ($isCandidate) {
+        $tableName = "license_candidate";
+      }
+      $this->dbHelper->getDbManager()->updateTableRow($tableName, $assocData,
+        "rf_pk", $license->getId(), __METHOD__ . ".updateLicense");
+      $newInfo = new Info(200, "License " . $license->getShortName() .
+        " updated.", InfoType::INFO);
+    } while(false);
+    return $response->withJson($newInfo->getArray(), $newInfo->getCode());
   }
 }

--- a/src/www/ui/api/Controllers/LicenseController.php
+++ b/src/www/ui/api/Controllers/LicenseController.php
@@ -324,7 +324,7 @@ class LicenseController extends RestController
         "rf_pk", $license->getId(), __METHOD__ . ".updateLicense");
       $newInfo = new Info(200, "License " . $license->getShortName() .
         " updated.", InfoType::INFO);
-    } while(false);
+    } while (false);
     return $response->withJson($newInfo->getArray(), $newInfo->getCode());
   }
 }

--- a/src/www/ui/api/Models/License.php
+++ b/src/www/ui/api/Models/License.php
@@ -31,6 +31,12 @@ namespace Fossology\UI\Api\Models;
 class License
 {
   /**
+   * @var array $ALLOWED_KEYS
+   * Allowed keys from user to parse
+   */
+  const ALLOWED_KEYS = ['shortName', 'fullName', 'text', 'url', 'risk',
+    'isCandidate', 'mergeRequest'];
+  /**
    * @var integer $id
    * License id
    */
@@ -51,10 +57,30 @@ class License
    */
   private $text;
   /**
+   * @var string $url
+   * License URL
+   */
+  private $url;
+  /**
+   * @var array|null $obligations
+   * Obligations for the license
+   */
+  private $obligations;
+  /**
    * @var integer|null $license
    * The risk level of the license
    */
   private $risk;
+  /**
+   * @var boolean $isCandidate
+   * Is the license a candidate license?
+   */
+  private $isCandidate;
+  /**
+   * @var boolean $mergeRequest
+   * Create merge request for candidate license?
+   */
+  private $mergeRequest;
 
   /**
    * License constructor.
@@ -63,28 +89,31 @@ class License
    * @param string $shortName
    * @param string $fullName
    * @param string $text
+   * @param string $url
+   * @param array  $obligations
    * @param integer|null $risk
+   * @param boolean $isCandidate
    */
   public function __construct(
     $id,
     $shortName = "",
     $fullName = "",
     $text = "",
-    $risk = null
+    $url = "",
+    $obligations = null,
+    $risk = null,
+    $isCandidate = false
   )
   {
     $this->id = intval($id);
-    $this->shortName = $shortName;
-    $this->fullName = $fullName;
-    $this->text = $text;
-
-    // invtval returns 0 for null, so check for nullness to preserve the
-    // difference in the response.
-    if (!is_null($risk)) {
-      $this->risk = intval($risk);
-    } else {
-      $this->risk = $risk;
-    }
+    $this->setShortName($shortName);
+    $this->setFullName($fullName);
+    $this->setText($text);
+    $this->setUrl($url);
+    $this->setObligations($obligations);
+    $this->setRisk($risk);
+    $this->setIsCandidate($isCandidate);
+    $this->mergeRequest = false;
   }
 
   /**
@@ -102,13 +131,28 @@ class License
    */
   public function getArray()
   {
-    return [
-      'id' => $this->id,
-      'shortName' => $this->shortName,
-      'fullName' => $this->fullName,
-      'text' => $this->text,
-      'risk' => $this->risk
+    $data = [
+      'id' => $this->getId(),
+      'shortName' => $this->getShortName(),
+      'fullName' => $this->getFullName(),
+      'text' => $this->getText(),
+      'url' => $this->getUrl(),
+      'risk' => $this->getRisk(),
+      'isCandidate' => $this->getIsCandidate()
     ];
+    if ($this->obligations !== null) {
+      $data['obligations'] = $this->getObligations();
+    }
+    return $data;
+  }
+
+  /**
+   * Get the license ID
+   * @return integer License's ID
+   */
+  public function getId()
+  {
+    return $this->id;
   }
 
   /**
@@ -117,6 +161,9 @@ class License
    */
   public function getShortName()
   {
+    if ($this->shortName === null) {
+      return "";
+    }
     return $this->shortName;
   }
 
@@ -126,6 +173,9 @@ class License
    */
   public function getFullName()
   {
+    if ($this->fullName === null) {
+      return "";
+    }
     return $this->fullName;
   }
 
@@ -135,7 +185,22 @@ class License
    */
   public function getText()
   {
+    if ($this->text === null) {
+      return "";
+    }
     return $this->text;
+  }
+
+  /**
+   * Get the license's URL
+   * @return string License's URL
+   */
+  public function getUrl()
+  {
+    if ($this->url === null) {
+      return "";
+    }
+    return $this->url;
   }
 
   /**
@@ -148,12 +213,43 @@ class License
   }
 
   /**
+   * Is the license a candidate?
+   * @return boolean
+   */
+  public function getIsCandidate()
+  {
+    return $this->isCandidate;
+  }
+
+  /**
+   * Get the license's associated obligations
+   * @return array|null License's associated obligations if set, null if not set
+   */
+  public function getObligations()
+  {
+    $obligationList = [];
+    foreach ($this->obligations as $obligation) {
+      $obligationList[] = $obligation->getArray();
+    }
+    return $obligationList;
+  }
+
+  /**
+   * A new merge request to be made for the license?
+   * @return boolean
+   */
+  public function getMergeRequest()
+  {
+    return $this->mergeRequest;
+  }
+
+  /**
    * Set the license's short name
    * @param string $shortName License's short name
    */
   public function setShortName($shortName)
   {
-    $this->shortName = $shortName;
+    $this->shortName = convertToUTF8($shortName, false);
   }
 
   /**
@@ -162,7 +258,7 @@ class License
    */
   public function setFullName($fullName)
   {
-    $this->$fullName = $fullName;
+    $this->fullName = convertToUTF8($fullName, false);
   }
 
   /**
@@ -171,7 +267,16 @@ class License
    */
   public function setText($text)
   {
-    $this->$text = $text;
+    $this->text = convertToUTF8($text, false);
+  }
+
+  /**
+   * Set the license's URL
+   * @param string $url License's URL
+   */
+  public function setUrl($url)
+  {
+    $this->url = convertToUTF8($url, false);
   }
 
   /**
@@ -180,6 +285,100 @@ class License
    */
   public function setRisk($risk)
   {
-    $this->$risk = $risk;
+    // invtval returns 0 for null, so check for nullness to preserve the
+    // difference in the response.
+    if (!is_null($risk)) {
+      $this->risk = intval($risk);
+    } else {
+      $this->risk = $risk;
+    }
+  }
+
+  /**
+   * Set if license is candidate.
+   * @param boolean $isCandidate
+   */
+  public function setIsCandidate($isCandidate)
+  {
+    $this->isCandidate = filter_var($isCandidate, FILTER_VALIDATE_BOOLEAN);
+  }
+
+  /**
+   * Set the license's associated obligations
+   * @param array $obligations Obligations to be added
+   */
+  public function setObligations($obligations)
+  {
+    if (is_array($obligations)) {
+      $this->obligations = [];
+    } elseif ($obligations === null) {
+      $this->obligations = null;
+      return;
+    }
+    foreach ($obligations as $obligation) {
+      $this->addObligation($obligation);
+    }
+  }
+
+  /**
+   * Add obligation to license's associated obligations
+   * @param Obligation $obligation A single obligation to be added
+   */
+  public function addObligation($obligation)
+  {
+    if ($this->obligations === null) {
+      $this->obligations = [];
+    }
+    $this->obligations[] = $obligation;
+  }
+
+  /**
+   * Set the merge request for new license
+   * @param boolean $mergeRequest
+   */
+  public function setMergeRequest($mergeRequest)
+  {
+    $this->mergeRequest = filter_var($mergeRequest, FILTER_VALIDATE_BOOLEAN);
+  }
+
+  /**
+   * Parse a license from JSON input.
+   *
+   * @param array $inputLicense Object sent by user
+   * @return License
+   */
+  public static function parseFromArray($inputLicense)
+  {
+    $inputKeys = array_keys($inputLicense);
+    $intersectKeys = array_intersect($inputKeys, self::ALLOWED_KEYS);
+    if (count($inputKeys) > 0 && count($intersectKeys) != count($inputKeys)) {
+      return -1;
+    }
+    if (array_search('shortName', $inputKeys) === false) {
+      return -2;
+    }
+    $newLicense = new License(0);
+    if (array_key_exists('shortName', $inputLicense)) {
+      $newLicense->setShortName($inputLicense['shortName']);
+    }
+    if (array_key_exists('fullName', $inputLicense)) {
+      $newLicense->setFullName($inputLicense['fullName']);
+    }
+    if (array_key_exists('text', $inputLicense)) {
+      $newLicense->setText($inputLicense['text']);
+    }
+    if (array_key_exists('url', $inputLicense)) {
+      $newLicense->setUrl($inputLicense['url']);
+    }
+    if (array_key_exists('risk', $inputLicense)) {
+      $newLicense->setRisk($inputLicense['risk']);
+    }
+    if (array_key_exists('isCandidate', $inputLicense)) {
+      $newLicense->setIsCandidate($inputLicense['isCandidate']);
+    }
+    if (array_key_exists('mergeRequest', $inputLicense)) {
+      $newLicense->setMergeRequest($inputLicense['mergeRequest']);
+    }
+    return $newLicense;
   }
 }

--- a/src/www/ui/api/Models/Obligation.php
+++ b/src/www/ui/api/Models/Obligation.php
@@ -1,0 +1,213 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2021 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Obligation
+ */
+namespace Fossology\UI\Api\Models;
+
+/**
+ * @class Obligation
+ * @package Fossology\UI\Api\Models
+ * @brief Obligation model to hold obligation related info
+ */
+class Obligation
+{
+  /**
+   * @var integer $id
+   * Obligation id
+   */
+  private $id;
+  /**
+   * @var string $topic
+   * Topic of the obligation
+   */
+  private $topic;
+  /**
+   * @var string $type
+   * Type of the obligation
+   */
+  private $type;
+  /**
+   * @var string $text
+   * The text of the obligation
+   */
+  private $text;
+  /**
+   * @var string $classification
+   * Classification of the obligation
+   */
+  private $classification;
+  /**
+   * @var string $comment
+   * Comment on the obligation
+   */
+  private $comment;
+
+  /**
+   * Obligation constructor.
+   *
+   * @param integer $id
+   * @param string $topic
+   * @param string $type
+   * @param string $text
+   * @param string $classification
+   * @param string $comment
+   */
+  public function __construct($id, $topic = "", $type = "", $text = "",
+    $classification = "", $comment = "")
+  {
+    $this->id = intval($id);
+    $this->setTopic($topic);
+    $this->setType($type);
+    $this->setText($text);
+    $this->setClassification($classification);
+    $this->setComment($comment);
+  }
+
+  /**
+   * JSON representation of the license
+   * @return string
+   */
+  public function getJSON()
+  {
+    return json_encode($this->getArray());
+  }
+
+  /**
+   * Get License element as associative array
+   * @return array
+   */
+  public function getArray()
+  {
+    return [
+      'id' => $this->id,
+      'topic' => $this->getTopic(),
+      'type' => $this->getType(),
+      'text' => $this->getText(),
+      'classification' => $this->getClassification(),
+      'comment' => $this->getComment()
+    ];
+  }
+
+  /**
+   * Get the topic of the obligation
+   * @return string
+   */
+  public function getTopic()
+  {
+    if ($this->topic === null) {
+      return "";
+    }
+    return $this->topic;
+  }
+
+  /**
+   * Get the type of the obligation
+   * @return string
+   */
+  public function getType()
+  {
+    if ($this->type === null) {
+      return "";
+    }
+    return $this->type;
+  }
+
+  /**
+   * Get the text of the obligation
+   * @return string
+   */
+  public function getText()
+  {
+    if ($this->text === null) {
+      return "";
+    }
+    return $this->text;
+  }
+
+  /**
+   * Get the obligation's classification
+   * @return string
+   */
+  public function getClassification()
+  {
+    if ($this->classification === null) {
+      return "";
+    }
+    return $this->classification;
+  }
+
+  /**
+   * Get the comment on the obligation
+   * @return string
+   */
+  public function getComment()
+  {
+    if ($this->comment === null) {
+      return "";
+    }
+    return $this->comment;
+  }
+
+  /**
+   * Set the topic of the obligation
+   * @param string $topic
+   */
+  public function setTopic($topic)
+  {
+    $this->topic = convertToUTF8($topic, false);
+  }
+
+  /**
+   * Set the type of the obligation
+   * @param string $type
+   */
+  public function setType($type)
+  {
+    $this->type = convertToUTF8($type, false);
+  }
+
+  /**
+   * Set the text of the obligation
+   * @param string $text
+   */
+  public function setText($text)
+  {
+    $this->text = convertToUTF8($text, false);
+  }
+
+  /**
+   * Set the obligation's classification
+   * @param string $classification
+   */
+  public function setClassification($classification)
+  {
+    $this->classification = convertToUTF8($classification, false);
+  }
+
+  /**
+   * Set the comment on the obligation
+   * @param string $comment
+   */
+  public function setComment($comment)
+  {
+    $this->comment = convertToUTF8($comment, false);
+  }
+}

--- a/src/www/ui/api/Models/ScanOptions.php
+++ b/src/www/ui/api/Models/ScanOptions.php
@@ -23,13 +23,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 namespace Fossology\UI\Api\Models;
 
 use Fossology\Lib\Auth\Auth;
-use Fossology\Reuser\ReuserAgentPlugin;
 use Fossology\UI\Api\Models\Info;
 use Fossology\UI\Api\Models\InfoType;
 use Symfony\Component\HttpFoundation\Request;
 use Fossology\Lib\Dao\UserDao;
 
-require_once dirname(dirname(__DIR__)) . "/agent-add.php";
+if (!class_exists("AgentAdder", false)) {
+  require_once dirname(dirname(__DIR__)) . "/agent-add.php";
+}
 require_once dirname(dirname(dirname(dirname(__DIR__)))) . "/lib/php/common-folders.php";
 
 /**
@@ -158,7 +159,7 @@ class ScanOptions
     }
     $userDao = $GLOBALS['container']->get("dao.user");
     $reuserSelector = $this->reuse->getReuseUpload() . "," . $userDao->getGroupIdByName($this->reuse->getReuseGroup());
-    $request->request->set(ReuserAgentPlugin::UPLOAD_TO_REUSE_SELECTOR_NAME, $reuserSelector);
+    $request->request->set('uploadToReuse', $reuserSelector);
     $request->request->set('reuseMode', $reuserRules);
   }
 

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1195,6 +1195,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Info'
+        '409':
+          description: License with same name or text already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
         default:
             $ref: '#/components/responses/defaultResponse'
   /license/{shortname}:

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1,4 +1,4 @@
-# Copyright (C) Siemens AG 2017-2020
+# Copyright (C) Siemens AG 2017-2021
 # Copyright (C) 2021 Orange by Piotr Pszczola <piotr.pszczola@orange.com>
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -15,7 +15,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.2.3
+  version: 1.3.0
   contact:
     email: fossology@fossology.org
   license:
@@ -26,10 +26,40 @@ servers:
     description: Localhost instance
 security:
   - bearerAuth: []
+externalDocs:
+  description: Basic guide
+  url: https://github.com/fossology/fossology/wiki/FOSSology-REST-API
+tags:
+- name: auth
+  description: Authentication endpoints
+- name: info
+  description: Basic info about API
+- name: Upload
+  description: Endpoints related to uploads
+- name: Organize
+  description: Endpoints for organization of data
+- name: Search
+  description: Searching data on FOSSology
+- name: User
+  description: User management
+- name: Admin
+  description: Administrator tasks
+- name: Job
+  description: FOSSology jobs
+- name: Folders
+  description: Folder management
+- name: Groups
+  description: User group management
+- name: Report
+  description: Upload's report
+- name: License
+  description: License and obligation management
 
 paths:
   /auth:
     get:
+      tags:
+        - auth
       deprecated: true
       security: []
       summary: Get a login session registered (deprecated, use /tokens)
@@ -71,6 +101,8 @@ paths:
 
   /tokens:
     post:
+      tags:
+        - auth
       security: []
       summary: Generate a new token
       description: >
@@ -108,6 +140,8 @@ paths:
 
   /version:
     get:
+      tags:
+        - info
       security: []
       summary: Get the current API information
       description: >
@@ -149,7 +183,6 @@ paths:
     get:
       tags:
         - Upload
-        - Organize
       summary: Get single upload by id
       description:
         Returns a single upload
@@ -749,7 +782,6 @@ paths:
           description: Group name, from last login if not provided
     get:
       tags:
-      - Organize
       - Folders
       summary: Get the list of accessible folders
       responses:
@@ -766,6 +798,7 @@ paths:
     post:
       tags:
       - Organize
+      - Admin
       - Folders
       summary: Create a new folder
       parameters:
@@ -819,7 +852,6 @@ paths:
           description: Group name, from last login if not provided
     get:
       tags:
-      - Organize
       - Folders
       summary: Get a single folder details
       responses:
@@ -835,6 +867,7 @@ paths:
       tags:
       - Organize
       - Folders
+      - Admin
       summary: Delete a folder
       responses:
         '202':
@@ -906,7 +939,6 @@ paths:
   /groups:
     get:
       tags:
-      - Organize
       - Groups
       summary: Get the list of groups (accessible groups for user, all groups for admin)
       responses:
@@ -924,7 +956,8 @@ paths:
       tags:
       - Organize
       - Groups
-      summary: Create a group folder
+      - Admin
+      summary: Create a new group
       parameters:
         - name: name
           in: header
@@ -950,7 +983,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Info'        
+                $ref: '#/components/schemas/Info'
         default:
             $ref: '#/components/responses/defaultResponse'
 
@@ -1075,28 +1108,184 @@ paths:
                   $ref: '#/components/schemas/File'
         default:
             $ref: '#/components/responses/defaultResponse'
-
   /license:
+    parameters:
+      - name: groupName
+        description: The group name to chose
+        in: header
+        required: false
+        schema:
+          type: string
+          description: Group name, from last login if not provided
     get:
       tags:
       - License
-      summary: Get license from the database
       parameters:
-        - name: shortName
+        - name: page
+          description: Page number to fetch
           in: header
-          required: true
-          description: Short name of the license
+          required: false
           schema:
-            type: string
+            type: integer
+            default: 1
+        - name: limit
+          description: Limits of responses per request
+          in: header
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 100
+        - name: active
+          description: Get only active licenses
+          in: header
+          required: false
+          schema:
+            type: boolean
+            default: false
+      summary: Get all license from the database
       responses:
         '200':
-          description: Requested license
+          description: All licenses from database
+          headers:
+            X-Total-Pages:
+              description: Total number of pages which can be fetched
+              schema:
+                type: integer
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/License'
+                type: array
+                items:
+                  allOf:
+                    - type: object
+                      properties:
+                        id:
+                          type: integer
+                          description: Id key
+                          example:
+                            125
+                    - $ref: '#/components/schemas/License'
+        default:
+            $ref: '#/components/responses/defaultResponse'
+    post:
+      tags:
+      - License
+      summary: Create a new license
+      requestBody:
+        description: Information about new license
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/License'
+                - type: object
+                  properties:
+                    mergeRequest:
+                      description: Open a merge request for candidate license?
+                      type: boolean
+                      default: false
+              required:
+                - shortName
+      responses:
+        '201':
+          description: License added successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+            $ref: '#/components/responses/defaultResponse'
+  /license/{shortname}:
+    parameters:
+      - name: shortname
+        in: path
+        required: true
+        description: Shortname of the license
+        schema:
+          type: string
+      - name: groupName
+        description: The group name to chose
+        in: header
+        required: false
+        schema:
+          type: string
+          description: Group name, from last login if not provided
+    get:
+      tags:
+      - License
+      summary: Get a specific license
+      responses:
+        '200':
+          description: License
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - type: object
+                    properties:
+                      id:
+                        type: integer
+                        description: Id key
+                        example:
+                          125
+                  - $ref: "#/components/schemas/License"
+                  - type: object
+                    properties:
+                      obligations:
+                        description: Obligations associated with the license
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Obligation'
         '404':
-          description: No license found with the given parameters
+          description: License not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+            $ref: '#/components/responses/defaultResponse'
+    patch:
+      tags:
+      - License
+      summary: Update a license
+      requestBody:
+        description: Information to be updated
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Set the properties to be updated
+              properties:
+                fullName:
+                  description: New fullname
+                  type: string
+                  nullable: true
+                  example:
+                    "Updated license name"
+                text:
+                  description: New license text
+                  type: string
+                  nullable: true
+                  example:
+                    "Updated and corrected license text"
+                url:
+                  description: New URL for license
+                  type: string
+                  nullable: true
+                  example:
+                    "https://opensource.org/licenses/MIT"
+                risk:
+                  description: New risk value
+                  type: integer
+                  nullable: true
+                  example:
+                    2
+      responses:
+        '200':
+          description: License added successfully
           content:
             application/json:
               schema:
@@ -1169,7 +1358,7 @@ components:
           description: Date, when the file was uploaded.
         assignee:
           type: integer
-          description: assignee id of the upload.          
+          description: assignee id of the upload.
           nullable: true
         hash:
           $ref: '#/components/schemas/Hash'
@@ -1184,7 +1373,7 @@ components:
           description: Display name of the upload.
         assignee:
           type: integer
-          description: assignee id of the upload.            
+          description: assignee id of the upload.
           nullable: true
         mainLicense:
           type: string
@@ -1562,11 +1751,6 @@ components:
       description: License from the database
       type: object
       properties:
-        id:
-          description: Id key
-          type: integer
-          example:
-            126
         shortName:
           description: Short name
           type: string
@@ -1582,12 +1766,20 @@ components:
           type: string
           example:
             "MIT License Copyright (c) <year> <copyright holders> ..."
+        url:
+          description: URL of the license text
+          type: string
+          example:
+            "https://opensource.org/licenses/MIT"
         risk:
           description: Risk level
           type: integer
           nullable: true
           example:
             3
+        isCandidate:
+          description: Is the license a candidate?
+          type: boolean
     Group:
       description: Group object
       type: object
@@ -1601,7 +1793,47 @@ components:
           description: Name of a group
           type: string
           example:
-            "Main group"    
+            "Main group"
+    Obligation:
+      description: Obligation information
+      type: object
+      properties:
+        id:
+          description: Id key
+          type: integer
+          example:
+            126
+        topic:
+          description: Obligation topic
+          type: string
+          example:
+            "Should preserve notice"
+        type:
+          description: Type of obligation
+          type: string
+          example:
+            "Obligation"
+        text:
+          description: Obligation text
+          type: string
+          example:
+            "All notices from the package should be preserved."
+        classification:
+          description: >
+            Level of attention this obligation
+            should raise in the clearing process
+          type: string
+          enum:
+            - green
+            - white
+            - yellow
+            - red
+        comment:
+          description: Comments for the obligation
+          type: string
+          nullable: true
+          example:
+            "Please respect the obligation"
   responses:
     defaultResponse:
       description: Some error occured. Check the "message"

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -182,9 +182,18 @@ $app->group(VERSION_1 . 'filesearch',
 /////////////////////////LICENSE SEARCH/////////////////
 $app->group(VERSION_1 . 'license',
   function (){
-    $this->get('', LicenseController::class . ':getLicense');
+    $this->get('', LicenseController::class . ':getAllLicenses');
+    $this->post('', LicenseController::class . ':createLicense');
+    $this->get('/{shortname:.+}', LicenseController::class . ':getLicense');
+    $this->patch('/{shortname:.+}', LicenseController::class . ':updateLicense');
     $this->any('/{params:.*}', BadRequestController::class);
   });
+
+// Catch all routes
+$app->map(['GET', 'POST', 'PUT', 'DELETE', 'PATCH'], '/{routes:.+}', function($req, $res) {
+  $handler = $this->get('notFoundHandler');
+  return $handler($req, $res);
+});
 
 $app->run();
 

--- a/src/www/ui_tests/api/Controllers/FolderControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/FolderControllerTest.php
@@ -21,7 +21,7 @@
  * @brief Controller for folder queries
  */
 
-namespace
+namespace Fossology\UI\Api\Controllers
 {
 
   /**
@@ -439,7 +439,7 @@ namespace Fossology\UI\Api\Test\Controllers
     public function testDeleteFolder()
     {
       $folderId = 3;
-      $folderName = FolderGetName($folderId);
+      $folderName = \Fossology\UI\Api\Controllers\FolderGetName($folderId);
       $this->folderDao->shouldReceive('getFolder')
         ->withArgs(array($folderId))->andReturn($this->getFolder($folderId));
       $this->deletePlugin->shouldReceive('Delete')
@@ -522,7 +522,7 @@ namespace Fossology\UI\Api\Test\Controllers
       $response = new Response();
       $actualResponse = $this->folderController->editFolder($request,
         $response, ["id" => $folderId]);
-      $expectedResponse = new Info(200, 'Folder "' . FolderGetName($folderId) .
+      $expectedResponse = new Info(200, 'Folder "' . \Fossology\UI\Api\Controllers\FolderGetName($folderId) .
         '" updated.', InfoType::INFO);
       $this->assertEquals($expectedResponse->getCode(),
         $actualResponse->getStatusCode());
@@ -598,8 +598,8 @@ namespace Fossology\UI\Api\Test\Controllers
       $folderId = 3;
       $parentId = 2;
       $folderContentPk = 5;
-      $folderName = FolderGetName($folderId);
-      $parentFolderName = FolderGetName($parentId);
+      $folderName = \Fossology\UI\Api\Controllers\FolderGetName($folderId);
+      $parentFolderName = \Fossology\UI\Api\Controllers\FolderGetName($parentId);
 
       $this->folderDao->shouldReceive('getFolder')
         ->andReturnUsing([$this, 'getFolder']);
@@ -639,8 +639,8 @@ namespace Fossology\UI\Api\Test\Controllers
       $folderId = 3;
       $parentId = 2;
       $folderContentPk = 5;
-      $folderName = FolderGetName($folderId);
-      $parentFolderName = FolderGetName($parentId);
+      $folderName = \Fossology\UI\Api\Controllers\FolderGetName($folderId);
+      $parentFolderName = \Fossology\UI\Api\Controllers\FolderGetName($parentId);
 
       $this->folderDao->shouldReceive('getFolder')
         ->andReturnUsing([$this, 'getFolder']);

--- a/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
@@ -1,0 +1,689 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2021 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for LicenseController
+ */
+
+namespace Fossology\UI\Api\Test\Controllers;
+
+use Mockery as M;
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\LicenseDao;
+use Fossology\Lib\Dao\UserDao;
+use Fossology\Lib\Db\DbManager;
+use Fossology\UI\Api\Controllers\LicenseController;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Fossology\UI\Api\Models\License;
+use Fossology\UI\Api\Models\Obligation;
+use Slim\Http\Headers;
+use Slim\Http\Body;
+use Slim\Http\Request;
+use Slim\Http\Uri;
+use Slim\Http\Response;
+
+/**
+ * @class LicenseControllerTest
+ * @brief Unit tests for LicenseController
+ */
+class LicenseControllerTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @var integer $assertCountBefore
+   * Assertions before running tests
+   */
+  private $assertCountBefore;
+
+  /**
+   * @var integer $userId
+   * User ID to mock
+   */
+  private $userId;
+
+  /**
+   * @var integer $groupId
+   * Group ID to mock
+   */
+  private $groupId;
+
+  /**
+   * @var DbHelper $dbHelper
+   * DbHelper mock
+   */
+  private $dbHelper;
+
+  /**
+   * @var DbManager $dbManager
+   * Dbmanager mock
+   */
+  private $dbManager;
+
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+
+  /**
+   * @var LicenseController $licenseController
+   * LicenseController mock
+   */
+  private $licenseController;
+
+  /**
+   * @var LicenseDao $licenseDao
+   * LicenseDao mock
+   */
+  private $licenseDao;
+
+  /**
+   * @var UserDao $userDao
+   * UserDao mock
+   */
+  private $userDao;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp()
+  {
+    global $container;
+    $this->userId = 2;
+    $this->groupId = 2;
+    $container = M::mock('ContainerBuilder');
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->dbManager = M::mock(DbManager::class);
+    $this->restHelper = M::mock(RestHelper::class);
+    $this->licenseDao = M::mock(LicenseDao::class);
+    $this->userDao = M::mock(UserDao::class);
+
+    $this->dbHelper->shouldReceive('getDbManager')->andReturn($this->dbManager);
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+    $this->restHelper->shouldReceive('getGroupId')->andReturn($this->groupId);
+    $this->restHelper->shouldReceive('getUserId')->andReturn($this->userId);
+    $this->restHelper->shouldReceive('getUserDao')->andReturn($this->userDao);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+    $container->shouldReceive('get')->withArgs(array(
+      'dao.license'))->andReturn($this->licenseDao);
+    $this->licenseController = new LicenseController($container);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+  }
+
+  /**
+   * @brief Remove test objects
+   * @see PHPUnit_Framework_TestCase::tearDown()
+   */
+  protected function tearDown()
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  /**
+   * Helper function to get JSON array from response
+   *
+   * @param Response $response
+   * @return array Decoded response
+   */
+  private function getResponseJson($response)
+  {
+    $response->getBody()->seek(0);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+
+  /**
+   * Helper function to generate obligations
+   * @param integer $id
+   * @return Obligation
+   */
+  private function getObligation($id)
+  {
+    return new Obligation($id, 'My obligation', 'Obligation',
+      'This should represent some valid obligation text.', 'yellow');
+  }
+
+  /**
+   * Helper function to generate obligations for License Dao
+   * @param integer $id
+   * @return Obligation
+   */
+  private function getDaoObligation($id)
+  {
+    return [
+      'ob_pk' => $id,
+      'ob_topic' => 'My obligation',
+      'ob_text' => 'This should represent some valid obligation text.',
+      'ob_active' => true,
+      'rf_fk' => 2,
+      'ob_type' => 'Obligation',
+      'ob_classification' => 'yellow',
+      'ob_comment' => "",
+      'rf_shortname' => null
+    ];
+  }
+
+  /**
+   * Helper function to generate licenses
+   * @param string  $shortname
+   * @param boolean $obligations
+   * @param boolean $emptyObligation
+   * @return License
+   */
+  private function getLicense($shortname, $obligations=false,
+    $emptyObligation=true)
+  {
+    $obligationList = [
+      $this->getObligation(123),
+      $this->getObligation(124)
+    ];
+    $license = null;
+    if ($shortname == "MIT") {
+      $license = new License(22, "MIT", "MIT License",
+        "MIT License Copyright (c) <year> <copyright holders> ...",
+        "https://opensource.org/licenses/MIT", null, 2, false);
+    } else {
+      $license = new License(25, $shortname, "Exotic License",
+        "Exotic license for magical codes", "", null, 0, true);
+    }
+    if ($obligations) {
+      if ($emptyObligation) {
+        $license->setObligations([]);
+      } else {
+        $license->setObligations($obligationList);
+      }
+    }
+    return $license;
+  }
+
+  /**
+   * Helper function to generate licenses from LicenseDao
+   * @param string  $shortname
+   * @return \Fossology\Lib\Data\License
+   */
+  private function getDaoLicense($shortname)
+  {
+    $license = null;
+    if ($shortname == "MIT") {
+      $license = new \Fossology\Lib\Data\License(22, "MIT", "MIT License",
+        2, "MIT License Copyright (c) <year> <copyright holders> ...",
+        "https://opensource.org/licenses/MIT", 1, true);
+    } else {
+      $license = new \Fossology\Lib\Data\License(25, $shortname,
+        "Exotic License", 0, "Exotic license for magical codes", "", 1,
+        false);
+    }
+    return $license;
+  }
+
+  /**
+   * Helper function to translate License to DB array
+   * @param array $licenses
+   * @return array
+   */
+  private function traslateLicenseToDb($licenses)
+  {
+    $licenseList = [];
+    foreach ($licenses as $license) {
+      $licenseList[] = [
+        'rf_pk' => $license->getId(),
+        'rf_shortname' => $license->getShortName(),
+        'rf_fullname' => $license->getFullName(),
+        'rf_text' => $license->getText(),
+        'rf_url' => $license->getUrl(),
+        'rf_risk' => $license->getRisk(),
+        'group_fk' => $license->getIsCandidate() ? $this->groupId : 0
+      ];
+    }
+    return $licenseList;
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::getLicense() to fetch single license
+   * -# Check if response is 200
+   */
+  public function testGetLicense()
+  {
+    $licenseShortName = "MIT";
+    $license = $this->getLicense($licenseShortName, true);
+
+    $requestHeaders = new Headers();
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("GET", new Uri("HTTP", "localhost", 80,
+      "/license/$licenseShortName"), $requestHeaders, [], [], $body);
+    $this->licenseDao->shouldReceive('getLicenseByShortName')
+      ->withArgs([$licenseShortName, $this->groupId])
+      ->andReturn($this->getDaoLicense($licenseShortName));
+    $this->licenseDao->shouldReceive('getLicenseObligations')
+      ->withArgs([[22], false])->andReturn([]);
+    $this->licenseDao->shouldReceive('getLicenseObligations')
+      ->withArgs([[22], true])->andReturn([]);
+    $expectedResponse = (new Response())->withJson($license->getArray(), 200);
+
+    $actualResponse = $this->licenseController->getLicense($request,
+      new Response(), ['shortname' => $licenseShortName]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::getLicense() to fetch single license
+   * -# The license now has obligations
+   * -# Check if response is 200
+   */
+  public function testGetLicenseObligations()
+  {
+    $licenseShortName = "MIT";
+    $license = $this->getLicense($licenseShortName, true, false);
+
+    $requestHeaders = new Headers();
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("GET", new Uri("HTTP", "localhost", 80,
+      "/license/$licenseShortName"), $requestHeaders, [], [], $body);
+    $this->licenseDao->shouldReceive('getLicenseByShortName')
+      ->withArgs([$licenseShortName, $this->groupId])
+      ->andReturn($this->getDaoLicense($licenseShortName));
+    $this->licenseDao->shouldReceive('getLicenseObligations')
+      ->withArgs([[22], false])->andReturn([$this->getDaoObligation(123)]);
+    $this->licenseDao->shouldReceive('getLicenseObligations')
+      ->withArgs([[22], true])->andReturn([$this->getDaoObligation(124)]);
+    $expectedResponse = (new Response())->withJson($license->getArray(), 200);
+
+    $actualResponse = $this->licenseController->getLicense($request,
+      new Response(), ['shortname' => $licenseShortName]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::getLicense(), license not found
+   * -# Check if response is 404
+   */
+  public function testGetLicenseNotFound()
+  {
+    $licenseShortName = "Bogus";
+
+    $requestHeaders = new Headers();
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("GET", new Uri("HTTP", "localhost", 80,
+      "/license/$licenseShortName"), $requestHeaders, [], [], $body);
+    $this->licenseDao->shouldReceive('getLicenseByShortName')
+      ->withArgs([$licenseShortName, $this->groupId])
+      ->andReturn(null);
+    $info = new Info(404,
+      "No license found with short name '{$licenseShortName}'.",
+      InfoType::ERROR);
+    $expectedResponse = (new Response())->withJson($info->getArray(),
+      $info->getCode());
+
+    $actualResponse = $this->licenseController->getLicense($request,
+      new Response(), ['shortname' => $licenseShortName]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::getAllLicenses() to fetch all licenses
+   * -# Check if response is 200
+   * -# Check if pagination headers are set
+   */
+  public function testGetAllLicense()
+  {
+    $licenses = [
+      $this->getLicense("MIT"),
+      $this->getLicense("Exotic"),
+      $this->getLicense("Exotic2"),
+      $this->getLicense("Exotic3")
+    ];
+
+    $requestHeaders = new Headers();
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("GET", new Uri("HTTP", "localhost", 80,
+      "/license"), $requestHeaders, [], [], $body);
+    $this->dbHelper->shouldReceive('getLicenseCount')
+      ->withArgs([$this->groupId])->andReturn(4);
+    $this->dbHelper->shouldReceive('getLicensesPaginated')
+      ->withArgs([1, 100, $this->groupId, false])
+      ->andReturn($this->traslateLicenseToDb($licenses));
+
+    $responseLicense = [];
+    foreach ($licenses as $license) {
+      $responseLicense[] = $license->getArray();
+    }
+    $expectedResponse = (new Response())->withHeader("X-Total-Pages", 1)
+      ->withJson($responseLicense, 200);
+
+    $actualResponse = $this->licenseController->getAllLicenses($request,
+      new Response(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+    $this->assertEquals($expectedResponse->getHeaders(),
+      $actualResponse->getHeaders());
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::getAllLicenses() to fetch all licenses
+   * -# The page requested is out of bounds
+   * -# Check if response is 400
+   * -# Check if pagination headers are set
+   */
+  public function testGetAllLicenseBounds()
+  {
+    $requestHeaders = new Headers();
+    $requestHeaders->set('limit', 5);
+    $requestHeaders->set('page', 2);
+    $body = new Body(fopen('php://temp', 'r+'));
+    $request = new Request("GET", new Uri("HTTP", "localhost", 80,
+      "/license"), $requestHeaders, [], [], $body);
+    $this->dbHelper->shouldReceive('getLicenseCount')
+      ->withArgs([$this->groupId])->andReturn(4);
+
+    $info = new Info(400, "Can not exceed total pages: 1", InfoType::ERROR);
+    $expectedResponse = (new Response())->withHeader("X-Total-Pages", 1)
+      ->withJson($info->getArray(), $info->getCode());
+
+    $actualResponse = $this->licenseController->getAllLicenses($request,
+      new Response(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+    $this->assertEquals($expectedResponse->getHeaders(),
+      $actualResponse->getHeaders());
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::createLicense() to create new license
+   * -# Check if response is 201
+   */
+  public function testCreateLicense()
+  {
+    $license = $this->getLicense("MIT");
+    $requestBody = $license->getArray();
+    $requestBody["isCandidate"] = true;
+    unset($requestBody['id']);
+
+    $requestHeaders = new Headers();
+    $requestHeaders->set('Content-Type', 'application/json');
+    $body = new Body(fopen('php://temp', 'wr+'));
+    $body->write(json_encode($requestBody));
+    $body->seek(0);
+    $request = new Request("POST", new Uri("HTTP", "localhost", 80,
+      "/license"), $requestHeaders, [], [], $body);
+
+    $tableName = "license_candidate";
+    $assocData = [
+      "rf_shortname" => $license->getShortName(),
+      "rf_fullname" => $license->getFullName(),
+      "rf_text" => $license->getText(),
+      "rf_risk" => $license->getRisk(),
+      "rf_url" => $license->getUrl(),
+      "rf_detector_type" => 1,
+      "group_fk" => $this->groupId,
+      "rf_user_fk_created" => $this->userId,
+      "rf_user_fk_modified" => $this->userId,
+      "marydone" => false
+    ];
+
+    $this->dbManager->shouldReceive('insertTableRow')
+      ->withArgs([$tableName, $assocData, M::any(), "rf_pk"])->andReturn(4);
+
+    $info = new Info(201, "License " . $license->getShortName() .
+      " added with id '4'.", InfoType::INFO);
+    $expectedResponse = (new Response())->withJson($info->getArray(),
+      $info->getCode());
+
+    $actualResponse = $this->licenseController->createLicense($request,
+      new Response(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::createLicense() to create new license
+   * -# The request body is malformed
+   * -# Check if response is 400
+   */
+  public function testCreateLicenseNoShort()
+  {
+    $license = $this->getLicense("MIT");
+    $requestBody = $license->getArray();
+    $requestBody["isCandidate"] = true;
+    unset($requestBody['id']);
+    unset($requestBody['shortName']);
+
+    $requestHeaders = new Headers();
+    $requestHeaders->set('Content-Type', 'application/json');
+    $body = new Body(fopen('php://temp', 'wr+'));
+    $body->write(json_encode($requestBody));
+    $body->seek(0);
+    $request = new Request("POST", new Uri("HTTP", "localhost", 80,
+      "/license"), $requestHeaders, [], [], $body);
+
+    $info = new Info(400, "Property 'shortName' is required.",
+      InfoType::ERROR);
+    $expectedResponse = (new Response())->withJson($info->getArray(),
+      $info->getCode());
+
+    $actualResponse = $this->licenseController->createLicense($request,
+      new Response(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::createLicense() to create new license
+   * -# Non admin user can't create main license
+   * -# Check if response is 403
+   */
+  public function testCreateLicenseNoAdmin()
+  {
+    $license = $this->getLicense("MIT");
+    $requestBody = $license->getArray();
+    unset($requestBody['id']);
+
+    $requestHeaders = new Headers();
+    $requestHeaders->set('Content-Type', 'application/json');
+    $body = new Body(fopen('php://temp', 'wr+'));
+    $body->write(json_encode($requestBody));
+    $body->seek(0);
+    $request = new Request("POST", new Uri("HTTP", "localhost", 80,
+      "/license"), $requestHeaders, [], [], $body);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+
+    $info = new Info(403, "Need to be admin to create non-candidate license.",
+      InfoType::ERROR);
+    $expectedResponse = (new Response())->withJson($info->getArray(),
+      $info->getCode());
+
+    $actualResponse = $this->licenseController->createLicense($request,
+      new Response(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::updateLicense() to edit a license
+   * -# Check if response is 200
+   */
+  public function testUpdateLicense()
+  {
+    $license = $this->getDaoLicense("Exotic");
+    $requestBody = [
+      "fullName" => "Exotic License - style",
+      "risk" => 0
+    ];
+
+    $requestHeaders = new Headers();
+    $requestHeaders->set('Content-Type', 'application/json');
+    $body = new Body(fopen('php://temp', 'wr+'));
+    $body->write(json_encode($requestBody));
+    $body->seek(0);
+    $request = new Request("PATCH", new Uri("HTTP", "localhost", 80,
+      "/license/" . $license->getShortName()), $requestHeaders, [], [], $body);
+
+    $tableName = "license_candidate";
+    $assocData = [
+      "rf_fullname" => "Exotic License - style",
+      "rf_risk" => 0
+    ];
+
+    $this->userDao->shouldReceive('isAdvisorOrAdmin')
+      ->withArgs([$this->userId, $this->groupId])->andReturn(true);
+    $this->licenseDao->shouldReceive('getLicenseByShortName')
+      ->withArgs([$license->getShortName(), $this->groupId])
+      ->andReturn($license);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["license_candidate", "rf_pk", $license->getId()])
+      ->andReturn(true);
+    $this->dbManager->shouldReceive('updateTableRow')
+      ->withArgs([$tableName, $assocData, "rf_pk", $license->getId(), M::any()]);
+
+    $info = new Info(200, "License " . $license->getShortName() . " updated.",
+      InfoType::INFO);
+    $expectedResponse = (new Response())->withJson($info->getArray(),
+      $info->getCode());
+
+    $actualResponse = $this->licenseController->updateLicense($request,
+      new Response(), ["shortname" => $license->getShortName()]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::updateLicense() to edit a license
+   * -# User is not admin/advisor of the group
+   * -# Check if response is 403
+   */
+  public function testUpdateLicenseNonAdvisor()
+  {
+    $license = $this->getDaoLicense("Exotic");
+    $requestBody = [
+      "fullName" => "Exotic License - style",
+      "risk" => 0
+    ];
+
+    $requestHeaders = new Headers();
+    $requestHeaders->set('Content-Type', 'application/json');
+    $body = new Body(fopen('php://temp', 'wr+'));
+    $body->write(json_encode($requestBody));
+    $body->seek(0);
+    $request = new Request("PATCH", new Uri("HTTP", "localhost", 80,
+      "/license/" . $license->getShortName()), $requestHeaders, [], [], $body);
+
+    $this->userDao->shouldReceive('isAdvisorOrAdmin')
+      ->withArgs([$this->userId, $this->groupId])->andReturn(false);
+    $this->licenseDao->shouldReceive('getLicenseByShortName')
+      ->withArgs([$license->getShortName(), $this->groupId])
+      ->andReturn($license);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["license_candidate", "rf_pk", $license->getId()])
+      ->andReturn(true);
+
+    $info = new Info(403, "Operation not permitted for this group.",
+      InfoType::ERROR);
+    $expectedResponse = (new Response())->withJson($info->getArray(),
+      $info->getCode());
+
+    $actualResponse = $this->licenseController->updateLicense($request,
+      new Response(), ["shortname" => $license->getShortName()]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::updateLicense() to edit a license
+   * -# User is not admin
+   * -# Check if response is 403
+   */
+  public function testUpdateLicenseNonAdmin()
+  {
+    $license = $this->getDaoLicense("MIT");
+    $requestBody = [
+      "fullName" => "MIT License - style",
+      "risk" => 0
+    ];
+
+    $requestHeaders = new Headers();
+    $requestHeaders->set('Content-Type', 'application/json');
+    $body = new Body(fopen('php://temp', 'wr+'));
+    $body->write(json_encode($requestBody));
+    $body->seek(0);
+    $request = new Request("PATCH", new Uri("HTTP", "localhost", 80,
+      "/license/" . $license->getShortName()), $requestHeaders, [], [], $body);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+
+    $this->userDao->shouldReceive('isAdvisorOrAdmin')
+      ->withArgs([$this->userId, $this->groupId])->andReturn(true);
+    $this->licenseDao->shouldReceive('getLicenseByShortName')
+      ->withArgs([$license->getShortName(), $this->groupId])
+      ->andReturn($license);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["license_candidate", "rf_pk", $license->getId()])
+      ->andReturn(false);
+
+    $info = new Info(403, "Only admin can edit main licenses.",
+      InfoType::ERROR);
+    $expectedResponse = (new Response())->withJson($info->getArray(),
+      $info->getCode());
+
+    $actualResponse = $this->licenseController->updateLicense($request,
+      new Response(), ["shortname" => $license->getShortName()]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+}

--- a/src/www/ui_tests/api/Controllers/UploadControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadControllerTest.php
@@ -48,7 +48,7 @@ use Fossology\UI\Api\Models\Hash;
 
 function TryToDelete($uploadpk, $user_pk, $group_pk, $uploadDao)
 {
-  return UploadControllerTests::$function->TryToDelete($uploadpk, $user_pk,
+  return UploadControllerTest::$function->TryToDelete($uploadpk, $user_pk,
     $group_pk, $uploadDao);
 }
 
@@ -56,7 +56,7 @@ function TryToDelete($uploadpk, $user_pk, $group_pk, $uploadDao)
  * @class UploadControllerTest
  * @brief Unit tests for UploadController
  */
-class UploadControllerTests extends \PHPUnit\Framework\TestCase
+class UploadControllerTest extends \PHPUnit\Framework\TestCase
 {
   /**
    * @var \Mockery\MockInterface $functions

--- a/src/www/ui_tests/api/Models/LicenseTest.php
+++ b/src/www/ui_tests/api/Models/LicenseTest.php
@@ -1,0 +1,109 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2021 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for License model
+ */
+
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\License;
+
+/**
+ * @class LicenseTest
+ * @brief Test for License model
+ */
+class LicenseTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @test
+   * -# Test data model returned by License::getArray() is correct
+   */
+  public function testDataFormat()
+  {
+    $expectedLicense = [
+      'id'        => 22,
+      'shortName' => "MIT",
+      'fullName'  => "MIT License",
+      'text'      => "MIT License Copyright (c) <year> <copyright holders> ...",
+      'url'       => "https://opensource.org/licenses/MIT",
+      'risk'      => 3,
+      'isCandidate' => false,
+      'obligations' => []
+    ];
+
+    $actualLicense = new License(22, "MIT", "MIT License",
+      "MIT License Copyright (c) <year> <copyright holders> ...",
+      "https://opensource.org/licenses/MIT", [], 3, false);
+
+    $this->assertEquals($expectedLicense, $actualLicense->getArray());
+  }
+
+  /**
+   * @test
+   * -# Test data model returned by License::getArray() is correct when there is
+   *    no obligation
+   */
+  public function testDataFormatNoObligation()
+  {
+    $expectedLicense = [
+      'id'        => 22,
+      'shortName' => "MIT",
+      'fullName'  => "MIT License",
+      'text'      => "MIT License Copyright (c) <year> <copyright holders> ...",
+      'url'       => "https://opensource.org/licenses/MIT",
+      'risk'      => 3,
+      'isCandidate' => true
+    ];
+
+    $actualLicense = new License(22, "MIT", "MIT License",
+      "MIT License Copyright (c) <year> <copyright holders> ...",
+      "https://opensource.org/licenses/MIT", null, 3, true);
+
+    $this->assertEquals($expectedLicense, $actualLicense->getArray());
+  }
+
+  /**
+   * @test
+   * -# Test parser License::parseFromArray()
+   * -# Create a valid license input and check the function.
+   * -# Create an input with invalid keys and check if function returns error.
+   */
+  public function testArrayParser()
+  {
+    $inputLicense = [
+      'shortName' => "MIT",
+      'fullName'  => "MIT License",
+      'text'      => "MIT License Copyright (c) <year> <copyright holders> ...",
+      'url'       => "https://opensource.org/licenses/MIT"
+    ];
+
+    $sampleLicense = new License(0, "MIT", "MIT License",
+      "MIT License Copyright (c) <year> <copyright holders> ...",
+      "https://opensource.org/licenses/MIT");
+
+    $actualLicense = License::parseFromArray($inputLicense);
+
+    $this->assertEquals($sampleLicense->getArray(), $actualLicense->getArray());
+
+    $bogusInput = array_merge($inputLicense, ["invalidKey" => 123]);
+    $bogusLicense = License::parseFromArray($bogusInput);
+    $this->assertEquals(-1, $bogusLicense);
+  }
+}

--- a/src/www/ui_tests/api/Models/ObligationTest.php
+++ b/src/www/ui_tests/api/Models/ObligationTest.php
@@ -1,0 +1,54 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2021 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for Obligation model
+ */
+
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\Obligation;
+
+/**
+ * @class ObligationTest
+ * @brief Test for Obligation model
+ */
+class ObligationTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @test
+   * -# Test data model returned by Obligation::getArray() is correct
+   */
+  public function testDataFormat()
+  {
+    $expectedObligation = [
+      'id'             => 123,
+      'topic'          => 'My obligation',
+      'type'           => 'Obligation',
+      'text'           => 'This should represent some valid obligation text.',
+      'classification' => 'yellow',
+      'comment'        => ""
+    ];
+
+    $actualObligation = new Obligation("123", 'My obligation', 'Obligation',
+      'This should represent some valid obligation text.', 'yellow');
+
+    $this->assertEquals($expectedObligation, $actualObligation->getArray());
+  }
+}

--- a/src/www/ui_tests/api/Models/ScanOptionsTest.php
+++ b/src/www/ui_tests/api/Models/ScanOptionsTest.php
@@ -1,0 +1,171 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2021 Siemens AG
+ * Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for Scan model
+ */
+
+namespace Fossology\UI\Api\Test\Models
+{
+  use Mockery as M;
+  use Fossology\UI\Api\Models\Analysis;
+  use Fossology\UI\Api\Models\ScanOptions;
+  use Fossology\UI\Api\Models\Reuser;
+  use Fossology\UI\Api\Models\Decider;
+  use Fossology\Lib\Dao\UserDao;
+  use Fossology\Lib\Auth\Auth;
+  use Symfony\Component\HttpFoundation\Request;
+
+  /**
+   * @class ScanOptionsTest
+   * @brief Tests for ScanOption model
+   */
+  class ScanOptionsTest extends \PHPUnit\Framework\TestCase
+  {
+    /**
+     * @var \Mockery\MockInterface $functions
+     * Public function mock
+     */
+    public static $functions;
+
+    /**
+     * @var AgentAdder $agentAdderMock
+     * Mock object of overloaded AgentAdder class
+     */
+    private $agentAdderMock;
+
+    /**
+     * @var UserDao $userDao
+     * UserDao mock
+     */
+    private $userDao;
+
+    /**
+     * @brief Setup test objects
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    public function setUp()
+    {
+      global $container;
+      $container = M::mock('ContainerBuilder');
+      $this->agentAdderMock = M::mock('overload:\AgentAdder');
+      $this->userDao = M::mock(UserDao::class);
+      $container->shouldReceive('get')->withArgs(["dao.user"])
+        ->andReturn($this->userDao);
+      $container->shouldReceive('get')->andReturn(null);
+
+      self::$functions = M::mock(\stdClass::class);
+      self::$functions->shouldReceive('FolderListUploads_perm')
+        ->withArgs([2, Auth::PERM_WRITE])->andReturn([
+          ['upload_pk' => 2],
+          ['upload_pk' => 3],
+          ['upload_pk' => 4]
+        ]);
+      self::$functions->shouldReceive('register_plugin')
+        ->with(\Hamcrest\Matchers::identicalTo(
+          new ScanOptions(null, null, null)));
+    }
+
+    /**
+     * Prepare request for scan
+     * @param Request $request
+     * @param array $reuserOpts
+     * @param array $deciderOpts
+     * @return Request
+     */
+    private function prepareRequest($request, $reuserOpts, $deciderOpts)
+    {
+      if (!empty($reuserOpts)) {
+        $reuserSelector = $reuserOpts['upload'] . "," . $reuserOpts['group'];
+        $request->request->set('uploadToReuse', $reuserSelector);
+        if (key_exists('rules', $reuserOpts)) {
+          $request->request->set('reuseMode', $reuserOpts['rules']);
+        }
+      }
+      if (!empty($deciderOpts)) {
+        $request->request->set('deciderRules', $deciderOpts);
+        if (in_array('nomosInMonk', $deciderOpts)) {
+          $request->request->set('Check_agent_nomos', 1);
+        }
+      }
+      return $request;
+    }
+
+    /**
+     * @test
+     * -# Test for ScanOptions::scheduleAgents()
+     * -# Prepare Request and call ScanOptions::scheduleAgents()
+     * -# Function should call AgentAdder::scheduleAgents()
+     */
+    public function testScheduleAgents()
+    {
+      $reuseUploadId = 2;
+      $uploadId = 4;
+      $folderId = 2;
+      $groupId = 2;
+      $groupName = "fossy";
+      $agentsToAdd = ['agent_nomos', 'agent_ojo', 'agent_monk'];
+      $reuserOpts = [
+        'upload' => $reuseUploadId,
+        'group' => $groupId,
+        'rules' => []
+      ];
+      $deciderOpts = [
+        'nomosInMonk',
+        'ojoNoContradiction'
+      ];
+      $request = new Request();
+      $request = $this->prepareRequest($request, $reuserOpts, $deciderOpts);
+
+      $analysis = new Analysis();
+      $analysis->setUsingString("nomos,ojo,monk");
+
+      $reuse = new Reuser($reuseUploadId, $groupName);
+
+      $decider = new Decider();
+      $decider->setOjoDecider(true);
+      $decider->setNomosMonk(true);
+
+      $scanOption = new ScanOptions($analysis, $reuse, $decider);
+
+      $this->userDao->shouldReceive('getGroupIdByName')
+        ->withArgs([$groupName])->andReturn($groupId);
+      $this->agentAdderMock->shouldReceive('scheduleAgents')
+        ->once()
+        ->andReturn(25);
+
+      $scanOption->scheduleAgents($folderId, $uploadId);
+    }
+  }
+}
+
+namespace Fossology\UI\Api\Models
+{
+  function register_plugin($obj)
+  {
+    return \Fossology\Ui\Api\Test\Models\ScanOptionsTest::$functions
+      ->register_plugin($obj);
+  }
+
+  function FolderListUploads_perm($parentFolder, $perm)
+  {
+    return \Fossology\Ui\Api\Test\Models\ScanOptionsTest::$functions
+      ->FolderListUploads_perm($parentFolder, $perm);
+  }
+}


### PR DESCRIPTION
## Description

Added new POST and PATCH endpoints to `/license` for creating and editing licenses from REST API.

The GET to `/license` is also edited. Now, the request without license name will list every license (paginated). Request to `/license/<shortname>` will list just the requested license but will also include the obligations associated to it.

### Changes

1. Added the POST and PATCH endpoints to `/license`.
2. New model `Obligation`.
3. Added `/license` endpoint for listing all licenses.
4. Update `/license/<shortname>` endpoint to list license obligations.

## How to test

1. Try to get all the licenses from the `/license` endpoint and check if they matched the DB.
2. Check the pagination feature of the `/license` endpoint.
3. Check the obligation list of a license with `/license/<shortname>` endpoint.
4. Try creating a new license with `POST` request.
5. Try updating a license with `PATCH` request.