### PR TITLE
fix(cd): Fix release workflow for version

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -74,7 +74,7 @@ jobs:
 
     - name: Get release info
       id: get_release
-      uses: bruceadams/get-release@v1.2.2
+      uses: bruceadams/get-release@v1.3.2
       env:
         GITHUB_TOKEN: ${{ github.token }}
 
@@ -98,17 +98,21 @@ jobs:
         mkdir -p packages
         mv build/*.deb packages/
         tar -czvf ${PACKAGE_NAME} packages
+        # Sleep between 3-22 seconds to allow GitHub API accept new packages
+        sleep $[$RANDOM % 20 + 3]s
 
     - name: Upload Release Asset
       id: upload-release-asset
-      uses: actions/upload-release-asset@v1
+      uses: shogo82148/actions-upload-release-asset@v1
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.get_release.outputs.upload_url }}
         asset_path: ${{ env.PACKAGE_NAME }}
         asset_name: ${{ env.PACKAGE_NAME }}
         asset_content_type: application/gzip
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        overwrite: true
 
   docker-release-build:
     runs-on: ubuntu-latest
@@ -132,9 +136,9 @@ jobs:
 
     - name: Get release info
       id: get_release
-      uses: bruceadams/get-release@v1.2.2
+      uses: bruceadams/get-release@v1.3.2
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push main image
       uses: docker/build-push-action@v3
@@ -143,3 +147,4 @@ jobs:
         tags: fossology/fossology:${{ steps.get_release.outputs.tag_name }}
         labels: |
           org.opencontainers.image.version=${{ steps.get_release.outputs.tag_name }}.0
+        context: .


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix following points for the release workflow:
1. Fetch at least last 10 commits before compiling.
2. Change release upload
  1. Repository [actions/upload-release-assets](http://github.com/actions/upload-release-assets) is now archived.
  2. Use [xresloader/upload-to-github-release](https://github.com/xresloader/upload-to-github-release) instead.

**Fixes**:
1. Closes #2152
2. Closes #2206
3. https://github.com/fossology/fossology/runs/4924129005?check_suite_focus=true#step:11:12

## How to test
Will setup a fork with updated workflow soon.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2156"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

