### PR TITLE
feat(upload): allow multifile upload from UI

### DIFF
--- a/src/lib/php/UI/template/include/upload.html.twig
+++ b/src/lib/php/UI/template/include/upload.html.twig
@@ -31,12 +31,14 @@
       </li>
       {% block fileselect %}
       {% endblock %}
+      {% block filedescription %}
       <li>
         <div class="form-group">
           <label for="{{ fileInputName }}">({{ 'Optional'|trans }}) {{ 'Enter a description of this file'| trans }}:</label>
           <input type="text" class="form-control" style="width:40%;" name="{{ descriptionInputName }}" value="{{ descriptionInputValue }}">
         </div>
       </li>
+      {% endblock %}
       <li>
         <div class="form-group">
           <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="globalDecisions" value="1"/>

--- a/src/reuser/ui/template/agent_reuser.html.twig
+++ b/src/reuser/ui/template/agent_reuser.html.twig
@@ -2,7 +2,12 @@
 
 <li>
   <div class="form-group">
-    <label for="reuse">({{ 'Optional'|trans }}) {{ 'Reuse'|trans }}</label>
+    <label for="reuse">
+      ({{ 'Optional'|trans }}) {{ 'Reuse'|trans }}
+      <span style="display:none" id="reusedisable">
+        ; {{ 'Disabled as multiple files being uploaded'|trans }}
+      </span>
+    </label>
     <img src="images/info_16.png" data-toggle="tooltip" title="{{ 'Copy clearing decisions if there is the same file hash between two files'|trans }}" alt="" class="info-bullet"/><br/>
     <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" id="searchInFolder"/> {{ 'Select an already uploaded package for reuse in specific folder ' | trans }}
     {% include 'reuse-folder.html.twig' with {'name': reuseFolderSelectorName, 'id': reuseFolderSelectorName} %}

--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -390,7 +390,7 @@ class UploadController extends RestController
         $info = new Info(500, $message . "\n" . $statusDescription,
           InfoType::ERROR);
       } else {
-        $uploadId = $uploadResponse[3];
+        $uploadId = $uploadResponse[3][0];
         $info = new Info(201, intval($uploadId), InfoType::INFO);
       }
       return $response->withJson($info->getArray(), $info->getCode());

--- a/src/www/ui/api/Helper/UploadHelper.php
+++ b/src/www/ui/api/Helper/UploadHelper.php
@@ -26,6 +26,7 @@
 namespace Fossology\UI\Api\Helper;
 
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UploadedFileInterface;
 use Fossology\UI\Api\Helper\UploadHelper\HelperToUploadFilePage;
 use Fossology\UI\Api\Helper\UploadHelper\HelperToUploadVcsPage;
 use Fossology\UI\Api\Helper\UploadHelper\HelperToUploadUrlPage;
