### PR TITLE
feat(rest): Update upload information

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -15,7 +15,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.3.4
+  version: 1.4.0
   contact:
     email: fossology@fossology.org
   license:
@@ -221,21 +221,43 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
     patch:
-      operationId: moveUploadById
+      operationId: updateUploadById
       tags:
         - Upload
         - Organize
-      description: Move upload from one folder to other
+      description: Update an upload information
       parameters:
-        - name: folderId
-          description: Folder Id, where upload should be moved to
-          in: header
-          required: true
+        - name: status
+          description: New status of the upload
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - Open
+              - InProgress
+              - Closed
+              - Rejected
+          example: Closed
+        - name: assignee
+          description: New assignee for the project
+          in: query
+          required: false
           schema:
             type: integer
+      requestBody:
+        description: >
+          Comment on the status, required for Closed and Rejected states.
+          Ignored for others.
+        content:
+          text/plain:
+            schema:
+              description: The comment for new status
+              type: string
+              example: "The upload cleared for use."
       responses:
         '202':
-          description: Upload will be moved
+          description: Upload will be updated
           content:
             application/json:
               schema:
@@ -243,11 +265,11 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
     put:
-      operationId: copyUploadById
+      operationId: moveUploadById
       tags:
         - Upload
         - Organize
-      description: Can be used to copy uploads
+      description: Copy or move an upload by id
       parameters:
         - name: folderId
           description: Folder Id, where upload should be copied to
@@ -255,9 +277,19 @@ paths:
           required: true
           schema:
             type: integer
+        - name: action
+          in: header
+          required: true
+          description: Action to be performed
+          schema:
+            type: string
+            enum:
+              - copy
+              - move
+      summary: Copy/Move an upload
       responses:
         '202':
-          description: Upload will be copied
+          description: Upload will be copied/moved
           content:
             application/json:
               schema:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -133,8 +133,8 @@ $app->group(VERSION_1 . 'uploads',
   function (){
     $this->get('[/{id:\\d+}]', UploadController::class . ':getUploads');
     $this->delete('/{id:\\d+}', UploadController::class . ':deleteUpload');
-    $this->patch('/{id:\\d+}', UploadController::class . ':moveUpload');
-    $this->put('/{id:\\d+}', UploadController::class . ':copyUpload');
+    $this->patch('/{id:\\d+}', UploadController::class . ':updateUpload');
+    $this->put('/{id:\\d+}', UploadController::class . ':moveUpload');
     $this->post('', UploadController::class . ':postUpload');
     $this->get('/{id:\\d+}/summary', UploadController::class . ':getUploadSummary');
     $this->get('/{id:\\d+}/licenses', UploadController::class . ':getUploadLicenses');


### PR DESCRIPTION
# BREAKING CHANGE
The `PATCH` was used for copy upload operations, now it is moved to `PUT` request with `action` parameter and have same format like `PUT /folders/{id}`.

## Description

Use `PATCH` to update the update the upload information.

New parameters `assignee` and `status` can be passed as query to the `/uploads/{id}` endpoint as `PATCH` request.
The comment for Rejected and Closed status can be sent as body of `text/plain` Content-type.

### Changes

1. Move and copy operations on `/uploads/{id}` is moved to `PUT` request.
2. `PATCH` request accepts `assignee` and `status` in request query.
3. Accept the comment for Closed and Rejected status in body of request.
4. Update test cases for UploadController.

## How to test

1. Test the copy/move operations on `PUT` request.
2. Try changing assignee on an upload. Try with invalid values and with users which can not access the upload.
3. Try changing the status of upload and send the comment as body (`text/plain`).
4. Try changing both fields in single `PATCH` request.

/cc @deveaud-m