### PR TITLE
docs(reuse): reuse status badge added

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Slack Channel](https://img.shields.io/badge/slack-fossology-blue.svg?longCache=true&logo=slack)](https://join.slack.com/t/fossology/shared_invite/enQtNzI0OTEzMTk0MjYzLTYyZWQxNDc0N2JiZGU2YmI3YmI1NjE4NDVjOGYxMTVjNGY3Y2MzZmM1OGZmMWI5NTRjMzJlNjExZGU2N2I5NGY)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/fossology/fossology)](https://github.com/fossology/fossology/releases/latest)
 [![YouTube Channel](https://img.shields.io/badge/youtube-FOSSology-red.svg?&logo=youtube&link=https://www.youtube.com/channel/UCZGPJnQZVnEPQWxOuNamLpw)](https://www.youtube.com/channel/UCZGPJnQZVnEPQWxOuNamLpw)
+[![REUSE status](https://api.reuse.software/badge/github.com/fossology/fossology)](https://api.reuse.software/info/github.com/fossology/fossology)
 
 ## About
 


### PR DESCRIPTION
Signed-off-by: Rohit Pandey <rohit.pandey4900@gmail.com>

## Description

In pull request #2274, @GMishx made FOSSology [reuser standard 3](https://reuse.software/spec/) compliant. 

I have added REUSE status badge in `README.md` file.

### Changes

Included a badge indicating the live status of REUSE.

The REUSE API checks repositories for their compliance with the REUSE best practices. It basically runs the lint command of the REUSE helper tool for the default branch of a project.



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2282"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

