### PR TITLE
feat(copyright): SPDX copyright detection added

### DIFF
--- a/src/copyright/agent/cleanEntries.cc
+++ b/src/copyright/agent/cleanEntries.cc
@@ -48,6 +48,20 @@ string cleanGeneral(string::const_iterator sBegin, string::const_iterator sEnd)
 }
 
 /**
+ * \brief Truncate SPDX-CopyrightText from copyright statement
+ * \param sBegin String begin
+ * \param sEnd   String end
+ * \return string Clean spdx statements
+ */
+string cleanSpdxStatement(string::const_iterator sBegin, string::const_iterator sEnd)
+{
+  stringstream ss;
+  rx::regex_replace(ostream_iterator<char>(ss), sBegin, sEnd, rx::regex("spdx-filecopyrighttext:", rx::regex_constants::icase), " ");
+  string s = ss.str();
+  return cleanGeneral(s.begin(), s.end());
+}
+
+/**
  * \brief Clean copyright statements from special characters
  * (comment characters in programming languages, multiple spaces etc.)
  * \param sBegin String begin
@@ -59,7 +73,7 @@ string cleanStatement(string::const_iterator sBegin, string::const_iterator sEnd
   stringstream ss;
   rx::regex_replace(ostream_iterator<char>(ss), sBegin, sEnd, rx::regex("\n[[:space:][:punct:]]*"), " ");
   string s = ss.str();
-  return cleanGeneral(s.begin(), s.end());
+  return cleanSpdxStatement(s.begin(), s.end());
 }
 
 /**

--- a/src/copyright/agent/copyright.conf
+++ b/src/copyright/agent/copyright.conf
@@ -26,7 +26,8 @@ author=__author____SPACESALL____NAMESLIST__\.?
 author=__author__|(?<=<author>)(.*?)(?=<\/author>)
 #
 COPYSYM=(?:\(c\)|&copy;|\xA9|\xC2\xA9|\$\xB8|\xE2\x92\xB8|\$\xD2|\xE2\x93\x92|\$\x9E|\xE2\x92\x9E)
-REG_COPYRIGHT=copyright(?:ed|s)?[[:space:]:]*|__COPYSYM__[ \t]+([[:alnum:] ][^\0]{0,2}){5,}
+REG_COPYRIGHT=(?:spdx-filecopyrighttext|copyright)(?:ed|s)?[[:space:]:]*|__COPYSYM__[ \t]+([[:alnum:] ][^\0]{0,2}){5,}
 REG_EXCEPTION=\bcopyrights?(?:[ \t/\\\*\+#"\.-]+)(?:licen[cs]es?|notices?|holders?|and|statements?|owners?)[ \t\.,][^\0]*
 REG_NON_BLANK=.*(?:[[:alpha:]][[:alpha:]]|[[:digit:]][[:digit:]]).*
 REG_SIMPLE_COPYRIGHT=\bcopyright\b|__COPYSYM__
+REG_SPDX_COPYRIGHT=spdx-filecopyrighttext:(.*)

--- a/src/copyright/agent/copyscan.cc
+++ b/src/copyright/agent/copyscan.cc
@@ -31,6 +31,8 @@ hCopyrightScanner::hCopyrightScanner()
 
   regSimpleCopyright = rx::regex(rcp.getRegexValue("copyright","REG_SIMPLE_COPYRIGHT"),
                      rx::regex_constants::icase);
+  regSpdxCopyright = rx::regex(rcp.getRegexValue("copyright","REG_SPDX_COPYRIGHT"),
+                     rx::regex_constants::icase);
 }
 
 /**
@@ -74,6 +76,10 @@ void hCopyrightScanner::ScanString(const string& s, list<match>& out) const
         string::const_iterator beginOfLine = j;
         ++beginOfLine;
         string::const_iterator endOfLine = find(beginOfLine, end, '\n');
+        if (rx::regex_search(beginOfLine, endOfLine, regSpdxCopyright)){
+          // Found end
+          break;
+        }
         if (rx::regex_search(beginOfLine, endOfLine, regSimpleCopyright)
           || !rx::regex_match(beginOfLine, endOfLine, regNonBlank))
         {

--- a/src/copyright/agent/copyscan.hpp
+++ b/src/copyright/agent/copyscan.hpp
@@ -29,8 +29,10 @@ private:
    * Regex to find non blank statements
    * \var rx::regex regSimpleCopyright
    * Simple regex for copyright
+   * \var rx::regex regSpdxCopyright
+   * Regex for SPDX-FileCopyrightText
    */
