### PR TITLE
 fix(nomos): Improved nomos GPL detection

### DIFF
--- a/src/nomos/agent/STRINGS.in
+++ b/src/nomos/agent/STRINGS.in
@@ -5094,6 +5094,10 @@
 %KEY% =NULL=
 %STR% "with exceptions as appearing in the file LICENSE\.GPL3-EXCEPT"
 #
+%ENTRY% _LT_OPENBSD_GPL_EXCEPTION
+%KEY% =NULL=
+%STR% "contribute changes back to the authors under this freer than gpl license"
+#
 %ENTRY% _LT_QUEST_EULA
 %KEY% "so(ftware|urce)"
 %STR% "this agreement the agreement is made between quest software inc Quest and you the customer licen[cs]ee"

--- a/src/nomos/agent/parse.c
+++ b/src/nomos/agent/parse.c
@@ -8461,7 +8461,7 @@ char *gplVersion(char *filetext, int size, int isML, int isPS)
     }
     kludge.base = NULL_STR;
   }
-  if (lstr == NULL_STR && NOT_INFILE(_PHR_JYTHON_NOTGPL) && !HASTEXT(_TITLE_QT_GPL_EXCEPTION_10, 0)) {
+  if (lstr == NULL_STR && NOT_INFILE(_PHR_JYTHON_NOTGPL) && !HASTEXT(_TITLE_QT_GPL_EXCEPTION_10, 0) && !HASTEXT(_LT_OPENBSD_GPL_EXCEPTION, 0)) {
     lstr = lDebug ? "GPL(NULL)" : "GPL";
   }
   return lstr;


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

 Improved nomos GPL detection(fix false alarm)

## How to test
 Use the follow test to check this PR (Should not be detected as GPL license)

```
/* From $OpenBSD: if_enc.h,v 1.8 2001/06/25 05:14:00 angelos Exp $ */
/*
 * The authors of this code are John Ioannidis (ji@tla.org),
 * Angelos D. Keromytis (kermit@csd.uch.gr) and
 * Niels Provos (provos@physnet.uni-hamburg.de).
 *
 * This code was written by John Ioannidis for BSD/OS in Athens, Greece,
 * in November 1995.
 *
 * Ported to OpenBSD and NetBSD, with additional transforms, in December 1996,
 * by Angelos D. Keromytis.
 *
 * Additional transforms and features in 1997 and 1998 by Angelos D. Keromytis
 * and Niels Provos.
 *
 * Copyright (C) 1995, 1996, 1997, 1998 by John Ioannidis, Angelos D. Keromytis
 * and Niels Provos.
 * Copyright (c) 2001, Angelos D. Keromytis.
 *
 * Permission to use, copy, and modify this software with or without fee
 * is hereby granted, provided that this entire notice is included in
 * all copies of any software which is or includes a copy or
 * modification of this software.
 * You may use this code under the GNU public license if you so wish. Please
 * contribute changes back to the authors under this freer than GPL license
 * so that we may further the use of strong encryption without limitations to
 * all.
 *
 * THIS SOFTWARE IS BEING PROVIDED "AS IS", WITHOUT ANY EXPRESS OR
 * IMPLIED WARRANTY. IN PARTICULAR, NONE OF THE AUTHORS MAKES ANY
 * REPRESENTATION OR WARRANTY OF ANY KIND CONCERNING THE
 * MERCHANTABILITY OF THIS SOFTWARE OR ITS FITNESS FOR ANY PARTICULAR
 * PURPOSE.
 */
```


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2183"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

