### PR TITLE
feat(reso): new agent for REUSE.Software standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,13 +169,8 @@ src/reportImport/agent/reportImport
 src/delagent/agent_tests/Unit/test_delagent
 src/delagent/agent_tests/Unit/testconf/
 /utils/fo_unicode_clean
-<<<<<<< HEAD
 install/db/db.cron
 install/fossdash/fossdash-publish.py
-=======
-install/fossdash/fossdash-publish.py
-install/db/db.cron
->>>>>>> origin/dev/reuse-software-agent/main
 src/reso/agent/version.php
 src/reso/agent/reso
 

--- a/.gitignore
+++ b/.gitignore
@@ -169,8 +169,15 @@ src/reportImport/agent/reportImport
 src/delagent/agent_tests/Unit/test_delagent
 src/delagent/agent_tests/Unit/testconf/
 /utils/fo_unicode_clean
+<<<<<<< HEAD
 install/db/db.cron
 install/fossdash/fossdash-publish.py
+=======
+install/fossdash/fossdash-publish.py
+install/db/db.cron
+>>>>>>> origin/dev/reuse-software-agent/main
+src/reso/agent/version.php
+src/reso/agent/reso
 
 # Add all the Ubuntu consol log file
 ubuntu-*

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,6 +26,7 @@ DIRS = \
 	pkgagent \
 	readmeoss \
 	unifiedreport \
+	reso \
 	reuser \
 	scheduler \
 	softwareHeritage \

--- a/src/decider/ui/template/agent_decider.html.twig
+++ b/src/decider/ui/template/agent_decider.html.twig
@@ -4,7 +4,7 @@
   {{ 'Automatic Concluded License Decider'|trans }}<img src="images/info_16.png" title="{{ 'only for relevant files'|trans }}" alt="" class="info-bullet"/>,
   {{ 'based on'|trans }}<br/>
   <input type="checkbox" name="deciderRules[]" value="nomosInMonk" /> {{ '... scanners matches if all Nomos findings are within the Monk findings'|trans }}<br />
-  <input type="checkbox" name="deciderRules[]" value="ojoNoContradiction" /> {{ '... scanners matches if Ojo findings are no contradiction with other findings'|trans }}<br />
+  <input type="checkbox" name="deciderRules[]" value="ojoNoContradiction" /> {{ '... scanners matches if Ojo or REUSE.Software findings are no contradiction with other findings'|trans }}<br />
   {% if isNinkaInstalled %}
   <input type="checkbox" name="deciderRules[]" value="nomosMonkNinka" /> {{ '... scanners matches if Nomos, Monk and Ninka find the same license'|trans }}<br />
   {% endif %}

--- a/src/fossy-ruleset.xml
+++ b/src/fossy-ruleset.xml
@@ -22,6 +22,7 @@
   <file>unifiedreport</file>
   <file>softwareHeritage</file>
   <file>www/ui</file>
+  <file>reso</file>
 
   <!--
     The vendor folder by composer must not be scanned.

--- a/src/lib/php/Data/AgentRef.php
+++ b/src/lib/php/Data/AgentRef.php
@@ -32,7 +32,8 @@ class AgentRef
     'ninka' => 'Nk',
     'reportImport' => 'I',
     'ojo' => 'O',
