### PR TITLE
feat(ubuntu): support ubuntu jammy 22.04 for fossology

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -22,6 +22,7 @@ jobs:
           - 'debian:bullseye'
           - 'ubuntu:bionic'
           - 'ubuntu:focal'
+          - 'ubuntu:jammy'
 
     runs-on: ubuntu-latest
     container: ${{ matrix.os }}

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>=9~), libglib2.0-dev, libmagic-dev, libxml2-dev,
  libmxml-dev, libtext-template-perl, librpm-dev, subversion, rpm, libpcre3-dev,
  libssl-dev, postgresql-server-dev-all, libboost-regex-dev, libicu-dev,
  libboost-program-options-dev, libjsoncpp-dev, libjson-c-dev, libpq-dev,
- php7.0-cli|php7.2-cli|php7.3-cli|php7.4-cli, php-mbstring, php-zip, php-curl,
+ php7.2-cli|php7.3-cli|php7.4-cli|php8.1-cli, php-mbstring, php-zip, php-curl,
  php-gd, php-pgsql, php-uuid, php-xml, libboost-system-dev,
  libboost-filesystem-dev, libgcrypt20-dev, composer
 Standards-Version: 3.9.1
@@ -14,7 +14,7 @@ Homepage: https://fossology.org
 
 Package: fossology-dev
 Architecture: any
-Depends: php7.0-cli|php7.2-cli|php7.3-cli|php7.4-cli, ${misc:Depends}
+Depends: php7.2-cli|php7.3-cli|php7.4-cli|php8.1-cli, ${misc:Depends}
 Description: architecture for analyzing software, development utils
  The FOSSology project is a web based framework that allows you to
  upload software to be picked apart and then analyzed by software agents
@@ -47,11 +47,11 @@ Description: open and modular architecture for analyzing software
 
 Package: fossology-common
 Architecture: any
-Depends: php7.0-pgsql|php7.2-pgsql|php7.3-pgsql|php7.4-pgsql, php-pear,
- php7.0-cli|php7.2-cli|php7.3-cli|php7.4-cli, php-mbstring, php-zip, php-xml,
- php7.0-gd|php7.2-gd|php7.3-gd|php7.4-gd, php-uuid,
- php7.0-json|php7.2-json|php7.3-json|php7.4-json,
- php7.0-curl|php7.2-curl|php7.3-curl|php7.4-curl,
+Depends: php7.2-pgsql|php7.3-pgsql|php7.4-pgsql|php8.1-pgsql, php-pear,
+ php7.2-cli|php7.3-cli|php7.4-cli|php8.1-cli, php-mbstring, php-zip, php-xml,
+ php7.2-gd|php7.3-gd|php7.4-gd|php8.1-gd, php-uuid,
+ php7.2-json|php7.3-json|php7.4-json|php8.1-json,
+ php7.2-curl|php7.3-curl|php7.4-curl|php8.1-curl,
  ${shlibs:Depends}, ${misc:Depends}
 Description: architecture for analyzing software, common files
  The FOSSology project is a web based framework that allows you to
@@ -65,8 +65,8 @@ Description: architecture for analyzing software, common files
 
 Package: fossology-web
 Architecture: any
-Depends: fossology-common, apache2, php7.0-gd|php7.2-gd|php7.3-gd|php7.4-gd,
- libapache2-mod-php7.0|libapache2-mod-php7.2|libapache2-mod-php7.3|libapache2-mod-php7.4,
+Depends: fossology-common, apache2, php7.2-gd|php7.3-gd|php7.4-gd|php8.1-gd,
+ libapache2-mod-php7.2|libapache2-mod-php7.3|libapache2-mod-php7.4|libapache2-mod-php8.1,
  ${misc:Depends}
 Recommends: fossology-db
 Description: architecture for analyzing software, web interface

--- a/src/copyright/mod_deps
+++ b/src/copyright/mod_deps
@@ -97,6 +97,8 @@ if [[ $RUNTIME ]]; then
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.65.1;;
         focal)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.71.0;;
+        jammy)
+          apt-get $YesOpt install libjsoncpp25 libboost-filesystem1.74.0;;
         *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
       esac;;
     Fedora)

