### PR TITLE
feat(API): delete user group

### DIFF
--- a/src/www/ui/api/Controllers/GroupController.php
+++ b/src/www/ui/api/Controllers/GroupController.php
@@ -1,7 +1,8 @@
 <?php
 /***************************************************************
  Copyright (C) 2021 Orange
- Author: Piotr Pszczola <piotr.pszczola@orange.com>
+ Copyright (C) 2022 Samuel Dushimimana <dushsam100@gmail.com>
+ Authors: Piotr Pszczola <piotr.pszczola@orange.com>
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -16,6 +17,7 @@
  with this program; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  ***************************************************************/
+
 /**
  * @file
  * @brief Controller for user queries
@@ -90,6 +92,46 @@ class GroupController extends RestController
     } else {
       $returnVal = new Info(400, "ERROR - no group name provided", InfoType::ERROR);
     }
+    return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+  }
+
+  /**
+   * Delete a given group
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function deleteGroup($request, $response, $args)
+  {
+    $returnVal = null;
+
+    if (!empty($args['id'])) {
+
+      $userId = $this->restHelper->getUserId();
+
+      /** @var UserDao $userDao */
+      $userDao = $this->restHelper->getUserDao();
+      $groupMap = $userDao->getDeletableAdminGroupMap($userId,
+        $_SESSION[Auth::USER_LEVEL]);
+      $groupId = intval($args['id']);
+
+      if ($this->dbHelper->doesIdExist("groups", "group_pk", $groupId)) {
+        try {
+          $userDao->deleteGroup($groupId);
+          $returnVal = new Info(202, "User Group will be deleted", InfoType::INFO);
+          unset($groupMap[$groupId]);
+        } catch (\Exception $e) {
+          $returnVal = new Info(400, $e->getMessage(), InfoType::ERROR);
+        }
+      } else {
+        $returnVal = new Info(404, "Group id not found!", InfoType::ERROR);
+      }
+    } else {
+      $returnVal = new Info(400, "ERROR - no group id provided", InfoType::ERROR);
+    }
+
     return $response->withJson($returnVal->getArray(), $returnVal->getCode());
   }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1144,6 +1144,30 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
             $ref: '#/components/responses/defaultResponse'
+  /groups/{id}:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the group
+        in: path
+        schema:
+          type: integer
+    delete:
+      operationId: deleteGroupById
+      tags:
+        - Groups
+      summary: Delete group by id
+      description: >
+        Deletes a single group by id.
+      responses:
+        '202':
+          description: User group will be deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
 
   /report:
     get:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -168,6 +168,8 @@ $app->group('/groups',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->get('', GroupController::class . ':getGroups');
     $app->post('', GroupController::class . ':createGroup');
+    $app->delete('/{id:\\d+}', GroupController::class . ':deleteGroup');
+    $app->any('/{params:.*}', BadRequestController::class);
   });
 
 ////////////////////////////JOBS/////////////////////

--- a/src/www/ui_tests/api/Controllers/GroupControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/GroupControllerTest.php
@@ -1,0 +1,152 @@
+<?php
+/***************************************************************
+ * Copyright (C) 2022 Samuel Dushimimana <dushsam100@gmail.com>
+
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***************************************************************/
+/**
+ * @file
+ * @brief Tests for GroupController
+ */
+
+namespace Fossology\UI\Api\Test\Controllers;
+
+require_once dirname(dirname(dirname(dirname(__DIR__)))) .
+  '/lib/php/Plugin/FO_Plugin.php';
+
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Mockery as M;
+use Fossology\Lib\Dao\UserDao;
+use Fossology\Lib\Db\DbManager;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Controllers\GroupController;
+
+/**
+ * @class GroupControllerTest
+ * @brief Tests for GroupController
+ */
+class GroupControllerTest extends \PHPUnit\Framework\TestCase
+{
+
+  /**
+   * @var string YAML_LOC
+   * Location of openapi.yaml file
+   */
+  const YAML_LOC = __DIR__ . '/../../../ui/api/documentation/openapi.yaml';
+
+  /**
+   * @var integer $assertCountBefore
+   * Assertions before running tests
+   */
+  private $assertCountBefore;
+
+  /**
+   * @var DbHelper $dbHelper
+   * DbHelper mock
+   */
+  private $dbHelper;
+
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp() : void
+  {
+    global $container;
+    $container = M::mock('ContainerBuilder');
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->restHelper = M::mock(RestHelper::class);
+    $this->userDao = M::mock(UserDao::class);
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+    $this->restHelper->shouldReceive('getUserDao')
+      ->andReturn($this->userDao);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+    $this->groupController = new GroupController($container);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+    $this->dbManager = M::mock(DbManager::class);
+    $this->dbHelper->shouldReceive('getDbManager')->andReturn($this->dbManager);
+
+  }
+
+
+  /**
+   * @brief Remove test objects
+   * @see PHPUnit_Framework_TestCase::tearDown()
+   */
+  protected function tearDown() : void
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  /**
+   * Helper function to get JSON array from response
+   *
+   * @param Response $response
+   * @return array Decoded response
+   */
+  private function getResponseJson($response)
+  {
+    $response->getBody()->seek(0);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+
+
+
+
+  /**
+   * @test
+   * -# Test GroupController::deleteGroup() for valid delete request
+   * -# Check if response status is 202
+   */
+  public function testDeleteGroup()
+  {
+    $groupId = 4;
+    $userId = 1;
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->userDao->shouldReceive('getDeletableAdminGroupMap')->withArgs([$userId,$_SESSION[Auth::USER_LEVEL]]);
+    $this->userDao->shouldReceive('deleteGroup')->withArgs([$groupId]);
+
+    $info = new Info(202, "User Group will be deleted", InfoType::INFO);
+    $expectedResponse = (new ResponseHelper())->withJson($info->getArray(),
+      $info->getCode());
+    $actualResponse = $this->groupController->deleteGroup(null, new ResponseHelper(),
+      ['id' => $groupId]);
+
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+
+}


### PR DESCRIPTION
Signed-off-by: dushimsam <dushsam100@gmail.com>

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Added a new API to delete a user group via a particular id.

### Changes

1. Added a new function to handle the deletion of the group in `GroupController`.
2. Updated  the main file(`index.php`) by adding a new route `/groups/id`.
3. Updated the `openapi.yaml` file , by introducing a new API.

## How to test

1. Add a new user group 

![new-group](https://user-images.githubusercontent.com/66276301/176197546-df8f6afe-958c-4458-ba73-144fa130783a.png)

2. Keep the new group's Id aside.
     
![get_group](https://user-images.githubusercontent.com/66276301/176197804-77dde1a8-67c7-40a4-8529-9e6561842ff0.png)

3. Call Delete API by passing the Id of the new group in params.
![deleted](https://user-images.githubusercontent.com/66276301/176197987-e2e6ba44-7008-49df-a5b4-d601aacdfb41.png)

### Related Issue:
Fixes #2241 
    
cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2244"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

