### PR TITLE
feat(ui): close banner for a session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ cov.txt
 *Tests-Listing.xml
 *Tests-Results.xml
 VERSION
+VERSIONSTRING
 /.project
 /.cproject
 .settings
@@ -24,8 +25,10 @@ VERSION
 tags
 php.ini
 .cache
+.phan
 
 # compiled or derived files
+compile_commands.json
 install/db/dbcreate
 install/defconf/Db.conf
 install/defconf/fossology.conf
@@ -135,6 +138,7 @@ src/ununpack/agent/departition-sa
 src/ununpack/agent/ununpack-sa
 src/ununpack/agent_tests/Unit/testconf
 src/wget_agent/agent/wget_agent
+src/wget_agent/agent_tests/test_result
 variable.list
 /nbproject/private/
 /src/monk/VERSION-monk
@@ -148,7 +152,6 @@ variable.list
 /src/readmeoss/agent/version.php
 /src/reuser/agent/reuser
 /src/reuser/agent/version.php
-/src/reuser/agent/reuser
 /src/copyright/agent/ecc
 /src/copyright/VERSION-ecc
 /src/copyright/VERSION-keyword
@@ -187,3 +190,4 @@ ubuntu-*
 
 # PHPUnit cache
 .phpunit.result.cache
+*-Xunit.xml

--- a/src/copyright/ui/template/copyrighthist.html.twig
+++ b/src/copyright/ui/template/copyrighthist.html.twig
@@ -13,7 +13,6 @@
   <script src="scripts/jquery.dataTables.select.js" type="text/javascript"></script>
   <script src="scripts/jquery.jeditable.js" type="text/javascript"></script>
   <script src="scripts/jquery.validate.js" type="text/javascript"></script>
-  <script src="scripts/jquery.cookie.js" type="text/javascript"></script>
 
   {% include "copyrighthist_scripts.html.twig" %}
   <script language="javascript">

--- a/src/copyright/ui/template/ui-cp-view.html.twig
+++ b/src/copyright/ui/template/ui-cp-view.html.twig
@@ -75,7 +75,6 @@
   <script src="scripts/legend.js" type="text/javascript"></script>
   <script src="scripts/tools.js" type="text/javascript"></script>
   <script src="scripts/supervised.js" type="text/javascript"></script>
-  <script src="scripts/jquery.cookie.js" type="text/javascript"></script>
   <script type="text/javascript">{% include "next-options.js.twig" %}</script>
 
 

