### PR TITLE
feat(ui): Remember assignee filter on Browse view

### DIFF
--- a/src/www/ui/scripts/browse.js
+++ b/src/www/ui/scripts/browse.js
@@ -29,6 +29,8 @@ var statusSelected = 0;
 var staSel = null;
 
 $(document).ready(function () {
+  assigneeSelected = ($.cookie("assigneeSelected") || 0);
+  $('#assigneeSelector').val(assigneeSelected);
   table = createBrowseTable();
   $('#insert_browsetbl_filter').append($('#browsetbl_filter'));
   initPrioClick();
@@ -37,7 +39,7 @@ $(document).ready(function () {
     initPrioDraw();
     $('.cc').dblclick( function (){
         var source=table.cell(this).data();
-        openCommentModal(source[0],source[1],source[2]); 
+        openCommentModal(source[0],source[1],source[2]);
     } );
     $('select.goto-active-option').change(function() {
       var url = $(this).val();
@@ -78,7 +80,7 @@ function initPrioDraw() {
       return prioColumn(table.cell(this).data(), 'display');
     });
   });
-  
+
   $('.limit-mover').click(function(){
     var uploadId = $(this).attr('data-source');
     var dir = $(this).attr('data-dir');
@@ -154,6 +156,7 @@ function changeTableEntry(sel, uploadId, columnName) {
 
 function filterAssignee() {
   assigneeSelected = $('#assigneeSelector').val();
+  $.cookie("assigneeSelected", assigneeSelected);
   var oTable = createBrowseTable();
   oTable.draw(false);
 }


### PR DESCRIPTION
## Description

Use cookies to remember the assignee filter value on the Browse view.

### Changes

1. Add new session cookie "assigneeSelected" to hold the filter value.

## How to test

1. On the browse view, filter the uploads based on assignment information.
2. Open an upload, perform some action and go back to browse.
3. The uploads should still be filtered by the assignee selected.

Closes #1927