### PR TITLE
feat(API): list groups that can be deleted

### DIFF
--- a/src/www/ui/api/Controllers/GroupController.php
+++ b/src/www/ui/api/Controllers/GroupController.php
@@ -165,4 +165,28 @@ class GroupController extends RestController
 
     return $response->withJson($returnVal->getArray(), $returnVal->getCode());
   }
+
+  /**
+   * Get a list of groups that can be deleted
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function getDeletableGroups($request, $response, $args)
+  {
+    $userId = $this->restHelper->getUserId();
+    /* @var $userDao UserDao */
+    $userDao = $this->restHelper->getUserDao();
+    $groupMap = $userDao->getDeletableAdminGroupMap($userId,
+      $_SESSION[Auth::USER_LEVEL]);
+
+    $groupList = array();
+    foreach ($groupMap as $key => $value) {
+      $groupObject = new Group($key, $value);
+      $groupList[] = $groupObject->getArray();
+    }
+    return $response->withJson($groupList, 200);
+  }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -603,7 +603,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-          
+
   /uploads/{id}/copyrights:
     parameters:
       - name: id
@@ -1298,7 +1298,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/Info'
         default:
-          $ref: '#/components/responses/defaultResponse' 
+          $ref: '#/components/responses/defaultResponse'
+  /groups/deletable:
+    get:
+      operationId: deletableGroups
+      tags:
+        - Groups
+      summary: Give a list of deletable groups
+      description: >
+        Return a list of the groups which it is possible to delete.
+      responses:
+        '200':
+          description: List of groups
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Group'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /report:
     get:
       operationId: getReportsByUpload

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -160,6 +160,7 @@ $app->group('/groups',
     $app->post('', GroupController::class . ':createGroup');
     $app->delete('/{id:\\d+}', GroupController::class . ':deleteGroup');
     $app->delete('/{id:\\d+}/user/{uid:\\d+}', GroupController::class . ':deleteGroupMember');
+    $app->get('/deletable', GroupController::class . ':getDeletableGroups');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui_tests/api/Controllers/GroupControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/GroupControllerTest.php
@@ -137,5 +137,23 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
       $this->getResponseJson($actualResponse));
   }
 
-
+  /**
+   * @test
+   * -# Test GroupController::getDeletableGroups()
+   * -# Check if the response is a list of groups.
+   */
+  public function testGetDeletableGroups()
+  {
+    $userId = 2;
+    $groupList = array();
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->userDao->shouldReceive('getDeletableAdminGroupMap')->withArgs([$userId,
+      $_SESSION[Auth::USER_LEVEL]])->andReturn([]);
+    $expectedResponse = (new ResponseHelper())->withJson($groupList, 200);
+    $actualResponse = $this->groupController->getDeletableGroups(null, new ResponseHelper(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(), $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse), $this->getResponseJson($actualResponse));
+  }
+  
 }


### PR DESCRIPTION
Signed-off-by: dushimsam <dushsam100@gmail.com>

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

To check if the user has any group that is possible to be deleted.

### Changes

1. Added a new function in `GroupController`. to check if the group exists.
2. Updated  the main file(`index.php`) by adding a new route `/groups/has-deletable-group`.
3. Updated the `openapi.yaml` file to introduce a new API.

## How to test

1. Open and run the project then visit  the url `http://localhost/repo/api/v1/groups/has-deletable-group`
2. Response

The following property in the response body called `available` should be marked as **true** if you have any group that is deletable  , else it will always be marked as **false**.

![has-deletable-group](https://user-images.githubusercontent.com/66276301/176673904-ad674f99-45fc-45fc-9e51-e902a898bb87.png)

By default you have group `fossy` , this one is not deletable , the deletable groups are the one you add afterwards.
In other words , by default you don't have any deletable group , unless you start adding your own groups.

### Related Issue:
Fixes #2246
    
cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2247"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

