### PR TITLE
fix(auth): fix call to add_user() when login from external auth

### DIFF
--- a/install/defconf/fossology.conf.in
+++ b/install/defconf/fossology.conf.in
@@ -111,6 +111,12 @@ CONF_EXT_AUTH_LOWERCASE_USER=true
 ; logging in for the first time
 CONF_EXT_AUTH_NEW_USER_AUTO_CREATE=true
 
+; Set new users' default visibility for new uploads. Choose between 
+;  private: Visible only for active group
+;  protected: Visible for all groups
+;  public: Visible to all
+CONF_EXT_AUTH_NEW_USER_UPLOAD_VISIBILITY=private
+
 ; List of agents attributed to newly created users
 ; Example:
 ; "agent_copyright,agent_keyword,agent_mimetype,agent_monk,agent_nomos,agent_ojo,agent_shagent"

--- a/src/www/ui/core-auth.php
+++ b/src/www/ui/core-auth.php
@@ -289,7 +289,8 @@ class core_auth extends FO_Plugin
         $Email = $this->authExternal['emailAuthExternal'];
         /* Set default list of agents when a new user is created */
         $agentList = $GLOBALS['SysConf']['EXT_AUTH']['CONF_EXT_AUTH_NEW_USER_AGENT_LIST'];
-        add_user($User, $Desc, $Hash, $Perm, $Email, $Email_notify, $agentList, $Folder);
+        add_user($User, $Desc, $Hash, $Perm, $Email, $Email_notify, 
+          $GLOBALS['SysConf']['EXT_AUTH']['CONF_EXT_AUTH_NEW_USER_UPLOAD_VISIBILITY'], $agentList, $Folder);
       }
     }
 

--- a/src/www/ui/core-auth.php
+++ b/src/www/ui/core-auth.php
@@ -289,7 +289,7 @@ class core_auth extends FO_Plugin
         $Email = $this->authExternal['emailAuthExternal'];
         /* Set default list of agents when a new user is created */
         $agentList = $GLOBALS['SysConf']['EXT_AUTH']['CONF_EXT_AUTH_NEW_USER_AGENT_LIST'];
-        add_user($User, $Desc, $Hash, $Perm, $Email, $Email_notify, 
+        add_user($User, $Desc, $Hash, $Perm, $Email, $Email_notify,
           $GLOBALS['SysConf']['EXT_AUTH']['CONF_EXT_AUTH_NEW_USER_UPLOAD_VISIBILITY'], $agentList, $Folder);
       }
     }


### PR DESCRIPTION
## Description
When introducing the 'default visibility' feature, the call to `add_user` had not been updated, and therefore the user creating was failing.

### Changes

I added a configuration entry in `fossology.conf` to configure the default visibility for new user creations, and used it for new user creations.

## How to test

Configure external configuration, then log in with a user that is not already in the database.
The user should be assigned the "default visibility" that is configured in the `fossology.conf`  file