### PR TITLE
feat(API): `users/` post route for adding a new user

### DIFF
--- a/src/www/ui/api/Helper/DbHelper.php
+++ b/src/www/ui/api/Helper/DbHelper.php
@@ -240,11 +240,11 @@ FROM $tableName WHERE $idRowName = $1", [$id],
   {
     if ($id == null) {
       $usersSQL = "SELECT user_pk, user_name, user_desc, user_email,
-                  email_notify, root_folder_fk, group_fk, user_perm, user_agent_list FROM users;";
+                  email_notify, root_folder_fk, group_fk, user_perm, user_agent_list, default_bucketpool_fk FROM users;";
       $statement = __METHOD__ . ".getAllUsers";
     } else {
       $usersSQL = "SELECT user_pk, user_name, user_desc, user_email,
-                email_notify, root_folder_fk, group_fk, user_perm, user_agent_list FROM users
+                email_notify, root_folder_fk, group_fk, user_perm, user_agent_list, default_bucketpool_fk FROM users
                 WHERE user_pk = $1;";
       $statement = __METHOD__ . ".getSpecificUser";
     }
@@ -263,10 +263,10 @@ FROM $tableName WHERE $idRowName = $1", [$id],
         ($row["user_pk"] == $currentUser)) {
         $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
           $row["user_email"], $row["user_perm"], $row["root_folder_fk"],
-          $row["email_notify"], $row["user_agent_list"], $row["group_fk"]);
+          $row["email_notify"], $row["user_agent_list"], $row["group_fk"], $row["default_bucketpool_fk"]);
       } else {
         $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
-          null, null, null, null, null);
+          null, null, null, null, null, null);
       }
       $users[] = $user->getArray();
     }

--- a/src/www/ui/api/Helper/UserHelper.php
+++ b/src/www/ui/api/Helper/UserHelper.php
@@ -35,7 +35,7 @@ class UserHelper
    *
    * @param $user_pk
    */
-  public function __construct($user_pk)
+  public function __construct($user_pk=null)
   {
     $this->user_pk = $user_pk;
   }
@@ -99,26 +99,7 @@ class UserHelper
     $symfonyRequest->request->set('default_bucketpool_fk', isset($userDetails['defaultBucketpool']) ? $userDetails['defaultBucketpool'] : $user['default_bucketpool_fk']);
 
     if (isset($userDetails['accessLevel'])) {
-      $user_perm = 0;
-      switch ($userDetails['accessLevel']) {
-        case 'none':
-          $user_perm = Auth::PERM_NONE;
-          break;
-        case 'read_only':
-          $user_perm = Auth::PERM_READ;
-          break;
-        case 'read_write':
-          $user_perm = Auth::PERM_WRITE;
-          break;
-        case 'clearing_admin':
-          $user_perm = Auth::PERM_CADMIN;
-          break;
-        case 'admin':
-          $user_perm = Auth::PERM_ADMIN;
-          break;
-        default:
-          break;
-      }
+      $user_perm = $this->getEquivalentValueForPermission($userDetails['accessLevel']);
       $symfonyRequest->request->set('user_perm', $user_perm);
     } else {
       $symfonyRequest->request->set('user_perm', $user['user_perm']);
@@ -178,5 +159,27 @@ class UserHelper
     $symfonyRequest->request->set('user_agent_list', userAgents($agents));
 
     return $symfonyRequest;
+  }
+
+  /**
+   * @param string $perm which is user permission
+   * @return int permission value
+   */
+  public function getEquivalentValueForPermission($perm)
+  {
+    switch ($perm) {
+      case 'none':
+        return Auth::PERM_NONE;
+      case 'read_only':
+        return Auth::PERM_READ;
+      case 'read_write':
+        return Auth::PERM_WRITE;
+      case 'clearing_admin':
+        return Auth::PERM_CADMIN;
+      case 'admin':
+        return Auth::PERM_ADMIN;
+      default:
+        return Auth::PERM_NONE;
+    }
   }
 }

--- a/src/www/ui/api/Models/User.php
+++ b/src/www/ui/api/Models/User.php
@@ -69,6 +69,11 @@ class User
    * Current user's analysis from $agents
    */
   private $analysis;
+  /**
+   * @var int $defaultBucketPool
+   * Default bucket pool of the user
+   */
+  private $defaultBucketPool;
 
   /**
    * User constructor.
@@ -81,8 +86,10 @@ class User
    * @param integer $default_group_fk
    * @param boolean $emailNotification
    * @param object $agents
+   * @param integer $defaultBucketPool
    */
