### PR TITLE
feat(reuse): REUSE best practices for licensing/copyright part-2

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,25 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: FOSSology
+Source: https://github.com/fossology/fossology/
+Upstream-Contact: FOSSology <fossology@fossology.org>
+Disclaimer: <text> This file is offered as-is, without any warranty. </text>
+
+Files: src/nomos/agent_tests/testdata/*
+Copyright: Fossology contributors
+License: GPL-2.0-only
+
+Files: src/nomos/ui_tests/testdata/*
+Copyright: Fossology contributors
+License: GPL-2.0-only
+
+Files: src/copyright/agent_tests/testdata/*
+Copyright: Fossology contributors
+License: GPL-2.0-only
+
+Files: src/lib/php/Test/repo/*
+Copyright: Fossology contributors
+License: GPL-2.0-only
+
+Files: src/pkgagent/agent_tests/testdata/*
+Copyright: Fossology contributors
+License: GPL-2.0-only

--- a/src/adj2nest/adj2nest.conf
+++ b/src/adj2nest/adj2nest.conf
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: © Fossology contributors
+
 ; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent

--- a/src/adj2nest/agent/readme.txt
+++ b/src/adj2nest/agent/readme.txt
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: © Fossology contributors
+
 # SPDX-License-Identifier: GPL-2.0-only
 
 To test adj2nest by simulating the scheduler:

--- a/src/buckets/buckets.conf
+++ b/src/buckets/buckets.conf
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: © Fossology contributors
+
 ; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent

--- a/src/cli/tests/1stest.php
+++ b/src/cli/tests/1stest.php
@@ -1,6 +1,10 @@
 #!/usr/bin/php
 <?php
+/*
+ SPDX-FileCopyrightText: © Fossology contributors
 
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * 1stest - play with simpletest
 */

--- a/src/cli/tests/install
+++ b/src/cli/tests/install
@@ -1,26 +1,13 @@
 #!/bin/bash
-#***********************************************************
-# cp2foss.php
-# Copyright (C) 2007 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-#51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-#***********************************************************/
-#
+/*
+ cp2foss.php
+ SPDX-FileCopyrightText: © 2007 Hewlett-Packard Development Company, L.P.
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 # install script for cp2foss tests MUST BE RUN AS ROOT
 # needs access to the svn repository at SourceForge, make sure subversion
 # servers file is correct.
-#
 # version "$Id: install 626 2008-05-24 03:04:12Z rrando $"
 
 if [[ -x "/usr/local/bin/test.cp2foss" ]]

--- a/src/cli/tests/tests.xml
+++ b/src/cli/tests/tests.xml
@@ -1,3 +1,8 @@
+<!-- 
+  SPDX-FileCopyrightText: © Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only 
+-->
 <phpunit>
   <testsuites>
     <testsuite name="cli Tests">

--- a/src/copyright/copyright.conf
+++ b/src/copyright/copyright.conf
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: © Fossology contributors
+
 ; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent

--- a/src/copyright/ecc.conf
+++ b/src/copyright/ecc.conf
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: © Fossology contributors
+
 ; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent

--- a/src/copyright/keyword.conf
+++ b/src/copyright/keyword.conf
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: © Fossology contributors
+
 ; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent

--- a/src/copyright/ui/services.php
+++ b/src/copyright/ui/services.php
@@ -1,5 +1,6 @@
 <?php
 /**
+ * SPDX-FileCopyrightText: © Fossology contributors 
  * SPDX-License-Identifier: GPL-2.0-only
  * @file services.php
  * @brief Add the template path of copyright twig templates

--- a/src/copyright/ui/template/copyrighthist.html.twig
+++ b/src/copyright/ui/template/copyrighthist.html.twig
@@ -1,4 +1,7 @@
-{# SPDX-License-Identifier: GPL-2.0-only #}
+{# SPDX-FileCopyrightText: © Fossology contributors
+ 
+   SPDX-License-Identifier: GPL-2.0-only
+#}
 
 {% extends "include/base.html.twig" %}
 

--- a/src/copyright/ui/template/copyrighthist_scripts.html.twig
+++ b/src/copyright/ui/template/copyrighthist_scripts.html.twig
@@ -1,4 +1,7 @@
-{# SPDX-License-Identifier: GPL-2.0-only #}
+{# SPDX-FileCopyrightText: © Fossology contributors
+ 
+   SPDX-License-Identifier: GPL-2.0-only
+#}
 
 <script language="javascript">
   function ChangeFilter(selectObj, upload, item) {

--- a/src/copyright/ui/template/copyrightlist.html.twig
+++ b/src/copyright/ui/template/copyrightlist.html.twig
@@ -1,4 +1,7 @@
-{# SPDX-License-Identifier: GPL-2.0-only #}
+{# SPDX-FileCopyrightText: © Fossology contributors
+ 
+   SPDX-License-Identifier: GPL-2.0-only
+#}
 
 {% extends "include/base.html.twig" %}
 

--- a/src/copyright/ui/template/histTable.html.twig
+++ b/src/copyright/ui/template/histTable.html.twig
@@ -1,4 +1,7 @@
-{# SPDX-License-Identifier: GPL-2.0-only #}
+{# SPDX-FileCopyrightText: © Fossology contributors
+ 
+   SPDX-License-Identifier: GPL-2.0-only
+#}
 
 <div>
   <table border="1" width="100%" id="copyright{{ type }}">

--- a/src/copyright/ui/template/ui-xp-view_rhs.html.twig
+++ b/src/copyright/ui/template/ui-xp-view_rhs.html.twig
@@ -1,4 +1,7 @@
-{# SPDX-License-Identifier: GPL-2.0-only #}
+{# SPDX-FileCopyrightText: © Fossology contributors
+ 
+   SPDX-License-Identifier: GPL-2.0-only
+#}
 
 <form method="post" id="{{ formName }}">
   <input name="lastItem" id="lastItem" type="hidden" value="{{ itemId }}"/>

--- a/src/decider/agent/version.php.in
+++ b/src/decider/agent/version.php.in
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: © Fossology contributors
+
 # SPDX-License-Identifier: GPL-2.0-only
 
 <?php

--- a/src/decider/decider.conf
+++ b/src/decider/decider.conf
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: © Fossology contributors
+
 ; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent

--- a/src/decider/ui/services.php
+++ b/src/decider/ui/services.php
@@ -1,5 +1,6 @@
 <?php
 /**
+ * SPDX-FileCopyrightText: © Fossology contributors 
  * SPDX-License-Identifier: GPL-2.0-only
  * @file
  * @brief Add the template path of decider twig templates

--- a/src/decider/ui/template/agent_decider.html.twig
+++ b/src/decider/ui/template/agent_decider.html.twig
@@ -1,4 +1,7 @@
-{# SPDX-License-Identifier: GPL-2.0-only #}
+{# SPDX-FileCopyrightText: © Fossology contributors
+ 
+   SPDX-License-Identifier: GPL-2.0-only
+#}
 
 {% import "include/macros.html.twig" as macro %}
 

--- a/src/deciderjob/agent/version.php.in
+++ b/src/deciderjob/agent/version.php.in
@@ -1,4 +1,6 @@
 <?php
+# SPDX-FileCopyrightText: © Fossology contributors
+
 # SPDX-License-Identifier: GPL-2.0-only
 
 define("AGENT_DECIDER_JOB_NAME", "deciderjob");

--- a/src/deciderjob/deciderjob.conf
+++ b/src/deciderjob/deciderjob.conf
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier: FSFAP
+; SPDX-FileCopyrightText: © Fossology contributors
+
+; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent
 [default]

--- a/src/delagent/delagent.conf
+++ b/src/delagent/delagent.conf
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: © Fossology contributors
+
 ; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent

--- a/src/delagent/ui/delete-helper.php
+++ b/src/delagent/ui/delete-helper.php
@@ -1,4 +1,6 @@
 <?php
+# SPDX-FileCopyrightText: © Fossology contributors
+
 # SPDX-License-Identifier: GPL-2.0-only
 
 include_once dirname(dirname(__DIR__)) . "/lib/php/common.php";

--- a/src/delagent/ui/services.php
+++ b/src/delagent/ui/services.php
@@ -1,5 +1,6 @@
 <?php
 /**
+ * SPDX-FileCopyrightText: © Fossology contributors
  * SPDX-License-Identifier: GPL-2.0-only
  * @file
  * @brief Add the template path of decider twig templates

--- a/src/delagent/ui/template/admin_upload_delete.html.twig
+++ b/src/delagent/ui/template/admin_upload_delete.html.twig
@@ -1,4 +1,7 @@
-{# SPDX-License-Identifier: GPL-2.0-only #}
+{# SPDX-FileCopyrightText: © Fossology contributors
+ 
+   SPDX-License-Identifier: GPL-2.0-only
+#}
 
 {% extends "include/base.html.twig" %}
      

--- a/src/demomod/README
+++ b/src/demomod/README
@@ -1,4 +1,7 @@
-SPDX-License-Identifier: GPL-2.0-only
+<!-- SPDX-FileCopyrightText: © Fossology contributors
+
+     SPDX-License-Identifier: GPL-2.0-only
+-->
 
 demomod is a working demonstration FOSSology module.  All you have to do is a make, sudo make install,
 and link this directory in your fossology/mods-enabled/ 

--- a/src/demomod/agent/Notes
+++ b/src/demomod/agent/Notes
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: © Fossology contributors
+
 # SPDX-License-Identifier: GPL-2.0-only
 
 CFLAGS:

--- a/src/demomod/demomod.conf
+++ b/src/demomod/demomod.conf
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: © Fossology contributors
+
 ; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent

--- a/src/example_wc_agent/example_wc_agent.conf
+++ b/src/example_wc_agent/example_wc_agent.conf
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: © Fossology contributors
+
 ; SPDX-License-Identifier: FSFAP
 
 

--- a/src/lib/c/tests/confdata/bad_key.conf
+++ b/src/lib/c/tests/confdata/bad_key.conf
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: © Fossology contributors
+
 ; SPDX-License-Identifier: GPL-2.0-only
 ; configuration test file to test for a bad key name
 [default]

--- a/src/lib/c/tests/confdata/conftest.conf
+++ b/src/lib/c/tests/confdata/conftest.conf
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: © Fossology contributors
+
 ; SPDX-License-Identifier: GPL-2.0-only
 ; this is a simple file that is used to test the configuration library
 ;

--- a/src/lib/c/tests/confdata/invalid_group.conf
+++ b/src/lib/c/tests/confdata/invalid_group.conf
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: © Fossology contributors
+
 ; SPDX-License-Identifier: GPL-2.0-only
 ; configuration test file to make sure that invalid group names cause an error
 [good_group_name]

--- a/src/lib/c/tests/confdata/key_name.conf
+++ b/src/lib/c/tests/confdata/key_name.conf
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: © Fossology contributors
+
 # SPDX-License-Identifier: GPL-2.0-only
 # this is not a valid line
 [default]

--- a/src/lib/c/tests/confdata/key_value.conf
+++ b/src/lib/c/tests/confdata/key_value.conf
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: © Fossology contributors
+
 ; SPDX-License-Identifier: GPL-2.0-only
 ; configuration test file to test an inavlid key/value expression
 [default]

--- a/src/lib/c/tests/confdata/no_group.conf
+++ b/src/lib/c/tests/confdata/no_group.conf
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: © Fossology contributors
+
 ; SPDX-License-Identifier: GPL-2.0-only
 ; configuration test file to test a key that doesn't have an associated group
 bad = no group

--- a/src/lib/php/Application/CurlRequest.php
+++ b/src/lib/php/Application/CurlRequest.php
@@ -1,4 +1,6 @@
 <?php
+# SPDX-FileCopyrightText: © Fossology contributors
+
 # SPDX-License-Identifier: GPL-2.0-only
 
 /**

--- a/src/lib/php/Application/CurlRequestService.php
+++ b/src/lib/php/Application/CurlRequestService.php
@@ -1,4 +1,6 @@
 <?php
+# SPDX-FileCopyrightText: © Fossology contributors
+
 # SPDX-License-Identifier: GPL-2.0-only
 
 namespace Fossology\Lib\Application;

--- a/src/lib/php/Application/RepositoryApi.php
+++ b/src/lib/php/Application/RepositoryApi.php
@@ -1,4 +1,6 @@
 <?php
+# SPDX-FileCopyrightText: © Fossology contributors
+
 # SPDX-License-Identifier: GPL-2.0-only
 
 namespace Fossology\Lib\Application;

--- a/src/lib/php/Application/test/RepositoryApiTest.php
+++ b/src/lib/php/Application/test/RepositoryApiTest.php
@@ -1,4 +1,6 @@
 <?php
+# SPDX-FileCopyrightText: © Fossology contributors
+
 # SPDX-License-Identifier: GPL-2.0-only
 
 namespace Fossology\Lib\Application;

--- a/src/lib/php/Dao/SpashtDao.php
+++ b/src/lib/php/Dao/SpashtDao.php
@@ -1,7 +1,7 @@
 <?php
 /*
  SPDX-FileCopyrightText: © 2019 Vivek Kumar
-Author: Vivek Kumar<vvksindia@gmail.com>
+ Author: Vivek Kumar<vvksindia@gmail.com>
  SPDX-FileCopyrightText: © 2022 Siemens AG
 
  SPDX-License-Identifier: GPL-2.0-only

--- a/src/lib/php/Db/ModernDbManager.php
+++ b/src/lib/php/Db/ModernDbManager.php
@@ -1,20 +1,9 @@
 <?php
 /*
-Copyright (C) 2014, Siemens AG
-Authors: Steffen Weber, Andreas Würl
+ SPDX-FileCopyrightText: © 2014 Siemens AG
+ Authors: Steffen Weber, Andreas Würl
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 namespace Fossology\Lib\Db;

--- a/src/lib/php/Test/Agent/AgentTestMockHelper.php
+++ b/src/lib/php/Test/Agent/AgentTestMockHelper.php
@@ -1,5 +1,7 @@
 <?php
-#  SPDX-License-Identifier: GPL-2.0-only
+# SPDX-FileCopyrightText: © Fossology contributors
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 namespace Fossology\Lib\Agent;
 

--- a/src/lib/php/Test/fosstestinit.sql
+++ b/src/lib/php/Test/fosstestinit.sql
@@ -1,3 +1,5 @@
+-- SPDX-FileCopyrightText: © Fossology contributors
+
 -- SPDX-License-Identifier: GPL-2.0-only
 do 
 $$

--- a/src/lib/php/Test/testdata.sql
+++ b/src/lib/php/Test/testdata.sql
@@ -1,3 +1,5 @@
+-- SPDX-FileCopyrightText: © Fossology contributors
+
 -- SPDX-License-Identifier: GPL-2.0-only
 
 SET statement_timeout = 0;

--- a/src/lib/php/UI/Component/MicroMenu.php
+++ b/src/lib/php/UI/Component/MicroMenu.php
@@ -1,4 +1,6 @@
 <?php
+# SPDX-FileCopyrightText: © Fossology contributors
+
 # SPDX-License-Identifier: GPL-2.0-only
 
 namespace Fossology\Lib\UI\Component;

--- a/src/lib/php/UI/template/include/head.html.twig
+++ b/src/lib/php/UI/template/include/head.html.twig
@@ -1,2 +1,5 @@
-{# SPDX-License-Identifier: GPL-2.0-only #}
+{# SPDX-FileCopyrightText: © Fossology contributors
+ 
+   SPDX-License-Identifier: GPL-2.0-only
+#}
 <meta charset="UTF-8">

--- a/src/lib/php/tests/README
+++ b/src/lib/php/tests/README
@@ -1,4 +1,7 @@
-SPDX-License-Identifier: GPL-2.0-only
+<!-- SPDX-FileCopyrightText: © Fossology contributors
+
+     SPDX-License-Identifier: GPL-2.0-only
+-->
 
 When adding a new test you MUST update the file tests.xml.  That file describes
 all the tests to be run when phpunit is run.  If the test is not in tests.xml it

--- a/src/lib/php/tests/sysconfigDirTest/Db.conf
+++ b/src/lib/php/tests/sysconfigDirTest/Db.conf
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: © Fossology contributors
+
 ; SPDX-License-Identifier: GPL-2.0-only
 
 dbname=fossology;

--- a/src/lib/php/tests/sysconfigDirTest/VERSION
+++ b/src/lib/php/tests/sysconfigDirTest/VERSION
@@ -1,3 +1,7 @@
+; SPDX-FileCopyrightText: © Fossology contributors
+
+; SPDX-License-Identifier: FSFAP
+
 [VERSION]
 VERSION=2.0.0
 COMMIT_HASH=4876M

--- a/src/lib/php/tests/sysconfigDirTest/fossology.conf
+++ b/src/lib/php/tests/sysconfigDirTest/fossology.conf
@@ -1,3 +1,5 @@
+; SPDX-FileCopyrightText: © Fossology contributors
+
 ; SPDX-License-Identifier: GPL-2.0-only
 ; basic fossology.conf for the version 2.0 of the scheduler
 ; this is a simple key-value configuration file

--- a/src/lib/php/tests/tests.xml
+++ b/src/lib/php/tests/tests.xml
@@ -1,4 +1,7 @@
-<!-- SPDX-License-Identifier: GPL-2.0-only -->
+<!-- SPDX-FileCopyrightText: © Fossology contributors
+
+     SPDX-License-Identifier: GPL-2.0-only 
+-->
 
 <phpunit>
   <testsuites>

--- a/src/maintagent/Makefile
+++ b/src/maintagent/Makefile
@@ -1,19 +1,6 @@
-######################################################################
-# Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2013 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../..
 VARS = $(TOP)/Makefile.conf

--- a/src/maintagent/agent/Makefile
+++ b/src/maintagent/agent/Makefile
@@ -1,19 +1,6 @@
-#####################################################################
-# Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2013 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/maintagent/agent/maintagent.c
+++ b/src/maintagent/agent/maintagent.c
@@ -1,21 +1,9 @@
-/***************************************************************
- Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2014,2019 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2013 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2014, 2019 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  \file maintagent.c
  \brief FOSSology maintenance agent

--- a/src/maintagent/agent/maintagent.h
+++ b/src/maintagent/agent/maintagent.h
@@ -1,21 +1,10 @@
-/***************************************************************
- Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2019 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2013 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2019 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
-***************************************************************/
 #ifndef _MAINTAGENT_H
 #define _MAINTAGENT_H 1
 #include <stdio.h>

