### PR TITLE
fix(reuser): add scancode as dependency if sched

### DIFF
--- a/src/reuser/ui/agent-reuser.php
+++ b/src/reuser/ui/agent-reuser.php
@@ -29,6 +29,7 @@ use Fossology\Lib\Dao\PackageDao;
 use Fossology\Lib\Dao\UploadDao;
 use Fossology\Lib\Plugin\AgentPlugin;
 use Fossology\Lib\Util\StringOperation;
+use Fossology\Scancode\Ui\ScancodesAgentPlugin;
 use Symfony\Component\HttpFoundation\Request;
 
 include_once(dirname(__DIR__) . "/agent/version.php");
@@ -189,6 +190,18 @@ class ReuserAgentPlugin extends AgentPlugin
     }
     if ($request->get("Check_agent_copyright", false)) {
       $dependencies[] = "agent_copyright";
+    }
+    if (!empty($request->get("scancodeFlags", []))) {
+      /**
+       * @var ScancodesAgentPlugin ScanCode agent
+       */
+      $agentScanCode = plugin_find('agent_scancode');
+      $flags = $request->get('scancodeFlags');
+      $unpackArgs = intval($request->get('scm', 0)) == 1 ? 'I' : '';
+      $dependencies[] = [
+        "name" => "agent_scancode",
+        "args" => $agentScanCode->getScanCodeArgs($flags, $unpackArgs)
+      ];
     }
     return $dependencies;
   }

--- a/src/scancode/ui/agent-scancode.php
+++ b/src/scancode/ui/agent-scancode.php
@@ -74,9 +74,27 @@ class ScancodesAgentPlugin extends AgentPlugin
   {
     $dependencies = array();
     $flags = $request->get('scancodeFlags') ?: array();
+    $unpackArgs = intval(@$_POST['scm']) == 1 ? 'I' : '';
+    $args = $this->getScanCodeArgs($flags, $unpackArgs);
+    if ($args === null) {
+      return 0;
+    }
+    if (!empty($unpackArgs)) {
+      $dependencies[] = 'agent_mimetype';
+    }
+    return parent::AgentAdd($jobId, $uploadId, $errorMsg, array_unique($dependencies) , $args);
+  }
+
+  /**
+   * Translate request flags to agent's args string
+   * @param string[] $flags Array of flags
+   * @param string $unpackArgs Unpack agent args
+   * @return null|string NULL if no args created, string otherwise
+   */
+  public function getScanCodeArgs($flags, $unpackArgs)
+  {
     $scanMode = '';
-    foreach ($flags as $flag)
-    {
+    foreach ($flags as $flag) {
       switch ($flag)
       {
         case "license":
@@ -93,18 +111,13 @@ class ScancodesAgentPlugin extends AgentPlugin
           break;
       }
     }
-    if (empty($scanMode))
-    {
-      return 0;
+    if (empty($scanMode)) {
+      return null;
     }
-    $unpackArgs = intval(@$_POST['scm']) == 1 ? 'I' : '';
-    if (!empty($unpackArgs))
-    {
-      $dependencies[] = 'agent_mimetype';
+    if (!empty($unpackArgs)) {
       $scanMode .= $unpackArgs;
     }
-    $args = self::SCAN_FLAG.$scanMode;
-    return parent::AgentAdd($jobId, $uploadId, $errorMsg, array_unique($dependencies) , $args);
+    return self::SCAN_FLAG . $scanMode;
   }
 
   /**


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add scancode as a dependency to reuser if it is scheduled to create a
correct job queue.

### Changes

Check if scancode agent is scheduled and add it to dependency list.

## How to test

1. Clear an upload with multiple monk bulk jobs.
2. Upload the same package again.
    1. Schedule scancode agent on it.
    2. Schedule the reuser with "Bulk phrases from reused packages" decider option.
3. In the job queue, reuser should not start untill scancode agent finishes.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2271"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