@@ -152,7 +153,7 @@ class UploadHelper
   /**
    * Create request required by UploadFilePage
    *
-   * @param array $uploadedFile Uploaded file object by Slim
+   * @param UploadedFileInterface $uploadedFile Uploaded file object by Slim
    * @param string $folderId    ID of the folder to upload the file
    * @param string $fileDescription Description of file uploaded
    * @param string $isPublic    Upload is `public, private or protected`
@@ -176,10 +177,11 @@ class UploadHelper
 
     $symfonyRequest->request->set($this->uploadFilePage::FOLDER_PARAMETER_NAME,
       $folderId);
-    $symfonyRequest->request->set($this->uploadFilePage::DESCRIPTION_INPUT_NAME,
-      $fileDescription);
+    $symfonyRequest->request->set(
+      $this->uploadFilePage::DESCRIPTION_INPUT_NAME,
+      [$fileDescription]);
     $symfonyRequest->files->set($this->uploadFilePage::FILE_INPUT_NAME,
-      $symfonyFile);
+      [$symfonyFile]);
     $symfonyRequest->setSession($symfonySession);
     $symfonyRequest->request->set(
       $this->uploadFilePage::UPLOAD_FORM_BUILD_PARAMETER_NAME, "restUpload");

--- a/src/www/ui/template/upload_file.html.twig
+++ b/src/www/ui/template/upload_file.html.twig
@@ -18,8 +18,22 @@
 {% block fileselect %}
 <li>
   <div class="form-group">
-    <label for="{{ fileInputName }}">{{ 'Select the file to upload'| trans }}:</label>
-    <input type="file" class="form-control-file" name="{{ fileInputName }}" id="fileUploader">
+    <label for="fileUploader">{{ 'Select the file(s) to upload'| trans }}:</label>
+    <input type="file" class="form-control-file" id="fileUploader" name="{{ fileInputName }}[]" multiple="multiple">
+  </div>
+</li>
+{% endblock %}
+{% block filedescription %}
+<li class="mb-4">
+  Description(s)
+  <div style="display:none" id="collapseDescription">
+    <button class="btn btn-info" type="button" data-toggle="collapse" data-target="#uploaddescriptions" aria-expanded="true" aria-controls="uploaddescriptions">+ expand</button>
+  </div>
+  <br />
+  <div id="uploaddescriptions" class="card-columns collapse show">
+    <span class="text-secondary">
+      {{ 'Select file(s) to enter description'|trans }}
+    </span>
   </div>
 </li>
 {% endblock %}
@@ -32,30 +46,96 @@
 {% block foot %}
   {{ parent() }}
   <script type="text/javascript">
-    $(document).ready(function () {
-      $('#fileUploader').change(function(e) {
-        var uploadName = e.target.files[0].name;
-        var folderId = $("#uploadFolderSelector").val();
-        $.ajax({
+    function checkDuplicateUploadWarning(e) {
+      const allFiles = e.target.files;
+      const folderId = $("#uploadFolderSelector").val();
+      var messages = new Array();
+      var ajaxList = new Array();
+      var ajaxCall;
+      for (let i = 0; i < allFiles.length; i++) {
+        const uploadName = allFiles[i].name;
+        ajaxCall = $.ajax({
           url : '?mod=foldercontents',
           type : 'post',
           dataType : 'json',
           data : {"folder": folderId, "upload": uploadName},
           success : function(data) {
             if (data.upload !== false) {
-              var message = `Same file was uploaded at ${data.date}. ` +
+              messages.push(`${uploadName} already uploaded at ${data.date}. ` +
                 `<a href='${data.upload}' target="blank">` +
-                'Click here to check the upload</a>.';
-              $('#fileUploader').popover({
-                "content": message, "html": true, "title": "Warning!",
-                "placement": "top", "trigger": "focus"
-              }).popover('show');
-            } else {
-              $('#fileUploader').popover('dispose');
+                'Check the upload</a>.');
             }
           }
         });
+        ajaxList.push(ajaxCall);
+      }
+      // Wait for all ajax calls to resolve
+      $.when.apply($, ajaxList).then(function(){
+        $('#fileUploader').popover('dispose');
+        if (messages.length != 0) {
+          $('#fileUploader').popover({
+            "content": messages.join("<br />"), "html": true,
+            "title": "Warning!", "placement": "top", "trigger": "focus"
+          }).popover('show');
+          $('html, body').animate({
+            scrollTop: $('#fileUploader').offset().top
+          }, 100);
+        }
       });
+    }
+    function disableReuserOptions() {
+      if ($('#searchInFolder').length < 1) {
+        return;
+      }
+      var reuserdiv = $("#searchInFolder").parent();
+      reuserdiv.find("input").attr("disabled", true);
+      reuserdiv.find("select[id=uploadToReuse]").attr("disabled", true);
+      reuserdiv.addClass("text-muted");
+      $("#reusedisable").show();
+    }
+    function enableReuserOptions() {
+      if ($('#searchInFolder').length < 1) {
+        return;
+      }
+      var reuserdiv = $("#searchInFolder").parent();
+      reuserdiv.find("input").attr("disabled", false);
+      reuserdiv.find("select[id=uploadToReuse]").attr("disabled", false);
+      reuserdiv.removeClass("text-muted");
+      $("#reusedisable").hide();
+    }
+    $("#fileUploader").on("change", function(e) {
+      checkDuplicateUploadWarning(e);
+
+      var holder = $("#uploaddescriptions");
+      holder.html("");
+      let allFiles = e.target.files;
+      if (allFiles.length > 10) {
+        $("#collapseDescription").show();
+        $("#uploaddescriptions").collapse('hide');
+      }
+      if (allFiles.length > 1) { // Disable reuser for multi file upload
+        disableReuserOptions();
+      } else {
+        enableReuserOptions();
+      }
+      for (let i = 0; i < allFiles.length; i++) {
+        const val = allFiles[i];
+        var tt = $("<h6 class='card-title'>").append(val.name);
+        var formg = $("<div class='form-group'>");
+        var ll = $(`<label for='desc${i}' class='card-text'>`).append("({{ 'Optional'|trans }}) {{ 'Enter a description of this file'| trans }}:");
+        formg.append(ll).append(`<input type='text' class='form-control' name='{{ descriptionInputName }}[${i}]' id='desc${i}'>`);
+        var body = $("<div class='card-body'>");
+        body.append(tt).append(formg);
+        var html = $("<div class='card'>");
+        html.append(body);
+        holder.append(html);
+      };
+    });
+    $('#uploaddescriptions').on('hidden.bs.collapse', function () {
+      $('#collapseDescription').find('button').text('+ expand');
+    });
+    $('#uploaddescriptions').on('shown.bs.collapse', function () {
+      $('#collapseDescription').find('button').text('- collapse');
     });
   </script>
 {% endblock %}

--- a/src/www/ui_tests/api/Controllers/UploadControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadControllerTest.php
@@ -573,7 +573,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     $uploadHelper->shouldReceive('createNewUpload')
       ->withArgs([$request, $folderId, $uploadDescription, 'protected', true,
         'vcs', false])
-      ->andReturn([true, '', '', 20]);
+      ->andReturn([true, '', '', [20]]);
 
     $this->folderDao->shouldReceive('getAllFolderIds')->andReturn([2,3,4]);
     $this->folderDao->shouldReceive('isFolderAccessible')
@@ -690,7 +690,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     $uploadHelper->shouldReceive('createNewUpload')
       ->withArgs([$request, $folderId, $uploadDescription, 'protected', true,
         'vcs', false])
-      ->andReturn([false, $errorMessage, $errorDesc, -1]);
+      ->andReturn([false, $errorMessage, $errorDesc, [-1]]);
 
     $this->folderDao->shouldReceive('getAllFolderIds')->andReturn([2,3,4]);
     $this->folderDao->shouldReceive('isFolderAccessible')


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Allow users to upload multiple files from "Upload from file" page.

![image](https://user-images.githubusercontent.com/18077542/153181173-973914a0-1c6b-4370-bf02-cda2b3e47eda.png)

Currently only description can be changed per upload file. Rest of the fields are considered common for all files.

Reuser options are disabled if more than 1 file is being uploaded.

More suggestions are welcome.

### Changes

1. Change file input to array `[]`.
2. Change description input for file upload as array `[]`.
3. Modify REST API to mimic multifile upload.

## How to test

1. Upload a single file and set the description.
2. Upload multiple files and set their respective descriptions.

Closes #2006