### PR TITLE
feat(API): get group members with corresponding roles

### DIFF
--- a/src/www/ui/api/Controllers/UserController.php
+++ b/src/www/ui/api/Controllers/UserController.php
@@ -43,10 +43,15 @@ class UserController extends RestController
       }
     }
     $users = $this->dbHelper->getUsers($id);
-    if ($id !== null) {
-      $users = $users[0];
+
+    $allUsers = array();
+    foreach ($users as $user) {
+      $allUsers[] = $user->getArray();
     }
-    return $response->withJson($users, 200);
+    if ($id !== null) {
+      $allUsers = $allUsers[0];
+    }
+    return $response->withJson($allUsers, 200);
   }
 
   /**
@@ -141,7 +146,7 @@ class UserController extends RestController
    */
   public function getCurrentUser($request, $response, $args)
   {
-    $user = $this->dbHelper->getUsers($this->restHelper->getUserId())[0];
+    $user = $this->dbHelper->getUsers($this->restHelper->getUserId())[0]->getArray();
     $userDao = $this->restHelper->getUserDao();
     $defaultGroup = $userDao->getUserAndDefaultGroupByUserName($user["name"])["group_name"];
     $user["default_group"] = $defaultGroup;

--- a/src/www/ui/api/Helper/DbHelper.php
+++ b/src/www/ui/api/Helper/DbHelper.php
@@ -99,7 +99,7 @@ class DbHelper
     if ($uploadId !== null) {
       $recursive = true;
       $user = $this->getUsers($userId);
-      $folderId = $user[0]['rootFolderId'];
+      $folderId = $user[0]->getArray()['rootFolderId'];
       $folders = [$folderId];
     }
 
@@ -234,7 +234,7 @@ FROM $tableName WHERE $idRowName = $1", [$id],
    *
    * @param integer $id User id of the required user, or NULL to fetch all
    *        users.
-   * @return User[][] Users as an associative array
+   * @return User[] Users as an associative array
    */
   public function getUsers($id = null)
   {
@@ -268,7 +268,7 @@ FROM $tableName WHERE $idRowName = $1", [$id],
         $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
           null, null, null, null, null, null);
       }
-      $users[] = $user->getArray();
+      $users[] = $user;
     }
 
     return $users;

--- a/src/www/ui/api/Models/UserGroupMember.php
+++ b/src/www/ui/api/Models/UserGroupMember.php
@@ -1,0 +1,97 @@
+<?php
+/*
+ * SPDX-FileCopyrightText: © 2022 Samuel Dushimimana <dushsam100@gmail.com>
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief UserGroupMember model
+ */
+
+namespace Fossology\UI\Api\Models;
+
+class UserGroupMember
+{
+
+  /**
+   * @var User $user
+   */
+  private $user;
+
+  /**
+   * @var int $group_perm
+   */
+  private $group_perm;
+
+  /**
+   * UserGroupMember constructor.
+   *
+   * @param User $user
+   * @param number $group_perm
+   */
+  public function __construct($user, $group_perm)
+  {
+    $this->user = $user;
+    $this->group_perm = intval($group_perm);
+  }
+
+  ////// Setters //////
+
+  /**
+   * @param User $user
+   */
+  public function setUser($user)
+  {
+    $this->user = $user;
+  }
+
+  /**
+   * @param number $group_perm
+   */
+  public function setGroupPerm($group_perm)
+  {
+    $this->group_perm = intval($group_perm);
+  }
+
+
+  ////// Getters //////
+
+  /**
+   * @return User
+   */
+  public function getUser()
+  {
+    return $this->user;
+  }
+
+  /**
+   * @return number
+   */
+  public function getGroupPerm()
+  {
+    return $this->group_perm;
+  }
+
+  /**
+   * @return string json
+   */
+  public function getJSON()
+  {
+    return json_encode($this->getArray());
+  }
+
+  /**
+   * Get the file element as associative array
+   *
+   * @return array
+   */
+  public function getArray()
+  {
+    return [
+      'user' => $this->user->getArray(),
+      'group_perm' => intval($this->group_perm)
+    ];
+  }
+}

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1512,6 +1512,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+
   /groups/deletable:
     get:
       operationId: deletableGroups
@@ -1531,6 +1532,34 @@ paths:
                   $ref: '#/components/schemas/Group'
         default:
           $ref: '#/components/responses/defaultResponse'
