### PR TITLE
refactor(clearingDao): add few functions to a single one

### DIFF
--- a/src/decider/agent_tests/Functional/schedulerTest.php
+++ b/src/decider/agent_tests/Functional/schedulerTest.php
@@ -626,7 +626,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
     /* insert NoLicenseKnown decisions */
     $this->dbManager->queryOnce("INSERT INTO clearing_decision (clearing_decision_pk, uploadtree_fk, pfile_fk, user_fk, group_fk, decision_type, scope, date_added)"
             . " VALUES (2, $itemId, $pfile, $userId, $groupId, ".DecisionTypes::IDENTIFIED.", ".DecisionScopes::ITEM.", '2015-05-04 11:43:18.276425+02')");
-    $isWipBeforeDecider = $this->clearingDao->isDecisionWip($itemId, $groupId);
+    $isWipBeforeDecider = $this->clearingDao->isDecisionCheck($itemId, $groupId, DecisionTypes::WIP);
     assertThat($isWipBeforeDecider, equalTo(false));
 
     $this->dbManager->queryOnce("INSERT INTO license_file (fl_pk,rf_fk,pfile_fk,agent_fk) VALUES(12222,$licId1,$pfile,$monkAgentId)");
@@ -638,7 +638,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
     $this->assertTrue($success, 'cannot run runner');
     $this->assertEquals($retCode, 0, 'decider failed (did you make test?): '.$output);
 
-    $isWip = $this->clearingDao->isDecisionWip($itemId, $groupId);
+    $isWip = $this->clearingDao->isDecisionCheck($itemId, $groupId, DecisionTypes::WIP);
     assertThat($isWip, equalTo(true));
 
     $this->rmRepo();

--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Copyright (C) 2014-2018,2020, Siemens AG
+Copyright (C) 2014-2018,2020,2022, Siemens AG
 Author: Johannes Najjar
 
 This program is free software; you can redistribute it and/or
@@ -357,7 +357,7 @@ class ClearingDao
     $uploadTreeTable = $this->uploadDao->getUploadtreeTableName($uploadId);
     $itemTreeBounds = $this->uploadDao->getItemTreeBounds($uploadTreeId, $uploadTreeTable);
 