--- a/src/maintagent/agent/process.c
+++ b/src/maintagent/agent/process.c
@@ -1,21 +1,9 @@
-/***************************************************************
- Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2014-2015,2019 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2013 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2014-2015, 2019 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file
  * \brief Functions to process a single file and process an upload

--- a/src/maintagent/agent/usage.c
+++ b/src/maintagent/agent/usage.c
@@ -1,21 +1,9 @@
-/***************************************************************
- Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2019 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2013 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2019 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file
  * \brief Maintenance agent validation, and usage functions

--- a/src/maintagent/agent/utils.c
+++ b/src/maintagent/agent/utils.c
@@ -1,21 +1,9 @@
-/***************************************************************
- Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2019 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2013 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2019 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file
  * \brief Miscellaneous utility functions for maintagent

--- a/src/maintagent/maintagent.conf
+++ b/src/maintagent/maintagent.conf
@@ -1,7 +1,6 @@
-; Copying and distribution of this file, with or without modification,
-; are permitted in any medium without royalty provided the copyright
-; notice and this notice are preserved. This file is offered as-is,
-; without any warranty.
+; SPDX-FileCopyrightText: © Fossology contributors
+
+; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent
 [default]

--- a/src/maintagent/ui/Makefile
+++ b/src/maintagent/ui/Makefile
@@ -1,19 +1,6 @@
-######################################################################
-# Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2013 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/maintagent/ui/maintagent.php
+++ b/src/maintagent/ui/maintagent.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
- Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2019 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2013 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2019 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-***********************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 define("TITLE_MAINTAGENT", _("FOSSology Maintenance"));
 

--- a/src/mimetype/Makefile
+++ b/src/mimetype/Makefile
@@ -1,19 +1,6 @@
-######################################################################
-# Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../..
 VARS = $(TOP)/Makefile.conf

--- a/src/mimetype/agent/Makefile
+++ b/src/mimetype/agent/Makefile
@@ -1,5 +1,7 @@
 # FOSSology Makefile - agents/mimetype
-# Copyright (C) 2008-2011 Hewlett-Packard Development Company, L.P.
+# SPDX-FileCopyrightText: © 2008-2011 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/mimetype/agent/finder.c
+++ b/src/mimetype/agent/finder.c
@@ -1,19 +1,8 @@
-/***************************************************************
- Copyright (C) 2011-2012 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2011-2012 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 /**
  * \file

--- a/src/mimetype/agent/finder.h
+++ b/src/mimetype/agent/finder.h
@@ -1,19 +1,9 @@
-/***************************************************************
- Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***************************************************************/
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/mimetype/agent/mimetype.c
+++ b/src/mimetype/agent/mimetype.c
@@ -1,19 +1,8 @@
-/***************************************************************
- Copyright (C) 2007-2013 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2007-2013 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file mimetype.c
  * \brief Get the mimetype for a package.

--- a/src/mimetype/agent_tests/Functional/Makefile
+++ b/src/mimetype/agent_tests/Functional/Makefile
@@ -1,19 +1,6 @@
-######################################################################
-# Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/mimetype/agent_tests/Functional/cliParamsTest4Mimetype.php
+++ b/src/mimetype/agent_tests/Functional/cliParamsTest4Mimetype.php
@@ -1,23 +1,10 @@
 <?php
-
 /*
- Copyright (C) 2011-2012 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2011-2012 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2018 Siemens AG
 
- Copyright (C) 2018 Siemens AG
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 /**
  * @dir

--- a/src/mimetype/agent_tests/Makefile
+++ b/src/mimetype/agent_tests/Makefile
@@ -1,19 +1,6 @@
-######################################################################
-# Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/mimetype/agent_tests/Unit/Makefile
+++ b/src/mimetype/agent_tests/Unit/Makefile
@@ -1,5 +1,7 @@
 # FOSSology Makefile - test for mimetype
-# Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
+# SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/mimetype/agent_tests/Unit/finder/testDBCheckMime.c
+++ b/src/mimetype/agent_tests/Unit/finder/testDBCheckMime.c
@@ -1,19 +1,9 @@
-/*********************************************************************
-Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*********************************************************************/
 
 /* cunit includes */
 #include <CUnit/CUnit.h>

--- a/src/mimetype/agent_tests/Unit/finder/testDBFindMime.c
+++ b/src/mimetype/agent_tests/Unit/finder/testDBFindMime.c
@@ -1,19 +1,8 @@
-/*********************************************************************
-Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*********************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 /* cunit includes */
 #include <CUnit/CUnit.h>

--- a/src/mimetype/agent_tests/Unit/finder/testDBLoadMime.c
+++ b/src/mimetype/agent_tests/Unit/finder/testDBLoadMime.c
@@ -1,19 +1,8 @@
-/*********************************************************************
-Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*********************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 /* cunit includes */
 #include <CUnit/CUnit.h>

--- a/src/mimetype/agent_tests/Unit/finder/testOtheFunctions.c
+++ b/src/mimetype/agent_tests/Unit/finder/testOtheFunctions.c
@@ -1,20 +1,8 @@
-/*********************************************************************
-Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*********************************************************************/
-
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /* cunit includes */
 #include <CUnit/CUnit.h>
 #include "finder.h"

--- a/src/mimetype/agent_tests/Unit/testRun.c
+++ b/src/mimetype/agent_tests/Unit/testRun.c
@@ -1,21 +1,9 @@
-/*********************************************************************
-Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2018 Siemens AG
 
-Copyright (C) 2018 Siemens AG
-
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*********************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include "testRun.h"
 #include "finder.h"

--- a/src/mimetype/agent_tests/Unit/testRun.h
+++ b/src/mimetype/agent_tests/Unit/testRun.h
@@ -1,19 +1,8 @@
-/*********************************************************************
-Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*********************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef RUN_TESTS_H
 #define RUN_TESTS_H

--- a/src/mimetype/mimetype.conf
+++ b/src/mimetype/mimetype.conf
@@ -1,7 +1,6 @@
-; Copying and distribution of this file, with or without modification,
-; are permitted in any medium without royalty provided the copyright
-; notice and this notice are preserved. This file is offered as-is,
-; without any warranty.
+; SPDX-FileCopyrightText: © Fossology contributors
+
+; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent
 [default]

--- a/src/mimetype/mod_deps
+++ b/src/mimetype/mod_deps
@@ -1,20 +1,10 @@
 #!/usr/bin/env bash
 # FOSSology mod_deps script
 # This script helps you install dependencies on a system. for a module
-#
-# Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+# SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 source "$(dirname ${BASH_SOURCE[0]})/../../utils/utils.sh"
 

--- a/src/mimetype/ui/Makefile
+++ b/src/mimetype/ui/Makefile
@@ -1,19 +1,6 @@
-######################################################################
-# Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/mimetype/ui/agent-mimetype.php
+++ b/src/mimetype/ui/agent-mimetype.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
-Copyright (C) 2008-2013 Hewlett-Packard Development Company, L.P.
-Copyright (C) 2015, Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2008-2013 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2015 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-***********************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 use Fossology\Lib\Plugin\AgentPlugin;
 

--- a/src/monk/Makefile
+++ b/src/monk/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../..
 VARS = $(TOP)/Makefile.conf

--- a/src/monk/agent/Makefile
+++ b/src/monk/agent/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014-2015
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/monk/agent/_squareVisitor.h.post
+++ b/src/monk/agent/_squareVisitor.h.post
@@ -1,10 +1,7 @@
 /*
-Copyright Siemens AG 2014
+ SPDX-FileCopyrightText: © 2014 Siemens AG
 
-Copying and distribution of this file, with or without modification,
-are permitted in any medium without royalty provided the copyright
-notice and this notice are preserved.  This file is offered as-is,
-without any warranty.
+ SPDX-License-Identifier: FSFAP
 */
 
 extern unsigned int squareVisitorX[SQUARE_VISITOR_LENGTH];

--- a/src/monk/agent/_squareVisitor.h.pre
+++ b/src/monk/agent/_squareVisitor.h.pre
@@ -1,11 +1,9 @@
 /*
-Copyright Siemens AG 2014
+ SPDX-FileCopyrightText: © 2014 Siemens AG
 
-Copying and distribution of this file, with or without modification,
-are permitted in any medium without royalty provided the copyright
-notice and this notice are preserved.  This file is offered as-is,
-without any warranty.
+ SPDX-License-Identifier: FSFAP
 */
+
 
 #ifndef SQUAREVISITOR_H
 #define SQUAREVISITOR_H

--- a/src/monk/agent/buildSquareVisitor.c
+++ b/src/monk/agent/buildSquareVisitor.c
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #include <math.h>

--- a/src/monk/agent/cli.c
+++ b/src/monk/agent/cli.c
@@ -1,20 +1,10 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
 #include "cli.h"
 #include "file_operations.h"
 #include "database.h"

--- a/src/monk/agent/cli.h
+++ b/src/monk/agent/cli.h
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #ifndef MONK_AGENT_CLI_H

--- a/src/monk/agent/common.c
+++ b/src/monk/agent/common.c
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #include <glib.h>

--- a/src/monk/agent/common.h
+++ b/src/monk/agent/common.h
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #ifndef MONK_AGENT_COMMON_H

--- a/src/monk/agent/database.c
+++ b/src/monk/agent/database.c
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2017, 2021, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2017, 2021 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #define _GNU_SOURCE

--- a/src/monk/agent/database.h
+++ b/src/monk/agent/database.h
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #ifndef MONK_AGENT_DATABASE_H

--- a/src/monk/agent/diff.c
+++ b/src/monk/agent/diff.c
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #include "diff.h"

--- a/src/monk/agent/diff.h
+++ b/src/monk/agent/diff.h
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #ifndef MONK_AGENT_DIFF_H

--- a/src/monk/agent/encoding.c
+++ b/src/monk/agent/encoding.c
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini
-Copyright (C) 2015, Siemens AG
+ Author: Daniele Fognini
+ SPDX-FileCopyrightText: © 2015 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #include "encoding.h"

--- a/src/monk/agent/encoding.h
+++ b/src/monk/agent/encoding.h
@@ -1,20 +1,10 @@
 /*
-Author: Daniele Fognini
-Copyright (C) 2015, Siemens AG
+ Author: Daniele Fognini
+ SPDX-FileCopyrightText: © 2015 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
 #ifndef MONK_AGENT_ENCODING_H
 #define MONK_AGENT_ENCODING_H
 

--- a/src/monk/agent/file_operations.c
+++ b/src/monk/agent/file_operations.c
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #include "file_operations.h"

--- a/src/monk/agent/file_operations.h
+++ b/src/monk/agent/file_operations.h
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #ifndef MONK_AGENT_FILE_OPERATIONS_H

--- a/src/monk/agent/genSquareVisitor
+++ b/src/monk/agent/genSquareVisitor
@@ -1,13 +1,9 @@
 #!/bin/sh
 
 # Author: Daniele Fognini, Andreas Wuerl
-# Copyright (C) 2013-2014, Siemens AG
-# 
-# This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
-# 
-# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+# SPDX-FileCopyrightText: © 2013-2014 Siemens AG
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 ./squareBuilder
 if [ ! -e _squareVisitor.h.gen ]; then

--- a/src/monk/agent/hash.c
+++ b/src/monk/agent/hash.c
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #include "hash.h"

--- a/src/monk/agent/hash.h
+++ b/src/monk/agent/hash.h
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #ifndef MONK_AGENT_HASH_H

--- a/src/monk/agent/highlight.c
+++ b/src/monk/agent/highlight.c
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #include "highlight.h"

--- a/src/monk/agent/highlight.h
+++ b/src/monk/agent/highlight.h
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #ifndef MONK_AGENT_HIGHLIGHT_H

--- a/src/monk/agent/license.c
+++ b/src/monk/agent/license.c
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2015, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2015 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #include <glib.h>

--- a/src/monk/agent/license.h
+++ b/src/monk/agent/license.h
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #ifndef MONK_AGENT_LICENSE_H

--- a/src/monk/agent/match.c
+++ b/src/monk/agent/match.c
@@ -1,19 +1,8 @@
 /*
-Authors: Daniele Fognini, Andreas Wuerl, Marion Deveaud
-Copyright (C) 2013-2015, Siemens AG
+ Authors: Daniele Fognini, Andreas Wuerl, Marion Deveaud
+ SPDX-FileCopyrightText: © 2013-2015 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #include "match.h"

--- a/src/monk/agent/match.h
+++ b/src/monk/agent/match.h
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #ifndef MONK_AGENT_MATCH_H

--- a/src/monk/agent/monk.c
+++ b/src/monk/agent/monk.c
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2015, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2015 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #include "monk.h"

--- a/src/monk/agent/monk.h
+++ b/src/monk/agent/monk.h
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #ifndef MONK_AGENT_MONK_H

--- a/src/monk/agent/monkbulk.c
+++ b/src/monk/agent/monkbulk.c
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2015,2018,2021 Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2015, 2018, 2021 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #include <stdlib.h>

--- a/src/monk/agent/monkbulk.h
+++ b/src/monk/agent/monkbulk.h
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014,2018 Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014, 2018 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #ifndef MONK_AGENT_BULK_H

--- a/src/monk/agent/scheduler.c
+++ b/src/monk/agent/scheduler.c
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #include "scheduler.h"

--- a/src/monk/agent/scheduler.h
+++ b/src/monk/agent/scheduler.h
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #ifndef MONK_AGENT_SCHEDULER_H

--- a/src/monk/agent/serialize.c
+++ b/src/monk/agent/serialize.c
@@ -1,20 +1,9 @@
 /*
-Author: Maximilian Huber
-Copyright (C) 2018, TNG Technology Consulting GmbH
+ Author: Maximilian Huber
+ SPDX-FileCopyrightText: © 2018 TNG Technology Consulting GmbH
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include "serialize.h"
 

--- a/src/monk/agent/serialize.h
+++ b/src/monk/agent/serialize.h
@@ -1,20 +1,9 @@
 /*
-Author: Maximilian Huber
-Copyright (C) 2018, TNG Technology Consulting GmbH
+ Author: Maximilian Huber
+ SPDX-FileCopyrightText: © 2018 TNG Technology Consulting GmbH
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef MONK_AGENT_SERIALIZE_H
 #define MONK_AGENT_SERIALIZE_H

--- a/src/monk/agent/string_operations.c
+++ b/src/monk/agent/string_operations.c
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2015, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2015 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #define _GNU_SOURCE

--- a/src/monk/agent/string_operations.h
+++ b/src/monk/agent/string_operations.h
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2015, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2015 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #ifndef MONK_AGENT_STRING_OPERATIONS_H

--- a/src/monk/agent_tests/Functional/Makefile
+++ b/src/monk/agent_tests/Functional/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014-2015
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/monk/agent_tests/Functional/bulkTest.php
+++ b/src/monk/agent_tests/Functional/bulkTest.php
@@ -1,19 +1,8 @@
 <?php
 /*
-Copyright (C) 2014-2015, Siemens AG
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 use Fossology\Lib\Dao\ClearingDao;

--- a/src/monk/agent_tests/Functional/cliTest.php
+++ b/src/monk/agent_tests/Functional/cliTest.php
@@ -1,19 +1,8 @@
 <?php
 /*
-Copyright (C) 2014-2015, Siemens AG
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 use Fossology\Lib\Db\DbManager;

--- a/src/monk/agent_tests/Functional/schedulerTest.php
+++ b/src/monk/agent_tests/Functional/schedulerTest.php
@@ -1,19 +1,8 @@
 <?php
 /*
-Copyright (C) 2014-2015,2019 Siemens AG
+ SPDX-FileCopyrightText: © 2014-2015, 2019 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 use Fossology\Lib\Dao\ClearingDao;

--- a/src/monk/agent_tests/Makefile
+++ b/src/monk/agent_tests/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2015
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2015 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/monk/agent_tests/Unit/Makefile
+++ b/src/monk/agent_tests/Unit/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014, 2015
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014, 2015 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/monk/agent_tests/Unit/run_tests.c
+++ b/src/monk/agent_tests/Unit/run_tests.c
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2015, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2015 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 /* local includes */

