### PR TITLE
feat(gdpr) deactivate users + Store last cnx timestamp

### DIFF
--- a/src/lib/php/Dao/UserDao.php
+++ b/src/lib/php/Dao/UserDao.php
@@ -2,6 +2,8 @@
 /***********************************************************
  * Copyright (C) 2014-2017 Siemens AG
  * Author: J. Najjar, S. Weber, A. Wührl
+ * Copyright (c) 2021-2022 Orange
+ * Contributors: Piotr Pszczola, Bartlomiej Drozdz
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/www/ui/api/Helper/AuthHelper.php
+++ b/src/www/ui/api/Helper/AuthHelper.php
@@ -1,6 +1,8 @@
 <?php
 /***************************************************************
  * Copyright (C) 2018 Siemens AG
+ * Copyright (c) 2021-2022 Orange
+ * Contributors: Piotr Pszczola, Bartlomiej Drozdz
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/www/ui/core-auth.php
+++ b/src/www/ui/core-auth.php
@@ -3,6 +3,8 @@
  * Copyright (C) 2008-2013 Hewlett-Packard Development Company, L.P.
  * Copyright (C) 2015 Siemens AG
  * Copyright (C) 2020 Robert Bosch GmbH, Dineshkumar Devarajan <Devarajan.Dineshkumar@in.bosch.com>
+ * Copyright (c) 2021-2022 Orange
+ * Contributors: Piotr Pszczola, Bartlomiej Drozdz
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -1980,7 +1980,7 @@
   $Schema["TABLE"]["users"]["user_desc"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"user_desc\" text";
   $Schema["TABLE"]["users"]["user_desc"]["ALTER"] = "ALTER TABLE \"users\" ALTER COLUMN \"user_desc\" DROP NOT NULL";
 
-  $Schema["TABLE"]["users"]["user_status"]["DESC"] = "COMMENT ON COLUMN \"users\".\"user_status\" IS 'active, incactive, anonymized'";
+  $Schema["TABLE"]["users"]["user_status"]["DESC"] = "COMMENT ON COLUMN \"users\".\"user_status\" IS 'active, incactive'";
   $Schema["TABLE"]["users"]["user_status"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"user_status\" text DEFAULT 'active'";
   $Schema["TABLE"]["users"]["user_status"]["ALTER"] = "ALTER TABLE \"users\" ALTER COLUMN \"user_status\" DROP NOT NULL, ALTER COLUMN \"user_status\" SET DEFAULT 'active'";
 

--- a/src/www/ui/page/AdminGroupUsers.php
+++ b/src/www/ui/page/AdminGroupUsers.php
@@ -2,6 +2,8 @@
 /***********************************************************
  Copyright (C) 2014-2015, 2018 Siemens AG
  Author: Steffen Weber
+ Copyright (c) 2021-2022 Orange
+ Contributors: Piotr Pszczola, Bartlomiej Drozdz
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License

--- a/src/www/ui/template/user_edit.html.twig
+++ b/src/www/ui/template/user_edit.html.twig
@@ -42,14 +42,7 @@
       </tr>
       <tr class="classic">
         <th width="25%">{{ "Select the user's status."|trans }} </th>
-        {% if userStatus == "anonymized" %}          
-          <td><select disabled name="disabled" }>
-                <option value="anonymized">Anonymized</option>
-              </select>
-          </td>           
-        {% else %}
-          <td> {{ macro.select('user_status', allUserStatuses, 'user_status', userStatus) }}</td>
-        {% endif %}
+        <td>{{ macro.select('user_status', allUserStatuses, 'user_status', userStatus) }}</td>
       </tr>
       <tr class="classic">
         <th width="25%">{{ "Select the user's top-level folder. Access is restricted to this folder."|trans }}</th>

--- a/src/www/ui/user-edit.php
+++ b/src/www/ui/user-edit.php
@@ -1,6 +1,8 @@
 <?php
 /***********************************************************
  Copyright (C) 2014 Hewlett-Packard Development Company, L.P.
+ Copyright (c) 2021-2022 Orange
+ Contributors: Piotr Pszczola, Bartlomiej Drozdz
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License


### PR DESCRIPTION
There are two GDPR related features in this PR:


## Description

**Deactivate users:**  
New user status to prevent users from logging in (or using existing tokens) without removing the account altogether.
This is handy to block account left unused for a long time, or block users (for ex. because they left the company) while keeping decision history as it is.  
If user is logged in wile being deactivated, s·he is not kicked out

**Store the "last connection date" for each user as a timestamp in the database**  
This is necessary to detect accounts left unused for some time. As simple SQL script can then list all users who have not connected for 6 months for example.

**Future features**  
- Another *anonymized* user status might be handy to keep the users in the database while allowing the removal of their private data (username & email address)
- automate the deactivation of users who have not logged in for a configurable time

### Changes

- Two new columns in the `users` database table
- changes in the authentication code
- changed in the user edition page

## How to test
### Create user `test_a`
No `last_connection` is stored, default status is `active`
```
fossology=# select user_pk,user_name,last_connection,user_status from users;
 user_pk |  user_name   |        last_connection        | user_status
---------+--------------+-------------------------------+-------------
       2 | Default User |                               | active
       3 | fossy        | 2021-12-29 14:05:56.671283+00 | active
       4 | test_a       |                               | active
(3 rows)
```

Generate a token and test REST API access:
```
$ curl --cacert ./ca-certificates.crt -s -S -H "Authorization:Bearer $FOSSOLOGY_TOKEN" -X GET  "$FOSSOLOGY_URL/folders"
[{"id":1,"name":"Software Repository","description":"Top Folder","parent":null}]%
```

### Log in with user `test_a`
Its  `last_connection` is updated
```
fossology=# select user_pk,user_name,last_connection,user_status from users;
 user_pk |  user_name   |        last_connection        | user_status
---------+--------------+-------------------------------+-------------
       2 | Default User |                               | active
       3 | fossy        | 2021-12-29 14:05:56.671283+00 | active
       4 | test_a       | 2021-12-29 14:08:02.522877+00 | active
(3 rows)
```
### Log out and back in with `fossy`
The  `last_connection` is updated
```
fossology=# select user_pk,user_name,last_connection,user_status from users;
 user_pk |  user_name   |        last_connection        | user_status
---------+--------------+-------------------------------+-------------
       2 | Default User |                               | active
       4 | test_a       | 2021-12-29 14:08:02.522877+00 | active
       3 | fossy        | 2021-12-29 14:08:21.474793+00 | active
(3 rows)
```

### Deactivate user
![image](https://user-images.githubusercontent.com/22956329/147673401-d8a81a73-03b1-4b82-8a43-354b8bdbd925.png)

Database is updated:
```
fossology=# select user_pk,user_name,last_connection,user_status from users;
 user_pk |  user_name   |        last_connection        | user_status
---------+--------------+-------------------------------+-------------
       2 | Default User |                               | active
       3 | fossy        | 2021-12-29 14:08:21.474793+00 | active
       4 | test_a       | 2021-12-29 14:08:02.522877+00 | inactive
(3 rows)
```

### Check user cannot log back in & use token
![image](https://user-images.githubusercontent.com/22956329/147673576-1a3ec8b1-a2af-4030-962e-3383240adbe2.png)

```
curl --cacert ./ca-certificates.crt -s -S -H "Authorization:Bearer $FOSSOLOGY_TOKEN" -X GET  "$FOSSOLOGY_URL/folders"
{"code":403,"message":"User inactive.","type":"ERROR"}%
```

