### PR TITLE
Deactivate users + store last cnx timestamp

### DIFF
--- a/src/lib/php/Dao/UserDao.php
+++ b/src/lib/php/Dao/UserDao.php
@@ -30,6 +30,8 @@ class UserDao
   const ADMIN = 1;
   const ADVISOR = 2;
 
+  const USER_ACTIVE_STATUS = 'active';
+
   const SUPER_USER = 'fossy';
 
   /* @var DbManager */
@@ -59,7 +61,7 @@ class UserDao
     $userChoices = array();
     $statementN = __METHOD__;
     $sql = "SELECT user_pk, user_name, user_desc FROM users LEFT JOIN group_user_member AS gum ON users.user_pk = gum.user_fk"
-            . " WHERE gum.group_fk = $1";
+            . " WHERE gum.group_fk = $1 AND users.user_status='active'";
     $this->dbManager->prepare($statementN, $sql);
     $res = $this->dbManager->execute($statementN, array($groupId));
     while ($rw = $this->dbManager->fetchArray($res)) {
@@ -296,6 +298,37 @@ class UserDao
     $userRow['group_fk'] = $groupRow['group_fk'];
     $userRow['group_name'] = $groupRow['group_name'];
     return $userRow;
+  }
+
+  /**
+   * @param string $userName
+   * @return boolean true if user status=active
+   */
+  public function isUserActive($userName)
+  {
+    $row = $this->dbManager->getSingleRow("SELECT user_status FROM users WHERE user_name=$1",
+        array($userName), __METHOD__);
+    return $row!==false && ($row['user_status']==self::USER_ACTIVE_STATUS);
+  }
+
+  /**
+   * @param int $userId
+   * @return boolean true if user status=active
+   */
+  public function isUserIdActive($userId)
+  {
+    $row = $this->dbManager->getSingleRow("SELECT user_status FROM users WHERE user_pk=$1",
+        array($userId), __METHOD__);
+    return $row!==false && ($row['user_status']==self::USER_ACTIVE_STATUS);
+  }
+
+  /**
+   * @param int $userId
+   */
+  public function updateUserLastConnection($userId)
+  {
+    $this->dbManager->getSingleRow("UPDATE users SET last_connection=now() WHERE user_pk=$1",
+        array($userId), __FUNCTION__);
   }
 
   /**

--- a/src/www/ui/api/Helper/AuthHelper.php
+++ b/src/www/ui/api/Helper/AuthHelper.php
@@ -123,7 +123,11 @@ class AuthHelper
 
       $dbRows = $this->dbHelper->getTokenKey($tokenId);
       $isTokenActive = $this->isTokenActive($dbRows, $tokenId);
-      if (empty($dbRows)) {
+      $isUserActive = $this->userDao->isUserIdActive($userId);
+
+      if (!$isUserActive) {
+        $returnValue = new Info(403, "User inactive.", InfoType::ERROR);
+      } elseif (empty($dbRows)) {
         $returnValue = new Info(403, "Invalid token sent.", InfoType::ERROR);
       } elseif ($isTokenActive !== true) {
         $returnValue = $isTokenActive;

--- a/src/www/ui/core-auth.php
+++ b/src/www/ui/core-auth.php
@@ -333,6 +333,12 @@ class core_auth extends FO_Plugin
       return false;
     }
 
+    if (!$this->userDao->isUserActive($userName)) {
+      /* user not active */
+      $this->vars['userInactive'] = true;
+      return false;
+    }
+
       /* If you make it here, then username and password were good! */
     $this->updateSession($row);
 
@@ -350,6 +356,9 @@ class core_auth extends FO_Plugin
     } else {
       $_SESSION['NoPopup'] = 0;
     }
