### PR TITLE
chore(browse): redirect to license view if empty

### DIFF
--- a/src/www/ui/ui-browse.php
+++ b/src/www/ui/ui-browse.php
@@ -24,6 +24,7 @@ use Fossology\Lib\Dao\UserDao;
 use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\UI\FolderNav;
 use Fossology\Lib\UI\MenuHook;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 define("TITLE_UI_BROWSE", _("Browse"));
@@ -322,6 +323,12 @@ class ui_browse extends FO_Plugin
       }
 
       if (! Iscontainer($row['ufile_mode'])) {
+        $parentItemBounds = $this->uploadDao->getParentItemBounds($Upload);
+        if (! $parentItemBounds->containsFiles()) {
+          // Upload with a single file, open license view
+          return new RedirectResponse(Traceback_uri() . '?mod=view-license'
+            . Traceback_parm_keep(array("upload", "item")));
+        }
         global $Plugins;
         $View = &$Plugins[plugin_find_id("view")];
         if (! empty($View)) {


### PR DESCRIPTION
## Description

Redirect user from browse view to license browser if upload contains single file.

See #496 for details.

### Changes

In `ui-browse`, check if given item is a file and parent of the upload contains only 1 file. Then redirect to the license browser view.

## How to test

1. Upload a single file (not compressed).
2. Click on the file name in job view.
  - Should be redirected to License browser.
3. Upload a compressed file.
4. Click on the file name in job view.
  - Normal browse view should be displayed.
  - Navigating though the upload should have no effect.

Closes #496

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2160"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

