### PR TITLE
fix(ci): Update OpenAPI lint

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -82,7 +82,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: swagger-cli
-      uses: vaibhav-jain/spectral-action/@v2.6
+    - name: Setup default rules
+      run: |
+        echo '{"extends": ["spectral:oas"]}' > .spectral.json
+    - name: Run spectral
+      uses: stoplightio/spectral-action@v0.8.0
       with:
-        file_path: src/www/ui/api/documentation/openapi.yaml
+        file_glob: src/www/ui/api/documentation/openapi.yaml


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

As the current api linter is not working, updated the OpenAPI linter from outdated repo to actual repo of `@stoplightio/spectral-action`

### Changes

Change linter action.

## How to test

See the Actions log.