### PR TITLE
feat(gitpod): Inital contribution

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,83 @@
+# FOSSology gitpod.io Dockerfile
+# Copyright (C) 2021 Siemens AG
+# Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# Description: Docker container image recipe for gitpod.io workspace
+
+FROM gitpod/workspace-full:latest
+
+USER root
+
+RUN install-packages --option Dpkg::Options::="--force-confold" \
+    binutils build-essential bzip2 cabextract composer cpio cppcheck \
+    curl debhelper devscripts dpkg-dev genisoimage git git-core gzip \
+    libboost-filesystem-dev libboost-program-options-dev \
+    libboost-regex-dev libboost-system-dev libcppunit-dev libcunit1-dev \
+    libdbd-sqlite3-perl libdistro-info-perl libgcrypt20-dev \
+    libicu66 libicu-dev libjson-c-dev libjsoncpp-dev \
+    liblocal-lib-perl libmagic-dev libmxml-dev libpcre3-dev libpq-dev \
+    librpm-dev libspreadsheet-writeexcel-perl libsqlite3-0 libsqlite3-dev \
+    libssl-dev libtext-template-perl libxml2-dev lsb-release p7zip p7zip-full \
+    poppler-utils postgresql-12 postgresql-contrib-12 \
+    postgresql-server-dev-all rpm sleuthkit s-nail sqlite3 subversion tar \
+    unrar-free unzip upx-ucl wget zip
+
+# Fix PHP for FOSSology
+RUN PHP_PATH=$(php --ini | awk '/\/etc\/php.*\/cli$/{print $5}') \
+ && phpIni="${PHP_PATH}/../apache2/php.ini" \
+ && TIMEZONE=$(cat /etc/timezone) \
+ && sed -i 's/^\(max_execution_time\s*=\s*\).*$/\1300/' $phpIni \
+ && sed -i 's/^\(memory_limit\s*=\s*\).*$/\1702M/' $phpIni \
+ && sed -i 's/^\(post_max_size\s*=\s*\).*$/\1701M/' $phpIni \
+ && sed -i 's/^\(upload_max_filesize\s*=\s*\).*$/\1700M/' $phpIni \
+ && sed -i "s%.*date.timezone =.*%date.timezone = $TIMEZONE%" $phpIni
+
+USER gitpod
+
+# Copy PostgreSQL setup from https://github.com/gitpod-io/workspace-images/blob/master/postgres/Dockerfile
+# Changes:
+# 1. Call initdb with `postgres' as the user
+# 2. Change the unix_socket_directories in postgresql.conf
+# Setup PostgreSQL server for user gitpod
+ENV PATH="$PATH:/usr/lib/postgresql/12/bin"
+ENV PGDATA="/workspace/.pgsql/data"
+ENV SOCLOC="${HOME}/.pg_ctl/sockets"
+RUN mkdir -p ~/.pg_ctl/bin ~/.pg_ctl/sockets \
+ && printf '#!/bin/bash\n[ ! -d $PGDATA ] && mkdir -p $PGDATA && initdb -D $PGDATA -U postgres\npg_ctl -D $PGDATA -l ~/.pg_ctl/log -o "-k ~/.pg_ctl/sockets" start\n' > ~/.pg_ctl/bin/pg_start \
+ && printf '#!/bin/bash\npg_ctl -D $PGDATA -l ~/.pg_ctl/log -o "-k ~/.pg_ctl/sockets" stop\n' > ~/.pg_ctl/bin/pg_stop \
+ && chmod +x ~/.pg_ctl/bin/* \
+ && sudo sed -i "s:^\(unix_socket_directories\s*=\s*\).*\$:\1'${SOCLOC}':" /etc/postgresql/12/main/postgresql.conf \
+ && echo "localhost:*:*:gitpod:gitpod" >> ~/.pgpass \
+ && chmod 600 ~/.pgpass
+ENV PATH="$PATH:$HOME/.pg_ctl/bin"
+ENV DATABASE_URL="postgresql://postgres@localhost"
+ENV PGHOSTADDR="127.0.0.1"
+ENV PGDATABASE="postgres"
+
+# This is a bit of a hack. At the moment we have no means of starting background
+# tasks from a Dockerfile. This workaround checks, on each bashrc eval, if the
+# PostgreSQL server is running, and if not starts it.
+RUN printf "\n# Auto-start PostgreSQL server.\n[[ \$(pg_ctl status | grep PID) ]] || pg_start > /dev/null\n" >> ~/.bashrc
+
+# Git branch prepend
+RUN printf "parse_git_branch() {\n  git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/(\\\1)/'\n}\n" >> ~/.bashrc \
+ && echo 'PS1="\[\e]0;\u: \w\a\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\] \[\033[0;33m\]\$(parse_git_branch)\[\033[00m\]$ "' >> ~/.bashrc
+
+# Add custom aliases
+RUN printf "fossinstallparams=\"PREFIX='/workspace/fossy/code' INITDIR='/workspace/fossy/etc' REPODIR='/workspace/fossy/srv' LOCALSTATEDIR='/workspace/fossy/var' APACHE2_SITE_DIR='/workspace/apache' SYSCONFDIR='/workspace/fossy/etc/fossology' PROJECTUSER='gitpod' PROJECTGROUP='gitpod'\"\n" >> ~/.bashrc \
+ && printf '# Fossology alias\nalias fossrun="sudo /workspace/fossy/code/share/fossology/scheduler/agent/fo_scheduler --verbose=3 --reset --config /workspace/fossy/etc/fossology/"\n' >> ~/.bash_aliases \
+ && printf 'alias fossinstallclean="make clean empty-cache ${fossinstallparams} && make install ${fossinstallparams} && sudo -E ./install/fo-postinstall -oe"\n' >> ~/.bash_aliases \
+ && printf 'alias fossinstallnoclean="make install empty-cache ${fossinstallparams} && sudo -E ./install/fo-postinstall -eo"\n' >> ~/.bash_aliases

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,72 @@
+# FOSSology gitpod.io configuration
+# Copyright (C) 2021 Siemens AG
+# Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+image:
+  file: .gitpod.Dockerfile
+ports:
+  - port: 5432
+    onOpen: ignore
+    visibility: private
+  - port: 24693
+    onOpen: ignore
+    visibility: private
+  - port: 8001
+    visibility: public
+    onOpen: notify
+github:
+  prebuilds:
+    master: true
+    branches: false
+    pullRequests: true
+    pullRequestsFromForks: true
+    addBadge: true
+workspaceLocation: fossology
+checkoutLocation:  fossology
+
+tasks:
+  - init: |
+      mkdir -p "/workspace/apache/"
+      ./utils/gitpod-install.sh
+    name: install
+    env:
+      FOSSOLOGY_DB_USER: gitpod
+      FOSSOLOGY_DB_PASSWORD: gitpod
+      SYSCONFDIR: /workspace/fossy/etc/fossology/
+      FO_SYSCONFDIR: /workspace/fossy/etc/fossology/
+    command: |
+      mkdir -p public "/workspace/apache" "/workspace/fossy/srv" "/workspace/fossy/var"
+      if [[ -z $(grep "/workspace/apache" "/etc/apache2/apache2.conf") ]];then printf '\nIncludeOptional /workspace/apache/*.conf\n' >> /etc/apache2/apache2.conf; fi
+      sudo /usr/sbin/a2enmod rewrite
+      sudo chown gitpod:gitpod -R /var/log/apache2/
+      apachectl restart
+      gp sync-done ui
+  - command: |
+      gp sync-await ui
+      sudo mkdir -p /var/log/fossology/
+      sudo chown gitpod:gitpod -R /var/log/fossology/
+      fossrun
+    name: fossology
+    env:
+      FOSSOLOGY_DB_USER: gitpod
+      FOSSOLOGY_DB_PASSWORD: gitpod
+      SYSCONFDIR: /workspace/fossy/etc/fossology/
+      FO_SYSCONFDIR: /workspace/fossy/etc/fossology/
+vscode:
+  extensions:
+    - "felixfbecker.php-debug"
+    - "ms-azuretools.vscode-docker"
+    - "fterrag.vscode-php-cs-fixer"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # FOSSology
 
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/fossology/fossology)
 [![GPL-2.0](https://img.shields.io/github/license/fossology/fossology)](LICENSE)
 [![Travis-CI Build Status](https://travis-ci.org/fossology/fossology.svg?branch=master)](https://travis-ci.org/fossology/fossology)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2395/badge)](https://bestpractices.coreinfrastructure.org/projects/2395)

--- a/install/db/Makefile
+++ b/install/db/Makefile
@@ -54,12 +54,12 @@ install: all
 
 	$(INSTALL_PROGRAM) export_license_ref.php $(DESTDIR)$(LIBEXECDIR)/export_license_ref.php
 	$(INSTALL_PROGRAM) dbcreate $(DESTDIR)$(LIBEXECDIR)/dbcreate
-	@if [ ! -f "$(DESTDIR)/etc/cron.d/fossology" -o "$(OVERWRITE)" ]; then \
-		mkdir -p $(DESTDIR)/etc/cron.d/; \
-		echo "NOTE: using default version for $(DESTDIR)/etc/cron.d/fossology"; \
-		$(INSTALL_DATA) db.cron $(DESTDIR)/etc/cron.d/fossology; \
+	@if [ ! -f "$(DESTDIR)$(INITDIR)/cron.d/fossology" -o "$(OVERWRITE)" ]; then \
+		mkdir -p $(DESTDIR)$(INITDIR)/cron.d/; \
+		echo "NOTE: using default version for $(DESTDIR)$(INITDIR)/cron.d/fossology"; \
+		$(INSTALL_DATA) db.cron $(DESTDIR)$(INITDIR)/cron.d/fossology; \
 	else \
-		echo "WARNING: $(DESTDIR)/etc/cron.d/fossology already exists."; \
+		echo "WARNING: $(DESTDIR)$(INITDIR)/cron.d/fossology already exists."; \
 		echo "  Not overwriting, consider checking it by hand or use the OVERWRITE option."; \
 	fi
 
@@ -98,7 +98,7 @@ uninstall:
 	fi
 
 	@echo "WARNING: Cowardly refusing to remove the following"
-	@echo "      $(DESTDIR)/etc/cron.d/fossology"
+	@echo "      $(DESTDIR)$(INITDIR)/cron.d/fossology"
 	@echo "  Remove by hand if you desire."
 
 clean:

--- a/install/db/dbcreate.in
+++ b/install/db/dbcreate.in
@@ -60,7 +60,7 @@ if [ $? = 0 ]; then
    fi
 else
    echo "*** Initializing database ***"
-   su postgres -c "psql < {$LIBEXECDIR}/fossologyinit.sql"
+   su postgres -c psql < {$LIBEXECDIR}/fossologyinit.sql
    if [ $? != 0 ] ; then
       echo "ERROR: Database failed during configuration.\n"
       exit 1

--- a/install/db/gitpod-fossologyinit.sql
+++ b/install/db/gitpod-fossologyinit.sql
@@ -1,0 +1,39 @@
+--
+-- Copy of fossologyinit.sql for gitpod
+--
+
+create role gitpod with createdb login password 'gitpod';
+--
+-- PostgreSQL database dump
+--
+
+SET client_encoding = 'UTF8';
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+
+--
+-- Name: fossology; Type: DATABASE; Schema: -; Owner: gitpod
+--
+
+CREATE DATABASE fossology WITH TEMPLATE = template1 ENCODING = 'UTF8';
+
+
+ALTER DATABASE fossology OWNER TO gitpod;
+
+\connect fossology
+CREATE LANGUAGE plpgsql;
+
+SET client_encoding = 'UTF8';
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+--
+-- Name: SCHEMA public; Type: COMMENT; Schema: -; Owner: postgres
+--
+
+COMMENT ON SCHEMA public IS 'Standard public schema';
+
+SET search_path = public, pg_catalog;
+SET default_tablespace = '';
+SET default_with_oids = false;
+

--- a/install/defconf/fossology.conf.in
+++ b/install/defconf/fossology.conf.in
@@ -13,7 +13,7 @@ address = localhost
 depth = 3
 
 ; REPLACEMENT for RepPath.conf
-path = /srv/fossology/repository
+path = {$REPODIR}
 
 ; REPLACEMENT for Proxy.conf
 ; proxy settings that will be used by fossology agents
@@ -26,7 +26,7 @@ path = /srv/fossology/repository
 ; REPLACEMENT for Hosts.conf
 ; set up the set of hosts available to analyze files. If there is an entry
 ; for localhost it will be read, if there isn't one then it is assumed that
-; localhost cannot host any agents. A man of -1 does not indicate that a 
+; localhost cannot host any agents. A man of -1 does not indicate that a
 ; host can have as many agents running as necessary, (i.e. there should always
 ; be a max on the number of agents for a particular host).
 [HOSTS]
@@ -37,11 +37,12 @@ localhost[] = * 00 ff
 
 [DIRECTORIES]
 
-; Project Name and Group 
-; Do not change after installation since PROJECT and PROJECTGROUP is used in installation 
-; directory names and ownership.
+; Project Name and Group
+; Do not change after installation since PROJECT, PROJECTUSER and PROJECTGROUP
+; is used in installation directory names and ownership.
 ; Use PREFIX to install multiple copies of FOSSology.
 PROJECT={$PROJECT}
+PROJECTUSER={$PROJECTUSER}
 PROJECTGROUP={$PROJECTGROUP}
 
 ; base of the program data tree

--- a/utils/gitpod-install.sh
+++ b/utils/gitpod-install.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# This script installs fossology in Gitpod's workspace
+# Copyright (C) 2021 Siemens AG
+# Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+sudo a2dismod php7.4 mpm_prefork
+
+# Install apache and PHP packages inside GitPod as gp is not available in Docker
+sudo apt-get update && sudo apt-get install -y \
+ --option Dpkg::Options::="--force-confold" \
+ apache2 libapache2-mod-php php php-cli php-curl php-mbstring php-pear \
+ php-pgsql php-sqlite3 php-xdebug php-xml php-zip
+sudo ./utils/fo-installdeps -ey
+
+sudo a2dismod mpm_event
+sudo a2enmod php7.4
+
+# Install FOSSology in Gitpod's workspace
+make install \
+ PREFIX='/workspace/fossy/code' \
+ INITDIR='/workspace/fossy/etc' \
+ REPODIR='/workspace/fossy/srv' \
+ LOCALSTATEDIR='/workspace/fossy/var' \
+ APACHE2_SITE_DIR='/workspace/apache' \
+ SYSCONFDIR='/workspace/fossy/etc/fossology' \
+ PROJECTUSER='gitpod' PROJECTGROUP='gitpod'
+
+# Setup DB for gitpod
+sudo su postgres -c psql < install/db/gitpod-fossologyinit.sql
+
+# Run postinstall script
+sudo -HE /workspace/fossy/code/lib/fossology/fo-postinstall || echo "Done with fo-postinstall"
+
+# Fix the FOSSology path for Apache
+echo "Fixing path in Apache"
+sed -i "s/\/usr\/local\/share/\/workspace\/fossy\/code\/share/" "/workspace/apache/fossology.conf"


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Initial commit for [gitpod.io](https://gitpod.io) integration.

#### What is working

- [x] The `make` installation
- [x] `fo-postinstall`
- [x] DB
- [x] Uploads
- [x] Other editor things

#### What is missing

- Way to do simple `make install`.
- The base image is tagged to `latest`, does not have specific tag for `focal`.
- Didn't check the behavior of `make test`.

#### Workaround used

- Since gitpod stores contents under `/workspace/` only, the FOSSology needs to be installed under it.
  + To implement this, following paths needed to be changes: `PREFIX`, `INITDIR`, `REPODIR`, `LOCALSTATEDIR`, `APACHE2_SITE_DIR`, `SYSCONFDIR`, `PROJECTUSER` and `PROJECTGROUP`.
- Changing the group of user in gitpod is difficult so FOSSology and DB are installed/setup under `gitpod:gitpod`.
- New aliases:
  + `fossrun` : Runs scheduler in shell, not as daemon
  + `fossinstallclean` : Runs `make clean` and then `make install` with all the appropriate path changes. Followed with `fo-postinstall`
  + `fossinstallnoclean` : Runs `make install` with all the appropriate path changes, no `clean`. Followed with `fo-postinstall`
  + `pg_start` : Starts postgres 12
  + `pg_stop` : Stops postgres

## Workflow
1. The `.gitpod.Dockerfile` is built and all the dependencies are installed. In the same image, the PHP settings are fixed too and Postgres 12 is setup. Also, create the helpful aliases.
2. Once the image is built, a workspace can be created.
3. Gitpod allows prebuilt which setups some commands on top of the Docker image and save boot time.
    - This includes installing some dependencies which can't be installed during image creation.
    - Compiling and installing FOSSology.
    - Setting up DB.
    - Setting up Apache.
4. When a user runs this workspace, another set of commands can be run:
    - Fixing some folders outside `/workspace`.
    - Restarting apache.
    - Running Scheduler in a separate terminal tab.

To take full advantage of prebuilds, the integration with gitpod needs to be setup in FOSSology repository. Doing so, will also allow to create a new workspace for reviewing PRs.

## How to test

Check https://gitpod.io/#https://github.com/GMishx/fossology

Review current PR: https://gitpod.io/#https://github.com/fossology/fossology/pull/2008