### PR TITLE
feat(api): Added `users/{id}` PUT route to modify user details

### DIFF
--- a/src/lib/php/common-agents.php
+++ b/src/lib/php/common-agents.php
@@ -358,9 +358,9 @@ function AgentSelect($TableName, $upload_pk, $SLName, &$agent_pk, $extra = "")
  *
  * \return String $agentsChecked list of checked agents
  */
-function userAgents()
+function userAgents($agents=null)
 {
-  return implode(',', array_keys(checkedAgents()));
+  return implode(',', array_keys(checkedAgents($agents)));
 }
 
 /**
@@ -369,13 +369,19 @@ function userAgents()
  *
  * \return Plugin[] list of checked agent plugins, mapped by name
  */
-function checkedAgents()
+function checkedAgents($agents=null)
 {
   $agentsChecked = array();
   $agentList = listAgents();
   foreach ($agentList as $agentName => &$agentPlugin) {
-    if (GetParm("Check_" . $agentName, PARM_INTEGER) == 1) {
-      $agentsChecked[$agentName] = &$agentPlugin;
+    if (is_null($agents)) {
+      if (GetParm("Check_" . $agentName, PARM_INTEGER) == 1) {
+        $agentsChecked[$agentName] = &$agentPlugin;
+      }
+    } else {
+      if ($agents["Check_" . $agentName] == 1) {
+        $agentsChecked[$agentName] = &$agentPlugin;
+      }
     }
   }
   unset($agentPlugin);

--- a/src/www/ui/api/Controllers/UserController.php
+++ b/src/www/ui/api/Controllers/UserController.php
@@ -16,7 +16,7 @@ use Fossology\UI\Api\Helper\ResponseHelper;
 use Psr\Http\Message\ServerRequestInterface;
 use Fossology\UI\Api\Models\Info;
 use Fossology\UI\Api\Models\InfoType;
-use Fossology\Lib\Dao\UserDao;
+use Fossology\UI\Api\Helper\UserHelper;
 
 /**
  * @class UserController
@@ -85,5 +85,27 @@ class UserController extends RestController
     $defaultGroup = $userDao->getUserAndDefaultGroupByUserName($user["name"])["group_name"];
     $user["default_group"] = $defaultGroup;
     return $response->withJson($user, 200);
+  }
+
+  /**
+   * Updates the user details
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function updateUser($request, $response, $args)
+  {
+    $id = intval($args['id']);
+    $returnVal = null;
+    if ($this->dbHelper->doesIdExist("users","user_pk", $id)) {
+      $reqBody = $this->getParsedBody($request);
+      $userHelper = new UserHelper($id);
+      $returnVal = $userHelper->modifyUserDetails($reqBody);
+    } else {
+      $returnVal = new Info(404, "UserId doesn't exist!", InfoType::ERROR);
+    }
+    return $response->withJson($returnVal->getArray(), $returnVal->getCode());
   }
 }

--- a/src/www/ui/api/Helper/DbHelper.php
+++ b/src/www/ui/api/Helper/DbHelper.php
@@ -240,11 +240,11 @@ FROM $tableName WHERE $idRowName = $1", [$id],
   {
     if ($id == null) {
       $usersSQL = "SELECT user_pk, user_name, user_desc, user_email,
-                  email_notify, root_folder_fk, user_perm, user_agent_list FROM users;";
+                  email_notify, root_folder_fk, group_fk, user_perm, user_agent_list FROM users;";
       $statement = __METHOD__ . ".getAllUsers";
     } else {
       $usersSQL = "SELECT user_pk, user_name, user_desc, user_email,
-                email_notify, root_folder_fk, user_perm, user_agent_list FROM users
+                email_notify, root_folder_fk, group_fk, user_perm, user_agent_list FROM users
                 WHERE user_pk = $1;";
       $statement = __METHOD__ . ".getSpecificUser";
     }
@@ -263,7 +263,7 @@ FROM $tableName WHERE $idRowName = $1", [$id],
         ($row["user_pk"] == $currentUser)) {
         $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
           $row["user_email"], $row["user_perm"], $row["root_folder_fk"],
-          $row["email_notify"], $row["user_agent_list"]);
+          $row["email_notify"], $row["user_agent_list"], $row["group_fk"]);
       } else {
         $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
           null, null, null, null, null);

--- a/src/www/ui/api/Helper/UserHelper.php
+++ b/src/www/ui/api/Helper/UserHelper.php
@@ -1,0 +1,182 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: © 2022 Krishna Mahato <krishhtrishh9304@gmail.com>
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+/**
+ * @user
+ * @brief Helper for User related queries
+ */
+
+namespace Fossology\UI\Api\Helper;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\UserDao;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @class UserHelper
+ * @brief Handle user related queries
+ */
+class UserHelper
+{
+  /**
+   * @var $user_pk
+   */
+  private $user_pk;
+
+  /**
+   * Constructor for UserHelper
+   *
+   * @param $user_pk
+   */
+  public function __construct($user_pk)
+  {
+    $this->user_pk = $user_pk;
+  }
+
+  public function modifyUserDetails($reqBody)
+  {
+    global $container;
+    $restHelper = $container->get('helper.restHelper');
+    $userEditObj = $restHelper->getPlugin('user_edit');
+    /* Is the session owner an admin? */
+    $sessionOwnerUser_pk = $restHelper->getUserId();
+    $SessionUserRec = $userEditObj->GetUserRec($sessionOwnerUser_pk);
+    $SessionIsAdmin = $userEditObj->IsSessionAdmin($SessionUserRec);
+
+    $symReq = $this->createSymRequest($reqBody);
+    if (!$SessionIsAdmin) {
+      $returnVal = new Info(403, "The session owner is not an admin!", InfoType::INFO);
+    } else {
+      $userRec = $userEditObj->CreateUserRec($symReq);
+      $ErrMsgs = $userEditObj->UpdateUser($userRec, $SessionIsAdmin);
+
+      if ($ErrMsgs == null) {
+        $returnVal = new Info(200, "User updated succesfully!", InfoType::INFO);
+      } else {
+        $returnVal = new Info(400, $ErrMsgs, InfoType::INFO);
+      }
+    }
+    return $returnVal;
+  }
+
+  /**
+   * @param array $userDetails parsed from request body
+   * @return Request $symfonyRequest
+   */
+  public function createSymRequest($userDetails)
+  {
+    global $container;
+    $restHelper = $container->get('helper.restHelper');
+
+    /**
+     * @var UserDao $userDao
+     * User dao
+     */
+    $userDao = $restHelper->getUserDao();
+    $user = $userDao->getUserByPk($this->user_pk);
+
+    $symfonyRequest = new Request();
+    $symfonyRequest->request->set('user_pk', isset($userDetails['id']) ? $userDetails['id'] : $this->user_pk);
+    $symfonyRequest->request->set('user_name', isset($userDetails['name']) ? $userDetails['name'] : $user['user_name']);
+    $symfonyRequest->request->set('root_folder_fk', isset($userDetails['rootFolderId']) ? $userDetails['rootFolderId'] : $user['root_folder_fk']);
+    $symfonyRequest->request->set('default_group_fk', isset($userDetails['defaultGroup']) ? $userDetails['defaultGroup'] : $user['group_fk']);
+    $symfonyRequest->request->set('public', isset($userDetails['defaultVisibility']) ? $userDetails['defaultVisibility'] : $user['upload_visibility']);
+    $symfonyRequest->request->set('default_folder_fk', isset($userDetails['defaultFolderId']) ? $userDetails['defaultFolderId'] : $user['default_folder_fk']);
+    $symfonyRequest->request->set('user_desc', isset($userDetails['description']) ? $userDetails['description'] : $user['user_desc']);
+    $symfonyRequest->request->set('_pass1', isset($userDetails['user_pass']) ? $userDetails['user_pass'] : null);
+    $symfonyRequest->request->set('_pass2', isset($userDetails['user_pass']) ? $userDetails['user_pass'] : null);
+    $symfonyRequest->request->set('_blank_pass', isset($userDetails['_blank_pass']) ? $userDetails['_blank_pass'] : "");
+    $symfonyRequest->request->set('user_status', isset($userDetails['user_status']) ? $userDetails['user_status'] : $user['user_status']);
+    $symfonyRequest->request->set('user_email', isset($userDetails['email']) ? $userDetails['email'] : $user['user_email']);
+    $symfonyRequest->request->set('email_notify', isset($userDetails['emailNotification']) && $userDetails['emailNotification'] ? "y" : $user['email_notify']);
+    $symfonyRequest->request->set('default_bucketpool_fk', isset($userDetails['defaultBucketpool']) ? $userDetails['defaultBucketpool'] : $user['default_bucketpool_fk']);
+
+    if (isset($userDetails['accessLevel'])) {
+      $user_perm = 0;
+      switch ($userDetails['accessLevel']) {
+        case 'none':
+          $user_perm = Auth::PERM_NONE;
+          break;
+        case 'read_only':
+          $user_perm = Auth::PERM_READ;
+          break;
+        case 'read_write':
+          $user_perm = Auth::PERM_WRITE;
+          break;
+        case 'clearing_admin':
+          $user_perm = Auth::PERM_CADMIN;
+          break;
+        case 'admin':
+          $user_perm = Auth::PERM_ADMIN;
+          break;
+        default:
+          break;
+      }
+      $symfonyRequest->request->set('user_perm', $user_perm);
+    } else {
+      $symfonyRequest->request->set('user_perm', $user['user_perm']);
+    }
+
+    $agentsExists = array();
+    // setting previous values from db
+    $agentsTempVal = explode(',', $user['user_agent_list']);
+    foreach ($agentsTempVal as $agent) {
+      $agentsExists['Check_' . $agent] = 1;
+    };
+    $newAgents = array();
+    if (isset($userDetails['agents'])) {
+      if (is_string($userDetails['agents'])) {
+        $userDetails['agents'] = json_decode($userDetails['agents'], true);
+      }
+      if (isset($userDetails['agents']['mime'])) {
+        $newAgents['Check_agent_mimetype'] = $userDetails['agents']['mime'] ? 1 : 0;
+      }
+      if (isset($userDetails['agents']['monk'])) {
+        $newAgents['Check_agent_monk'] = $userDetails['agents']['monk'] ? 1 : 0;
+      }
+      if (isset($userDetails['agents']['ojo'])) {
+        $newAgents['Check_agent_ojo'] = $userDetails['agents']['ojo'] ? 1 : 0;
+      }
+      if (isset($userDetails['agents']['copyright_email_author'])) {
+        $newAgents['Check_agent_copyright'] = $userDetails['agents']['copyright_email_author'] ? 1 : 0;
+      }
+      if (isset($userDetails['agents']['ecc'])) {
+        $newAgents['Check_agent_ecc'] = $userDetails['agents']['ecc'] ? 1 : 0;
+      }
+      if (isset($userDetails['agents']['keyword'])) {
+        $newAgents['Check_agent_keyword'] = $userDetails['agents']['keyword'] ? 1 : 0;
+      }
+      if (isset($userDetails['agents']['nomos'])) {
+        $newAgents['Check_agent_nomos'] = $userDetails['agents']['nomos'] ? 1 : 0;
+      }
+      if (isset($userDetails['agents']['package'])) {
+        $newAgents['Check_agent_pkgagent'] = $userDetails['agents']['package'] ? 1 : 0;
+      }
+      if (isset($userDetails['agents']['reso'])) {
+        $newAgents['Check_agent_reso'] = $userDetails['agents']['reso'] ? 1 : 0;
+      }
+      if (isset($userDetails['agents']['heritage'])) {
+        $newAgents['Check_agent_shagent'] = $userDetails['agents']['heritage'] ? 1 : 0;
+      }
+      // Make sure all agents are in the list
+      $agentList = listAgents();
+      foreach (array_keys($agentList) as $agentName) {
+        if (!array_key_exists("Check_$agentName", $newAgents)) {
+          $newAgents["Check_$agentName"] = 0;
+        }
+      }
+    }
+    $agents = array_replace($agentsExists, $newAgents);
+
+    $symfonyRequest->request->set('user_agent_list', userAgents($agents));
+
+    return $symfonyRequest;
+  }
+}

--- a/src/www/ui/api/Models/User.php
+++ b/src/www/ui/api/Models/User.php
@@ -50,6 +50,11 @@ class User
    */
   private $rootFolderId;
   /**
+   * @var integer $defaultGroup
+   * Current user's default group id
+   */
+  private $defaultGroup;
+  /**
    * @var boolean $emailNotification
    * Current user's email preference
    */
@@ -73,10 +78,11 @@ class User
    * @param string $email
    * @param integer $accessLevel
    * @param integer $root_folder_id
+   * @param integer $default_group_fk
    * @param boolean $emailNotification
    * @param object $agents
    */
-  public function __construct($id, $name, $description, $email, $accessLevel, $root_folder_id, $emailNotification, $agents)
+  public function __construct($id, $name, $description, $email, $accessLevel, $root_folder_id, $emailNotification, $agents, $default_group_fk=null)
   {
     $this->id = intval($id);
     $this->name = $name;
@@ -96,6 +102,7 @@ class User
         $this->accessLevel = "none";
     }
     $this->rootFolderId = intval($root_folder_id);
+    $this->defaultGroup = is_null($default_group_fk) ? null : intval($default_group_fk);
     $this->emailNotification = $emailNotification;
     $this->agents = $agents;
     $this->analysis = new Analysis();
@@ -152,6 +159,14 @@ class User
   }
 
   /**
+   * @return integer
+   */
+  public function getDefaultGroupId()
+  {
+    return $this->defaultGroup;
+  }
+
+  /**
    * @return boolean
    */
   public function getEmailNotification()
@@ -192,6 +207,9 @@ class User
     }
     if ($this->rootFolderId !== null && $this->rootFolderId != 0) {
       $returnUser["rootFolderId"] = $this->rootFolderId;
+    }
+    if ($this->defaultGroup !== null) {
+      $returnUser["defaultGroup"] = $this->defaultGroup;
     }
     if ($this->emailNotification !== null) {
       $returnUser["emailNotification"] = $this->emailNotification;

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -795,6 +795,77 @@ paths:
                 $ref: '#/components/schemas/User'
         default:
             $ref: '#/components/responses/defaultResponse'
+    put:
+      operationId: modifyUserById
+      tags:
+        - User
+        - Admin
+      summary: Edit user details by id
+      description: >
+        Edit user details by id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/User'
+                - type: object
+                  properties:
+                    user_pass:
+                      type: string
+                    defaultFolderId:
+                      type: integer
+                    defaultVisibility:
+                      type: string
+                      enum:
+                        - public
+                        - protected
+                        - private
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/User'
+                - type: object
+                  properties:
+                    user_pass:
+                      type: string
+                    defaultFolderId:
+                      type: integer
+                    defaultVisibility:
+                      type: string
+                      enum:
+                        - public
+                        - protected
+                        - private
+      responses:
+        '200':
+          description: User updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Missing or wrong parameters in request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: The session owner is not an admin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: UserId doesn't exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        
+        default:
+            $ref: '#/components/responses/defaultResponse'
     delete:
       operationId: deleteUserById
       tags:
@@ -824,15 +895,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/User'
-                  - type: object
-                    properties:
-                      default_group:
-                        type: string
-                        description: Default group of the user
-                        example:
-                          "fossy"        
+                $ref: '#/components/schemas/User'      
         default:
           $ref: '#/components/responses/defaultResponse'
   /jobs:
@@ -1841,6 +1904,7 @@ components:
             - none
             - read_only
             - read_write
+            - clearing_admin
             - admin
         rootFolderId:
           type: number
@@ -1849,12 +1913,13 @@ components:
         emailNotification:
           type: boolean
           description: enable email notification when upload scan completes
+        defaultGroup:
+          type: integer
+          description: Default group id of the user
         agents:
           $ref: '#/components/schemas/Analysis'
       required:
         - id
-        - name
-        - description
     Analysis:
       type: object
       properties:
@@ -1888,6 +1953,9 @@ components:
         reso:
           type: boolean
           description: Should REUSE.Software Analysis be run on this upload.
+        heritage:
+          type: boolean
+          description: Should Software Heritage Analysis be run on this upload.
     Reuser:
       type: object
       properties:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -148,6 +148,7 @@ $app->group('/uploads',
 $app->group('/users',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->get('[/{id:\\d+}]', UserController::class . ':getUsers');
+    $app->put('[/{id:\\d+}]', UserController::class . ':updateUser');
     $app->delete('/{id:\\d+}', UserController::class . ':deleteUser');
     $app->get('/self', UserController::class . ':getCurrentUser');
     $app->any('/{params:.*}', BadRequestController::class);

--- a/src/www/ui/user-edit.php
+++ b/src/www/ui/user-edit.php
@@ -59,7 +59,7 @@ class UserEditPage extends DefaultPlugin
    * 2) User has chosen a user to edit from the 'userid' select list  \n
    * 3) User hit submit to update user data\n
    */
-  protected function handle(Request $request)
+  function handle(Request $request)
   {
     global $SysConf;
     /* Is the session owner an admin? */
@@ -364,7 +364,7 @@ class UserEditPage extends DefaultPlugin
    *
    * \return TRUE if the session user is an admin.  Otherwise, return FALSE
    */
-  private function IsSessionAdmin($UserRec)
+  function IsSessionAdmin($UserRec)
   {
     return ($UserRec['user_perm'] == PLUGIN_DB_ADMIN);
   }
@@ -425,7 +425,7 @@ class UserEditPage extends DefaultPlugin
       if (!empty($UserRec['email_notify'])) {
         $UserRec['email_notify'] = 'y';
       }
-      $UserRec['user_agent_list'] = userAgents();
+      $UserRec['user_agent_list'] = is_null($request->get('user_agent_list')) ? userAgents() : $request->get('user_agent_list');
       $UserRec['default_bucketpool_fk'] = intval($request->get("default_bucketpool_fk"));
     }
     return $UserRec;

--- a/src/www/ui_tests/api/Controllers/UserControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UserControllerTest.php
@@ -114,7 +114,7 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
         continue;
       }
       $user = new User($userId, "user$userId", "User $userId",
-        "user$userId@example.com", $accessLevel, 2, 4, "");
+        "user$userId@example.com", $accessLevel, 2, 4, "", 0);
       $userArray[] = $user->getArray();
     }
     return $userArray;

