### PR TITLE
fix(ui): Fix the modal height for small screens

### DIFF
--- a/src/www/ui/template/ui-clearing-view_bulk.html.twig
+++ b/src/www/ui/template/ui-clearing-view_bulk.html.twig
@@ -26,7 +26,7 @@
       <a class="buttonLink" style="width:7em;" onclick="closeAckInputModal();">{{ 'Cancel'|trans }}</a>
   </div>
 
-<div class="modal" id="bulkModal" hidden>
+<div class="modal" id="bulkModal" style="max-height:max-content !important;" hidden>
   <form name="bulkForm">
     <h2>{{ 'Bulk recognition'| trans }}</h2>
     {{ 'Notice'|trans }}: {{ 'Since punctuation is included in the matching process, periods needs to be included in the phrases if the word just before is included.'|trans }}

--- a/src/www/ui/template/ui-clearing-view_rhs.html.twig
+++ b/src/www/ui/template/ui-clearing-view_rhs.html.twig
@@ -72,13 +72,13 @@
     <span id="bulkIdResult" name="bulkIdResult" hidden></span>
     <div style="padding-top: 10px;">
 
-      <div class="modal" id="userModal" hidden>
+      <div class="modal" id="userModal" style="max-height:max-content !important;" hidden>
         <div style="padding-bottom: 10px">
           {{ macro.table("licenseSelectionTable") }}
         </div>
       </div>
 
-      <div class="modal" id="ClearingHistoryDataModal" hidden>
+      <div class="modal" id="ClearingHistoryDataModal" style="max-height:max-content !important;" hidden>
         <div style="padding-bottom: 10px;">
           {{ macro.table("ClearingHistoryDataModalTable") }}
         </div>


### PR DESCRIPTION
## Description

Fix the modal box height for small screens.

### Changes

Change the `max-height` for non-popup modal to fix the content, rather than view-port.

## How to test

Open single file view and check the modals created for "User decision", "Bulk Recognition" and "Clearing History". The brown background should cover the whole content.