### PR TITLE
fix(debian): Add php-gd package as dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -64,7 +64,7 @@ Description: architecture for analyzing software, common files
 
 Package: fossology-web
 Architecture: any
-Depends: fossology-common, apache2,
+Depends: fossology-common, apache2, php7.0-gd|php7.2-gd|php7.3-gd|php7.4-gd,
  libapache2-mod-php7.0|libapache2-mod-php7.2|libapache2-mod-php7.3|libapache2-mod-php7.4,
  ${misc:Depends}
 Recommends: fossology-db


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add `php-gd` dependency to Debian `fossology-web` package required by `PhpOffice\PhpSpreadsheet`.

## How to test

- Build and install debian packages.
- Check if you can export spreadsheet of licenses.

See #1958 for more.