### PR TITLE
fix(copyright):Change menu text of copyright page

### DIFF
--- a/src/copyright/ui/copyright-hist.php
+++ b/src/copyright/ui/copyright-hist.php
@@ -96,12 +96,12 @@ class CopyrightHistogram extends HistogramBase {
     {
       if (GetParm("mod",PARM_STRING) == $this->Name)
       {
-        menu_insert("Browse::Copyright agent/user findings",10);
+        menu_insert("Browse::Copyright",10);
         menu_insert("Browse::[BREAK]",100);
       }
       else
       {
-        $text = _("View copyright agent/user findings histogram");
+        $text = _("View copyright histogram");
         menu_insert("Browse::Copyright",10,$URI,$text);
       }
     }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Changing copyright browser menu text and tool-tip text from `copyright agent/user findings` to `copyright`.
Signed-off-by: Sarita Singh <saritasingh.0425@gmail.com>

### Changes

![image](https://user-images.githubusercontent.com/43489890/125901226-8312731c-d386-42f0-bed9-fb672cc6692e.png)

## How to test

- Install copyright and www agent
- Upload a file and check `Copyright Browser`
