### PR TITLE
chore(workflow): update GHA dependencies

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,30 +15,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Login to DockerHub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Build and push main image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         push: true
         tags: fossology/fossology:latest
         context: .
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Build and push runner image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         push: true
         tags: fossology/fossology:scanner
         file: utils/automation/Dockerfile.ci
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Build images
       run: docker-compose build

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         os:
           - 'debian:buster'
-          - 'debian:stretch'
           - 'debian:bullseye'
           - 'ubuntu:bionic'
           - 'ubuntu:focal'
@@ -30,17 +29,36 @@ jobs:
     - name: Install git
       run: |
         apt-get update
-        apt-get install --no-install-recommends -y git ca-certificates
+        apt-get install -y lsb-release sudo gpg ca-certificates
+        ## Add repo for latest git
+        if case "${{ matrix.os }}" in debian*) true;; *) false;; esac; then
+          echo "deb http://deb.debian.org/debian $(lsb_release -cs)-backports main" > /etc/apt/sources.list.d/backport.list
+        else
+          apt-get install -y software-properties-common
+          add-apt-repository $GIT_REPO -y
+        fi
+        apt-get update
+        apt-get install git -y
+        # Remove added repos
+        if case "${{ matrix.os }}" in debian*) true;; *) false;; esac; then
+          rm /etc/apt/sources.list.d/backport.list
+        else
+          add-apt-repository --remove $GIT_REPO -y
+        fi
+        apt-get update
+      env:
+        GIT_REPO: "ppa:git-core/ppa"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
-        fetch-depth: 10
+        fetch-depth: 0
 
     - name: Install dependencies
       run: |
         apt-get install --no-install-recommends -y wget lsb-release sudo composer curl php-cli
         apt-get install --no-install-recommends -y libcppunit-dev libcunit1-dev libdbd-sqlite3-perl
         apt-get install --no-install-recommends -y php-sqlite3 php-zip tar debhelper libssl-dev postgresql-server-dev-all
+        sudo chown -R $(id -u):$(id -g) .
         ./utils/fo-installdeps -y -b
         ./install/scripts/install-spdx-tools.sh
         rm -rf src/vendor
@@ -82,14 +100,19 @@ jobs:
   docker-release-build:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Login to DockerHub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -101,7 +124,7 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
 
     - name: Build and push main image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         push: true
         tags: fossology/fossology:${{ steps.get_release.outputs.tag_name }}


### PR DESCRIPTION
## Description

1. Update dependencies used in GitHub Actions workflows.
2. Fetch all code base while building release packages and Docker images.

### Changes

1. Update dependencies to latest version where possible for GitHub Actions.
2. Use `fetch-depth` as `0` to pull everything while building release packages and Docker images.

## How to test

1. Check build logs.

Potentially fixes #2152 and #2206

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2230"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

