### PR TITLE
feat(API): delete admin-license candidate

### DIFF
--- a/src/www/ui/api/Controllers/LicenseController.php
+++ b/src/www/ui/api/Controllers/LicenseController.php
@@ -424,4 +424,31 @@ class LicenseController extends RestController
     $info = new Info(200, $licenses, InfoType::INFO);
     return $response->withJson($info->getArray(), $info->getCode());
   }
+
+  /**
+   * Delete license candidate by id.
+   *
+   * @param Request $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function deleteAdminLicenseCandidate($request, $response, $args)
+  {
+    $resInfo = null;
+    if (!Auth::isAdmin()) {
+      $resInfo = new Info(400, "Only admin can perform this operation.", InfoType::ERROR);
+    } else {
+      $id = intval($args['id']);
+      $adminLicenseCandidate = $this->restHelper->getPlugin('admin_license_candidate');
+
+      if ($adminLicenseCandidate->getDataRow($id)) {
+        $res = $adminLicenseCandidate->doDeleteCandidate($id,false);
+        $resInfo = new Info($res->getStatusCode(),$res->getContent() === 'true' ? "License candidate will be deleted." : $res->getContent(), $res->getStatusCode() == 200 ? InfoType::INFO : InfoType::ERROR);
+      } else {
+        $resInfo = new Info(404, "License candidate not found.", InfoType::ERROR);
+      }
+    }
+    return $response->withJson($resInfo->getArray(), $resInfo->getCode());
+  }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -2352,6 +2352,43 @@ paths:
               schema:
                 $ref: '#/components/schemas/Info'
         default:
+            $ref: '#/components/responses/defaultResponse'
+  /license/candidates/{id}:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the license-candidate
+        in: path
+        schema:
+          type: integer
+    delete:
+      operationId: deleteByLicenseCandidateId
+      tags:
+        - LicenseCandidate
+        - Admin
+      summary: Delete license candidate by id.
+      description: >
+        Delete a single admin-license-candidate by the given id.
+      responses:
+        '200':
+          description: License candidate will be deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
           $ref: '#/components/responses/defaultResponse'
 components:
   securitySchemes:

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1764,7 +1764,7 @@ paths:
     put:
       operationId: updatePermissionByGroupIdAndUserId
       tags:
-        - Users
+        - User
         - Groups
       summary: Update Permission
       description: >
@@ -1852,20 +1852,6 @@ paths:
                   $ref: '#/components/schemas/UserGroupMember'
         default:
           $ref: '#/components/responses/defaultResponse'
-  /groups/{groupId}/user/{userId}:
-    parameters:
-      - name: groupId
-        in: path
-        required: true
-        description: Group id
-        schema:
-          type: string
-      - name: userId
-        in: path
-        required: true
-        description: User Id
-        schema:
-          type: string
   /report:
     get:
       operationId: getReportsByUpload
@@ -2343,8 +2329,7 @@ paths:
               schema:
                 type: array
                 items:
-                  allOf:
-                   - $ref: '#/components/schemas/LicenseCandidate'
+                  $ref: '#/components/schemas/LicenseCandidate'
         '500':
           description: Internal server error with details
           content:
@@ -2353,7 +2338,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
             $ref: '#/components/responses/defaultResponse'
-  /license/candidates/{id}:
+  /license/admincandidates/{id}:
     parameters:
       - name: id
         required: true
@@ -2364,19 +2349,19 @@ paths:
     delete:
       operationId: deleteByLicenseCandidateId
       tags:
-        - LicenseCandidate
+        - License
         - Admin
       summary: Delete license candidate by id.
       description: >
         Delete a single admin-license-candidate by the given id.
       responses:
-        '200':
+        '202':
           description: License candidate will be deleted.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Info'
-        '400':
+        '403':
           description: Validation error.
           content:
             application/json:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -250,6 +250,7 @@ $app->group('/license',
     $app->get('/admincandidates', LicenseController::class . ':getCandidates');
     $app->get('/{shortname:.+}', LicenseController::class . ':getLicense');
     $app->patch('/{shortname:.+}', LicenseController::class . ':updateLicense');
+    $app->delete('/candidates/{id:\\d+}', LicenseController::class . ':deleteAdminLicenseCandidate');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -250,7 +250,8 @@ $app->group('/license',
     $app->get('/admincandidates', LicenseController::class . ':getCandidates');
     $app->get('/{shortname:.+}', LicenseController::class . ':getLicense');
     $app->patch('/{shortname:.+}', LicenseController::class . ':updateLicense');
-    $app->delete('/candidates/{id:\\d+}', LicenseController::class . ':deleteAdminLicenseCandidate');
+    $app->delete('/admincandidates/{id:\\d+}',
+      LicenseController::class . ':deleteAdminLicenseCandidate');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui/page/AdminLicenseCandidate.php
+++ b/src/www/ui/page/AdminLicenseCandidate.php
@@ -174,7 +174,7 @@ class AdminLicenseCandidate extends DefaultPlugin
   }
 
 
-  private function getDataRow($licId,$table='license_candidate')
+  public function getDataRow($licId,$table='license_candidate')
   {
     $sql = "SELECT rf_pk,rf_spdx_id,rf_shortname,rf_fullname,rf_text,rf_url,rf_notes,rf_notes,rf_risk";
     if ($table == 'license_candidate') {
@@ -261,7 +261,7 @@ class AdminLicenseCandidate extends DefaultPlugin
     return true;
   }
 
-  protected function doDeleteCandidate($rfPk)
+  public function doDeleteCandidate($rfPk,$includeHtml=true)
   {
     $dbManager = $this->getObject('db.manager');
     $stmt = __METHOD__.".getUploadtreeFkForUsedCandidates";
@@ -280,11 +280,12 @@ class AdminLicenseCandidate extends DefaultPlugin
       return new Response('true', Response::HTTP_OK, array('Content-type'=>'text/plain'));
     } else {
       $treeDao = $this->getObject('dao.tree');
-      $message = "<div class='candidateFileList'><ol>";
+      $message = $includeHtml ? "<div class='candidateFileList'><ol>":"";
       foreach ($dataFetch as $cnt => $uploadTreeFk) {
-        $message .= "<li>".$treeDao->getFullPath($uploadTreeFk['uploadtree_fk'], 'uploadtree')."</li>";
+        $path= $treeDao->getFullPath($uploadTreeFk['uploadtree_fk'], 'uploadtree');
+        $message .= $includeHtml ? "<li>".$path."</li>":$path;
       }
-      $message .= "</ol></div>";
+      $message .= $includeHtml ? "</ol></div>":"";
       return new Response($message, Response::HTTP_OK, array('Content-type'=>'text/plain'));
     }
   }

--- a/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
@@ -110,6 +110,12 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
 
 
   /**
+   * @var Auth $auth
+   * Auth mock
+   */
+  private $auth;
+
+  /**
    * @brief Setup test objects
    * @see PHPUnit_Framework_TestCase::setUp()
    */