-  rx::regex regCopyright, regException, regNonBlank, regSimpleCopyright;
+  rx::regex regCopyright, regException, regNonBlank, regSimpleCopyright, regSpdxCopyright;
 } ;
 
 #endif

--- a/src/copyright/ui/CopyrightView.php
+++ b/src/copyright/ui/CopyrightView.php
@@ -43,8 +43,12 @@ class CopyrightView extends Xpview
   protected function additionalVars($uploadId, $uploadTreeId, $agentId)
   {
     if (empty($agentId)) {
-      $agentMap = $this->agentDao->getLatestAgentResultForUpload($uploadId,array('copyright'));
+      $agentMap = $this->agentDao->getLatestAgentResultForUpload($uploadId,array('copyright', 'reso'));
       $agentId = array_key_exists('copyright',$agentMap) ? $agentMap['copyright'] : 0;
+      if (array_key_exists('reso',$agentMap)) {
+        $ResoagentId = $agentMap['reso'];
+        $agentId = $agentId . "," . $ResoagentId;
+      }
     }
     $typeDescriptionPairs = array(
       'statement' => _("FOSSology"),
@@ -56,7 +60,7 @@ class CopyrightView extends Xpview
     $filter = '';
     foreach ($typeDescriptionPairs as $type=>$description) {
       if ($type==="scancode_statement") {
-        $agentId=LatestAgentpk($uploadId, 'scancode_ars');
+        $agentId = LatestAgentpk($uploadId, 'scancode_ars');
         $this->agentName = "scancode";
       }
       list($out, $vars) = $modCopyrightHist->getTableForSingleType($type, $description, $uploadId, $uploadTreeId, $filter, $agentId);

--- a/src/copyright/ui/Xpview.php
+++ b/src/copyright/ui/Xpview.php
@@ -149,11 +149,18 @@ class Xpview extends DefaultPlugin
     }
 
     $scanJobProxy = new ScanJobProxy($this->agentDao, $uploadId);
-    $scanJobProxy->createAgentStatus(array($this->agentName));
+    if ($this->agentName == "copyright") {
+      $scanJobProxy->createAgentStatus(array($this->agentName, 'reso'));
+    } else {
+      $scanJobProxy->createAgentStatus(array($this->agentName));
+    }
     $selectedScanners = $scanJobProxy->getLatestSuccessfulAgentIds();
     $highlights = array();
+    if (array_key_exists('reso', $selectedScanners)) {
+      $latestXpAgentId[] = $selectedScanners['reso'];
+    }
     if (array_key_exists($this->agentName, $selectedScanners)) {
-      $latestXpAgentId = $selectedScanners[$this->agentName];
+      $latestXpAgentId[] = $selectedScanners[$this->agentName];
       $highlights = $this->copyrightDao->getHighlights($uploadTreeId, $this->tableName, $latestXpAgentId, $this->typeToHighlightTypeMap);
     }
 
@@ -185,7 +192,7 @@ class Xpview extends DefaultPlugin
     $vars['clearingTypes'] = $copyrightDecisionMap;
     $vars['xptext'] = $this->xptext;
 
-    $agentId = intval($request->get("agent"));
+    $agentId = strval($request->get("agent"));
     $vars = array_merge($vars,$this->additionalVars($uploadId, $uploadTreeId, $agentId));
     return $this->render('ui-cp-view.html.twig',$this->mergeWithDefault($vars));
   }
@@ -194,7 +201,7 @@ class Xpview extends DefaultPlugin
    * @brief Get additional variables for a give item
    * @param int $uploadId
    * @param int $uploadTreeId
-   * @param int $agentId
+   * @param string $agentId
    * @return array
    * @todo Not implemented
    */

--- a/src/copyright/ui/ajax-copyright-hist.php
+++ b/src/copyright/ui/ajax-copyright-hist.php
@@ -193,7 +193,7 @@ class CopyrightHistogramProcessPost extends FO_Plugin
    * @brief Get the copyright data and fill in expected format
    * @param int     $upload    Upload id to get results from
    * @param int     $item      Upload tree id of the item
-   * @param int     $agent_pk  Id of the agent who loaded the results
+   * @param string  $agent_pk  Id of the agent who loaded the results
    * @param string  $type      Type of the statement (statement, url, email, author or ecc)
    * @param string  $listPage  Page slug to use
    * @param string  $filter    Filter data from query
@@ -220,7 +220,7 @@ class CopyrightHistogramProcessPost extends FO_Plugin
    * @param int     $upload_pk           Upload id to get results from
    * @param int     $item                Upload tree id of the item
    * @param string  $uploadTreeTableName Upload tree table to use
-   * @param int     $agentId             Id of the agent who loaded the results
+   * @param string  $agentId             Id of the agent who loaded the results
    * @param string  $type                Type of the statement (statement, url, email, author or ecc)
    * @param string  $filter              Filter data from query
    * @param boolean $activated           True to get activated copyrights, else false
@@ -256,7 +256,7 @@ class CopyrightHistogramProcessPost extends FO_Plugin
     } else {
       // No filter, nothing to do
     }