--- a/src/www/ui_tests/api/Helper/DbHelperTest.php
+++ b/src/www/ui_tests/api/Helper/DbHelperTest.php
@@ -103,7 +103,7 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
       $row = [
         'user_pk' => $i, 'user_name' => "user$i", 'user_desc' => "user $i",
         'user_email' => "user$i@local", 'email_notify' => 'y',
-        'root_folder_fk' => 2, 'user_perm' => $perm_list[$i],
+        'root_folder_fk' => 2, 'group_fk' => 2, 'user_perm' => $perm_list[$i],
         'user_agent_list' => $agent_list[$i]
       ];
       $userRows[$i] = $row;
@@ -125,10 +125,10 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
       if ($currentUser === null || $row['user_pk'] == $currentUser) {
         $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
             $row["user_email"], $row["user_perm"], $row["root_folder_fk"],
-          $row["email_notify"], $row["user_agent_list"]);
+          $row["email_notify"], $row["user_agent_list"], $row['group_fk']);
       } else {
         $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
-          null, null, null, null, null);
+          null, null, null, null, null, null);
       }
       $users[$row["user_pk"]] = $user->getArray();
     }
@@ -148,7 +148,7 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $sql = 'SELECT user_pk, user_name, user_desc, user_email,
-                  email_notify, root_folder_fk, user_perm, user_agent_list ' .
+                  email_notify, root_folder_fk, group_fk, user_perm, user_agent_list ' .
       'FROM users;';
     $statement = DbHelper::class . "::getUsers.getAllUsers";
     $userRows = $this->generateUserRow();
