### PR TITLE
feat(nomos): New see-url pattern

### DIFF
--- a/src/nomos/agent/STRINGS.in
+++ b/src/nomos/agent/STRINGS.in
@@ -6288,6 +6288,10 @@ k
 %KEY% =NULL=
 %STR% "(org|com|net|cn|de)\.?\/licenses?"
 #
+%ENTRY% _LT_SEE_URL_ref2
+%KEY% =NULL=
+%STR% "licen[cs]e =FEW= (https?|ftp) =SOME= \/licen[cs]es?"
+#
 %ENTRY% _LT_SEE_COPYING_1
 %KEY% "licen[cs]"
 %STR% "under th(e|e terms of the) licen[cs]e (contained|listed|described|set (out|forth)|given|found) in the (file =FEW= \<copying\>|\<copying\> file)"

--- a/src/nomos/agent/parse.c
+++ b/src/nomos/agent/parse.c
@@ -9903,7 +9903,7 @@ void checkFileReferences(char *filetext, int size, int score, int kwbm,
   if(HASTEXT(_LT_SEE_COPYING_LICENSE_1, REG_EXTENDED) || HASTEXT(_LT_SEE_COPYING_LICENSE_2, REG_EXTENDED)) {
     INTERESTING("See-file");
   }
-  else if (HASTEXT(_LT_SEE_URL, REG_EXTENDED) || HASTEXT(_LT_SEE_URL_ref1, REG_EXTENDED)) {
+  else if (HASTEXT(_LT_SEE_URL, REG_EXTENDED) || HASTEXT(_LT_SEE_URL_ref1, REG_EXTENDED) || HASTEXT(_LT_SEE_URL_ref2, REG_EXTENDED)) {
     INTERESTING("See-URL");
   }
   return;


### PR DESCRIPTION
## Description

Added new pattern `_LT_SEE_URL_ref2` to identify strings using following regex:

`licen[cs]e.{0,30}(https?|ftp).{0,60}\/licen[cs]es?`
    
It will match strings like
"// License: https://github.com/my-project/LICENSE"

### Changes

New pattern `_LT_SEE_URL_ref2` added for `See-URL`.

## How to test

Scan a package with interesting lines.

Tested with https://github.com/zzzprojects/html-agility-pack