### PR TITLE
feat(nomos): See file regex to include view

### DIFF
--- a/src/nomos/agent/STRINGS.in
+++ b/src/nomos/agent/STRINGS.in
@@ -6463,7 +6463,7 @@ k
 #
 %ENTRY% _LT_SEE_LICENSE_2
 %KEY% "(condit|vers)ion"
-%STR% "under (certain|the) conditions (refer t(o|o the)|for details (read|read the|refer t(o|o the)|see|see the)|listed in the) (file =FEW= \<licen[cs]e\>|\<licen[cs]e\> file)"
+%STR% "under (certain|the) conditions (refer t(o|o the)|for details (read|read the|refer t(o|o the)|see|view|see the)|listed in the) (file =FEW= \<licen[cs]e\>|\<licen[cs]e\> file)"
 #
 %ENTRY% _LT_SEE_LICENSE_3
 %KEY% "licen[cs]"
@@ -6492,23 +6492,23 @@ k
 #
 %ENTRY% _LT_SEE_LICENSE_9
 %KEY% "licen[cs]"
-%STR% "see license?(qla|qlcnic|qlge) =SOME= for copyright and licensing details"
+%STR% "(see|view) license?(qla|qlcnic|qlge) =SOME= for copyright and licensing details"
 #
 %ENTRY% _LT_SEE_LICENSE_10
-%KEY% "licen[cs]" 
-%STR% "licen[cs]e see licen[cs]e?txt" 
+%KEY% "licen[cs]"
+%STR% "licen[cs]e (see|view) licen[cs]e?txt"
 #
 %ENTRY% _LT_SEE_LICENSE_11
 %KEY% "licen[cs]"
-%STR% "see the accompanying file license =SOME= for terms of use"
+%STR% "(see|view) the accompanying file license =SOME= for terms of use"
 #
 %ENTRY% _LT_SEE_LICENSE_12
 %KEY% "licen[cs]"
-%STR% "license please see accompanying LICENSE"
+%STR% "license please (see|view) accompanying LICENSE"
 #
 %ENTRY% _LT_SEE_LICENSE_13
 %KEY% "licen[cs]"
-%STR% "see =FEW= license file =FEW= for more information"
+%STR% "(see|view) =FEW= license file =FEW= for more information"
 #
 %ENTRY% _LT_SEE_LICENSE_14
 %KEY% "licen[cs]"
@@ -6528,7 +6528,7 @@ k
 #
 %ENTRY% _LT_SEE_LICENSE_18
 %KEY% "licen[cs]"
-%STR% "see (the )?license( file|\.?txt) =FEW= for licens(ing terms|e information)"
+%STR% "(see|view) (the )?license( file|\.?txt) =FEW= for licens(ing terms|e information)"
 #
 %ENTRY% _LT_SEE_LICENSE_19
 %KEY% "licen[cs]"
@@ -6540,13 +6540,18 @@ k
 #####
 # These MUST be the last 2 checks for license references in the file "license"
 #####
+# Following two strings have (see|view) as alternative which does not work with
+# CHECKSTR. Thus the NOCHECK
+#####
 %ENTRY% _LT_SEE_LICENSE_FINAL1
-%KEY% "\<(see|sell|sale|sold|charge)\>"
-%STR% "(distribut|copy|mod) =SOME= for details see th(e|is) (file =FEW= \<licen[cs]e\>|\<licen[cs]e\> file)"
+%NOCHECK%
+%KEY% "\<(see|sell|sale|sold|charge|view)\>"
+%STR% "(distribut|copy|mod) =SOME= for details (see|view) th(e|is) (file =FEW= \<licen[cs]e\>|\<licen[cs]e\> file)"
 #
 %ENTRY% _LT_SEE_LICENSE_FINAL2
-%KEY% "\<(see|sell|sale|sold|charge)\>"
-%STR% "see the (file =FEW= \<licen[cs]e\>|\<licen[cs]e\> file) =SOME= (distribut|dir|copy|us(e|age)|mod|free soft)"
+%NOCHECK%
+%KEY% "\<(see|sell|sale|sold|charge|view)\>"
+%STR% "(see|view) the (file =FEW= \<licen[cs]e\>|\<licen[cs]e\> file) =SOME= (distribut|dir|copy|us(e|age)|mod|free soft)"
 #
 %ENTRY% _LT_SEE_LICENSE_FINAL3
 %NOCHECK%

--- a/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan
+++ b/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan
@@ -961,6 +961,7 @@ File NomosTestfiles/Ruby/rdoc contains license(s) Ruby
 File NomosTestfiles/See-file/popt_options.h contains license(s) See-file.COPYING
 File NomosTestfiles/See-file/rtctype.h contains license(s) See-file.COPYING
 File NomosTestfiles/See-file/Connection.java contains license(s) See-file.LICENSE
+File NomosTestfiles/See-file/ContainerRuntimeLoaderTest.php contains license(s) See-file.LICENSE
 File NomosTestfiles/See-file/findme.c contains license(s) See-file.COPYING
 File NomosTestfiles/See-file/bzip2.c contains license(s) See-file.LICENSE
 File NomosTestfiles/See-file/perf_event.c contains license(s) See-file.COPYING

--- a/src/nomos/agent_tests/testdata/NomosTestfiles/See-file/ContainerRuntimeLoaderTest.php
+++ b/src/nomos/agent_tests/testdata/NomosTestfiles/See-file/ContainerRuntimeLoaderTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Twig\RuntimeLoader\ContainerRuntimeLoader;
+
+class Twig_Tests_ContainerRuntimeLoaderTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @requires PHP 5.3
+     */
+    public function testLoad()
+    {
+        $container = $this->getMockBuilder('Psr\Container\ContainerInterface')->getMock();
+        $container->expects($this->once())->method('has')->with('stdClass')->willReturn(true);
+        $container->expects($this->once())->method('get')->with('stdClass')->willReturn(new \stdClass());
+
+        $loader = new ContainerRuntimeLoader($container);
+
+        $this->assertInstanceOf('stdClass', $loader->load('stdClass'));
+    }
+
+    /**
+     * @requires PHP 5.3
+     */
+    public function testLoadUnknownRuntimeReturnsNull()
+    {
+        $container = $this->getMockBuilder('Psr\Container\ContainerInterface')->getMock();
+        $container->expects($this->once())->method('has')->with('Foo');
+        $container->expects($this->never())->method('get');
+
+        $loader = new ContainerRuntimeLoader($container);
+        $this->assertNull($loader->load('Foo'));
+    }
+}


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

While looking out for files with `See-file.LICENSE` regex, look for "view" as an alternative for "see".

For example, "please view the LICENSE file" and "please see the LICENSE file" to be matched.

### Changes

Change the regex for SEE_FILE with `(see|view)` instead of `see`.

## How to test

Scan a file which contains wordings like "please view the license file for usage".

Tested with https://github.com/twigphp/Twig/tree/v1.38.4