### PR TITLE
FOSSdash: Version issue fix

### DIFF
--- a/install/fossdash/fossdash-publish.py.in
+++ b/install/fossdash/fossdash-publish.py.in
@@ -114,7 +114,7 @@ def getBuildVersionData(uuid) :
             variableName = version_entry_array[0].lower()
             variableValue = version_entry_array[1].strip()
             if line_number == 1 :
-                variableValueArray = variableValue.split('-')
+                variableValueArray = variableValue.split('.')
                 # print(variableValueArray)
                 variableValueArray[0] = variableValueArray[0].replace('"','')
                 finalData = "version"+",instance="+uuid+" value=\""+variableValueArray[0]  + "\" " + timestamp


### PR DESCRIPTION
root@kannan:/usr/local/etc/fossology# cat VERSION
[BUILD]
VERSION="3.11.0"
BRANCH="master"
COMMIT_HASH=
BUILD_DATE=2021 UTC
COMMIT_DATE=2021 UTC

line number 117 throws an error when using "-", whereas It worked perfectly when using  "."
Error message:  "ERROR ::  list index out of range"

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

 "ERROR ::  list index out of range" 
 to fix the above error In FossDash cronjob.



## How to test

Describe the steps required to test the changes proposed in the pull request.

To test the above scenario, please enable fossdash and check for crontab logs. 