### PR TITLE
feat(dev-ctbutton): Added clean text button at license text field

### DIFF
--- a/src/www/ui/scripts/change-license-browse.js
+++ b/src/www/ui/scripts/change-license-browse.js
@@ -133,9 +133,8 @@ function markDecisions(decisionToBeApplied, isRemoval) {
   });
 }
 
-function cleanText() {
-  var $textField = $('#bulkRefText');
-  var text = $textField.val();
+function cleanText(textField) {
+  var text = textField.val();
 
   var delimiters = $("#delimdrop").val();
   if (delimiters.toLowerCase() === "default") {
@@ -151,5 +150,5 @@ function cleanText() {
              .replace(re, ' ')
              .replace(/(^|\n)[ \t]*/gim, '$1')
              ;
-  $textField.val(text);
+  textField.val(text);
 }

--- a/src/www/ui/scripts/change-license-common.js
+++ b/src/www/ui/scripts/change-license-common.js
@@ -264,6 +264,13 @@ function openTextModel(uploadTreeId, licenseId, what, type) {
     $('#selectFromNoticeFile').css('display','none');
   }
 
+  if (what == 2 || what === 'reportinfo') {
+    // clicked to add button to display child modal
+    $('#clearText').show();
+  } else {
+    $('#clearText').hide();
+  }
+
   if(type == 0) {
     let clearingsForSingleFile = $("#clearingsForSingleFile"+licenseId+what).attr("title");
     idLicUploadTree = uploadTreeId+','+licenseId;

--- a/src/www/ui/scripts/change-license-view.js
+++ b/src/www/ui/scripts/change-license-view.js
@@ -94,9 +94,8 @@ function scheduleBulkScan() {
   scheduleBulkScanCommon($('#bulkIdResult'), reloadClearingTable);
 }
 
-function cleanText() {
-  var $textField = $('#bulkRefText');
-  var text = $textField.val();
+function cleanText(textField) {
+  var text = textField.val();
 
   var delimiters = $("#delimdrop").val();
   if (delimiters.toLowerCase() === "default") {
@@ -112,7 +111,7 @@ function cleanText() {
              .replace(re, ' ')
              .replace(/(^|\n)[ \t]*/gim, '$1')
              ;
-  $textField.val(text);
+  textField.val(text);
 }
 
 

--- a/src/www/ui/template/ui-clearing-view_bulk.html.twig
+++ b/src/www/ui/template/ui-clearing-view_bulk.html.twig
@@ -23,6 +23,7 @@
         <!-- Modal footer -->
         <div class="modal-footer">
           <button type="button" class="btn" id="selectFromNoticeFile" style="display:none;width:96%;" onclick="openAckInputModal();">Select from Notice File</button>
+          <button type="button" class="btn" id="clearText" style="display:none;width:96%;" onclick="cleanText( $('#referenceText') );">{{ 'Clean Text'|trans }}</button>
           <button type="button" class="btn btn-danger" onclick="closeTextModal();" data-dismiss="modal">{{ 'Cancel'|trans }}</button>
           <button type="button" class="btn btn-success" onclick="submitTextModal();" data-dismiss="modal">{{ 'Ok'|trans }}</button>
         </div>
@@ -185,7 +186,7 @@
         <!-- Modal footer -->
         <div class="modal-footer">
           <button type="button" class="btn btn-danger" onclick="closeBulkModal();" data-dismiss="modal">Cancel</button>
-          <button type="button" class="btn btn-success" onclick="cleanText();">{{ 'Clean text'|trans }}</button>
+          <button type="button" class="btn btn-success" onclick="cleanText( $('#bulkRefText') );">{{ 'Clean text'|trans }}</button>
           <img src="images/info_16.png" data-toggle="tooltip" style="vertical-align:middle;" title="{{ 'The matching process ignores comment symbols, e.g. double-slashes. Hence, these symbols can be remove from bulk text.'|trans }}" alt="" class="info-bullet"/></img>
           <button type="button" class="btn btn-success" onclick="scheduleBulkScan();" data-dismiss="modal">{{ 'Schedule Bulk scan'|trans }}</button>
         </div>


### PR DESCRIPTION
Signed-off-by: rohitpandey49 <rohit.pandey4900@gmail.com>

## Description

Added 'Clean Text' button in license text field for #2108 

### Changes

Added 'Clean Text' button

## How to test

1. Go to change concluded license
2. Click on license text field

closing #2108 


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2161"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

