### PR TITLE
fix(copyright): Make check strict

### DIFF
--- a/src/copyright/ui/ajax-copyright-hist.php
+++ b/src/copyright/ui/ajax-copyright-hist.php
@@ -278,21 +278,20 @@ class CopyrightHistogramProcessPost extends FO_Plugin
     $filterParms = $params;
     $searchFilter = $this->addSearchFilter($filterParms);
 
-    $activatedClause = "";
+    $activatedClause = "ce.is_enabled = 'false'";
     if ($activated) {
-      $activatedClause = "NOT";
+      $activatedClause = "ce.is_enabled IS NULL OR ce.is_enabled = 'true'";
     }
     $unorderedQuery = "FROM $tableName AS cp " .
         "INNER JOIN $uploadTreeTableName AS UT ON cp.pfile_fk = UT.pfile_fk " .
         "LEFT JOIN $tableNameEvent AS ce ON ce.".$tableName."_fk = cp.".$tableName."_pk " .
-        "AND ce.upload_fk = $5 " .
+        "AND ce.upload_fk = $5 AND ce.uploadtree_fk = UT.uploadtree_pk " .
         $join .
         "WHERE cp.content!='' " .
         "AND ( UT.lft  BETWEEN  $1 AND  $2 ) " .
         "AND cp.type = $3 " .
         "AND cp.agent_fk= $4 " .
-        "AND cp." . $tableName . "_pk $activatedClause IN " .
-        "(SELECT " . $tableName . "_fk FROM $tableNameEvent WHERE upload_fk = $5 AND is_enabled = false)" .
+        "AND ($activatedClause)" .
         $sql_upload;
     $grouping = " GROUP BY mcontent ";
 
@@ -440,6 +439,13 @@ count(*) AS copyright_count " .
     $link = "<a href='";
     $link .= Traceback_uri();
     $urlArgs = "?mod=".$listPage."&agent=$agentId&item=$uploadTreeId&hash=$hash&type=$type";
+    if ((empty($filter) || $filter == "all")) {
+      if ($activated) {
+        $filter = "active";
+      } else {
+        $filter = "inactive";
+      }
+    }
     if (!empty($filter)) {
       $urlArgs .= "&filter=$filter";
     }

--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -219,9 +219,9 @@ class CopyrightDao
       $statementName .= "._".$extrawhere."_";
     }
 
-    $activatedClause = "";
+    $activatedClause = "ce.is_enabled = 'false'";
     if ($enabled != 'false') {
-      $activatedClause = "NOT";
+      $activatedClause = "ce.is_enabled IS NULL OR ce.is_enabled = 'true'";
       $statementName .= "._"."enabled";
     }
 
@@ -232,11 +232,10 @@ C.agent_fk as agent_fk
   FROM $tableName C
   INNER JOIN $uploadTreeTableName UT ON C.pfile_fk = UT.pfile_fk
   LEFT JOIN $tableNameEvent AS CE ON CE.".$tableName."_fk = C.".$tableName."_pk
-    AND CE.upload_fk = $1
+    AND CE.upload_fk = $1 AND CE.uploadtree_fk = UT.uploadtree_pk
   WHERE C.content IS NOT NULL
     AND C.content!=''
-    AND C." . $tableName . "_pk $activatedClause IN
-(SELECT " . $tableName . "_fk FROM $tableNameEvent WHERE upload_fk = $1 AND is_enabled = false)
+    AND ($activatedClause)
   $extendWClause
 ORDER BY UT.uploadtree_pk, content DESC";
     return $this->dbManager->getRows($sql, $params, $statementName);
@@ -369,12 +368,12 @@ ORDER BY UT.uploadtree_pk, content DESC";
               ON C.pfile_fk = UT.pfile_fk
             LEFT JOIN $tableNameEvent AS CE
               ON CE.".$tableName."_fk = C.".$tableName."_pk
-              AND CE.upload_fk = $1
+              AND CE.upload_fk = $1 AND CE.uploadtree_fk = UT.uploadtree_pk
             $joinType JOIN (SELECT * FROM $tableNameDecision WHERE is_enabled='true') AS CD
               ON C.pfile_fk = CD.pfile_fk
             WHERE C.content IS NOT NULL
               AND C.content!=''
