### PR TITLE
fix(ui): Break long lines in copyright table

### DIFF
--- a/src/copyright/ui/HistogramBase.php
+++ b/src/copyright/ui/HistogramBase.php
@@ -79,7 +79,7 @@ abstract class HistogramBase extends FO_Plugin {
       $typeDescriptor = $description;
     }
     $output = "<h4>Activated $typeDescriptor statements:</h4>
-<div><table border=1 width='100%' id='copyright".$type."'></table></div>
+<div><table border=1 width='100%' id='copyright".$type."' class='wordbreaktable'></table></div>
 <br/><br/>
 <div>
   <table border=0 width='100%' id='searchReplaceTable".$type."'>
@@ -100,14 +100,14 @@ abstract class HistogramBase extends FO_Plugin {
   <a style='cursor: pointer; margin-left:10px;' id='replaceSelected".$type."' class='buttonLink'>Replace selected rows</a>
   <a style='cursor: pointer; margin-left:10px;' id='deleteSelected".$type."' class='buttonLink'>Deactivate selected rows</a>
   <br /><br />
-  <table border=1 id='testVal".$type."' style='display:none' class='dataTable'>
+  <table border=1 id='testVal".$type."' style='display:none' class='dataTable wordbreaktable'>
     <tr><th style='width:50%'>From</th><th style='width:50%'>To</th></tr>
     <tr><td id='testVal".$type."From'></td><td id='testVal".$type."To'></td></tr>
   </table>
   <br/><br/>
   <h4>Deactivated $typeDescriptor statements:</h4>
 </div>
-<div><table border=1 width='100%' id='copyright".$type."deactivated'></table>
+<div><table border=1 width='100%' id='copyright".$type."deactivated' class='wordbreaktable'></table>
   <br/><br/>
   <a id='undoSelected".$type."' class='buttonLink'>Undo selected rows</a>
   <br /><br />

--- a/src/spasht/ui/template/agent_spasht_ui_tabs.html.twig
+++ b/src/spasht/ui/template/agent_spasht_ui_tabs.html.twig
@@ -24,7 +24,7 @@
             {{ " They are not processed with FOSSology copyrights."|e }}
             <br />
             <span style="font-weight:bold;display:block;padding:1em 0 1em;font-size:15pt;">Activated statements</span>
-            <table id="copyright_spasht_table" class="dataTable">
+            <table id="copyright_spasht_table" class="dataTable wordbreaktable">
               <thead>
                 <tr>
                   <th>COUNT</th>
@@ -48,7 +48,7 @@
               <br />
             </div>
             <span style="font-weight:bold;display:block;padding:3em 0 1em;font-size:15pt;">Deactivated statements</span>
-            <table id="copyright_spasht_table_deactivated" class="dataTable">
+            <table id="copyright_spasht_table_deactivated" class="dataTable wordbreaktable">
               <thead>
                 <tr>
                   <th>COUNT</th>

--- a/src/www/ui/css/jquery.dataTables.css
+++ b/src/www/ui/css/jquery.dataTables.css
@@ -317,6 +317,12 @@ table.dataTable thead td:active {
   /* W3C */
   box-shadow: inset 0 0 3px #111;
 }
+
 .dataTables_wrapper .dataTables_paginate .ellipsis {
   padding: 0 1em;
+}
+
+table.wordbreaktable td {
+  word-break: normal;
+  overflow-wrap: anywhere;
 }


### PR DESCRIPTION
## Description

Break very long lines with the help of CSS properties.

### Changes

Created new class `wordbreaktable` which can be applied on tables and apply `word-break` & `overflow-wrap` properties to all `td`s.

## How to test
Scan an upload with very long copyrights which can not be broken.
I tested it with [Angular-9.1.1](https://github.com/angular/angular/releases/tag/9.1.1). Copyright captures a string with a very long base64 string which breaks the UI.