### PR TITLE
feat(API): import csv-license file

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1628,6 +1628,52 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
             $ref: '#/components/responses/defaultResponse'
+  /license/import-csv:
+    post:
+      operationId: importLicense
+      tags:
+        - License
+      summary: Import a csv license
+      description: >
+        Import a csv license to the database
+      requestBody:
+        description: Information about delimiters, inclosure and csv file.
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                enclosure:
+                  type: string
+                  description: Enclosure for string in CSV
+                  default: '"'
+                  required: false
+                delimiter:
+                  type: string
+                  description: Delimiters for fields in CSV
+                  default: ','
+                  required: false
+                file_input:
+                  type: string
+                  format: binary
+                  description: CSV to be imported
+                  required: true
+      responses:
+          '400':
+            description: Validation Error
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Info'
+          '200':
+            description: Successfully imported
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Info'
+          default:
+            $ref: '#/components/responses/defaultResponse'
   /license/{shortname}:
     parameters:
       - name: shortname

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -224,6 +224,7 @@ $app->group('/filesearch',
 $app->group('/license',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->get('', LicenseController::class . ':getAllLicenses');
+    $app->post('/import-csv', LicenseController::class . ':handleImportLicense');
     $app->post('', LicenseController::class . ':createLicense');
     $app->get('/{shortname:.+}', LicenseController::class . ':getLicense');
     $app->patch('/{shortname:.+}', LicenseController::class . ':updateLicense');


### PR DESCRIPTION
Signed-off-by: dushimsam <dushsam100@gmail.com>


## Description

The controller function to handle the import of a csv license file.

### Changes

1. Added a new controller file and the function to handle the logic in `LicenseController`.
2. Updated the file `AdminLicenseFromCSV.php` to be reusable by the outside callers.
3. Updated  the main file(`index.php`) by adding a new route `POST` `/license/import`.
4. Updated the `openapi.yaml` file  to introduce a new API.


## How to test

1. Design a request as follows. 
2. The **delimiter** property (_Free to keep it as empty_).
3. The **enclosure** property (_Free to keep it as empty_).
4. The **file_input** form-data property. 
3. Run the API.

## Example

#### FIRST SCENARIO 

![body_request](https://user-images.githubusercontent.com/66276301/184801756-01ed75e2-e6ff-4f68-9802-7f2d75233c48.png)

![form_data_file_request](https://user-images.githubusercontent.com/66276301/184801760-21c31c50-99b2-48bc-85f7-b72c66efed20.png)

#### SECOND SCENARIO 

![no_file_selected](https://user-images.githubusercontent.com/66276301/184801946-0680d900-4f83-4431-8470-fce23e6612c7.png)

### Related Issue:
Fixes #2291

    
cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2292"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

