### PR TITLE
style(fossology/highlightRow): highlighted the deleted row in copyright/URL/Author/Email tables

### DIFF
--- a/src/copyright/ui/template/copyrighthist_scripts.html.twig
+++ b/src/copyright/ui/template/copyrighthist_scripts.html.twig
@@ -16,7 +16,7 @@
       },
       success: function(data) {
         $("#deleteHashDecision" + type + hash).hide();
-        $("#undoDeleteHashDecision" + type + hash).attr("style","display:inline !important;");
+        $("#undoDeleteHashDecision" + type + hash).attr("style","display:inline !important; background-color:yellow !important;");
       },
       error: function() { alert('error'); }
     });

--- a/src/copyright/ui/template/histTable.js.twig
+++ b/src/copyright/ui/template/histTable.js.twig
@@ -237,7 +237,7 @@ function delete{{ table.type }}(upload, item, hash, kind) {
     data: { id : upload + ',' + item + ',' + hash + ',' + kind },
       success: function(data) {
         $("#delete{{ table.type }}" + hash).hide();
-        $("#update{{ table.type }}" + hash).attr("style","display:inline !important;");
+        $("#update{{ table.type }}" + hash).attr("style","display:inline !important; background-color:yellow !important;");
       },
       error: function(errorResponse) {
         alert(errorResponse.responseText);

--- a/src/copyright/ui/template/ui-xp-view_rhs.html.twig
+++ b/src/copyright/ui/template/ui-xp-view_rhs.html.twig
@@ -109,7 +109,7 @@
               , uploadTreePk : '{{ itemId }}'},
         success: function(data) {
           $("#actionsOf" + pk + " .basicActions").hide();
-          $("#actionsOf" + pk + " .undoActions").attr("style","display:inline !important;");
+          $("#actionsOf" + pk + " .undoActions").attr("style","display:inline !important; background-color:yellow !important;");
         },
         error: function() { alert('error'); }
       });


### PR DESCRIPTION
Signed-off-by: Thanvi Pendyala [[thanvipendyala194@gmail.com](mailto:thanvipendyala194@gmail.com)]

## Description
Fixes issue  #797
This change highlights a part of row when the user deletes it from the copyright/ URL/ Email/Author analysis tables.

### Changes
```src/copyright/ui/template/copyrighthist_scripts.html.twig```
```src/copyright/ui/template/histTable.js.twig```
```src/copyright/ui/template/ui-xp-view_rhs.html.twig```

Added changes to highlight the row of table when user deletes it.

## How to test
1. Upload any package and do some clearing.
2. Open the copyright/ URL/ Email/Author browser.
3. Delete any row by clicking on the delete icon.

Closes #797

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2192"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

