### PR TITLE
fix(unifiedreport): Fix upload link for API

### DIFF
--- a/src/unifiedreport/agent/unifiedreport.php
+++ b/src/unifiedreport/agent/unifiedreport.php
@@ -681,7 +681,9 @@ class UnifiedReport extends Agent
     $timestamp = $jobInfo['ts'];
     $packageUri = "";
     if (!empty($jobInfo['jq_cmd_args'])) {
-      $packageUri = trim($jobInfo['jq_cmd_args'])."?mod=showjobs&upload=".$uploadId;
+      $packageUri = trim($jobInfo['jq_cmd_args']);
+      $packageUri = preg_replace("/api\/.*/i", "", $packageUri); // Remove api/v1/report
+      $packageUri .= "?mod=showjobs&upload=" . $uploadId;
     }
 
     /* Applying document properties and styling */

--- a/src/unifiedreport/ui/agent-foreport.php
+++ b/src/unifiedreport/ui/agent-foreport.php
@@ -125,7 +125,9 @@ class FoUnifiedReportGenerator extends DefaultPlugin
     $uploadId = $upload->getId();
     $jobId = JobAddJob($userId, $groupId, $upload->getFilename(), $uploadId);
     $error = "";
-    $jobQueueId = $reportGenAgent->AgentAdd($jobId, $uploadId, $error, array(), tracebackTotalUri());
+    $url = tracebackTotalUri();
+    $url = preg_replace("/api\/.*/i", "", $url); // Remove api/v1/report
+    $jobQueueId = $reportGenAgent->AgentAdd($jobId, $uploadId, $error, array(), $url);
     return array($jobId, $jobQueueId, $error);
   }
 }


### PR DESCRIPTION
## Description

By default, unified report saves traceback URL in `jq_cmd_args`. For UI jobs, it will be `http://localhost/repo/` (or as server's location).
If the report is generated from REST API, it gets changed to `http://localhost/repo/api/v1/report`

This URL is then used to populate the "Fossology Upload" field in unified report.

Add filters to remove everything after `api/` from the traceback URL while generating jobs and report.

### Changes

1. Add filter to remove `api/.*` from URL while generating job.
2. Add the same filter while generating report.

## How to test

1. Before installing branch, create a unified report from UI and check the "Fossology Upload" field.
2. Create a unified report from REST API and check the "Fossology Upload" field.
3. Install the branch and generate report from REST API and check the "Fossology Upload" field.