### PR TITLE
feat(API): Created an API end-point for copyright

### DIFF
--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -403,7 +403,7 @@ class UploadController extends RestController
   }
 
   /**
-   * Get list of licenses for given upload
+   * Get list of licenses and copyright for given upload
    *
    * @param ServerRequestInterface $request
    * @param ResponseHelper $response
@@ -426,6 +426,22 @@ class UploadController extends RestController
       $containers = (strcasecmp($query[self::CONTAINER_PARAM], "true") === 0);
     }
 
+    $license = true;
+    if (array_key_exists('license', $query)) {
+      $license = (strcasecmp($query['license'], "true") === 0);
+    }
+
+    $copyright = false;
+    if (array_key_exists('copyright', $query)) {
+      $copyright = (strcasecmp($query['copyright'], "true") === 0);
+    }
+
+    if (!$license && !$copyright) {
+      $error = new Info(400, "'license' and 'copyright' atleast one should be true.",
+        InfoType::ERROR);
+      return $response->withJson($error->getArray(), $error->getCode());
+    }
+
     $upload = $this->uploadAccessible($this->restHelper->getGroupId(), $id);
     if ($upload !== true) {
       return $response->withJson($upload->getArray(), $upload->getCode());
@@ -439,8 +455,7 @@ class UploadController extends RestController
     }
 
     $uploadHelper = new UploadHelper();
-    $licenseList = $uploadHelper->getUploadLicenseList($id, $agents,
-      $containers);
+    $licenseList = $uploadHelper->getUploadLicenseList($id, $agents, $containers, $license, $copyright);
     return $response->withJson($licenseList, 200);
   }
 

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -551,6 +551,20 @@ paths:
         schema:
           type: boolean
           default: true
+      - name: license
+        required: false
+        description: Show license in response
+        in: query
+        schema:
+          type: boolean
+          default: true    
+      - name: copyright
+        required: false
+        description: Show copyrights in response
+        in: query
+        schema:
+          type: boolean
+          default: false    
       - name: groupName
         description: The group name to chose while accessing the package
         in: header

--- a/src/www/ui_tests/api/Controllers/UploadControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadControllerTest.php
@@ -757,7 +757,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
 
     $uploadHelper = M::mock('overload:Fossology\UI\Api\Helper\UploadHelper');
     $uploadHelper->shouldReceive('getUploadLicenseList')
-      ->withArgs([$uploadId, ['nomos', 'monk'], false])
+      ->withArgs([$uploadId, ['nomos', 'monk'], false, true, false])
       ->andReturn($licenseResponse);
 
     $expectedResponse = (new ResponseHelper())->withJson($licenseResponse, 200);


### PR DESCRIPTION
## Description

Added a copyright feat in  `/uploads/{id}/licenses` API .

see #2081 for details.

### Changes

 edited `/uploads/{id}/licenses` endpoint for getting copyright.
- If `license=true` and `copyright=false`  Returns the list of licenses.
- If `license=true` and `copyright=true` Returns the list of licenses and copyrights.
- If `license=false` and `copyright=true` Returns the list of copyrights only. 

## How to test

Send a get request to `/uploads/{id}/licenses` by changing the `license` and `copyright` param value  and check the response .

Closes #2081 


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2165"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

