### PR TITLE
feat(Spasht):Added new API request to send data back to clearlyDefined

### DIFF
--- a/src/spasht/ui/template/agent_spasht.js.twig
+++ b/src/spasht/ui/template/agent_spasht.js.twig
@@ -51,6 +51,50 @@ function StoreIntoDb() {
   }
 }
 
+function submitCuration() {
+  var namespace = $.trim($("#contributeNamespace").text());
+  var name = $.trim($("#contributeName").text());
+  var revision = $.trim($("#contributeRevision").text());
+  var type = $.trim($("#contributeType").text());
+  var provider = $.trim($("#contributeProvider").text()); 
+
+  var coordinates = { "type": type, "provider": provider, "namespace": namespace, "name": name, "revision": revision};
+
+  var jsonStringCoordinates = JSON.stringify(coordinates);
+
+  $("#jsonStringCoordinates").val(jsonStringCoordinates);
+
+  var ContributionType = $.trim($("#ContributionType").val());
+  var ContributionTitle = $.trim($("#ContributionTitle").val());
+  var ContributionDetails = $.trim($("#ContributionDetails").val());
+  var ContributionResolution = $.trim($("#ContributionResolution").val());
+  var contributionBox = false;
+
+  if ($('#contributionBox').is(":checked")) 
+  {
+    var contributionBox = true;
+  }
+
+  var contributionInfo = { "summary": ContributionTitle,
+    "details": ContributionDetails,
+    "resolution": ContributionResolution,
+    "type": ContributionType,
+    "removeDefinitions": contributionBox
+  }
+
+  var jsonStringContributionInfo = JSON.stringify(contributionInfo);
+  $("#jsonStringContributionInfo").val(jsonStringContributionInfo);
+  $("#hiddenRevision").val(revision);
+
+  if(ContributionType !== "" && ContributionTitle !== "" && ContributionDetails !== "" && ContributionResolution !== "") {
+    $("#contributionDataValid").val("true");
+    $("#contributtionSubmitButton").submit();
+  } else {
+    $("#contributionDataValid").val("false");
+  }
+
+}
+
 function showDetails(key) {
   var modalId = "#detailsModal" + key;
   var rowId = "#definitionsRow" + key;

--- a/src/spasht/ui/template/agent_spasht_contribute.html.twig
+++ b/src/spasht/ui/template/agent_spasht_contribute.html.twig
@@ -1,0 +1,102 @@
+{% if pageNo == "show_upload_table" %}
+  <div class="spasht-full-row">
+    <table id="detailsTable" class="simpleTable detailsTable left-align-cells">
+      <tbody>
+        <tr class="detailsRow">
+          <th>Namespace</th>
+          <td>
+            <span id="contributeNamespace">{{ body.namespace }}</span>
+          </td>
+        </tr>
+        <tr class="detailsRow">
+          <th>Name</th>
+          <td>
+            <span id="contributeName">{{ body.name }}</span>
+          </td>
+        </tr>
+        <tr class="detailsRow">
+          <th>Revision</th>
+          <td>
+            <span id="contributeRevision">{{ body.revision }}</span>
+          </td>
+        </tr>
+        <tr class="detailsRow">
+          <th>Type</th>
+          <td>
+            <span id="contributeType"> {{ body.type }}</span>
+          </td>
+        </tr>
+        <tr class="detailsRow">
+          <th>Provider</th>
+          <td>
+            <span id="contributeProvider">{{ body.provider }}</span>
+          </td>
+        </tr>
+        <tr class="detailsRow">
+          <th>status</th>
+          <td>
+            <span>{{ body_menu }}</span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  {# contribution details form #}
+  <div class="spasht-full-row">
+    <form name="contributeForm" id="contributeForm" method="post" action="">
+      <table>
+        <tr>
+          <td>
+            <p style="text-align:left">Type</p>
+            <select id="ContributionType" style="width:100%">
+              <option value="select" disabled selected>Select</option>
+              <option value="Missing">Missing</option>
+              <option value="Incorrect">Incorrect</option>
+              <option value="Incomplete">Incomplete</option>
+              <option value="Ambigious">Ambigious</option>
+              <option value="Other">Other</option>
+            </select>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <p style="text-align:left">Title</p>
+            <input type="text" id="ContributionTitle" style="width:100%"/>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <p style="text-align:left">Details</p>
+            <textarea id="ContributionDetails" style="width:100%"></textarea>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <p style="text-align:left">Resolution</p>
+            <textarea id="ContributionResolution" style="width:100%"></textarea>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <input type="checkbox" id="contributionBox"/> Remove contributed definitions from the list
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <br>
+            <button id="contributtionSubmitButton" onclick="submitCuration()">Submit</button>
+          </td>
+        </tr>
+      </table>
+      <input id="jsonStringCoordinates" type="hidden" name="jsonStringCoordinates" value="" />
+      <input id="jsonStringContributionInfo" type="hidden" name="jsonStringContributionInfo" value="" />
+      <input id="hiddenRevision" type="hidden" name="hiddenRevision" value="" />
+      <input id="contributionDataValid" type="hidden" name="contributionDataValid" value="false" />
+    </form>
+  </div>
+{% else %}
+  <div class="spasht-full-row">
+    <b>Please Search and Select Revision</b>
+  </div>
+{% endif %}

--- a/src/spasht/ui/template/agent_spasht_ui_tabs.html.twig
+++ b/src/spasht/ui/template/agent_spasht_ui_tabs.html.twig
@@ -13,6 +13,7 @@
         <ul>
           <li><a href="#ConfigureTab">Configure</a></li>
           <li><a href="#CopyrightTab">Copyrights</a></li>
+          <li><a href="#ContributeTab">Contribute</a></li>
         </ul>
         <div id="ConfigureTab">
           {% include 'agent_spasht_ui_content.html.twig' %}
@@ -86,6 +87,9 @@
           </td>
           {% endif %}
           </tr></table>
+        </div>
+        <div id="ContributeTab">
+          {% include 'agent_spasht_contribute.html.twig' %}
         </div>
       </div>
     </td>

--- a/src/spasht/ui/ui-spasht.php
+++ b/src/spasht/ui/ui-spasht.php
@@ -141,6 +141,12 @@ class ui_spasht extends FO_Plugin
     $typeName = trim(GetParm("typeName", PARM_STRING));
     $providerName = trim(GetParm("providerName", PARM_STRING));
 
+    // Reading contribution data
+    $coordinatesInfo = trim(GetParm("jsonStringCoordinates", PARM_STRING));
+    $contributionInfo = trim(GetParm("jsonStringContributionInfo", PARM_STRING));
+    $contributionRevision = trim(GetParm("hiddenRevision", PARM_STRING));
+    $contributionDataValid = trim(GetParm("contributionDataValid", PARM_STRING));
+    
     $this->vars['storeStatus'] = "false";
     $this->vars['pageNo'] = "definition_not_found";
 
@@ -344,9 +350,77 @@ class ui_spasht extends FO_Plugin
     $this->vars['fileList'] = $this->getFileListing($uploadtree_pk, $uri,
       $uploadtree_tablename, $agentId, $uploadId);
 
+    
+    if($contributionDataValid === "true" && !empty($coordinatesInfo) && !empty($contributionInfo)) 
+    {
+      $contributionJsonPacket = $this->handleContributionToClearlyDefined($coordinatesInfo ,$contributionInfo, $contributionRevision);
+
+      try {
+        // Point to curations section in the api
+        $res = $client->request('PATCH', 'curations', [
+          'data' => [$contributionJsonPacket], //send data to the api
+          'proxy' => $proxy
+        ]);
+      } catch (RequestException $e) {
+        $this->vars['message'] = "Unable to reach " .
+          $SysConf['SYSCONFIG']["ClearlyDefinedURL"] . ". Code: " .
+          $e->getCode();
+        return $this->render('agent_spasht.html.twig', $this->vars);
+      } catch (ClientException $e) {
+        $this->vars['message'] = "Request failed. Status: " .
+          $e->getCode();
+        return $this->render('agent_spasht.html.twig', $this->vars);
+      } catch (ServerException $e) {
+        $this->vars['message'] = "Request failed. Status: " .
+          $e->getCode();
+        return $this->render('agent_spasht.html.twig', $this->vars);
+      }
+    }
+
     $out = $this->render('agent_spasht.html.twig', $this->vars);
 
     return($out);
+  }
+
+
+  /**
+    * @param string  $coordinatesInfo       coordinates from selected definition
+    * @param string  $contributionInfo      PR information filled by user
+    * @param string  $contributionRevision  Revision of selected definition
+    * @return array
+    */
+  protected function handleContributionToClearlyDefined($coordinatesInfo, $contributionInfo, $contributionRevision) 
+  {
+    $contributionPacket = array();
+
+    $coordinatesInfo = json_decode($coordinatesInfo);
+    $contributionInfo = json_decode($contributionInfo);
+
+    $contributionPacket["contributionInfo"] = $contributionInfo;
+        $patches =array();
+
+          $patch = array();
+          $patch["coordinates"] = $coordinatesInfo;
+            $revision = array();
+              $contributionFiles = array();
+                $file = array();
+                $file["path"] = "";
+                $file["license"] = "";
+                $file["attributions"] = "";
+
+              array_push($contributionFiles, $file);
+
+            $revision[$contributionRevision]["files"] = $contributionFiles;
+          $patch["revisions"] = $revision;
+
+        array_push($patches, $patch);
+        $contributionPacket["patches"] = $patches;
+
+    if(!empty($contributionPacket)) 
+    {
+      $jsonPacket = json_encode($contributionPacket);
+      return $contributionPacket;
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
This PR introduces a new API request to send data back to clearlyDefined.

### Changes

`src/spasht/ui/ui-spasht.php`
`src/spasht/ui/template/agent_spasht_contribute.html.twig`
`src/spasht/ui/template/agent_spasht.js.twig`
`src/spasht/ui/template/agent_spasht_ui_tabs.html.twig`

## How to test
1. Upload any package
2. Click on the package --> Spasht
3. Search for any definition and schedule the agent.
4. Click on contribute tab and fill the form
5. Click on submit

![image](https://user-images.githubusercontent.com/74642911/178772762-554ee712-c222-4ca2-b2a0-0e4b54737624.png)
