### PR TITLE
feat(rest): Filter licenses by kind

### DIFF
--- a/src/www/ui/api/Controllers/LicenseController.php
+++ b/src/www/ui/api/Controllers/LicenseController.php
@@ -145,6 +145,7 @@ class LicenseController extends RestController
   public function getAllLicenses($request, $response, $args)
   {
     $retVal = null;
+    $query = $request->getQueryParams();
     $limit = $request->getHeaderLine(self::LIMIT_PARAM);
     if (! empty($limit)) {
       $limit = filter_var($limit, FILTER_VALIDATE_INT);
@@ -157,7 +158,13 @@ class LicenseController extends RestController
       $limit = self::LICENSE_FETCH_LIMIT;
     }
 
-    $totalPages = $this->dbHelper->getLicenseCount(
+    $kind = "all";
+    if (array_key_exists("kind", $query) && !empty($query["kind"]) &&
+      (array_search($query["kind"], ["all", "candidate", "main"]) !== false)) {
+        $kind = $query["kind"];
+    }
+
+    $totalPages = $this->dbHelper->getLicenseCount($kind,
       $this->restHelper->getGroupId());
     $totalPages = intval(ceil($totalPages / $limit));
 
@@ -189,7 +196,7 @@ class LicenseController extends RestController
     }
 
     $licenses = $this->dbHelper->getLicensesPaginated($page, $limit,
-      $this->restHelper->getGroupId(), $onlyActive);
+      $kind, $this->restHelper->getGroupId(), $onlyActive);
     $licenseList = [];
 
     foreach ($licenses as $license) {

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -15,7 +15,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.3.1
+  version: 1.3.2
   contact:
     email: fossology@fossology.org
   license:
@@ -1144,6 +1144,17 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: kind
+          description: Which kind of licenses to get.
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - candidate
+              - main
+              - all
+            default: all
       summary: Get all license from the database
       responses:
         '200':


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Filter licenses based on query from `/license` endpoint. Possible values:
- `?kind=all`
  + Get all licenses
  + Default option
- `?kind=candidate`
  + Get only candidate licenses
- `?kind=main`
  + Get only main licenses

### Changes

1. Added new query parameter `kind` to `/license` endpoint.

## How to test

1. List of licenses with and without `?kind=all` should be same from endpoint.
2. List candidate licenses with `?kind=candidate`.
3. List main licenses with `?kind=main`.

Closes #2045