### PR TITLE
fix(copyright): do not update empty copyrights

### DIFF
--- a/install/db/Makefile
+++ b/install/db/Makefile
@@ -36,6 +36,7 @@ install: all
 	$(INSTALL_DATA) dbmigrate_3.5-3.6.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.5-3.6.php
 	$(INSTALL_DATA) dbmigrate_3.6-3.7.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.6-3.7.php
 	$(INSTALL_DATA) dbmigrate_3.7-3.8.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_3.7-3.8.php
+	$(INSTALL_DATA) dbmigrate_4.0-4.1.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_4.0-4.1.php
 	$(INSTALL_DATA) dbmigrate_copyright-event.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_copyright-event.php
 	$(INSTALL_DATA) dbmigrate_clearing-event.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_clearing-event.php
 	$(INSTALL_DATA) dbmigrate_real-parent.php $(DESTDIR)$(LIBEXECDIR)/dbmigrate_real-parent.php

--- a/install/db/dbmigrate_4.0-4.1.php
+++ b/install/db/dbmigrate_4.0-4.1.php
@@ -1,0 +1,129 @@
+<?php
+/***********************************************************
+ Copyright (C) 2022 Siemens AG
+ Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***********************************************************/
+
+/**
+ * @file
+ * @brief Migrate DB from release 4.0.0 to 4.1.0
+ */
+
+use Fossology\Lib\Db\DbManager;
+
+/**
+ * Tables which needs to be processed
+ * @var array PROCESS_TABLES
+ */
+const PROCESS_TABLES = array(
+  "copyright",
+  "author",
+  "ecc",
+  "keyword",
+  "copyright_event",
+  "author_event",
+  "ecc_event",
+  "keyword_event"
+);
+
+/**
+ * Total number of records to be migirated by script.
+ * @var int $MIG_4041_TOTAL_RECORDS
+ */
+$GLOBALS['MIG_4041_TOTAL_RECORDS'] = 0;
+
+/**
+ * Check if migration is required.
+ * @param DbManager $dbManager
+ * @return boolean True if migration is required, false otherwise
+ */
+function checkMigrate4041Required($dbManager)
+{
+  global $MIG_4041_TOTAL_RECORDS;
+  if ($dbManager == NULL) {
+    echo "No connection object passed!\n";
+    return false;
+  }
+
+  $migRequired = true;
+  foreach (PROCESS_TABLES as $table) {
+    if (DB_TableExists($table) != 1) {
+      $migRequired = false;
+      break;
+    }
+  }
+  if ($migRequired) {
+    $count = 0;
+    foreach (PROCESS_TABLES as $table) {
+      $sql = "SELECT count(*) AS cnt FROM $table " .
+        "WHERE hash = 'd41d8cd98f00b204e9800998ecf8427e';"; // hash = md5('')
+      $result = $dbManager->getSingleRow($sql, [],
+        __METHOD__ . ".checkMig." . $table);
+      $count += intval($result['cnt']);
+    }
+    $MIG_4041_TOTAL_RECORDS = $count;
+    if ($count == 0) {
+      $migRequired = false;
+    }
+  }
+
+  return $migRequired;
+}
+
+/**
+ * Start the recoding process
+ * @param DbManager $dbManager
+ * @return number Return code
+ */
+function fixEmptyContentHash($dbManager)
+{
+  global $MIG_4041_TOTAL_RECORDS;
+  $updated = 0;
+  foreach (PROCESS_TABLES as $table) {
+    $sql = "WITH temp_h AS (" .
+      "UPDATE $table SET " .
+        "content = NULL, hash = NULL " .
+      "WHERE (" .
+        "hash = 'd41d8cd98f00b204e9800998ecf8427e' OR content = ''" .
+      ") RETURNING 1 AS c) " .
+      "SELECT sum(c) AS cnt FROM temp_h;";
+    $statement = __METHOD__ . ".fixHash." . $table;
+    $dbManager->begin();
+    $result = $dbManager->getSingleRow($sql, [], $statement);
+    $dbManager->commit();
+    $updated += intval($result['cnt']);
+  }
+  echo "*** Corrected hash of $updated/$MIG_4041_TOTAL_RECORDS entries from " .
+    count(PROCESS_TABLES) . " tables ***\n";
+}
+
+/**
+ * Migration from FOSSology 4.0.0 to 4.1.0
+ * @param DbManager $dbManager
+ */
+function Migrate_40_41($dbManager)
+{
+  if (!checkMigrate4041Required($dbManager)) {
+    // Migration not required
+    return;
+  }
+  try {
+    fixEmptyContentHash($dbManager);
+  } catch (Exception $e) {
+    echo "Something went wrong. Try running postinstall again!\n";
+    $dbManager->rollback();
+  }
+}