@@ -120,6 +126,7 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
     $this->groupId = 2;
     $container = M::mock('ContainerBuilder');
     $this->dbHelper = M::mock(DbHelper::class);
+    $this->auth = M::mock(Auth::class);
     $this->dbManager = M::mock(DbManager::class);
     $this->restHelper = M::mock(RestHelper::class);
     $this->licenseDao = M::mock(LicenseDao::class);
@@ -847,6 +854,76 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
     $this->assertEquals($expectedResponse->getStatusCode(),
       $actualResponse->getStatusCode());
     $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+
+  /**
+   * @test
+   * -# Test for LicenseController::deleteAdminLicenseCandidate() to delete license-candidate.
+   * -# User is admin
+   * -# License-candidate is does exist
+   * -# Check if response is 200
+   * -# Check if reponse-body matches
+   */
+  public function testDeleteAdminLicenseCandidateIsAdmin(){
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $id = 1;
+    $this->auth->shouldReceive('isAdmin')->andReturn(true);
+    $this->adminLicenseCandidate->shouldReceive('getDataRow')->withArgs([$id])->andReturn(true);
+    $res = new Response('true',Response::HTTP_OK,array('Content-type'=>'text/plain'));
+    $this->adminLicenseCandidate->shouldReceive("doDeleteCandidate")->withArgs([$id,false])->andReturn($res);
+    $expectedResponse = new Info(200,"License candidate will be deleted.",  InfoType::INFO);
+    $actualResponse = $this->licenseController->deleteAdminLicenseCandidate(null,
+      new ResponseHelper(), ["id" => $id]);
+    $this->assertEquals($expectedResponse->getCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse->getArray(),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::deleteAdminLicenseCandidate() to delete license-candidate.
+   * -# User is not-admin
+   * -# License-candidate is does exist
+   * -# Check if response is 400
+   * -# Check if reponse-body matches
+   */
+  public function testDeleteAdminLicenseCandidateNotAdmin(){
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $id = 1;
+    $this->auth->shouldReceive('isAdmin')->andReturn(false);
+    $expectedResponse = new Info(400, "Only admin can perform this operation.", InfoType::ERROR);
+    $actualResponse = $this->licenseController->deleteAdminLicenseCandidate(null,
+      new ResponseHelper(), ["id" => $id]);
+    $this->assertEquals($expectedResponse->getCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse->getArray(),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::deleteAdminLicenseCandidate() to delete license-candidate.
+   * -# User is admin
+   * -# License-candidate is doesn't exist
+   * -# Check if response is 404
+   * -# Check if reponse-body matches
+   */
+  public function testDeleteAdminLicenseCandidateNotFound(){
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $id = 1;
+    $this->auth->shouldReceive('isAdmin')->andReturn(true);
+    $this->adminLicenseCandidate->shouldReceive('getDataRow')->withArgs([$id])->andReturn(false);
+    $res = new Response('true',Response::HTTP_OK,array('Content-type'=>'text/plain'));
+    $this->adminLicenseCandidate->shouldReceive("doDeleteCandidate")->withArgs([$id])->andReturn($res);
+    $expectedResponse = new Info(404, "License candidate not found.", InfoType::ERROR);
+    $actualResponse = $this->licenseController->deleteAdminLicenseCandidate(null,
+      new ResponseHelper(), ["id" => $id]);
+    $this->assertEquals($expectedResponse->getCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse->getArray(),
       $this->getResponseJson($actualResponse));
   }
 

--- a/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
@@ -29,6 +29,7 @@ use Slim\Psr7\Factory\StreamFactory;
 use Slim\Psr7\Headers;
 use Slim\Psr7\Request;
 use Slim\Psr7\Uri;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @class LicenseControllerTest
@@ -870,10 +871,10 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
     $id = 1;
     $this->auth->shouldReceive('isAdmin')->andReturn(true);
-    $this->adminLicenseCandidate->shouldReceive('getDataRow')->withArgs([$id])->andReturn(true);
+    $this->licenseCandidatePlugin->shouldReceive('getDataRow')->withArgs([$id])->andReturn(true);
     $res = new Response('true',Response::HTTP_OK,array('Content-type'=>'text/plain'));
-    $this->adminLicenseCandidate->shouldReceive("doDeleteCandidate")->withArgs([$id,false])->andReturn($res);
-    $expectedResponse = new Info(200,"License candidate will be deleted.",  InfoType::INFO);
+    $this->licenseCandidatePlugin->shouldReceive("doDeleteCandidate")->withArgs([$id,false])->andReturn($res);
+    $expectedResponse = new Info(202,"License candidate will be deleted.",  InfoType::INFO);
     $actualResponse = $this->licenseController->deleteAdminLicenseCandidate(null,
       new ResponseHelper(), ["id" => $id]);
     $this->assertEquals($expectedResponse->getCode(),
@@ -894,7 +895,7 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
     $id = 1;
     $this->auth->shouldReceive('isAdmin')->andReturn(false);
-    $expectedResponse = new Info(400, "Only admin can perform this operation.", InfoType::ERROR);
+    $expectedResponse = new Info(403, "Only admin can perform this operation.", InfoType::ERROR);
     $actualResponse = $this->licenseController->deleteAdminLicenseCandidate(null,
       new ResponseHelper(), ["id" => $id]);
     $this->assertEquals($expectedResponse->getCode(),
@@ -915,9 +916,9 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
     $id = 1;
     $this->auth->shouldReceive('isAdmin')->andReturn(true);
-    $this->adminLicenseCandidate->shouldReceive('getDataRow')->withArgs([$id])->andReturn(false);
+    $this->licenseCandidatePlugin->shouldReceive('getDataRow')->withArgs([$id])->andReturn(false);
     $res = new Response('true',Response::HTTP_OK,array('Content-type'=>'text/plain'));
-    $this->adminLicenseCandidate->shouldReceive("doDeleteCandidate")->withArgs([$id])->andReturn($res);
+    $this->licenseCandidatePlugin->shouldReceive("doDeleteCandidate")->withArgs([$id])->andReturn($res);
     $expectedResponse = new Info(404, "License candidate not found.", InfoType::ERROR);
     $actualResponse = $this->licenseController->deleteAdminLicenseCandidate(null,
       new ResponseHelper(), ["id" => $id]);
@@ -939,9 +940,7 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
     $this->licenseCandidatePlugin->shouldReceive('getCandidateArrayData')->andReturn([]);
 
-    $info = new Info(200, [], InfoType::INFO);
-    $expectedResponse = (new ResponseHelper())->withJson($info->getArray(),
-      $info->getCode());
+    $expectedResponse = (new ResponseHelper())->withJson([], 200);
     $actualResponse = $this->licenseController->getCandidates(null,
       new ResponseHelper(), null);
     $this->assertEquals($expectedResponse->getStatusCode(),


### PR DESCRIPTION
Signed-off-by: dushimsam <dushsam@gmail.com>


## Description

An endpoint to delete admin-license candidate.

### Changes

1. Added a new controller file and the function to handle the logic in `LicenseController`.
2. Updated the file `AdminLicenseCandidate.php` to be reusable by the outside callers.
3. Updated  the main file(`index.php`) by adding a new route `DELETE` `/license/candidates/{id}`.
4. Updated the `openapi.yaml` file  to introduce a new API.

## How to test

Make a DELETE request on the endpoint accessed at "/license/candidates/{id}"

## Example

 #### 1. FIRST CASE  
 
 In this case, the Admin-license-candidate exists, and the license-candidate will be deleted successfully.

![license_candidate_delete](https://user-images.githubusercontent.com/66276301/185834159-5ab1fb72-a7a4-4b92-a8e5-a8e2ac621a8c.png)


 #### 2. SECOND CASE 
  In this case, the Admin-license-candidate doesn't exist, so 404 error will be returned instead.

![license_candidate_delete_2](https://user-images.githubusercontent.com/66276301/185834171-348f8264-eeb9-4943-948b-c1d0df0d67d0.png)

#### 3. THIRD CASE 
   The request is not coming from the Admin.
   This request can only be run by the admin , else the request will fail returning 400 ERROR.

   ![not_admin](https://user-images.githubusercontent.com/66276301/185834446-8190e34a-3c13-40ca-beaf-2734b48cd781.png)


### Related Issue:
Fixes #2297

    
cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2298"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