--- a/src/monk/agent_tests/Unit/test_database.c
+++ b/src/monk/agent_tests/Unit/test_database.c
@@ -1,20 +1,10 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2017, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2017 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
+
 #include <CUnit/CUnit.h>
 #include <libfocunit.h>
 

--- a/src/monk/agent_tests/Unit/test_diff.c
+++ b/src/monk/agent_tests/Unit/test_diff.c
@@ -1,20 +1,10 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
 #include <stdlib.h>
 #include <stdio.h>
 #include <CUnit/CUnit.h>

--- a/src/monk/agent_tests/Unit/test_encoding.c
+++ b/src/monk/agent_tests/Unit/test_encoding.c
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #include <stdlib.h>

--- a/src/monk/agent_tests/Unit/test_file_operations.c
+++ b/src/monk/agent_tests/Unit/test_file_operations.c
@@ -1,19 +1,8 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #include <stdlib.h>

--- a/src/monk/agent_tests/Unit/test_hash.c
+++ b/src/monk/agent_tests/Unit/test_hash.c
@@ -1,20 +1,10 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <CUnit/CUnit.h>

--- a/src/monk/agent_tests/Unit/test_highlight.c
+++ b/src/monk/agent_tests/Unit/test_highlight.c
@@ -1,20 +1,10 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/monk/agent_tests/Unit/test_license.c
+++ b/src/monk/agent_tests/Unit/test_license.c
@@ -1,20 +1,10 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2017, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2017 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
+
 #include <stdlib.h>
 #include <stdarg.h>
 #include <libfocunit.h>

--- a/src/monk/agent_tests/Unit/test_match.c
+++ b/src/monk/agent_tests/Unit/test_match.c
@@ -1,20 +1,10 @@
 /*
-Authors: Daniele Fognini, Andreas Wuerl, Marion Deveaud
-Copyright (C) 2013-2015, Siemens AG
+ Authors: Daniele Fognini, Andreas Wuerl, Marion Deveaud
+ SPDX-FileCopyrightText: © 2013-2015 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
 #include <stdlib.h>
 #include <stdio.h>
 #include <CUnit/CUnit.h>

--- a/src/monk/agent_tests/Unit/test_serialize.c
+++ b/src/monk/agent_tests/Unit/test_serialize.c
@@ -1,20 +1,10 @@
 /*
-Author: Maximilian Huber
-Copyright (C) 2018, TNG Technology Consulting GmbH
+ Author: Maximilian Huber
+ SPDX-FileCopyrightText: © 2018 TNG Technology Consulting GmbH
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
+
 #define _GNU_SOURCE
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/monk/agent_tests/Unit/test_string_operations.c
+++ b/src/monk/agent_tests/Unit/test_string_operations.c
@@ -1,20 +1,10 @@
 /*
-Author: Daniele Fognini, Andreas Wuerl
-Copyright (C) 2013-2014, Siemens AG
+ Author: Daniele Fognini, Andreas Wuerl
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <CUnit/CUnit.h>

--- a/src/monk/monk.conf
+++ b/src/monk/monk.conf
@@ -1,7 +1,6 @@
-; Copying and distribution of this file, with or without modification,
-; are permitted in any medium without royalty provided the copyright
-; notice and this notice are preserved. This file is offered as-is,
-; without any warranty.
+; SPDX-FileCopyrightText: © Fossology contributors
+
+; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent
 [default]

--- a/src/monk/monkbulk.conf
+++ b/src/monk/monkbulk.conf
@@ -1,7 +1,6 @@
-; Copying and distribution of this file, with or without modification,
-; are permitted in any medium without royalty provided the copyright
-; notice and this notice are preserved. This file is offered as-is,
-; without any warranty.
+; SPDX-FileCopyrightText: © Fossology contributors
+
+; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent
 [default]

--- a/src/monk/ui/Makefile
+++ b/src/monk/ui/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/monk/ui/admin-monk-revision.php
+++ b/src/monk/ui/admin-monk-revision.php
@@ -1,20 +1,9 @@
 <?php
-/***********************************************************
-  Copyright (C) 2014, Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2014 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 namespace Fossology\Monk;
 

--- a/src/monk/ui/agent-monk-bulk.php
+++ b/src/monk/ui/agent-monk-bulk.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
- * Copyright (C) 2008-2013 Hewlett-Packard Development Company, L.P.
- * Copyright (C) 2014-2015, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+/*
+ SPDX-FileCopyrightText: © 2008-2013 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 use Fossology\Lib\Plugin\AgentPlugin;
 

--- a/src/monk/ui/agent-monk.php
+++ b/src/monk/ui/agent-monk.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
- * Copyright (C) 2008-2013 Hewlett-Packard Development Company, L.P.
- * Copyright (C) 2014-2015, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+/*
+ SPDX-FileCopyrightText: © 2008-2013 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 use Fossology\Lib\Plugin\AgentPlugin;
 

--- a/src/monk/ui/oneshot.php
+++ b/src/monk/ui/oneshot.php
@@ -1,20 +1,10 @@
 <?php
 /*
-Copyright (C) 2014, Siemens AG
+ SPDX-FileCopyrightText: © 2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
+
 
 namespace Fossology\Monk\UI;
 

--- a/src/ninka/Makefile
+++ b/src/ninka/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014-2015
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../..
 VARS = $(TOP)/Makefile.conf

--- a/src/ninka/README.md
+++ b/src/ninka/README.md
@@ -1,3 +1,7 @@
+<!-- SPDX-FileCopyrightText: © Fossology contributors
+
+     SPDX-License-Identifier: GPL-2.0-only
+-->
 Introduction
 --------------
 

--- a/src/ninka/agent/Makefile
+++ b/src/ninka/agent/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014-2015
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/ninka/agent/databasehandler.cc
+++ b/src/ninka/agent/databasehandler.cc
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2014-2015, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include "databasehandler.hpp"
 #include "libfossUtils.hpp"

--- a/src/ninka/agent/databasehandler.hpp
+++ b/src/ninka/agent/databasehandler.hpp
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2014-2015, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef NINKA_AGENT_DATABASE_HANDLER_HPP
 #define NINKA_AGENT_DATABASE_HANDLER_HPP

--- a/src/ninka/agent/licensematch.cc
+++ b/src/ninka/agent/licensematch.cc
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2014-2015, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include "licensematch.hpp"
 

--- a/src/ninka/agent/licensematch.hpp
+++ b/src/ninka/agent/licensematch.hpp
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2014-2015, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef NINKA_AGENT_LICENSE_MATCH_HPP
 #define NINKA_AGENT_LICENSE_MATCH_HPP

--- a/src/ninka/agent/ninka.cc
+++ b/src/ninka/agent/ninka.cc
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2014-2015, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include "ninka.hpp"
 

--- a/src/ninka/agent/ninka.hpp
+++ b/src/ninka/agent/ninka.hpp
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2014-2015, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef NINKA_AGENT_NINKA_HPP
 #define NINKA_AGENT_NINKA_HPP

--- a/src/ninka/agent/ninkawrapper.cc
+++ b/src/ninka/agent/ninkawrapper.cc
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2014-2015, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include <iostream>
 #include <boost/tokenizer.hpp>

--- a/src/ninka/agent/ninkawrapper.hpp
+++ b/src/ninka/agent/ninkawrapper.hpp
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2014-2015, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef NINKA_AGENT_NINKA_WRAPPER_HPP
 #define NINKA_AGENT_NINKA_WRAPPER_HPP

--- a/src/ninka/agent/state.cc
+++ b/src/ninka/agent/state.cc
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2014-2015, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include "state.hpp"
 

--- a/src/ninka/agent/state.hpp
+++ b/src/ninka/agent/state.hpp
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2014-2015, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef NINKA_AGENT_STATE_HPP
 #define NINKA_AGENT_STATE_HPP

--- a/src/ninka/agent/utils.cc
+++ b/src/ninka/agent/utils.cc
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2014-2015, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include <iostream>
 #include "ninkawrapper.hpp"

--- a/src/ninka/agent/utils.hpp
+++ b/src/ninka/agent/utils.hpp
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2014-2015, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef NINKA_AGENT_UTILS_HPP
 #define NINKA_AGENT_UTILS_HPP

--- a/src/ninka/agent_tests/Functional/Makefile
+++ b/src/ninka/agent_tests/Functional/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/ninka/agent_tests/Functional/schedulerTest.php
+++ b/src/ninka/agent_tests/Functional/schedulerTest.php
@@ -1,19 +1,8 @@
 <?php
 /*
-Copyright (C) 2014-2015, Siemens AG
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 use Fossology\Lib\Dao\LicenseDao;

--- a/src/ninka/agent_tests/Makefile
+++ b/src/ninka/agent_tests/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/ninka/agent_tests/Unit/Makefile
+++ b/src/ninka/agent_tests/Unit/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/ninka/agent_tests/Unit/run_tests.cc
+++ b/src/ninka/agent_tests/Unit/run_tests.cc
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2014-2015, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include <cppunit/BriefTestProgressListener.h>
 #include <cppunit/CompilerOutputter.h>

--- a/src/ninka/agent_tests/Unit/test_ninkawrapper.cc
+++ b/src/ninka/agent_tests/Unit/test_ninkawrapper.cc
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2014-2015, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include <boost/format.hpp>
 #include <boost/assign/list_of.hpp>

--- a/src/ninka/ninka.conf
+++ b/src/ninka/ninka.conf
@@ -1,7 +1,6 @@
-; Copying and distribution of this file, with or without modification,
-; are permitted in any medium without royalty provided the copyright
-; notice and this notice are preserved. This file is offered as-is,
-; without any warranty.
+; SPDX-FileCopyrightText: © Fossology contributors
+
+; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent
 [default]

--- a/src/ninka/ui/Makefile
+++ b/src/ninka/ui/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/ninka/ui/agent-ninka.php
+++ b/src/ninka/ui/agent-ninka.php
@@ -1,20 +1,9 @@
 <?php
-/***********************************************************
- * Copyright (C) 2014-2015, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+/*
+ SPDX-FileCopyrightText: © 2014-2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 namespace Fossology\Ninka\Ui;
 

--- a/src/nomos/Makefile
+++ b/src/nomos/Makefile
@@ -1,19 +1,6 @@
-######################################################################
-# Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../..
 VARS = $(TOP)/Makefile.conf

--- a/src/nomos/agent/CHECKSTR
+++ b/src/nomos/agent/CHECKSTR
@@ -1,21 +1,8 @@
 #!/bin/sh
-#**************************************************************
-# Copyright (C) 2006-2009 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-#
-# ***************************************************************
+# SPDX-FileCopyrightText: © 2006-2009 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
+
 PROG=$(basename $0)
 
 DATA=_strings.data

--- a/src/nomos/agent/DMalloc.3x
+++ b/src/nomos/agent/DMalloc.3x
@@ -1,6 +1,7 @@
-.\"
-.\" (C) Copyright 2006 Hewlett-Packard Development Company, L.P.
-.\"
+.\" SPDX-FileCopyrightText: © 2006 Hewlett-Packard Development Company, L.P.
+
+.\" SPDX-License-Identifier: GPL-2.0-only
+
 .de G
 .br
 .B

--- a/src/nomos/agent/DMalloc.c
+++ b/src/nomos/agent/DMalloc.c
@@ -1,20 +1,8 @@
-/***************************************************************
- Copyright (C) 2007-2011 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2007-2011 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file
  * - Several global variables control actions taken by the memory check

--- a/src/nomos/agent/DMalloc.h
+++ b/src/nomos/agent/DMalloc.h
@@ -1,20 +1,9 @@
-/***************************************************************
- Copyright (C) 2007-2011 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2007-2011 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
 #ifndef _DMALLOC_H_
 #define _DMALLOC_H_
 

--- a/src/nomos/agent/GENSEARCHDATA
+++ b/src/nomos/agent/GENSEARCHDATA
@@ -5,22 +5,9 @@
 #     and _autodefs.h files for initializing the search strings structure
 #     used to search for licenses.
 #
-#  Copyright (C) 2006,2009,2013 Hewlett-Packard Development Company, L.P.
-#  
-#  This program is free software; you can redistribute it and/or
-#  modify it under the terms of the GNU General Public License
-#  version 2 as published by the Free Software Foundation.
-# 
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-# 
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-# 
-###########
+# SPDX-FileCopyrightText: © 2006, 2009, 2013 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 PROG=$(basename $0)
 ## [ $# -ne 1 ] && echo "Usage: $PROG input-file" && exit 1

--- a/src/nomos/agent/Makefile
+++ b/src/nomos/agent/Makefile
@@ -1,5 +1,7 @@
 # FOSSology Makefile - agent/nomos
-# Copyright (C) 2006-2014 Hewlett-Packard Development Company, L.P.
+# SPDX-FileCopyrightText: © 2006-2014 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/nomos/agent/Makefile.sa
+++ b/src/nomos/agent/Makefile.sa
@@ -1,6 +1,8 @@
 # FOSSology Makefile - agent/nomossa
 # This is to make a version of nomos that does not require any of the fossology build dependencies.
-# Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
+# SPDX-FileCopyrightText: © 2013 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/nomos/agent/Notes
+++ b/src/nomos/agent/Notes
@@ -1,3 +1,7 @@
+<!-- SPDX-FileCopyrightText: © Fossology contributors
+
+     SPDX-License-Identifier: GPL-2.0-only
+-->
 
 To Whom it May Concern: 
 

--- a/src/nomos/agent/PRECHECK
+++ b/src/nomos/agent/PRECHECK
@@ -1,21 +1,8 @@
 #!/bin/sh
-#***************************************************************
-# Copyright (C) 2006-2009 Hewlett-Packard Development Company, L.P.
-# 
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-#
-#***************************************************************
+# SPDX-FileCopyrightText: © 2006-2009 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
+
 IN=STRINGS.in
 DATA=_strings.data
 LIST=_split_words

--- a/src/nomos/agent/README
+++ b/src/nomos/agent/README
@@ -1,3 +1,7 @@
+<!-- SPDX-FileCopyrightText: © Fossology contributors
+
+     SPDX-License-Identifier: GPL-2.0-only
+-->
 
 "Pssssst. Over here
 

--- a/src/nomos/agent/STRINGS.in
+++ b/src/nomos/agent/STRINGS.in
@@ -1,7 +1,7 @@
-#####
-# (C) Copyright 2006-2015 Hewlett-Packard Development Company, L.P.
-# (C) Copyright 2017-2019 Bittium Wireless Ltd.
-#####
+# SPDX-FileCopyrightText: © 2006-2015 Hewlett-Packard Development Company, L.P.
+# SPDX-FileCopyrightText: © 2017-2019 Bittium Wireless Ltd.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 /* License footprints */
 

