### PR TITLE
feat(spasht): Show effective score

### DIFF
--- a/src/lib/php/Data/Spasht/Coordinate.php
+++ b/src/lib/php/Data/Spasht/Coordinate.php
@@ -55,6 +55,12 @@ class Coordinate
   private $namespace;
 
   /**
+   * @var integer $score
+   * Package score
+   */
+  private $score;
+
+  /**
    * Set the object based on array returned by API
    * @param array $obj Array containing the data
    * @throws \InvalidArgumentException If the input obj does not contain
@@ -132,6 +138,14 @@ class Coordinate
   }
 
   /**
+   * @return integer
+   */
+  public function getScore()
+  {
+    return $this->score;
+  }
+
+  /**
    * Helper function to generate Coordinate from string
    * @param string $coordinate Coordinates returned from definintions API
    * @throws \InvalidArgumentException If the coordinate string is not in valid
@@ -152,5 +166,15 @@ class Coordinate
       'revision' => $parts[4]
     ];
     return new Coordinate($obj);
+  }
+
+  /**
+   * Set the score for this coordinate of package.
+   *
+   * @param integer $score Score
+   */
+  public function setScore($score)
+  {
+    $this->score = intval($score);
   }
 }

--- a/src/lib/php/Data/Spasht/DefinitionSummary.php
+++ b/src/lib/php/Data/Spasht/DefinitionSummary.php
@@ -57,6 +57,12 @@ class DefinitionSummary
   private $discoveredLicenses;
 
   /**
+   * @var integer $score
+   * Package score
+   */
+  private $score;
+
+  /**
    * Set the object based on object returned by API
    * @param array $obj Array containing the data
    */
@@ -68,6 +74,7 @@ class DefinitionSummary
     $this->files = 0;
     $this->release = "";
     $this->url = "";
+    $this->score = 0;
 
     if (array_key_exists('licensed', $result)) {
       $licensed = $result["licensed"];
@@ -105,6 +112,11 @@ class DefinitionSummary
       if (array_key_exists("releaseDate", $described)) {
         $this->release = $described["releaseDate"];
       }
+    }
+
+    if (array_key_exists("scores", $result) &&
+        array_key_exists("effective", $result["scores"])) {
+      $this->score = $result["scores"]["effective"];
     }
   }
 
@@ -154,5 +166,13 @@ class DefinitionSummary
   public function getDiscoveredLicenses()
   {
     return $this->discoveredLicenses;
+  }
+
+  /**
+   * @return integer
+   */
+  public function getScore()
+  {
+    return $this->score;
   }
 }

--- a/src/spasht/ui/template/agent_spasht.js.twig
+++ b/src/spasht/ui/template/agent_spasht.js.twig
@@ -117,7 +117,7 @@ $( function() {
     var t = $("#definitionsTable").DataTable({
       "processing": false,
       "paginationType": "listbox",
-      "order": [[ 1, 'asc' ]],
+      "order": [[ 4, 'desc' ]],
       "autoWidth": false,
       "columnDefs": [{
         "orderable": true,
@@ -126,7 +126,7 @@ $( function() {
       },{
         "orderable": false,
         "searchable": false,
-        "targets": [4]
+        "targets": [5]
       }]
     });
   });

--- a/src/spasht/ui/template/show_definitions.html.twig
+++ b/src/spasht/ui/template/show_definitions.html.twig
@@ -14,6 +14,7 @@
       <th>Revision</th>
       <th>Type</th>
       <th>Provider</th>
+      <th>Effective Score</th>
       <th>Action</th>
     </tr>
   </thead>
@@ -34,6 +35,7 @@
       </td>
       <td id="definitionsRow_type{{ loop.index0 }}">{{ result.type }}</td>
       <td id="definitionsRow_provider{{ loop.index0 }}">{{ result.provider }}</td>
+      <td id="definitionsRow_score{{ loop.index0 }}">{{ result.score }}</td>
       <td onclick="showDetails({{ loop.index0 }})"><a href="#!">Show Details</a></td>
     </tr>
   {% endfor %}

--- a/src/spasht/ui/template/show_details_table.html.twig
+++ b/src/spasht/ui/template/show_details_table.html.twig
@@ -61,6 +61,14 @@
           <span>{{ result.discoveredLicenses|e }}{% if result.discoveredLicenses is not empty %}...{% endif %}</span>
         </td>
       </tr>
+      <tr class="detailsRow detailsId{{ loop.index0 }}">
+        <th>
+          Score
+        </th>
+        <td>
+          <span>{{ result.score }}</span>
+        </td>
+      </tr>
     </tbody>
   </table>
 {% endfor %}

--- a/src/spasht/ui/ui-spasht.php
+++ b/src/spasht/ui/ui-spasht.php
@@ -208,7 +208,6 @@ class ui_spasht extends FO_Plugin
 
             if ($this->checkAdvanceSearch($obj, $revisionName, $namespaceName,
               $typeName, $providerName)) {
-              $matches[] = $obj;
               $uri = "definitions/" . $obj->generateUrlString();
 
               //details section
@@ -238,7 +237,9 @@ class ui_spasht extends FO_Plugin
                 true);
 
               $details_temp = new DefinitionSummary($detail_body);
+              $obj->setScore($details_temp->getScore());
 
+              $matches[] = $obj;
               $details[] = $details_temp;
             }
           }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Display scores from ClearlyDefined in Spahst configuration.
The effective is only considered here. Can be extended to tool scores.

### Changes

1. Update the Coordinate object to hold score information.
2. Update the DefinitionSummary ro hold score information.
3. Filter search results based on scores (desc) by default.
4. Update show_definitions and show_details tables with score.

## How to test

1. Upload a package and goto "Spasht" configuration page.
2. Search for package and check the score in the results.
  - They should be available on the result and details table.

Closes #1964

#### Screenshots
![image](https://user-images.githubusercontent.com/18077542/123951194-2a360c00-d9c2-11eb-998e-2207210c1594.png)
![image](https://user-images.githubusercontent.com/18077542/123951235-35893780-d9c2-11eb-9d15-02af6379fbee.png)
