### PR TITLE
feat(rest): Filter uploads with 4 new parameters

### DIFF
--- a/src/www/ui/api/Helper/DbHelper.php
+++ b/src/www/ui/api/Helper/DbHelper.php
@@ -91,15 +91,16 @@ class DbHelper
    * @param integer $limit    Max number of results
    * @param integer $page     Page to get
    * @param integer $uploadId Pass the upload id to check for single upload.
-   * @param integer $folderId Folder to limit the uploads to
+   * @param integer $options  Filter options
    * @param bool $recursive   True to recursive listing of uploads
    * @return array Total pages as first value, uploads as an array in second
    *         value
    */
   public function getUploads($userId, $groupId, $limit, $page = 1,
-    $uploadId = null, $folderId = null, $recursive = true)
+    $uploadId = null, $options = null, $recursive = true)
   {
     $uploadProxy = new UploadBrowseProxy($groupId, 0, $this->dbManager);
+    $folderId = $options["folderId"];
     if ($folderId === null) {
       $user = $this->getUsers($userId);
       $folderId = $user[0]['rootFolderId'];
@@ -128,9 +129,35 @@ class DbHelper
     $statementGet = __METHOD__ . ".getAllUploads.$limit";
     if ($uploadId !== null) {
       $params[] = $uploadId;
-      $where = "AND upload.upload_pk = $" . count($params);
+      $where .= " AND upload.upload_pk = $" . count($params);
       $statementGet .= ".upload";
       $statementCount .= ".upload";
+    }
+    if (! empty($options["name"])) {
+      $params[] = strtolower("%" . $options["name"] . "%");
+      $where .= " AND (LOWER(upload_desc) LIKE $" . count($params) .
+        " OR LOWER(ufile_name) LIKE $" . count($params) .
+        " OR LOWER(upload_filename) LIKE $" . count($params) . ")";
+      $statementGet .= ".name";
+      $statementCount .= ".name";
+    }
+    if (! empty($options["status"])) {
+      $params[] = $options["status"];
+      $where .= " AND status_fk = $" . count($params);
+      $statementGet .= ".stat";
+      $statementCount .= ".stat";
+    }
+    if (! empty($options["assignee"])) {
+      $params[] = $options["assignee"];
+      $where .= " AND assignee = $" . count($params);
+      $statementGet .= ".assi";
+      $statementCount .= ".assi";
+    }
+    if (! empty($options["since"])) {
+      $params[] = $options["since"];
+      $where .= " AND upload_ts >= to_timestamp($" . count($params) . ")";
+      $statementGet .= ".since";
+      $statementCount .= ".since";
     }
     $sql = "SELECT count(*) AS cnt FROM $partialQuery $where;";
     $totalResult = $this->dbManager->getSingleRow($sql, $params, $statementCount);

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -15,7 +15,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.3.3
+  version: 1.3.4
   contact:
     email: fossology@fossology.org
   license:
@@ -293,6 +293,37 @@ paths:
           schema:
             type: boolean
             default: true
+        - name: name
+          description: Filter pattern for name and description
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: status
+          description: Status of uploads
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - Open
+              - InProgress
+              - Closed
+              - Rejected
+        - name: assignee
+          description: >
+            User name to which uploads are assigned to or -me- or -unassigned-
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: since
+          description: Uploads since given date in YYYY-MM-DD format
+          in: query
+          required: false
+          schema:
+            type: string
+            pattern: \d{4}\-\d{2}\-\d{2}
         - name: page
           description: Page number to fetch
           in: header


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Provide 4 new filters while listing uploads:
- `name`
  + Allow filter uploads based on name and description.
  + *Example:* `?name=foss`
- `status`
  + Filter uploads with status as `Open`, `InProgress`, `Closed`, `Rejected`.
- `assignee`
  + Filter uploads assigned to someone.
  + Expects username as the value not the numerical userid.
  + Special value `-me-` (for self) and `-unassigned-` (for unassigned).
- `since`
  + Uploads which are done since the given date (`YYYY-MM-DD`).
  + Note, the check is `>=`.

All the filters, along with `folderId` can be combined to get desired result. For example "All uploads in folder 4 which are assigned to me, have word "python" in description, are in progress and uploaded after 1st Feb" can be fetched with
`GET http://localhost/repo/api/v1/uploads?folderId=4&assignee=-me-&name=python&status=InProgress&since=2021-02-01`

### Changes

1. New query parameters `name`, `status`, `assignee` and `since` added to `/uploads` endpoint.
2. Corresponding changes done in `DbHelper::getUploads()`.

## How to test

1. Check if the filters are working individually and combined.
2. Check if no parameters are passed, every upload is returned.

Closes #2007

/cc @deveaud-m  