### PR TITLE
hotfix(rest): fix scope for oauth

### DIFF
--- a/src/www/ui/api/Helper/AuthHelper.php
+++ b/src/www/ui/api/Helper/AuthHelper.php
@@ -328,6 +328,11 @@ class AuthHelper
       }
       $userId = $dbRows['user_fk'];
       $tokenScope = $dbRows['token_scope'];
+      if ($tokenScope == "w") {
+        $tokenScope = "write";
+      } elseif ($tokenScope == "r") {
+        $tokenScope = "read";
+      }
     } catch (\UnexpectedValueException $e) {
       return new Info(403, $e->getMessage(), InfoType::ERROR);
     }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix token scope for OAuth. Change it to `read` or `write` based on `r` and `w` values from DB, respectively.

### Changes

Change `r` to `read` and `w` to `write` for OAuth scope.

## How to test

1. Add OAuth client with read/write scope and use it for REST API authentication.
2. Create a request which is not `GET`.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2184"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

