### PR TITLE
chore(cd): Continue release build on failure

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -24,6 +24,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container: ${{ matrix.os }}
+    continue-on-error: true
 
     steps:
     - name: Install git


### PR DESCRIPTION
## Description

For release package builds, do not fail the complete build if one matrix item fails.

See https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error

### Changes

Add `continue-on-error: true` for `release-build` step.