### PR TITLE
feat(os): Support Debian 11

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -18,6 +18,7 @@ jobs:
         os:
           - 'debian:buster'
           - 'debian:stretch'
+          - 'debian:bullseye'
           - 'ubuntu:bionic'
           - 'ubuntu:focal'
 

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           composer install --prefer-dist --working-dir=src
           src/vendor/bin/phpcs --standard=src/fossy-ruleset.xml -p
-  
+
   copy-paste:
     runs-on: ubuntu-20.04
     continue-on-error: true

--- a/src/copyright/mod_deps
+++ b/src/copyright/mod_deps
@@ -99,8 +99,10 @@ if [[ $RUNTIME ]]; then
       case "$CODENAME" in
         stretch)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.62.0;;
-        buster|sid)
+        buster)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.67.0;;
+        bullseye|sid)
+          apt-get $YesOpt install libjsoncpp24 libboost-filesystem1.74.0;;
         bionic)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.65.1;;
         focal)

--- a/src/nomos/mod_deps
+++ b/src/nomos/mod_deps
@@ -92,8 +92,10 @@ if [[ $RUNTIME ]]; then
   case "$DISTRO" in
     Debian|Ubuntu)
       case "$CODENAME" in
-        stretch|buster|sid|bionic|cosmic)
+        stretch|buster|bionic|cosmic)
           apt-get $YesOpt install libjson-c3;;
+        bullseye|sid)
+          apt-get $YesOpt install libjson-c5;;
         focal)
           apt-get $YesOpt install libjson-c4;;
         *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;

--- a/src/ojo/mod_deps
+++ b/src/ojo/mod_deps
@@ -102,10 +102,12 @@ if [[ $RUNTIME ]]; then
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.62.0 libboost-program-options1.62.0 libboost-regex1.62.0;;
         buster)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.67.0 libboost-program-options1.67.0 libboost-regex1.67.0;;
+        bullseye)
+          apt-get $YesOpt install libjsoncpp24 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0;;
         bionic)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.65.1 libboost-program-options1.65.1 libboost-regex1.65.1;;
         sid)
-          apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.67.0 libboost-program-options1.67.0 libboost-regex1.67.0;;
+          apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0;;
         focal)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.71.0 libboost-program-options1.71.0 libboost-regex1.71.0;;
         *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -111,6 +111,8 @@ if [[ $BUILDTIME ]]; then
              apt-get $YesOpt install php-mbstring php7.0-cli php7.0-xml php7.0-zip php7.0-gd;;
            buster)
              apt-get $YesOpt install php-mbstring php7.3-cli php7.3-xml php7.3-zip php7.3-gd;;
+           bullseye)
+             apt-get $YesOpt install php7.4-mbstring php7.4-cli php7.4-xml php7.4-zip php7.4-gd;;
            bionic)
              apt-get $YesOpt install php-mbstring php7.2-cli php7.2-xml php7.2-zip php7.2-gd;;
            sid)
@@ -124,6 +126,8 @@ if [[ $BUILDTIME ]]; then
                 apt-get $YesOpt install postgresql-server-dev-9.6;;
               buster)
                 apt-get $YesOpt install postgresql-server-dev-11;;
+              bullseye)
+                apt-get $YesOpt install postgresql-server-dev-13;;
               bionic)
                 apt-get $YesOpt install postgresql-server-dev-10;;
               sid)
@@ -181,13 +185,18 @@ if [[ $RUNTIME ]]; then
                apt-get $YesOpt install postgresql-11 php7.3 php7.3-pgsql libapache2-mod-php7.3 php7.3-pgsql \
                  php7.3-cli php7.3-curl php7.3-xml php7.3-zip php7.3-mbstring php-gettext s-nail libboost-program-options1.67.0 \
                  libboost-regex1.67.0 libicu63;;
+            bullseye)
+               apt-get $YesOpt install postgresql-13 php7.4 php7.4-pgsql \
+               libapache2-mod-php7.4 php7.4-pgsql php7.4-cli php7.4-curl \
+               php7.4-xml php7.4-zip php7.4-mbstring php-php-gettext s-nail \
+               libboost-program-options1.74.0 libboost-regex1.74.0 libicu67;;
             bionic)
                apt-get $YesOpt install postgresql-10 php7.2 php7.2-pgsql libapache2-mod-php7.2 php7.2-pgsql \
                  php7.2-cli php7.2-curl php7.2-xml php7.2-zip php7.2-mbstring php-gettext s-nail libboost-program-options1.65.1 \
                  libboost-regex1.65.1 libicu60;;
             sid)
                apt-get $YesOpt install postgresql php php-pgsql php-cli php-curl php-xml php-zip php-mbstring php-gettext s-nail \
-                 libboost-program-options1.67.0 libboost-regex1.67.0 libicu63;;
+                 libboost-program-options1.74.0 libboost-regex1.74.0 libicu67;;
             focal)
                apt-get $YesOpt install postgresql php php-pgsql php-cli php-curl php-xml php-zip php-mbstring s-nail \
                  libboost-program-options1.71.0 libboost-regex1.71.0 libicu66;;


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Added support for Debian 11 (Bullseye).

### Changes

1. Added packages for bullseye.
2. Update packaging script to include bullseye packages.

## How to test

Install Debian bullseye, clone the repo and follow the source install instructions.