--- a/src/nomos/agent/doctorBuffer_utils.c
+++ b/src/nomos/agent/doctorBuffer_utils.c
@@ -1,21 +1,10 @@
-/***************************************************************
- Copyright (C) 2006-2014 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2014, Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2006-2014 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2014 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
 #include "doctorBuffer_utils.h"
 #define INVISIBLE       (int) '\377'
 

--- a/src/nomos/agent/doctorBuffer_utils.h
+++ b/src/nomos/agent/doctorBuffer_utils.h
@@ -1,21 +1,9 @@
-/***************************************************************
- Copyright (C) 2006-2014 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2014, Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2006-2014 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2014 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef DOCTORBUFFER_UTILS_H_
 #define DOCTORBUFFER_UTILS_H_

--- a/src/nomos/agent/encode.c
+++ b/src/nomos/agent/encode.c
@@ -1,20 +1,8 @@
-/***************************************************************
- Copyright (C) 2006-2011 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2006-2011 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file
  * \brief Simple utility program for escaping C strings for inclusion in code.

--- a/src/nomos/agent/json_writer.c
+++ b/src/nomos/agent/json_writer.c
@@ -1,21 +1,9 @@
-/***************************************************************
- Copyright (C) 2019 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2019 Siemens AG
  Author: Gaurav Mishra <mishra.gaurav@siemens.com>
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include "json_writer.h"
 #include "nomos.h"

--- a/src/nomos/agent/json_writer.h
+++ b/src/nomos/agent/json_writer.h
@@ -1,21 +1,9 @@
-/***************************************************************
- Copyright (C) 2019 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2019 Siemens AG
  Author: Gaurav Mishra <mishra.gaurav@siemens.com>
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 /**
  * \file

--- a/src/nomos/agent/licenses.c
+++ b/src/nomos/agent/licenses.c
@@ -1,20 +1,8 @@
-/***************************************************************
- Copyright (C) 2006-2013 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2006-2013 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /* Equivalent to core nomos v1.48 */
 
 /**

--- a/src/nomos/agent/licenses.h
+++ b/src/nomos/agent/licenses.h
@@ -1,20 +1,9 @@
-/***************************************************************
- Copyright (C) 2006-2009 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2006-2009 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
 #ifndef _LICENSES_H
 #define _LICENSES_H
 

--- a/src/nomos/agent/list.c
+++ b/src/nomos/agent/list.c
@@ -1,21 +1,8 @@
-/***************************************************************
- Copyright (C) 2006-2013 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2006-2013 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
-
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /* Equivalent to core nomos v1.10 */
 
 /**

--- a/src/nomos/agent/list.h
+++ b/src/nomos/agent/list.h
@@ -1,20 +1,9 @@
-/***************************************************************
- Copyright (C) 2006-2009 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2006-2009 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
 #ifndef _LIST_H
 #define _LIST_H
 #include "nomos.h"

--- a/src/nomos/agent/nomos.c
+++ b/src/nomos/agent/nomos.c
@@ -1,21 +1,9 @@
-/***************************************************************
- Copyright (C) 2006-2015 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2014, 2018 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2006-2015 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2014, 2018 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file
  * \brief Main for the nomos agent

--- a/src/nomos/agent/nomos.h
+++ b/src/nomos/agent/nomos.h
@@ -1,21 +1,9 @@
-/***************************************************************
- Copyright (C) 2006-2014 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2014, Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2006-2014 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2014 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 /**
  * \dir

--- a/src/nomos/agent/nomos_gap.c
+++ b/src/nomos/agent/nomos_gap.c
@@ -1,18 +1,7 @@
 /*
-Copyright (C) 2013-2014, Siemens AG
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #include "nomos_gap.h"

--- a/src/nomos/agent/nomos_gap.h
+++ b/src/nomos/agent/nomos_gap.h
@@ -1,18 +1,7 @@
 /*
-Copyright (C) 2013-2014, Siemens AG
+ SPDX-FileCopyrightText: © 2013-2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 #ifndef NOMOS_GAP_H

--- a/src/nomos/agent/nomos_regex.c
+++ b/src/nomos/agent/nomos_regex.c
@@ -1,21 +1,9 @@
-/***************************************************************
- Copyright (C) 2006-2011 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2014, Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2006-2011 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2014 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 //#define DEBUG_TNG
 #ifndef DEBUG_TNG
 #define CALL_IF_DEBUG_MODE(x)

--- a/src/nomos/agent/nomos_regex.h
+++ b/src/nomos/agent/nomos_regex.h
@@ -1,21 +1,9 @@
-/***************************************************************
- Copyright (C) 2006-2009 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2014, Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2006-2009 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2014 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef _NOMOS_REGEX_H
 #define _NOMOS_REGEX_H

--- a/src/nomos/agent/nomos_utils.c
+++ b/src/nomos/agent/nomos_utils.c
@@ -1,20 +1,8 @@
-/***************************************************************
- Copyright (C) 2006-2014 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2006-2014 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE

--- a/src/nomos/agent/nomos_utils.h
+++ b/src/nomos/agent/nomos_utils.h
@@ -1,20 +1,8 @@
-/***************************************************************
- Copyright (C) 2006-2014 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2006-2014 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef NOMOS_UTILS_H_
 #define NOMOS_UTILS_H_

--- a/src/nomos/agent/parse.c
+++ b/src/nomos/agent/parse.c
@@ -1,21 +1,9 @@
-/***************************************************************
- Copyright (C) 2006-2015 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2017-2019 Bittium Wireless Ltd.
+/*
+ SPDX-FileCopyrightText: © 2006-2015 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2017-2019 Bittium Wireless Ltd.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /* Equivalent to version 1.83 of Core Nomos code. */
 #include <ctype.h>
 

--- a/src/nomos/agent/parse.h
+++ b/src/nomos/agent/parse.h
@@ -1,20 +1,9 @@
-/***************************************************************
- Copyright (C) 2006-2009 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2006-2009 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
 #ifndef _PARSE_H
 #define _PARSE_H
 #include "doctorBuffer_utils.h"

--- a/src/nomos/agent/process.c
+++ b/src/nomos/agent/process.c
@@ -1,20 +1,8 @@
-/***************************************************************
- Copyright (C) 2006-2011 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2006-2011 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file
  * \brief some common functions that process the files for scanning

--- a/src/nomos/agent/process.h
+++ b/src/nomos/agent/process.h
@@ -1,20 +1,9 @@
-/***************************************************************
- Copyright (C) 2006-2009 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2006-2009 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
 #ifndef _PROCESS_H
 #define _PROCESS_H
 

--- a/src/nomos/agent/standalone.c
+++ b/src/nomos/agent/standalone.c
@@ -1,3 +1,8 @@
+/*
+ SPDX-FileCopyrightText: © Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file
  * \brief Dummy implementations of library functions for stand-alone operations

--- a/src/nomos/agent/standalone.h
+++ b/src/nomos/agent/standalone.h
@@ -1,3 +1,9 @@
+/*
+ SPDX-FileCopyrightText: © Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
 #ifndef _STANDALONE_H
 #define _STANDALONE_H 1
 #include <stdlib.h>

--- a/src/nomos/agent/transition.notes
+++ b/src/nomos/agent/transition.notes
@@ -1,4 +1,7 @@
+<!-- SPDX-FileCopyrightText: © Fossology contributors
 
+     SPDX-License-Identifier: GPL-2.0-only
+-->
 
 Notes related to the transition of GF's original Nomos code to the current 
 version of the nomos agent checked into FOSSology's svn archive on 

--- a/src/nomos/agent/util.c
+++ b/src/nomos/agent/util.c
@@ -1,20 +1,8 @@
-/***************************************************************
- Copyright (C) 2006-2009 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2006-2009 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /* Equivalent to core nomos v1.29 */
 
 /**

--- a/src/nomos/agent/util.h
+++ b/src/nomos/agent/util.h
@@ -1,20 +1,8 @@
-/***************************************************************
- Copyright (C) 2006-2009 Hewlett-Packard Development Company, L.P.
- 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
+/*
+ SPDX-FileCopyrightText: © 2006-2009 Hewlett-Packard Development Company, L.P.
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
-***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef _UTIL_H
 #define _UTIL_H

--- a/src/nomos/agent_tests/Functional/CommonCliTest.php
+++ b/src/nomos/agent_tests/Functional/CommonCliTest.php
@@ -1,18 +1,9 @@
 <?php
 /*
- * Copyright (C) 2015 Siemens AG
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2015 Siemens AG
 
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  *
  * @file

--- a/src/nomos/agent_tests/Functional/Makefile
+++ b/src/nomos/agent_tests/Functional/Makefile
@@ -1,19 +1,6 @@
-######################################################################
-# Copyright (C) 2011-2013 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2011-2013 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/nomos/agent_tests/Functional/Nomos-fun-test.php
+++ b/src/nomos/agent_tests/Functional/Nomos-fun-test.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
- Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2015 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2013 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2015 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  * @brief Regression test for NOMOS

--- a/src/nomos/agent_tests/Functional/OneShot-JSON.php
+++ b/src/nomos/agent_tests/Functional/OneShot-JSON.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
- Copyright (C) 2012 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2015 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2012 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2015 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  * @brief Run one-shot license analysis on JSON license

--- a/src/nomos/agent_tests/Functional/OneShot-Oracle-Berkeley-DB.php
+++ b/src/nomos/agent_tests/Functional/OneShot-Oracle-Berkeley-DB.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
- Copyright (C) 2012 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2015 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2012 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2015 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  * @brief Perform a one-shot license analysis on Oracle-Berkeley-DB and

--- a/src/nomos/agent_tests/Functional/OneShot-affero.php
+++ b/src/nomos/agent_tests/Functional/OneShot-affero.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
- Copyright (C) 2012 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2015 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2012 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2015 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 require_once ('CommonCliTest.php');
 /**
  * @file

--- a/src/nomos/agent_tests/Functional/OneShot-bsd.php
+++ b/src/nomos/agent_tests/Functional/OneShot-bsd.php
@@ -1,25 +1,10 @@
 <?php
-/***********************************************************
- Copyright (C) 2012 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2015 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2012 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2015 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
-/**
- * @file
- * @brief Perform a one-shot license analysis on a file (include bsd license)
- */
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 require_once ('CommonCliTest.php');
 
 /**

--- a/src/nomos/agent_tests/Functional/OneShot-empty.php
+++ b/src/nomos/agent_tests/Functional/OneShot-empty.php
@@ -1,22 +1,10 @@
 <?php
-/***********************************************************
- Copyright (C) 2012 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2015 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2012 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2015 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
-
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  * @brief Perform a one-shot license analysis on an empty file

--- a/src/nomos/agent_tests/Functional/OneShot-gpl3.php
+++ b/src/nomos/agent_tests/Functional/OneShot-gpl3.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
- Copyright (C) 2012-2013 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2015 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2012-2013 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2015 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  * @brief Perform a one-shot license analysis on a glpv3 license

--- a/src/nomos/agent_tests/Functional/OneShot-lgpl2.1.php
+++ b/src/nomos/agent_tests/Functional/OneShot-lgpl2.1.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
- Copyright (C) 2012 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2015 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2012 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2015 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  * @brief Run one-shot license analysis on LGPL_v2.1 license

--- a/src/nomos/agent_tests/Functional/OneShot-multiFile.php
+++ b/src/nomos/agent_tests/Functional/OneShot-multiFile.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
- Copyright (C) 2012-2013 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2015 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2012-2013 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2015 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  * @brief Perform a one-shot license analysis on multiple files

--- a/src/nomos/agent_tests/Functional/OneShot-none.php
+++ b/src/nomos/agent_tests/Functional/OneShot-none.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
- Copyright (C) 2012 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2015 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2012 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2015 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  * @brief Perform a one-shot license analysis on a file with no license

--- a/src/nomos/agent_tests/Functional/OneShot_test.sh
+++ b/src/nomos/agent_tests/Functional/OneShot_test.sh
@@ -1,27 +1,11 @@
 #! /bin/sh
-#/***********************************************************
-# Copyright (C) 2012 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-# ***********************************************************/
+# SPDX-FileCopyrightText: © 2012 Hewlett-Packard Development Company, L.P.
 
-#
+# SPDX-License-Identifier: GPL-2.0-only
+
 # \file OneShot_test.sh:testOneShotaffero
 # \brief Perform a one-shot license analysis on a file containing an affero license
 #       License returned should be: Affero_v1