-              AND C.".$tableName."_pk NOT IN (SELECT DISTINCT(".$tableName."_fk) FROM $tableNameEvent TE WHERE TE.upload_fk = $1 AND is_enabled = false)
+              AND (ce.is_enabled IS NULL OR ce.is_enabled = 'true')
               $whereClause
             ORDER BY CD.pfile_fk, UT.uploadtree_pk, C.content, CD.textfinding, CD.$decisionTableKey DESC";
 
@@ -482,11 +481,11 @@ ORDER BY UT.uploadtree_pk, content DESC";
       $agentFilter = ' AND cp.agent_fk='.$latestAgentId;
     }
 
-    $sql = "SELECT DISTINCT ON ($cpTablePk) $cpTablePk, ut.uploadtree_pk, ut.upload_fk, ce." . $cpTableEvent . "_pk
+    $sql = "SELECT DISTINCT ON ($cpTablePk, ut.uploadtree_pk) $cpTablePk, ut.uploadtree_pk, ut.upload_fk, ce." . $cpTableEvent . "_pk
 FROM $cpTable as cp
 INNER JOIN $itemTable AS ut ON cp.pfile_fk = ut.pfile_fk
 LEFT JOIN $cpTableEvent AS ce ON ce.$cpTableEventFk = cp.$cpTablePk
-  AND ce.upload_fk = $3
+  AND ce.upload_fk = ut.upload_fk AND ce.uploadtree_fk = ut.uploadtree_pk
 WHERE $withHash ( ut.lft BETWEEN $1 AND $2 ) $agentFilter AND ut.upload_fk = $3";
 
     $rows = $this->dbManager->getRows($sql, $params, $stmt);
@@ -496,41 +495,34 @@ WHERE $withHash ( ut.lft BETWEEN $1 AND $2 ) $agentFilter AND ut.upload_fk = $3"
       $paramEvent[] = $row['upload_fk'];
       $paramEvent[] = $row[$cpTablePk];
       $paramEvent[] = $row['uploadtree_pk'];
-      $sqlExists = "SELECT exists(SELECT 1 FROM $cpTableEvent WHERE $cpTableEventFk = $1 AND upload_fk = $2)::int";
-      $rowExists = $this->dbManager->getSingleRow($sqlExists, array($row[$cpTablePk], $row['upload_fk']), $stmt.'Exists');
+      $sqlExists = "SELECT exists(SELECT 1 FROM $cpTableEvent WHERE $cpTableEventFk = $1 AND upload_fk = $2 AND uploadtree_fk = $3)::int";
+      $rowExists = $this->dbManager->getSingleRow($sqlExists, array($row[$cpTablePk], $row['upload_fk'], $row['uploadtree_pk']), $stmt.'Exists');
       $eventExists = $rowExists['exists'];
       if ($action == "delete") {
+        $paramEvent[] = $scope;
         if ($eventExists) {
-          $paramEvent[] = $scope;
           $sqlEvent = "UPDATE $cpTableEvent SET scope = $4, is_enabled = false
           WHERE upload_fk = $1 AND $cpTableEventFk = $2 AND uploadtree_fk = $3";
           $statement = "$stmt.delete.up";
         } else {
-          $paramEvent[] = $scope;
-          $sqlEvent = "INSERT INTO $cpTableEvent (upload_fk, $cpTableEventFk, uploadtree_fk, scope) VALUES($1, $2, $3, $4)";
+          $sqlEvent = "INSERT INTO $cpTableEvent (upload_fk, $cpTableEventFk, uploadtree_fk, is_enabled, scope) VALUES($1, $2, $3, 'f', $4)";
           $statement = "$stmt.delete";
         }
-      } else if ($action == "rollback") {
-        if ($eventExists) {
+      } else if ($action == "rollback" && $eventExists) {
           $sqlEvent = "UPDATE $cpTableEvent SET scope = 1, is_enabled = true
           WHERE upload_fk = $1 AND $cpTableEventFk = $2 AND uploadtree_fk = $3";
           $statement = "$stmt.rollback.up";
-        } else {
-          $sqlEvent = "DELETE FROM $cpTableEvent WHERE upload_fk = $1 AND uploadtree_fk = $3 AND $cpTableEventFk = $2";
-          $statement = "$stmt.rollback";
-        }
       } else {
-        $paramEvent[] = "true";
         $paramEvent[] = StringOperation::replaceUnicodeControlChar($content);
 
         if ($eventExists) {
           $sqlEvent = "UPDATE $cpTableEvent
-                        SET upload_fk = $1, uploadtree_fk = $3, is_enabled = $4, content = $5, hash = md5($5)
+                       SET upload_fk = $1, content = $4, hash = md5($4)
                        WHERE $cpTableEventFk = $2 AND uploadtree_fk = $3";
           $statement = "$stmt.update";
         } else {
           $sqlEvent = "INSERT INTO $cpTableEvent(upload_fk, uploadtree_fk, $cpTableEventFk, is_enabled, content, hash)
-                       VALUES($1, $3, $2, $4, $5, md5($5))";
+                       VALUES($1, $3, $2, 'true', $4, md5($4))";
           $statement = "$stmt.insert";
         }
       }

