### PR TITLE
fix(ci): update spectral-action to fix ci test

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -86,6 +86,6 @@ jobs:
       run: |
         echo '{"extends": ["spectral:oas"]}' > .spectral.json
     - name: Run spectral
-      uses: stoplightio/spectral-action@v0.8.0
+      uses: stoplightio/spectral-action@v0.8.2
       with:
         file_glob: src/www/ui/api/documentation/openapi.yaml


### PR DESCRIPTION
## Description

Bump version of spectral-action from 0.8.0 to 0.8.2
It fixes issue with linter for OpenAPI YAML

Check issue https://github.com/stoplightio/spectral-action/issues/634

### Changes

Bump version of spectral-action from 0.8.0 to 0.8.2

## How to test

Check CI test logs.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2227"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