-#
-
 
 testOneShotaffero()
 {

--- a/src/nomos/agent_tests/Functional/shunit2
+++ b/src/nomos/agent_tests/Functional/shunit2
@@ -1,9 +1,9 @@
 #! /bin/sh
 # $Id: shunit2 335 2011-05-01 20:10:33Z kate.ward@forestent.com $
 # vim:et:ft=sh:sts=2:sw=2
+# SPDX-FileCopyrightText: © 2008 Kate Ward
 #
-# Copyright 2008 Kate Ward. All Rights Reserved.
-# Released under the LGPL (GNU Lesser General Public License)
+# SPDX-License-Identifier: LGPL-2.0-only
 #
 # shUnit2 -- Unit testing framework for Unix shell scripts.
 # http://code.google.com/p/shunit2/

--- a/src/nomos/agent_tests/Functional/shunit2_plugin_example
+++ b/src/nomos/agent_tests/Functional/shunit2_plugin_example
@@ -1,13 +1,14 @@
 #! /bin/sh
 # vim:et:ft=sh:sts=2:sw=2
-#-----------------------------------------------------------------------------
+# SPDX-FileCopyrightText: © Fossology contributors
+#
+# SPDX-License-Identifier: GPL-2.0-only
 #
 # shunit_plugin_argv should pick out args that it reconizes from the
 # beginning of $*
 #
 # It should set shunit_plugin_argv_return to command to eval to shift away
 # all the args that it consumes.
-#
 
 shunit_plugin_argv() {
   shunit_plugin_output_file="./nomos-shunit-Xunit.xml"

--- a/src/nomos/agent_tests/Functional/tests.xml
+++ b/src/nomos/agent_tests/Functional/tests.xml
@@ -1,3 +1,7 @@
+<!-- SPDX-FileCopyrightText: © Fossology contributors
+
+     SPDX-License-Identifier: FSFAP
+-->
 <phpunit backupGlobals="true">
   <testsuites>
     <testsuite name="nomos/agent_tests/Functional Tests">

--- a/src/nomos/agent_tests/Makefile
+++ b/src/nomos/agent_tests/Makefile
@@ -1,19 +1,7 @@
-######################################################################
-# Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
+
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/nomos/agent_tests/Unit/Makefile
+++ b/src/nomos/agent_tests/Unit/Makefile
@@ -1,11 +1,6 @@
-######################################################################
-# Copyright Siemens AG 2014
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty
-######################################################################
+# SPDX-FileCopyrightText: © 2014 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/nomos/agent_tests/Unit/run_tests.c
+++ b/src/nomos/agent_tests/Unit/run_tests.c
@@ -1,19 +1,8 @@
-/*********************************************************************
-Copyright (C) 2014, Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*********************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file
  * \brief Unit test cases for Nomos

--- a/src/nomos/agent_tests/Unit/test_DoctoredBuffer.c
+++ b/src/nomos/agent_tests/Unit/test_DoctoredBuffer.c
@@ -1,19 +1,7 @@
 /*
-Copyright (C) 2014, Siemens AG
+ SPDX-FileCopyrightText: © 2014 Siemens AG
 
-Author: Johannes Najjar, Steffen Weber
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 /**
  * \file

--- a/src/nomos/agent_tests/Unit/test_nomos_gap.c
+++ b/src/nomos/agent_tests/Unit/test_nomos_gap.c
@@ -1,19 +1,7 @@
 /*
-Copyright (C) 2014, Siemens AG
+ SPDX-FileCopyrightText: © 2014 Siemens AG
 
-Author:  Steffen Weber, Johannes Najjar
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 /**
  * \file

--- a/src/nomos/mod_deps
+++ b/src/nomos/mod_deps
@@ -1,20 +1,9 @@
 #!/usr/bin/env bash
 # FOSSology mod_deps script
 # This script helps you install dependencies on a system. for a module
-#
-# Copyright (C) 2019 Siemens AG
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# SPDX-FileCopyrightText: © 2019 Siemens AG
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 source "$(dirname ${BASH_SOURCE[0]})/../../utils/utils.sh"
 

--- a/src/nomos/nomos.conf
+++ b/src/nomos/nomos.conf
@@ -1,7 +1,6 @@
-; Copying and distribution of this file, with or without modification,
-; are permitted in any medium without royalty provided the copyright
-; notice and this notice are preserved. This file is offered as-is,
-; without any warranty.
+; SPDX-FileCopyrightText: © Fossology contributors
+
+; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent
 [default]

--- a/src/nomos/ui/Makefile
+++ b/src/nomos/ui/Makefile
@@ -1,19 +1,6 @@
-######################################################################
-# Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/nomos/ui/agent-nomos-once.php
+++ b/src/nomos/ui/agent-nomos-once.php
@@ -1,21 +1,11 @@
 <?php
-/***********************************************************
- * Copyright (C) 2008-2013 Hewlett-Packard Development Company, L.P.
- * Copyright (C) 2015 Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-***********************************************************/
+/*
+ SPDX-FileCopyrightText: © 2008-2013 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Data\Highlight;
 

--- a/src/nomos/ui/agent-nomos.php
+++ b/src/nomos/ui/agent-nomos.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
- * Copyright (C) 2008-2013 Hewlett-Packard Development Company, L.P.
- * Copyright (C) 2015 Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- ***********************************************************/
+/*
+ SPDX-FileCopyrightText: © 2008-2013 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  * @brief UI plugin for NOMOS

--- a/src/nomos/ui/ajax-filelic.php
+++ b/src/nomos/ui/ajax-filelic.php
@@ -1,21 +1,9 @@
 <?php
-/***********************************************************
- * Copyright (C) 2009-2013 Hewlett-Packard Development Company, L.P.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-***********************************************************/
+/*
+ SPDX-FileCopyrightText: © 2009-2013 Hewlett-Packard Development Company, L.P.
 
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file
  * \brief This plugin finds all the uploadtree_pk's in the first directory

--- a/src/nomos/ui/nomos-diff.php
+++ b/src/nomos/ui/nomos-diff.php
@@ -1,22 +1,11 @@
 <?php
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\UploadDao;
-/***********************************************************
- * Copyright (C) 2010-2013 Hewlett-Packard Development Company, L.P.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-***********************************************************/
+/*
+ SPDX-FileCopyrightText: © 2010-2013 Hewlett-Packard Development Company, L.P.
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file
  * \brief Compare License Browser, list license histogram

--- a/src/nomos/ui_tests/Functional/Makefile
+++ b/src/nomos/ui_tests/Functional/Makefile
@@ -1,21 +1,7 @@
-######################################################################
-# Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
 
-#
+# SPDX-License-Identifier: GPL-2.0-only
+
 # Makefile for nomos UI functional tests
 test:
 	echo "Make UI Functional Tests"

--- a/src/nomos/ui_tests/Functional/ckZendTest.php
+++ b/src/nomos/ui_tests/Functional/ckZendTest.php
@@ -1,20 +1,9 @@
 <?php
 /*
- Copyright (C) 2010 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2010 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 /**
  * Verify zend license was processed correctly by nomos

--- a/src/nomos/ui_tests/Functional/verifyRedHatTest.php
+++ b/src/nomos/ui_tests/Functional/verifyRedHatTest.php
@@ -1,20 +1,9 @@
 <?php
 /*
- Copyright (C) 2010 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2010 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 /**
  * Verify/Establish baseline of licenses found by nomos

--- a/src/nomos/ui_tests/Makefile
+++ b/src/nomos/ui_tests/Makefile
@@ -1,19 +1,6 @@
-######################################################################
-# Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 all:
 	@echo "nothing to do"

--- a/src/nomos/ui_tests/Unit/Makefile
+++ b/src/nomos/ui_tests/Unit/Makefile
@@ -1,21 +1,7 @@
-######################################################################
-# Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
 
-#
+# SPDX-License-Identifier: GPL-2.0-only
+
 # Makefile for nomos agent Unit tests
 
 TOP = ../../../..

--- a/src/ojo/Makefile
+++ b/src/ojo/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2019
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2019 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../..
 VARS = $(TOP)/Makefile.conf

--- a/src/ojo/README.md
+++ b/src/ojo/README.md
@@ -1,3 +1,7 @@
+<!-- SPDX-FileCopyrightText: © Fossology contributors
+
+     SPDX-License-Identifier: GPL-2.0-only
+-->
 Introduction
 --------------
 

--- a/src/ojo/agent/Makefile
+++ b/src/ojo/agent/Makefile
@@ -1,9 +1,7 @@
-# Copyright Siemens AG 2019
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2019 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
+
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/ojo/agent/OjoAgent.cc
+++ b/src/ojo/agent/OjoAgent.cc
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2019, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2019 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include "OjoAgent.hpp"
 

--- a/src/ojo/agent/OjoAgent.hpp
+++ b/src/ojo/agent/OjoAgent.hpp
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2019, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2019 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  * OjoAgent - the regex runner

--- a/src/ojo/agent/OjoState.cc
+++ b/src/ojo/agent/OjoState.cc
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2019,2021 Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2019, 2021 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include "OjoState.hpp"
 

--- a/src/ojo/agent/OjoState.hpp
+++ b/src/ojo/agent/OjoState.hpp
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2019,2021 Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2019, 2021 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  * State and CLI options for OJO agent

--- a/src/ojo/agent/OjoUtils.cc
+++ b/src/ojo/agent/OjoUtils.cc
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2019, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2019 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  * The utility functions for OJO agent

--- a/src/ojo/agent/OjoUtils.hpp
+++ b/src/ojo/agent/OjoUtils.hpp
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2019, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2019 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef OJOS_AGENT_UTILS_HPP
 #define OJOS_AGENT_UTILS_HPP

--- a/src/ojo/agent/OjosDatabaseHandler.cc
+++ b/src/ojo/agent/OjosDatabaseHandler.cc
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2019, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2019 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  * @brief Data base handler for OJO

--- a/src/ojo/agent/OjosDatabaseHandler.hpp
+++ b/src/ojo/agent/OjosDatabaseHandler.hpp
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2019, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2019 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  * @brief Database handler for OJO

--- a/src/ojo/agent/directoryScan.cc
+++ b/src/ojo/agent/directoryScan.cc
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2019, Siemens AG
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2019 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 /**
  * \file

--- a/src/ojo/agent/directoryScan.hpp
+++ b/src/ojo/agent/directoryScan.hpp
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2019, Siemens AG
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2019 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef SRC_OJO_AGENT_DIRECTORYSCAN_HPP_
 #define SRC_OJO_AGENT_DIRECTORYSCAN_HPP_

--- a/src/ojo/agent/ojomatch.hpp
+++ b/src/ojo/agent/ojomatch.hpp
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2019, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2019 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef SRC_OJO_AGENT_OJOMATCH_HPP_
 #define SRC_OJO_AGENT_OJOMATCH_HPP_

--- a/src/ojo/agent/ojoregex.hpp
+++ b/src/ojo/agent/ojoregex.hpp
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2020, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2020 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  * The list of regex used in the agent.

--- a/src/ojo/agent/ojos.cc
+++ b/src/ojo/agent/ojos.cc
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2019, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2019 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @dir
  * @brief The OJO agent

--- a/src/ojo/agent/ojos.hpp
+++ b/src/ojo/agent/ojos.hpp
@@ -1,19 +1,8 @@
 /*
- * Copyright (C) 2019, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2019 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef OJOS_AGENT_OJOS_HPP
 #define OJOS_AGENT_OJOS_HPP

--- a/src/ojo/agent_tests/Functional/Makefile
+++ b/src/ojo/agent_tests/Functional/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2019
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2019 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/ojo/agent_tests/Functional/SchedulerTestRunner.php
+++ b/src/ojo/agent_tests/Functional/SchedulerTestRunner.php
@@ -1,19 +1,8 @@
 <?php
 /*
-Copyright (C) 2019, Siemens AG
+ SPDX-FileCopyrightText: © 2019 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 namespace Fossology\Ojo\Test;

--- a/src/ojo/agent_tests/Functional/SchedulerTestRunnerCli.php
+++ b/src/ojo/agent_tests/Functional/SchedulerTestRunnerCli.php
@@ -1,19 +1,8 @@
 <?php
 /*
-Copyright (C) 2019, Siemens AG
+ SPDX-FileCopyrightText: © 2019 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 namespace Fossology\Ojo\Test;

--- a/src/ojo/agent_tests/Functional/SchedulerTestRunnerScheduler.php
+++ b/src/ojo/agent_tests/Functional/SchedulerTestRunnerScheduler.php
@@ -1,19 +1,8 @@
 <?php
 /*
-Copyright (C) 2019, Siemens AG
+ SPDX-FileCopyrightText: © 2019 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 namespace Fossology\Ojo\Test;

--- a/src/ojo/agent_tests/Functional/cli_test.sh
+++ b/src/ojo/agent_tests/Functional/cli_test.sh
@@ -1,19 +1,7 @@
 #! /bin/sh
-#
-# Copyright (C) 2019 Siemens AG
-# 
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# SPDX-FileCopyrightText: © 2019 Siemens AG
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 _runojo()
 {

--- a/src/ojo/agent_tests/Functional/regexTest.json.license
+++ b/src/ojo/agent_tests/Functional/regexTest.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: © Fossology contributors
+
+SPDX-License-Identifier: GPL-2.0-only

--- a/src/ojo/agent_tests/Functional/schedulerTest.php
+++ b/src/ojo/agent_tests/Functional/schedulerTest.php
@@ -1,17 +1,9 @@
 <?php
 /*
- * Copyright (C) 2019, Siemens AG
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2019 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 /**
  * @file

--- a/src/ojo/agent_tests/Functional/shunit2
+++ b/src/ojo/agent_tests/Functional/shunit2
@@ -1,9 +1,9 @@
 #! /bin/sh
 # $Id: shunit2 335 2011-05-01 20:10:33Z kate.ward@forestent.com $
 # vim:et:ft=sh:sts=2:sw=2
+# SPDX-FileCopyrightText: © 2008 Kate Ward
 #
-# Copyright 2008 Kate Ward. All Rights Reserved.
-# Released under the LGPL (GNU Lesser General Public License)
+# SPDX-License-Identifier: LGPL-2.0-only
 #
 # shUnit2 -- Unit testing framework for Unix shell scripts.
 # http://code.google.com/p/shunit2/

--- a/src/ojo/agent_tests/Makefile
+++ b/src/ojo/agent_tests/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2019
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2019 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/ojo/agent_tests/Unit/Makefile
+++ b/src/ojo/agent_tests/Unit/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2019
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2019 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/ojo/agent_tests/Unit/run_tests.cc
+++ b/src/ojo/agent_tests/Unit/run_tests.cc
@@ -1,19 +1,8 @@
-/*********************************************************************
-Copyright (C) 2019, Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2019 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*********************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file
  * \brief Unit test executioner for OJO agent

--- a/src/ojo/agent_tests/Unit/test_regex.cc
+++ b/src/ojo/agent_tests/Unit/test_regex.cc
@@ -1,19 +1,8 @@
-/*********************************************************************
-Copyright (C) 2019, Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2019 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*********************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file test_regex.cc
  * \brief Test for regex accuracy

--- a/src/ojo/agent_tests/Unit/test_scanners.cc
+++ b/src/ojo/agent_tests/Unit/test_scanners.cc
@@ -1,19 +1,8 @@
-/*********************************************************************
-Copyright (C) 2019 Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2019 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*********************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include <cppunit/TestFixture.h>
 #include <cppunit/extensions/HelperMacros.h>

--- a/src/ojo/mod_deps
+++ b/src/ojo/mod_deps
@@ -1,20 +1,9 @@
 #!/usr/bin/env bash
 # FOSSology mod_deps script
 # This script helps you install dependencies on a system. for a module
+# SPDX-FileCopyrightText: © 2018 Siemens AG
 #
-# Copyright (C) 2018 Siemens AG
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# SPDX-License-Identifier: GPL-2.0-only
 
 source "$(dirname ${BASH_SOURCE[0]})/../../utils/utils.sh"
 

--- a/src/ojo/ojo.conf
+++ b/src/ojo/ojo.conf
@@ -1,7 +1,6 @@
-; Copying and distribution of this file, with or without modification,
-; are permitted in any medium without royalty provided the copyright
-; notice and this notice are preserved. This file is offered as-is,
-; without any warranty.
+; SPDX-FileCopyrightText: © Fossology contributors
+
+; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent
 [default]

--- a/src/ojo/ui/Makefile
+++ b/src/ojo/ui/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2019
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2019 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/ojo/ui/agent-ojos.php
+++ b/src/ojo/ui/agent-ojos.php
@@ -1,20 +1,7 @@
 <?php
-/***********************************************************
- * Copyright (C) 2019, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+# SPDX-FileCopyrightText: © 2019 Siemens AG
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 namespace Fossology\Ojo\Ui;
 

--- a/src/pkgagent/Makefile
+++ b/src/pkgagent/Makefile
@@ -1,19 +1,6 @@
-######################################################################
-# Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../..
 VARS = $(TOP)/Makefile.conf

--- a/src/pkgagent/agent/Makefile
+++ b/src/pkgagent/agent/Makefile
@@ -1,19 +1,6 @@
-######################################################################
-# Copyright (C) 2010-2011 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2010-2011 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 LANG = C
 TOP = ../../..

--- a/src/pkgagent/agent/main.c
+++ b/src/pkgagent/agent/main.c
@@ -1,20 +1,8 @@
-/***************************************************************
- Copyright (C) 2010-2013 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2010-2013 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \dir
  * \brief Package agent source

--- a/src/pkgagent/agent/pkgagent.c
+++ b/src/pkgagent/agent/pkgagent.c
@@ -1,20 +1,8 @@
-/***************************************************************
- Copyright (C) 2011-2014 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2011-2014 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file
  * \brief Local function of pkgagent

--- a/src/pkgagent/agent/pkgagent.h
+++ b/src/pkgagent/agent/pkgagent.h
@@ -1,20 +1,8 @@
-/**************************************************************
- Copyright (C) 2010-2011 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2010-2011 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file
  * \brief pkgagent header

--- a/src/pkgagent/agent_tests/Functional/Makefile
+++ b/src/pkgagent/agent_tests/Functional/Makefile
@@ -1,19 +1,6 @@
-######################################################################
-# Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/pkgagent/agent_tests/Functional/ft_cliPkgagentTest.php
+++ b/src/pkgagent/agent_tests/Functional/ft_cliPkgagentTest.php
@@ -1,22 +1,9 @@
 <?php
-/***************************************************************
- Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
- ***************************************************************/
-
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \dir
  * \brief Function test the pkgagent

--- a/src/pkgagent/agent_tests/Makefile
+++ b/src/pkgagent/agent_tests/Makefile
@@ -1,19 +1,6 @@
-######################################################################
-# Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/pkgagent/agent_tests/Unit/Makefile
+++ b/src/pkgagent/agent_tests/Unit/Makefile
@@ -1,5 +1,7 @@
 # FOSSology Makefile - test for agents/pkgagent
-# Copyright (C) 2009-2013 Hewlett-Packard Development Company, L.P.
+# SPDX-FileCopyrightText: © 2009-2013 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/pkgagent/agent_tests/Unit/testGetFieldValue.c
+++ b/src/pkgagent/agent_tests/Unit/testGetFieldValue.c
@@ -1,19 +1,8 @@
-/*********************************************************************
-Copyright (C) 2011-2012 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2011-2012 Hewlett-Packard Development Company, L.P.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *********************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 /* library includes */
 #include <stdio.h>

--- a/src/pkgagent/agent_tests/Unit/testGetMetadata.c
+++ b/src/pkgagent/agent_tests/Unit/testGetMetadata.c
@@ -1,19 +1,8 @@
-/*********************************************************************
-Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *********************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 #include "pkgagent.h"
 
 #include <stdio.h>

--- a/src/pkgagent/agent_tests/Unit/testGetMetadataDebBinary.c
+++ b/src/pkgagent/agent_tests/Unit/testGetMetadataDebBinary.c
@@ -1,19 +1,8 @@
-/*********************************************************************
-Copyright (C) 2011-2014 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2011-2014 Hewlett-Packard Development Company, L.P.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *********************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 #include "pkgagent.h"
 
 #include <stdio.h>

--- a/src/pkgagent/agent_tests/Unit/testGetMetadataDebSource.c
+++ b/src/pkgagent/agent_tests/Unit/testGetMetadataDebSource.c
@@ -1,19 +1,8 @@
-/*********************************************************************
-Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *********************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 #include "pkgagent.h"
 
 #include <stdio.h>

--- a/src/pkgagent/agent_tests/Unit/testRecordMetadataDEB.c
+++ b/src/pkgagent/agent_tests/Unit/testRecordMetadataDEB.c
@@ -1,19 +1,8 @@
-/*********************************************************************
-Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *********************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 #include "pkgagent.h"
 
 #include <stdio.h>

--- a/src/pkgagent/agent_tests/Unit/testRecordMetadataRPM.c
+++ b/src/pkgagent/agent_tests/Unit/testRecordMetadataRPM.c
@@ -1,19 +1,8 @@
-/*********************************************************************
-Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *********************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 #include "pkgagent.h"
 
 #include <stdio.h>

--- a/src/pkgagent/agent_tests/Unit/testRun.c
+++ b/src/pkgagent/agent_tests/Unit/testRun.c
@@ -1,19 +1,8 @@
-/*********************************************************************
-Copyright (C) 2011-2013 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2011-2013 Hewlett-Packard Development Company, L.P.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *********************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \dir
  * \brief Unit test for pkgagent

--- a/src/pkgagent/agent_tests/Unit/testTrim.c
+++ b/src/pkgagent/agent_tests/Unit/testTrim.c
@@ -1,19 +1,8 @@
-/*********************************************************************
-Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
+/*
+ SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *********************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include <stdio.h>
 #include "CUnit/CUnit.h"

--- a/src/pkgagent/mod_deps
+++ b/src/pkgagent/mod_deps
@@ -2,19 +2,9 @@
 # FOSSology mod_deps script
 # This script helps you install dependencies on a system. for a module
 #
-# Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
+# SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# SPDX-License-Identifier: GPL-2.0-only
 
 source "$(dirname ${BASH_SOURCE[0]})/../../utils/utils.sh"
 

--- a/src/pkgagent/pkgagent.conf
+++ b/src/pkgagent/pkgagent.conf
@@ -1,7 +1,6 @@
-; Copying and distribution of this file, with or without modification,
-; are permitted in any medium without royalty provided the copyright
-; notice and this notice are preserved. This file is offered as-is,
-; without any warranty.
+; SPDX-FileCopyrightText: © Fossology contributors
+
+; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent
 [default]

--- a/src/pkgagent/ui/Makefile
+++ b/src/pkgagent/ui/Makefile
@@ -1,19 +1,6 @@
-######################################################################
-# Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/pkgagent/ui/agent-pkgagent.php
+++ b/src/pkgagent/ui/agent-pkgagent.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
- Copyright (C) 2009-2013 Hewlett-Packard Development Company, L.P.
- Copyright (C) 2015, Siemens AG
+/*
+ SPDX-FileCopyrightText: © 2009-2013 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2015 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 use Fossology\Lib\Plugin\AgentPlugin;
 

--- a/src/readmeoss/Makefile
+++ b/src/readmeoss/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../..
 VARS = $(TOP)/Makefile.conf

--- a/src/readmeoss/agent/Makefile
+++ b/src/readmeoss/agent/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP=../../..
 VARS=$(TOP)/Makefile.conf

--- a/src/readmeoss/agent/readmeoss.php
+++ b/src/readmeoss/agent/readmeoss.php
@@ -1,21 +1,10 @@
 <?php
 /*
- * Author: Daniele Fognini, Shaheem Azmal M MD
- * Copyright (C) 2016-2018, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ Author: Daniele Fognini, Shaheem Azmal M MD
+ SPDX-FileCopyrightText: © 2016-2018 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @dir readmeoss
  * @brief Readme_OSS agent

--- a/src/readmeoss/agent/version.php.in
+++ b/src/readmeoss/agent/version.php.in
@@ -1,4 +1,10 @@
 <?php
+/*
+ SPDX-FileCopyrightText: © Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
 define("README_AGENT_NAME", "readmeoss");
 define("AGENT_VERSION", "{$VERSION}");
 define("AGENT_REV", "{$COMMIT_HASH}");

--- a/src/readmeoss/readmeoss.conf
+++ b/src/readmeoss/readmeoss.conf
@@ -1,7 +1,6 @@
-; Copying and distribution of this file, with or without modification,
-; are permitted in any medium without royalty provided the copyright
-; notice and this notice are preserved. This file is offered as-is,
-; without any warranty.
+; SPDX-FileCopyrightText: © Fossology contributors
+
+; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent
 [default]

--- a/src/readmeoss/ui/Makefile
+++ b/src/readmeoss/ui/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/readmeoss/ui/ReadMeOssAgentPlugin.php
+++ b/src/readmeoss/ui/ReadMeOssAgentPlugin.php
@@ -1,20 +1,9 @@
 <?php
-/***********************************************************
- * Copyright (C) 2015, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+/*
+ SPDX-FileCopyrightText: © 2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 /**
  * @file

--- a/src/readmeoss/ui/ReadMeOssPlugin.php
+++ b/src/readmeoss/ui/ReadMeOssPlugin.php
@@ -1,20 +1,9 @@
 <?php
 /*
- Copyright (C) 2014-2018 Siemens AG
+ SPDX-FileCopyrightText: © 2014-2018 Siemens AG
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 /**
  * @file

--- a/src/regexscan/Makefile
+++ b/src/regexscan/Makefile
@@ -1,19 +1,6 @@
-######################################################################
-# Copyright (C) 2011 Hewlett-Packard Development Company, L.P.
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2011 Hewlett-Packard Development Company, L.P.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../..
 VARS = $(TOP)/Makefile.conf

--- a/src/regexscan/agent/Makefile
+++ b/src/regexscan/agent/Makefile
@@ -1,20 +1,7 @@
-######################################################################
-# Copyright (C) 2008-2011 Hewlett-Packard Development Company, L.P.
-# Copyright (C) 2016 Siemens AG
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+# SPDX-FileCopyrightText: © 2008-2011 Hewlett-Packard Development Company, L.P.
+# SPDX-FileCopyrightText: © 2016 Siemens AG
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/regexscan/agent/regexscan-Stage1.c
+++ b/src/regexscan/agent/regexscan-Stage1.c
@@ -1,22 +1,10 @@
-/***************************************************************
+/*
  regexscan: Scan file(s) for regular expression(s)
+ 
+ SPDX-FileCopyrightText: © 2007-2013 Hewlett-Packard Development Company, L.P.
 
- Copyright (C) 2007-2013 Hewlett-Packard Development Company, L.P.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***************************************************************/
-
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file
  * \brief Stage 1 demonstration

--- a/src/regexscan/agent/regexscan-Stage2.c
+++ b/src/regexscan/agent/regexscan-Stage2.c
@@ -1,21 +1,10 @@
-/***************************************************************
+/*
  regexscan: Scan file(s) for regular expression(s)
+ 
+ SPDX-FileCopyrightText: © 2007-2013 Hewlett-Packard Development Company, L.P.
 
- Copyright (C) 2007-2013 Hewlett-Packard Development Company, L.P.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file
  * \brief Stage 2 demonstration

--- a/src/regexscan/agent/regexscan-Stage3.c
+++ b/src/regexscan/agent/regexscan-Stage3.c
@@ -1,22 +1,10 @@
-/***************************************************************
+/*
  regexscan: Scan file(s) for regular expression(s)
 
- Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
+ SPDX-FileCopyrightText: © 2013 Hewlett-Packard Development Company, L.P.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***************************************************************/
-
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * \file
  * \brief Stage 3 demonstration

--- a/src/regexscan/agent/regexscan.c
+++ b/src/regexscan/agent/regexscan.c
@@ -1,21 +1,10 @@
-/***************************************************************
+/*
  regexscan: Scan file(s) for regular expression(s)
+ 
+ SPDX-FileCopyrightText: © 2013 Hewlett-Packard Development Company, L.P.
 
- Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***************************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /*!
  * \dir
  * \brief Sample scanner with multiple stages.

--- a/src/regexscan/regexscan.conf
+++ b/src/regexscan/regexscan.conf
@@ -1,7 +1,6 @@
-; Copying and distribution of this file, with or without modification,
-; are permitted in any medium without royalty provided the copyright
-; notice and this notice are preserved. This file is offered as-is,
-; without any warranty.
+; SPDX-FileCopyrightText: © Fossology contributors
+
+; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent
 [default]

--- a/src/reportImport/Makefile
+++ b/src/reportImport/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../..
 VARS = $(TOP)/Makefile.conf

--- a/src/reportImport/agent/ImportSource.php
+++ b/src/reportImport/agent/ImportSource.php
@@ -1,20 +1,9 @@
 <?php
 /*
- * Copyright (C) 2017, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2017 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 namespace Fossology\ReportImport;
 

--- a/src/reportImport/agent/Makefile
+++ b/src/reportImport/agent/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014-2016
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014-2016 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/reportImport/agent/ReportImportAgent.php
+++ b/src/reportImport/agent/ReportImportAgent.php
@@ -1,20 +1,9 @@
 <?php
 /*
- * Copyright (C) 2015-2017, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2015-2017 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 namespace Fossology\ReportImport;
 
 use Fossology\Lib\Agent\Agent;

--- a/src/reportImport/agent/ReportImportConfiguration.php
+++ b/src/reportImport/agent/ReportImportConfiguration.php
@@ -1,20 +1,9 @@
 <?php
 /*
- * Copyright (C) 2017, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2017 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 namespace Fossology\ReportImport;
 
 use Fossology\Lib\Data\DecisionTypes;

--- a/src/reportImport/agent/ReportImportData.php
+++ b/src/reportImport/agent/ReportImportData.php
@@ -1,20 +1,9 @@
 <?php
 /*
- * Copyright (C) 2017, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2017 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 namespace Fossology\ReportImport;
 
 class ReportImportData

--- a/src/reportImport/agent/ReportImportDataItem.php
+++ b/src/reportImport/agent/ReportImportDataItem.php
@@ -1,20 +1,9 @@
 <?php
 /*
- * Copyright (C) 2017, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2017 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 namespace Fossology\ReportImport;
 
 use Fossology\Lib\Data\License;

--- a/src/reportImport/agent/ReportImportHelper.php
+++ b/src/reportImport/agent/ReportImportHelper.php
@@ -1,20 +1,9 @@
 <?php
 /*
- * Copyright (C) 2015-2017, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2015-2017 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 namespace Fossology\ReportImport;
 
 use EasyRdf\Graph;

--- a/src/reportImport/agent/ReportImportSink.php
+++ b/src/reportImport/agent/ReportImportSink.php
@@ -1,20 +1,9 @@
 <?php
 /*
- * Copyright (C) 2015-2017, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2015-2017 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 namespace Fossology\ReportImport;
 
 use Fossology\Lib\Dao\ClearingDao;

--- a/src/reportImport/agent/SpdxTwoImportSource.php
+++ b/src/reportImport/agent/SpdxTwoImportSource.php
@@ -1,20 +1,9 @@
 <?php
 /*
- * Copyright (C) 2015-2017, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2015-2017 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 namespace Fossology\ReportImport;
 
 use Fossology\Lib\Data\License;

--- a/src/reportImport/agent/XmlImportSource.php
+++ b/src/reportImport/agent/XmlImportSource.php
@@ -1,20 +1,9 @@
 <?php
 /*
- * Copyright (C) 2017, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2017 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 namespace Fossology\ReportImport;
 

--- a/src/reportImport/agent/reportImport.php
+++ b/src/reportImport/agent/reportImport.php
@@ -1,20 +1,9 @@
 <?php
 /*
- * Copyright (C) 2015-2017, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2015-2017 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 namespace Fossology\ReportImport;
 
 include_once(__DIR__ . "/ReportImportAgent.php");

--- a/src/reportImport/agent/services.php
+++ b/src/reportImport/agent/services.php
@@ -1,10 +1,8 @@
 <?php
 /*
- Copyright Siemens AG 2015
+ SPDX-FileCopyrightText: © 2015 Siemens AG
 
- Copying and distribution of this file, with or without modification,
- are permitted in any medium without royalty provided the copyright
- notice and this notice are preserved. This file is offered as-is,
- without any warranty.
- */
+ SPDX-License-Identifier: FSFAP
+*/
+
 global $container;

--- a/src/reportImport/agent/version.php.in
+++ b/src/reportImport/agent/version.php.in
@@ -1,4 +1,10 @@
 <?php
+/*
+ SPDX-FileCopyrightText: © Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
 define("AGENT_REPORTIMPORT_NAME", "reportImport");
 define("AGENT_REPORTIMPORT_VERSION", "{$VERSION}");
 define("AGENT_REPORTIMPORT_REV", "{$COMMIT_HASH}");

--- a/src/reportImport/reportImport.conf
+++ b/src/reportImport/reportImport.conf
@@ -1,3 +1,7 @@
+; SPDX-FileCopyrightText: © Fossology contributors
+
+; SPDX-License-Identifier: GPL-2.0-only
+
 ; scheduler configure file for this agent
 [default]
 

--- a/src/reportImport/ui/Makefile
+++ b/src/reportImport/ui/Makefile
@@ -1,9 +1,7 @@
-# Copyright Siemens AG 2014
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
+
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/reportImport/ui/ReportImportAgentPlugin.php
+++ b/src/reportImport/ui/ReportImportAgentPlugin.php
@@ -1,20 +1,9 @@
 <?php
-/***********************************************************
- * Copyright (C) 2015-2017, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+/*
+ SPDX-FileCopyrightText: © 2015-2017 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 use Fossology\Lib\Plugin\AgentPlugin;
 

--- a/src/reportImport/ui/ReportImportPlugin.php
+++ b/src/reportImport/ui/ReportImportPlugin.php
@@ -1,19 +1,8 @@
 <?php
 /*
-  Copyright (C) 2014-2016 Siemens AG
+ SPDX-FileCopyrightText: © 2014-2016 Siemens AG
 
-  This program is free software; you can redistribute it and/or
-  modify it under the terms of the GNU General Public License
-  version 2 as published by the Free Software Foundation.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License along
-  with this program; if not, write to the Free Software Foundation, Inc.,
-  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 use Fossology\Lib\Auth\Auth;

--- a/src/reportImport/ui/services.php
+++ b/src/reportImport/ui/services.php
@@ -1,3 +1,8 @@
 <?php
+/*
+ SPDX-FileCopyrightText: © Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 $loader = $GLOBALS['container']->get('twig.loader');
 $loader->addPath(dirname(__FILE__).'/template');

--- a/src/reportImport/ui/template/ReportImportPlugin.html.twig
+++ b/src/reportImport/ui/template/ReportImportPlugin.html.twig
@@ -1,8 +1,6 @@
-{# Copyright 2015-2017 Siemens AG
+{# SPDX-FileCopyrightText: © 2015-2017 Siemens AG
 
-Copying and distribution of this file, with or without modification,
-are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
-This file is offered as-is, without any warranty.
+   SPDX-License-Identifier: FSFAP
 #}
 {% extends "include/base.html.twig" %}
 

--- a/src/reso/Makefile
+++ b/src/reso/Makefile
@@ -1,19 +1,7 @@
-# SPDX-License-Identifier: GPL-2.0
-# SPDX-FileCopyrightText: Copyright (c) 2021 Orange
+# SPDX-FileCopyrightText: © 2021 Orange
 # Author: Bartłomiej Dróżdż <bartlomiej.drozdz@orange.com>
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../..
 VARS = $(TOP)/Makefile.conf

--- a/src/reso/agent/Makefile
+++ b/src/reso/agent/Makefile
@@ -1,20 +1,7 @@
-# SPDX-License-Identifier: GPL-2.0
-# SPDX-FileCopyrightText: Copyright (c) 2021 Orange
+# SPDX-FileCopyrightText: © 2021 Orange
 # Author: Bartłomiej Dróżdż <bartlomiej.drozdz@orange.com>
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/reso/agent/ResoAgent.php
+++ b/src/reso/agent/ResoAgent.php
@@ -1,23 +1,11 @@
 <?php
-/**
- * SPDX-License-Identifier: GPL-2.0
- * SPDX-FileCopyrightText: Copyright (c) 2021 Orange
- * Author: Bartłomiej Dróżdż <bartlomiej.drozdz@orange.com>
- * Author: Piotr Pszczoła <piotr.pszczola@orange.com>
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+/*
+ SPDX-FileCopyrightText: © 2021 Orange
+ Author: Bartłomiej Dróżdż <bartlomiej.drozdz@orange.com>
+ Author: Piotr Pszczoła <piotr.pszczola@orange.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 namespace Fossology\Reso;
 

--- a/src/reso/agent/reso.php
+++ b/src/reso/agent/reso.php
@@ -1,22 +1,10 @@
 <?php
-/**
- * SPDX-License-Identifier: GPL-2.0
- * SPDX-FileCopyrightText: Copyright (c) 2021 Orange
- * Author: Bartłomiej Dróżdż <bartlomiej.drozdz@orange.com>
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+/*
+ SPDX-FileCopyrightText: © 2021 Orange
+ Author: Bartłomiej Dróżdż <bartlomiej.drozdz@orange.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 /**
  * @dir

--- a/src/reso/agent/version.php.in
+++ b/src/reso/agent/version.php.in
@@ -1,4 +1,10 @@
 <?php
+/*
+ SPDX-FileCopyrightText: © Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
 define("RESO_AGENT_NAME", "reso");
 defined("AGENT_VERSION") or define("AGENT_VERSION", "{$VERSION}");
 defined("AGENT_REV") or define("AGENT_REV", "{$COMMIT_HASH}");

--- a/src/reso/reso.conf
+++ b/src/reso/reso.conf
@@ -1,7 +1,6 @@
-; Copying and distribution of this file, with or without modification,
-; are permitted in any medium without royalty provided the copyright
-; notice and this notice are preserved. This file is offered as-is,
-; without any warranty.
+; SPDX-FileCopyrightText: © Fossology contributors
+
+; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent
 [default]

--- a/src/reso/ui/Makefile
+++ b/src/reso/ui/Makefile
@@ -1,20 +1,7 @@
-# SPDX-License-Identifier: GPL-2.0
-# SPDX-FileCopyrightText: Copyright (c) 2021 Orange
+# SPDX-FileCopyrightText: © 2021 Orange
 # Author: Bartłomiej Dróżdż <bartlomiej.drozdz@orange.com>
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/reso/ui/ResoAgentPlugin.php
+++ b/src/reso/ui/ResoAgentPlugin.php
@@ -1,22 +1,10 @@
 <?php
-/**
- * SPDX-License-Identifier: GPL-2.0
- * SPDX-FileCopyrightText: Copyright (c) 2021 Orange
- * Author: Bartłomiej Dróżdż <bartlomiej.drozdz@orange.com>
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+/*
+ SPDX-FileCopyrightText: © 2021 Orange
+ Author: Bartłomiej Dróżdż <bartlomiej.drozdz@orange.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 use Fossology\Lib\Plugin\AgentPlugin;
 

--- a/src/reuser/Makefile
+++ b/src/reuser/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../..
 VARS = $(TOP)/Makefile.conf

--- a/src/reuser/agent/Makefile
+++ b/src/reuser/agent/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/reuser/agent/ReuserAgent.php
+++ b/src/reuser/agent/ReuserAgent.php
@@ -1,20 +1,9 @@
 <?php
 /*
- Copyright (C) 2014-2018, Siemens AG
- Author: Daniele Fognini, Andreas Würl
+ SPDX-FileCopyrightText: © 2014-2018 Siemens AG
+Author: Daniele Fognini, Andreas Würl
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 namespace Fossology\Reuser;

--- a/src/reuser/agent/reuser.php
+++ b/src/reuser/agent/reuser.php
@@ -1,21 +1,10 @@
 <?php
 /*
- Copyright (C) 2014-2018, Siemens AG
- Author: Daniele Fognini, Andreas Würl
+ SPDX-FileCopyrightText: © 2014-2018 Siemens AG
+Author: Daniele Fognini, Andreas Würl
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @dir
  * @brief Source for reuser agent

--- a/src/reuser/agent/version.php.in
+++ b/src/reuser/agent/version.php.in
@@ -1,4 +1,10 @@
 <?php
+/*
+ SPDX-FileCopyrightText: © Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
 define("REUSER_AGENT_NAME", "reuser");
 defined("AGENT_VERSION") or define("AGENT_VERSION", "{$VERSION}");
 defined("AGENT_REV") or define("AGENT_REV", "{$COMMIT_HASH}");

--- a/src/reuser/agent_tests/Functional/Makefile
+++ b/src/reuser/agent_tests/Functional/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/reuser/agent_tests/Functional/SchedulerTestRunner.php
+++ b/src/reuser/agent_tests/Functional/SchedulerTestRunner.php
@@ -1,19 +1,8 @@
 <?php
 /*
-Copyright (C) 2014, Siemens AG
+ SPDX-FileCopyrightText: © 2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 namespace Fossology\Reuser\Test;

--- a/src/reuser/agent_tests/Functional/SchedulerTestRunnerCli.php
+++ b/src/reuser/agent_tests/Functional/SchedulerTestRunnerCli.php
@@ -1,19 +1,8 @@
 <?php
 /*
-Copyright (C) 2014, Siemens AG
+ SPDX-FileCopyrightText: © 2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 namespace Fossology\Reuser\Test;

--- a/src/reuser/agent_tests/Functional/SchedulerTestRunnerMock.php
+++ b/src/reuser/agent_tests/Functional/SchedulerTestRunnerMock.php
@@ -1,19 +1,8 @@
 <?php
 /*
-Copyright (C) 2014, Siemens AG
+ SPDX-FileCopyrightText: © 2014 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 namespace Fossology\Reuser\Test;

--- a/src/reuser/agent_tests/Functional/schedulerTest.php
+++ b/src/reuser/agent_tests/Functional/schedulerTest.php
@@ -1,19 +1,8 @@
 <?php
 /*
-Copyright (C) 2014-2015,2019 Siemens AG
+ SPDX-FileCopyrightText: © 2014-2015, 2019 Siemens AG
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 /**
  * @dir

--- a/src/reuser/agent_tests/Makefile
+++ b/src/reuser/agent_tests/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/reuser/reuser.conf
+++ b/src/reuser/reuser.conf
@@ -1,7 +1,6 @@
-; Copying and distribution of this file, with or without modification,
-; are permitted in any medium without royalty provided the copyright
-; notice and this notice are preserved. This file is offered as-is,
-; without any warranty.
+; SPDX-FileCopyrightText: © Fossology contributors
+
+; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent
 [default]

--- a/src/reuser/ui/Makefile
+++ b/src/reuser/ui/Makefile
@@ -1,9 +1,6 @@
-# Copyright Siemens AG 2014
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © 2014 Siemens AG
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/reuser/ui/agent-reuser.php
+++ b/src/reuser/ui/agent-reuser.php
@@ -1,20 +1,9 @@
 <?php
-/***********************************************************
- * Copyright (C) 2014-2018, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+/*
+ SPDX-FileCopyrightText: © 2014-2018 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 /**
  * @dir

--- a/src/reuser/ui/reuser-plugin.php
+++ b/src/reuser/ui/reuser-plugin.php
@@ -1,20 +1,9 @@
 <?php
-/***********************************************************
- * Copyright (C) 2014-2018, Siemens AG
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+/*
+ SPDX-FileCopyrightText: © 2014-2018 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  */

--- a/src/reuser/ui/services.php
+++ b/src/reuser/ui/services.php
@@ -1,4 +1,9 @@
 <?php
+/*
+ SPDX-FileCopyrightText: © Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  * @brief Add the template path of copyright twig templates

--- a/src/reuser/ui/template/agent_reuser.html.twig
+++ b/src/reuser/ui/template/agent_reuser.html.twig
@@ -1,3 +1,7 @@
+{# SPDX-FileCopyrightText: © Fossology contributors
+ 
+   SPDX-License-Identifier: GPL-2.0-only
+#}
 {% import "include/macros.html.twig" as macro %}
 
 <li>

--- a/src/reuser/ui/template/agent_reuser.js.twig
+++ b/src/reuser/ui/template/agent_reuser.js.twig
@@ -1,3 +1,7 @@
+{# SPDX-FileCopyrightText: © Fossology contributors
+ 
+   SPDX-License-Identifier: GPL-2.0-only
+#}
 $.getScript( "scripts/tools.js", function( data, textStatus, jqxhr ) {console.log( "Failure handler loaded." ); });
 
 $('#{{ reuseFolderSelectorName }}').change(function () {

--- a/src/reuser/ui/template/reuse-folder.html.twig
+++ b/src/reuser/ui/template/reuse-folder.html.twig
@@ -1,8 +1,6 @@
-{# Copyright 2014-2015 Siemens AG
+{# SPDX-FileCopyrightText: © 2014-2015 Siemens AG
 
-   Copying and distribution of this file, with or without modification,
-   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
-   This file is offered as-is, without any warranty.
+   SPDX-License-Identifier: FSFAP
 #}
 {% if selected is not defined %}
   {% set selected = -1 %}

--- a/src/scancode/Makefile
+++ b/src/scancode/Makefile
@@ -1,20 +1,6 @@
-##############################################################################
-# SPDX-License-Identifier: GPL-2.0
-# SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com> 
-#
-# This program is free software; you can redistribute it and/or 
-# modify it under the terms of the GNU General Public License 
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-##############################################################################
+# SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../..
 VARS = $(TOP)/Makefile.conf

--- a/src/scancode/README.md
+++ b/src/scancode/README.md
@@ -1,3 +1,8 @@
+<!-- SPDX-FileCopyrightText: © Fossology contributors
+
+     SPDX-License-Identifier: GPL-2.0-only
+-->
+
 ### ScanCode Toolkit
 ScanCode Toolkit is a very established license scanner. It is a simple python based command line scanner that runs on Windows, Linux, and Mac. It implements a number of different approaches and integrates these into one application for identifying and classifying license-relevant content in packages.
 

--- a/src/scancode/agent/Makefile
+++ b/src/scancode/agent/Makefile
@@ -1,19 +1,6 @@
-##############################################################################
-# SPDX-License-Identifier: GPL-2.0 
-# SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com> 
-#
-# This program is free software; you can redistribute it and/or 
-# modify it under the terms of the GNU General Public License 
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-##############################################################################
+# SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/scancode/agent/match.cc
+++ b/src/scancode/agent/match.cc
@@ -1,20 +1,8 @@
-/*****************************************************************************
- * SPDX-License-Identifier: GPL-2.0
- * SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ****************************************************************************/
+/*
+ SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include "match.hpp"
 

--- a/src/scancode/agent/match.hpp
+++ b/src/scancode/agent/match.hpp
@@ -1,20 +1,8 @@
-/*****************************************************************************
- * SPDX-License-Identifier: GPL-2.0
- * SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ****************************************************************************/
+/*
+ SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef SCANCODE_AGENT_MATCH_HPP
 #define SCANCODE_AGENT_MATCH_HPP

--- a/src/scancode/agent/scancode.cc
+++ b/src/scancode/agent/scancode.cc
@@ -1,20 +1,8 @@
-/*****************************************************************************
- * SPDX-License-Identifier: GPL-2.0
- * SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ****************************************************************************/
+/*
+ SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include "scancode.hpp"
 

--- a/src/scancode/agent/scancode.hpp
+++ b/src/scancode/agent/scancode.hpp
@@ -1,20 +1,8 @@
-/*****************************************************************************
- * SPDX-License-Identifier: GPL-2.0
- * SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ****************************************************************************/
+/*
+ SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef SCANCODE_AGENT_SCANCODE_HPP
 #define SCANCODE_AGENT_SCANCODE_HPP

--- a/src/scancode/agent/scancode_dbhandler.cc
+++ b/src/scancode/agent/scancode_dbhandler.cc
@@ -1,20 +1,8 @@
-/*****************************************************************************
- * SPDX-License-Identifier: GPL-2.0
- * SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *****************************************************************************/
+/*
+ SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include "scancode_dbhandler.hpp"
 

--- a/src/scancode/agent/scancode_dbhandler.hpp
+++ b/src/scancode/agent/scancode_dbhandler.hpp
@@ -1,20 +1,8 @@
-/*****************************************************************************
- * SPDX-License-Identifier: GPL-2.0
- * SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ****************************************************************************/
+/*
+ SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef SCANCODE_AGENT_DATABASE_HANDLER_HPP
 #define SCANCODE_AGENT_DATABASE_HANDLER_HPP

--- a/src/scancode/agent/scancode_state.cc
+++ b/src/scancode/agent/scancode_state.cc
@@ -1,20 +1,8 @@
-/*****************************************************************************
- * SPDX-License-Identifier: GPL-2.0
- * SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ****************************************************************************/
+/*
+ SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include "scancode_state.hpp"
 

--- a/src/scancode/agent/scancode_state.hpp
+++ b/src/scancode/agent/scancode_state.hpp
@@ -1,20 +1,8 @@
-/*****************************************************************************
- * SPDX-License-Identifier: GPL-2.0
- * SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ****************************************************************************/
+/*
+ SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef SCANCODE_AGENT_STATE_HPP
 #define SCANCODE_AGENT_STATE_HPP

--- a/src/scancode/agent/scancode_template.html
+++ b/src/scancode/agent/scancode_template.html
@@ -1,22 +1,7 @@
-{#
-    SPDX-License-Identifier: GPL-2.0
-    SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>  
+{# SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
 
-   This program is free software; you can redistribute it and/or 
-   modify it under the terms of the GNU General Public License 
-   version 2 as published by the Free Software Foundation.
+   SPDX-License-Identifier: GPL-2.0-only
 
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of 
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-   GNU General Public License for more details. 
-
-   You should have received a copy of the GNU General Public License along
-   with this program; if not, write to the Free Software Foundation, Inc.,
-   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
-  --------------------------------------------------------------------------------
-   
    ScanCode has no plugin for custom template but it has a builtin to write scan results 
    using a custom template.
    @see https://scancode-toolkit.readthedocs.io/en/latest/tutorials/how_to_format_scan_output.html#custom-output-format 

--- a/src/scancode/agent/scancode_utils.cc
+++ b/src/scancode/agent/scancode_utils.cc
@@ -1,20 +1,8 @@
-/*****************************************************************************
- * SPDX-License-Identifier: GPL-2.0
- * SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ****************************************************************************/
+/*
+ SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include "scancode_utils.hpp"
 

--- a/src/scancode/agent/scancode_utils.hpp
+++ b/src/scancode/agent/scancode_utils.hpp
@@ -1,20 +1,8 @@
-/*****************************************************************************
- * SPDX-License-Identifier: GPL-2.0
- * SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ****************************************************************************/
+/*
+ SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef SCANCODE_AGENT_UTILS_HPP
 #define SCANCODE_AGENT_UTILS_HPP

--- a/src/scancode/agent/scancode_wrapper.cc
+++ b/src/scancode/agent/scancode_wrapper.cc
@@ -1,20 +1,8 @@
-/*****************************************************************************
- * SPDX-License-Identifier: GPL-2.0
- * SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ****************************************************************************/
+/*
+ SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #include "scancode_wrapper.hpp"
 

--- a/src/scancode/agent/scancode_wrapper.hpp
+++ b/src/scancode/agent/scancode_wrapper.hpp
@@ -1,20 +1,8 @@
-/*****************************************************************************
- * SPDX-License-Identifier: GPL-2.0
- * SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ****************************************************************************/
+/*
+ SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 #ifndef SCANCODE_AGENT_SCANCODE_WRAPPER_HPP
 #define SCANCODE_AGENT_SCANCODE_WRAPPER_HPP

--- a/src/scancode/mod_deps
+++ b/src/scancode/mod_deps
@@ -1,22 +1,8 @@
 #!/usr/bin/env bash
 
-##############################################################################
-# SPDX-License-Identifier: GPL-2.0
-# SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-##############################################################################
+# SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 source "$(dirname ${BASH_SOURCE[0]})/../../utils/utils.sh"
 

--- a/src/scancode/scancode.conf
+++ b/src/scancode/scancode.conf
@@ -1,20 +1,6 @@
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; SPDX-License-Identifier: GPL-2.0 
-; SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com> 
+; SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
 
-; This program is free software; you can redistribute it and/or 
-; modify it under the terms of the GNU General Public License 
-; version 2 as published by the Free Software Foundation.
-
-; This program is distributed in the hope that it will be useful,
-; but WITHOUT ANY WARRANTY; without even the implied warranty of 
-; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-; GNU General Public License for more details. 
-;
-; You should have received a copy of the GNU General Public License along
-; with this program; if not, write to the Free Software Foundation, Inc.,
-; 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; SPDX-License-Identifier: GPL-2.0-only
 
 ; scheduler configure file for this agent
 [default]

--- a/src/scancode/ui/Makefile
+++ b/src/scancode/ui/Makefile
@@ -1,20 +1,6 @@
-##############################################################################
-# SPDX-License-Identifier: GPL-2.0
-# SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com> 
-#
-# This program is free software; you can redistribute it and/or 
-# modify it under the terms of the GNU General Public License 
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-# GNU General Public License for more details. 
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-##############################################################################
+# SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/scancode/ui/agent-scancode.php
+++ b/src/scancode/ui/agent-scancode.php
@@ -1,21 +1,9 @@
 <?php
-/*****************************************************************************
- * SPDX-License-Identifier: GPL-2.0
- * SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ****************************************************************************/
+/*
+ SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 namespace Fossology\Scancode\Ui;
 

--- a/src/scancode/ui/services.php
+++ b/src/scancode/ui/services.php
@@ -1,21 +1,9 @@
 <?php
-/*****************************************************************************
- * SPDX-License-Identifier: GPL-2.0
- * SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ****************************************************************************/
+/*
+ SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 /**
  * @file

--- a/src/scancode/ui/template/scancode.html.twig
+++ b/src/scancode/ui/template/scancode.html.twig
@@ -1,19 +1,6 @@
-{#
-    SPDX-License-Identifier: GPL-2.0
-    SPDX-FileCopyrightText: 2021 Sarita Singh <saritasingh.0425@gmail.com>  
+{# SPDX-FileCopyrightText: © 2021 Sarita Singh <saritasingh.0425@gmail.com>
 
-   This program is free software; you can redistribute it and/or 
-   modify it under the terms of the GNU General Public License 
-   version 2 as published by the Free Software Foundation.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of 
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-   GNU General Public License for more details. 
-
-   You should have received a copy of the GNU General Public License along
-   with this program; if not, write to the Free Software Foundation, Inc.,
-   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+   SPDX-License-Identifier: GPL-2.0-only
 #}
 {% import "include/macros.html.twig" as macro %}
 

--- a/src/softwareHeritage/Makefile
+++ b/src/softwareHeritage/Makefile
@@ -1,9 +1,6 @@
-# Copyright 2019
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © Fossology contributors
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../..
 VARS = $(TOP)/Makefile.conf

--- a/src/softwareHeritage/agent/Makefile
+++ b/src/softwareHeritage/agent/Makefile
@@ -1,9 +1,6 @@
-# Copyright 2019
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © Fossology contributors
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/softwareHeritage/agent/softwareHeritage.php
+++ b/src/softwareHeritage/agent/softwareHeritage.php
@@ -1,21 +1,10 @@
 <?php
 /*
- Copyright (C) 2019
+ SPDX-FileCopyrightText: © 2019 Sandip Kumar Bhuyan <sandipbhyan@gmail.com>
  Author: Sandip Kumar Bhuyan<sandipbhyan@gmail.com>
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @dir
  * @brief Source for software heritage agent

--- a/src/softwareHeritage/agent/softwareHeritageAgent.php
+++ b/src/softwareHeritage/agent/softwareHeritageAgent.php
@@ -1,22 +1,11 @@
 <?php
 /*
- Copyright (C) 2019
- Copyright (C) 2020, Siemens AG
+ SPDX-FileCopyrightText: © 2019 Sandip Kumar Bhuyan <sandipbhuyan@gmail.com>
+ SPDX-FileCopyrightText: © 2020 Siemens AG
  Author: Sandip Kumar Bhuyan<sandipbhuyan@gmail.com>,
          Shaheem Azmal M MD<shaheem.azmal@siemens.com>
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ SPDX-License-Identifier: GPL-2.0-only
 */
 
 namespace Fossology\SoftwareHeritage;

--- a/src/softwareHeritage/agent/version.php.in
+++ b/src/softwareHeritage/agent/version.php.in
@@ -1,4 +1,10 @@
 <?php
+/*
+ SPDX-FileCopyrightText: © Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
 define("SOFTWARE_HERITAGE_AGENT_NAME", "softwareHeritage");
 defined("AGENT_VERSION") or define("AGENT_VERSION", "{$VERSION}");
 defined("AGENT_REV") or define("AGENT_REV", "{$COMMIT_HASH}");

--- a/src/softwareHeritage/softwareHeritage.conf
+++ b/src/softwareHeritage/softwareHeritage.conf
@@ -1,7 +1,6 @@
-; Copying and distribution of this file, with or without modification,
-; are permitted in any medium without royalty provided the copyright
-; notice and this notice are preserved. This file is offered as-is,
-; without any warranty.
+; SPDX-FileCopyrightText: © Fossology contributors
+
+; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent
 [default]

--- a/src/softwareHeritage/ui/AjaxSHDetailsBrowser.php
+++ b/src/softwareHeritage/ui/AjaxSHDetailsBrowser.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
-Copyright (C) 2019
-Author: Sandip Kumar Bhuyan<sandipbhyan@gmail.com>
+/*
+ SPDX-FileCopyrightText: © 2019 Sandip Kumar Bhuyan <sandipbhuyan@gmail.com>
+ Author: Sandip Kumar Bhuyan<sandipbhyan@gmail.com>
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\BusinessRules\LicenseMap;
 use Fossology\Lib\Dao\AgentDao;

--- a/src/softwareHeritage/ui/Makefile
+++ b/src/softwareHeritage/ui/Makefile
@@ -1,9 +1,6 @@
-# Copyright 2019
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# SPDX-FileCopyrightText: © Fossology contributors
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/softwareHeritage/ui/agent-shagent.php
+++ b/src/softwareHeritage/ui/agent-shagent.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
-Copyright (C) 2019
-Author: Sandip Kumar Bhuyan<sandipbhyan@gmail.com>
+/*
+ SPDX-FileCopyrightText: © 2019 Sandip Kumar Bhuyan <sandipbhuyan@gmail.com>
+ Author: Sandip Kumar Bhuyan<sandipbhyan@gmail.com>
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 use Fossology\Lib\Plugin\AgentPlugin;
 
 /**

--- a/src/softwareHeritage/ui/services.php
+++ b/src/softwareHeritage/ui/services.php
@@ -1,4 +1,9 @@
 <?php
+/*
+ SPDX-FileCopyrightText: © Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  * @brief Add the template path of copyright twig templates

--- a/src/softwareHeritage/ui/softwareHeritage-plugin.php
+++ b/src/softwareHeritage/ui/softwareHeritage-plugin.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
-Copyright (C) 2019
-Author: Sandip Kumar Bhuyan<sandipbhyan@gmail.com>
+/*
+ SPDX-FileCopyrightText: © 2019 Sandip Kumar Bhuyan <sandipbhuyan@gmail.com>
+ Author: Sandip Kumar Bhuyan<sandipbhyan@gmail.com>
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-version 2 as published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 namespace Fossology\SoftwareHeritage\UI;
 
 use Fossology\Lib\Auth\Auth;

--- a/src/softwareHeritage/ui/template/softwareHeritage.html.twig
+++ b/src/softwareHeritage/ui/template/softwareHeritage.html.twig
@@ -1,9 +1,7 @@
-{# Copyright 2019
-    Author: Sandip Kumar Bhuyan(sandipbhuyan@gmail.com)
-
-   Copying and distribution of this file, with or without modification,
-   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
-   This file is offered as-is, without any warranty.
+{# SPDX-FileCopyrightText: © 2019 Sandip Kumar Bhuyan <sandipbhuyan@gmail.com>
+   Author: Sandip Kumar Bhuyan(sandipbhuyan@gmail.com)
+ 
+   SPDX-License-Identifier: FSFAP
 #}
 {% extends "include/base.html.twig" %}
 

--- a/src/softwareHeritage/ui/template/softwareHeritage.js.twig
+++ b/src/softwareHeritage/ui/template/softwareHeritage.js.twig
@@ -1,9 +1,7 @@
-{# Copyright 2019
-    Author: Sandip Kumar Bhuyan(sandipbhuyan@gmail.com)
+{# SPDX-FileCopyrightText: © 2019 Sandip Kumar Bhuyan <sandipbhuyan@gmail.com>
+   Author: Sandip Kumar Bhuyan(sandipbhuyan@gmail.com)
 
-   Copying and distribution of this file, with or without modification,
-   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
-   This file is offered as-is, without any warranty.
+   SPDX-License-Identifier: FSFAP
 #}
 
 function createDataTable() {

--- a/src/spasht/Makefile
+++ b/src/spasht/Makefile
@@ -1,10 +1,7 @@
-# Copyright 2019
+# SPDX-FileCopyrightText: © 2019 Vivek Kumar <vvksindia@gmail.com>
 # Author: Vivek Kumar <vvksindia@gmaail.com>
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+
+# SPDX-License-Identifier: FSFAP
 
 TOP = ../..
 VARS = $(TOP)/Makefile.conf

--- a/src/spasht/agent/Makefile
+++ b/src/spasht/agent/Makefile
@@ -1,20 +1,7 @@
-######################################################################
-# Copyright (C) 2019.
+# SPDX-FileCopyrightText: © 2019 Vivek Kumar <vvksindia@gmail.com>
 # Author: Vivek Kumar<vvksindia@gmail.com>
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/spasht/agent/SpashtAgent.php
+++ b/src/spasht/agent/SpashtAgent.php
@@ -1,18 +1,10 @@
 <?php
 /*
- * Copyright (C) 2019
- * Author: Vivek Kumar <vvksindia@gmail.com>
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- */
+ SPDX-FileCopyrightText: © 2019 Vivek Kumar <vvksindia@gmail.com>
+ Author: Vivek Kumar <vvksindia@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 namespace Fossology\Spasht;
 
 use Fossology\Lib\Agent\Agent;

--- a/src/spasht/agent/spasht.php
+++ b/src/spasht/agent/spasht.php
@@ -1,21 +1,10 @@
 <?php
 /*
- Copyright (C) 2019
+ SPDX-FileCopyrightText: © 2019 Vivek Kumar <vvksindia@gmail.com>
  Author: Vivek Kumar <vvksindia@gmail.com>
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License along
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 namespace Fossology\Spasht;
 

--- a/src/spasht/agent/version.php.in
+++ b/src/spasht/agent/version.php.in
@@ -1,4 +1,10 @@
 <?php
+/*
+ SPDX-FileCopyrightText: © Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
 define("SPASHT_AGENT_NAME", "spasht");
 defined("AGENT_VERSION") or define("AGENT_VERSION", "{$VERSION}");
 defined("AGENT_REV") or define("AGENT_REV", "{$COMMIT_HASH}");

--- a/src/spasht/spasht.conf
+++ b/src/spasht/spasht.conf
@@ -1,7 +1,6 @@
-; Copying and distribution of this file, with or without modification,
-; are permitted in any medium without royalty provided the copyright
-; notice and this notice are preserved. This file is offered as-is,
-; without any warranty.
+; SPDX-FileCopyrightText: © Fossology contributors
+
+; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent
 [default]

--- a/src/spasht/ui/Makefile
+++ b/src/spasht/ui/Makefile
@@ -1,20 +1,7 @@
-######################################################################
-# Copyright (C) 2019.
+# SPDX-FileCopyrightText: © 2019 Vivek Kumar <vvksindia@gmail.com>
 # Author: Vivek Kumar<vvksindia@gmail.com>
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# version 2 as published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-######################################################################
+
+# SPDX-License-Identifier: GPL-2.0-only
 
 TOP = ../../..
 VARS = $(TOP)/Makefile.conf

--- a/src/spasht/ui/agent-spasht.php
+++ b/src/spasht/ui/agent-spasht.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
- * Copyright (C) 2019
- * Author: Vivek Kumar<vvksindia@gmail.com>
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+/*
+ SPDX-FileCopyrightText: © 2019 Vivek Kumar <vvksindia@gmail.com>
+ Author: Vivek Kumar<vvksindia@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\AgentDao;

--- a/src/spasht/ui/ajax-spasht-copyright-hist.php
+++ b/src/spasht/ui/ajax-spasht-copyright-hist.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
- * Copyright (C) 2019
- * Author: Vivek Kumar<vvksindia@gmail.com>
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+/*
+ SPDX-FileCopyrightText: © 2019 Vivek Kumar <vvksindia@gmail.com>
+ Author: Vivek Kumar<vvksindia@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\SpashtDao;

--- a/src/spasht/ui/services.php
+++ b/src/spasht/ui/services.php
@@ -1,4 +1,9 @@
 <?php
+/*
+ SPDX-FileCopyrightText: © Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 /**
  * @file
  * @brief Add the template path of copyright twig templates

--- a/src/spasht/ui/template/agent_spasht.html.twig
+++ b/src/spasht/ui/template/agent_spasht.html.twig
@@ -1,9 +1,7 @@
-{# Copyright 2019
+{# SPDX-FileCopyrightText: © 2019 Vivek Kumar <vvksindia@gmail.com>
    Author: Vivek Kumar<vvksindia@gmail.com>
 
-   Copying and distribution of this file, with or without modification,
-   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
-   This file is offered as-is, without any warranty.
+   SPDX-License-Identifier: FSFAP
 #}
 
 {% extends "include/base.html.twig" %}

--- a/src/spasht/ui/template/agent_spasht.js.twig
+++ b/src/spasht/ui/template/agent_spasht.js.twig
@@ -1,9 +1,7 @@
-{# Copyright 2019
+{# SPDX-FileCopyrightText: © 2019 Vivek Kumar <vvksindia@gmail.com>
    Author: Vivek Kumar<vvksindia@gmail.com>
 
-   Copying and distribution of this file, with or without modification,
-   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
-   This file is offered as-is, without any warranty.
+   SPDX-License-Identifier: FSFAP
 #}
 
 <script>

--- a/src/spasht/ui/template/agent_spasht_search.html.twig
+++ b/src/spasht/ui/template/agent_spasht_search.html.twig
@@ -1,9 +1,7 @@
-{# Copyright 2019
+{# SPDX-FileCopyrightText: © 2019 Vivek Kumar <vvksindia@gmail.com>
    Author: Vivek Kumar<vvksindia@gmail.com>
 
-   Copying and distribution of this file, with or without modification,
-   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
-   This file is offered as-is, without any warranty.
+   SPDX-License-Identifier: FSFAP
 #}
 
 <form id="searchForm" method="post" action="">

--- a/src/spasht/ui/template/agent_spasht_ui_content.html.twig
+++ b/src/spasht/ui/template/agent_spasht_ui_content.html.twig
@@ -1,9 +1,7 @@
-{# Copyright 2019
+{# SPDX-FileCopyrightText: © 2019 Vivek Kumar <vvksindia@gmail.com>
    Author: Vivek Kumar<vvksindia@gmail.com>
 
-   Copying and distribution of this file, with or without modification,
-   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
-   This file is offered as-is, without any warranty.
+   SPDX-License-Identifier: FSFAP
 #}
 
 <div class="spasht-full-row">

--- a/src/spasht/ui/template/agent_spasht_ui_tabs.html.twig
+++ b/src/spasht/ui/template/agent_spasht_ui_tabs.html.twig
@@ -1,9 +1,7 @@
-{# Copyright 2019
+{# SPDX-FileCopyrightText: © 2019 Vivek Kumar <vvksindia@gmail.com>
    Author: Vivek Kumar<vvksindia@gmail.com>
 
-   Copying and distribution of this file, with or without modification,
-   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
-   This file is offered as-is, without any warranty.
+   SPDX-License-Identifier: FSFAP
 #}
 
 <table border="0" width="100%">

--- a/src/spasht/ui/template/show_definitions.html.twig
+++ b/src/spasht/ui/template/show_definitions.html.twig
@@ -1,9 +1,7 @@
-{# Copyright 2019
+{# SPDX-FileCopyrightText: © 2019 Vivek Kumar <vvksindia@gmail.com>
    Author: Vivek Kumar<vvksindia@gmail.com>
 
-   Copying and distribution of this file, with or without modification,
-   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
-   This file is offered as-is, without any warranty.
+   SPDX-License-Identifier: FSFAP
 #}
 
 <div id="definitionsTableContent">

--- a/src/spasht/ui/template/show_details_table.html.twig
+++ b/src/spasht/ui/template/show_details_table.html.twig
@@ -1,9 +1,7 @@
-{# Copyright 2019
+{# SPDX-FileCopyrightText: © 2019 Vivek Kumar <vvksindia@gmail.com>
    Author: Vivek Kumar<vvksindia@gmail.com>
 
-   Copying and distribution of this file, with or without modification,
-   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
-   This file is offered as-is, without any warranty.
+   SPDX-License-Identifier: FSFAP
 #}
 
 {% for result in details %}

--- a/src/spasht/ui/template/show_uploads_table.html.twig
+++ b/src/spasht/ui/template/show_uploads_table.html.twig
@@ -1,9 +1,7 @@
-{# Copyright 2019
+{# SPDX-FileCopyrightText: © 2019 Vivek Kumar <vvksindia@gmail.com>
    Author: Vivek Kumar <vvksindia@gmail.com>
 
-   Copying and distribution of this file, with or without modification,
-   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
-   This file is offered as-is, without any warranty.
+   SPDX-License-Identifier: FSFAP
 #}
 
 <table class="simpleTable wrapTable">

--- a/src/spasht/ui/template/spasht_histTable.js.twig
+++ b/src/spasht/ui/template/spasht_histTable.js.twig
@@ -1,9 +1,7 @@
-{# Copyright 2019
+{# SPDX-FileCopyrightText: © 2019 Vivek Kumar <vvksindia@gmail.com>
    Author: Vivek Kumar<vvksindia@gmail.com>
 
-   Copying and distribution of this file, with or without modification,
-   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
-   This file is offered as-is, without any warranty.
+   SPDX-License-Identifier: FSFAP
 #}
 
 function createTableBase{{ table.type }}(activated) {

--- a/src/spasht/ui/ui-spasht.php
+++ b/src/spasht/ui/ui-spasht.php
@@ -1,21 +1,10 @@
 <?php
-/***********************************************************
- * Copyright (C) 2019
- * Author: Vivek Kumar<vvksindia@gmail.com>
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- ***********************************************************/
+/*
+ SPDX-FileCopyrightText: © 2019 Vivek Kumar <vvksindia@gmail.com>
+ Author: Vivek Kumar<vvksindia@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\UploadDao;


### PR DESCRIPTION
Signed-off-by: Rohit Pandey <rohit.pandey4900@gmail.com>

## Description

REUSE best practices for licensing/copyright

### Changes

1. Implemented correct licensing/copyright format
2. Used dep5 for `testdata` files

### Current REUSE status

When running reuse lint over this branch, the result is as follows:

```
* Files with copyright information: 4038 / 4360
* Files with license information: 3157 / 4360
```

Before that we were at:

```
* Files with copyright information: 2619 / 4360
* Files with license information: 1066 / 4360
```

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2238"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

