### PR TITLE
feat(api): PUT api to Set permissions for a upload and GET API to fetch respective permissions of groups

### DIFF
--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -688,6 +688,8 @@ class UploadController extends RestController
 
       $query = "SELECT perm, perm_upload_pk FROM perm_upload WHERE upload_fk=$1 and group_fk=$2;";
       $result = $dbManager->getSingleRow($query, [$upload_pk, $newgroup], __METHOD__.".getOldPerm");
+      $perm_upload_pk = 0;
+      $perm = 0;
       if (!empty($result)) {
         $perm_upload_pk = intVal($result['perm_upload_pk']);
         $perm = $newperm;

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -660,6 +660,128 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /uploads/{id}/permissions:
+    parameters:
+      - name: id
+        required: true
+        description: Enter any upload id
+        in: path
+        schema:
+          type: integer
+    put:
+      operationId: setUploadPermissions
+      tags:
+        - Upload
+      summary: Set permissions for a upload in a folder for different groups
+      description: >
+        Set permissions for a upload in a folder for different groups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                folderId:
+                  type: integer
+                  description: Enter a folder id
+                allUploadsPermission:
+                  type: boolean
+                  enum:
+                  - true
+                  - false
+                  description: Apply same permissions to all uploads in this folder
+                groupId:
+                  type: integer
+                  description: Enter the id of the group you want to add or edit permission for this upload
+                newPermission:
+                  type: string
+                  enum:
+                  - none
+                  - read_only
+                  - read_write
+                  - clearing_admin
+                  - admin
+                  description: Select the permission for selected group
+                publicPermission:
+                  type: string
+                  enum:
+                  - none
+                  - read_only
+                  - read_write
+                  - clearing_admin
+                  - admin
+                  description: Select the public permission for this upload
+              required:
+                - allUploadsPermission
+      responses:
+        '202':
+          description: Permissions updated successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Info'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Info'
+        '404':
+          description: Upload does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Info'
+        '503':
+          description: Scheduler is not running
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /uploads/{id}/perm-groups:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+    get:
+      operationId: getGroupsWithPermissions
+      tags:
+        - Upload
+      summary: Get all the groups with their respective permissions for a upload
+      description:
+        Returns the list of all the groups with their respective permissions for a upload
+      responses:
+        '200':
+          description: Get Groups with permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UploadPermGroups'
+        '404':
+          description: Upload does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /search:
     get:
       operationId: searchFile
@@ -2289,6 +2411,25 @@ components:
             example: 
             - "path/to/file1"
             - "path/to/file2"
+    UploadPermGroups:
+      description: Groups with their respective permissions for a upload
+      type: object
+      properties:
+        publicPerm:
+          type: string
+          description: Public permission for the upload
+        permGroups:
+          type: array
+          description: Indexed Object of GroupIds with their respective permissions for a upload
+          items:
+            type: object
+            properties:
+              perm:
+                type: string
+              group_pk:
+                type: string
+              group_name:
+                type: string
     UrlUpload:
       description: To create an upload from a URL
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -138,6 +138,8 @@ $app->group('/uploads',
     $app->patch('/{id:\\d+}', UploadController::class . ':updateUpload');
     $app->put('/{id:\\d+}', UploadController::class . ':moveUpload');
     $app->post('', UploadController::class . ':postUpload');
+    $app->put('/{id:\\d+}/permissions', UploadController::class . ':setUploadPermissions');
+    $app->get('/{id:\\d+}/perm-groups', UploadController::class . ':getGroupsWithPermissions');
     $app->get('/{id:\\d+}/summary', UploadController::class . ':getUploadSummary');
     $app->get('/{id:\\d+}/licenses', UploadController::class . ':getUploadLicenses');
     $app->get('/{id:\\d+}/copyrights', UploadController::class . ':getUploadCopyrights');


### PR DESCRIPTION
Signed-off-by : Krishna Mahato <krishhtrishh9304@gmail.com>

## Description

Now, 
- There is a PUT route which is available at `/api/v1/uploads/{id}/permissions` that will Set permissions for a upload in a folder for different groups.
- There is a GET route which is available at `/api/v1/uploads/{id}/perm-groups` that will return all the groups with their respective permissions for a upload.
Here `{id} : is the upload Id`.

## How to test
- Use any API platform like postman.
- Pull the changes from this PR.

### To test `PUT /api/v1/uploads/{id}/permissions`
- Provide the request body as following ----
<img width="469" alt="Screenshot 2022-07-23 at 2 25 39 AM" src="https://user-images.githubusercontent.com/71918441/180567280-72c2ddbb-9089-4013-8489-066147867af2.png">

- You can expect a response like this
<img width="469" alt="Screenshot 2022-07-23 at 2 26 11 AM" src="https://user-images.githubusercontent.com/71918441/180567337-c9261701-de78-4ba7-b7fe-8c12a831419d.png">

### To test `GET /api/v1/uploads/{id}/perm-groups`
- If your upload exists, you can expect a response like this.
<img width="379" alt="Screenshot 2022-08-24 at 11 43 23 PM" src="https://user-images.githubusercontent.com/71918441/186492712-58361493-e7ec-484e-8ec2-8ffe98b94501.png">

PTAL : @GMishx @Shruti3004 

This closes #2270 .



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2275"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

