### PR TITLE
feat(lbtablelength):Added all for license browser table

### DIFF
--- a/src/www/ui/template/browse_file.js.twig
+++ b/src/www/ui/template/browse_file.js.twig
@@ -60,7 +60,7 @@ function createDirlistTable() {
     },
     "oLanguage":{"sInfo":"Showing _START_ to _END_ of _TOTAL_ files" ,
       "sSearch":'_INPUT_<button class="btn btn-default btn-sm" style="vertical-align:top;margin:1px;" onclick="clearSearchFiles();" title=\"{{ 'Clear file filter'|trans }}\" >Clear<\/button>',
-      "sLengthMenu":'Display <select class="form-control-sm"><option value="10">10<\/option><option value="25">25<\/option><option value="50">50<\/option><option value="100">100<\/option><\/select> {#
+      "sLengthMenu":'Display <select class="form-control-sm"><option value="10">10<\/option><option value="25">25<\/option><option value="50">50<\/option><option value="100">100<\/option><option value="{{ iTotalRecords }}">ALL<\/option><\/select> {#
        #}   {{ 'files'|trans }} ({% if isFlat %}<a href="{{ fileSwitch }}">{{ 'tree view'|trans }}</a> {{ 'or'|trans }} <b>{{ 'flat'|trans }}</b>{#
        #}{% else %}<b>{{ 'tree view'|trans }}</b> {{ 'or'|trans }} <a href="{{ fileSwitch }}">{{ 'flat'|trans }}</a>{% endif %})'
       }


### PR DESCRIPTION
Signed-off-by: Rohit Pandey <rohit.pandey4900@gmail.com>

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Added "ALL" option license browser table for #2110 

### Changes

Added a new "ALL" option

## How to test

1. Go to license browser table
2. For table length select ALL
3. You will see all the licenses

closing #2110 

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)
