### PR TITLE
fix(api): Add missing reuser options

### DIFF
--- a/src/www/ui/api/Models/Reuser.php
+++ b/src/www/ui/api/Models/Reuser.php
@@ -1,6 +1,6 @@
 <?php
 /***************************************************************
- * Copyright (C) 2018 Siemens AG
+ * Copyright (C) 2018,2021 Siemens AG
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -47,6 +47,16 @@ class Reuser
    * Use enhanced reuse
    */
   private $reuseEnhanced;
+  /**
+   * @var boolean $reuseReport
+   * Use enhanced reuse
+   */
+  private $reuseReport;
+  /**
+   * @var boolean $reuseCopyright
+   * Use enhanced reuse
+   */
+  private $reuseCopyright;
 
   /**
    * Reuser constructor.
@@ -66,6 +76,8 @@ class Reuser
       $this->reuseGroup = $reuseGroup;
       $this->reuseMain = $reuseMain;
       $this->reuseEnhanced = $reuseEnhanced;
+      $this->reuseReport = false;
+      $this->reuseCopyright = false;
     } else {
       throw new \UnexpectedValueException(
         "reuse_upload should be integer", 400);
@@ -83,19 +95,22 @@ class Reuser
   public function setUsingArray($reuserArray)
   {
     if (array_key_exists("reuse_upload", $reuserArray)) {
-      $this->reuseUpload = filter_var($reuserArray["reuse_upload"],
-        FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
+      $this->setReuseUpload($reuserArray["reuse_upload"]);
     }
     if (array_key_exists("reuse_group", $reuserArray)) {
       $this->reuseGroup = $reuserArray["reuse_group"];
     }
     if (array_key_exists("reuse_main", $reuserArray)) {
-      $this->reuseMain = filter_var($reuserArray["reuse_main"],
-        FILTER_VALIDATE_BOOLEAN);
+      $this->setReuseMain($reuserArray["reuse_main"]);
     }
     if (array_key_exists("reuse_enhanced", $reuserArray)) {
-      $this->reuseEnhanced = filter_var($reuserArray["reuse_enhanced"],
-        FILTER_VALIDATE_BOOLEAN);
+      $this->setReuseEnhanced($reuserArray["reuse_enhanced"]);
+    }
+    if (array_key_exists("reuse_report", $reuserArray)) {
+      $this->setReuseReport($reuserArray["reuse_report"]);
+    }
+    if (array_key_exists("reuse_copyright", $reuserArray)) {
+      $this->setReuseCopyright($reuserArray["reuse_copyright"]);
     }
     if ($this->reuseUpload === null) {
       throw new \UnexpectedValueException(
@@ -141,6 +156,22 @@ class Reuser
     return $this->reuseEnhanced;
   }
 
+  /**
+   * @return boolean
+   */
+  public function getReuseReport()
+  {
+    return $this->reuseReport;
+  }
+
+  /**
+   * @return boolean
+   */
+  public function getReuseCopyright()
+  {
+    return $this->reuseCopyright;
+  }
+
   ////// Setters //////
   /**
    * @param integer $reuseUpload
@@ -184,16 +215,36 @@ class Reuser
   }
 
   /**
+   * @param boolean $reuseReport
+   */
+  public function setReuseReport($reuseReport)
+  {
+    $this->reuseReport = filter_var($reuseReport,
+      FILTER_VALIDATE_BOOLEAN);
+  }
+
+  /**
+   * @param boolean $reuseCopyright
+   */
+  public function setReuseCopyright($reuseCopyright)
+  {
+    $this->reuseCopyright = filter_var($reuseCopyright,
+      FILTER_VALIDATE_BOOLEAN);
+  }
+
+  /**
    * Get reuser info as an associative array
    * @return array
    */
   public function getArray()
   {
     return [
-      "reuse_upload"   => $this->reuseUpload,
-      "reuse_group"    => $this->reuseGroup,
-      "reuse_main"     => $this->reuseMain,
-      "reuse_enhanced" => $this->reuseEnhanced
+      "reuse_upload"    => $this->reuseUpload,
+      "reuse_group"     => $this->reuseGroup,
+      "reuse_main"      => $this->reuseMain,
+      "reuse_enhanced"  => $this->reuseEnhanced,
+      "reuse_report"    => $this->reuseReport,
+      "reuse_copyright" => $this->reuseCopyright
     ];
   }
 }

