### PR TITLE
fix(api): Return full uploadId

### DIFF
--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -391,7 +391,7 @@ class UploadController extends RestController
         $info = new Info(500, $message . "\n" . $statusDescription,
           InfoType::ERROR);
       } else {
-        $uploadId = $uploadResponse[3][0];
+        $uploadId = $uploadResponse[3];
         $info = new Info(201, intval($uploadId), InfoType::INFO);
       }
       return $response->withJson($info->getArray(), $info->getCode());

--- a/src/www/ui/api/Helper/UploadHelper/HelperToUploadFilePage.php
+++ b/src/www/ui/api/Helper/UploadHelper/HelperToUploadFilePage.php
@@ -44,6 +44,10 @@ class HelperToUploadFilePage extends UploadFilePage
    */
   public function handleRequest(Request $request)
   {
-    return $this->handleUpload($request);
+    $response = $this->handleUpload($request);
+    if ($response[0]) {
+      $response[3] = $response[3][0];
+    }
+    return $response;
   }
 }

--- a/src/www/ui_tests/api/Controllers/UploadControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadControllerTest.php
@@ -580,7 +580,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     $uploadHelper->shouldReceive('createNewUpload')
       ->withArgs([null, $folderId, $uploadDescription, 'protected', 'true',
         'vcs', false])
-      ->andReturn([true, '', '', [20]]);
+      ->andReturn([true, '', '', 20]);
 
     $this->folderDao->shouldReceive('getAllFolderIds')->andReturn([2,3,4]);
     $this->folderDao->shouldReceive('isFolderAccessible')


### PR DESCRIPTION
Removed unnecessary subindex to return full uploadId instead of first digit only


## Description

When uploading a package from URL via the API, the uploadId in the response is not complete, but only the first digit. This is caused by an unnecessary "subindex", which was removed. Maybe this issue was created with a change in the database structure.

### Changes

Removed subindex for array $uploadResponse.

## How to test

This can easily be tested by checking the response for an API call as described in https://www.fossology.org/get-started/basic-rest-api-calls/ under "Upload a package".


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2174"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