--- a/src/lib/php/UI/Component/Menu.php
+++ b/src/lib/php/UI/Component/Menu.php
@@ -25,6 +25,11 @@ use Twig\Environment;
 class Menu
 {
   const FULL_MENU_DEBUG = 'fullmenudebug';
+  /**
+   * @var string
+   * Name of cookie to handle banner close state.
+   */
+  const BANNER_COOKIE = 'close_banner';
   var $MenuTarget = "treenav";
   protected $renderer;
 
@@ -233,9 +238,16 @@ class Menu
     global $SysConf;
     $sysConfig = $SysConf['SYSCONFIG'];
 
+    $hide_banner = (array_key_exists(self::BANNER_COOKIE, $_COOKIE)
+                    && $_COOKIE[self::BANNER_COOKIE] == 1);
+
     $vars = array();
     $vars['title'] = empty($title) ? _("Welcome to FOSSology") : $title;
-    $vars['bannerMsg'] = @$sysConfig['BannerMsg'];
+    if ($hide_banner) {
+      $vars['bannerMsg'] = "";
+    } else {
+      $vars['bannerMsg'] = @$sysConfig['BannerMsg'];
+    }
     $vars['logoLink'] =  $sysConfig['LogoLink']?: 'http://fossology.org';
     $vars['logoImg'] =  $sysConfig['LogoImage']?: 'images/fossology-logo.gif';
 

--- a/src/lib/php/UI/template/components/menu.html.twig
+++ b/src/lib/php/UI/template/components/menu.html.twig
@@ -5,7 +5,7 @@
    This file is offered as-is, without any warranty.
 #}
 {% if bannerMsg %}
-  <div class="alert alert-danger">
+  <div class="alert alert-danger" id="topBanner">
     <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
   {{ bannerMsg }}
   </div>

--- a/src/lib/php/UI/template/include/foot.html.twig
+++ b/src/lib/php/UI/template/include/foot.html.twig
@@ -9,6 +9,7 @@
 <script src="scripts/select2.full.min.js" type="text/javascript"></script>
 <script src="scripts/popper.min.js" type="text/javascript"></script>
 <script src="scripts/bootstrap/bootstrap.min.js" type="text/javascript"></script>
+<script src="scripts/jquery.cookie.js" type="text/javascript"></script>
 <script type="text/javascript">
   function renderSelect2() {
     if(!$('.ui-render-select2').attr("size") > 0) {
@@ -27,6 +28,11 @@
   }
   $(document).ready(function() {
     renderSelect2();
+    $('#topBanner').on('closed.bs.alert', function () {
+      $.cookie("close_banner", 1, {
+        secure: (location.protocol === 'https:')
+      });
+    });
   });
 </script>
 {{ scripts }}

--- a/src/spasht/ui/template/agent_spasht.html.twig
+++ b/src/spasht/ui/template/agent_spasht.html.twig
@@ -24,7 +24,6 @@
   <script src="scripts/jquery.dataTables.select.js" type="text/javascript"></script>
   <script src="scripts/jquery.jeditable.js" type="text/javascript"></script>
   <script src="scripts/jquery.validate.js" type="text/javascript"></script>
-  <script src="scripts/jquery.cookie.js" type="text/javascript"></script>
   <script src="scripts/jquery-ui.js" type="text/javascript"></script>
 
   <script language="javascript">

--- a/src/www/ui/core-auth.php
+++ b/src/www/ui/core-auth.php
@@ -23,6 +23,7 @@
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\UserDao;
 use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\UI\Component\Menu;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use League\OAuth2\Client\Provider\GenericProvider;
@@ -182,6 +183,10 @@ class core_auth extends FO_Plugin
     if (!$oauth) {
       $_SESSION['oauthCheck'] = $userRow['oauth'];
     }
+    if (array_key_exists(Menu::BANNER_COOKIE, $_COOKIE)) {
+      $_COOKIE[Menu::BANNER_COOKIE] = 0;
+    }
+    setcookie(Menu::BANNER_COOKIE, "", time() - 3600);
   }
 
   /**

--- a/src/www/ui/template/ui-browse.html.twig
+++ b/src/www/ui/template/ui-browse.html.twig
@@ -46,7 +46,7 @@
           &raquo;&nbsp;{{ 'Folder Navigation'|trans|replace({' ':'&nbsp;'}) }}&nbsp;&raquo;
       </td>
       <td valign="top">
-        <div style="text-align:center;font-size:large;"><strong><u>{{ 'Uploads'|trans }} {{ 'in'|trans }} <span id="current-folder">{{ folderName }}</span></strong></u></div>
+        <div style="text-align:center;font-size:large;"><strong><u>{{ 'Uploads'|trans }} {{ 'in'|trans }} <span id="current-folder">{{ folderName }}</span></u></strong></div>
         <form name="uploadMultiSelect">
         <table class="semibordered" id="browsetbl" width="100%" cellpadding="0">
         <thead>
@@ -100,7 +100,6 @@
   <script src="scripts/browse.js" type="text/javascript"></script>
   <script src="scripts/tools.js" type="text/javascript"></script>
   <script src="scripts/jquery.treeview.js" type="text/javascript"></script>
-  <script src="scripts/jquery.cookie.js" type="text/javascript"></script>
   <script src="scripts/bootstrap4-toggle.min.js"></script>
   <link href="css/bootstrap4-toggle.min.css" rel="stylesheet">
   <script type="text/javascript"> {% include 'ui-browse.js.twig' %}</script>

--- a/src/www/ui/template/ui-export-list.html.twig
+++ b/src/www/ui/template/ui-export-list.html.twig
@@ -185,8 +185,6 @@
 {% endblock %}
 {% block foot %}
   {{ parent() }}
-  <script src="scripts/jquery.cookie.js" type="text/javascript"></script>
-
   <script type="text/javascript">
     var exportCookie = 'stickyEmailTab';
 

--- a/src/www/ui/template/ui-report-conf.html.twig
+++ b/src/www/ui/template/ui-report-conf.html.twig
@@ -291,7 +291,6 @@
 {% endblock %}
 {% block foot %}
 {{ parent() }}
-<script src="scripts/jquery.cookie.js" type="text/javascript"></script>
 <script language="javascript" type="text/javascript">
   {{ scriptBlock }}
 </script>


### PR DESCRIPTION
## Description

When a user closes the banner message, it should remain closed on all page loads for current session.

### Changes

1. New JS function `closeBannerForSession()` to close banner if session cookie exists.
2. Adding more files to `.gitignore`
3. Add `jquery.cookie.js` from `foot.html.twig`, eventually removing redundant imports from other places.

## How to test

1. Goto "Admin >> Customize" and add a new "Banner message".
2. Close the banner message and navigate through FOSSology.
  1. The banner should remain closed for all page loads.
3. Navigate other pages which uses cookies for stickiness, and make sure they still work.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2278"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

