### PR TITLE
fix(nomos): improved nomos MPL-2.0 detection

### DIFF
--- a/src/nomos/agent/STRINGS.in
+++ b/src/nomos/agent/STRINGS.in
@@ -12209,6 +12209,10 @@ k
 %KEY% "(\<gnu|free\>|l?gpl)"
 %STR% "(lesser|library) (gpl|general public licen[cs]e)"
 #
+%ENTRY% _TEXT_MPLV2
+%KEY% "licen[cs]"
+%STR% "MPL.?([\/ -])?2(\.?0)?"
+#
 %ENTRY% _TEXT_LICSET
 %KEY% "licen[cs]"
 %STR% "(these licen[cs]es|this licen[cs]e set|set of licen[cs]es)"
@@ -12722,7 +12726,7 @@ k
 #
 %ENTRY% _URL_MPL_LATEST
 %KEY% "\<([mn]pl|mozilla|netscape)\>"
-%STR% "w?w?w?\.?mozilla\.?org/[MN]PL/ "
+%STR% "w?w?w?\.?mozilla\.?org/[MN]PL/"
 #
 %ENTRY% _URL_MPL10
 %KEY% "\<([mn]pl|mozilla|netscape)\>"
@@ -12734,7 +12738,7 @@ k
 #
 %ENTRY% _URL_MPL20
 %KEY% "\<([mn]pl|mozilla|netscape)\>"
-%STR% "w?w?w?\.?mozilla\.?org/[MN]PL/MPL-2\.?0"
+%STR% "w?w?w?\.?mozilla\.?org/[MN]PL/(MPL-)?2\.?0"
 #
 %ENTRY% _URL_MulanPSL
 %KEY% "licen[cs]"

--- a/src/nomos/agent/parse.c
+++ b/src/nomos/agent/parse.c
@@ -6831,7 +6831,11 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
   }
   cleanLicenceBuffer();
   /* Mozilla Public License possibility */
-  if (!lmem[_mMPL] && URL_INFILE(_URL_MPL_LATEST)) {
+  if (!lmem[_mMPL] && INFILE(_TEXT_MPLV2) && INFILE(_URL_MPL20)) {
+      INTERESTING("MPL-2.0");
+      lmem[_mMPL] = 1;
+  }
+  else if (!lmem[_mMPL] && URL_INFILE(_URL_MPL_LATEST)) {
     INTERESTING(lDebug ? "MPL(latest)" : "MPL");
   }
   cleanLicenceBuffer();


### PR DESCRIPTION
Signed-off-by: Anupam Ghosh <anupam.ghosh@siemens.com>

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Improved nomos MPL-2.0 detection

### Changes

added a regex for MPL-2.0 detection
added the same in the parse.c

## How to test
use this text to check the PR

```
Eigen is primarily MPL2 licensed. See COPYING.MPL2 and these links:
http://www.mozilla.org/MPL/2.0/
http://www.mozilla.org/MPL/2.0/FAQ.html

Some files contain third-party code under BSD or LGPL licenses, whence the other
COPYING.* files here.

All the LGPL code is either LGPL 2.1-only, or LGPL 2.1-or-later.
For this reason, the COPYING.LGPL file contains the LGPL 2.1 text.

If you want to guarantee that the Eigen code that you are #including is licensed
under the MPL2 and possibly more permissive licenses (like BSD), #define this
preprocessor symbol:
EIGEN_MPL2_ONLY
For example, with most compilers, you could add this to your project CXXFLAGS:
-DEIGEN_MPL2_ONLY
This will cause a compilation error to be generated if you #include any code that is
LGPL licensed.
```