--- a/src/www/ui/api/Models/ScanOptions.php
+++ b/src/www/ui/api/Models/ScanOptions.php
@@ -150,11 +150,15 @@ class ScanOptions
     if ($this->reuse->getReuseEnhanced() === true) {
       $reuserRules[] = 'reuseEnhanced';
     }
+    if ($this->reuse->getReuseReport() === true) {
+      $reuserRules[] = 'reuseConf';
+    }
+    if ($this->reuse->getReuseCopyright() === true) {
+      $reuserRules[] = 'reuseCopyright';
+    }
     $userDao = $GLOBALS['container']->get("dao.user");
     $reuserSelector = $this->reuse->getReuseUpload() . "," . $userDao->getGroupIdByName($this->reuse->getReuseGroup());
     $request->request->set(ReuserAgentPlugin::UPLOAD_TO_REUSE_SELECTOR_NAME, $reuserSelector);
-    //global $SysConf;
-    //$request->request->set('groupId', $SysConf['auth'][Auth::GROUP_ID]);
     $request->request->set('reuseMode', $reuserRules);
   }
 

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -15,7 +15,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.2.2
+  version: 1.2.3
   contact:
     email: fossology@fossology.org
   license:
@@ -1328,10 +1328,16 @@ components:
           description: The group of the reused upload
         reuse_main:
           type: boolean
-          description: Scanners matches if all Nomos findings are within the Monk findings.
+          description: Copy the main license from reused package?
         reuse_enhanced:
           type: boolean
-          description: Bulk phrases from reused packages.
+          description: Run enhanced reuser with diff tool (slow)
+        reuse_report:
+          type: boolean
+          description: Copy all report configuration from conf page.
+        reuse_copyright:
+          type: boolean
+          description: Copy the copyright deactivation and edits.
       required:
         - reuse_uplod
         - reuse_group

--- a/src/www/ui_tests/api/Models/ReuserTest.php
+++ b/src/www/ui_tests/api/Models/ReuserTest.php
@@ -41,7 +41,9 @@ class ReuserTest extends \PHPUnit\Framework\TestCase
       "reuse_upload"   => 2,
       "reuse_group"    => 'fossy',
       "reuse_main"     => true,
-      "reuse_enhanced" => false
+      "reuse_enhanced" => false,
+      "reuse_copyright" => false,
+      "reuse_report"   => false
     ];
 
     $actualReuser = new Reuser(2, 'fossy', true);
@@ -71,13 +73,39 @@ class ReuserTest extends \PHPUnit\Framework\TestCase
       "reuse_upload"   => 2,
       "reuse_group"    => 'fossy',
       "reuse_main"     => 'true',
-      "reuse_enhanced" => false
+      "reuse_enhanced" => false,
+      "reuse_copyright" => false,
+      "reuse_report"   => false
     ];
 
     $actualReuser = new Reuser(1, 'fossy');
     $actualReuser->setUsingArray($expectedArray);
 
     $expectedArray["reuse_main"] = true;
+    $this->assertEquals($expectedArray, $actualReuser->getArray());
+  }
+
+  /**
+   * @test
+   * -# Test for Reuser::setUsingArray()
+   * -# Add some changes to the array.
+   */
+  public function testSetUsingArraySomeOptions()
+  {
+    $expectedArray = [
+      "reuse_upload"   => 2,
+      "reuse_group"    => 'fossy',
+      "reuse_main"     => 'true',
+      "reuse_enhanced" => false,
+      "reuse_copyright" => 'true',
+      "reuse_report"   => false
+    ];
+
+    $actualReuser = new Reuser(1, 'fossy');
+    $actualReuser->setUsingArray($expectedArray);
+
+    $expectedArray["reuse_main"] = true;
+    $expectedArray["reuse_copyright"] = true;
     $this->assertEquals($expectedArray, $actualReuser->getArray());
   }
 
@@ -96,7 +124,7 @@ class ReuserTest extends \PHPUnit\Framework\TestCase
     ];
 
     $this->expectException(\UnexpectedValueException::class);
-    $this->expectExceptionMessage("reuse_upload should be integer");
+    $this->expectExceptionMessage("Reuse upload should be an integer");
 
     $actualReuser = new Reuser(1, 'fossy');
     $actualReuser->setUsingArray($expectedArray);


### PR DESCRIPTION
## Description

Add the missing "Reuse report conf" and "Reuse deactivated copyright" options to the REST API.

### Changes

Added `reuse_report` and `reuse_copyright` to reuser object in REST API.

## How to test

Create a new job with REST API using new options.