### PR TITLE
fix(default_group): exposed deafult_group in /users/self

### DIFF
--- a/src/www/ui/api/Controllers/UserController.php
+++ b/src/www/ui/api/Controllers/UserController.php
@@ -27,6 +27,7 @@ use Fossology\UI\Api\Helper\ResponseHelper;
 use Psr\Http\Message\ServerRequestInterface;
 use Fossology\UI\Api\Models\Info;
 use Fossology\UI\Api\Models\InfoType;
+use Fossology\Lib\Dao\UserDao;
 
 /**
  * @class UserController
@@ -90,7 +91,10 @@ class UserController extends RestController
    */
   public function getCurrentUser($request, $response, $args)
   {
-    $user = $this->dbHelper->getUsers($this->restHelper->getUserId());
-    return $response->withJson($user[0], 200);
+    $user = $this->dbHelper->getUsers($this->restHelper->getUserId())[0];
+    $userDao = $this->restHelper->getUserDao();
+    $defaultGroup = $userDao->getUserAndDefaultGroupByUserName($user["name"])["group_name"];
+    $user["default_group"] = $defaultGroup;
+    return $response->withJson($user, 200);
   }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -750,7 +750,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                allOf:
+                  - $ref: '#/components/schemas/User'
+                  - type: object
+                    properties:
+                      default_group:
+                        type: string
+                        description: Default group of the user
+                        example:
+                          "fossy"        
         default:
           $ref: '#/components/responses/defaultResponse'
   /jobs:

--- a/src/www/ui_tests/api/Controllers/UserControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UserControllerTest.php
@@ -34,6 +34,7 @@ use Fossology\UI\Api\Models\User;
 use Fossology\UI\Api\Models\Info;
 use Fossology\UI\Api\Models\InfoType;
 use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\Lib\Dao\UserDao;
 
 /**
  * @class UserControllerTest
@@ -70,8 +71,11 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
     $container = M::mock('ContainerBuilder');
     $this->dbHelper = M::mock(DbHelper::class);
     $this->restHelper = M::mock(RestHelper::class);
+    $this->userDao = M::mock(UserDao::class);
 
     $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+    $this->restHelper->shouldReceive('getUserDao')
+      ->andReturn($this->userDao);  
 
     $container->shouldReceive('get')->withArgs(array(
       'helper.restHelper'))->andReturn($this->restHelper);
@@ -240,10 +244,13 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
   {
     $userId = 2;
     $user = $this->getUsers([$userId]);
+    $user[0]["default_group"] = "fossy";
     $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
     $this->dbHelper->shouldReceive('getUsers')->withArgs([$userId])
       ->andReturn($user);
     $expectedResponse = (new ResponseHelper())->withJson($user[0], 200);
+    $this->userDao->shouldReceive('getUserAndDefaultGroupByUserName')->withArgs([$user[0]["name"]])
+      ->andReturn(["group_name" => "fossy"]);
     $actualResponse = $this->userController->getCurrentUser(null,
       new ResponseHelper(), []);
     $this->assertEquals($expectedResponse->getStatusCode(),


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Exposed `default_group` in endpoint `/api/v1/users/self`. Closes #2208. This in regards to the discussion I and @GMishx had on thread [#199](https://github.com/fossology/FOSSologyUI/pull/199#issuecomment-1089839237).

### Changes

Edited `UserController.php` for exposing key and `openapi.yaml` for updating documentation.

## How to test

Send GET request to endpoint `/api/v1/users/self`

Closes #2208
Closes #2054

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2209"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