@@ -177,7 +177,7 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
 
     $sql = 'SELECT user_pk, user_name, user_desc, user_email,
-                  email_notify, root_folder_fk, user_perm, user_agent_list ' .
+                  email_notify, root_folder_fk, group_fk, user_perm, user_agent_list ' .
       'FROM users;';
     $statement = DbHelper::class . "::getUsers.getAllUsers";
     $userRows = $this->generateUserRow();
@@ -207,7 +207,7 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $sql = "SELECT user_pk, user_name, user_desc, user_email,
-                email_notify, root_folder_fk, user_perm, user_agent_list FROM users
+                email_notify, root_folder_fk, group_fk, user_perm, user_agent_list FROM users
                 WHERE user_pk = $1;";
     $statement = DbHelper::class . "::getUsers.getSpecificUser";
     $userRows = $this->generateUserRow();
@@ -237,7 +237,7 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
 
     $sql = "SELECT user_pk, user_name, user_desc, user_email,
-                email_notify, root_folder_fk, user_perm, user_agent_list FROM users
+                email_notify, root_folder_fk, group_fk, user_perm, user_agent_list FROM users
                 WHERE user_pk = $1;";
     $statement = DbHelper::class . "::getUsers.getSpecificUser";
     $userRows = $this->generateUserRow();

