### PR TITLE
feat(api): jobs/all endpoint added

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -881,6 +881,51 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+  
+  /jobs/all:
+    get:
+      operationId: getAllJobs
+      tags:
+      - Job
+      summary: Gets all jobs created by all users
+      description: Returns all jobs with their status created by every user. This API returns a response only if the requesting user is an Admin.
+      parameters:
+        - name: limit
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+          in: header
+        - name: page
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+          in: header
+      responses:
+        '200':
+          description: OK
+          headers:
+            X-Total-Pages:
+              description: Total number of pages which can be generated based on limit
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Job'
+        '403':
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+
+        
+        default:
+          $ref: '#/components/responses/defaultResponse'    
   /jobs/{id}:
     parameters:
       - name: id

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -174,6 +174,7 @@ $app->group('/groups',
 $app->group('/jobs',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->get('[/{id:\\d+}]', JobController::class . ':getJobs');
+    $app->get('/all', JobController::class . ':getAllJobs');
     $app->post('', JobController::class . ':createJob');
     $app->any('/{params:.*}', BadRequestController::class);
   });


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

introduces `jobs/all` endpoint. This endpoint returns all the jobs created by all the users. This endpoint only returns the jobs if the logged in user is an admin. Otherwise it returns an 403 error.

### Changes

in `src/www/ui/api`:
`index.php` is changed
`Controllers/JobController.php` is changed.

Also added the required docs for the new endpoint in the `openapi.yaml` file
## How to test

make a call to the /jobs/all endpoint in a API testing application like Postman.


## Screenshots

Admin response: <br/>

![Screenshot from 2022-07-13 20-00-05](https://user-images.githubusercontent.com/63705023/178758890-fcaf56f8-c8bd-4cca-b887-237f07f21251.png)

Other user's response: <br/>

![Screenshot from 2022-07-13 20-03-07](https://user-images.githubusercontent.com/63705023/178759627-7f47153c-9fb9-4a6f-ad8b-19bce13f0296.png)



Update to: #2253 



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2260"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

