### PR TITLE
fix (build): do not fail is /usr/share/man* folders already exist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ WORKDIR /fossology
 # Fix for Postgres and other packages in slim variant
 # Note: cron, python, python-psycopg2 are installed
 #       specifically for metrics reporting
-RUN mkdir /usr/share/man/man1 /usr/share/man/man7 \
+RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
  && DEBIAN_FRONTEND=noninteractive apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Description
Recently, docker build has been failing with that error message:
```
INFO[0357] Running: [/bin/sh -c mkdir /usr/share/man/man1 /usr/share/man/man7  && DEBIAN_FRONTEND=noninteractive apt-get update  && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends       curl       lsb-release       sudo       cron       python       python3       python3-yaml       python3-psycopg2       python3-requests  && DEBIAN_FRONTEND=noninteractive /fossology/utils/fo-installdeps --offline --runtime -y  && DEBIAN_FRONTEND=noninteractive apt-get purge -y lsb-release  && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y  && rm -rf /var/lib/apt/lists/*] 
mkdir: cannot create directory '/usr/share/man/man1': File exists
mkdir: cannot create directory '/usr/share/man/man7': File exists
error building image: error building stage: failed to execute command: waiting for process to exit: exit status 1
```
It turns out the folders `/usr/share/man/man*` are now created automatically by another package beforehand, and cannot be created again.

### Changes

Simply using option `mkdir -p ` to avoid failing if folders already exist.

## How to test

Build Docker image.