### PR TITLE
fix(rest): Allows client ID claim to be configurable

### DIFF
--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -204,65 +204,71 @@ function Populate_sysconfig()
   $valueArray[$variable] = array("'$variable'", "null", "'$oidcPrompt'",
     strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "1", "'$oidcDesc'", "null", "null");
 
+  $variable = "OidcClientIdClaim";
+  $oidcPrompt = _('OIDC Client Id Claim');
+  $oidcDesc = _('e.g. "azp"<br>Client ID claim in the decoded payload.');
+  $valueArray[$variable] = array("'$variable'", "null", "'$oidcPrompt'",
+    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "2", "'$oidcDesc'", "null", "null");
+
   $variable = "OidcAppId";
   $oidcPrompt = _('OIDC Client Id');
   $oidcDesc = _('e.g. "e0ec21b9f4b21adc76f185962b52bdfc13af134a"<br>Client ID generated while registering your application.');
   $valueArray[$variable] = array("'$variable'", "null", "'$oidcPrompt'",
-    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "2", "'$oidcDesc'", "null", "null");
+    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "3", "'$oidcDesc'", "null", "null");
 
   $variable = "OidcSecret";
   $oidcPrompt = _('OIDC Secret');
   $oidcDesc = _('e.g. "cf13476f185b9f4b2e0ec962b52211adbdfc13aa"<br>Secret generated while registering your application.');
   $valueArray[$variable] = array("'$variable'", "null", "'$oidcPrompt'",
-    strval(CONFIG_TYPE_PASSWORD), "'OauthSupport'", "3", "'$oidcDesc'", "null", "null");
+    strval(CONFIG_TYPE_PASSWORD), "'OauthSupport'", "4", "'$oidcDesc'", "null", "null");
 
   $variable = "OidcRedirectURL";
   $oidcPrompt = _('Redirect URL');
   $oidcDesc = _('e.g. "http://fossology.application.url.com/repo"<br>URL of your fossology application.');
   $valueArray[$variable] = array("'$variable'", "null", "'$oidcPrompt'",
-    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "4", "'$oidcDesc'", "null", "null");
+    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "5", "'$oidcDesc'", "null", "null");
 
   $variable = "OidcDiscoveryURL";
   $oidcPrompt = _('OIDC Discovery URL');
   $oidcDesc = _('e.g. "http://oauth.com/.well-known/openid-configuration"<br>URL for OIDC Discovery document JSON to fill following fields upon save.');
   $valueArray[$variable] = array("'$variable'", "null", "'$oidcPrompt'",
-    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "5", "'$oidcDesc'", "null", "null");
+    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "6", "'$oidcDesc'", "null", "null");
 
   $variable = "OidcIssuer";
   $oidcPrompt = _('OIDC Token Issuer');
   $oidcDesc = _('e.g. "http://oauth.com"<br>Issuer for OIDC tokens.');
   $valueArray[$variable] = array("'$variable'", "null", "'$oidcPrompt'",
-    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "6", "'$oidcDesc'", "null", "null");
+    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "7", "'$oidcDesc'", "null", "null");
 
   $variable = "OidcAuthorizeURL";
   $oidcPrompt = _('OIDC Authorize URL');
   $oidcDesc = _('e.g. "http://oauth.com/authorization.oauth2"<br>URL for OAuth2 authorization endpoint.');
   $valueArray[$variable] = array("'$variable'", "null", "'$oidcPrompt'",
-    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "7", "'$oidcDesc'", "null", "null");
+    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "8", "'$oidcDesc'", "null", "null");
 
   $variable = "OidcAccessTokenURL";
   $oidcPrompt = _('OIDC Access Token URL');
   $oidcDesc = _('e.g. "http://oauth.com/token.oauth2"<br>URL for OAuth2 access token endpoint.');
   $valueArray[$variable] = array("'$variable'", "null", "'$oidcPrompt'",
-    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "8", "'$oidcDesc'", "null", "null");
+    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "9", "'$oidcDesc'", "null", "null");
 
   $variable = "OidcResourceURL";
   $oidcPrompt = _('OIDC User Info URL');
   $oidcDesc = _('e.g. "http://oauth.com/userinfo.oauth2"<br>URL for OAuth2 user info endpoint.');
   $valueArray[$variable] = array("'$variable'", "null", "'$oidcPrompt'",
-    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "9", "'$oidcDesc'", "null", "null");
+    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "10", "'$oidcDesc'", "null", "null");
 
   $variable = "OidcJwksURL";
   $oidcPrompt = _('OIDC JWKS URL');
   $oidcDesc = _('e.g. "http://oauth.com/jwks.oauth2"<br>URL for OIDC JWKS keys.');
   $valueArray[$variable] = array("'$variable'", "null", "'$oidcPrompt'",
-    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "10", "'$oidcDesc'", "null", "null");
+    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "11", "'$oidcDesc'", "null", "null");
 
   $variable = "OidcLogoutURL";
   $oidcPrompt = _('Logout URL');
   $oidcDesc = _('e.g. "http://oauth.com/logout.oauth2"<br>URL to redirect user to for logout.');
   $valueArray[$variable] = array("'$variable'", "null", "'$oidcPrompt'",
-    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "11", "'$oidcDesc'", "null", "null");
+    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "12", "'$oidcDesc'", "null", "null");
 
   /*  Banner Message */
   $variable = "BannerMsg";

--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -207,7 +207,7 @@ function Populate_sysconfig()
   $variable = "OidcClientIdClaim";
   $oidcPrompt = _('OIDC Client Id Claim');
   $oidcDesc = _('e.g. "azp"<br>Client ID claim in the decoded payload.');
-  $valueArray[$variable] = array("'$variable'", "null", "'$oidcPrompt'",
+  $valueArray[$variable] = array("'$variable'", "'client-id'", "'$oidcPrompt'",
     strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "2", "'$oidcDesc'", "null", "null");
 
   $variable = "OidcAppId";

--- a/src/www/ui/api/Helper/AuthHelper.php
+++ b/src/www/ui/api/Helper/AuthHelper.php
@@ -308,6 +308,7 @@ class AuthHelper
    */
   private function validateOauthLogin($jwtToken, &$userId, &$tokenScope)
   {
+    global $SysConf;
     $jwks = $this->loadJwks();
     try {
       $jwtTokenDecoded = JWT::decode(
@@ -315,7 +316,7 @@ class AuthHelper
         JWK::parseKeySet($jwks),
         ["RS256", "RS384", "RS512", "ES256"]
       );
-      $clientId = $jwtTokenDecoded->{'client_id'};
+      $clientId = $jwtTokenDecoded->{$SysConf['SYSCONFIG']['OidcClientIdClaim']};
       $tokenId = $this->dbHelper->getTokenIdFromClientId($clientId);
       $dbRows = $this->dbHelper->getTokenKey($tokenId);
 


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Closes #2204

### Changes

- `src/lib/php/common-sysconfig.php` - Added `OidcClientIdClaim` to system configuration
- `src/www/ui/api/Helper/AuthHelper.php` - Replaced `client_id` with `$SysConf['SYSCONFIG']['OidcClientIdClaim']`

## How to test

- Repopulate db
- Go to "Admin > Customize" in Fossology and edit OIDC Client Id Claim


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2205"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

