### PR TITLE
fix(vuln) upgrade phpoffice/phpspreadsheet" from 1.8.2 to 1.16.0

### DIFF
--- a/src/composer.lock
+++ b/src/composer.lock
@@ -828,11 +828,11 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "1.8.2",
+            "version": "1.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "0c1346a1956347590b7db09533966307d20cb7cc"
+                "reference": "76d4323b85129d0c368149c831a07a3e258b2b50"
             },
             "dist": {
                 "type": "zip",


### PR DESCRIPTION
Proposing 

GitHub Dependabot shows a vulnerability warning about the [phpoffice/phpspreadsheet/](https://github.com/PHPOffice/PhpSpreadsheet) used in `src/composer.lock`

https://github.com/Orange-OpenSource/fossology/security/dependabot/src/composer.lock/phpoffice%2Fphpspreadsheet/open
![image](https://user-images.githubusercontent.com/22956329/147668108-5541772d-18d6-4fca-89b6-117bb0800c61.png)

I don't think that Fossology is impacted by the vulnerability, but it would still make sense to upgrade the dependency.
We could also upgrade directly to newest version 1.20.

I tested licences export and import feature, but I'm not sure where else the library is used

