### PR TITLE
feat(api): added `/users/tokens` POST Route  and `/users/tokens/{type}` GET Route

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -62,12 +62,22 @@ paths:
         description: Required details for generating new token
         required: true
         content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TokenRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/TokenRequest'
+              allOf:
+                - $ref: '#/components/schemas/TokenRequest'
+                - type: object
+                  properties:
+                    username:
+                      type: string
+                      description: Username of the login user.
+                    password:
+                      type: string
+                      format: password
+                      description: Password of the user trying to login.
+                  required:
+                    - username
+                    - password
       responses:
         '201':
           description: Token generated
@@ -898,6 +908,82 @@ paths:
                 $ref: '#/components/schemas/User'      
         default:
           $ref: '#/components/responses/defaultResponse'
+  /users/tokens:
+    post:
+      operationId: createRestApiToken
+      tags:
+        - User
+        - Admin
+      summary: Create a new REST API Token
+      description: >
+        Create a new REST API Token
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TokenRequest'
+      responses:
+        '201':
+          description: Token created successfully
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Info'
+                  - type: object
+                    properties:
+                      token:
+                        type: string
+                        example: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2NTgwODI1OTksIm5iZiI6MTY1NzkwOTgwMCwianRpIjoiTXk0eiIsInNjb3BlIjoid3JpdGUifQ.Sl1acvN0GlCe7VUZJQX00u_vpfWrtfJlVYQ63FBkzP4
+        '400':
+          description: Following parameters are required in the request body -- token_name,token_scope,token_expire
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        
+        default:
+            $ref: '#/components/responses/defaultResponse'
+  /users/tokens/{type}:
+    parameters:
+      - name: type
+        required: true
+        in: path
+        schema:
+          type: string
+          enum:
+          - active
+          - expired
+    get:
+      operationId: getTokensByType
+      tags:
+        - User
+        - Admin
+      summary: Get all the REST API tokens (active | expired)
+      description: >
+        Get all the REST API tokens (active | expired)
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Info'
+                  - type: object
+                    properties:
+                      active_tokens:
+                        $ref: '#/components/schemas/Token'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        
+        default:
+            $ref: '#/components/responses/defaultResponse'
   /jobs:
     parameters:
       - name: groupName
@@ -1902,6 +1988,35 @@ components:
             - INFO
             - ERROR
           description: Denotes if info was created on error
+    Token:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Token Id
+        token_name:
+          type: string
+          description: Name of the Token
+        created:
+          type: string
+          format: date
+          description: Denotes when the token was created
+          example: 2022-07-11
+        token_expire:
+          type: string
+          format: date
+          description: Denotes when the token was created
+          example: 2022-07-11
+        scope:
+          type: string
+          enum:
+          - read
+          - write
+          description: Scope of the token
+        token:
+          type: string
+          description: Scope of the token
+          example: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2NTg5NDY1OTksIm5iZiI6MTY1NzkwOTgwMCwianRpIjoiTnk0eiIsInNjb3BlIjoid3JpdGUifQ.Yqwdt7Fzx-Qw3megYix_OYu1mqBOoz4Rrc1cgJasmJA
     User:
       type: object
       properties:
@@ -2032,13 +2147,6 @@ components:
     TokenRequest:
       type: object
       properties:
