### PR TITLE
feat(API): REST-API to initiate FOSSology maintenance

### DIFF
--- a/src/www/ui/api/Controllers/MaintenanceController.php
+++ b/src/www/ui/api/Controllers/MaintenanceController.php
@@ -1,0 +1,87 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2022 Samuel Dushimimana <dushsam100@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\UI\Api\Controllers;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Valid status inputs
+ */
+
+
+/**
+ * @class ReportController
+ * @brief Controller for Maintenance model
+ */
+class MaintenanceController extends RestController
+{
+  /**
+   * Create maintenance
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function createMaintenance($request, $response, $args)
+  {
+    // Check if the request comes from the admin.
+    if (!Auth::isAdmin()) {
+      $returnVal =  new Info(401, "Only admins can run this job.", InfoType::ERROR);
+    } else {
+
+      $body = $this->getParsedBody($request);
+
+      if ($body['options']) {
+
+        //Remove all duplicate options
+
+        if (!is_array($body['options'])) {
+
+          $returnVal = new Info(400, "Options property should be an array.", InfoType::ERROR);
+
+        } else if (in_array("o",$body["options"]) && empty($body["goldDate"])) {
+
+            $returnVal = new Info(400, "Please provide a gold date.", InfoType::ERROR);
+
+        } else if (in_array("l",$body["options"]) && empty($body["logsDate"])) {
+
+          $returnVal = new Info(400, "Please provide a log date.", InfoType::ERROR);
+
+        } else {
+
+          $body['options'] = array_unique($body['options']);
+          $alteredOptions = array();
+          $maintain = $this->restHelper->getPlugin('maintagent');
+          $existingOptions = $maintain->getOptions();
+
+          //Check if all the given keys exist in the known options array
+          foreach ($body['options'] as $key) {
+            if (!array_key_exists($key, $existingOptions)) {
+              $returnVal = new Info(404, "KEY '" . $key . "' NOT FOUND!", InfoType::ERROR);
+              return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+            }
+            $alteredOptions[$key] = $key;
+          }
+
+          $body['options'] = $alteredOptions;
+          $mess = $maintain->handle($body);
+          $returnVal = new Info(201, $mess, InfoType::INFO);
+        }
+
+      } else {
+        $returnVal = new Info(400,"No options provided!", InfoType::ERROR);
+      }
+    }
+    return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+  }
+}

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -128,7 +128,48 @@ paths:
                 $ref: '#/components/schemas/ApiInfo'
         default:
           $ref: '#/components/responses/defaultResponse'
-
+  /maintenance:
+    post:
+      operationId: initiateMaintenance
+      tags:
+        - Maintenance
+      summary:  Initiate maintenance operations
+      description: > 
+        Perform maintenance operations corresponding to the user options.
+      requestBody:
+        description: Maintenance options
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateMaintenance'
+      responses:
+        '201':
+          description: Maintenance Initiated Successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Key Not Found Error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Validation Error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal Server Error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /health:
     get:
       operationId: getHealth
@@ -2294,6 +2335,43 @@ components:
               description: Date on which packages were built in ISO8601 format
               nullable: true
               example: "2022-01-07T11:13:00+05:30"
+    CreateMaintenance:
+      description: Maintenance options
+      type: object
+      properties:
+        options:
+          type: array
+          description: options list
+          nullable: false
+          items:
+            type: string
+            enum:
+              - a
+              - A
+              - F
+              - g
+              - E
+              - L
+              - N
+              - R
+              - t
+              - T
+              - D
+              - Z
+              - I
+              - v
+              - o
+              - l
+        logsDate:
+          type: string
+          description: Date from which to remove older gold files from repository.
+          nullable: true
+          example: "2021-08-19"
+        goldDate:
+          type: string
+          description: Date from which to remove older log files from repository.
+          nullable: true
+          example: "2022-07-16"
     HealthInfo:
       description: Health status of server
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -25,6 +25,7 @@ use Fossology\UI\Api\Controllers\BadRequestController;
 use Fossology\UI\Api\Controllers\FolderController;
 use Fossology\UI\Api\Controllers\FileSearchController;
 use Fossology\UI\Api\Controllers\JobController;
+use Fossology\UI\Api\Controllers\MaintenanceController;
 use Fossology\UI\Api\Controllers\ReportController;
 use Fossology\UI\Api\Controllers\SearchController;
 use Fossology\UI\Api\Controllers\UploadController;
@@ -177,6 +178,14 @@ $app->group('/search',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->get('', SearchController::class . ':performSearch');
   });
+
+////////////////////////////MAINTENANCE/////////////////////
+$app->group('/maintenance',
+  function (\Slim\Routing\RouteCollectorProxy $app) {
+    $app->post('', MaintenanceController::class . ':createMaintenance');
+    $app->any('/{params:.*}', BadRequestController::class);
+  });
+
 
 ////////////////////////////FOLDER/////////////////////
 $app->group('/folders',


### PR DESCRIPTION
Signed-off-by: dushimsam <dushsam100@gmail.com>

## Description
 A rest API to initiate FOSSology maintenance operations.

### Changes

1. Added a new controller file and the function to handle the logic in `MaintenanceController`.
2. Updated the file `maintagent.php` to be reusable by the outside callers.
3. Updated  the main file(`index.php`) by adding a new route `POST` `/maintenance`.
4. Updated the `openapi.yaml` file  to introduce a new API.

## How to test

1. Design a request as follows. 
2. The **options** property should contain the list of the keys whose operations are to be executed.
3. The **logsDate** property is the date from which to remove older gold files from repository (_Free to keep it as null_).
4. The **goldDate** property is the date from which to remove older log files from repository (_Free to keep it as null_).
3. Run the API.

![maintenance_operations](https://user-images.githubusercontent.com/66276301/184081603-2550d88c-e0d0-477b-9248-cc0569402def.png)

### Related Issue:
Fixes #2289
    
cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2290"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