-    'spasht' => 'Sp'
+    'spasht' => 'Sp',
+    'reso' => 'Rs'
   );
   /**
    * @var int

--- a/src/lib/php/UI/template/include/base.html.twig
+++ b/src/lib/php/UI/template/include/base.html.twig
@@ -6,7 +6,7 @@
 #}
 {# Set common list of agents. Displayed by various pages #}
 {%
-  set agent_list = "(N: nomos, M: monk, Nk: ninka, I: reportImport, O: ojo, Sp: spasht)"
+  set agent_list = "(N: nomos, M: monk, Nk: ninka, I: reportImport, O: ojo, Sp: spasht, Rs: reso)"
 %}
 <!DOCTYPE html>
 <html lang="en">

--- a/src/reso/Makefile
+++ b/src/reso/Makefile
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: GPL-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2021 Orange 
+# Author: Bartłomiej Dróżdż <bartlomiej.drozdz@orange.com>
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+TOP = ../..
+VARS = $(TOP)/Makefile.conf
+include $(VARS)
+
+MOD_NAME = reso
+
+DIRS = agent ui
+
+DIR_LOOP = @set -e; for dir in $(DIRS); do $(MAKE) -s -C $$dir $(1); done
+
+all: VERSIONFILE
+	$(call DIR_LOOP, )
+
+coverage: all
+	@echo "nothing to do"
+
+VERSIONFILE:
+	$(call WriteVERSIONFile,$(MOD_NAME))
+
+install: all
+	$(call DIR_LOOP,install)
+	$(INSTALL_DATA) VERSION $(DESTDIR)$(MODDIR)/$(MOD_NAME)/VERSION
+	$(INSTALL_DATA) $(MOD_NAME).conf $(DESTDIR)$(MODDIR)/$(MOD_NAME)/$(MOD_NAME).conf
+	mkdir -p $(DESTDIR)$(SYSCONFDIR)/mods-enabled
+	if test ! -e $(DESTDIR)$(SYSCONFDIR)/mods-enabled/$(MOD_NAME); then \
+		ln -s $(MODDIR)/$(MOD_NAME) $(DESTDIR)$(SYSCONFDIR)/mods-enabled; \
+	fi
+
+uninstall:
+	$(call DIR_LOOP,uninstall)
+	rm -rf $(DESTDIR)$(MODDIR)/$(MOD_NAME)
+	rm -f $(DESTDIR)$(SYSCONFDIR)/mods-enabled/$(MOD_NAME)
+
+clean:
+	rm -f VERSION
+	$(call DIR_LOOP,clean)
+	
+
+
+.PHONY: all test coverage VERSIONFILE install uninstall clean

--- a/src/reso/agent/Makefile
+++ b/src/reso/agent/Makefile
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: GPL-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2021 Orange
+# Author: Bartłomiej Dróżdż <bartlomiej.drozdz@orange.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+TOP = ../../..
+VARS = $(TOP)/Makefile.conf
+DEPS = $(TOP)/Makefile.deps
+include $(VARS)
+
+MOD_NAME = reso
+
+COPY = reso.php version.php ResoAgent.php
+WRAP = reso
+
+all: version.php reso
+
+version.php: version-process_php
+
+# include the preprocessing stuff
+include $(TOP)/Makefile.process
+
+reso:
+	@echo "making locally runnable reso (only for testing)"
+	$(MAKE) -C $(FOCLIDIR) fo_wrapper
+	ln -sf $(FOCLIDIR)/fo_wrapper.php reso
+
+install: all
+	$(INSTALL_PROGRAM) -d $(DESTDIR)$(MODDIR)/$(MOD_NAME)/agent/
+	for file in $(COPY); do \
+		echo "installing $$file"; \
+		$(INSTALL_PROGRAM) $$file $(DESTDIR)$(MODDIR)/$(MOD_NAME)/agent/$$file; \
+	done
+	for file in $(WRAP); do \
+		echo "Making wrapper for $$file"; \
+		ln -sf $(LIBEXECDIR)/fo_wrapper  $(DESTDIR)$(MODDIR)/$(MOD_NAME)/agent/$$file; \
+	done
+
+uninstall:
+	for file in $(WRAP); do \
+		rm -rf $(DESTDIR)$(MODDIR)/$(MOD_NAME)/agent/$$file; \
+	done
+
+clean:
+	rm -f version.php $(WRAP)
+
+.PHONY: all install uninstall clean
+
+include $(DEPS)

--- a/src/reso/agent/ResoAgent.php
+++ b/src/reso/agent/ResoAgent.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * SPDX-License-Identifier: GPL-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Orange
+ * Author: Bartłomiej Dróżdż <bartlomiej.drozdz@orange.com>
+ * Author: Piotr Pszczoła <piotr.pszczola@orange.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace Fossology\Reso;
+
+use Fossology\Lib\Agent\Agent;
+use Fossology\Lib\Dao\AgentDao;
+use Fossology\Lib\Dao\UploadDao;
+
+
+include_once(__DIR__ . "/version.php");
+
+/**
+ * @file
+ * @brief Reso  agent source
+ * @class Reso
+ * @brief The reso  agent
+ */
+class ResoAgent extends Agent
+{
+
+  /** @var reuse software
+   * license file suffix (extention)
+   */
+  const REUSE_FILE_SUFFIX = ".license";
+
+  /** @var UploadDao $uploadDao
+   * UploadDao object
+   */
+  private $uploadDao;
+
+  /**
+   * @var AgentDao $agentDao
+   * AgentDao object
+   */
+  protected $agentDao;
+
+  /**
+   * ResoAgent constructor.
+   * @throws \Exception
+   */
+  function __construct()
+  {
+    parent::__construct(RESO_AGENT_NAME, AGENT_VERSION, AGENT_REV);
+    $this->uploadDao = $this->container->get('dao.upload');
+    $this->agentDao = $this->container->get('dao.agent');
+  }
+
+  /**
+   * @brief Run reso for a package
+   * @param int $uploadId
+   * @return bool
+   * @throws \Fossology\Lib\Exception
+   * @see Fossology::Lib::Agent::Agent::processUploadId()
+   */
+  function processUploadId($uploadId)
+  {
+    $uploadTreeTableName = $this->uploadDao->getUploadtreeTableName($uploadId);
+
+    $reSoUploadFiles = $this->findReSoUploadFiles($uploadId);
+    if (empty($reSoUploadFiles)) {
+      file_put_contents('php://stderr', "Files with " . self::REUSE_FILE_SUFFIX . " suffix not found. \n");
+      return true;
+    }
+    $linkedFiles = $this->associateBaseFile($reSoUploadFiles, $uploadTreeTableName);
+    $this->copyOjoFindings($linkedFiles,$uploadId);
+
+    return true;
+  }
+
+  /**
+   * @brief Find all files with specific suffix.
+   * @param int $uploadId
+   * @return array[] Array of uploadtree objects
+   */
+  protected function findReSoUploadFiles($uploadId)
+  {
+    $uploadTreeTableName = $this->uploadDao->getUploadtreeTableName($uploadId);
+    $param = array();
+    $stmt = __METHOD__ .'reSo_files'.self::REUSE_FILE_SUFFIX;
+    $sql = "SELECT * FROM $uploadTreeTableName
+      WHERE upload_fk=$1 AND pfile_fk != 0 AND ufile_name like '%" . self::REUSE_FILE_SUFFIX . "' ";
+    $param[] = $uploadId;
+    $this->dbManager->prepare($stmt, $sql);
+    $res = $this->dbManager->execute($stmt,$param);
+
+    return $this->dbManager->fetchAll($res);
+  }
+
+  /**
+   * @brief Find and associate base file to files containting license info
+   * @param array[] $reSoUploadFiles list of uploadtree objects to process
+   * @param string $uploadTreeTableName - uploadtree table for upload
+   * @return array[][] multi-dimensional array with license holding files with associated base files
+   */
+  protected function associateBaseFile($reSoUploadFiles, $uploadTreeTableName)
+  {
+    $mergedArray = array();
+    foreach ($reSoUploadFiles as $row) {
+      $baseFileRow = $this->findAssociatedFile($row, $uploadTreeTableName);
+      if (!empty($baseFileRow)) {
+        $row['assoc_file'] = $baseFileRow;
+        $mergedArray[] = $row;
+      }
+    }
+    return $mergedArray;
+  }
+
+  /**
+   * @brief Find associated base file.
+   * @param array[] $row - uploadtree entry to process
+   * @param string $uploadTreeTableName - uploadtree table for upload
+   * @return array[] uploadtree entry containing base file for input param
+   */
+  protected function findAssociatedFile($row, $uploadTreeTableName)
+  {
+    $stmt = __METHOD__ .'find_reso_base_file';
+    $sql = "SELECT * FROM $uploadTreeTableName
+      WHERE upload_fk=$1 AND ufile_name =$2 AND pfile_fk != 0 AND realparent=$3";
+    $param[] = $row['upload_fk'];
+    $param[] = substr($row['ufile_name'],0,-1 * abs(strlen(self::REUSE_FILE_SUFFIX)));
+    $param[] = $row['realparent'];
+    $this->dbManager->prepare($stmt, $sql);
+    $res = $this->dbManager->execute($stmt,$param);
+
+    return $this->dbManager->fetchAll($res);
+  }
+
+  /**
+   * @brief Cupy license from licene holder to base file
+   * @param array[][] $linkedFiles - multi-dimensional array with license holding files with associated base files
+   * @param int $uploadId
+   * @return true on success, Error on failure
+   */
+  protected function copyOjoFindings($linkedFiles,$uploadId)
+  {
+    //find agentId used for specific upload
+    $latestOjoAgent=$this->agentDao->agentARSList("ojo_ars",$uploadId);
+    $resoAgentId=$this->agentDao->getCurrentAgentId("reso");
+
+    foreach ($linkedFiles as $file) {
+      $this->heartbeat(1);
+      $param = array();
+      $insertParam = array();
+      $stmt = __METHOD__ .'readLicenseFindongsOjo';
+      $sql = "SELECT * FROM license_file
+        WHERE pfile_fk =$1 AND agent_fk=$2 and rf_fk IS NOT NULL";
+      $param[] = $file['pfile_fk'];
+      $param[] = $latestOjoAgent[0]['agent_fk'];
+
+      $this->dbManager->prepare($stmt, $sql);
+      $res = $this->dbManager->execute($stmt,$param);
+      while ($row=$this->dbManager->fetchArray($res)) {
+        $insertParam = array();
+        $Istmt = __METHOD__ .'insertLicenseFindongsReso';
+        $Isql = "INSERT INTO license_file (rf_fk, agent_fk, pfile_fk)
+          VALUES($1,$2,$3) RETURNING fl_pk";
+        $insertParam[] = $row['rf_fk'];
+        $insertParam[] = $resoAgentId;
+        $insertParam[] = $file['assoc_file'][0]['pfile_fk'];
+
+        $this->dbManager->prepare($Istmt, $Isql);
+        $Ires = $this->dbManager->execute($Istmt,$insertParam);
+      }
+    }
+    return true;
+  }
+}