--- a/install/db/instance_uuid.php
+++ b/install/db/instance_uuid.php
@@ -51,5 +51,5 @@ COMMIT;
 
  }
 
-echo "*** Instance UUID ***";
+echo "*** Instance UUID ***\n";
 CreateInstanceUUIDTable($dbManager);

--- a/install/fossinit.php
+++ b/install/fossinit.php
@@ -414,6 +414,10 @@ require_once("$LIBEXECDIR/instance_uuid.php");
 require_once("$LIBEXECDIR/dbmigrate_3.7-3.8.php");
 Migrate_37_38($dbManager, $MODDIR);
 
+// Migration script for 4.0 => 4.1
+require_once("$LIBEXECDIR/dbmigrate_4.0-4.1.php");
+Migrate_40_41($dbManager);
+
 // Migration script for copyright_event table
 require_once("$LIBEXECDIR/dbmigrate_copyright-event.php");
 createCopyrightMigrationForCopyrightEvents($dbManager);

--- a/src/copyright/ui/ajax-copyright-hist.php
+++ b/src/copyright/ui/ajax-copyright-hist.php
@@ -486,9 +486,10 @@ count(*) AS copyright_count " .
   protected function doUpdate($itemId, $hash, $type)
   {
     $content = GetParm("value", PARM_RAW);
-    if (!$content)
+    if (empty($content))
     {
-      return new Response('empty content not allowed', Response::HTTP_BAD_REQUEST ,array('Content-type'=>'text/plain'));
+      return new Response('empty content not allowed',
+        Response::HTTP_BAD_REQUEST ,array('Content-type'=>'text/plain'));
     }
 
     $item = $this->uploadDao->getItemTreeBounds($itemId, $this->uploadtree_tablename);

--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -115,6 +115,9 @@ class CopyrightDao
                                $description, $textFinding, $comment, $decision_pk=-1)
   {
     $textFinding = StringOperation::replaceUnicodeControlChar($textFinding);
+    if (empty($textFinding)) {
+      return;
+    }
     $primaryColumn = $tableName . '_pk';
     $assocParams = array(
       'user_fk' => $userId,


### PR DESCRIPTION
## Description

Do not update the hash of copyrights where content is empty in `3.7-3.8` migration.
Empty/NULL content and hash are used to denote no copyrights found situations.
The migration script updates the hash which causes multiple collisions due to same hash.
(Same applies for ecc/keyword/author).

Add new migration script `dbmigrate_4.0-4.1.php` to revert content and hash to `NULL` if the hash was updated to `md5('')`.

### Changes

1. Update 3.7-3.8 script to exclude copyright where content is NULL or empty.
2. Add new script 4.0-4.1 to update content and hash of copyright where hash was `md5('') => d41d8cd98f00b204e9800998ecf8427e`.
3. Updated `ajax-copyright-hist.php` to use `empty()` instead of `!` to detect empty strings.

## How to test

1. On an existing server with copyright findings, run the installation of master branch.
    - Copyrights where content is empty will get hash `d41d8cd98f00b204e9800998ecf8427e`.
2. Install the branch
    - Copyrights where content is empty/null should have null hash as well.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2212"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