-  public function __construct($id, $name, $description, $email, $accessLevel, $root_folder_id, $emailNotification, $agents, $default_group_fk=null)
+  public function __construct($id, $name, $description, $email, $accessLevel, $root_folder_id, $emailNotification,
+                              $agents, $default_group_fk=null, $defaultBucketPool=null)
   {
     $this->id = intval($id);
     $this->name = $name;
@@ -94,6 +101,9 @@ class User
         break;
       case PLUGIN_DB_WRITE:
         $this->accessLevel = "read_write";
+        break;
+      case PLUGIN_DB_CADMIN:
+        $this->accessLevel = "clearing_admin";
         break;
       case PLUGIN_DB_ADMIN:
         $this->accessLevel = "admin";
@@ -107,6 +117,11 @@ class User
     $this->agents = $agents;
     $this->analysis = new Analysis();
     $this->analysis->setUsingString($this->agents);
+    if ($defaultBucketPool != null) {
+      $this->defaultBucketPool = intval($defaultBucketPool);
+    } else {
+      $this->defaultBucketPool = null;
+    }
   }
 
   ////// Getters //////
@@ -183,6 +198,14 @@ class User
   }
 
   /**
+   * @return int
+   */
+  public function getDefaultBucketPool()
+  {
+    return $this->defaultBucketPool;
+  }
+
+  /**
    * Get current user in JSON representation
    * @return string
    */
@@ -216,6 +239,9 @@ class User
     }
     if ($this->agents !== null) {
       $returnUser["agents"] = $this->analysis->getArray();
+    }
+    if ($this->defaultBucketPool !== null) {
+      $returnUser["defaultBucketpool"] = $this->defaultBucketPool;
     }
     return $returnUser;
   }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -764,6 +764,70 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
   /users:
+    post:
+        operationId: createUser
+        tags:
+        - User
+        - Admin
+        summary: Create a new user
+        description: >
+          Create a new user
+        requestBody:
+          required: true
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/User'
+                  - type: object
+                    properties:
+                      user_pass:
+                        type: string
+                      defaultVisibility:
+                        type: string
+                        enum:
+                          - public
+                          - protected
+                          - private
+                    required:
+                      - name
+            application/x-www-form-urlencoded:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/User'
+                  - type: object
+                    properties:
+                      user_pass:
+                        type: string
+                      defaultVisibility:
+                        type: string
+                        enum:
+                          - public
+                          - protected
+                          - private
+                    required:
+                      - name
+        responses:
+          '201':
+            description: User created successfully
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Info'
+          '409':
+            description: User with the same email or username already exists
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Info'
+          '500':
+            description: Internal server error with details
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Info'
+          default:
+              $ref: '#/components/responses/defaultResponse'
     get:
       operationId: getUsers
       tags:
@@ -2052,6 +2116,10 @@ components:
           description: Default group id of the user
         agents:
           $ref: '#/components/schemas/Analysis'
