### PR TITLE
feat(report): accept package URL

### DIFF
--- a/src/clixml/agent/clixml.php
+++ b/src/clixml/agent/clixml.php
@@ -19,6 +19,7 @@ namespace Fossology\CliXml;
 
 use Fossology\Lib\Agent\Agent;
 use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Data\Package\ComponentType;
 use Fossology\Lib\Data\Upload\Upload;
 use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Report\XpClearedGetter;
@@ -28,7 +29,6 @@ use Fossology\Lib\Report\ObligationsGetter;
 use Fossology\Lib\Report\OtherGetter;
 use Fossology\Lib\Report\LicenseIrrelevantGetter;
 use Fossology\Lib\Report\LicenseDNUGetter;
-
 
 include_once(__DIR__ . "/version.php");
 include_once(__DIR__ . "/services.php");
@@ -169,7 +169,7 @@ class CliXml extends Agent
     return $prefix . $partname . $postfix;
   }
 
-  protected function getUri($fileBase,$packageName)
+  protected function getUri($fileBase)
   {
     $fileName = $fileBase. strtoupper($this->outputFormat)."_".$this->packageName.'_'.date("Y-m-d_H:i:s");
     $fileName = $fileName .".xml" ;
@@ -435,7 +435,7 @@ class CliXml extends Agent
 
     $fileBase = $SysConf['FOSSOLOGY']['path']."/report/";
 
-    $this->uri = $this->getUri($fileBase,$packageName);
+    $this->uri = $this->getUri($fileBase);
   }
 
   protected function writeReport($contents, $packageIds, $uploadId)
@@ -471,7 +471,7 @@ class CliXml extends Agent
    */
   protected function renderString($templateName, $vars)
   {
-    return $this->renderer->loadTemplate($templateName)->render($vars);
+    return $this->renderer->load($templateName)->render($vars);
   }
 
   /**
@@ -523,6 +523,12 @@ class CliXml extends Agent
         $usage = 'Found';
       }
     }
+    $componentType = $row['ri_component_type'];
+    $componentType = ComponentType::TYPE_MAP[$componentType];
+    $componentId = $row['ri_component_id'];
+    if (empty($componentId) || $componentId == "NA") {
+      $componentId = "";
+    }
 
     return [[
       'reportId' => uuid_create(UUID_TYPE_TIME),
@@ -532,7 +538,9 @@ class CliXml extends Agent
       'version' => htmlspecialchars($row['ri_version']),
       'componentHash' => '',
       'componentReleaseDate' => htmlspecialchars($row['ri_release_date']),
-      'linkComponentManagement' => htmlspecialchars($row['ri_sw360_link'])
+      'linkComponentManagement' => htmlspecialchars($row['ri_sw360_link']),
+      'componentType' => htmlspecialchars($componentType),
+      'componentId' => htmlspecialchars($componentId)
     ], [
       'generalAssessment' => $row['ri_general_assesment'],
       'criticalFilesFound' => $critical,

--- a/src/clixml/agent/template/clixml-file.xml.twig
+++ b/src/clixml/agent/template/clixml-file.xml.twig
@@ -21,6 +21,12 @@
     <ComponentHash>{{ generalInformation.componentHash|trim }}</ComponentHash>
     <ComponentReleaseDate>{{ generalInformation.componentReleaseDate|trim }}</ComponentReleaseDate>
     <LinkComponentManagement><![CDATA[{{ generalInformation.linkComponentManagement|trim }}]]></LinkComponentManagement>
+    {%- if generalInformation.componentId is not empty ~%}
+    <ComponentId>
+      <Type>{{ generalInformation.componentType|trim }}</Type>
+      <Id>{{ generalInformation.componentId|trim }}</Id>
+    </ComponentId>
+    {%- endif ~%}
   </GeneralInformation>
 
   <AssessmentSummary>

--- a/src/clixml/ui/CliXmlGeneratorUi.php
+++ b/src/clixml/ui/CliXmlGeneratorUi.php
@@ -18,6 +18,7 @@
 
 namespace Fossology\CliXml;
 
+use Exception;
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\UploadDao;
 use Fossology\Lib\Data\Upload\Upload;
@@ -104,7 +105,7 @@ class CliXmlGeneratorUi extends DefaultPlugin
                   'reportType' => $this->outputFormat);
     $text = sprintf(_("Generating ". $this->outputFormat . " report for '%s'"), $upload->getFilename());
     $vars['content'] = "<h2>".$text."</h2>";
-    $content = $this->renderer->loadTemplate("report.html.twig")->render($vars);
+    $content = $this->renderer->load("report.html.twig")->render($vars);
     $message = '<h3 id="jobResult"></h3>';
     $request->duplicate(array('injectedMessage'=>$message,'injectedFoot'=>$content,'mod'=>'showjobs'))->overrideGlobals();
     $showJobsPlugin = \plugin_find('showjobs');

--- a/src/lib/php/Data/Package/ComponentType.php
+++ b/src/lib/php/Data/Package/ComponentType.php
@@ -1,0 +1,59 @@
+<?php
+/*
+Copyright (C) 2022, Siemens AG
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+namespace Fossology\Lib\Data\Package;
+
+class ComponentType
+{
+  /**
+   * @var int PURL
+   * Component Type purl
+   */
+  const PURL = 0;
+  /**
+   * @var int MAVEN
+   * Component Type maven
+   */
+  const MAVEN = 1;
+  /**
+   * @var int NUGET
+   * Component Type nuget
+   */
+  const NUGET = 2;
+  /**
+   * @var int NPM
+   * Component Type npm
+   */
+  const NPM = 3;
+  /**
+   * @var int PYPI
+   * Component Type pypi
+   */
+  const PYPI = 4;
+  /**
+   * @var array TYPE_MAP
+   * Corresponding type name for id
+   */
+  const TYPE_MAP = [
+    self::PURL => 'purl',
+    self::MAVEN => 'maven',
+    self::NUGET => 'nuget',
+    self::NPM => 'npm',
+    self::PYPI => 'pypi'
+  ];
+}

