### PR TITLE
feat(rest): Provide server version on REST api

### DIFF
--- a/Makefile.conf
+++ b/Makefile.conf
@@ -167,10 +167,10 @@ WriteVERSIONFile = echo "writing VERSION file for $(1)"; \
     echo "VERSION=\"$(VERSION)\"";\
     echo "BRANCH=\"$(BRANCH)\"";\
     echo "COMMIT_HASH=$(COMMIT_HASH)";\
-    echo BUILD_DATE=`date +"%Y/%m/%d %R %Z"`;\
+    echo BUILD_DATE=`date +"%Y/%m/%d %R %:z"`;\
     git show -s --format="%ct.%h" 2>/dev/null | {\
      IFS='.' read ctimestamp chash && {\
-      echo "COMMIT_DATE=$$(date -d"@$$ctimestamp" +"%Y/%m/%d %R %Z" )";\
+      echo "COMMIT_DATE=$$(date -d"@$$ctimestamp" +"%Y/%m/%d %R %:z" )";\
      } || {\
       echo "COMMIT_DATE=unknown";\
      }\

--- a/src/www/ui/api/Controllers/InfoController.php
+++ b/src/www/ui/api/Controllers/InfoController.php
@@ -44,6 +44,7 @@ class InfoController extends RestController
    */
   public function getInfo($request, $response, $args)
   {
+    global $SysConf;
     try {
       $yaml = new Parser();
       $yamlDocArray = $yaml->parse(file_get_contents(__DIR__ ."/../documentation/openapi.yaml"));
@@ -60,6 +61,26 @@ class InfoController extends RestController
     foreach ($yamlDocArray["security"] as $secMethod) {
       $security[] = key($secMethod);
     }
+    $fossInfo = [
+      "version"    => null,
+      "branchName" => null,
+      "commitHash" => null,
+      "commitDate" => null,
+      "buildDate"  => null
+    ];
+    if (array_key_exists('BUILD', $SysConf)) {
+      $fossInfo["version"]    = $SysConf['BUILD']['VERSION'];
+      $fossInfo["branchName"] = $SysConf['BUILD']['BRANCH'];
+      $fossInfo["commitHash"] = $SysConf['BUILD']['COMMIT_HASH'];
+      if (strcasecmp($SysConf['BUILD']['COMMIT_DATE'], "unknown") != 0) {
+        $fossInfo["commitDate"] = date(DATE_ATOM,
+          strtotime($SysConf['BUILD']['COMMIT_DATE']));
+      }
+      if (strcasecmp($SysConf['BUILD']['BUILD_DATE'], "unknown") != 0) {
+        $fossInfo["buildDate"] = date(DATE_ATOM,
+          strtotime($SysConf['BUILD']['BUILD_DATE']));
+      }
+    }
     return $response->withJson(array(
       "name" => $apiTitle,
       "description" => $apiDescription,
@@ -69,7 +90,8 @@ class InfoController extends RestController
       "license" => [
         "name" => $apiLicense["name"],
         "url" => $apiLicense["url"]
-      ]
+      ],
+      "fossology" => $fossInfo
     ), 200);
   }
 

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -15,7 +15,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.4.2
+  version: 1.4.3
   contact:
     email: fossology@fossology.org
   license:
@@ -2022,6 +2022,37 @@ components:
               type: string
               description: Link to license
           description: Licensing of API
+        fossology:
+          type: object
+          description: Information about FOSSology server. Values can be null.
+          properties:
+            version:
+              type: string
+              description: Version of the FOSSology server
+              nullable: true
+              example: "4.0.0"
+            branchName:
+              type: string
+              description: Branch deployed on the FOSSology server
+              nullable: true
+              example: master
+            commitHash:
+              type: string
+              description: Hash of commit deployed on the FOSSology server
+              nullable: true
+              example: "306260"
+            commitDate:
+              type: string
+              description: |
+                Date of commit deployed on the FOSSology server in
+                ISO8601 format
+              nullable: true
+              example: "2022-01-05T22:03:00+05:30"
+            buildDate:
+              type: string
+              description: Date on which packages were built in ISO8601 format
+              nullable: true
+              example: "2022-01-07T11:13:00+05:30"
     HeathInfo:
       description: Health status of server
       type: object

--- a/src/www/ui_tests/api/Controllers/InfoControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/InfoControllerTest.php
@@ -115,6 +115,22 @@ class InfoControllerTest extends \PHPUnit\Framework\TestCase
     foreach ($yamlDocArray["security"] as $secMethod) {
       $security[] = key($secMethod);
     }
+    $GLOBALS["SysConf"] = [
+      "BUILD" => [
+        "VERSION" => "1.0.0",
+        "BRANCH" => "tree",
+        "COMMIT_HASH" => "deadbeef",
+        "COMMIT_DATE" => "2022/01/01 00:01 +05:30",
+        "BUILD_DATE" => "2022/01/01 00:02 +05:30"
+      ]
+    ];
+    $fossInfo = [
+      "version"    => "1.0.0",
+      "branchName" => "tree",
+      "commitHash" => "deadbeef",
+      "commitDate" => "2021-12-31T18:31:00+00:00",
+      "buildDate"  => "2021-12-31T18:32:00+00:00"
+    ];
     $expectedResponse = (new Response())->withJson(array(
       "name" => $apiTitle,
       "description" => $apiDescription,
@@ -124,7 +140,8 @@ class InfoControllerTest extends \PHPUnit\Framework\TestCase
       "license" => [
         "name" => $apiLicense["name"],
         "url" => $apiLicense["url"]
-      ]
+      ],
+      "fossology" => $fossInfo
     ), 200);
     $actualResponse = $this->infoController->getInfo(null, new Response(),
       []);


### PR DESCRIPTION
## Description

﻿Export version information about the server on REST API. Information includes:
- Version
- Branch Name
- Commit Hash
- Commit Date
- Build Date

The date stored in VERSION file is also changed to include timezone in `+hh:mm` format to avoid confusion with abbreveated timezones. PHP for some reason confuses `IST` and reports `Europe/Istanbul` (TRT), not `Asia/Kolkata`.

### Changes

1. Added new object `fossology` to `/info` endpoint with all the information.
2. Update `WriteVERSIONFile` function to use `%:z` timezone format.

## How to test

1. Install the branch and check if the UI shows new timezone format.
2. Call `/info` endpoint and check if the response contains all the required fields.

