### PR TITLE
feat(unifiedreport): include assigned to in component clearing section

### DIFF
--- a/src/unifiedreport/agent/reportSummary.php
+++ b/src/unifiedreport/agent/reportSummary.php
@@ -83,7 +83,7 @@ class ReportSummary
    * @param string $groupName
    * @param string $packageUri
    */
-  function summaryTable(Section $section, $uploadId, $userName, $mainLicenses, $licenses, $histLicenses, $otherStatement, $timestamp, $groupName, $packageUri)
+  function summaryTable(Section $section, $uploadId, $userName, $mainLicenses, $licenses, $histLicenses, $otherStatement, $timestamp, $groupName, $packageUri, $assignedToUserName)
   {
     $cellRowContinue = array("vMerge" => "continue");
     $firstRowStyle = array("size" => 14, "bold" => true);
@@ -122,9 +122,15 @@ class ReportSummary
 
     $table->addRow($rowWidth);
     $table->addCell($cellFirstLen, $cellRowContinue);
-    $table->addCell($cellSecondLen)->addText(htmlspecialchars(" Prepared by"), $firstRowStyle1, "pStyle");
-    $table->addCell($cellThirdLen)->addText(htmlspecialchars(" "
-      .date("Y/m/d", $timestamp)."  ".$userName." (".$groupName.") "), null, "pStyle");
+    $table->addCell($cellSecondLen)->addText(htmlspecialchars(" Report Created by"), $firstRowStyle1, "pStyle");
+    $table->addCell($cellThirdLen)->addText(htmlspecialchars(
+      date("Y/m/d", $timestamp)."  ".$userName." (".$groupName.") "), null, "pStyle");
+
+    $table->addRow($rowWidth);
+    $table->addCell($cellFirstLen, $cellRowContinue);
+    $table->addCell($cellSecondLen)->addText(htmlspecialchars(" Analyzed by"),$firstRowStyle1, "pStyle");
+    $table->addCell($cellThirdLen)->addText(htmlspecialchars($assignedToUserName), null, "pStyle");
+
     $table->addRow($rowWidth);
     $table->addCell($cellFirstLen, $cellRowContinue);
     $table->addCell($cellSecondLen)->addText(htmlspecialchars(" Reviewed by (opt.)"),$firstRowStyle1, "pStyle");

--- a/src/unifiedreport/agent/unifiedreport.php
+++ b/src/unifiedreport/agent/unifiedreport.php
@@ -704,9 +704,15 @@ class UnifiedReport extends Agent
     list($contents['licensesMain']['statements'], $contents['licenses']['statements']) = $this->licenseClearedGetter->updateIdentifiedGlobalLicenses($contents['licensesMain']['statements'], $contents['licenses']['statements']);
 
     /* Summery table */
+    $assignedToUserId = $this->uploadDao->getAssignee($uploadId, $groupId);
+    if ($assignedToUserId != 1) {
+      $assignedToUserName = $this->userDao->getUserName($assignedToUserId);
+    } else {
+      $assignedToUserName = "";
+    }
     $reportSummarySection->summaryTable($section, $uploadId, $userName,
       $contents['licensesMain']['statements'], $contents['licenses']['statements'],
-      $contents['licensesHist']['statements'], $contents['otherStatement'], $timestamp, $groupName, $packageUri);
+      $contents['licensesHist']['statements'], $contents['otherStatement'], $timestamp, $groupName, $packageUri, $assignedToUserName);
 
     if (!empty($contents['otherStatement']['ri_unifiedcolumns'])) {
       $unifiedColumns = (array) json_decode($contents['otherStatement']['ri_unifiedcolumns'], true);


### PR DESCRIPTION
## Description

* Assigned to information from browse page was missing in report.
*  Renamed "Prepared by" to "Report Created by"

### Changes

* New row in OSS Component Clearing report table, Analyzed by to capture Assigned to information.

## How to test

* Generate unified report with different assigned to information. 
* Check  Analyzed by row.