+        defaultBucketpool:
+          description: Default bucket pool id
+          type: integer
+          nullable: true
       required:
         - id
     Analysis:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -149,6 +149,7 @@ $app->group('/users',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->get('[/{id:\\d+}]', UserController::class . ':getUsers');
     $app->put('[/{id:\\d+}]', UserController::class . ':updateUser');
+    $app->post('', UserController::class . ':addUser');
     $app->delete('/{id:\\d+}', UserController::class . ':deleteUser');
     $app->get('/self', UserController::class . ':getCurrentUser');
     $app->post('/tokens', UserController::class . ':createRestApiToken');

--- a/src/www/ui/template/user_add.html.twig
+++ b/src/www/ui/template/user_add.html.twig
@@ -1,0 +1,97 @@
+{# SPDX-FileCopyrightText: © Fossology contributors
+ 
+   SPDX-License-Identifier: FSFAP
+#}
+{% extends "include/base.html.twig" %}
+
+{% block styles %}
+  {{ parent() }}
+  <link rel='stylesheet' href='css/access-token.css'>
+{% endblock %}
+
+{% block content %}
+  {% set style = "style='border-bottom:1px solid black'" %}
+
+  <form name="{{ formName }}" method="POST">
+  {{ "To create a new user, enter the following information:<P />"|trans }}
+
+  <table style='border:1px solid black; text-align:left; background:lightyellow;'>
+    <tr {{ style }}>
+      <th width="25%">{{ "Username."|trans }}</th>
+      <td><input type="text" value="{{ userName|e }}" name="username" size="20" /></td>
+    </tr>
+    <tr {{ style }}>
+      <th width="25%">{{ "Description (name, contact, or other information)."|trans }} {{ "This may be blank."|trans }}</th>
+      <td><input type="text" value="{{ userDescription|e }}" name="description" size="60" /></td>
+    </tr>
+    <tr {{ style }}>
+      <th width="25%">{{ "Email address."|trans }} {{ "This may be blank."|trans }}</th>
+      <td><input type="text" value="{{ userEmail|e }}" name="email" size="60" /></td>
+    </tr>
+    <tr {{ style }}>
+      <th width="25%">{{ "Access level"|trans }}</th>
+      <td><select name='permission'>
+        <option value="{{ accessLevel[0] }}">{{ "None (very basic, no database access)"|trans }}</option>
+        <option value="{{ accessLevel[1] }}">{{ "Read-only (read, but no writes or downloads)"|trans }}</option>
+        <option value="{{ accessLevel[2] }}">{{ "Read-Write (read, download, or edit information)"|trans }}</option>
+        <option value="{{ accessLevel[3] }}">{{ "Clearing Administrator (read, download, edit information and edit decisions)"|trans }}</option>
+        <option value="{{ accessLevel[4] }}">{{ "Full Administrator (all access including adding and deleting users)"|trans }}</option>
+        </select>
+      </td>
+    </tr>
+    <tr {{ style }}>
+      <th width="25%">{{ "User root folder"|trans }}</th>
+      <td><select name="folder" class="ui-render-select2">
+        {{ folderListOption }}
+      </select></td>
+    </tr>
+    <tr {{ style }}>
+      <th width="25%">{{ "Password"|trans }}{{ passOptional|trans }}</th>
+      <td><input type="password" name="pass1" size="20" id="passcheck" />{% if passwordPolicy is not empty %}
+      <br /><span class="passPolicy">{{ passwordPolicy }}</span>
+      {% endif %}</td>
+    </tr>
+    <tr {{ style }}>
+      <th width='25%'>{{ "Re-enter password."|trans }}</th>
+      <td><input type="password" name="pass2" size="20" id="pass2" style='margin:4px' /></td>
+    </tr>
+    <tr {{ style }}>
+      <th width="25%">{{ "E-mail Notification"|trans }}</th>
+      <td><input type="checkbox" name="enote" value="y" checked="checked" />
+        {{ "Check to enable email notification when upload scan completes."|trans }}</td>
+    </tr>
+    <tr {{ style }}>
+      <th width='25%'>{{ "Default upload visibility" |trans }}</th>
+      <td>
+        <input type="radio" name="public" value="private" id="apr" />
+        <label for="apr">
+          {{ 'Visible only for active group'| trans }}<img src="images/info_16.png" title="{{ 'which is the currently selected group'|trans }}" alt="" class="info-bullet"/>
+        </label><br/>
+        <input type="radio" name="public" value="protected" id="app" />
+        <label for="app">
+          {{ 'Visible for all groups'| trans }}<img src="images/info_16.png" title="{{ 'which are accessible by you now'|trans }}" alt="" class="info-bullet"/>
+        </label><br/>
+        <input type="radio" name="public" value="public" id="apu" />
+        <label for="apu">
+          {{ 'Make Public'| trans }}<img src="images/info_16.png" title="{{ 'visible for all users'|trans }}" alt="" class="info-bullet"/>
+        </label><br/>
+      </td>
+    </tr>
+    <tr {{ style }}>
+      <th width='25%'>{{ 'Agents selected by default when uploading'|trans }}</th>
+      <td>{{ agentSelector }}</td>
+    </tr>
+    <tr {{ style }}>
+      <th width="25%">{{ "Default bucket pool"| trans }}</th>
+      <td>{{ bucketPool }}</td>
+    </tr>
+  </table><P />
+  <br />
+  <input type="submit" value="{{ 'Add User'|trans }}"/>
+  </form>
+{% endblock %}
+
+{% block foot %}
+  {{ parent() }}
+  <script type="text/javascript">{% include "password-policy-check.js.twig" %}</script>
+{% endblock %}

--- a/src/www/ui_tests/api/Controllers/UserControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UserControllerTest.php
@@ -114,7 +114,7 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
         continue;
       }
       $user = new User($userId, "user$userId", "User $userId",
-        "user$userId@example.com", $accessLevel, 2, 4, "", 0);
+        "user$userId@example.com", $accessLevel, 2, 4, "", 2);
       $userArray[] = $user->getArray();
     }
     return $userArray;

