### PR TITLE
fix(delagent): Use bcrypt to check password

### DIFF
--- a/src/delagent/agent/CMakeLists.txt
+++ b/src/delagent/agent/CMakeLists.txt
@@ -7,7 +7,7 @@ set(FO_CWD ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FO_C_FLAGS} -fPIC")
 
 include_directories(${glib_INCLUDE_DIRS} ${PostgreSQL_INCLUDE_DIRS})
-    
+
 if(NOT TARGET fossology)
     add_subdirectory(${FO_CLIB_SRC} buildc EXCLUDE_FROM_ALL)
 endif()
@@ -15,9 +15,9 @@ endif()
 add_executable(delagent "")
 target_sources(delagent PRIVATE ${FO_CWD}/delagent.c ${FO_CWD}/util.c)
 target_compile_definitions(delagent PRIVATE _FILE_OFFSET_BITS=64)
-target_link_libraries(delagent PRIVATE fossology gcrypt)
+target_link_libraries(delagent PRIVATE fossology gcrypt crypt)
 
 install(TARGETS delagent
     RUNTIME
-    DESTINATION ${FO_MODDIR}/${PROJECT_NAME}/agent 
+    DESTINATION ${FO_MODDIR}/${PROJECT_NAME}/agent
     COMPONENT delagent)

--- a/src/delagent/agent/util.c
+++ b/src/delagent/agent/util.c
@@ -11,6 +11,9 @@
  * delagent: Remove an upload from the DB and repository
  *
  */
+
+#include <crypt.h>
+
 #include "delagent.h"
 
 int Verbose = 0;
@@ -99,7 +102,7 @@ int authentication(char *user, char *password, int *userId, int *userPerm)
   char SQL[MAXSQL] = {0};
   PGresult *result;
   char user_seed[myBUFSIZ] = {0};
-  char pass_hash_valid[41] = {0};
+  char pass_hash_valid[myBUFSIZ] = {0};
   unsigned char pass_hash_actual_raw[21] = {0};
   char pass_hash_actual[41] = {0};
 
@@ -122,6 +125,11 @@ int authentication(char *user, char *password, int *userId, int *userPerm)
   *userPerm = atoi(PQgetvalue(result, 0, 2));
   *userId = atoi(PQgetvalue(result, 0, 3));
   PQclear(result);
+  if (pass_hash_valid[0] &&
+    strcmp(crypt(password, pass_hash_valid), pass_hash_valid) == 0)
+  {
+    return 0;
+  }
   if (user_seed[0] && pass_hash_valid[0])
   {
     strcat(user_seed, password);  // get the hash code on seed+pass

--- a/src/delagent/agent_tests/CMakeLists.txt
+++ b/src/delagent/agent_tests/CMakeLists.txt
@@ -33,7 +33,7 @@ target_include_directories(test_delagent
     PRIVATE ${FO_TESTDIR}/lib/c ${FO_TESTDIR}/db/c ${FO_CWD}/../agent
     ${glib_INCLUDE_DIRS} ${PostgreSQL_INCLUDE_DIRS} ${FO_CWD}/Unit ${FO_CLIB_SRC})
 target_link_libraries(test_delagent
-    PRIVATE fossology ${cunit_LIBRARIES} fodbreposysconf focunit gcrypt
+    PRIVATE fossology ${cunit_LIBRARIES} fodbreposysconf focunit gcrypt crypt
         ${glib_LIBRARIES} ${PostgreSQL_LIBRARIES})
 
 # FIXME: Tests need to migrate to alternate framework for generating repo and db

--- a/src/delagent/mod_deps
+++ b/src/delagent/mod_deps
@@ -66,7 +66,7 @@ if [[ $BUILDTIME ]]; then
   case "$DISTRO" in
     Debian|Ubuntu)
       apt-get $YesOpt install \
-        libgcrypt20-dev
+        libgcrypt20-dev libcrypt-dev
       ;;
     RedHatEnterprise*|CentOS|Fedora)
       yum $YesOpt install \
@@ -80,7 +80,7 @@ if [[ $RUNTIME ]]; then
   case "$DISTRO" in
     Debian|Ubuntu)
       apt-get $YesOpt install \
-        libgcrypt20
+        libgcrypt20 libcrypt1
       ;;
     RedHatEnterprise*|CentOS|Fedora)
       yum $YesOpt install \


### PR DESCRIPTION
## Description

The password hash stored in the DB are no longer SHA1 but [bcrypt](https://en.wikipedia.org/wiki/Bcrypt). This caused command line of delagent to fail in checking the password, even throw overflow errors.

Use function `crypt()` to check the password from library [libxcrypt](https://salsa.debian.org/md/libxcrypt#readme-for-libxcrypt) which is licensed under [LGPL-2.1-only](https://salsa.debian.org/md/libxcrypt/-/blob/master/COPYING.LIB)

### Changes

1. Added bcrypt password check along with sha1 in delagent.

## How to test

1. Should be able to list uploads from delagent (`sudo ./src/delagent/agent/delagent -u --user fossy --password fossy`)
2. The Debian packages should build without issue.

Closes #2026 

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2030"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>
