### PR TITLE
fix(ui): Fix bulk modal with selectable bg

### DIFF
--- a/src/www/ui/scripts/change-license-browse.js
+++ b/src/www/ui/scripts/change-license-browse.js
@@ -30,7 +30,7 @@ $(document).ready(function () {
   clearingHistoryDataModal = $('#ClearingHistoryDataModal').modal('hide');
   $('#bulkModal').draggable({
     stop: function(){
-      $(this).css({'width':'','height':''});
+      $(this).css('height', '');
     }
   });
 });
@@ -46,14 +46,18 @@ $("#textModal").on('hide.bs.modal', function (e) {
 function openBulkModal(uploadTreeId) {
   bulkModal = $('#bulkModal').modal('hide');
   $('#uploadTreeId').val(uploadTreeId);
-  $("#bulkModal").attr("hidden",false);
-  $("#bulkModal").addClass("modal");
   bulkModal.toggle();
 }
 
 function closeBulkModal() {
   $('#bulkModal').hide();
 }
+
+// Hide backdrop for bulk modal
+$('#bulkModal').on('shown.bs.modal', function () {
+  $('.modal-backdrop').css('display', 'none');
+  $('#bulkModal').css({'width': 'fit-content', 'margin': '0 auto'});
+});
 
 function loadBulkHistoryModal() {
   refreshBulkHistory(function(data) {

--- a/src/www/ui/scripts/change-license-common.js
+++ b/src/www/ui/scripts/change-license-common.js
@@ -260,6 +260,8 @@ function openTextModel(uploadTreeId, licenseId, what, type) {
   if (what == 3 || what === 'acknowledgement') {
     // clicked to add button to display child modal
     $('#selectFromNoticeFile').css('display','inline-block');
+  } else {
+    $('#selectFromNoticeFile').css('display','none');
   }
 
   if(type == 0) {
@@ -358,7 +360,6 @@ function submitTextModal(){
       data: post_data,
       success: () => doOnSuccess(textModal)
     });
-    $('#selectFromNoticeFile').css('display','none');
   } else {
     textModal.modal('hide');
     $("#"+ whatLicId + whatCol +"Bulk").attr('title', $(refTextId).val());
@@ -368,7 +369,6 @@ function submitTextModal(){
     } else {
       $("#"+ whatLicId + whatCol +"Bulk").attr('title','');
     }
-    $('#selectFromNoticeFile').css('display','none');
   }
 }
 
@@ -417,9 +417,14 @@ $(document).ready(function () {
 
   $('[data-toggle="tooltip"]').tooltip();
   textModal = $('#textModal').modal('hide');
-  $('#textModal, #bulkModal, #ClearingHistoryDataModal, #userModal, #bulkHistoryModal').draggable({
+  $('#textModal, #ClearingHistoryDataModal, #userModal, #bulkHistoryModal').draggable({
     stop: function(){
       $(this).css({'width':'','height':''});
+    }
+  });
+  $('#bulkModal').draggable({
+    stop: function(){
+      $(this).css('height', '');
     }
   });
 

--- a/src/www/ui/scripts/change-license-view.js
+++ b/src/www/ui/scripts/change-license-view.js
@@ -28,7 +28,6 @@ function openBulkModal() {
   $('#userModal').hide();
   $('#ClearingHistoryDataModal').hide();
   bulkModalOpened = 1;
-  $("#bulkModal").attr("hidden",false);
   $('#bulkModal').toggle();
 }
 
@@ -36,6 +35,12 @@ function closeBulkModal() {
   bulkModalOpened = 0;
   $('#bulkModal').hide();
 }
+
+// Hide backdrop for bulk modal
+$('#bulkModal').on('shown.bs.modal', function () {
+  $('.modal-backdrop').css('display', 'none');
+  $('#bulkModal').css({'width': 'fit-content', 'margin': '0 auto'});
+});
 
 function openUserModal() {
   $('#bulkModal').hide();

--- a/src/www/ui/template/ui-clearing-view_bulk.html.twig
+++ b/src/www/ui/template/ui-clearing-view_bulk.html.twig
@@ -55,7 +55,7 @@
   </div>
 
   <!-- The bulk Modal -->
-  <div class="" id="bulkModal" tabindex="-1" role="dialog" aria-labelledby="bulkModelLabel" aria-hidden="true" data-backdrop="false" data-keyboard="false" hidden="true">
+  <div class="modal" id="bulkModal" tabindex="-1" role="dialog" aria-labelledby="bulkModelLabel" aria-hidden="true" data-backdrop="false" data-keyboard="false">
     <div class="modal-dialog modal-dialog-centered modal-lg">
       <div class="modal-content">
         <!-- Modal Header -->

--- a/src/www/ui/template/ui-clearing-view_rhs.html.twig
+++ b/src/www/ui/template/ui-clearing-view_rhs.html.twig
@@ -74,7 +74,7 @@
       {{ 'User Decision ...'| trans }}
     </button><img src="images/info_16.png" data-toggle="tooltip" title="{{ 'Add manually a license that is not found by scanners or bulk'|trans }}" alt="" class="info-bullet"/>
     &nbsp;
-    <button type="button" data-toggle="modal" data-target="#bulkModal" class="btn btn-default btn-sm" onclick="openBulkModal();">
+    <button type="button" data-toggle="modal" data-backdrop="false" data-target="#bulkModal" class="btn btn-default btn-sm" onclick="openBulkModal();">
       {{ 'Bulk Recognition ...'| trans }}
     </button><img src="images/info_16.png" data-toggle="tooltip" title="{{ 'Adding or removing a license based on a text fragment that is searched for across the relevant files'|trans }}" alt="" class="info-bullet"/>
     &nbsp;


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix bulk modal to go full screen with a selectable background.

### Changes

1. Revert changes to modal.
2. Add new event listener `shown.bs.modal` to update CSS properties of modal.
3. Update `draggable` function to not update width for `#bulkModal`.

## How to test

1. Open a file for clearing.
2. Open the bulk modal.
    1. The background text from file should still be selectable.
    2. Adding new license should work as expected with select 2 search bar.
    3. Other child modals like "License text" should work as expected.
3. On folder view, open bulk modal from `[Bulk]` link.
    - Everything should work as mentioned in point 2.