--- a/src/lib/c/fossconfig.c
+++ b/src/lib/c/fossconfig.c
@@ -207,11 +207,18 @@ static gboolean fo_config_eval(const GMatchInfo* match, GTree** g_current,
   /* check to make sure we haven't hit an error */
   if ((error_t = g_match_info_fetch_named(match, "error")) != NULL)
   {
-    g_set_error(error, PARSE_ERROR, fo_invalid_file,
-      "%s[line %d]: incorrectly formated line \"%s\".",
-      yyfile, yyline, error_t);
-    g_free(error_t);
-    return TRUE;
+    if (strlen(error_t) > 0)
+    {
+      g_set_error(error, PARSE_ERROR, fo_invalid_file,
+        "%s[line %d]: incorrectly formated line \"%s\".",
+        yyfile, yyline, error_t);
+      g_free(error_t);
+      return TRUE;
+    }
+    else
+    {
+      g_free(error_t);
+    }
   }
 
   gchar* group = g_match_info_fetch_named(match, "group");

--- a/src/lib/php/libschema.php
+++ b/src/lib/php/libschema.php
@@ -763,7 +763,9 @@ class fo_libschema
         if (!empty($Key)) {
           $Key .= ",";
         }
-        $Key .= '"' . $this->currSchema['TABLEID'][$Results[$i]['table_name']][$K] . '"';
+        if (!empty($this->currSchema['TABLEID'][$Results[$i]['table_name']][$K])) {
+          $Key .= '"' . $this->currSchema['TABLEID'][$Results[$i]['table_name']][$K] . '"';
+        }
       }
       $Results[$i]['constraint_key'] = $Key;
       $Key = "";

--- a/src/nomos/mod_deps
+++ b/src/nomos/mod_deps
@@ -87,6 +87,8 @@ if [[ $RUNTIME ]]; then
           apt-get $YesOpt install libjson-c5;;
         focal)
           apt-get $YesOpt install libjson-c4;;
+        jammy)
+          apt-get $YesOpt install libjson-c5;;
         *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
       esac;;
     Fedora|RedHatEnterprise*|CentOS)

--- a/src/ojo/mod_deps
+++ b/src/ojo/mod_deps
@@ -99,6 +99,8 @@ if [[ $RUNTIME ]]; then
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0;;
         focal)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.71.0 libboost-program-options1.71.0 libboost-regex1.71.0;;
+        jammy)
+          apt-get $YesOpt install libjsoncpp25 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0;;
         *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
       esac;;
     Fedora)

--- a/src/scancode/mod_deps
+++ b/src/scancode/mod_deps
@@ -101,6 +101,8 @@ if [[ $RUNTIME ]]; then
           apt-get $YesOpt install libjsoncpp1 libboost-program-options1.74.0;;
         focal)
           apt-get $YesOpt install libjsoncpp1 libboost-program-options1.71.0;;
+        jammy)
+          apt-get $YesOpt install libjsoncpp25 libboost-program-options1.74.0;;
         *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
       esac;;
     Fedora)

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -109,6 +109,8 @@ if [[ $BUILDTIME ]]; then
              apt-get $YesOpt install php-mbstring php-cli php-xml php-zip php-gd php-pgsql php-curl php-uuid;;
            focal)
              apt-get $YesOpt install php-mbstring php-cli php-xml php-zip php-gd php-pgsql php-curl php-uuid;;
+           jammy)
+             apt-get $YesOpt install php-mbstring php-cli php-xml php-zip php-gd php-pgsql php-curl php-uuid;;
          esac
          if ! dpkg --get-selections | grep -q postgresql-server-dev; then  ## if postgresql-server-dev is not installed
            case "$CODENAME" in
@@ -124,6 +126,8 @@ if [[ $BUILDTIME ]]; then
                 apt-get $YesOpt install postgresql-server-dev-11;;
               focal)
                 apt-get $YesOpt install postgresql-server-dev-12;;
+              jammy)
+                apt-get $YesOpt install postgresql-server-dev-14;;
               *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
            esac
          fi
@@ -190,6 +194,11 @@ if [[ $RUNTIME ]]; then
             focal)
                apt-get $YesOpt install postgresql php php-pgsql php-cli php-curl php-xml php-zip php-mbstring php-uuid s-nail \
                  libboost-program-options1.71.0 libboost-regex1.71.0 libicu66;;
+            jammy)
+               apt-get $YesOpt install postgresql-14 php8.1 php8.1-pgsql \
+               libapache2-mod-php8.1 php8.1-pgsql php8.1-cli php8.1-curl \
+               php8.1-xml php8.1-zip php8.1-mbstring php8.1-uuid php-php-gettext s-nail \
+               libboost-program-options1.74.0 libboost-regex1.74.0 libicu70;;
             *) echo "ERROR: Unknown or Unsupported $DISTRO $CODENAME release, please report to the mailing list"; exit 1;;
          esac
          ;;


### PR DESCRIPTION
## Description

Add support for ubuntu jammy 22.04 for fossology.

### Changes

added jammy support in installdeps file and corrected a warning.

## How to test

* Test every functionality of fossology using source install as well as debian install in Ubuntu 22.04

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2300"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

