### PR TITLE
fix(rest): fix CORS issue

### DIFF
--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -174,7 +174,7 @@ function Populate_sysconfig()
   $variable = "CorsOrigins";
   $prompt = _('Allowed origins for REST API');
   $desc = _('[scheme]://[hostname]:[port], "*" for anywhere');
-  $valueArray[$variable] = array("'$variable'", "'http://localhost:3000'", "'$prompt'",
+  $valueArray[$variable] = array("'$variable'", "'*'", "'$prompt'",
     strval(CONFIG_TYPE_TEXT), "'PAT'", "3", "'$desc'", "null", "null");
 
   /*  Email */

--- a/src/www/ui/api/Middlewares/RestAuthMiddleware.php
+++ b/src/www/ui/api/Middlewares/RestAuthMiddleware.php
@@ -105,7 +105,6 @@ class RestAuthMiddleware
       ->withHeader('Access-Control-Allow-Origin', $SysConf['SYSCONFIG']['CorsOrigins'])
       ->withHeader('Access-Control-Expose-Headers', 'Look-at, X-Total-Pages, Retry-After')
       ->withHeader('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Authorization, action, active, copyright, Content-Type, description, filename, filesizemax, filesizemin, folderDescription, folderId, folderName, groupName, ignoreScm, applyGlobal, license, limit, name, page, parent, parentFolder, public, reportFormat, searchType, tag, upload, uploadDescription, uploadId, uploadType')
-      ->withHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS')
-      ->withHeader('Access-Control-Allow-Credentials', 'true');
+      ->withHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS');
   }
 }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The header 'Access-Control-Allow-Credentials' is used to expose credentials from JavaScript from other domains as well ([reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials)) which is not required for the application. By removing the header from CORS middleware, the allowed origin can be marked as '*'.

### Changes

1. Remove the `Access-Control-Allow-Credentials` header from REST middleware.
2. Set default value for `Access-Control-Allow-Origin` as `*`.

## How to test

1. Install the new branch and install the [FOSSologyUI project](https://github.com/fossology/FOSSologyUI).
2. Setup the correct endpoint in `.env` (`localhost/repo/api/v1`).
3. Test if using UI causes any CORS issues.

Closes https://github.com/fossology/FOSSologyUI/issues/202

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2207"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