-    $params = array($left, $right, $type, $agentId, $upload_pk);
+    $params = array($left, $right, $type, "{" . $agentId . "}", $upload_pk);
 
     $filterParms = $params;
     $searchFilter = $this->addSearchFilter($filterParms);
@@ -273,7 +273,7 @@ class CopyrightHistogramProcessPost extends FO_Plugin
         "WHERE cp.content!='' " .
         "AND ( UT.lft  BETWEEN  $1 AND  $2 ) " .
         "AND cp.type = $3 " .
-        "AND cp.agent_fk= $4 " .
+        "AND cp.agent_fk = ANY($4::int[]) " .
         "AND ($activatedClause)" .
         $sql_upload;
     $grouping = " GROUP BY mcontent ";
@@ -415,7 +415,7 @@ count(*) AS copyright_count " .
    * @param array   $row          Result row from database
    * @param int     $uploadTreeId Upload tree id of the item
    * @param int     $upload       Upload id
-   * @param int     $agentId      Agent id
+   * @param string  $agentId      Agent id
    * @param string  $type         Type of content
    * @param string  $listPage     Page slug
    * @param string  $filter       Filter for query

--- a/src/copyright/ui/copyright-hist.php
+++ b/src/copyright/ui/copyright-hist.php
@@ -30,7 +30,7 @@ class CopyrightHistogram extends HistogramBase
    * @param int    $upload_pk    Upload id for fetch request
    * @param int    $uploadtreeId Upload tree id of the item
    * @param string $filter       Filter to apply for query
-   * @param int    $agentId      Agent id which populate the result
+   * @param string $agentId      Agent id which populate the result
    * @return array Copyright contents, upload tree items in result
    */
   protected function getTableContent($upload_pk, $uploadtreeId, $filter, $agentId)

--- a/src/copyright/ui/list.php
+++ b/src/copyright/ui/list.php
@@ -75,7 +75,7 @@ class copyright_list extends FO_Plugin
   /**
    * @brief Get statement rows for a specified set
    * @param int $Uploadtree_pk Uploadtree id
-   * @param int $Agent_pk Agent id
+   * @param string $Agent_pk Agent id
    * @param int $upload_pk Upload id
    * @param string $hash Content hash
    * @param string $type Content type
@@ -126,11 +126,11 @@ type, uploadtree_pk, ufile_name, cp.pfile_fk AS PF
                 AND ut.lft BETWEEN $2 AND $3
               LEFT JOIN $eventTable AS ce ON ce.$eventFk = cp.$tablePk
                 AND ce.upload_fk = ut.upload_fk AND ce.uploadtree_fk = ut.uploadtree_pk
-              WHERE agent_fk=$4 AND (cp.hash=$5 OR ce.hash=$5) AND type=$6
+              WHERE agent_fk = ANY($4::int[]) AND (cp.hash=$5 OR ce.hash=$5) AND type=$6
                 $active_filter
               ORDER BY uploadtree_pk";
       $params = [
-        $upload_pk, $lft, $rgt, $Agent_pk, $hash, $type
+        $upload_pk, $lft, $rgt, "{". $Agent_pk . "}", $hash, $type
       ];
     }
     $statement = __METHOD__.$tableName;
@@ -268,7 +268,7 @@ type, uploadtree_pk, ufile_name, cp.pfile_fk AS PF
     $Max = 50;
 
     /*  Input parameters */
-    $agent_pk = GetParm("agent",PARM_INTEGER);
+    $agent_pk = GetParm("agent",PARM_STRING);
     $uploadtree_pk = GetParm("item",PARM_INTEGER);
     $hash = GetParm("hash",PARM_RAW);
     $type = GetParm("type",PARM_RAW);