--- a/src/www/ui_tests/api/Helper/DbHelperTest.php
+++ b/src/www/ui_tests/api/Helper/DbHelperTest.php
@@ -104,7 +104,7 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
         'user_pk' => $i, 'user_name' => "user$i", 'user_desc' => "user $i",
         'user_email' => "user$i@local", 'email_notify' => 'y',
         'root_folder_fk' => 2, 'group_fk' => 2, 'user_perm' => $perm_list[$i],
-        'user_agent_list' => $agent_list[$i]
+        'user_agent_list' => $agent_list[$i], 'default_bucketpool_fk' => 2
       ];
       $userRows[$i] = $row;
     }
@@ -125,7 +125,7 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
       if ($currentUser === null || $row['user_pk'] == $currentUser) {
         $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
             $row["user_email"], $row["user_perm"], $row["root_folder_fk"],
-          $row["email_notify"], $row["user_agent_list"], $row['group_fk']);
+          $row["email_notify"], $row["user_agent_list"], $row['group_fk'], $row["default_bucketpool_fk"]);
       } else {
         $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
           null, null, null, null, null, null);
@@ -148,8 +148,8 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $sql = 'SELECT user_pk, user_name, user_desc, user_email,
-                  email_notify, root_folder_fk, group_fk, user_perm, user_agent_list ' .
-      'FROM users;';
+                  email_notify, root_folder_fk, group_fk, user_perm, user_agent_list, ' .
+      'default_bucketpool_fk FROM users;';
     $statement = DbHelper::class . "::getUsers.getAllUsers";
     $userRows = $this->generateUserRow();
 
@@ -177,8 +177,8 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
 
     $sql = 'SELECT user_pk, user_name, user_desc, user_email,
-                  email_notify, root_folder_fk, group_fk, user_perm, user_agent_list ' .
-      'FROM users;';
+                  email_notify, root_folder_fk, group_fk, user_perm, user_agent_list, ' .
+      'default_bucketpool_fk FROM users;';
     $statement = DbHelper::class . "::getUsers.getAllUsers";
     $userRows = $this->generateUserRow();
 
@@ -207,7 +207,7 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $sql = "SELECT user_pk, user_name, user_desc, user_email,
-                email_notify, root_folder_fk, group_fk, user_perm, user_agent_list FROM users
+                email_notify, root_folder_fk, group_fk, user_perm, user_agent_list, default_bucketpool_fk FROM users
                 WHERE user_pk = $1;";
     $statement = DbHelper::class . "::getUsers.getSpecificUser";
     $userRows = $this->generateUserRow();
@@ -237,7 +237,7 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
 
     $sql = "SELECT user_pk, user_name, user_desc, user_email,
-                email_notify, root_folder_fk, group_fk, user_perm, user_agent_list FROM users
+                email_notify, root_folder_fk, group_fk, user_perm, user_agent_list, default_bucketpool_fk FROM users
                 WHERE user_pk = $1;";
     $statement = DbHelper::class . "::getUsers.getSpecificUser";
     $userRows = $this->generateUserRow();


### PR DESCRIPTION
Signed-off-by : Krishna Mahato <krishhtrishh9304@gmail.com>

## Description

Now, there is a POST route which is available at `/api/v1/users` that will create a new user.

## How to test

- Use any API platform like postman.
- Pull the changes from this PR.
- Provide the request body as following ----
<img width="311" alt="Screenshot 2022-07-23 at 2 04 44 PM" src="https://user-images.githubusercontent.com/71918441/180597426-b67e3d74-c734-47b2-b5b7-0d312af4f9cd.png">

- You can expect a response like this
<img width="331" alt="Screenshot 2022-07-23 at 2 05 10 PM" src="https://user-images.githubusercontent.com/71918441/180597440-64be4ac8-38ab-49c7-a0b5-622456a9e0bd.png">

PTAL : @GMishx @Shruti3004 


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2256"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

This closes #2255 .