+
+  /groups/{id}/members:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: ID of the group
+        schema:
+          type: integer
+    get:
+      operationId: getGroupUsersWithRoles
+      tags:
+        - Groups
+      summary: Get the users with their roles from a group
+      description: >
+        Returns accessible objects of users with roles from the group
+      responses:
+        '200':
+          description: List of group-user-member
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserGroupMember'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+          
   /report:
     get:
       operationId: getReportsByUpload
@@ -2455,6 +2484,15 @@ components:
           type: string
           example:
             "Main group"
+    UserGroupMember:
+      type: object
+      properties:
+        user:
+            $ref: '#/components/schemas/User'
+        group_perm:
+          type: integer
+          description: Permission of the user in the group.
+          example: 1
     Obligation:
       description: Obligation information
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -165,6 +165,7 @@ $app->group('/groups',
     $app->delete('/{id:\\d+}', GroupController::class . ':deleteGroup');
     $app->delete('/{id:\\d+}/user/{uid:\\d+}', GroupController::class . ':deleteGroupMember');
     $app->get('/deletable', GroupController::class . ':getDeletableGroups');
+    $app->get('/{id:\\d+}/members', GroupController::class . ':getGroupMembers');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui_tests/api/Helper/DbHelperTest.php
+++ b/src/www/ui_tests/api/Helper/DbHelperTest.php
@@ -161,7 +161,12 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     $expectedUsers = array_values($this->generateUserFromRow($userRows));
     $actualUsers = $this->dbHelper->getUsers();
 
-    $this->assertEquals($expectedUsers, $actualUsers);
+    $allUsers = array();
+    foreach ($actualUsers as $user) {
+      $allUsers[] = $user->getArray();
+    }
+
+    $this->assertEquals($expectedUsers, $allUsers);
   }
 
   /**
@@ -190,8 +195,11 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     $expectedUsers = array_values($this->generateUserFromRow($userRows,
       $userId));
     $actualUsers = $this->dbHelper->getUsers();
-
-    $this->assertEquals($expectedUsers, $actualUsers);
+    $allUsers = array();
+    foreach ($actualUsers as $user) {
+      $allUsers[] = $user->getArray();
+    }
+    $this->assertEquals($expectedUsers, $allUsers);
   }
 
   /**
@@ -220,7 +228,11 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     $expectedUsers = $this->generateUserFromRow($userRows, $userId);
     $actualUsers = $this->dbHelper->getUsers($userId);
 
-    $this->assertEquals([$expectedUsers[$userId]], $actualUsers);
+    $allUsers = array();
+    foreach ($actualUsers as $user) {
+      $allUsers[] = $user->getArray();
+    }
+    $this->assertEquals([$expectedUsers[$userId]], $allUsers);
   }
 
   /**
@@ -250,6 +262,10 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     $expectedUsers = $this->generateUserFromRow($userRows, $userId);
     $actualUsers = $this->dbHelper->getUsers($fetchId);
 
-    $this->assertEquals([$expectedUsers[$fetchId]], $actualUsers);
+    $allUsers = array();
+    foreach ($actualUsers as $user) {
+      $allUsers[] = $user->getArray();
+    }
+    $this->assertEquals([$expectedUsers[$fetchId]], $allUsers);
   }
 }


### PR DESCRIPTION
Signed-off-by: dushimsam <dushsam100@gmail.com>



## Description

Get all group members with corresponding roles / permissions from the given group via REST API.

### Changes

1. Added a new function in `GroupController`. to get all  group members.
2. Updated  the main file(`index.php`) by adding a new route `/groups/members/{id}`.
3. Updated the `openapi.yaml` file to introduce a new API.

## How to test

1. Open and run the project then visit  the url `http://localhost/repo/api/v1/groups/members/{id}`
2. Response

i. **When the group id is given:**

Getting all the users from the group whose id is 14. 

![group_memebers_with_id](https://user-images.githubusercontent.com/66276301/177048043-55d67901-92c7-4922-bacd-9c48d419a3e7.png)

ii. **When the group Id is not given:**

Since the group id is not specified, we are going to pick the default group which is `Default User` instead.

![group_members_wout_id](https://user-images.githubusercontent.com/66276301/177048200-15942c00-d6c0-4b72-b1b6-2cb2f4c02f93.png)

**_Hence our API can handle both situations, Group Id is given, and the group Id is not given._**

### Related Issue:
Fixes #2249
    
cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2251"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

