### PR TITLE
fix(scancode): add missing class name to fix tooltip

### DIFF
--- a/src/scancode/ui/template/scancode.html.twig
+++ b/src/scancode/ui/template/scancode.html.twig
@@ -18,9 +18,9 @@
 {% import "include/macros.html.twig" as macro %}
 
 <li>
-  {{ 'ScanCode Toolkit'|trans }}<img src="images/info_16.png" title="{{ 'To scan code and detect licenses, copyrights, author and more.'|trans }}" alt="" class="info-bullet"/>, {{'scan for'|trans }}<br/>
-  <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="scancodeFlags[]" value="license" /> {{ 'License'|trans }}<img src="images/info_16.png" title="{{ 'A full comparison between the database of licenses present in ScanCode and the code uploaded by users based approach'|trans }}" alt="" class="info-bullet"/><br />
-  <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="scancodeFlags[]" value="copyright" /> {{ 'Copyright'|trans }}<img src="images/info_16.png" title="{{ 'Copyright along with copyright holder/author information'|trans }}" alt="" class="info-bullet"/><br />
-  <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="scancodeFlags[]" value="email" /> {{ 'Email'|trans }}<img src="images/info_16.png" title="{{ 'Email(s) present in the scan code file'|trans }}" alt="" class="info-bullet"/><br />
-  <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="scancodeFlags[]" value="url" /> {{ 'URL'|trans }} <img src="images/info_16.png" title="{{ 'URL(s) present in the scan code file'|trans }}" alt="" class="info-bullet"/>
+  {{ 'ScanCode Toolkit'|trans }}<img src="images/info_16.png" data-toggle="tooltip" title="{{ 'To scan code and detect licenses, copyrights, author and more.'|trans }}" alt="" class="info-bullet"/>, {{'scan for'|trans }}<br/>
+  <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="scancodeFlags[]" value="license" /> {{ 'License'|trans }}<img src="images/info_16.png" data-toggle="tooltip" title="{{ 'A full comparison between the database of licenses present in ScanCode and the code uploaded by users based approach'|trans }}" alt="" class="info-bullet"/><br />
+  <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="scancodeFlags[]" value="copyright" /> {{ 'Copyright'|trans }}<img src="images/info_16.png" data-toggle="tooltip" title="{{ 'Copyright along with copyright holder/author information'|trans }}" alt="" class="info-bullet"/><br />
+  <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="scancodeFlags[]" value="email" /> {{ 'Email'|trans }}<img src="images/info_16.png" data-toggle="tooltip" title="{{ 'Email(s) present in the scan code file'|trans }}" alt="" class="info-bullet"/><br />
+  <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="scancodeFlags[]" value="url" /> {{ 'URL'|trans }} <img src="images/info_16.png" data-toggle="tooltip" title="{{ 'URL(s) present in the scan code file'|trans }}" alt="" class="info-bullet"/>
 </li>


### PR DESCRIPTION
Signed-off-by: Shaheem Azmal M MD <shaheem.azmal@siemens.com>

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add tooltip class to scan code in upload page.

## How to test

* Install fossology.
* Check if the tooltips of scan code works in upload page.