--- a/src/lib/php/Util/PurlOperations.php
+++ b/src/lib/php/Util/PurlOperations.php
@@ -1,0 +1,93 @@
+<?php
+/*
+Copyright (C) 2022, Siemens AG
+Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+namespace Fossology\Lib\Util;
+
+class PurlOperations
+{
+  /**
+   * Implemented following specs at https://github.com/package-url/purl-spec/blob/a748c36ad415c8aeffe2b8a4a5d8a50d16d6d85f/PURL-SPECIFICATION.rst#how-to-parse-a-purl-string-in-its-components
+   * @todo Replace with https://packagist.org/packages/package-url/packageurl-php
+   * @param string $input pURL as a string
+   * @return array Each part of pURL as key and corresponding values
+   */
+  public static function fromString($input)
+  {
+    $scheme = null;
+    $type = null;
+    $namespace = null;
+    $name = null;
+    $version = null;
+    $qualifiers = null;
+    $subpath = null;
+    $split = explode("#", $input);
+    if (count($split) > 1) {
+      $subpath = trim($split[1], " /");
+      $subpaths = explode("/", $subpath);
+      $subpath = [];
+      foreach ($subpaths as $sp) {
+        if ($sp != "." || $sp != "..") {
+          $subpath[] = urldecode($sp);
+        }
+      }
+      $subpath = implode("/", $subpath);
+    }
+    $split = explode("?", $split[0]);
+    if (count($split) > 1) {
+      $qualifiers = [];
+      $parts = explode("&", $split[1]);
+      foreach ($parts as $part) {
+        $pair = explode("=", $part);
+        if (empty($pair[1])) {
+          continue;
+        }
+        $qualifiers[$pair[0]] = urldecode($pair[1]);
+      }
+    }
+    $split = explode(":", $split[0]);
+    $scheme = strtolower($split[0]);
+    $split = explode("/", trim($split[1], " /"));
+    $type = strtolower($split[0]);
+    $split = explode("@", implode("/", array_slice($split, 1)));
+    if (count($split) > 1) {
+      $version = urldecode($split[1]);
+    }
+    $split = explode("/", $split[0]);
+    $splitClone = array_values($split);
+    $name = end($splitClone);
+    $name = urldecode($name);
+    $namespace = [];
+    for ($i = 0; $i < count($split) - 1; $i++) {
+      $namespace[] = urldecode($split[$i]);
+    }
+    $namespace = implode("/", $namespace);
+    if (empty($namespace)) {
+      $namespace = null;
+    }
+    return [
+      "scheme" => $scheme,
+      "type" => $type,
+      "namespace" => $namespace,
+      "name" => $name,
+      "version" => $version,
+      "qualifiers" => $qualifiers,
+      "subpath" => $subpath
+    ];
+  }
+}

