### PR TITLE
fix(rest): fix typo in openapi.yaml, s/reuse_uplod/reuse_upload/

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1687,7 +1687,7 @@ components:
           type: boolean
           description: Copy the copyright deactivation and edits.
       required:
-        - reuse_uplod
+        - reuse_upload
         - reuse_group
     Folder:
       type: object


### PR DESCRIPTION
Here, a tiny typo slipt through:
https://github.com/fossology/fossology/blob/107d44e2c125d8234291b49e8aab50e8198f77e5/src/www/ui/api/documentation/openapi.yaml#L1690


The PR fixes `reuse_uplod` to `reuse_uplod`