### PR TITLE
hotfix(rest): fix file upload

### DIFF
--- a/src/www/ui/api/Helper/AuthHelper.php
+++ b/src/www/ui/api/Helper/AuthHelper.php
@@ -411,10 +411,11 @@ class AuthHelper
     list ($tokenId, $userId) = explode(".", $jwtJti);
 
     $dbRows = $this->dbHelper->getTokenKey($tokenId);
-    $isTokenActive = $this->isTokenActive($dbRows, $tokenId);
     if (empty($dbRows)) {
-      $returnValue = new Info(403, "Invalid token sent.", InfoType::ERROR);
-    } elseif ($isTokenActive !== true) {
+      return new Info(403, "Invalid token sent.", InfoType::ERROR);
+    }
+    $isTokenActive = $this->isTokenActive($dbRows, $tokenId);
+    if ($isTokenActive !== true) {
       $returnValue = $isTokenActive;
     } else {
       $returnValue = true;

--- a/src/www/ui/api/Helper/UploadHelper.php
+++ b/src/www/ui/api/Helper/UploadHelper.php
@@ -174,7 +174,7 @@ class UploadHelper
       $this->uploadFilePage::DESCRIPTION_INPUT_NAME,
       [$fileDescription]);
     $symfonyRequest->files->set($this->uploadFilePage::FILE_INPUT_NAME,
-      [$symfonyFile]);
+      [$uploadedFile]);
     $symfonyRequest->setSession($symfonySession);
     $symfonyRequest->request->set(
       $this->uploadFilePage::UPLOAD_FORM_BUILD_PARAMETER_NAME, "restUpload");


### PR DESCRIPTION
## Description

Fix REST API for file upload.

### Changes

1. Rename the variable `$symfonyFile` to `$uploadedFile`.
2. Check if DB row exists before looking for value in AuthHelper.

## How to test

Create uploads from file and VCS.

Closes #2178 

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2179"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

