### PR TITLE
fix(report): Set content type header

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1,4 +1,4 @@
-# Copyright (C) Siemens AG 2017-2021
+# Copyright (C) Siemens AG 2017-2022
 # Copyright (C) 2021 Orange by Piotr Pszczola <piotr.pszczola@orange.com>
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -15,7 +15,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.4.1
+  version: 1.4.2
   contact:
     email: fossology@fossology.org
   license:
@@ -1174,7 +1174,11 @@ paths:
               schema:
                 type: string
                 format: binary
-            application/zip:
+            application/vnd.openxmlformats-officedocument.wordprocessingml.document:
+              schema:
+                type: string
+                format: binary
+            application/xml:
               schema:
                 type: string
                 format: binary

--- a/src/www/ui/ui-download.php
+++ b/src/www/ui/ui-download.php
@@ -204,7 +204,7 @@ class ui_download extends FO_Plugin
   /**
    * @global type $container
    * @param type $path
-   * @param type $filename
+   * @param string $filename
    * @return BinaryFileResponse
    */
   protected function downloadFile($path, $filename)
@@ -220,7 +220,11 @@ class ui_download extends FO_Plugin
     $response = new BinaryFileResponse($path);
     $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $filename, $filenameFallback);
     if (pathinfo($filename, PATHINFO_EXTENSION) == 'docx') {
-      $response->headers->set('Content-Type', ''); // otherwise mineType would be zip
+      $response->headers->set('Content-Type', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+    } elseif (pathinfo($filename, PATHINFO_EXTENSION) == 'rdf') {
+      $response->headers->set('Content-Type', 'application/xml');
+    } else {
+      $response->headers->set('Content-Type', 'text/plain');
     }
 
     $logger = $container->get("logger");


### PR DESCRIPTION
## Description

Set the `Content-Type` headers while downloading reports.

Currently the header is missing causing issues with REST API clients.

### Changes

Check if report is docx or spdx and set `Content-Type` header to `application/vnd.openxmlformats-officedocument.wordprocessingml.document` or `application/xml` respectively. For other reports, set header to `text/plain`.

## How to test

Generate reports from UI and REST API and check for `Content-Type` header.

Closes #1767