### PR TITLE
feat(API): add user to a group.

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1627,7 +1627,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-  /groups/{id}/user/{uid}:
+  /groups/{id}/user/{userId}:
     parameters:
       - name: id
         required: true
@@ -1635,7 +1635,7 @@ paths:
         in: path
         schema:
           type: integer
-      - name: uid
+      - name: userId
         required: true
         description: user id of the member
         in: path
@@ -1675,7 +1675,42 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-
+    post:
+      operationId: addMember
+      tags:
+        - Groups
+        - Admin
+      summary: Add user to a group
+      description: >
+        add a new user to group
+      requestBody:
+        description: Request options
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddMember'
+      responses:
+        '200':
+          description: User has been added to group
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /groups/deletable:
     get:
       operationId: deletableGroups
@@ -2860,6 +2895,17 @@ components:
           description: Date from which to remove older log files from repository.
           nullable: true
           example: "2022-07-16"
+    AddMember:
+      description: UserMember options
+      type: object
+      properties:
+        perm:
+          type: integer
+          description: Default permission of the new member.
+          nullable: false
+          minimum: 0
+          maximum: 2
+          example: 0
     HealthInfo:
       description: Health status of server
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -165,8 +165,9 @@ $app->group('/groups',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->get('', GroupController::class . ':getGroups');
     $app->post('', GroupController::class . ':createGroup');
+    $app->post('/{id:\\d+}/user/{userId:\\d+}', GroupController::class . ':addMember');
     $app->delete('/{id:\\d+}', GroupController::class . ':deleteGroup');
-    $app->delete('/{id:\\d+}/user/{uid:\\d+}', GroupController::class . ':deleteGroupMember');
+    $app->delete('/{id:\\d+}/user/{userId:\\d+}', GroupController::class . ':deleteGroupMember');
     $app->get('/deletable', GroupController::class . ':getDeletableGroups');
     $app->get('/{id:\\d+}/members', GroupController::class . ':getGroupMembers');
     $app->any('/{params:.*}', BadRequestController::class);


### PR DESCRIPTION
Signed-off-by: dushimsam <dushsam@gmail.com>

## Description

An endpoint to add the user to a group as a new member.

### Changes

1. Added a new controller file and the function to handle the logic in `GroupController`.
2. Updated  the main file(`index.php`) by adding a new route `POST` `/groups/{id}/user`.
3. Updated the `openapi.yaml` file  to introduce a new API.

## How to test

Make a POST request on the endpoint to be accessed at ``/groups/{id}/user``

## STEPS TO TEST

 #### 1. DELETE - GROUP MEMBER  
 
Choose one user who was already a member to act as the sample of the following tests.

![delete_member](https://user-images.githubusercontent.com/66276301/187281825-64177134-dfb9-417c-8746-c298f6ffefde.png)



 #### 2.  GET- GROUP MEMBERS
Check if he was successfully removed from the group members of that  group.

![get_group_members](https://user-images.githubusercontent.com/66276301/187282172-bc3ca3c6-8820-43c9-b2fa-a2cac5012cdd.png)


Great , at this moment it's obviously visible that the member was removed.

#### 3. RE-ADD MEMBER

This is the core API we are currently testing if it works.

![add_user](https://user-images.githubusercontent.com/66276301/187282486-b68ad606-d7bc-4f16-a787-290ca5f23844.png)


In this response, we can easily see that the member was successfully re-added again to the group. With his default permission of `2`

#### 4. ATTEMPT TO RE-ADD AN EXISTING MEMBER

![already_member](https://user-images.githubusercontent.com/66276301/187282948-9966e5dd-5ea5-46b8-9973-93ac034f3165.png)

We avoid generating duplicate user-members by checking if the given user in request already exists on the part of the group.

### Related Issue:
Fixes #2302 

    
cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2303"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