+
+    $this->userDao->updateUserLastConnection($row['user_pk']);
+
     return true;
   }
 }

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -1971,9 +1971,17 @@
   $Schema["TABLE"]["users"]["default_folder_fk"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"default_folder_fk\" int4 DEFAULT -1";
   $Schema["TABLE"]["users"]["default_folder_fk"]["ALTER"] = "ALTER TABLE \"users\" ALTER COLUMN \"default_folder_fk\" SET NOT NULL";
 
+  $Schema["TABLE"]["users"]["last_connection"]["DESC"] = "";
+  $Schema["TABLE"]["users"]["last_connection"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"last_connection\" timestamptz";
+  $Schema["TABLE"]["users"]["last_connection"]["ALTER"] = "ALTER TABLE \"users\" ALTER COLUMN \"last_connection\" DROP NOT NULL";
+
   $Schema["TABLE"]["users"]["user_desc"]["DESC"] = "";
   $Schema["TABLE"]["users"]["user_desc"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"user_desc\" text";
   $Schema["TABLE"]["users"]["user_desc"]["ALTER"] = "ALTER TABLE \"users\" ALTER COLUMN \"user_desc\" DROP NOT NULL";
+
+  $Schema["TABLE"]["users"]["user_status"]["DESC"] = "COMMENT ON COLUMN \"users\".\"user_status\" IS 'active, incactive'";
+  $Schema["TABLE"]["users"]["user_status"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"user_status\" text DEFAULT 'active'";
+  $Schema["TABLE"]["users"]["user_status"]["ALTER"] = "ALTER TABLE \"users\" ALTER COLUMN \"user_status\" DROP NOT NULL, ALTER COLUMN \"user_status\" SET DEFAULT 'active'";
 
   $Schema["TABLE"]["users"]["user_seed"]["DESC"] = "";
   $Schema["TABLE"]["users"]["user_seed"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"user_seed\" text";

--- a/src/www/ui/page/AdminGroupUsers.php
+++ b/src/www/ui/page/AdminGroupUsers.php
@@ -113,8 +113,8 @@ class AdminGroupUsers extends DefaultPlugin
         'groupMapAction' => $onchange);
 
     $stmt = __METHOD__ . "getUsersWithGroup";
-    $dbManager->prepare($stmt, "select  user_pk, user_name, user_desc, group_user_member_pk, group_perm
-         FROM users LEFT JOIN group_user_member gum ON gum.user_fk=users.user_pk AND gum.group_fk=$1
+    $dbManager->prepare($stmt, "select user_pk, user_name, user_status, user_desc, group_user_member_pk, group_perm
+         FROM users LEFT JOIN group_user_member gum ON gum.user_fk=users.user_pk AND gum.group_fk=$1 
          ORDER BY user_name");
     $result = $dbManager->execute($stmt, array($group_pk));
     $vars['usersWithGroup'] = $dbManager->fetchAll($result);
@@ -122,7 +122,7 @@ class AdminGroupUsers extends DefaultPlugin
 
     $otherUsers = array('0' => '');
     foreach ($vars['usersWithGroup'] as $row) {
-      if ($row['group_user_member_pk']) {
+      if ($row['group_user_member_pk'] || $row['user_status']!='active') {
         continue;
       }
       $otherUsers[$row['user_pk']] = !empty($row['user_desc']) ? $row['user_desc']. ' ('. $row['user_name'] .')' : $row['user_name'];

--- a/src/www/ui/template/login.html.twig
+++ b/src/www/ui/template/login.html.twig
@@ -7,8 +7,10 @@
 {% extends "include/base.html.twig" %}
 
 {% block content %}
-    {% if loginFailure %}
-      {{ 'The combination of user name and password was not found.'|trans }}<br/><br/> 
+    {% if userInactive %}
+      {{ 'User is inactive'|trans }}<br/><br/>
+    {% elseif loginFailure %}
+      {{ 'The combination of user name and password was not found.'|trans }}<br/><br/>
     {% endif %}
     {% include "components/login-form.html.twig" with {'referrer': referrer, 'protocol': protocol, 'authUrl': authUrl, 'userName': userName} only %}
 {% endblock %}

--- a/src/www/ui/template/user_edit.html.twig
+++ b/src/www/ui/template/user_edit.html.twig
@@ -41,6 +41,10 @@
         <td>{{ macro.select('user_perm', allAccessLevels, 'user_perm', accessLevel) }}</td>
       </tr>
       <tr class="classic">
+        <th width="25%">{{ "Select the user's status."|trans }} </th>
+        <td>{{ macro.select('user_status', allUserStatuses, 'user_status', userStatus) }}</td>
+      </tr>
+      <tr class="classic">
         <th width="25%">{{ "Select the user's top-level folder. Access is restricted to this folder."|trans }}</th>
         <td><select name="root_folder_fk" class="ui-render-select2">
           {{ folderListOption }}

--- a/src/www/ui/user-edit.php
+++ b/src/www/ui/user-edit.php
@@ -190,6 +190,13 @@ class UserEditPage extends DefaultPlugin
         );
       $vars['accessLevel'] = $UserRec['user_perm'];
 
+      $vars['allUserStatuses'] = array(
+        "active" => _("Active"),
+        "inactive" => _("Inactive")
+      );
+
+      $vars['userStatus'] = $UserRec['user_status'];
+
       $SelectedFolderPk = $UserRec['root_folder_fk'];
       $vars['folderListOption'] = FolderListOption($ParentFolder = -1, $Depth = 0, $IncludeTop = 1, $SelectedFolderPk);
     }
@@ -304,7 +311,7 @@ class UserEditPage extends DefaultPlugin
       if ($key[0] == '_' || $key == "user_pk") {
         continue;
       }
-      if (!$SessionIsAdmin && ($key == "user_perm" || $key == "root_folder_fk")) {
+      if (!$SessionIsAdmin && ($key == "user_perm" || $key == "root_folder_fk" || $key == "user_status")) {
         continue;
       }
       if (!$first) {
@@ -400,6 +407,7 @@ class UserEditPage extends DefaultPlugin
       }
 
       $UserRec['user_perm'] = intval($request->get('user_perm'));
+      $UserRec['user_status'] = stripslashes($request->get('user_status'));
       $UserRec['user_email'] = stripslashes($request->get('user_email'));
       $UserRec['email_notify'] = stripslashes($request->get('email_notify'));
       if (!empty($UserRec['email_notify'])) {


### PR DESCRIPTION
There are two GDPR related features in this PR:


## Description

**Deactivate users:**  
New user status to prevent users from logging in (or using existing tokens) without removing the account altogether.
This is handy to block account left unused for a long time, or block users (for ex. because they left the company) while keeping decision history as it is.  
If user is logged in wile being deactivated, s·he is not kicked out

**Store the "last connection date" for each user as a timestamp in the database**  
This is necessary to detect accounts left unused for some time. As simple SQL script can then list all users who have not connected for 6 months for example.

**Future features**  
- Another *anonymized* user status might be handy to keep the users in the database while allowing the removal of their private data (username & email address)
- automate the deactivation of users who have not logged in for a configurable time

### Changes

- Two new columns in the `users` database table
- changes in the authentication code
- changed in the user edition page

## How to test
### Create user `test_a`
No `last_connection` is stored, default status is `active`
```
fossology=# select user_pk,user_name,last_connection,user_status from users;
 user_pk |  user_name   |        last_connection        | user_status
---------+--------------+-------------------------------+-------------
       2 | Default User |                               | active
       3 | fossy        | 2021-12-29 14:05:56.671283+00 | active
       4 | test_a       |                               | active
(3 rows)
```

Generate a token and test REST API access:
```
$ curl --cacert ./ca-certificates.crt -s -S -H "Authorization:Bearer $FOSSOLOGY_TOKEN" -X GET  "$FOSSOLOGY_URL/folders"
[{"id":1,"name":"Software Repository","description":"Top Folder","parent":null}]%
```

### Log in with user `test_a`
Its  `last_connection` is updated
```
fossology=# select user_pk,user_name,last_connection,user_status from users;
 user_pk |  user_name   |        last_connection        | user_status
---------+--------------+-------------------------------+-------------
       2 | Default User |                               | active
       3 | fossy        | 2021-12-29 14:05:56.671283+00 | active
       4 | test_a       | 2021-12-29 14:08:02.522877+00 | active
(3 rows)
```
### Log out and back in with `fossy`
The  `last_connection` is updated
```
fossology=# select user_pk,user_name,last_connection,user_status from users;
 user_pk |  user_name   |        last_connection        | user_status
---------+--------------+-------------------------------+-------------
       2 | Default User |                               | active
       4 | test_a       | 2021-12-29 14:08:02.522877+00 | active
       3 | fossy        | 2021-12-29 14:08:21.474793+00 | active
(3 rows)
```

### Deactivate user
![image](https://user-images.githubusercontent.com/22956329/147673401-d8a81a73-03b1-4b82-8a43-354b8bdbd925.png)

Database is updated:
```
fossology=# select user_pk,user_name,last_connection,user_status from users;
 user_pk |  user_name   |        last_connection        | user_status
---------+--------------+-------------------------------+-------------
       2 | Default User |                               | active
       3 | fossy        | 2021-12-29 14:08:21.474793+00 | active
       4 | test_a       | 2021-12-29 14:08:02.522877+00 | inactive
(3 rows)
```

### Check user cannot log back in & use token
![image](https://user-images.githubusercontent.com/22956329/147673576-1a3ec8b1-a2af-4030-962e-3383240adbe2.png)

```
curl --cacert ./ca-certificates.crt -s -S -H "Authorization:Bearer $FOSSOLOGY_TOKEN" -X GET  "$FOSSOLOGY_URL/folders"
{"code":403,"message":"User inactive.","type":"ERROR"}%
```

