### PR TITLE
fix(php) Fix SQL query checking is a similar job is already scheduled

### DIFF
--- a/src/lib/php/common-job.php
+++ b/src/lib/php/common-job.php
@@ -391,11 +391,11 @@ function IsAlreadyScheduled($job_pk, $AgentName, $upload_pk)
    * it is unneccessary to reschedule ununpack and adj2nest, one time is enough
    */
   if ($AgentName == "ununpack" || $AgentName == "adj2nest") {
-    $sql = "SELECT jq_pk FROM jobqueue, job where job_pk=jq_job_fk " .
+    $sql = "SELECT jq_pk FROM jobqueue, job where job_pk=$job_pk " .
       "AND jq_type='$AgentName' and job_upload_fk = $upload_pk";
   } else {
     /* check if the upload_pk is currently in the job queue being processed */
-    $sql = "SELECT jq_pk FROM jobqueue, job where job_pk=jq_job_fk AND jq_type='$AgentName' and job_pk=$job_pk";
+    $sql = "SELECT jq_pk FROM jobqueue, job where jq_type='$AgentName' and job_pk=$job_pk";
   }
   $result = pg_query($PG_CONN, $sql);
   DBCheckResult($result, $sql, __FILE__, __LINE__);


### PR DESCRIPTION
## Description

On my new Fossology instance, probably because networking or filesystem is slower than it used to be, the frontend keeps on rescheduling new jobs, for example when requesting report generation.

One report request would trigger from a few to 8 or 10 jobs - and until all are processed by the scheduler, the frontend would be totally non-responsive. Then all of a sudden, the web page would "unlock", and all jobs appear green in the job list.

It turns out that the queries used to detect that a similar job had a problem, as they include `job_pk=jq_job_fk`, meaning the query would never return any result.

### Changes
Changed both SQL queries to include `job_pk=$job_pk` instead

## How to test

Browse in Fossology, and generate reports. Reports are generated + job page appear immediately, when it would have taken up to 15 minutes before.