### PR TITLE
fix(openapi.yaml): OpenAPI Description: Fixed typo in HeathInfo

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -152,13 +152,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HeathInfo'
+                $ref: '#/components/schemas/HealthInfo'
         '503':
           description: The API is not unavailable
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HeathInfo'
+                $ref: '#/components/schemas/HealthInfo'
 
   /uploads/{id}:
     parameters:
@@ -2081,7 +2081,7 @@ components:
               description: Date on which packages were built in ISO8601 format
               nullable: true
               example: "2022-01-07T11:13:00+05:30"
-    HeathInfo:
+    HealthInfo:
       description: Health status of server
       type: object
       properties:


### PR DESCRIPTION
## Description

Typo error in `openapi.yaml` file. 

### Changes Done

- heathInfo -> healthinfo

This closes the issue ( https://github.com/fossology/fossology/issues/2185)

Closes #2185 


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2189"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