--- a/src/reso/agent/reso.php
+++ b/src/reso/agent/reso.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * SPDX-License-Identifier: GPL-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Orange
+ * Author: Bartłomiej Dróżdż <bartlomiej.drozdz@orange.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/**
+ * @dir
+ * @brief Source for reso  agent
+ * @page reso Reso agent
+ * @tableofcontents
+ * @section reso About Reso agent
+ *
+ *
+ * @section reso Agent source
+ *   - @link src/reso/agent @endlink
+ *   - @link src/reso/ui @endlink
+ */
+/**
+ * @namespace Fossology\Reso
+ * @brief Namespace used by reso agent
+ */
+namespace Fossology\Reso;
+
+include_once(__DIR__ . "/ResoAgent.php");
+
+$agent = new ResoAgent();
+$agent->scheduler_connect();
+$agent->run_scheduler_event_loop();
+$agent->scheduler_disconnect(0);

--- a/src/reso/agent/version.php.in
+++ b/src/reso/agent/version.php.in
@@ -1,0 +1,4 @@
+<?php
+define("RESO_AGENT_NAME", "reso");
+defined("AGENT_VERSION") or define("AGENT_VERSION", "{$VERSION}");
+defined("AGENT_REV") or define("AGENT_REV", "{$COMMIT_HASH}");