-    if ($this->isDecisionIrrelevant($uploadTreeId, $groupId)) {
+    if ($this->isDecisionCheck($uploadTreeId, $groupId, DecisionTypes::IRRELEVANT)) {
       $this->copyrightDao->updateTable($itemTreeBounds, '', '', $userId, 'copyright', 'rollback');
     } else if ($decType == DecisionTypes::IRRELEVANT) {
       $this->copyrightDao->updateTable($itemTreeBounds, '', '', $userId, 'copyright', 'delete', '2');
@@ -618,62 +618,33 @@ INSERT INTO clearing_decision (
     $this->dbManager->freeResult($res);
   }
 
-  public function isDecisionWip($uploadTreeId, $groupId)
+  /**
+   * @param int $uploadTreeId
+   * @param int $groupId
+   * @param Char $decisionType
+   */
+  public function isDecisionCheck($uploadTreeId, $groupId, $decisionType)
   {
-    $sql = "SELECT decision_type FROM clearing_decision WHERE uploadtree_fk=$1 AND group_fk = $2 ORDER BY date_added DESC LIMIT 1";
-    $latestDec = $this->dbManager->getSingleRow($sql,
-                 array($uploadTreeId, $groupId), $sqlLog = __METHOD__);
-    if ($latestDec === false) {
-      return false;
+    $columns = "decision_type";
+    if (!in_array($decisionType,
+         [DecisionTypes::WIP, DecisionTypes::TO_BE_DISCUSSED,
+          DecisionTypes::DO_NOT_USE, DecisionTypes::IRRELEVANT])
+       ) {
+      $columns = "decision_type, scope";
     }
-    return ($latestDec['decision_type'] == DecisionTypes::WIP);
-  }
-
-  public function isDecisionTBD($uploadTreeId, $groupId)
-  {
-    $sql = "SELECT decision_type FROM clearing_decision WHERE uploadtree_fk=$1 AND group_fk = $2 ORDER BY date_added DESC LIMIT 1";
-    $latestDec = $this->dbManager->getSingleRow($sql,
-                 array($uploadTreeId, $groupId), $sqlLog = __METHOD__);
-    if ($latestDec === false) {
-      return false;
-    }
-    return ($latestDec['decision_type'] == DecisionTypes::TO_BE_DISCUSSED);
-  }
-
-  public function isDecisionDNU($uploadTreeId, $groupId)
-  {
-    $sql = "SELECT decision_type FROM clearing_decision
+    $sql = "SELECT $columns FROM clearing_decision
               WHERE uploadtree_fk=$1 AND group_fk = $2
             ORDER BY clearing_decision_pk DESC LIMIT 1";
     $latestDec = $this->dbManager->getSingleRow($sql,
                  array($uploadTreeId, $groupId), $sqlLog = __METHOD__);
+
     if ($latestDec === false) {
       return false;
+    } else if ($decisionType != "") {
+      return ($latestDec['decision_type'] == $decisionType);
+    } else {
+      return $latestDec;
     }
-    return ($latestDec['decision_type'] == DecisionTypes::DO_NOT_USE);
-  }
-
-  public function getClearingType($uploadTreeId, $groupId, $type)
-  {
-    $sql = "SELECT decision_type, scope FROM clearing_decision
-              WHERE uploadtree_fk=$1 AND group_fk = $2
-            ORDER BY clearing_decision_pk DESC LIMIT 1";
-    $latestDec = $this->dbManager->getSingleRow($sql,
-                 array($uploadTreeId, $groupId), $sqlLog = __METHOD__);
-    return $latestDec;
-  }
-
-  public function isDecisionIrrelevant($uploadTreeId, $groupId)
-  {
-    $sql = "SELECT decision_type FROM clearing_decision
-              WHERE uploadtree_fk=$1 AND group_fk = $2
-            ORDER BY clearing_decision_pk DESC LIMIT 1";
-    $latestDec = $this->dbManager->getSingleRow($sql,
-                 array($uploadTreeId, $groupId), $sqlLog = __METHOD__);
-    if ($latestDec === false) {
-      return false;
-    }
-    return ($latestDec['decision_type'] == DecisionTypes::IRRELEVANT);
   }
 
   /**

--- a/src/lib/php/Dao/test/ClearingDaoTest.php
+++ b/src/lib/php/Dao/test/ClearingDaoTest.php
@@ -246,17 +246,17 @@ class ClearingDaoTest extends \PHPUnit\Framework\TestCase
     $this->buildDecisions(array(
         array(301,1,$groupId,DecisionTypes::IDENTIFIED,-90,DecisionScopes::REPO,array($firstEventId,$firstEventId+1))
     ));
-    $watchThis = $this->clearingDao->isDecisionWip(301, $groupId);
+    $watchThis = $this->clearingDao->isDecisionCheck(301, $groupId, DecisionTypes::WIP);
     assertThat($watchThis,is(FALSE));
-    $watchOther = $this->clearingDao->isDecisionWip(303, $groupId);
+    $watchOther = $this->clearingDao->isDecisionCheck(303, $groupId, DecisionTypes::WIP);
     assertThat($watchOther,is(FALSE));
     $this->buildProposals(array(
         array(301,1,$groupId,403,false,-89),
     ),$firstEventId+3);
     $this->clearingDao->markDecisionAsWip(301, 1, $groupId);
-    $watchThisNow = $this->clearingDao->isDecisionWip(301, $groupId);
+    $watchThisNow = $this->clearingDao->isDecisionCheck(301, $groupId, DecisionTypes::WIP);
     assertThat($watchThisNow,is(TRUE));
-    $watchOtherNow = $this->clearingDao->isDecisionWip(303, $groupId);
+    $watchOtherNow = $this->clearingDao->isDecisionCheck(303, $groupId, DecisionTypes::WIP);
     assertThat($watchOtherNow,is(FALSE));
   }
 

--- a/src/www/ui/async/AjaxExplorer.php
+++ b/src/www/ui/async/AjaxExplorer.php
@@ -33,6 +33,7 @@ use Fossology\Lib\Data\Tree\ItemTreeBounds;
 use Fossology\Lib\Plugin\DefaultPlugin;
 use Fossology\Lib\Proxy\ScanJobProxy;
 use Fossology\Lib\Proxy\UploadTreeProxy;
+use Fossology\Lib\Data\DecisionTypes;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -414,11 +415,11 @@ class AjaxExplorer extends DefaultPlugin
     }
 
     // override green/red flag with yellow flag in case of single file with decision type "To Be Discussed"
-    $isDecisionTBD = $this->clearingDao->isDecisionTBD($childUploadTreeId, $groupId);
+    $isDecisionTBD = $this->clearingDao->isDecisionCheck($childUploadTreeId, $groupId, DecisionTypes::TO_BE_DISCUSSED);
     $img = $isDecisionTBD ? 'yellow' : $img;
 
     // override green/red flag with greenRed flag in case of single file with decision type "Do Not Use"
-    $isDecisionDNU = $this->clearingDao->isDecisionDNU($childUploadTreeId, $groupId);
+    $isDecisionDNU = $this->clearingDao->isDecisionCheck($childUploadTreeId, $groupId, DecisionTypes::DO_NOT_USE);
     $img = $isDecisionDNU ? 'redGreen' : $img;
     return array($fileName, $licenseList, $editedLicenseList, $img, "$filesCleared / $filesToBeCleared / $totalFilesCount", $fileListLinks);
   }

--- a/src/www/ui/ui-clearing-view.php
+++ b/src/www/ui/ui-clearing-view.php
@@ -302,7 +302,7 @@ class ClearingView extends FO_Plugin
     $this->vars['clearingTypes'] = $this->decisionTypes->getMap();
     $this->vars['selectedClearingType'] = $selectedClearingType;
     $this->vars['selectedClearingScope'] = $selectedClearingScope;
-    $this->vars['tmpClearingType'] = $this->clearingDao->isDecisionWip($uploadTreeId, $groupId);
+    $this->vars['tmpClearingType'] = $this->clearingDao->isDecisionCheck($uploadTreeId, $groupId, DecisionTypes::WIP);
     $this->vars['bulkHistory'] = $bulkHistory;
 
     $noLicenseUploadTreeView = new UploadTreeProxy($uploadId,
@@ -358,8 +358,8 @@ class ClearingView extends FO_Plugin
     $uploadTreeTableName = $this->uploadDao->getUploadtreeTableName($lastItem);
     $itemBounds = $this->uploadDao->getItemTreeBounds($lastItem, $uploadTreeTableName);
     if ($global) {
-      $isDecisionWip = $this->clearingDao->isDecisionWip($currentUploadtreeId, $groupId);
-      $hasChangedClearingType = $this->clearingDao->getClearingType($currentUploadtreeId, $groupId, $type);
+      $isDecisionWip = $this->clearingDao->isDecisionCheck($currentUploadtreeId, $groupId, DecisionTypes::WIP);
+      $hasChangedClearingType = $this->clearingDao->isDecisionCheck($currentUploadtreeId, $groupId, '');
       if ($isDecisionWip) {
         $this->clearingDecisionEventProcessor->makeDecisionFromLastEvents($itemBounds, $userId, $groupId, $type, $global);
       } else if (empty($hasChangedClearingType['scope'])


### PR DESCRIPTION
## Description

Refactor following functions into one (isDecisionCheck).
* isDecisionWip
* isDecisionTBD
* isDecisionDnu
* isDecisionIrrelevant
* getClearingType

### Changes

* add new functions where ever required.

## How to test

* Apply some decisions as do not use and to be discussed and check clearing status color in treeview.
* Test if global decisions were getting applied to file with WIP decision.