--- a/src/spasht/ui/ui-spasht.php
+++ b/src/spasht/ui/ui-spasht.php
@@ -1,4 +1,21 @@
 <?php
+/***********************************************************
+ * Copyright (C) 2019
+ * Author: Vivek Kumar<vvksindia@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***********************************************************/
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\UploadDao;
@@ -297,6 +314,22 @@ class ui_spasht extends FO_Plugin
     $this->vars['tables'] = [$table];
 
     $advanceSearchFormStatus = "hidden";
+    if (empty(trim(GetParm("advanceSearchFormStatus", PARM_STRING)))) {
+      // First load
+      /**
+       * @var Coordinate $coord
+       * Coordinate from component ID (can be null)
+       */
+      $coord = $this->spashtDao->getCoordinateFromCompId($uploadId);
+      if ($coord != null) {
+        $upload_name = $coord->getName();
+        $revisionName = $coord->getRevision();
+        $namespaceName = $coord->getNamespace();
+        $typeName = $coord->getType();
+        $providerName = $coord->getProvider();
+        $advanceSearchFormStatus = "show";
+      }
+    }
     $this->vars['uploadName']    = $upload_name;
     $this->vars['revisionName']  = $revisionName;
     $this->vars['namespaceName'] = $namespaceName;

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -72,6 +72,7 @@ use Fossology\Lib\Proxy\UploadTreeProxy;
 use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Data\License;
 use Fossology\Lib\Data\AgentRef;
+use Fossology\Lib\Data\Package\ComponentType;
 
 include_once(__DIR__ . "/spdx2utils.php");
 
@@ -347,11 +348,26 @@ class SpdxTwoAgent extends Agent
     }
 
     $hashes = $this->uploadDao->getUploadHashes($uploadId);
