### PR TITLE
ci(actions): Build Docker images in Actions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,44 @@
+# Copyright 2021 Siemens AG, Gaurav Mishra <mishra.gaurav@siemens.com>
+# SPDX-License-Identifier: GPL-2.0 AND LGPL-2.1
+name: Docker images - master
+
+on:
+  push:
+    branches:
+      - master
+  release:
+    types:
+      - published
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build and push main image
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: fossology/fossology:latest
+        context: .
+
+    - name: Build and push runner image
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: fossology/fossology:scanner
+        file: utils/automation/Dockerfile.ci

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,3 +1,5 @@
+# Copyright 2021 Siemens AG, Gaurav Mishra <mishra.gaurav@siemens.com>
+# SPDX-License-Identifier: GPL-2.0 AND LGPL-2.1
 name: Publish Release Packages
 
 on:
@@ -9,7 +11,7 @@ env:
   DEBIAN_FRONTEND: noninteractive
 
 jobs:
-  build:
+  release-build:
 
     strategy:
       matrix:
@@ -75,3 +77,30 @@ jobs:
         asset_path: ${{ env.PACKAGE_NAME }}
         asset_name: ${{ env.PACKAGE_NAME }}
         asset_content_type: application/gzip
+
+  docker-release-build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Get release info
+      id: get_release
+      uses: bruceadams/get-release@v1.2.2
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+
+    - name: Build and push main image
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: fossology/fossology:${{ steps.get_release.outputs.tag_name }}


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Since [free auto builds are no longer available on Docker Hub](https://www.docker.com/blog/changes-to-docker-hub-autobuilds/), use GitHub Actions to build the image and push to Docker Hub.

### Changes

1. Added new build workflow for builds on push to master and release which will build the "fossology/fossology:latest" and "fossology/fossology:scanner" images.
2. Modify release workflow to add build steps for "fossology/fossology:<release_version>" images.

## How to test

Check the build logs from: https://github.com/GMishx/fossology/runs/3277301909?check_suite_focus=true#logs

#### Note
Since builds are using QEMU and Buildx, there is a posibility to compile fossology for other architectures as well. I did [a trial with linux/arm64](https://github.com/GMishx/fossology/runs/3263935510?check_suite_focus=true#logs) but it was extremely slow (2h compared to 15m).
If anyone is in favour of it, following architectures are supported by QEMU on Actions and can produce builds from them:
- linux/amd64
- linux/arm64
- linux/riscv64
- linux/ppc64le
- linux/s390x
- linux/386
- linux/mips64le
- linux/mips64
- linux/arm/v7
- linux/arm/v6

Closes a task from #1913