--- a/src/reso/reso.conf
+++ b/src/reso/reso.conf
@@ -1,0 +1,24 @@
+; Copying and distribution of this file, with or without modification,
+; are permitted in any medium without royalty provided the copyright
+; notice and this notice are preserved. This file is offered as-is,
+; without any warranty.
+
+; scheduler configure file for this agent
+[default]
+
+; name: The name of the agent from the agent table
+name = reso
+
+; command: The command that the scheduler will use when creating an instance of this agent.
+; This will be parsed like a normal Unix command line.
+command = reso
+
+; max: The maximum number of this agent that is allowed to exist at any one time.
+; This is set to -1 if there is no limit on the number of instances of the agent.
+max = -1
+
+; special: Scheduler directive for special agent attributes.
+; A comma separated list of values.
+; Directives:
+;     EXCLUSIVE: the agent cannot run concurrently with any other agent.
+special[] =

--- a/src/reso/ui/Makefile
+++ b/src/reso/ui/Makefile
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: GPL-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2021 Orange
+# Author: Bartłomiej Dróżdż <bartlomiej.drozdz@orange.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+TOP = ../../..
+VARS = $(TOP)/Makefile.conf
+include $(VARS)
+
+MOD_NAME = reso
+MOD_SUBDIR = ui
+
+all:
+	@echo "nothing to do"
+
+install:
+	mkdir -p $(DESTDIR)$(MODDIR)/$(MOD_NAME)/$(MOD_SUBDIR)
+	$(INSTALL_DATA) ./*.php $(DESTDIR)$(MODDIR)/$(MOD_NAME)/$(MOD_SUBDIR)
+
+uninstall:
+	rm -rf $(DESTDIR)$(MODDIR)/$(MOD_NAME)/$(MOD_SUBDIR)
+
+clean:
+	@echo "nothing to do"
+
+.PHONY: all install uninstall clean

--- a/src/reso/ui/ResoAgentPlugin.php
+++ b/src/reso/ui/ResoAgentPlugin.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * SPDX-License-Identifier: GPL-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Orange
+ * Author: Bartłomiej Dróżdż <bartlomiej.drozdz@orange.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+use Fossology\Lib\Plugin\AgentPlugin;
+
+/**
+ * @class ResoAgentPlugin
+ * @brief Create UI plugin for Reso  agent
+ */
+class ResoAgentPlugin extends AgentPlugin
+{
+  public function __construct()
+  {
+    $this->Name = "agent_reso";
+    $this->Title =  ("REUSE.Software Analysis (forces *Ojo License Analysis*)");
+    $this->AgentName = "reso";
+
+    parent::__construct();
+  }
+
+  /**
+   * @copydoc Fossology::Lib::Plugin::AgentPlugin::AgentHasResults()
+   * @see Fossology::Lib::Plugin::AgentPlugin::AgentHasResults()
+   */
+  function AgentHasResults($uploadId=0)
+  {
+    return CheckARS($uploadId, $this->AgentName, "reso agent", "reso_ars");
+  }
+
+  /**
+   * @copydoc Fossology\Lib\Plugin\AgentPlugin::AgentAdd()
+   * @see \Fossology\Lib\Plugin\AgentPlugin::AgentAdd()
+   */
+  public function AgentAdd($jobId, $uploadId, &$errorMsg, $dependencies=array(), $arguments=null)
+  {
+    $dependencies[] = "ojo";
+    if ($this->AgentHasResults($uploadId) == 1) {
+      return 0;
+    }
+
+    $jobQueueId = \IsAlreadyScheduled($jobId, $this->AgentName, $uploadId);
+    if ($jobQueueId != 0) {
+      return $jobQueueId;
+    }
+
+    return $this->doAgentAdd($jobId, $uploadId, $errorMsg, array("agent_ojo"),$uploadId);
+  }
+
+  /**
+   * Check if agent already included in the dependency list
+   * @param mixed  $dependencies Array of job dependencies
+   * @param string $agentName    Name of the agent to be checked for
+   * @return boolean true if agent already in dependency list else false
+   */
+  protected function isAgentIncluded($dependencies, $agentName)
+  {
+    foreach ($dependencies as $dependency) {
+      if ($dependency == $agentName) {
+        return true;
+      }
+      if (is_array($dependency) && $agentName == $dependency['name']) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+register_plugin(new ResoAgentPlugin());

--- a/src/www/ui/api/Models/Analysis.php
+++ b/src/www/ui/api/Models/Analysis.php
@@ -1,6 +1,7 @@
 <?php
 /***************************************************************
 Copyright (C) 2017 Siemens AG
+Copyright (C) 2021 Orange by Piotr Pszczola <piotr.pszczola@orange.com>
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -73,6 +74,11 @@ class Analysis
    * @var boolean $pkgagent
    * Whether to schedule package agent or not
    */
+  private $reso;
+  /**
+   * @var boolean $pkgagent
+   * Whether to schedule package agent or not
+   */
   private $pkgagent;
 
   /**
@@ -85,10 +91,11 @@ class Analysis
    * @param boolean $monk
    * @param boolean $nomos
    * @param boolean $ojo
+   * @param boolean $reso
    * @param boolean $package
    */
   public function __construct($bucket = false, $copyright = false, $ecc = false, $keyword = false,
-    $mimetype = false, $monk = false, $nomos = false, $ojo = false, $pkgagent = false)
+    $mimetype = false, $monk = false, $nomos = false, $ojo = false, $reso = false, $pkgagent = false)
   {
     $this->bucket = $bucket;
     $this->copyright = $copyright;
@@ -98,6 +105,7 @@ class Analysis
     $this->monk = $monk;
     $this->nomos = $nomos;
     $this->ojo = $ojo;
+    $this->reso = $reso;
     $this->pkgagent = $pkgagent;
   }
 
@@ -136,6 +144,9 @@ class Analysis
     if (array_key_exists("ojo", $analysisArray)) {
       $this->ojo = filter_var($analysisArray["ojo"], FILTER_VALIDATE_BOOLEAN);
     }
+    if (array_key_exists("reso", $analysisArray)) {
+      $this->reso = filter_var($analysisArray["reso"], FILTER_VALIDATE_BOOLEAN);
+    }
     if (array_key_exists("package", $analysisArray)) {
       $this->pkgagent = filter_var($analysisArray["package"],
         FILTER_VALIDATE_BOOLEAN);
@@ -173,6 +184,9 @@ class Analysis
     }
     if (stristr($analysisString, "ojo")) {
       $this->ojo = true;
+    }
+    if (stristr($analysisString, "reso")) {
+      $this->reso = true;
     }
     if (stristr($analysisString, "pkgagent")) {
       $this->pkgagent = true;
@@ -243,6 +257,14 @@ class Analysis
   public function getOjo()
   {
     return $this->ojo;
+  }
+
+  /**
+   * @return boolean
+   */
+  public function getReso()
+  {
+    return $this->reso;
   }
 
   /**
@@ -319,6 +341,14 @@ class Analysis
   }
 
   /**
+   * @param boolean $reso
+   */
+  public function setReso($reso)
+  {
+    $this->reso = filter_var($reso, FILTER_VALIDATE_BOOLEAN);
+  }
+
+  /**
    * @param boolean $package
    */
   public function setPackage($package)
@@ -341,6 +371,7 @@ class Analysis
       "monk"      => $this->monk,
       "nomos"     => $this->nomos,
       "ojo"       => $this->ojo,
+      "reso"       => $this->reso,
       "package"   => $this->pkgagent
     ];
   }

--- a/src/www/ui/api/Models/Decider.php
+++ b/src/www/ui/api/Models/Decider.php
@@ -2,6 +2,7 @@
 /**
  * *************************************************************
  * Copyright (C) 2017 Siemens AG
+ * Copyright (C) 2021 Orange by Piotr Pszczola <piotr.pszczola@orange.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -48,7 +49,7 @@ class Decider
   private $newScanner;
   /**
    * @var boolean $ojoDecider
-   * Scanners matches if Ojo findings are no contradiction with other findings
+   * Scanners matches if Ojo or Reso findings are no contradiction with other findings
    */
   private $ojoDecider;
 

--- a/src/www/ui/api/Models/ScanOptions.php
+++ b/src/www/ui/api/Models/ScanOptions.php
@@ -1,6 +1,7 @@
 <?php
 /***************************************************************
 Copyright (C) 2017 Siemens AG
+Copyright (C) 2021 Orange by Piotr Pszczola <piotr.pszczola@orange.com>
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -104,6 +105,7 @@ class ScanOptions
 
     $paramAgentRequest = new Request();
     $agentsToAdd = $this->prepareAgents();
+    file_put_contents('php://stderr', "AgentsToAdd: " . print_r($agentsToAdd, true) . " \n");
     $this->prepareReuser($paramAgentRequest);
     $this->prepareDecider($paramAgentRequest);
     $returnStatus = (new \AgentAdder())->scheduleAgents($uploadId, $agentsToAdd, $paramAgentRequest);
@@ -122,6 +124,7 @@ class ScanOptions
   {
     $agentsToAdd = [];
     foreach ($this->analysis->getArray() as $agent => $set) {
+      file_put_contents('php://stderr', "AgentsToAdd: " . $agent . " set: " . $set . " \n");
       if ($set === true) {
         if ($agent == "copyright_email_author") {
           $agentsToAdd[] = "agent_copyright";

--- a/src/www/ui/api/Models/ScanOptions.php
+++ b/src/www/ui/api/Models/ScanOptions.php
@@ -105,7 +105,6 @@ class ScanOptions
 
     $paramAgentRequest = new Request();
     $agentsToAdd = $this->prepareAgents();
-    file_put_contents('php://stderr', "AgentsToAdd: " . print_r($agentsToAdd, true) . " \n");
     $this->prepareReuser($paramAgentRequest);
     $this->prepareDecider($paramAgentRequest);
     $returnStatus = (new \AgentAdder())->scheduleAgents($uploadId, $agentsToAdd, $paramAgentRequest);
@@ -124,7 +123,6 @@ class ScanOptions
   {
     $agentsToAdd = [];
     foreach ($this->analysis->getArray() as $agent => $set) {
-      file_put_contents('php://stderr', "AgentsToAdd: " . $agent . " set: " . $set . " \n");
       if ($set === true) {
         if ($agent == "copyright_email_author") {
           $agentsToAdd[] = "agent_copyright";

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -15,7 +15,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.2.2
+  version: 1.2.3
   contact:
     email: fossology@fossology.org
   license:

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -433,6 +433,7 @@ paths:
               - ninka
               - ojo
               - reportImport
+              - reso
           uniqueItems: true
         style: form
         explode: false
@@ -1122,7 +1123,7 @@ components:
           description: New scanner results, i.e., decisions were marked as work in progress if new scanner finds additional licenses.
         ojo_decider:
           type: boolean
-          description: Scanners matches if Ojo findings are no contradiction with other findings.
+          description: Scanners matches if Ojo or REUSE.Software findings are no contradiction with other findings.
     ScanOptions:
       type: object
       properties:
@@ -1317,6 +1318,9 @@ components:
         package:
           type: boolean
           description: Should Package Analysis be run on this upload.
+        reso:
+          type: boolean
+          description: Should REUSE.Software Analysis be run on this upload.
     Reuser:
       type: object
       properties:


### PR DESCRIPTION
Fixes #1833 

## Description

As discussed in issue #1833, implements a part of the RESUSE.Software specification, by detecting the `.license` suffixed files, and applying the license detected by the *Ojo* agent to the associated file.

### Changes
A new agent, named **ReSo**.

More details already available on Wiki page: [ReSo-(REUSE.Software)](https://github.com/fossology/fossology/wiki/ReSo-%28REUSE.Software%29)

Known limitations, bugs:
- Commas appear in the license table for files taht have been scanned multiple times. No incidence on workflow detected.
![image](https://user-images.githubusercontent.com/22956329/122936703-a51f7700-d371-11eb-8030-e1266c598556.png)
- the name of the agent displayed could be changed from '*reso* to *REUSE.Software*, to be discussed
- Copyrights not handled
- Next, [still-in-discussion](https://github.com/spdx/spdx-spec/issues/502) REUSE.yml files could be supported


## How to test

1. Start new upload - you may want to use example package available here: https://github.com/fossology/fossology/wiki/ReSo-%28REUSE.Software%29#testing
2. Select `REUSE.Software Analysis -> will also trigger a scan with Ojo agent` option
3. Select `... scanners matches if Ojo or REUSE.Software findings are no contradiction with other findings` option
4. ![image](https://user-images.githubusercontent.com/22956329/122937264-1f4ffb80-d372-11eb-9edd-c445c0e3b233.png)
5. Start Upload
6. Check that licenses are applied accordingly, while license conflicts are not concluded
7. ![image](https://user-images.githubusercontent.com/22956329/122937800-8968a080-d372-11eb-8ad8-337ddce7fef9.png)
