### PR TITLE
chore(component-id): use package-url instead purl

### DIFF
--- a/src/clixml/agent/clixml.php
+++ b/src/clixml/agent/clixml.php
@@ -278,7 +278,6 @@ class CliXml extends Agent
       'organisation' => '',
       'componentHash' => strtolower($componentHash['sha1']),
       'contents' => $contents,
-      'packageIds' => $packageIds,
       'commentAdditionalNotes' => $notes,
       'externalIdLink' => htmlspecialchars($otherStatement['ri_sw360_link']),
       'generalInformation' => $generalInformation,

--- a/src/lib/php/Dao/SpashtDao.php
+++ b/src/lib/php/Dao/SpashtDao.php
@@ -214,7 +214,10 @@ class SpashtDao
     if (
       empty($compRow) || empty($compRow['ri_component_id'])
       || $compRow['ri_component_id'] == "NA"
-      || $compRow['ri_component_type'] != ComponentType::PURL
+      || (
+        $compRow['ri_component_type'] != ComponentType::PURL
+        && $compRow['ri_component_type'] != ComponentType::PACKAGEURL
+        )
     ) {
       return null;
     }

--- a/src/lib/php/Data/Package/ComponentType.php
+++ b/src/lib/php/Data/Package/ComponentType.php
@@ -46,6 +46,11 @@ class ComponentType
    */
   const PYPI = 4;
   /**
+   * @var int PACKAGEURL
+   * Component Type package-url
+   */
+  const PACKAGEURL = 5;
+  /**
    * @var array TYPE_MAP
    * Corresponding type name for id
    */
@@ -54,6 +59,7 @@ class ComponentType
     self::MAVEN => 'maven',
     self::NUGET => 'nuget',
     self::NPM => 'npm',
-    self::PYPI => 'pypi'
+    self::PYPI => 'pypi',
+    self::PACKAGEURL => 'package-url'
   ];
 }

--- a/src/lib/php/Report/ObligationsGetter.php
+++ b/src/lib/php/Report/ObligationsGetter.php
@@ -158,6 +158,7 @@ class ObligationsGetter
    */
   function contentOnly($licenseStatements)
   {
+    $licenseId = [];
     foreach ($licenseStatements as $licenseStatement) {
       $licenseId[] = $licenseStatement["licenseId"];
     }

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -357,6 +357,8 @@ class SpdxTwoAgent extends Agent
     }
     if ($componentType == ComponentType::MAVEN) {
       $componentType = "maven-central";
+    } elseif ($componentType == ComponentType::PACKAGEURL) {
+      $componentType = "purl";
     } else {
       $componentType = ComponentType::TYPE_MAP[$componentType];
     }

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -2010,7 +2010,7 @@
 
   $Schema["TABLE"]["users"]["upload_visibility"]["DESC"] = "COMMENT ON COLUMN \"users\".\"upload_visibility\" IS 'Default Visibility for uploads by the user'";
   $Schema["TABLE"]["users"]["upload_visibility"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"upload_visibility\" text";
-  $Schema["TABLE"]["users"]["upload_visibility"]["ALTER"] = "ALTER TABLE \"users\" ALTER COLUMN \"upload_visibility\" DROP NOT NULL";  
+  $Schema["TABLE"]["users"]["upload_visibility"]["ALTER"] = "ALTER TABLE \"users\" ALTER COLUMN \"upload_visibility\" DROP NOT NULL";
 
   $Schema["TABLE"]["users"]["user_agent_list"]["DESC"] = "COMMENT ON COLUMN \"users\".\"user_agent_list\" IS 'list of user agents to automatically run on upload'";
   $Schema["TABLE"]["users"]["user_agent_list"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"user_agent_list\" text";
@@ -2077,8 +2077,8 @@
   $Schema["TABLE"]["report_info"]["ri_sw360_link"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_sw360_link\" SET NOT NULL, ALTER COLUMN \"ri_sw360_link\" SET DEFAULT 'NA'::text";
 
   $Schema["TABLE"]["report_info"]["ri_component_type"]["DESC"] = "";
-  $Schema["TABLE"]["report_info"]["ri_component_type"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_component_type\" int4 DEFAULT 0";
-  $Schema["TABLE"]["report_info"]["ri_component_type"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_component_type\" SET NOT NULL, ALTER COLUMN \"ri_component_type\" SET DEFAULT 0";
+  $Schema["TABLE"]["report_info"]["ri_component_type"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_component_type\" int4 DEFAULT 5";
+  $Schema["TABLE"]["report_info"]["ri_component_type"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_component_type\" SET NOT NULL, ALTER COLUMN \"ri_component_type\" SET DEFAULT 5";
 
   $Schema["TABLE"]["report_info"]["ri_component_id"]["DESC"] = "";
   $Schema["TABLE"]["report_info"]["ri_component_id"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_component_id\" text DEFAULT 'NA'::text";

--- a/src/www/ui/template/ui-report-conf.html.twig
+++ b/src/www/ui/template/ui-report-conf.html.twig
@@ -121,7 +121,7 @@
               <div class="input-group-prepend">
                 <select class="custom-select" name="componentType">
                   <optgroup label="Recommended">
-                    <option value="0" {% if componentType == 0 %}selected{% endif %}>purl</option>
+                    <option value="5" {% if componentType == 5 %}selected{% endif %}>package-url</option>
                   </optgroup>
                   <optgroup label="Legacy">
                   {%- for type in typemap ~%}

--- a/src/www/ui/ui-report-conf.php
+++ b/src/www/ui/ui-report-conf.php
@@ -383,7 +383,7 @@ class ui_report_conf extends FO_Plugin
     $this->vars += $this->allReportConfiguration($uploadId, $groupId);
     $this->vars['typemap'] = [];
     foreach (ComponentType::TYPE_MAP as $key => $name) {
-      if ($key == ComponentType::PURL) {
+      if ($key == ComponentType::PACKAGEURL) {
         continue;
       }
       $this->vars['typemap'][] = ['key' => $key, 'name' => $name];


### PR DESCRIPTION
## Description

Use component id "package-url" instead of purl as recommended value. It is added at index 5 and also is now the default value in database.

For SPDX reports, it is changed back to purl to be conformant with spec.

### Changes

1. Add new ComponentType::PACKAGEURL
2. Treat ComponentType::PACKAGEURL and ComponentType::PURL same in spasht and SPDX
3. Change default value of 'ri_component_type' from 0 to 5 in 'report_info' table.

## How to test

1. On existing packages with component ID set to purl, there should be no effect.
2. `purl` should now appear in "Legacy" section of Report Config page.
3. `package-url` should be "Recommended" in Report Config.
4. Changing `purl` to `package-url` in config should have no effect on SPDX reports. Spasht should not throw errors. Only CLIXML should have `package-url` in `<ComponentId><Type>`.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2217"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