--- a/src/lib/php/Dao/test/CopyrightDaoTest.php
+++ b/src/lib/php/Dao/test/CopyrightDaoTest.php
@@ -286,11 +286,18 @@ class CopyrightDaoTest extends \PHPUnit\Framework\TestCase
     $agentDao = M::mock('Fossology\Lib\Dao\AgentDao');
     $agentDao->shouldReceive('arsTableExists')->withArgs(['copyright'])
       ->andReturn(true);
+    $agentDao->shouldReceive('arsTableExists')->withArgs(['reso'])
+      ->andReturn(true);
     $agentDao->shouldReceive('getSuccessfulAgentEntries')
       ->withArgs(['copyright', 1])->andReturn([['agent_id' => '8',
       'agent_rev' => 'trunk.271e3e', 'agent_name' => 'copyright']]);
+    $agentDao->shouldReceive('getSuccessfulAgentEntries')
+      ->withArgs(['reso', 1])->andReturn([['agent_id' => '8',
+      'agent_rev' => 'trunk.271e3e', 'agent_name' => 'reso']]);
     $agentDao->shouldReceive('getCurrentAgentRef')->withArgs(['copyright'])
       ->andReturn(new AgentRef(8, 'copyright', 'trunk.271e3e'));
+    $agentDao->shouldReceive('getCurrentAgentRef')->withArgs(['reso'])
+      ->andReturn(new AgentRef(8, 'reso', 'trunk.271e3e'));
 
     $container->shouldReceive('get')->withArgs(['dao.agent'])
       ->andReturn($agentDao);
@@ -317,11 +324,18 @@ class CopyrightDaoTest extends \PHPUnit\Framework\TestCase
     $agentDao = M::mock('Fossology\Lib\Dao\AgentDao');
     $agentDao->shouldReceive('arsTableExists')->withArgs(['copyright'])
       ->andReturn(true);
+    $agentDao->shouldReceive('arsTableExists')->withArgs(['reso'])
+      ->andReturn(true);
     $agentDao->shouldReceive('getSuccessfulAgentEntries')
       ->withArgs(['copyright', 1])->andReturn([['agent_id' => '8',
       'agent_rev' => 'trunk.271e3e', 'agent_name' => 'copyright']]);
+    $agentDao->shouldReceive('getSuccessfulAgentEntries')
+      ->withArgs(['reso', 1])->andReturn([['agent_id' => '8',
+      'agent_rev' => 'trunk.271e3e', 'agent_name' => 'reso']]);
     $agentDao->shouldReceive('getCurrentAgentRef')->withArgs(['copyright'])
       ->andReturn(new AgentRef(8, 'copyright', 'trunk.271e3e'));
+    $agentDao->shouldReceive('getCurrentAgentRef')->withArgs(['reso'])
+      ->andReturn(new AgentRef(8, 'reso', 'trunk.271e3e'));
 
     $container->shouldReceive('get')->withArgs(['dao.agent'])
       ->andReturn($agentDao);

--- a/src/lib/php/Report/XpClearedGetter.php
+++ b/src/lib/php/Report/XpClearedGetter.php
@@ -39,18 +39,25 @@ class XpClearedGetter extends ClearedGetterCommon
   {
     $agentName = $this->tableName;
     $scanJobProxy = new ScanJobProxy($GLOBALS['container']->get('dao.agent'), $uploadId);
-    $scanJobProxy->createAgentStatus(array($agentName));
+    if ($agentName == "copyright") {
+      $scanJobProxy->createAgentStatus(array($agentName, 'reso'));
+    } else {
+      $scanJobProxy->createAgentStatus(array($agentName));
+    }
     $selectedScanners = $scanJobProxy->getLatestSuccessfulAgentIds();
     if (!array_key_exists($agentName, $selectedScanners)) {
       return array();
     }
-    $latestXpAgentId = $selectedScanners[$agentName];
+    $latestXpAgentId[] = $selectedScanners[$agentName];
+    if (array_key_exists('reso', $selectedScanners)) {
+      $latestXpAgentId[] = $selectedScanners['reso'];
+    }
+    $ids = implode(',', $latestXpAgentId);
     if (!empty($this->extrawhere)) {
       $this->extrawhere .= ' AND';
     }
-    $this->extrawhere .= ' agent_fk='.$latestXpAgentId;
+    $this->extrawhere .= ' agent_fk IN ('.$ids.')';
 
     return $this->copyrightDao->getAllEntriesReport($this->tableName, $uploadId, $uploadTreeTableName, $this->type, $this->getOnlyCleared, DecisionTypes::IDENTIFIED, $this->extrawhere, $groupId);
   }
 }
