### PR TITLE
feat(rest): Add /users/self endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ cov.txt
 VERSION
 /.project
 /.cproject
+.settings
 .*.sw?
 *~
 /src/vendor
@@ -22,6 +23,7 @@ VERSION
 .#*
 tags
 php.ini
+.cache
 
 # compiled or derived files
 install/db/dbcreate
@@ -147,7 +149,7 @@ variable.list
 /src/copyright/VERSION-ecc
 /src/copyright/VERSION-keyword
 /src/copyright/VERSION-copyright
-/src/spdx2/agent_tests/Functional/spdx-tools-2.0.2-jar-with-dependencies.jar*
+/src/spdx2/agent_tests/Functional/spdx-tools-2.2.2-jar-with-dependencies.jar*
 /src/spdx2/agent/version.php
 /src/unifiedreport/agent/version.php
 /src/spdx2/agent/spdx2

--- a/src/www/ui/api/Controllers/UserController.php
+++ b/src/www/ui/api/Controllers/UserController.php
@@ -1,6 +1,6 @@
 <?php
 /***************************************************************
- Copyright (C) 2018 Siemens AG
+ Copyright (C) 2018,2021 Siemens AG
  Author: Gaurav Mishra <mishra.gaurav@siemens.com>
 
  This program is free software; you can redistribute it and/or
@@ -78,5 +78,19 @@ class UserController extends RestController
       $returnVal = new Info(404, "UserId doesn't exist", InfoType::ERROR);
     }
     return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+  }
+
+  /**
+   * Get information of current user
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseInterface $response
+   * @param array $args
+   * @return ResponseInterface
+   */
+  public function getCurrentUser($request, $response, $args)
+  {
+    $user = $this->dbHelper->getUsers($this->restHelper->getUserId());
+    return $response->withJson($user[0], 200);
   }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -15,7 +15,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.2.2
+  version: 1.2.3
   contact:
     email: fossology@fossology.org
   license:
@@ -568,22 +568,22 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
   /users:
-      get:
-        tags:
-          - User
-          - Admin
-        description: Get the registered users
-        responses:
-          '200':
-            description: OK
-            content:
-              application/json:
-                schema:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/User'
-          default:
-            $ref: '#/components/responses/defaultResponse'
+    get:
+      tags:
+        - User
+        - Admin
+      description: Get the registered users
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /users/{id}:
     parameters:
       - name: id
@@ -619,6 +619,20 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
             $ref: '#/components/responses/defaultResponse'
+  /users/self:
+    get:
+      tags:
+        - User
+      description: Get the information about logged in user
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /jobs:
     parameters:
       - name: groupName

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -1,6 +1,6 @@
 <?php
 /***************************************************************
- Copyright (C) 2017-2018 Siemens AG
+ Copyright (C) 2017-2018,2021 Siemens AG
  Copyright (C) 2021 Orange by Piotr Pszczola <piotr.pszczola@orange.com>
 
  This program is free software; you can redistribute it and/or
@@ -122,6 +122,7 @@ $app->group(VERSION_1 . 'users',
   function (){
     $this->get('[/{id:\\d+}]', UserController::class . ':getUsers');
     $this->delete('/{id:\\d+}', UserController::class . ':deleteUser');
+    $this->get('/self', UserController::class . ':getCurrentUser');
     $this->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui_tests/api/Controllers/UserControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UserControllerTest.php
@@ -230,4 +230,25 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
     $this->assertEquals($this->getResponseJson($expectedResponse),
       $this->getResponseJson($actualResponse));
   }
+
+  /**
+   * @test
+   * -# Test UserController::getCurrentUser()
+   * -# Check if response contains current user's info
+   */
+  public function testGetCurrentUser()
+  {
+    $userId = 2;
+    $user = $this->getUsers([$userId]);
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->dbHelper->shouldReceive('getUsers')->withArgs([$userId])
+      ->andReturn($user);
+    $expectedResponse = (new Response())->withJson($user[0], 200);
+    $actualResponse = $this->userController->getCurrentUser(null,
+      new Response(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
 }


### PR DESCRIPTION
## Description

Add `/self` endpoint to `/users` to allow user to get their information.

Currently if non-admin users `GET /users` they get only their info but if admin users do that, they get info about every user which is not helpful in all cases.

### Changes

1. Add new `/users/self` endpoint.

## How to test

1. Test if the endpoint returns only one user's info regardless if you are admin or not.

Closes #2017