### PR TITLE
Check service IDs are valid

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -29,12 +29,21 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+    - name: Set build version
+      run: |
+        VERSION_PATTERN='([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+)(-?rc[[:digit:]]+)?-?([[:digit:]]*)-?[[:alnum:]]*'
+        echo VERSION=$(git describe --tags > /dev/null 2>&1 && git describe --tags | head -1 | sed -re "s/${VERSION_PATTERN}/\\1.\\3\\2/" | sed -re 's/\.$/.0/') >> $GITHUB_ENV
+
     - name: Build and push main image
       uses: docker/build-push-action@v2
       with:
         push: true
         tags: fossology/fossology:latest
         context: .
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        labels: |
+          org.opencontainers.image.version=${VERSION}
 
     - name: Build and push runner image
       uses: docker/build-push-action@v2
@@ -42,3 +51,7 @@ jobs:
         push: true
         tags: fossology/fossology:scanner
         file: utils/automation/Dockerfile.ci
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        labels: |
+          org.opencontainers.image.version=${VERSION}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -105,3 +105,5 @@ jobs:
       with:
         push: true
         tags: fossology/fossology:${{ steps.get_release.outputs.tag_name }}
+        labels: |
+          org.opencontainers.image.version=${{ steps.get_release.outputs.tag_name }}.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,10 @@
 # Description: Docker container image recipe
 
 FROM debian:buster-slim as builder
-LABEL maintainer="Fossology <fossology@fossology.org>"
+LABEL org.opencontainers.image.authors="Fossology <fossology@fossology.org>"
+LABEL org.opencontainers.image.source="https://github.com/fossology/fossology"
+LABEL org.opencontainers.image.vendor="FOSSology"
+LABEL org.opencontainers.image.licenses="GPL-2.0-only AND LGPL-2.1-only"
 
 WORKDIR /fossology
 
@@ -52,7 +55,13 @@ RUN make clean install \
 
 FROM debian:buster-slim
 
-LABEL maintainer="Fossology <fossology@fossology.org>"
+LABEL org.opencontainers.image.authors="Fossology <fossology@fossology.org>"
+LABEL org.opencontainers.image.url="https://fossology.org"
+LABEL org.opencontainers.image.source="https://github.com/fossology/fossology"
+LABEL org.opencontainers.image.vendor="FOSSology"
+LABEL org.opencontainers.image.licenses="GPL-2.0-only AND LGPL-2.1-only"
+LABEL org.opencontainers.image.title="FOSSology"
+LABEL org.opencontainers.image.description="FOSSology is an open source license compliance software system and toolkit.  As a toolkit you can run license, copyright and export control scans from the command line.  As a system, a database and web ui are provided to give you a compliance workflow. License, copyright and export scanners are tools used in the workflow."
 
 ### install dependencies
 COPY --from=builder /fossology/dependencies-for-runtime /fossology


### PR DESCRIPTION
In Symfony before 2.7.51, 2.8.x before 2.8.50, 3.x before 3.4.26, 4.x before 4.1.12, and 4.2.x before 4.2.7, when service ids allow user input, this could allow for SQL Injection and remote code execution. This is related to symfony/dependency-injection.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2280"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

