### PR TITLE
fix(copyright): fix regex conf files

### DIFF
--- a/install/defconf/Db.conf.in
+++ b/install/defconf/Db.conf.in
@@ -1,6 +1,3 @@
-; SPDX-FileCopyrightText: © Fossology contributors
-
-; SPDX-License-Identifier: GPL-2.0-only
 dbname={$PROJECT};
 host=localhost;
 user={$PROJECTUSER};

--- a/install/defconf/Db.conf.in.license
+++ b/install/defconf/Db.conf.in.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: © Fossology contributors
+
+SPDX-License-Identifier: GPL-2.0-only

--- a/install/defconf/fossology.conf.in
+++ b/install/defconf/fossology.conf.in
@@ -1,6 +1,6 @@
-; basic Scheduer.conf for the version 2.0 of the scheduler
+; basic Scheduler.conf for the version 2.0 of the scheduler
 ; SPDX-FileCopyrightText: © Fossology contributors
-
+;
 ; SPDX-License-Identifier: GPL-2.0-only
 
 ; this is a simple key-value configuration file

--- a/install/src-install-apache-example.conf
+++ b/install/src-install-apache-example.conf
@@ -1,6 +1,6 @@
 # FOSSology example apache config
 # SPDX-FileCopyrightText: © Fossology contributors
-
+#
 # SPDX-License-Identifier: FSFAP
 
 Alias /repo /usr/local/share/fossology/www/ui

--- a/src/copyright/agent/copyright.conf
+++ b/src/copyright/agent/copyright.conf
@@ -1,7 +1,7 @@
 # properties file of the fossology Copyright agent
 # SPDX-FileCopyrightText: © 2021 Siemens AG
 # SPDX-FileCopyrightText: © maximilian.huber@tngtech.com
-
+#
 # SPDX-License-Identifier: FSFAP
 #
 # Description: this file holds the regex configurations for the Copyright agent

--- a/src/copyright/agent/ecc.conf
+++ b/src/copyright/agent/ecc.conf
@@ -1,9 +1,9 @@
 # properties file of the fossology ECC agent
 # SPDX-FileCopyrightText: © 2015 Siemens AG
 # SPDX-FileCopyrightText: © maximilian.huber@tngtech.com
-
+#
 # SPDX-License-Identifier: FSFAP
-
+#
 # Description: this file holds the regex configurations for the ECC agent
 SPACES=[\t ]+
 ecc=__ecc__\beccn\b|\btsu\b|\becc\b|\bccl\b|\bwco\b


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The conf files are not supposed to have any empty lines.

### Changes

Add comment `#` to empty lines.

## How to test

1. Compile the tool.
2. Run the `copyright`, `ecc` and `keyword` agents from `src/copyright/agent` folder.
3. Install the tool and run the agents from UI.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2286"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