--- a/src/www/ui_tests/api/Models/UserTest.php
+++ b/src/www/ui_tests/api/Models/UserTest.php
@@ -36,6 +36,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
       "email"        => 'fossy@localhost',
       "accessLevel"  => 'admin',
       "rootFolderId" => 2,
+      "defaultGroup" => 0,
       "emailNotification" => true,
       "agents"       => [
         "bucket"    => true,
@@ -54,12 +55,13 @@ class UserTest extends \PHPUnit\Framework\TestCase
       "id"           => 8,
       "name"         => 'userii',
       "description"  => 'very useri',
+      "defaultGroup" => 0,
     ];
 
     $actualCurrentUser = new User(2, 'fossy', 'super user', 'fossy@localhost',
-      PLUGIN_DB_ADMIN, 2, true, "bucket,copyright,nomos,ojo");
+      PLUGIN_DB_ADMIN, 2, true, "bucket,copyright,nomos,ojo", 0);
     $actualNonAdminUser = new User(8, 'userii', 'very useri', null, null, null,
-      null, null);
+      null, null, 0);
 
     $this->assertEquals($expectedCurrentUser, $actualCurrentUser->getArray());
     $this->assertEquals($expectedNonAdminUser, $actualNonAdminUser->getArray());


### PR DESCRIPTION
Signed-off-by : Krishna Mahato <krishhtrishh9304@gmail.com>

## Description

Now, there is a PUT route which is available at `/api/v1/users/{id}` that will edit the user details of a given user id. 

## How to test

- Use any API platform like postman.
- Pull the changes from this PR.
- Provide the request body as following ----
<img width="401" alt="Screenshot 2022-07-18 at 10 49 24 PM" src="https://user-images.githubusercontent.com/71918441/179567244-75b3ffb0-7c83-4cb8-aa7d-4acc199c1c5d.png">


- You can expect a response like this
<img width="433" alt="Screenshot 2022-07-15 at 9 13 36 PM" src="https://user-images.githubusercontent.com/71918441/179258687-3fda5df7-2303-4bb3-b54d-5f4746a69fae.png">

PTAL : @GMishx @Shruti3004 


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2256"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

This closes #2257 .

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2262"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