+
+    $reportInfo = $this->uploadDao->getReportInfo($uploadId);
+    $componentId = $reportInfo['ri_component_id'];
+    $componentType = $reportInfo['ri_component_type'];
+    if ($componentId == "NA") {
+      $componentId = "";
+    }
+    if ($componentType == ComponentType::MAVEN) {
+      $componentType = "maven-central";
+    } else {
+      $componentType = ComponentType::TYPE_MAP[$componentType];
+    }
+
     return $this->renderString($this->getTemplateFile('package'),array(
         'packageId' => $uploadId,
         'uri' => $this->uri,
         'packageName' => $upload->getFilename(),
         'uploadName' => $upload->getFilename(),
+        'componentType' => $componentType,
+        'componentId' => htmlspecialchars($componentId),
         'sha1' => $hashes['sha1'],
         'md5' => $hashes['md5'],
         'sha256' => $hashes['sha256'],

--- a/src/spdx2/agent/template/spdx2-package.xml.twig
+++ b/src/spdx2/agent/template/spdx2-package.xml.twig
@@ -12,6 +12,17 @@
         <spdx:name>{{ packageName }}</spdx:name>
         <spdx:packageFileName>{{ uploadName }}</spdx:packageFileName>
         <spdx:downloadLocation rdf:resource="http://spdx.org/rdf/terms#noassertion" />
+        {%- if componentId is not empty ~%}
+        <spdx:externalRef>
+          <spdx:ExternalRef>
+            <spdx:referenceCategory rdf:resource
+              ="http://spdx.org/rdf/terms#referenceCategory_packageManager" />
+            <spdx:referenceType rdf:resource
+              ="http://spdx.org/rdf/references/{{ componentType }}" />
+            <spdx:referenceLocator>{{ componentId|trim }}</spdx:referenceLocator>
+          </spdx:ExternalRef>
+        </spdx:externalRef>
+        {%- endif ~%}
         <spdx:packageVerificationCode>
           <spdx:PackageVerificationCode>
           <spdx:packageVerificationCodeValue>{{ verificationCode }}</spdx:packageVerificationCodeValue>

--- a/src/spdx2/agent/template/spdx2tv-package.twig
+++ b/src/spdx2/agent/template/spdx2tv-package.twig
@@ -28,6 +28,9 @@ PackageCopyrightText: NOASSERTION
 
 Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-upload{{ packageId }}
 {# RelationshipComment: #}
+{%- if componentId is not empty ~%}
+ExternalRef: PACKAGE-MANAGER {{ componentType }} {{ componentId }}
+{%- endif ~%}
 
 ##--------------------------
 ## File Information

--- a/src/unifiedreport/agent/reportSummary.php
+++ b/src/unifiedreport/agent/reportSummary.php
@@ -16,6 +16,7 @@
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+use Fossology\Lib\Data\Package\ComponentType;
 use PhpOffice\PhpWord\Element\Section;
 use \PhpOffice\PhpWord\Style;
 
@@ -60,6 +61,7 @@ class ReportSummary
    */
   private function accumulateLicenses($licenses)
   {
+    $allOtherLicenses = "";
     if (!empty($licenses)) {
       $licenses = array_unique(array_column($licenses, 'content'));
       foreach ($licenses as $otherLicenses) {
@@ -101,6 +103,7 @@ class ReportSummary
     $allMainLicenses = $this->accumulateLicenses($mainLicenses);
     $allOtherLicenses = $this->accumulateLicenses($licenses);
 
+    $allHistLicenses = "";
     if (!empty($histLicenses)) {
       foreach ($histLicenses as $histLicense) {
         $allHistLicenses .= $histLicense["licenseShortname"].", ";
@@ -183,6 +186,28 @@ class ReportSummary
       $table->addCell($cellThirdLen)->addText(htmlspecialchars($newSw360Component["Release date"]), null, "pStyle");
     } else {
       $table->addCell($cellThirdLen)->addText(htmlspecialchars($otherStatement['ri_release_date']), null, "pStyle");
+    }
+
+    $table->addRow($rowWidth);
+    $table->addCell($cellFirstLen, $cellRowContinue);
+    $table->addCell($cellSecondLen)->addText(htmlspecialchars(" Component Id"), $firstRowStyle1, "pStyle");
+
+    if (!empty($newSw360Component["Component Id"])) {
+      $table->addCell($cellThirdLen)->addText(htmlspecialchars($newSw360Component["Component Id"]), null, "pStyle");
+    } else {
+      if (
+        empty($otherStatement['ri_component_id']) ||
+        $otherStatement['ri_component_id'] == "NA"
+      ) {
+        $componentType = "";
+      } else {
+        $componentType = ComponentType::TYPE_MAP[
+          $otherStatement['ri_component_type']
+        ] . ": ";
+      }
+      $table->addCell($cellThirdLen)->addText(
+        $componentType . htmlspecialchars($otherStatement['ri_component_id']),
+        null, "pStyle");
     }
 
     $table->addRow($rowWidth);

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -2072,6 +2072,14 @@
   $Schema["TABLE"]["report_info"]["ri_sw360_link"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_sw360_link\" text DEFAULT 'NA'::text";
   $Schema["TABLE"]["report_info"]["ri_sw360_link"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_sw360_link\" SET NOT NULL, ALTER COLUMN \"ri_sw360_link\" SET DEFAULT 'NA'::text";
 
+  $Schema["TABLE"]["report_info"]["ri_component_type"]["DESC"] = "";
+  $Schema["TABLE"]["report_info"]["ri_component_type"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_component_type\" int4 DEFAULT 0";
+  $Schema["TABLE"]["report_info"]["ri_component_type"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_component_type\" SET NOT NULL, ALTER COLUMN \"ri_component_type\" SET DEFAULT 0";
+
+  $Schema["TABLE"]["report_info"]["ri_component_id"]["DESC"] = "";
+  $Schema["TABLE"]["report_info"]["ri_component_id"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_component_id\" text DEFAULT 'NA'::text";
+  $Schema["TABLE"]["report_info"]["ri_component_id"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_component_id\" SET NOT NULL, ALTER COLUMN \"ri_component_id\" SET DEFAULT 'NA'::text";
+
   $Schema["TABLE"]["report_info"]["ri_general_assesment"]["DESC"] = "";
   $Schema["TABLE"]["report_info"]["ri_general_assesment"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_general_assesment\" text DEFAULT 'NA'::text";
   $Schema["TABLE"]["report_info"]["ri_general_assesment"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_general_assesment\" SET NOT NULL, ALTER COLUMN \"ri_general_assesment\" SET DEFAULT 'NA'::text";

--- a/src/www/ui/template/ui-report-conf.html.twig
+++ b/src/www/ui/template/ui-report-conf.html.twig
@@ -113,6 +113,30 @@
           </td>
         </tr>
         <tr>
+          <td align="left" style="vertical-align: middle">
+            {{ "Component Id"|trans }}
+          </td>
+          <td align="left">
+            <div class="input-group" style="width:98%">
+              <div class="input-group-prepend">
+                <select class="custom-select" name="componentType">
+                  <optgroup label="Recommended">
+                    <option value="0" {% if componentType == 0 %}selected{% endif %}>purl</option>
+                  </optgroup>
+                  <optgroup label="Legacy">
+                  {%- for type in typemap ~%}
+                    <option value="{{ type.key }}"
+                    {%- if componentType == type.key %} selected{% endif -%}
+                    >{{ type.name }}</option>
+                  {%- endfor ~%}
+                  </optgroup>
+                </select>
+              </div>
+              <input type="text" class="form-control" aria-label="Component Id" name="componentId" value="{{ componentId|e }}" />
+            </div>
+          </td>
+        </tr>
+        <tr>
           <td align="left">
             {{ "General assessment"|trans }}
           </td>

--- a/src/www/ui/ui-report-conf.php
+++ b/src/www/ui/ui-report-conf.php
@@ -24,6 +24,7 @@ use Fossology\Lib\Dao\ClearingDao;
 use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Data\DecisionTypes;
 use Fossology\Lib\BusinessRules\LicenseMap;
+use Fossology\Lib\Data\Package\ComponentType;
 
 class ui_report_conf extends FO_Plugin
 {
@@ -62,6 +63,8 @@ class ui_report_conf extends FO_Plugin
     "version" => "ri_version",
     "relDate" => "ri_release_date",
     "sw360Link" => "ri_sw360_link",
+    "componentType" => "ri_component_type",
+    "componentId" => "ri_component_id",
     "footerNote" => "ri_footer",
     "generalAssesment" => "ri_general_assesment",
     "gaAdditional" => "ri_ga_additional",
@@ -72,7 +75,7 @@ class ui_report_conf extends FO_Plugin
   );
 
   /**
-   * @var radioListUR $radioListUR
+   * @var array $radioListUR
    */
   private $radioListUR = array(
     "nonCritical" => "critical",
@@ -87,7 +90,7 @@ class ui_report_conf extends FO_Plugin
   );
 
   /**
-   * @var checkBoxListSPDX $checkBoxListSPDX
+   * @var array $checkBoxListSPDX
    */
   private $checkBoxListSPDX = array(
     "spdxLicenseComment" => "spdxLicenseComment",
@@ -378,6 +381,13 @@ class ui_report_conf extends FO_Plugin
       }
     }
     $this->vars += $this->allReportConfiguration($uploadId, $groupId);
+    $this->vars['typemap'] = [];
+    foreach (ComponentType::TYPE_MAP as $key => $name) {
+      if ($key == ComponentType::PURL) {
+        continue;
+      }
+      $this->vars['typemap'][] = ['key' => $key, 'name' => $name];
+    }
   }
 
   public function getTemplateName()


### PR DESCRIPTION
## Description

Read package information (called "Component Id") and type of information from report conf page. Possible values are "purl, maven, npm, nuget and pypi". If the information is a [purl](https://github.com/package-url/purl-spec), it can be parsed to extract coordinates for Spasht agent.

The information is also presented in CLI, Unified report and SPDX RDF & Tag/Value reports.

### Changes

1. New columns `ri_component_type` and `ri_component_id` in `report_info` table.
2. New class `PurlOperations` to parse pURLs to extract ClearlyDefined coordinates.
3. New class `ComponentType` as an enum.
3. New field `ExternalRef` in SPDX reports.
4. New field `ComponentId` in CLI report.
5. New field `Component Id` in Unified report.

## How to test

1. Upload a component.
2. Edit the report conf for the component and add component id.
3. Goto Spasht agent's config page, the coordinates in search should be filled based on component id (only for purl).
4. Generate CLIXML, SPDX RDF, SPDX TV and Unified reports.
5. Change the component id type and repeat the process above.
6. There should be no warning in apache or agents.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2169"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