--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -178,11 +178,11 @@ class CopyrightDao
     $params[] = $uploadFk;
     $params[] = $agentId;
     $params[] = $scope;
-    $sql = "SELECT DISTINCT ON (copyright_pk) copyright_pk, C.content, c.hash,
+    $sql = "SELECT copyright_pk, CE.is_enabled, C.content, c.hash,
               CE.content AS contentedited, CE.hash AS hashedited
             FROM copyright_event CE
               INNER JOIN copyright C ON C.copyright_pk = CE.copyright_fk
-            WHERE CE.upload_fk=$1 AND CE.is_enabled=false AND scope=$3 AND C.agent_fk = $2";
+            WHERE CE.upload_fk=$1 AND scope=$3 AND C.agent_fk = $2";
     return $this->dbManager->getRows($sql, $params, $statementName);
   }
 
@@ -225,7 +225,8 @@ class CopyrightDao
       $statementName .= "._"."enabled";
     }
 
-    $sql = "SELECT DISTINCT(copyright_pk), UT.uploadtree_pk as uploadtree_pk,
+    $sql = "SELECT DISTINCT ON(copyright_pk, UT.uploadtree_pk)
+copyright_pk, UT.uploadtree_pk as uploadtree_pk,
 (CASE WHEN (CE.content IS NULL OR CE.content = '') THEN C.content ELSE CE.content END) AS content,
 (CASE WHEN (CE.hash IS NULL OR CE.hash = '') THEN C.hash ELSE CE.hash END) AS hash,
 C.agent_fk as agent_fk
@@ -237,7 +238,7 @@ C.agent_fk as agent_fk
     AND C.content!=''
     AND ($activatedClause)
   $extendWClause
-ORDER BY UT.uploadtree_pk, content DESC";
+ORDER BY copyright_pk, UT.uploadtree_pk, content DESC";
     return $this->dbManager->getRows($sql, $params, $statementName);
   }
 

--- a/src/reuser/agent/ReuserAgent.php
+++ b/src/reuser/agent/ReuserAgent.php
@@ -223,8 +223,13 @@ class ReuserAgent extends Agent
       foreach ($reusedCopyrights as $reusedCopyright) {
         foreach ($allCopyrights as $copyrightKey => $copyright) {
           if (strcmp($copyright['hash'], $reusedCopyright['hash']) == 0) {
-            $action = "delete";
-            $content = "";
+            if ($this->dbManager->booleanFromDb($reusedCopyright['is_enabled'])) {
+              $action = "update";
+              $content = $reusedCopyright["contentedited"];
+            } else {
+              $action = "delete";
+              $content = "";
+            }
             $hash = $copyright['hash'];
             $item = $this->uploadDao->getItemTreeBounds(intval($copyright['uploadtree_pk']),
                       $uploadTreeTableName);


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

While editing/fetching the copyrights, the association with uploadtree_pk was not very strong. It caused issue while editing copyrights from a single file view instead of aggregated table view.

This causes problem when same upload has duplicate files. Since `copyright` table holds information of `pfile_fk` and `agent_fk` only, there will be only one entry for a copyright in those files. But if someone made some changes, the `copyright_event` is involved which takes `uploadtree_fk` into account. This caused ambiguity on which copyright to show.

### Changes

1. Add checks for `uploadtree_fk` while fetching copyrights to get only relevant copyrights.
2. Update the check while inserting edits in `copyright_event` to make sure all `uploadtree_fk` are updated.

## How to test

1. Upload a package with duplicate files which contains copyright texts.
2. Update some copyrights from single file view.
3. See if the updates are reflected in the aggregated table view.
4. Editing copyrights from aggregated view should be consistent as well.