### PR TITLE
fix(ojo): Set candidate license creator

### DIFF
--- a/src/ojo/agent/OjoAgent.cc
+++ b/src/ojo/agent/OjoAgent.cc
@@ -39,6 +39,7 @@ OjoAgent::OjoAgent() :
  * @param filePath        The file to be scanned.
  * @param databaseHandler Database handler to be used.
  * @param groupId         Group running the scan
+ * @param userId          User running the scan
  * @return List of matches found.
  * @sa OjoAgent::scanString()
  * @sa OjoAgent::filterMatches()
@@ -47,7 +48,7 @@ OjoAgent::OjoAgent() :
  * read with the file path in description.
  */
 vector<ojomatch> OjoAgent::processFile(const string &filePath,
-  OjosDatabaseHandler &databaseHandler, const int groupId)
+  OjosDatabaseHandler &databaseHandler, const int groupId, const int userId)
 {
   ifstream stream(filePath);
   std::stringstream sstr;
@@ -68,7 +69,7 @@ vector<ojomatch> OjoAgent::processFile(const string &filePath,
     scanString(m.content, regDualLicense, licenseNames, m.start, true);
   }
 
-  findLicenseId(licenseNames, databaseHandler, groupId);
+  findLicenseId(licenseNames, databaseHandler, groupId, userId);
   filterMatches(licenseNames);
 
   return licenseNames;
@@ -169,14 +170,15 @@ void OjoAgent::filterMatches(vector<ojomatch> &matches)
  * @param[in,out] matches List of matches to be updated
  * @param databaseHandler Database handler to be used
  * @param groupId         Group running the scan
+ * @param userId          User running the scan
  */
 void OjoAgent::findLicenseId(vector<ojomatch> &matches,
-  OjosDatabaseHandler &databaseHandler, const int groupId)
+  OjosDatabaseHandler &databaseHandler, const int groupId, const int userId)
 {
   // Update license_fk
   for (size_t i = 0; i < matches.size(); ++i)
   {
     matches[i].license_fk = databaseHandler.getLicenseIdForName(
-      matches[i].content, groupId);
+      matches[i].content, groupId, userId);
   }
 }

--- a/src/ojo/agent/OjoAgent.hpp
+++ b/src/ojo/agent/OjoAgent.hpp
@@ -37,7 +37,8 @@ class OjoAgent
   public:
     OjoAgent();
     std::vector<ojomatch> processFile(const std::string &filePath,
-      OjosDatabaseHandler &databaseHandler, const int groupId);
+      OjosDatabaseHandler &databaseHandler, const int groupId,
+      const int userId);
     std::vector<ojomatch> processFile(const std::string &filePath);
   private:
     /**
@@ -53,7 +54,8 @@ class OjoAgent
         std::vector<ojomatch> &result, unsigned int offset, bool isDualTest);
     void filterMatches(std::vector<ojomatch> &matches);
     void findLicenseId(std::vector<ojomatch> &matches,
-      OjosDatabaseHandler &databaseHandler, const int groupId);
+      OjosDatabaseHandler &databaseHandler, const int groupId,
+      const int userId);
 };
 
 #endif /* SRC_OJO_AGENT_OJOAGENT_HPP_ */

--- a/src/ojo/agent/OjoUtils.cc
+++ b/src/ojo/agent/OjoUtils.cc
@@ -153,7 +153,8 @@ bool processUploadId(const OjoState &state, int uploadId,
       try
       {
         identified = agentObj.processFile(filePath, threadLocalDatabaseHandler,
-                                          state.getCliOptions().getGroupId());
+                                          state.getCliOptions().getGroupId(),
+                                          state.getCliOptions().getUserId());
       }
       catch (std::runtime_error &e)
       {

--- a/src/ojo/agent/OjosDatabaseHandler.hpp
+++ b/src/ojo/agent/OjosDatabaseHandler.hpp
@@ -87,13 +87,15 @@ class OjosDatabaseHandler: public fo::AgentDatabaseHandler
       const unsigned long fl_fk) const;
 
     unsigned long getLicenseIdForName(std::string const &rfShortName,
-                                      const int groupId);
+                                      const int groupId,
+                                      const int userId);
 
   private:
     unsigned long getCachedLicenseIdForName (
       std::string const &rfShortName) const;
     unsigned long selectOrInsertLicenseIdForName (std::string rfShortname,
-                                                  const int groupId);
+                                                  const int groupId,
+                                                  const int userId);
     /**
      * Cached license pairs
      */


### PR DESCRIPTION
## Description

With the new audit information added for `license_candidate` table, add `rf_user_fk_created` and `rf_user_fk_modified` from ojo while creating new candidate license.

### Changes

Add the user id for `rf_user_fk_created` and `rf_user_fk_modified` while creating new candidate license.

## How to test

1. Create dummy package with `SPDX-License-Identifier` where the license name does not exists in main license table.
2. Ojo should create new candidate license for the file.
3. Edit the license and check the "User Created" and "User Modified" fields.