-

--- a/src/lib/php/common-agents.php
+++ b/src/lib/php/common-agents.php
@@ -340,7 +340,7 @@ function AgentSelect($TableName, $upload_pk, $SLName, &$agent_pk, $extra = "")
     if (empty($agent_pk)) {
       $select .= " SELECTED ";
       $agent_pk = $row["agent_pk"];
-    } else if ($agent_pk == $row['agent_pk']) {
+    } else if (in_array($row['agent_pk'], $agent_pk)) {
       $select .= " SELECTED ";
     }
 

--- a/src/reso/ui/ResoAgentPlugin.php
+++ b/src/reso/ui/ResoAgentPlugin.php
@@ -38,7 +38,11 @@ class ResoAgentPlugin extends AgentPlugin
    */
   public function AgentAdd($jobId, $uploadId, &$errorMsg, $dependencies=array(), $arguments=null)
   {
-    $dependencies[] = "ojo";
+    $copyrightAgentScheduled = GetParm("Check_agent_copyright", PARM_INTEGER) == 1;
+    $dependencies[] = "agent_ojo";
+    if ($copyrightAgentScheduled) {
+      $dependencies[] = "agent_copyright";
+    }
     if ($this->AgentHasResults($uploadId) == 1) {
       return 0;
     }
@@ -48,7 +52,7 @@ class ResoAgentPlugin extends AgentPlugin
       return $jobQueueId;
     }
 
-    return $this->doAgentAdd($jobId, $uploadId, $errorMsg, array("agent_ojo"),$uploadId);
+    return $this->doAgentAdd($jobId, $uploadId, $errorMsg, $dependencies, $uploadId);
   }
 
   /**

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -542,20 +542,24 @@ class SpdxTwoAgent extends Agent
    */
   protected function addCopyrightResults(&$filesWithLicenses, $uploadId)
   {
-    $agentName = 'copyright';
+    $agentName = array('copyright', 'reso');
     /** @var CopyrightDao $copyrightDao */
     $copyrightDao = $this->container->get('dao.copyright');
     /** @var ScanJobProxy $scanJobProxy */
     $scanJobProxy = new ScanJobProxy($this->container->get('dao.agent'),
       $uploadId);
 
-    $scanJobProxy->createAgentStatus(array($agentName));
+    $scanJobProxy->createAgentStatus($agentName);
     $selectedScanners = $scanJobProxy->getLatestSuccessfulAgentIds();
-    if (!array_key_exists($agentName, $selectedScanners)) {
+    if (!array_key_exists($agentName[0], $selectedScanners)) {
       return;
     }
-    $latestAgentId = $selectedScanners[$agentName];
-    $extrawhere = ' agent_fk='.$latestAgentId;
+    $latestAgentId[] = $selectedScanners[$agentName[0]];
+    if (array_key_exists($agentName[1], $selectedScanners)) {
+      $latestAgentId[] = $selectedScanners[$agentName[1]];
+    }
+    $ids = implode(',', $latestAgentId);
+    $extrawhere = ' agent_fk IN ('.$ids.')';
 
     $uploadtreeTable = $this->uploadDao->getUploadtreeTableName($uploadId);
     $allScannerEntries = $copyrightDao->getScannerEntries('copyright', $uploadtreeTable, $uploadId, $type='statement', $extrawhere);


### PR DESCRIPTION
Signed-off-by: Rohit Pandey <rohit.pandey4900@gmail.com>

## Description
As discussed in issue #1592 , implements a part of the REUSE.Software specification, by detecting the `SPDX-FileCopyrightText` keyword from .license suffixed files, and applying the copyright detected by the Copyright agent to the associated file.

### Changes

1. New regex added to identify SPDX copyright statement.
2. Applied copyright detected in .license file to the associated file.

## How to test

1. Start new upload - you may want to use example package available here: https://github.com/fossology/fossology/wiki/ReSo-%28REUSE.Software%29#testing
2. Select `REUSE.Software Analysis`  and `Copyright` option.
![Screenshot from 2022-08-09 16-10-15](https://user-images.githubusercontent.com/80946926/183629094-e41c9bc9-005a-4555-8db9-41a9af3e74b7.png)
3. Start Upload
4. Check the copyright applied to associated file of .license file.


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2276"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

