### PR TITLE
fix(upload): Fix upload description input

### DIFF
--- a/src/lib/php/UI/template/include/upload.html.twig
+++ b/src/lib/php/UI/template/include/upload.html.twig
@@ -34,7 +34,7 @@
       <li>
         <div class="form-group">
           <label for="{{ fileInputName }}">({{ 'Optional'|trans }}) {{ 'Enter a description of this file'| trans }}:</label>
-          <input type="text" class="form-control" style="width:40%;" name="{{ descriptionInputName }} value="{{ descriptionInputValue }}">
+          <input type="text" class="form-control" style="width:40%;" name="{{ descriptionInputName }}" value="{{ descriptionInputValue }}">
         </div>
       </li>
       <li>


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix the template issue for upload page.

### Changes

Fix syntax error in upload page form.

## How to test

1. Upload a file with description, check in browse page, the description will be missing.
2. Install the fix and repeat steps above, the description should be there.