### PR TITLE
feat(gdpr) New global option to make all user details read-only

### DIFF
--- a/src/www/ui/template/user_edit.html.twig
+++ b/src/www/ui/template/user_edit.html.twig
@@ -21,15 +21,15 @@
   <table style="border:1px solid black; border-collapse: collapse;" width="100%">
     <tr class="classic">
       <th width="25%">{{ "Username."|trans }}</th>
-      <td><input type="text" value="{{ userName|e }}" name="user_name" size="20" {% if not isSessionAdmin %}disabled="disabled"{% endif %}></td>
+      <td><input type="text" value="{{ userName|e }}" name="user_name" size="20" {%- if not isSessionAdmin or userDescReadOnly == "true" -%}readonly="true"{%- endif -%}></td>
     </tr>
     <tr class="classic">
       <th width="25%">{{ "Description (name, contact, or other information)."|trans }} {{ "This may be blank."|trans }}</th>
-      <td><input type="text" value="{{ userDescription|e }}" name="user_desc" size="60"></td>
+      <td><input type="text" value="{{ userDescription|e }}" name="user_desc" size="60" {%- if userDescReadOnly == "true" -%}readonly="true"{%- endif -%}></td>
     </tr>
     <tr class="classic">
       <th width="25%">{{ "Email address."|trans }} {{ "This may be blank."|trans }}</th>
-      <td><input type="text" value="{{ userEMail|e }}" name="user_email" size="60"></td>
+      <td><input type="text" value="{{ userEMail|e }}" name="user_email" size="60" {%- if userDescReadOnly == "true" -%}readonly="true"{%- endif -%}></td>
     </tr>
     <tr class="classic">
       <th width="25%">{{ "E-mail notification on job completion"|trans }}</th>


### PR DESCRIPTION
## Description

A new option in the Customize page make all user details read-only (Username, email, Description)
Useful when details are retrieved from external auth server and should never be altered by hand.

### Changes

New option in Customize page 
![image](https://user-images.githubusercontent.com/22956329/147830848-338202e2-9920-4166-8664-f1b7f65867eb.png)


## How to test

Create User, details are editable
![image](https://user-images.githubusercontent.com/22956329/147830879-ebdc4bb7-6eae-4c53-b5b1-4b28556cfe01.png)

Go to Admin -> Customize, down the page, click on `Make account details read-only`
![image](https://user-images.githubusercontent.com/22956329/147830917-c06d6fe4-74d3-4ff9-9c90-66f1fed5b3c6.png)

Check value in database:
```
fossology=# select variablename,conf_value from sysconfig where variablename='UserDescReadOnly';
   variablename   | conf_value 
------------------+------------
 UserDescReadOnly | true
(1 row)
```

Accounts become read-only
![image](https://user-images.githubusercontent.com/22956329/147830975-1e0d8ea3-0da7-46e7-8056-1f887dcbd568.png)

Operation is reversible.