### PR TITLE
fix(login): Allow non-admin user to update

### DIFF
--- a/src/www/ui/user-edit.php
+++ b/src/www/ui/user-edit.php
@@ -101,6 +101,10 @@ class UserEditPage extends DefaultPlugin
     if (! empty($BtnText)) {
       /* Get the form data to in an associated array */
       $UserRec = $this->CreateUserRec($request, "");
+      if (empty($UserRec['user_name']) && !$SessionIsAdmin) {
+        // Possibly disabled field due to non admin user
+        $UserRec['user_name'] = $SessionUserRec['user_name'];
+      }
 
       $rv = $this->UpdateUser($UserRec, $SessionIsAdmin);
       if (empty($rv)) {


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Currently, the username field for non-admin users are disabled. It cause any update request to fail.

### Changes

Added a check if field is empty and user is non-admin, update it with with user id from session.

## How to test

1. Login as admin user, goto Admin > Users > Edit User Account and update some field.
2. Login as non-admin user, goto same page and edit some fields (like password).