### PR TITLE
feat(commit): Added commit field for the user to checkout to any commit

### DIFF
--- a/src/wget_agent/agent/wget_agent.c
+++ b/src/wget_agent/agent/wget_agent.c
@@ -1158,11 +1158,11 @@ char* GetVersionControlCommand(int withPassword)
     replace_url_with_auth();
     if (GlobalProxy[0] && GlobalProxy[0][0])
     {
-      res = asprintf(&command, "git config --global http.proxy %s && git clone %s %s %s  && rm -rf %s/.git", GlobalProxy[0], GlobalURL, GlobalParam, tmpfile_dir, tmpfile_dir);
+      res = asprintf(&command, "git config --global http.proxy %s && git clone %s %s && cd %s && git checkout %s && rm -rf %s/.git", GlobalProxy[0], GlobalURL, tmpfile_dir, tmpfile_dir, GlobalParam, tmpfile_dir);
     }
     else
     {
-      res = asprintf(&command, "git clone %s %s %s >/dev/null 2>&1 && rm -rf %s/.git", GlobalURL, GlobalParam, tmpfile_dir, tmpfile_dir);
+      res = asprintf(&command, "git clone %s %s && cd %s && git checkout %s >/dev/null 2>&1 && rm -rf %s/.git", GlobalURL, tmpfile_dir, tmpfile_dir, GlobalParam, tmpfile_dir);
     }
   }
   if (res == -1)

--- a/src/www/ui/api/Helper/UploadHelper.php
+++ b/src/www/ui/api/Helper/UploadHelper.php
@@ -287,6 +287,9 @@ class UploadHelper
     if (! array_key_exists("vcsBranch", $vcsData)) {
       $vcsData["vcsBranch"] = "";
     }
+    if (! array_key_exists("vcsCommit", $vcsData)) {
+      $vcsData["vcsCommit"] = "";
+    }
     $vcsData["vcsType"] = $vcsType;
     if ($code !== 0) {
       return array(false, $message, $statusDescription, $code);
@@ -385,6 +388,7 @@ class UploadHelper
     $vcsUsername = $vcsData["vcsUsername"];
     $vcsPasswd = $vcsData["vcsPassword"];
     $vcsBranch = $vcsData["vcsBranch"];
+    $vcsCommit = $vcsData["vcsCommit"];
 
     $symfonySession = $GLOBALS['container']->get('session');
     $symfonySession->set($this->uploadVcsPage::UPLOAD_FORM_BUILD_PARAMETER_NAME,
@@ -406,6 +410,7 @@ class UploadHelper
     $symfonyRequest->request->set('username', $vcsUsername);
     $symfonyRequest->request->set('passwd', $vcsPasswd);
     $symfonyRequest->request->set('branch', $vcsBranch);
+    $symfonyRequest->request->set('commit', $vcsCommit);
     $symfonyRequest->request->set('globalDecisions', $applyGlobal);
     $symfonyRequest->request->set('scm', $ignoreScm);
 

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1763,6 +1763,9 @@ components:
         vcsBranch:
           description: Branch to checkout for analysis (for Git only)
           type: string
+        vcsCommit:
+          description: Commit to checkout for analysis (for Git only)
+          type: string
         vcsName:
           description: Display name of the upload
           type: string

--- a/src/www/ui/page/UploadVcsPage.php
+++ b/src/www/ui/page/UploadVcsPage.php
@@ -141,12 +141,12 @@ class UploadVcsPage extends UploadPageBase
 
     $Branch = trim(explode(' ',trim($request->get('branch')))[0]);
     if (!empty($Branch) && strcasecmp($VCSType,'git') == 0) {
-      $jq_args .= $Branch;
+      $jq_args .= "--single-branch --branch $Branch ";
     }
 
     $Commit = trim(explode(' ',trim($request->get('commit')))[0]);
     if (!empty($Commit) && strcasecmp($VCSType,'git') == 0) {
-      $jq_args .= $Commit;
+      $jq_args .= "--commit $Commit ";
     }
 
     $jobqueuepk = JobQueueAdd($jobpk, "wget_agent", $jq_args, NULL, NULL);

--- a/src/www/ui/page/UploadVcsPage.php
+++ b/src/www/ui/page/UploadVcsPage.php
@@ -52,6 +52,7 @@ class UploadVcsPage extends UploadPageBase
     $vars['passwdField'] = 'passwd';
     $vars['geturlField'] = self::GETURL_PARAM;
     $vars['branchField'] = 'branch';
+    $vars['commitField'] = 'commit';
     $vars['nameField'] = 'name';
     return $this->render("upload_vcs.html.twig", $this->mergeWithDefault($vars));
   }
@@ -140,7 +141,12 @@ class UploadVcsPage extends UploadPageBase
 
     $Branch = trim(explode(' ',trim($request->get('branch')))[0]);
     if (!empty($Branch) && strcasecmp($VCSType,'git') == 0) {
-      $jq_args .= "--single-branch --branch '$Branch'";
+      $jq_args .= $Branch;
+    }
+
+    $Commit = trim(explode(' ',trim($request->get('commit')))[0]);
+    if (!empty($Commit) && strcasecmp($VCSType,'git') == 0) {
+      $jq_args .= $Commit;
     }
 
     $jobqueuepk = JobQueueAdd($jobpk, "wget_agent", $jq_args, NULL, NULL);

--- a/src/www/ui/template/upload_vcs.html.twig
+++ b/src/www/ui/template/upload_vcs.html.twig
@@ -39,6 +39,13 @@
   <input name="{{ branchField }}" type="text" size="60"/><br/>
 </li>
 <li>
+  <label for="{{ commitField }}">
+    {{ '(Optional for Git) Commit name'| trans }}:
+  </label>
+  <br/>
+  <input name="{{ commitField }}" type="text" size="60"/><br/>
+</li>
+<li>
   <label for="{{ usernameField }}">
     {{ '(Optional) Username'| trans }}:
   </label>


### PR DESCRIPTION
Signed-off-by: Thanvi pendyala [[Thanvipendyala194@gmail.com](mailto:thanvipendyala194@gmail.com)]

## Description
Fixes #1921 Issue

This change adds possibility to indicate specific git commit when uploading source code for analysis using both GUI and Rest API.

### Changes
src/wget_agent/agent/wget_agent.c - changes in agent to pass additional argument to shell command

src/www/ui/api/Helper/UploadHelper.php - changes to handle additional parameter in RestApi call and pass it to agent

src/www/ui/page/UploadVcsPage.php - changes in upload agent to handle additional request parameter from restApi and GUI

src/www/ui/template/upload_vcs.html.twig - changes in twig template to acquire commit parameter from GUI user

## How to test

RestAPI - try to pass vcsCommit param in RestApi call to checkout commit specified
GUI - pass (or not) specific commit when uploading source code for analysis from Git repository.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2170"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

