### PR TITLE
fix(API): Fixes FossologyUI CORS error for localhost

### DIFF
--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -174,7 +174,7 @@ function Populate_sysconfig()
   $variable = "CorsOrigins";
   $prompt = _('Allowed origins for REST API');
   $desc = _('[scheme]://[hostname]:[port], "*" for anywhere');
-  $valueArray[$variable] = array("'$variable'", "'localhost:3000'", "'$prompt'",
+  $valueArray[$variable] = array("'$variable'", "'http://localhost:3000'", "'$prompt'",
     strval(CONFIG_TYPE_TEXT), "'PAT'", "3", "'$desc'", "null", "null");
 
   /*  Email */


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fixes issue #2188

### Changes
`src/lib/php/common-sysconfig.php ` - conf_value for CorsOrigins changed from 'localhost:3000' to 'http://localhost:3000'

## How to test

- Repopulate db
- Attempt to log in using fossologyUI


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2195"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

