### PR TITLE
feat(API): get license candidates

### DIFF
--- a/src/www/ui/api/Controllers/LicenseController.php
+++ b/src/www/ui/api/Controllers/LicenseController.php
@@ -366,4 +366,20 @@ class LicenseController extends RestController
       $statement);
     return $result["cnt"] == 0;
   }
+
+  /**
+   * Get list of all license candidates, paginated upon request params
+   *
+   * @param Request $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function getCandidates($request, $response, $args)
+  {
+     $adminLicenseCandidate = $this->restHelper->getPlugin("admin_license_candidate");
+     $res = $adminLicenseCandidate->handleGetArrayData();
+     $newInfo = new Info(200, $res, InfoType::INFO);
+     return $response->withJson($newInfo->getArray(), $newInfo->getCode());
+  }
 }

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -225,6 +225,7 @@ $app->group('/license',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->get('', LicenseController::class . ':getAllLicenses');
     $app->post('', LicenseController::class . ':createLicense');
+    $app->get('/candidates', LicenseController::class . ':getCandidates');
     $app->get('/{shortname:.+}', LicenseController::class . ':getLicense');
     $app->patch('/{shortname:.+}', LicenseController::class . ':updateLicense');
     $app->any('/{params:.*}', BadRequestController::class);

--- a/src/www/ui/page/AdminLicenseCandidate.php
+++ b/src/www/ui/page/AdminLicenseCandidate.php
@@ -145,18 +145,26 @@ class AdminLicenseCandidate extends DefaultPlugin
     return $this->render('admin_license_candidate-merge.html.twig', $this->mergeWithDefault($vars));
   }
 
-  private function getArrayArrayData()
+  public function handleGetArrayData()
   {
     $sql = "SELECT rf_pk,rf_shortname,rf_fullname,rf_text,group_name,group_pk "
-            . "FROM license_candidate, groups "
-            . "WHERE group_pk=group_fk AND marydone";
+      . "FROM license_candidate, groups "
+      . "WHERE group_pk=group_fk AND marydone";
     /* @var $dbManager DbManager */
     $dbManager = $this->getObject('db.manager');
     $dbManager->prepare($stmt = __METHOD__, $sql);
     $res = $dbManager->execute($stmt);
+    $rows =  $dbManager->fetchArray($res);
+    $dbManager->freeResult($res);
+    return $rows;
+  }
+
+  private function getArrayArrayData()
+  {
+    $rows = $this->handleGetArrayData();
     $aaData = array();
     $delete = "";
-    while ($row = $dbManager->fetchArray($res)) {
+    while ($row = $rows) {
       $link = Traceback_uri() . '?mod=' . self::NAME . '&rf=' . $row['rf_pk'];
       $edit = '<a href="' . $link . '"><img border="0" src="images/button_edit.png"></a>';
       $delete = '<img border="0" id="deletecandidate'.$row['rf_pk'].'" onClick="deleteCandidate('.$row['rf_pk'].')" src="images/icons/close_16.png">';
@@ -167,7 +175,6 @@ class AdminLicenseCandidate extends DefaultPlugin
           htmlentities($row['group_name']),$delete
           );
     }
-    $dbManager->freeResult($res);
     return $aaData;
   }
 

--- a/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
@@ -12,6 +12,7 @@
 
 namespace Fossology\UI\Api\Test\Controllers;
 
+use Fossology\UI\Page\AdminLicenseCandidate;
 use Mockery as M;
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\LicenseDao;
@@ -97,6 +98,13 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
   private $streamFactory;
 
   /**
+   * @var M\MockInterface $licenseCandidatePlugin
+   * admin_license_candidate mock
+   */
+  private $licenseCandidatePlugin;
+
+
+  /**
    * @brief Setup test objects
    * @see PHPUnit_Framework_TestCase::setUp()
    */
@@ -111,9 +119,11 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
     $this->restHelper = M::mock(RestHelper::class);
     $this->licenseDao = M::mock(LicenseDao::class);
     $this->userDao = M::mock(UserDao::class);
+    $this->licenseCandidatePlugin = M::mock('admin_license_candidate');
 
     $this->dbHelper->shouldReceive('getDbManager')->andReturn($this->dbManager);
 
+    $this->restHelper->shouldReceive('getPlugin')->withArgs(["admin_license_candidate"])->andReturn($this->licenseCandidatePlugin);
     $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
     $this->restHelper->shouldReceive('getGroupId')->andReturn($this->groupId);
     $this->restHelper->shouldReceive('getUserId')->andReturn($this->userId);
@@ -780,6 +790,28 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
 
     $actualResponse = $this->licenseController->updateLicense($request,
       new ResponseHelper(), ["shortname" => $license->getShortName()]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::getCandidates()
+   * -# Check if status is 200
+   * -# Check if response-body matches
+   */
+  public function testGetCandidates()
+  {
+    $this->licenseCandidatePlugin->shouldReceive('handleGetArrayData')->andReturn([]);
+    $rows = array();
+    $info = new Info(200, $rows,
+      InfoType::INFO);
+    $expectedResponse = (new ResponseHelper())->withJson($info->getArray(),
+      $info->getCode());
+    $actualResponse = $this->licenseController->getCandidates(null,
+      new ResponseHelper(), null);
     $this->assertEquals($expectedResponse->getStatusCode(),
       $actualResponse->getStatusCode());
     $this->assertEquals($this->getResponseJson($expectedResponse),


### PR DESCRIPTION
Signed-off-by: dushimsam <dushsam@gmail.com>


## Description
 A rest API to list the license candidates.

### Changes

1. Added a new controller file and the function to handle the logic in `LicenseController`.
2. Updated the file `AdminLicenseCandidate.php` to be reusable by the outside callers.
3. Updated  the main file(`index.php`) by adding a new route `GET` `/license/candidates`.
4. Updated the `openapi.yaml` file  to introduce a new API.

## How to test
 Make the get request on endpoint at "`/license/candidates`"
  
![license_candidates](https://user-images.githubusercontent.com/66276301/185035089-44e29560-d4a2-45f4-8b07-01565ef222ca.png)


### Related Issue:
Fixes #2293
    
cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2294"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

