### PR TITLE
fix(scancode): move python dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ COPY ./src/mimetype/mod_deps ./src/mimetype/
 COPY ./src/nomos/mod_deps ./src/nomos/
 COPY ./src/ojo/mod_deps ./src/ojo/
 COPY ./src/pkgagent/mod_deps ./src/pkgagent/
+COPY ./src/scancode/mod_deps ./src/scancode/
 COPY ./src/scheduler/mod_deps ./src/scheduler/
 COPY ./src/ununpack/mod_deps ./src/ununpack/
 COPY ./src/wget_agent/mod_deps ./src/wget_agent/
@@ -77,8 +78,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
       python3-pip \
  && python3 -m pip install pip==21.2.2 \
  && DEBIAN_FRONTEND=noninteractive /fossology/utils/fo-installdeps --offline --runtime -y \
- && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \
- && rm -rf /var/lib/apt/lists/*
+ && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y
 
 # configure php
 COPY ./install/scripts/php-conf-fix.sh ./install/scripts/php-conf-fix.sh
@@ -98,4 +98,6 @@ COPY --from=builder /etc/init.d/fossology /etc/init.d/fossology
 COPY --from=builder /usr/local/ /usr/local/
 
 # the database is filled in the entrypoint
-RUN /usr/local/lib/fossology/fo-postinstall --agent --common --scheduler-only --web-only --no-running-database --python-experimental
+RUN /usr/local/lib/fossology/fo-postinstall --agent --common --scheduler-only \
+     --web-only --no-running-database --python-experimental \
+ && rm -rf /var/lib/apt/lists/*

--- a/install/fo-install-pythondeps
+++ b/install/fo-install-pythondeps
@@ -146,11 +146,11 @@ if [[ $RUNTIME && -z "$DEBIAN" ]]; then
   case "$DISTRO" in
     Debian|Ubuntu)
       apt-get $YesOpt install \
-        python3 python3-pip
+        python3 python3-pip python3-dev
       ;;
     Fedora|RedHatEnterprise*|CentOS)
       yum $YesOpt install \
-        python3-pip
+        python3-pip python3-devel
       ;;
     *) echo "ERROR: distro not recognised, please fix and send a patch"; exit 1;;
   esac
@@ -160,11 +160,19 @@ if [[ $RUNTIME ]]; then
     su $TARGETUSER -c 'mkdir -p $HOME/pythondeps && touch $HOME/.bashrc'
     su $TARGETUSER -c 'grep -qF pythondeps $HOME/.bashrc || printf "export PATH=\"$PATH:$HOME/pythondeps/bin\"\nexport PYTHONPATH=\"$HOME/pythondeps\"" >> $HOME/.bashrc'
     ###########################################################################
-    # Experimental dependencies
+    # Install pip dependencies together.
+    # Using --target causes conflict in bin dir, using --upgrade overwrites it.
+    # See https://github.com/pypa/pip/issues/8063
+    # Dependencies for scancode
+    su $TARGETUSER -c 'python3 -m pip install --target=$HOME/pythondeps --no-input setuptools wheel'
+    ###########################################################################
     if [[ $EXPERIMENTAL ]]; then
-      # Dependencies for decider
-      su $TARGETUSER -c 'python3 -m pip install --target=$HOME/pythondeps --no-input spacy pandas'
+      # Include experimental dependencies
+      su $TARGETUSER -c 'PYTHONPATH="$HOME/pythondeps" python3 -m pip install --target=$HOME/pythondeps --no-input --upgrade spacy pandas scancode-toolkit'
       su $TARGETUSER -c 'PYTHONPATH="$HOME/pythondeps" python3 -m spacy download en_core_web_sm --target=$HOME/pythondeps'
+    else
+      # Only non-experimental dependencies
+      su $TARGETUSER -c 'PYTHONPATH="$HOME/pythondeps" python3 -m pip install --target=$HOME/pythondeps --no-input --upgrade scancode-toolkit'
     fi
     ###########################################################################
   else

--- a/src/scancode/agent/scancode_wrapper.cc
+++ b/src/scancode/agent/scancode_wrapper.cc
@@ -1,16 +1,16 @@
 /*****************************************************************************
  * SPDX-License-Identifier: GPL-2.0
  * SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -22,10 +22,10 @@
 
 /**
  * @brief convertes start line to start byte of the matched text
- * 
- * count number of characters before start line and add it to the 
+ *
+ * count number of characters before start line and add it to the
  * characters before the matched text in the start line.
- * 
+ *
  * @param filename name of the file uploaded
  * @param start_line  start line of the matched text by scancode
  * @param match_text  text inthe codefile matched by scancode
@@ -41,7 +41,7 @@ unsigned getFilePointer(const string &filename, size_t start_line,
     }
     unsigned int file_p = checkfile.tellg();
     getline(checkfile, str);
-    unsigned int pos = str.find(match_text); 
+    unsigned int pos = str.find(match_text);
     if (pos != string::npos) {
       return file_p + pos;
     }else{
@@ -53,34 +53,41 @@ unsigned getFilePointer(const string &filename, size_t start_line,
 
 
 /**
- * @brief scan file with scancode-toolkit 
- * 
+ * @brief scan file with scancode-toolkit
+ *
  * using cli command for custom template
  * scancode <scancode flags> --custom-output <output> --custom-template scancode_template.html <input>
  * scancode is a parametric agent, depending upon user's choice flags will be set.
  * -l flag scans for license
  * -c flag scans for copyright and holder
- * license score in ScanCode is percentage and 
+ * license score in ScanCode is percentage and
  * copyright holder in scancode is author in FOSSology
- * The option --license-text is a sub-option of and requires the option --license, it provides the text 
+ * The option --license-text is a sub-option of and requires the option --license, it provides the text
  * in the upload file matched with the scancode license rule.
  * custom template provide only those information which
  * user wants to see.
  * --quiet helps to remove summary and/or progress message
- * 
+ *
  * @param state  an object of class State which can provide agent Id and CliOptions
  * @param file  code/binary file sent by scheduler
  * @return scanned data output on success, null otherwise
- * 
+ *
  * @see https://scancode-toolkit.readthedocs.io/en/latest/cli-reference/list-options.html#all-basic-scan-options
  */
 string scanFileWithScancode(const State &state, const fo::File &file) {
 
   FILE *in;
   char buffer[512];
+  string projectUser = fo_config_get(sysconfig, "DIRECTORIES", "PROJECTUSER",
+    NULL);
+  string cacheDir = fo_config_get(sysconfig, "DIRECTORIES", "CACHEDIR",
+    NULL);
 
   string command =
-      "scancode -" + state.getCliOptions() +
+      "PYTHONPATH='/home/" + projectUser + "/pythondeps/' " +
+      "SCANCODE_CACHE=" + cacheDir + "/scancode " + // Use fossology's cache
+      "/home/" + projectUser + "/pythondeps/bin/scancode -" +
+      state.getCliOptions() +
       " --custom-output - --custom-template scancode_template.html " +
       file.getFileName() + " --quiet " +
       ((state.getCliOptions().find('l') != string::npos) ? " --license-text --license-score " + to_string(MINSCORE): "");
@@ -106,7 +113,7 @@ return result;
 
 /**
  * @brief extract data from scancode scanned result
- * 
+ *
  * In licenses array:
  * key-> license spdx key
  * score-> score of a rule to matched with the output licenes
@@ -114,8 +121,8 @@ return result;
  * text_url-> license text reference url
  * matched_text-> text in code file matched for the license
  * start_line-> matched text start line
- * 
- * Incase there is no license found by scancode, 
+ *
+ * Incase there is no license found by scancode,
  * FOSSology has "No_license_found" license short name.
  *
  * In copyright array:
@@ -146,7 +153,7 @@ map<string, vector<Match>> extractDataFromScancodeResult(const string& scancodeR
     }
     else
     {
-      for (unsigned int i = 0; i < licensearrays.size(); i++) 
+      for (unsigned int i = 0; i < licensearrays.size(); i++)
       {
           Json::Value oneresult = licensearrays[i];
           string licensename = oneresult["key"].asString();

--- a/src/scancode/mod_deps
+++ b/src/scancode/mod_deps
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 
 ##############################################################################
-# SPDX-License-Identifier: GPL-2.0 
-# SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com> 
+# SPDX-License-Identifier: GPL-2.0
+# SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>
 #
-# This program is free software; you can redistribute it and/or 
-# modify it under the terms of the GNU General Public License 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
 # version 2 as published by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
@@ -78,24 +78,22 @@ if [[ $BUILDTIME ]]; then
   case "$DISTRO" in
     Debian|Ubuntu)
       apt-get $YesOpt install \
-        python3 python3-pip \
-        python3-dev libbz2-1.0 xz-utils zlib1g libxml2-dev libxslt1-dev libpopt0
+        libboost-program-options-dev libjsoncpp-dev \
+        libbz2-1.0 xz-utils zlib1g libxml2-dev libxslt1-dev libpopt0
       ;;
     Fedora)
       yum $YesOpt install \
-        python3 python3-pip \
-        python3-devel xz-libs zlib libxml2-devel libxslt-devel bzip2-libs libpopt0
+        boost-devel jsoncpp-devel \
+        xz-libs zlib libxml2-devel libxslt-devel bzip2-libs libpopt0
       ;;
     RedHatEnterprise*|CentOS)
       yum $YesOpt install epel-release;
       yum $YesOpt install \
-        rh-python3 python3-pip \
-        python3-devel zlib bzip2-libs xz-libs libxml2-devel libxslt-devel libpopt0
+        boost-devel jsoncpp-devel \
+        zlib bzip2-libs xz-libs libxml2-devel libxslt-devel libpopt0
       ;;
     *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
   esac
-  python3 -m pip install --upgrade pip setuptools wheel
-  python3 -m pip install scancode-toolkit
 fi
 
 if [[ $RUNTIME ]]; then
@@ -103,25 +101,35 @@ if [[ $RUNTIME ]]; then
   case "$DISTRO" in
     Debian|Ubuntu)
       apt-get $YesOpt install \
-        python3 python3-pip \
-        python3-dev libbz2-1.0 xz-utils zlib1g libxml2-dev libxslt1-dev libpopt0
-        ;;
+        libbz2-1.0 xz-utils zlib1g libxml2-dev libxslt1-dev libpopt0
+      case "$CODENAME" in
+        stretch)
+          apt-get $YesOpt install libjsoncpp1 libboost-program-options1.62.0;;
+        buster)
+          apt-get $YesOpt install libjsoncpp1 libboost-program-options1.67.0;;
+        bullseye)
+          apt-get $YesOpt install libjsoncpp24 libboost-program-options1.74.0;;
+        bionic)
+          apt-get $YesOpt install libjsoncpp1 libboost-program-options1.65.1;;
+        sid)
+          apt-get $YesOpt install libjsoncpp1 libboost-program-options1.74.0;;
+        focal)
+          apt-get $YesOpt install libjsoncpp1 libboost-program-options1.71.0;;
+        *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
+      esac;;
     Fedora)
       yum $YesOpt install \
-        python3 python3-pip \
-        python3-devel xz-libs zlib libxml2-devel libxslt-devel bzip2-libs libpopt0
+        jsoncpp boost \
+        xz-libs zlib libxml2-devel libxslt-devel bzip2-libs libpopt0
       ;;
     RedHatEnterprise*|CentOS)
       yum $YesOpt install epel-release;
       yum $YesOpt install \
-        rh-python3 python3-pip \
-        python3-devel zlib bzip2-libs xz-libs libxml2-devel libxslt-devel libpopt0
+        jsoncpp boost \
+        zlib bzip2-libs xz-libs libxml2-devel libxslt-devel libpopt0
       ;;
     *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
   esac
-  python3 -m pip install --upgrade pip setuptools wheel
-  python3 -m pip install scancode-toolkit
-
 fi
 
 #######################################################################

--- a/src/scancode/ui/agent-scancode.php
+++ b/src/scancode/ui/agent-scancode.php
@@ -2,16 +2,16 @@
 /*****************************************************************************
  * SPDX-License-Identifier: GPL-2.0
  * SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -57,27 +57,27 @@ class ScancodesAgentPlugin extends AgentPlugin
 
   /**
    * @brief Schedule scancode agent
-   * 
+   *
    * flags:
    * l-> license,
    * r-> copyright,
    * e-> email,
    * u->url
-   * 
+   *
    * @param int $jobId  schedule Job Id which has to add
-   * @param int $uploadId     Uploaded pfile Id 
+   * @param int $uploadId     Uploaded pfile Id
    * @param string $errorMsg  Erraor message which has to be dispalyed
-   * @param Request $request  Session request in html 
-   * @return int  $jobQueueId jq_pk of scheduled jobqueue or 0 if not scheduled 
+   * @param Request $request  Session request in html
+   * @return int  $jobQueueId jq_pk of scheduled jobqueue or 0 if not scheduled
    */
   public function scheduleAgent($jobId, $uploadId, &$errorMsg, $request)
   {
     $dependencies = array();
     $flags = $request->get('scancodeFlags') ?: array();
     $scanMode = '';
-    foreach ($flags as $flag) 
+    foreach ($flags as $flag)
     {
-      switch ($flag) 
+      switch ($flag)
       {
         case "license":
           $scanMode .= 'l';
@@ -98,7 +98,7 @@ class ScancodesAgentPlugin extends AgentPlugin
       return 0;
     }
     $unpackArgs = intval(@$_POST['scm']) == 1 ? 'I' : '';
-    if (!empty($unpackArgs)) 
+    if (!empty($unpackArgs))
     {
       $dependencies[] = 'agent_mimetype';
       $scanMode .= $unpackArgs;
@@ -106,7 +106,7 @@ class ScancodesAgentPlugin extends AgentPlugin
     $args = self::SCAN_FLAG.$scanMode;
     return parent::AgentAdd($jobId, $uploadId, $errorMsg, array_unique($dependencies) , $args);
   }
-  
+
   /**
    * @copydoc Fossology::Lib::Plugin::AgentPlugin::AgentHasResults()
    * @see Fossology::Lib::Plugin::AgentPlugin::AgentHasResults()
@@ -115,7 +115,7 @@ class ScancodesAgentPlugin extends AgentPlugin
   {
     return CheckARS($uploadId, $this->AgentName, "scancode agent", "scancode_ars");
   }
-  
+
   /**
    * Check if agent already included in the dependency list
    * @param mixed  $dependencies Array of job dependencies
@@ -143,6 +143,21 @@ class ScancodesAgentPlugin extends AgentPlugin
   {
     menu_insert("ParmAgents::" . $this->Title, 0, $this->Name);
   }
+
+  /**
+   * Is scancode-toolkit installed on the system?
+   *
+   * Checks if scancode executable exists
+   */
+  public function isScanCodeInstalled()
+  {
+    global $SysConf;
+    return file_exists("/home/" .
+      $SysConf['DIRECTORIES']['PROJECTUSER'] . "/pythondeps/bin/scancode");
+  }
 }
 
-register_plugin(new ScancodesAgentPlugin());
+$scanCode = new ScancodesAgentPlugin();
+if ($scanCode->isScanCodeInstalled()) {
+  register_plugin($scanCode);
+}


### PR DESCRIPTION
## Description

Move scancode's dependencies from `mod_deps` to `fo-install-pythondeps`.

Also, do not install scancode's UI if executable is not installed on the system.

### Changes

1. Move Python dependencies of scancode agent to `fo-install-pythondeps`.
2. Rearrange how Python dependencies install to call `pip install` only once.
  - See https://github.com/pypa/pip/issues/8063 for the issue (`bin` folder is replaced by each install).
3. Use FOSSology' cache explicitly for scancode (default is `~/.cache` which can resolve to `/root/.cache`).
4. Check if `scancode` executable exists before installing agent's UI.

## How to test

1. On a clean system, install branch from scratch.
  - `scancode` agent and "False Positive Copyright Deactivation" and "False Positive Copyright Deactivation and clutter removal" options of decider agent should work.
2. Check if everything works on Docker container.
3. Uninstall/remove scancode (remove `/home/fossy/pythondeps/bin/scancode`)
  - User should not see options to schedule scancode agent from UI.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2221"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