-        username:
-          type: string
-          description: Username of the login user.
-        password:
-          type: string
-          format: password
-          description: Password of the user trying to login.
         token_name:
           type: string
           maxLength: 40

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -151,6 +151,8 @@ $app->group('/users',
     $app->put('[/{id:\\d+}]', UserController::class . ':updateUser');
     $app->delete('/{id:\\d+}', UserController::class . ':deleteUser');
     $app->get('/self', UserController::class . ':getCurrentUser');
+    $app->post('/tokens', UserController::class . ':createRestApiToken');
+    $app->get('/tokens/{type:\\w+}', UserController::class . ':getTokens');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui/async/AjaxManageToken.php
+++ b/src/www/ui/async/AjaxManageToken.php
@@ -81,7 +81,7 @@ class AjaxManageToken extends DefaultPlugin
    * @param string $hostname Host issuing the token
    * @returns array Array with success status and token.
    */
-  private function revealToken($tokenPk, $hostname)
+  function revealToken($tokenPk, $hostname="")
   {
     global $container;
     $restDbHelper = $container->get("helper.dbHelper");

--- a/src/www/ui/user-edit.php
+++ b/src/www/ui/user-edit.php
@@ -441,17 +441,17 @@ class UserEditPage extends DefaultPlugin
    * @uses Fossology::UI::Api::Helper::RestHelper::validateTokenRequest()
    * @uses Fossology::UI::Api::Helper::DbHelper::insertNewTokenKey()
    */
-  private function generateNewToken(Request $request)
+  function generateNewToken(Request $request)
   {
     global $container;
 
     $user_pk = Auth::getUserId();
-    $tokenName = GetParm('pat_name', PARM_STRING);
-    $tokenExpiry = GetParm('pat_expiry', PARM_STRING);
+    $tokenName = $request->get('pat_name');
+    $tokenExpiry = $request->get('pat_expiry');
     if ($_SESSION[Auth::USER_LEVEL] < 3) {
       $tokenScope = 'r';
     } else {
-      $tokenScope = GetParm('pat_scope', PARM_STRING);
+      $tokenScope = $request->get('pat_scope');
     }
     $tokenScope = array_search($tokenScope, RestHelper::SCOPE_DB_MAP);
     $restHelper = $container->get('helper.restHelper');
@@ -493,7 +493,7 @@ class UserEditPage extends DefaultPlugin
    * template. Also check if the token is expired.
    * @return array
    */
-  private function getListOfActiveTokens()
+  function getListOfActiveTokens()
   {
     $user_pk = Auth::getUserId();
     $sql = "SELECT pat_pk, user_fk, expire_on, token_scope, token_name, created_on, active " .
@@ -522,7 +522,7 @@ class UserEditPage extends DefaultPlugin
    * Get a list of expired tokens for current user.
    * @return array
    */
-  private function getListOfExpiredTokens()
+  function getListOfExpiredTokens()
   {
     $user_pk = Auth::getUserId();
     $sql = "SELECT pat_pk, user_fk, expire_on, token_scope, token_name, created_on " .


### PR DESCRIPTION
Signed-off-by : Krishna Mahato <krishhtrishh9304@gmail.com>

## Description

The following REST routes have been implemented.

- There is a POST route which is available at `/api/v1/users/tokens` that will Create a new REST API Token. 
- There is a GET route which is available at `/api/v1/users/tokens/{type}` that will Get all the REST API tokens based on the type specified (active | expired). 

## How to test

- Use any API platform like postman.
- Pull the changes from this PR.

## Testing `/api/v1/users/tokens`
- Provide the request body as following ----
<img width="460" alt="Screenshot 2022-07-19 at 1 03 11 AM" src="https://user-images.githubusercontent.com/71918441/179602804-2471c3ba-338d-4322-a387-2a3bade9b727.png">

- You can expect a response like this
<img width="999" alt="Screenshot 2022-07-16 at 11 30 36 AM" src="https://user-images.githubusercontent.com/71918441/179342194-6bcbce95-16a3-4beb-b123-67a788578192.png">

## Testing `/api/v1/users/tokens/{type}`
- You can expect a response like this
   - type = `active`
<img width="1058" alt="Screenshot 2022-07-19 at 1 05 00 AM" src="https://user-images.githubusercontent.com/71918441/179603078-d13d9593-3412-48f3-995f-48d195581412.png">

   - type = `expired`
<img width="1058" alt="Screenshot 2022-07-19 at 1 05 40 AM" src="https://user-images.githubusercontent.com/71918441/179603127-7afa0cd5-921d-4989-9dc0-084ea7672324.png">

PTAL : @GMishx @Shruti3004 

This closes #2265 .

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2266"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

