### PR TITLE
Feat/user details read only2

### DIFF
--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -478,10 +478,17 @@ function Populate_sysconfig()
   $perm_admin=Auth::PERM_ADMIN;
   $perm_write=Auth::PERM_WRITE;
   $variable = "SourceCodeDownloadRights";
-  $SourceDownloadRightsPrompt = _('Acces rights required to download source code');
-  $SourceDownloadRightsDesc = _('Choose which acces level will be required for user to be able to download source code.');
+  $SourceDownloadRightsPrompt = _('Access rights required to download source code');
+  $SourceDownloadRightsDesc = _('Choose which access level will be required for user to be able to download source code.');
   $valueArray[$variable] = array("'$variable'", "'$perm_write'", "'$SourceDownloadRightsPrompt'",
   strval(CONFIG_TYPE_DROP), "'DOWNLOAD'", "1", "'$SourceDownloadRightsDesc'", "null", "'Administrator{{$perm_admin}}|Read_Write{{$perm_write}}'");
+
+  $variable = "UserDescReadOnly";
+  $prompt = _('Make account details read-only');
+  $desc = _('Make account details (username, email, description) read-only');
+  $valueArray[$variable] = array("'$variable'", "false", "'$prompt'",
+    strval(CONFIG_TYPE_BOOL), "'USER_READ_ONLY'", "1", "'$desc'",
+    "'check_boolean'", "null");
 
   /* SoftwareHeritage agent config */
   $variable = "SwhURL";

--- a/src/www/ui/template/user_edit.html.twig
+++ b/src/www/ui/template/user_edit.html.twig
@@ -21,15 +21,15 @@
   <table style="border:1px solid black; border-collapse: collapse;" width="100%">
     <tr class="classic">
       <th width="25%">{{ "Username."|trans }}</th>
-      <td><input type="text" value="{{ userName|e }}" name="user_name" size="20" {% if not isSessionAdmin %}disabled="disabled"{% endif %}></td>
+      <td><input type="text" value="{{ userName|e }}" name="user_name" size="20" {%- if not isSessionAdmin or userDescReadOnly == "true" -%}readonly="true"{%- endif -%}></td>
     </tr>
     <tr class="classic">
       <th width="25%">{{ "Description (name, contact, or other information)."|trans }} {{ "This may be blank."|trans }}</th>
-      <td><input type="text" value="{{ userDescription|e }}" name="user_desc" size="60"></td>
+      <td><input type="text" value="{{ userDescription|e }}" name="user_desc" size="60" {%- if userDescReadOnly == "true" -%}readonly="true"{%- endif -%}></td>
     </tr>
     <tr class="classic">
       <th width="25%">{{ "Email address."|trans }} {{ "This may be blank."|trans }}</th>
-      <td><input type="text" value="{{ userEMail|e }}" name="user_email" size="60"></td>
+      <td><input type="text" value="{{ userEMail|e }}" name="user_email" size="60" {%- if userDescReadOnly == "true" -%}readonly="true"{%- endif -%}></td>
     </tr>
     <tr class="classic">
       <th width="25%">{{ "E-mail notification on job completion"|trans }}</th>

--- a/src/www/ui/user-edit.php
+++ b/src/www/ui/user-edit.php
@@ -101,10 +101,6 @@ class UserEditPage extends DefaultPlugin
     if (! empty($BtnText)) {
       /* Get the form data to in an associated array */
       $UserRec = $this->CreateUserRec($request, "");
-      if (empty($UserRec['user_name']) && !$SessionIsAdmin) {
-        // Possibly disabled field due to non admin user
-        $UserRec['user_name'] = $SessionUserRec['user_name'];
-      }
 
       $rv = $this->UpdateUser($UserRec, $SessionIsAdmin);
       if (empty($rv)) {

--- a/src/www/ui/user-edit.php
+++ b/src/www/ui/user-edit.php
@@ -156,8 +156,11 @@ class UserEditPage extends DefaultPlugin
    */
   private function DisplayForm($UserRec, $SessionIsAdmin)
   {
+    global $SysConf;
+
     $vars = array('isSessionAdmin' => $SessionIsAdmin,
                   'userId' => $UserRec['user_pk']);
+    $vars['userDescReadOnly'] = $SysConf['SYSCONFIG']['UserDescReadOnly'];
 
     /* For Admins, get the list of all users
      * For non-admins, only show themself


### PR DESCRIPTION
PR taking over https://github.com/fossology/fossology/pull/2137


## Description

A new option in the Customize page make all user details read-only (Username, email, Description)
Useful when details are retrieved from external auth server and should never be altered by hand.

### Changes

New option in Customize page 
![image](https://user-images.githubusercontent.com/22956329/147830848-338202e2-9920-4166-8664-f1b7f65867eb.png)

At the same time, username fields are also made readonly to non-admin users, allowing to revert https://github.com/fossology/fossology/commit/36a1573aee1e0633213986b152ef3d6b31fa7a21

## How to test
See PR https://github.com/fossology/fossology/pull/2137
