### PR TITLE
feat(project): add readme_oss reprot generation code in project view

### DIFF
--- a/src/delagent/agent/delagent.h
+++ b/src/delagent/agent/delagent.h
@@ -57,6 +57,8 @@ extern PGconn* pgConn;
  */
 #define myBUFSIZ 2048
 
+#define MAXSQLProject 1024
+
 /* authentication and permission checking */
 int authentication(char *user, char * password, int *userId, int *userPerm);
 

--- a/src/delagent/ui/admin-project-delete.php
+++ b/src/delagent/ui/admin-project-delete.php
@@ -1,0 +1,158 @@
+<?php
+/***********************************************************
+ Copyright (C) 2008-2013 Hewlett-Packard Development Company, L.P.
+ Copyright (C) 2015-2017 Siemens AG
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***********************************************************/
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Db\DbManager;
+
+define("TITLE_ADMIN_PROJECT_DELETE", _("Delete Project"));
+
+/**
+ * @class admin_project_delete
+ * @brief UI plugin to delete projects
+ */
+class admin_project_delete extends FO_Plugin
+{
+
+  /** @var DbManager */
+  private $dbManager;
+
+  function __construct()
+  {
+    $this->Name = "admin_project_delete";
+    $this->Title = TITLE_ADMIN_PROJECT_DELETE;
+    $this->MenuList = "Organize::Project::Delete Project";
+    $this->Dependency = array();
+    $this->DBaccess = PLUGIN_DB_WRITE;
+    parent::__construct();
+    $this->dbManager = $GLOBALS['container']->get('db.manager');
+    $this->folderDao = $GLOBALS['container']->get('dao.folder');
+    $this->projectDao = $GLOBALS['container']->get('dao.project');
+  }
+
+  /**
+   * @brief Creates a job to detele the project
+   * @param int $projectpk the project_pk to remove
+   * @param int $userId   the user deleting the project
+   * @return NULL on success, string on failure.
+   */
+  function Delete($projectpk, $userId)
+  {
+
+    $splitProject = explode(" ",$projectpk);
+
+    if (! $this->projectDao->isProjectAccessible($splitProject[1], $userId)) {
+      $text = _("No access to delete this project");
+      return ($text);
+    }
+    /* Can't remove top project */
+    if ($splitProject[1] == ProjectGetTop()) {
+      $text = _("Can Not Delete Root Project");
+      return ($text);
+    }
+    /* Get the project's name */
+    $ProjectName = ProjectGetName($splitProject[1]);
+
+    /* Prepare the job: job "Delete" */
+    $groupId = Auth::getGroupId();
+    $jobpk = JobAddJob($userId, $groupId, "Delete Project: $ProjectName");
+    if (empty($jobpk) || ($jobpk < 0)) {
+      $text = _("Failed to create job record");
+      return ($text);
+    }
+
+    /* Add job: job "Delete" has jobqueue item "delagent" */
+    $jqargs = "DELETE PROJECT $projectpk";
+    $jobqueuepk = JobQueueAdd($jobpk, "delagent", $jqargs, NULL, NULL);
+    if (empty($jobqueuepk)) {
+      $text = _("Failed to place delete in job queue");
+      return ($text);
+    }
+
+    /* Tell the scheduler to check the queue. */
+    $success  = fo_communicate_with_scheduler("database", $output, $error_msg);
+
+    if (! $success) {
+      return $error_msg . "\n" . $output;
+    }
+
+    return (null);
+  } // Delete()
+
+  /**
+   * @copydoc FO_Plugin::Output()
+   * @see FO_Plugin::Output()
+   */
+  public function Output()
+  {
+    /* If this is a POST, then process the request. */
+    $project = GetParm('project', PARM_RAW);
+    $splitProject = explode(" ",$project);
+    if (!empty($project)) {
+      $userId = Auth::getUserId();
+      $sql = "SELECT project_name FROM project join users on (users.user_pk = project.user_fk or users.user_perm = 10) where project_pk = $1 and users.user_pk = $2;";
+      $Project = $this->dbManager->getSingleRow($sql,array($splitProject[1],$userId),__METHOD__."GetRowWithProjectName");
+      if (!empty($Project['project_name'])) {
+        $rc = $this->Delete($project, $userId);
+        if (empty($rc)) {
+          /* Need to refresh the screen */
+          $text = _("Deletion of project ");
+          $text1 = _(" added to job queue");
+          $this->vars['message'] = $text . $Project['project_name'] . $text1;
+        } else {
+          $text = _("Deletion of ");
+          $text1 = _(" failed: ");
+          $this->vars['message'] =  $text . $Project['project_name'] . $text1 . $rc;
+        }
+      } else {
+        $text = _("Cannot delete this project :: Permission denied");
+        $this->vars['message'] = $text;
+      }
+    }
+
+    $V= "<form method='post'>\n"; // no url = this url
+    $text  =  _("Select the project to");
+    $text1 = _("delete");
+    $V.= "$text <em>$text1</em>.\n";
+    $V.= "<ul>\n";
+    $text = _("This will");
+    $text1 = _("delete");
+    $text2 = _("the project, all subprojects, and all uploaded files stored within the project!");
+    $V.= "<li>$text <em>$text1</em> $text2\n";
+    $text = _("Be very careful with your selection since you can delete a lot of work!");
+    $V.= "<li>$text\n";
+    $text = _("All analysis only associated with the deleted uploads will also be deleted.");
+    $V.= "<li>$text\n";
+    $text = _("THERE IS NO UNDELETE. When you select something to delete, it will be removed from the database and file repository.");
+    $V.= "<li>$text\n";
+    $V.= "</ul>\n";
+    $text = _("Select the project to delete:  ");
+    $V.= "<P>$text\n";
+    $V.= "<select name='project' class='ui-render-select2'>\n";
+    $text = _("select project");
+    $V.= "<option value='' disabled selected>[$text]</option>\n";
+    $V.= ProjectListOption(-1, 0, 1, -1, true);
+    $V.= "</select><P />\n";
+    $text = _("Delete");
+    $V.= "<input type='submit' value='$text'>\n";
+    $V.= "</form>\n";
+    return $V;
+  }
+}
+
+$NewPlugin = new admin_project_delete();

--- a/src/lib/php/Agent/Agent.php
+++ b/src/lib/php/Agent/Agent.php
@@ -138,13 +138,23 @@ abstract class Agent
    */
   function scheduler_connect()
   {
+
+    // echo("scheduler_connect begin\n");
+    
+
     $schedulerHandledOpts = "c:";
     $schedulerHandledLongOpts = array("userID:","groupID:","jobId:","scheduler_start",'config:');
 
     $longOpts = array_merge($schedulerHandledLongOpts, $this->agentSpecifLongOptions);
     $shortOpts = $schedulerHandledOpts . $this->agentSpecifOptions;
 
+
+    
+
+
     $args = getopt($shortOpts, $longOpts);
+
+
 
     $this->schedulerMode = (array_key_exists("scheduler_start", $args));
 
@@ -169,6 +179,14 @@ abstract class Agent
     }
 
     $this->args = $args;
+
+    // echo("longOpts\n");
+    // echo(json_encode($longOpts));
+    // echo("shortOpts\n");
+    // echo(json_encode($shortOpts));
+
+    // echo("args\n");
+    // echo(json_encode($args));
   }
 
   /**

--- a/src/lib/php/Dao/ProjectDao.php
+++ b/src/lib/php/Dao/ProjectDao.php
@@ -1,0 +1,515 @@
+<?php
+/*
+Copyright (C) 2014-2015, Siemens AG
+Authors: Wenhan Feng
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+namespace Fossology\Lib\Dao;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Data\Project\Project;
+use Fossology\Lib\Data\Upload\UploadProgress;
+use Fossology\Lib\Db\DbManager;
+use Monolog\Logger;
+
+class ProjectDao
+{
+    const PROJECT_KEY = "project";
+    const DEPTH_KEY = "depth";
+    const REUSE_KEY = 'reuse';
+    const TOP_LEVEL = 1;
+
+    const MODE_PROJECT = 1;
+    const MODE_UPLOAD = 2;
+    const MODE_ITEM = 4;
+
+    /** @var DbManager */
+    private $dbManager;
+    /** @var UserDao */
+    private $userDao;
+    /** @var UploadDao */
+    private $uploadDao;
+    /** @var Logger */
+    private $logger;
+
+    public function __construct(DbManager $dbManager, UserDao $userDao, UploadDao $uploadDao)
+    {
+        $this->dbManager = $dbManager;
+        $this->logger = new Logger(self::class);
+        $this->uploadDao = $uploadDao;
+        $this->userDao = $userDao;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function hasTopLevelProject()
+    {
+        $projectInfo = $this->dbManager->getSingleRow("SELECT count(*) cnt FROM project WHERE project_pk=$1", array(self::TOP_LEVEL), __METHOD__);
+        $hasProject = $projectInfo['cnt'] > 0;
+        return $hasProject;
+    }
+
+    public function insertProject($projectName, $projectDescription, $parentProjectId = self::TOP_LEVEL)
+    {
+
+        $statementName = __METHOD__;
+        $this->dbManager->prepare(
+            $statementName,
+            "INSERT INTO project (project_name, project_desc) VALUES ($1, $2) returning project_pk"
+        );
+        $res = $this->dbManager->execute($statementName, array($projectName, $projectDescription));
+        $projectRow = $this->dbManager->fetchArray($res);
+        $projectId = $projectRow["project_pk"];
+        $this->dbManager->freeResult($res);
+        $this->insertProjectContents($parentProjectId, self::MODE_PROJECT, $projectId);
+
+        return $projectId;
+    }
+
+    public function getProjectId($projectName, $parentProjectId = self::TOP_LEVEL)
+    {
+        $statementName = __METHOD__;
+        $this->dbManager->prepare(
+            $statementName,
+            "SELECT project_pk FROM project, projectcontents fc"
+                . " WHERE LOWER(project_name)=LOWER($1) AND fc.parent_fk=$2 AND fc.projectcontents_mode=$3 AND project_pk=child_id"
+        );
+        $res = $this->dbManager->execute($statementName, array($projectName, $parentProjectId, self::MODE_PROJECT));
+        $rows = $this->dbManager->fetchAll($res);
+
+        $rootProject = !empty($rows) ? intval($rows[0]['project_pk']) : null;
+        $this->dbManager->freeResult($res);
+
+        return $rootProject;
+    }
+
+    public function insertProjectContents($parentId, $projectcontentsMode, $childId)
+    {
+        $statementName = __METHOD__;
+        $this->dbManager->prepare(
+            $statementName,
+            "INSERT INTO projectcontents (parent_fk, projectcontents_mode, child_id) VALUES ($1, $2, $3)"
+        );
+        $res = $this->dbManager->execute($statementName, array($parentId, $projectcontentsMode, $childId));
+        $this->dbManager->freeResult($res);
+    }
+
+    protected function fixProjectSequence()
+    {
+        $statementName = __METHOD__;
+        $this->dbManager->prepare(
+            $statementName,
+            "SELECT setval('project_project_pk_seq', (SELECT max(project_pk) + 1 FROM project LIMIT 1))"
+        );
+        $res = $this->dbManager->execute($statementName);
+        $this->dbManager->freeResult($res);
+    }
+
+    /**
+     * @param int $userId
+     * @return Project|null
+     */
+    public function getRootProject($userId)
+    {
+        $statementName = __METHOD__;
+        $this->dbManager->prepare(
+            $statementName,
+            "SELECT f.* FROM project f INNER JOIN users u ON f.project_pk = u.root_project_fk WHERE u.user_pk = $1"
+        );
+        $res = $this->dbManager->execute($statementName, array($userId));
+        $row = $this->dbManager->fetchArray($res);
+        $rootProject = $row ? new Project(intval($row['project_pk']), $row['project_name'], $row['project_desc'], intval($row['project_perm'])) : null;
+        $this->dbManager->freeResult($res);
+        return $rootProject;
+    }
+
+    /**
+     * @param int $userId
+     * @return Project|null
+     */
+    public function getDefaultProject($userId)
+    {
+        $statementName = __METHOD__;
+        $this->dbManager->prepare(
+            $statementName,
+            "SELECT f.* FROM project f INNER JOIN users u ON f.project_pk = u.default_project_fk WHERE u.user_pk = $1"
+        );
+        $res = $this->dbManager->execute($statementName, array($userId));
+        $row = $this->dbManager->fetchArray($res);
+        $rootProject = $row ? new Project(intval($row['project_pk']), $row['project_name'], $row['project_desc'], intval($row['project_perm'])) : null;
+        $this->dbManager->freeResult($res);
+        return $rootProject;
+    }
+
+    public function getProjectTreeCte($parentId = null)
+    {
+        $parentCondition = $parentId ? 'project_pk=$1' : 'project_pk=' . self::TOP_LEVEL;
+
+        return "WITH RECURSIVE project_tree(project_pk, parent_fk, project_name, project_desc, project_perm, id_path, name_path, depth, cycle_detected) AS (
+  SELECT
+    f.project_pk, fc.parent_fk, f.project_name, f.project_desc, f.project_perm,
+    ARRAY [f.project_pk]   AS id_path,
+    ARRAY [f.project_name] AS name_path,
+    0                     AS depth,
+    FALSE                 AS cycle_detected
+  FROM project f LEFT JOIN projectcontents fc ON fc.projectcontents_mode=" . self::MODE_PROJECT . " AND f.project_pk=fc.child_id
+  WHERE $parentCondition
+  UNION ALL
+  SELECT
+    f.project_pk, fc.parent_fk, f.project_name, f.project_desc, f.project_perm,
+    id_path || f.project_pk,
+    name_path || f.project_name,
+    array_length(id_path, 1),
+    f.project_pk = ANY (id_path)
+  FROM project f, projectcontents fc, project_tree ft
+  WHERE f.project_pk=fc.child_id AND projectcontents_mode=" . self::MODE_PROJECT . " AND fc.parent_fk = ft.project_pk AND NOT cycle_detected
+)";
+    }
+
+    public function getProjectStructure($parentId = null)
+    {
+        $statementName = __METHOD__ . ($parentId ? '.relativeToParent' : '');
+        $parameters = $parentId ? array($parentId) : array();
+        $this->dbManager->prepare($statementName, $this->getProjectTreeCte($parentId)
+            . " SELECT project_pk, parent_fk, project_name, project_desc, project_perm, depth FROM project_tree ORDER BY name_path");
+        $res = $this->dbManager->execute($statementName, $parameters);
+
+        $userGroupMap = $this->userDao->getUserGroupMap(Auth::getUserId());
+
+        $results = array();
+        while ($row = $this->dbManager->fetchArray($res)) {
+            $countUploads = $this->countProjectUploads(intval($row['project_pk']), $userGroupMap);
+
+            $results[] = array(
+                self::PROJECT_KEY => new Project(
+                    intval($row['project_pk']),
+                    $row['project_name'],
+                    $row['project_desc'],
+                    intval($row['project_perm'])
+                ),
+                self::DEPTH_KEY => $row['depth'],
+                self::REUSE_KEY => $countUploads
+            );
+        }
+        $this->dbManager->freeResult($res);
+        return $results;
+    }
+
+    /**
+     * @param int $parentId
+     * @param string[] $userGroupMap map groupId=>groupName
+     * @return array  of array(group_id,count,group_name)
+     */
+    public function countProjectUploads($parentId, $userGroupMap)
+    {
+        $trustGroupIds = array_keys($userGroupMap);
+        $statementName = __METHOD__;
+        $trustedGroups = '{' . implode(',', $trustGroupIds) . '}';
+        $parameters = array($parentId, $trustedGroups);
+
+        $this->dbManager->prepare($statementName, "
+SELECT group_fk group_id,count(*) FROM projectcontents fc
+  INNER JOIN upload u ON u.upload_pk = fc.child_id
+  INNER JOIN upload_clearing uc ON u.upload_pk=uc.upload_fk AND uc.group_fk=ANY($2)
+WHERE fc.parent_fk = $1 AND fc.projectcontents_mode = " . self::MODE_UPLOAD . " AND (u.upload_mode = 100 OR u.upload_mode = 104)
+GROUP BY group_fk
+");
+        $res = $this->dbManager->execute($statementName, $parameters);
+        $results = array();
+        while ($row = $this->dbManager->fetchArray($res)) {
+            $row['group_name'] = $userGroupMap[$row['group_id']];
+            $results[$row['group_name']] = $row;
+        }
+        $this->dbManager->freeResult($res);
+        return $results;
+    }
+
+    public function getAllProjectIds()
+    {
+        $statementName = __METHOD__;
+        $this->dbManager->prepare($statementName, "SELECT DISTINCT project_pk FROM project");
+        $res = $this->dbManager->execute($statementName);
+        $results = $this->dbManager->fetchAll($res);
+        $this->dbManager->freeResult($res);
+
+        $allIds = array();
+        for ($i = 0; $i < sizeof($results); $i++) {
+            array_push($allIds, intval($results[$i]['project_pk']));
+        }
+
+        return $allIds;
+    }
+
+    public function getProjectChildUploads($parentId, $trustGroupId)
+    {
+        $statementName = __METHOD__;
+        $parameters = array($parentId, $trustGroupId);
+
+        $this->dbManager->prepare($statementName, $sql = "
+SELECT u.*,uc.*,fc.projectcontents_pk FROM projectcontents fc
+  INNER JOIN upload u ON u.upload_pk = fc.child_id
+  INNER JOIN upload_clearing uc ON u.upload_pk=uc.upload_fk AND uc.group_fk=$2
+WHERE fc.parent_fk = $1 AND fc.projectcontents_mode = " . self::MODE_UPLOAD . " AND (u.upload_mode = 100 OR u.upload_mode = 104);");
+        $res = $this->dbManager->execute($statementName, $parameters);
+        $results = $this->dbManager->fetchAll($res);
+        $this->dbManager->freeResult($res);
+        return $results;
+    }
+
+    /**
+     * @param int $parentId
+     * @param int $trustGroupId
+     * @return UploadProgress[]
+     */
+    public function getProjectUploads($parentId, $trustGroupId = null)
+    {
+        if (empty($trustGroupId)) {
+            $trustGroupId = Auth::getGroupId();
+        }
+        $results = array();
+        foreach ($this->getProjectChildUploads($parentId, $trustGroupId) as $row) {
+            $results[] = UploadProgress::createFromTable($row);
+        }
+        return $results;
+    }
+
+    public function createProject($projectName, $projectDescription, $parentId)
+    {
+        $projectId = $this->dbManager->insertTableRow("project", array("project_name" => $projectName, "user_fk" => Auth::getUserId(), "project_desc" => $projectDescription), null, 'project_pk');
+        $this->insertProjectContents($parentId, self::MODE_PROJECT, $projectId);
+        return $projectId;
+    }
+
+
+    public function ensureTopLevelProject()
+    {
+        if (!$this->hasTopLevelProject()) {
+            $this->dbManager->insertTableRow("project", array("project_pk" => self::TOP_LEVEL, "project_name" => "Software Repository", "project_desc" => "Top Project"));
+            $this->insertProjectContents(1, 0, 0);
+            $this->fixProjectSequence();
+        }
+    }
+
+    public function isWithoutReusableProjects($projectStructure)
+    {
+        foreach ($projectStructure as $project) {
+            $posibilities = array_reduce($project[self::REUSE_KEY], function ($sum, $groupInfo) {
+                return $sum + $groupInfo['count'];
+            }, 0);
+            if ($posibilities > 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    protected function isInProjectTree($parentId, $projectId)
+    {
+        $cycle = $this->dbManager->getSingleRow(
+            $this->getProjectTreeCte($parentId) . " SELECT depth FROM project_tree WHERE project_pk=$2 LIMIT 1",
+            array($parentId, $projectId),
+            __METHOD__
+        );
+        return !empty($cycle);
+    }
+
+    public function getContent($projectContentId)
+    {
+        $content = $this->dbManager->getSingleRow(
+            'SELECT * FROM projectcontents WHERE projectcontents_pk=$1',
+            array($projectContentId),
+            __METHOD__ . '.getContent'
+        );
+        if (empty($content)) {
+            throw new \Exception('invalid ProjectContentId');
+        }
+        return $content;
+    }
+
+    protected function isContentMovable($content, $newParentId)
+    {
+        if ($content['parent_fk'] == $newParentId) {
+            return false;
+        }
+        $newParent = $this->dbManager->getSingleRow(
+            'SELECT * FROM project WHERE project_pk=$1',
+            array($newParentId),
+            __METHOD__ . '.getParent'
+        );
+        if (empty($newParent)) {
+            throw new \Exception('invalid parent project');
+        }
+
+        if ($content['projectcontents_mode'] == self::MODE_PROJECT) {
+            if ($this->isInProjectTree($content['child_id'], $newParentId)) {
+                throw new \Exception("action would cause a cycle");
+            }
+        } elseif ($content['projectcontents_mode'] == self::MODE_UPLOAD) {
+            $uploadId = $content['child_id'];
+            if (!$this->uploadDao->isEditable($uploadId, Auth::getGroupId())) {
+                throw new \Exception('permission to upload denied');
+            }
+        }
+
+        return true;
+    }
+
+    public function moveContent($projectContentId, $newParentId)
+    {
+        $content = $this->getContent($projectContentId);
+        if (!$this->isContentMovable($content, $newParentId)) {
+            return;
+        }
+
+        $this->dbManager->getSingleRow(
+            'UPDATE projectcontents SET parent_fk=$2 WHERE projectcontents_pk=$1',
+            array($projectContentId, $newParentId),
+            __METHOD__ . '.updateProjectParent'
+        );
+    }
+
+    public function copyContent($projectContentId, $newParentId)
+    {
+        $content = $this->getContent($projectContentId);
+        if (!$this->isContentMovable($content, $newParentId)) {
+            return;
+        }
+
+        $this->insertProjectContents($newParentId, $content['projectcontents_mode'], $content['child_id']);
+    }
+
+    public function getRemovableContents($projectId)
+    {
+        $sqlChildren = "SELECT child_id,projectcontents_mode
+             FROM projectcontents GROUP BY child_id,projectcontents_mode
+             HAVING count(*)>1 AND bool_or(parent_fk=$1)";
+        $sql = "SELECT fc.* FROM projectcontents fc,($sqlChildren) chi "
+            . "WHERE fc.child_id=chi.child_id AND fc.projectcontents_mode=chi.projectcontents_mode and fc.parent_fk=$1";
+        $this->dbManager->prepare($stmt = __METHOD__, $sql);
+        $res = $this->dbManager->execute($stmt, array($projectId));
+        $contents = array();
+        while ($row = $this->dbManager->fetchArray($res)) {
+            $contents[] = $row['projectcontents_pk'];
+        }
+        $this->dbManager->freeResult($res);
+        return $contents;
+    }
+
+    public function isRemovableContent($childId, $mode)
+    {
+        $sql = "SELECT count(parent_fk) FROM projectcontents WHERE child_id=$1 AND projectcontents_mode=$2";
+        $parentCounter = $this->dbManager->getSingleRow($sql, array($childId, $mode), __METHOD__);
+        return $parentCounter['count'] > 1;
+    }
+
+    public function removeContent($projectContentId)
+    {
+        $content = $this->getContent($projectContentId);
+        if ($this->isRemovableContent($content['child_id'], $content['projectcontents_mode'])) {
+            $sql = "DELETE FROM projectcontents WHERE projectcontents_pk=$1";
+            $this->dbManager->getSingleRow($sql, array($projectContentId), __METHOD__);
+        }
+    }
+
+    public function removeContentById($uploadpk, $projectId)
+    {
+        $sql = "DELETE FROM projectcontents WHERE child_id=$1 AND parent_fk=$2 AND projectcontents_mode=$3";
+        $this->dbManager->getSingleRow($sql, array($uploadpk, $projectId, 2), __METHOD__);
+    }
+
+    public function getProjectChildProjects($projectId)
+    {
+        $results = array();
+        $stmtProject = __METHOD__;
+        $sqlProject = "SELECT projectcontents_pk,projectcontents_mode, project_name FROM projectcontents,project "
+            . "WHERE projectcontents.parent_fk=$1 AND projectcontents.child_id=project.project_pk"
+            . " AND projectcontents_mode=" . self::MODE_PROJECT;
+        $this->dbManager->prepare($stmtProject, $sqlProject);
+        $res = $this->dbManager->execute($stmtProject, array($projectId));
+        while ($row = $this->dbManager->fetchArray($res)) {
+            $results[$row['projectcontents_pk']] = $row;
+        }
+        $this->dbManager->freeResult($res);
+        return $results;
+    }
+
+    /**
+     * @param int $projectId
+     * @return Project|null
+     */
+    public function getProject($projectId)
+    {
+        $projectRow = $this->dbManager->getSingleRow('SELECT * FROM project WHERE project_pk = $1', array($projectId));
+        if (!$projectRow) {
+            return null;
+        }
+        return new Project($projectRow['project_pk'], $projectRow['project_name'], $projectRow['project_desc'], $projectRow['project_perm']);
+    }
+
+    /**
+     * @param int $projectId
+     * @param int $userId
+     * @return true|false
+     */
+    public function isProjectAccessible($projectId, $userId = null)
+    {
+        $allUserProjects = array();
+        if ($userId == null) {
+            $userId = Auth::getUserId();
+        }
+        $rootProject = $this->getRootProject($userId)->getId();
+        GetProjectArray($rootProject, $allUserProjects);
+        if (in_array($projectId, array_keys($allUserProjects))) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Get the project contents id for a given child id
+     * @param integer $childId Id of the child
+     * @param integer $mode    Mode of child
+     * @return NULL|integer Project content id if success, NULL otherwise
+     */
+    public function getProjectContentsId($childId, $mode)
+    {
+        $projectContentsRow = $this->dbManager->getSingleRow(
+            'SELECT projectcontents_pk FROM projectcontents ' .
+                'WHERE child_id = $1 AND projectcontents_mode = $2',
+            [$childId, $mode]
+        );
+        if (!$projectContentsRow) {
+            return null;
+        }
+        return intval($projectContentsRow['projectcontents_pk']);
+    }
+
+    /**
+     * For a given project id, get the parent project id.
+     * @param integer $projectPk ID of the project
+     * @return number Parent id if parent exists, null otherwise.
+     */
+    public function getProjectParentId($projectPk)
+    {
+        $sql = "SELECT parent_fk FROM projectcontents " .
+            "WHERE projectcontents_mode = " . self::MODE_PROJECT .
+            " AND child_id = $1;";
+        $statement = __METHOD__ . ".getParentId";
+        $row = $this->dbManager->getSingleRow($sql, [$projectPk], $statement);
+        return (empty($row)) ? null : $row['parent_fk'];
+    }
+}

--- a/src/lib/php/Data/Project/Project.php
+++ b/src/lib/php/Data/Project/Project.php
@@ -1,0 +1,81 @@
+<?php
+/*
+Copyright (C) 2014, Siemens AG
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+namespace Fossology\Lib\Data\Project;
+
+class Project
+{
+
+  /** @var int */
+  private $id;
+
+  /** @var string */
+  private $name;
+
+  /** @var string */
+  private $description;
+
+  /** @var int */
+  private $permissions;
+
+  /**
+   * @param int $id
+   * @param string $name
+   * @param string $description
+   * @param int $permissions
+   */
+  public function __construct($id, $name, $description, $permissions)
+  {
+    $this->id = $id;
+    $this->name = $name;
+    $this->description = $description;
+    $this->permissions = $permissions;
+  }
+
+  /**
+   * @return string
+   */
+  public function getDescription()
+  {
+    return $this->description;
+  }
+
+  /**
+   * @return int
+   */
+  public function getId()
+  {
+    return $this->id;
+  }
+
+  /**
+   * @return string
+   */
+  public function getName()
+  {
+    return $this->name;
+  }
+
+  /**
+   * @return int
+   */
+  public function getPermissions()
+  {
+    return $this->permissions;
+  }
+}

--- a/src/lib/php/Report/ClearedGetterCommon.php
+++ b/src/lib/php/Report/ClearedGetterCommon.php
@@ -104,6 +104,8 @@ abstract class ClearedGetterCommon
 
   protected function groupStatements($ungrupedStatements, $extended, $agentCall, $isUnifiedReport, $objectAgent)
   {
+    echo("groupStatements begin"."\n");
+    
     $statements = array();
     $findings = array();
     $countLoop = 0;

--- a/src/lib/php/Report/LicenseClearedGetter.php
+++ b/src/lib/php/Report/LicenseClearedGetter.php
@@ -47,10 +47,19 @@ class LicenseClearedGetter extends ClearedGetterCommon
 
   protected function getStatements($uploadId, $uploadTreeTableName, $groupId = null)
   {
+
+    echo("getStatements"."\n");
+
     $itemTreeBounds = $this->uploadDao->getParentItemBounds($uploadId,$uploadTreeTableName);
     $clearingDecisions = $this->clearingDao->getFileClearingsFolder($itemTreeBounds, $groupId);
     $dbManager = $GLOBALS['container']->get('db.manager');
     $licenseMap = new LicenseMap($dbManager, $groupId, LicenseMap::REPORT);
+
+    echo("clearingDecisions"."\n");
+    echo(json_encode($clearingDecisions)."\n");
+    echo("licenseMap"."\n");
+    echo(json_encode($licenseMap)."\n");
+
     $ungroupedStatements = array();
     foreach ($clearingDecisions as $clearingDecision) {
       if ($clearingDecision->getType() == DecisionTypes::IRRELEVANT) {
@@ -106,11 +115,23 @@ class LicenseClearedGetter extends ClearedGetterCommon
   public function getCleared($uploadId, $objectAgent, $groupId=null,
     $extended=true, $agentCall=null, $isUnifiedReport=false)
   {
+    echo("getCleared begin"."\n");
+
     $uploadTreeTableName = $this->uploadDao->getUploadtreeTableName($uploadId);
     $ungroupedStatements = $this->getStatements($uploadId, $uploadTreeTableName,
       $groupId);
+
+    echo("uploadTreeTableName"."\n");
+    echo(json_encode($uploadTreeTableName)."\n");
+    echo("ungroupedStatements"."\n");
+    echo(json_encode($ungroupedStatements)."\n");
+
     $this->changeTreeIdsToPaths($ungroupedStatements, $uploadTreeTableName,
       $uploadId);
+
+    echo("ungroupedStatements"."\n");
+    echo(json_encode($ungroupedStatements)."\n");
+  
     if ($this->onlyAcknowledgements || $this->onlyComments) {
       return $this->groupStatementsSpecial($ungroupedStatements, $objectAgent);
     }

--- a/src/lib/php/UI/ProjectNav.php
+++ b/src/lib/php/UI/ProjectNav.php
@@ -1,0 +1,84 @@
+<?php
+/***********************************************************
+ * Copyright (C) 2015 Siemens AG
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***********************************************************/
+
+namespace Fossology\Lib\UI;
+
+use Fossology\Lib\Dao\FolderDao;
+use Fossology\Lib\Dao\ProjectDao;
+use Fossology\Lib\Db\DbManager;
+
+class ProjectNav
+{
+  /** @var DbManager */
+  private $dbManager;
+
+  /** @var ProjectDao */
+  private $projectDao;
+
+  public function __construct(DbManager $dbManager, ProjectDao $projectDao)
+  {
+    $this->dbManager = $dbManager;
+    $this->projectDao = $projectDao;
+  }
+
+  /**
+   * @param int $parentProject  parent project_pk
+   * @return string HTML of the project tree
+   */
+  public function showProjectTree($parentProject)
+  {
+
+    $uri = Traceback_uri();
+    $sql = $this->projectDao->getProjectTreeCte($parentProject)
+            ." SELECT project_pk, project_name, project_desc, depth, name_path FROM project_tree ORDER BY name_path";
+    $stmt = __METHOD__;
+    $this->dbManager->prepare($stmt, $sql);
+    $res = $this->dbManager->execute($stmt,array($parentProject));
+    $out = '';
+    $lastDepth = -1;
+    while ($row = $this->dbManager->fetchArray($res)) {
+      for (; $row['depth']<$lastDepth; $lastDepth--) {
+        $out .= '</li></ul>';
+      }
+      if ($row['depth']==$lastDepth) {
+        $out .= "</li>\n<li>";
+      }
+      if ($row['depth']==0) {
+        $out .= '<ul id="tree"><li>';
+        $lastDepth++;
+      }
+      for (;$row['depth']>$lastDepth;$lastDepth++) {
+        $out .= '<ul><li>';
+      }
+      $out .= $this->getFormattedItem($row, $uri);
+    }
+    for (; - 1<$lastDepth;$lastDepth--) {
+      $out .= '</li></ul>';
+    }
+    return $out;
+  }
+
+  protected function getFormattedItem($row,$uri)
+  {
+    $title = empty($row['project_desc']) ? '' : ' title="' . htmlspecialchars($row['project_desc']) . '"';
+    return '<a'.$title.
+           ' href="'.$uri.'?mod=browse&project='.$row['project_pk'].'"'.
+           ' class="clickable-project text-info stretched-link" style="padding:2px;" data-project="'.$row['project_pk'].'"'.
+           '>'.htmlentities($row['project_name']).'</a>';
+  }
+}

--- a/src/lib/php/UI/template/components/select-project.html.twig
+++ b/src/lib/php/UI/template/components/select-project.html.twig
@@ -1,0 +1,16 @@
+{# Copyright 2014-2015 Siemens AG
+
+   Copying and distribution of this file, with or without modification,
+   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
+   This file is offered as-is, without any warranty.
+#}
+{% if selected is not defined %}
+  {% set selected = -1 %}
+{% endif %}
+<select name="{{ name }}"{% if id is defined %} id="{{ id }}"{% endif %} class="ui-render-select2 form-control-sm">
+  {% for entry in projectStructure %}
+    <option value="{{ entry.project.id }}"{% if selected == entry.project.id %} selected="selected"{% endif %}>
+      {% for i in range(1, entry.depth*2) %}&nbsp;{% endfor %}{{ entry.project.name | escape('html') }}
+    </option>
+  {% endfor %}
+</select>

--- a/src/lib/php/UI/template/include/upload.html.twig
+++ b/src/lib/php/UI/template/include/upload.html.twig
@@ -27,6 +27,13 @@
             {% include 'components/select-folder.html.twig' with {'name': folderParameterName, 'id': 'uploadFolderSelector'} %}
         </div>
       </li>
+      <li>
+        <div class="form-group">
+          <label for="{{ projectParameterName }}">{{ 'Select the project for storing the uploaded files'| trans }}:</label>
+            <br/>
+            {% include 'components/select-project.html.twig' with {'name': projectParameterName, 'id': 'uploadProjectSelector'} %}
+        </div>
+      </li>
       {% block fileselect %}
       {% endblock %}
       {% block filedescription %}

--- a/src/lib/php/common-projects.php
+++ b/src/lib/php/common-projects.php
@@ -1,0 +1,605 @@
+<?php
+/***********************************************************
+ Copyright (C) 2008-2015 Hewlett-Packard Development Company, L.P.
+ Copyright (C) 2014-2017 Siemens AG
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License version 2.1 as published by the Free Software Foundation.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.0
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ ***********************************************************/
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\ProjectDao;
+use Fossology\Lib\Dao\UploadDao;
+
+/**
+ * \file
+ * \brief Common Project Functions
+ * Design note:
+ * Projects could be stored in a menu listing (using menu_insert).
+ * However, since menu_insert() runs a usort() during each insert,
+ * this can be really slow. For speed, projects are handled separately.
+ */
+
+/**
+ * \brief DEPRECATED! Find the top-of-tree project_pk for the current user.
+ * \deprecated Use GetUserRootProject()
+ */
+function ProjectGetTop()
+{
+  /* Get the list of projects */
+  if (! empty($_SESSION['Project'])) {
+    return ($_SESSION['Project']);
+  }
+  global $PG_CONN;
+  if (empty($PG_CONN)) {
+    return;
+  }
+  $sql = "SELECT root_project_fk FROM users ORDER BY user_pk ASC LIMIT 1";
+  $result = pg_query($PG_CONN, $sql);
+  DBCheckResult($result, $sql, __FILE__, __LINE__);
+  $row = pg_fetch_assoc($result);
+  pg_free_result($result);
+  return($row['root_project_fk']);
+} // ProjectGetTop()
+
+/**
+ * \brief Get the top-of-tree project_pk for the current user.
+ *  Fail if there is no user session.
+ *
+ * \return project_pk for the current user
+ */
+function GetUserRootProject()
+{
+
+  global $PG_CONN;
+
+  /* validate inputs */
+  $user_pk = Auth::getUserId();
+
+    /* everyone has a user_pk, even if not logged in. But verify. */
+  if (empty($user_pk)) {
+    return "__FILE__:__LINE__ GetUserRootProject(Not logged in)<br>";
+  }
+
+  /* Get users root project */
+  $sql = "select root_project_fk from users where user_pk=$user_pk";
+  $result = pg_query($PG_CONN, $sql);
+
+  DBCheckResult($result, $sql, __FILE__, __LINE__);
+  $UsersRow = pg_fetch_assoc($result);
+  $root_project_fk = $UsersRow['root_project_fk'];
+  pg_free_result($result);
+  if (empty($root_project_fk)) {
+    $text = _("Missing root_project_fk for user ");
+    fatal("<h2>".$text.$user_pk."</h2>", __FILE__, __LINE__);
+  }
+  return $root_project_fk;
+} // GetUserRootProject()
+
+/**
+ * \brief Return an array of project_pk, project_name
+ *        from the users.root_project_fk to $project_pk
+ *
+ * Array is in top down order.
+ * If you need to know the project_pk of an upload or uploadtree, use GetProjectFromItem()
+ *
+ * \param int $project_pk
+ *
+ * \return The project list:
+ * \code
+ * ProjectList = array({'project_pk'=>project_pk, 'project_name'=>project_name}, ...
+ * \endcode
+ */
+function Project2Path($project_pk)
+{
+
+  global $PG_CONN;
+  $ProjectList = array();
+
+  /* validate inputs */
+  if (empty($project_pk)) {
+    return __FILE__.":".__LINE__." Project2Browse(empty)<br>";
+  }
+
+  /* Get users root project */
+  $root_project_fk = GetUserRootProject();   // will fail if no user session
+
+  while ($project_pk) {
+    $sql = "select project_pk, project_name from project where project_pk='$project_pk'";
+    $result = pg_query($PG_CONN, $sql);
+    DBCheckResult($result, $sql, __FILE__, __LINE__);
+    $ProjectRow = pg_fetch_assoc($result);
+    pg_free_result($result);
+    array_unshift($ProjectList, $ProjectRow);
+
+    // Limit projects to user root.  Limit to an arbitrary 20 projects as a failsafe
+    // against this loop going infinite.
+    if (($project_pk == $root_project_fk) || (count($ProjectList)>20)) {
+      break;
+    }
+
+    $sql = "select parent_fk from projectcontents where child_id='$project_pk' and projectcontents_mode=".ProjectDao::MODE_PROJECT;
+    $result = pg_query($PG_CONN, $sql);
+    DBCheckResult($result, $sql, __FILE__, __LINE__);
+    $ProjectRow = pg_fetch_assoc($result);
+    pg_free_result($result);
+    $project_pk = $ProjectRow['parent_fk'];
+  }
+  return($ProjectList);
+} // Project2Path()
+
+
+/**
+ * \brief Find what project an item is in.
+ *
+ * \param int $upload_pk NULL if $uploadtree_pk is passed in
+ * \param int $uploadtree_pk NULL if $upload_pk is passed in
+ *
+ * \note If both $upload_pk and $uploadtree_pk are passed in, $upload_pk will be used.
+ *
+ * \return The project_pk that the upload_pk (or uploadtree_pk) is in
+ */
+function GetProjectFromItem($upload_pk="", $uploadtree_pk = "")
+{
+  global $PG_CONN;
+
+  /* validate inputs */
+  if (empty($uploadtree_pk) && empty($upload_pk)) {
+    return "__FILE__:__LINE__ GetProjectFromItem(empty)<br>";
+  }
+
+  if (empty($upload_pk)) {
+    $UTrec = GetSingleRec("uploadtree", "where uploadtree_pk=$uploadtree_pk");
+    $upload_pk = $UTrec['upload_fk'];
+  }
+
+  $sql = "select parent_fk from projectcontents where child_id='$upload_pk' and projectcontents_mode=".ProjectDao::MODE_UPLOAD;
+  $result = pg_query($PG_CONN, $sql);
+  DBCheckResult($result, $sql, __FILE__, __LINE__);
+  $ProjectRow = pg_fetch_assoc($result);
+  pg_free_result($result);
+  return $ProjectRow['parent_fk'];
+} // GetProjectFromItem()
+
+
+/**
+ * \brief Create the project tree, using OPTION tags.
+ * \note The caller must already have created the FORM and SELECT tags.
+ * \note This is recursive!
+ * \note If there is a recursive loop in the project table, then
+ * this will loop INFINITELY.
+ *
+ * \param int $ParentProject Parents project_fk
+ * \param int $Depth  Tree depth to create
+ * \param bool $IncludeTop  True to include fossology root project
+ * \param int $SelectId project_fk of selected project
+ * \param bool $linkParent If true, the option tag will have $OldParent and
+ * $ParentProject as the value
+ * \param int $OldParent Parent of the parent project
+ *
+ * \return HTML of the project tree
+ */
+function ProjectListOption($ParentProject,$Depth, $IncludeTop=1, $SelectId=-1, $linkParent=false, $OldParent=0)
+{
+  if ($ParentProject == "-1") {
+    $ParentProject = ProjectGetTop();
+  }
+  if (empty($ParentProject)) {
+    return;
+  }
+  global $PG_CONN;
+  if (empty($PG_CONN)) {
+    return;
+  }
+  $V = "";
+
+  if (($Depth != 0) || $IncludeTop) {
+    if ($ParentProject == $SelectId) {
+      $V .= "<option value='$ParentProject' SELECTED>";
+    } elseif ($linkParent) {
+      if (empty($OldParent)) {
+        $OldParent = 0;
+      }
+      $V .= "<option value='$OldParent $ParentProject'>";
+    } else {
+      $V .= "<option value='$ParentProject'>";
+    }
+    if ($Depth != 0) {
+      $V .= "&nbsp;&nbsp;";
+    }
+    for ($i=1; $i < $Depth; $i++) {
+      $V .= "&nbsp;&nbsp;";
+    }
+
+    /* Load this project's name */
+    $sql = "SELECT project_name FROM project WHERE project_pk=$ParentProject LIMIT 1;";
+    $result = pg_query($PG_CONN, $sql);
+    DBCheckResult($result, $sql, __FILE__, __LINE__);
+    $row = pg_fetch_assoc($result);
+    $Name = trim($row['project_name']);
+    if ($Name == "") {
+      $Name = "[default]";
+    }
+
+    /* Load any subprojects */
+    /* Now create the HTML */
+    $V .= htmlentities($Name);
+    $V .= "</option>\n";
+  }
+  /* Load any subprojects */
+  $sql = "SELECT project.project_pk, project.project_name AS name,
+            project.project_desc AS description,
+            projectcontents.parent_fk AS parent,
+            projectcontents.projectcontents_mode,
+            NULL AS ts, NULL AS upload_pk, NULL AS pfile_fk, NULL AS ufile_mode
+            FROM project, projectcontents
+            WHERE projectcontents.projectcontents_mode = ".ProjectDao::MODE_PROJECT."
+            AND projectcontents.parent_fk =$ParentProject
+            AND projectcontents.child_id = project.project_pk
+            AND project.project_pk is not null
+            ORDER BY name";
+  $result = pg_query($PG_CONN, $sql);
+  DBCheckResult($result, $sql, __FILE__, __LINE__);
+  if (pg_num_rows($result) > 0) {
+    $Hide = "";
+    if ($Depth > 0) {
+      $Hide = "style='display:none;'";
+    }
+    while ($row = pg_fetch_assoc($result)) {
+      $V .= ProjectListOption($row['project_pk'], $Depth+1,$IncludeTop,$SelectId,$linkParent,$row['parent']);
+    }
+  }
+  pg_free_result($result);
+  return($V);
+} // ProjectListOption()
+
+/**
+ * \brief Given a project_pk, return the full path to this project.
+ * \note This is recursive!
+ * \note If there is a recursive loop in the project table, then
+ * this will loop INFINITELY.
+ *
+ * \param int $ProjectPk Project id
+ * \param int $Top Optional, default is user's top project. project_pk of top of desired path.
+ *
+ * \return string full path of this project
+ */
+function ProjectGetName($ProjectPk,$Top=-1)
+{
+  global $PG_CONN;
+  if ($Top == -1) {
+    $Top = ProjectGetTop();
+  }
+  $sql = "SELECT project_name,projectcontents.parent_fk FROM project
+	LEFT JOIN projectcontents ON projectcontents_mode = ".ProjectDao::MODE_PROJECT."
+	AND child_id = '$ProjectPk'
+	WHERE project_pk = '$ProjectPk'
+	LIMIT 1;";
+  $result = pg_query($PG_CONN, $sql);
+  DBCheckResult($result, $sql, __FILE__, __LINE__);
+  $row = pg_fetch_assoc($result);
+  $Parent = $row['parent_fk'];
+  $Name = $row['project_name'];
+  if (! empty($Parent) && ($ProjectPk != $Top)) {
+    $Name = ProjectGetName($Parent,$Top) . "/" . $Name;
+  }
+  return($Name);
+}
+
+
+/**
+ * \brief DEPRECATED! Given an upload number, return the
+ * project path in an array containing project_pk and name.
+ * \note This is recursive!
+ * \note If there is a recursive loop in the project table, then
+ * this will loop INFINITELY.
+ * \deprecated Use Project2Path() and GetProjectFromItem()
+ */
+function ProjectGetFromUpload($Uploadpk, $Project = -1, $Stop = -1)
+{
+  global $PG_CONN;
+  if (empty($PG_CONN)) {
+    return;
+  }
+  if (empty($Uploadpk)) {
+    return;
+  }
+  if ($Stop == - 1) {
+    $Stop = ProjectGetTop();
+  }
+  if ($Project == $Stop) {
+    return;
+  }
+
+  $sql = "";
+  $Parm = "";
+  if ($Project < 0) {
+    /* Mode 2 means child_id is an upload_pk */
+    $Parm = $Uploadpk;
+    $sql = "SELECT projectcontents.parent_fk,project_name FROM projectcontents
+              INNER JOIN project ON projectcontents.parent_fk = project.project_pk
+			  AND projectcontents.projectcontents_mode = " . ProjectDao::MODE_UPLOAD."
+			  WHERE projectcontents.child_id = $Parm LIMIT 1;";
+  } else {
+    /* Mode 1 means child_id is a project_pk */
+    $Parm = $Project;
+    $sql = "SELECT projectcontents.parent_fk,project_name FROM projectcontents
+			  INNER JOIN project ON projectcontents.parent_fk = project.project_pk
+			  AND projectcontents.projectcontents_mode = 1
+			  WHERE projectcontents.child_id = $Parm LIMIT 1;";
+  }
+  $result = pg_query($PG_CONN, $sql);
+  DBCheckResult($result, $sql, __FILE__, __LINE__);
+  $R = pg_fetch_assoc($result);
+  if (empty($R['parent_fk'])) {
+    pg_free_result($result);
+    return;
+  }
+  $V = array();
+  $V['project_pk'] = $R['parent_fk'];
+  $V['project_name'] = $R['project_name'];
+  if ($R['parent_fk'] != 0) {
+    $List = ProjectGetFromUpload($Uploadpk, $R['parent_fk'],$Stop);
+  }
+  if (empty($List)) {
+    $List = array();
+  }
+  array_push($List,$V);
+  pg_free_result($result);
+  return($List);
+} // ProjectGetFromUpload()
+
+
+/**
+ * \brief Returns an array of uploads in a project.
+ *
+ *  Only uploads for which the user has permission >= $perm are returned.
+ *  This does NOT recurse.
+ *  The returned array is sorted by ufile_name and upload_pk.
+ * \param int $ParentProject Optional project_pk, default is users root project.
+ * \param int $perm Minimum permission
+ * \return `array{upload_pk, upload_desc, upload_ts, ufile_name}`
+ *  for all uploads in a given project.
+ *
+ */
+function ProjectListUploads_perm($ParentProject, $perm)
+{
+  global $PG_CONN;
+
+  if (empty($PG_CONN)) {
+    return;
+  }
+  if (empty($ParentProject)) {
+    return;
+  }
+  if ($ParentProject == "-1") {
+    $ParentProject = GetUserRootProject();
+  }
+  $groupId = Auth::getGroupId();
+  /* @var $uploadDao UploadDao */
+  $uploadDao = $GLOBALS['container']->get('dao.upload');
+  $List=array();
+
+  /* Get list of uploads under $ParentProject */
+  /* mode 2 = upload_fk */
+  $sql = "SELECT upload_pk, upload_desc, upload_ts, upload_filename
+	FROM projectcontents,upload
+  INNER JOIN uploadtree ON upload_fk = upload_pk AND upload.pfile_fk = uploadtree.pfile_fk AND parent IS NULL AND lft IS NOT NULL
+	WHERE projectcontents.parent_fk = '$ParentProject'
+	AND projectcontents.projectcontents_mode = ".ProjectDao::MODE_UPLOAD."
+	AND projectcontents.child_id = upload.upload_pk
+	ORDER BY upload_filename,upload_pk;";
+  $result = pg_query($PG_CONN, $sql);
+  DBCheckResult($result, $sql, __FILE__, __LINE__);
+  while ($R = pg_fetch_assoc($result)) {
+    if (empty($R['upload_pk'])) {
+      continue;
+    }
+    if ($perm == Auth::PERM_READ &&
+      ! $uploadDao->isAccessible($R['upload_pk'], $groupId)) {
+      continue;
+    }
+    if ($perm == Auth::PERM_WRITE &&
+      ! $uploadDao->isEditable($R['upload_pk'], $groupId)) {
+      continue;
+    }
+
+    $New = array();
+    $New['upload_pk'] = $R['upload_pk'];
+    $New['upload_desc'] = $R['upload_desc'];
+    $New['upload_ts'] = Convert2BrowserTime(substr($R['upload_ts'], 0, 19));
+    $New['name'] = $R['upload_filename'];
+    array_push($List,$New);
+  }
+  pg_free_result($result);
+  return($List);
+} // ProjectListUploads_perm()
+
+/**
+ * @brief Get uploads and project info, starting from $ParentProject.
+ *
+ * The array is sorted by project and upload name.
+ * Projects that are empty do not show up.
+ * \note This is recursive!
+ * \note If there is a recursive loop in the project table, then
+ * this will loop INFINITELY.
+ *
+ * @param int $ParentProject project_pk, -1 for users root project
+ * @param string $ProjectPath Used for recursion, caller should not specify.
+ * @param Auth::PERM_READ|Auth::PERM_WRITE $perm Permission required
+ * @return array of `{upload_pk, upload_desc, name, project}`
+ */
+function ProjectListUploadsRecurse($ParentProject=-1, $ProjectPath = '',
+  $perm = Auth::PERM_READ)
+{
+  global $PG_CONN;
+  if (empty($PG_CONN)) {
+    return array();
+  }
+  if (empty($ParentProject)) {
+    return array();
+  }
+  if ($perm != Auth::PERM_READ && $perm = Auth::PERM_WRITE) {
+    return array();
+  }
+  if ($ParentProject == "-1") {
+    $ParentProject = ProjectGetTop();
+  }
+  $groupId = Auth::getGroupId();
+  /* @var $uploadDao UploadDao */
+  $uploadDao = $GLOBALS['container']->get('dao.upload');
+  $List=array();
+
+  /* Get list of uploads */
+  /* mode 1<<1 = upload_fk */
+  $sql = "SELECT upload_pk, upload_desc, ufile_name, project_name FROM project,projectcontents,uploadtree, upload
+    WHERE
+        projectcontents.parent_fk = '$ParentProject'
+    AND projectcontents.projectcontents_mode = ". ProjectDao::MODE_UPLOAD ."
+    AND projectcontents.child_id = upload.upload_pk
+    AND project.project_pk = $ParentProject
+    AND uploadtree.upload_fk = upload.upload_pk
+    AND uploadtree.parent is null
+    ORDER BY uploadtree.ufile_name,upload.upload_desc";
+  $result = pg_query($PG_CONN, $sql);
+  DBCheckResult($result, $sql, __FILE__, __LINE__);
+  while ($R = pg_fetch_assoc($result)) {
+    if (empty($R['upload_pk'])) {
+      continue;
+    }
+    if ($perm == Auth::PERM_READ &&
+      ! $uploadDao->isAccessible($R['upload_pk'], $groupId)) {
+      continue;
+    }
+    if ($perm == Auth::PERM_WRITE &&
+      ! $uploadDao->isEditable($R['upload_pk'], $groupId)) {
+      continue;
+    }
+
+    $New = array();
+    $New['upload_pk'] = $R['upload_pk'];
+    $New['upload_desc'] = $R['upload_desc'];
+    $New['name'] = $R['ufile_name'];
+    $New['project'] = $ProjectPath . "/" . $R['project_name'];
+    array_push($List,$New);
+  }
+  pg_free_result($result);
+
+  /* Get list of subprojects and recurse */
+  /* mode 1<<0 = project_pk */
+  $sql = "SELECT A.child_id AS id,B.project_name AS project,B.project_name AS subproject
+	FROM projectcontents AS A
+	INNER JOIN project AS B ON A.parent_fk = B.project_pk
+	AND A.projectcontents_mode = ". ProjectDao::MODE_PROJECT ."
+	AND A.parent_fk = '$ParentProject'
+  AND B.project_pk = $ParentProject
+	ORDER BY B.project_name;";
+  $result = pg_query($PG_CONN, $sql);
+  DBCheckResult($result, $sql, __FILE__, __LINE__);
+  while ($R = pg_fetch_assoc($result)) {
+    if (empty($R['id'])) {
+      continue;
+    }
+    /* RECURSE! */
+    $SubList = ProjectListUploadsRecurse($R['id'], $ProjectPath . "/" . $R['project'], $perm);
+    $List = array_merge($List,$SubList);
+  }
+  pg_free_result($result);
+  /* Return findings */
+  return($List);
+} // ProjectListUploadsRecurse()
+
+
+/**
+ * \brief Get an array of all the projects from a $RootProject on down.
+ *
+ * Recursive. This is typically used to build a select list of project names.
+ *
+ * \param int $RootProject Default is entire software repository
+ * \param[out] array $ProjectArray Returned array of project_pk=>project_name's
+ *
+ * \return $ProjectArray of `{project_pk=>project_name, project_pk=>project_name, ...}`
+ * in project order.
+ * If no projects are in the list, an empty array is returned.
+ *
+ * \todo Possibly this could be a common function and ProjectListOption() could
+ *       use this for its data.  In general data collection and data formatting
+ *       should be separate functions.
+ */
+function GetProjectArray($RootProject, &$ProjectArray)
+{
+  global $PG_CONN;
+
+  if ($RootProject == "-1") {
+    $RootProject = ProjectGetTop();
+  }
+  if (empty($RootProject)) {
+    return $ProjectArray;
+  }
+
+  /* Load this project's name */
+  $sql = "SELECT project_name, project_pk FROM project WHERE project_pk=$RootProject LIMIT 1;";
+  $result = pg_query($PG_CONN, $sql);
+  DBCheckResult($result, $sql, __FILE__, __LINE__);
+  $row = pg_fetch_assoc($result);
+  pg_free_result($result);
+
+  $Name = trim($row['project_name']);
+  $ProjectArray[$row['project_pk']] = $row['project_name'];
+
+  /* Load any subprojects */
+  $sql = "SELECT project.project_pk, project.project_name,
+            projectcontents.parent_fk
+            FROM project, projectcontents
+            WHERE projectcontents.projectcontents_mode = ".ProjectDao::MODE_PROJECT."
+            AND projectcontents.parent_fk =$RootProject
+            AND projectcontents.child_id = project.project_pk
+            AND project.project_pk is not null
+            ORDER BY project_name";
+  $result = pg_query($PG_CONN, $sql);
+  DBCheckResult($result, $sql, __FILE__, __LINE__);
+  if (pg_num_rows($result) > 0) {
+    while ($row = pg_fetch_assoc($result)) {
+      GetProjectArray($row['project_pk'], $ProjectArray);
+    }
+  }
+  pg_free_result($result);
+}
+
+// /**
+//  * \brief Check if one file path contains an excluding text
+//  *
+//  * \param string $FilePath File path
+//  * \param string $ExcludingText Excluding text
+//  *
+//  * \return 1: include, 0: not include
+//  */
+// function ContainExcludeString($FilePath, $ExcludingText)
+// {
+//   $excluding_length = 0;
+//   $excluding_flag = 0; // 1: exclude 0: not exclude
+//   if ($ExcludingText) {
+//     $excluding_length = strlen($ExcludingText);
+//   }
+
+//   /* filepath contains 'xxxx/', '/xxxx/', 'xxxx', '/xxxx' */
+//   if ($excluding_length > 0 && strstr($FilePath, $ExcludingText)) {
+//     $excluding_flag = 1;
+//     /* filepath does not contain 'xxxx/' */
+//     if ('/' != $ExcludingText[0] && '/' == $ExcludingText[$excluding_length - 1] &&
+//       ! strstr($FilePath, '/'.$ExcludingText)) {
+//       $excluding_flag = 0;
+//     }
+//   }
+//   return $excluding_flag;
+// }

--- a/src/lib/php/common-scheduler.php
+++ b/src/lib/php/common-scheduler.php
@@ -126,6 +126,7 @@ function fo_communicate_with_scheduler($input, &$output, &$error_msg)
   $sock = fo_scheduler_connect($address, $port, $error_msg);
   if ($sock) {
     $msg = trim($input);
+
     $write_result = fo_scheduler_write($sock, $msg);
     if ($write_result) {
       while ($buf = fo_scheduler_read($sock)) {

--- a/src/lib/php/common.php
+++ b/src/lib/php/common.php
@@ -36,6 +36,9 @@ require_once("common-scheduler.php");
 require_once("common-menu.php");
 require_once("common-plugin.php");
 require_once("common-folders.php");
+
+require_once("common-projects.php");
+
 require_once("common-dir.php");
 require_once("common-parm.php");
 require_once("common-repo.php");

--- a/src/lib/php/services.xml.in
+++ b/src/lib/php/services.xml.in
@@ -52,6 +52,13 @@ SPDX-License-Identifier: FSFAP
             <argument type="service" id="dao.user"/>
             <argument type="service" id="dao.upload"/>
         </service>
+
+        <service id="dao.project" class="Fossology\Lib\Dao\ProjectDao" public="true">
+            <argument type="service" id="db.manager"/>
+            <argument type="service" id="dao.user"/>
+            <argument type="service" id="dao.upload"/>
+        </service>
+
         <service id="dao.package" class="Fossology\Lib\Dao\PackageDao" public="true">
             <argument type="service" id="db.manager"/>
             <argument type="service" id="logger"/>
@@ -170,6 +177,12 @@ SPDX-License-Identifier: FSFAP
         <service id="ui.folder.nav" class="Fossology\Lib\UI\FolderNav" public="true">
             <argument type="service" id="db.manager"/>
             <argument type="service" id="dao.folder"/>
+        </service>
+
+        <service id="ui.project.nav" class="Fossology\Lib\UI\ProjectNav" public="true">
+            <argument type="service" id="db.manager"/>
+            <!-- <argument type="service" id="dao.folder"/> -->
+            <argument type="service" id="dao.project"/>
         </service>
 
         <service id="twig.loader" class="Twig\Loader\FilesystemLoader" public="true">

--- a/src/readmeoss/agent/readmeoss.php
+++ b/src/readmeoss/agent/readmeoss.php
@@ -88,6 +88,8 @@ class ReadmeOssAgent extends Agent
     $this->uploadDao = $this->container->get('dao.upload');
 
     $this->agentSpecifLongOptions[] = self::UPLOAD_ADDS.':';
+    // $this->agentSpecifLongOptions[] = 'type:';
+    
   }
 
   /**
@@ -97,10 +99,45 @@ class ReadmeOssAgent extends Agent
    */
   function processUploadId($uploadId)
   {
+
+    echo("<script>console.log('processUploadId begin');</script>");
+    echo("<script>console.log('uploadId');</script>");
+    echo("<script>console.log('".json_encode($uploadId)."');</script>");
+
     $groupId = $this->groupId;
 
     $args = $this->args;
-    $this->additionalUploadIds = array_key_exists(self::UPLOAD_ADDS,$args) ? explode(',',$args[self::UPLOAD_ADDS]) : array();
+
+    echo("args");
+    echo(json_encode($args));
+
+
+    $type = array_key_exists("type", $args) ? $args["type"] : "";
+    echo("<script>console.log('type');</script>");
+    echo("<script>console.log('".json_encode($type)."');</script>");
+
+
+    // $this->additionalUploadIds = array_key_exists(self::UPLOAD_ADDS,$args) ? explode(',',$args[self::UPLOAD_ADDS]) : array();
+
+    if ( array_key_exists(self::UPLOAD_ADDS,$args)) {
+      $tmp1 = $args[self::UPLOAD_ADDS];
+      echo("tmp1"."\n");
+      echo(json_encode($tmp1)."\n");
+
+      $tmpArr = explode(' ',$tmp1);
+      echo("tmpArr"."\n");
+      echo(json_encode($tmpArr)."\n");
+
+      $this->additionalUploadIds = explode(',',$tmpArr[0]);
+      echo("additionalUploadIds"."\n");
+      echo(json_encode($this->additionalUploadIds)."\n");
+      
+      $type = substr($tmpArr[1], 7);
+      echo("type"."\n");
+      echo(json_encode($type)."\n");
+    }
+    
+
     $uploadIds = $this->additionalUploadIds;
     array_unshift($uploadIds, $uploadId);
 
@@ -115,17 +152,52 @@ class ReadmeOssAgent extends Agent
         continue;
       }
       $moreLicenses = $this->licenseClearedGetter->getCleared($addUploadId, $this, $groupId, true, "license", false);
+
+      echo("moreLicenses"."\n");
+      echo(json_encode($moreLicenses)."\n");
+
       $licenseStmts = array_merge($licenseStmts, $moreLicenses['statements']);
       $this->heartbeat(count($moreLicenses['statements']));
+
+      
+      echo("licenseStmts"."\n");
+      echo(json_encode($licenseStmts)."\n");
+
       $this->licenseClearedGetter->setOnlyAcknowledgements(true);
       $moreAcknowledgements = $this->licenseClearedGetter->getCleared($addUploadId, $this, $groupId, true, "license", false);
+
+      echo("moreAcknowledgements"."\n");
+      echo(json_encode($moreAcknowledgements)."\n");
+
       $licenseAcknowledgements = array_merge($licenseAcknowledgements, $moreAcknowledgements['statements']);
+
+      echo("licenseAcknowledgements"."\n");
+      echo(json_encode($licenseAcknowledgements)."\n");
+
       $this->heartbeat(count($moreAcknowledgements['statements']));
       $moreCopyrights = $this->cpClearedGetter->getCleared($addUploadId, $this, $groupId, true, "copyright", false);
+
+      echo("moreCopyrights"."\n");
+      echo(json_encode($moreCopyrights)."\n");
+
       $copyrightStmts = array_merge($copyrightStmts, $moreCopyrights['statements']);
+
+      echo("copyrightStmts"."\n");
+      echo(json_encode($copyrightStmts)."\n");
+
       $this->heartbeat(count($moreCopyrights['statements']));
       $moreMainLicenses = $this->licenseMainGetter->getCleared($addUploadId, $this, $groupId, true, null, false);
+
+      echo("moreMainLicenses"."\n");
+      echo(json_encode($moreMainLicenses)."\n");
+      
       $licenseStmtsMain = array_merge($licenseStmtsMain, $moreMainLicenses['statements']);
+
+
+      echo("licenseStmtsMain"."\n");
+      echo(json_encode($licenseStmtsMain)."\n");
+      
+
       $this->heartbeat(count($moreMainLicenses['statements']));
     }
     list($licenseStmtsMain, $licenseStmts) = $this->licenseClearedGetter->updateIdentifiedGlobalLicenses($licenseStmtsMain, $licenseStmts);

--- a/src/readmeoss/ui/ReadMeOssAgentPlugin.php
+++ b/src/readmeoss/ui/ReadMeOssAgentPlugin.php
@@ -50,6 +50,14 @@ class ReadMeOssAgentPlugin extends AgentPlugin
     }
     return '--uploadsAdd='. implode(',', array_keys($uploads));
   }
+
+  public function uploadsAddWithType($uploads, $type)
+  {
+    if (count($uploads) == 0) {
+      return '';
+    }
+    return '--uploadsAdd='. implode(',', array_keys($uploads))." --type=".$type;
+  }
 }
 
 register_plugin(new ReadMeOssAgentPlugin());

--- a/src/www/ui/admin-project-create.php
+++ b/src/www/ui/admin-project-create.php
@@ -1,0 +1,100 @@
+<?php
+/***********************************************************
+ Copyright (C) 2008-2011 Hewlett-Packard Development Company, L.P.
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***********************************************************/
+use Fossology\Lib\Dao\ProjectDao;
+
+class project_create extends FO_Plugin
+{
+  function __construct()
+  {
+    $this->Name = "project_create";
+    $this->Title = _("Create a new Fossology project");
+    $this->MenuList = "Organize::Project::Create";
+    $this->Dependency = array ();
+    $this->DBaccess = PLUGIN_DB_WRITE;
+    parent::__construct();
+  }
+
+  /**
+   * \brief Given a parent project ID, a name and description,
+   * create the named project under the parent.
+   *
+   * Includes idiot checking since the input comes from stdin.
+   *
+   * @param $parentId - parent project id
+   * @param $newProject - new project name
+   * @param $desc - new project discription
+   *
+   * @return int 1 if created, 0 if failed
+   */
+  public function create($parentId, $newProject, $desc)
+  {
+    $projectName = trim($newProject);
+    if (empty($projectName)) {
+      return (0);
+    }
+
+    /* @var $projectDao ProjectDao*/
+    $projectDao = $GLOBALS['container']->get('dao.project');
+
+    $parentExists = $projectDao->getProject($parentId);
+    if (! $parentExists) {
+      return (0);
+    }
+
+    $projectWithSameNameUnderParent = $projectDao->getProjectId($projectName, $parentId);
+    if (! empty($projectWithSameNameUnderParent)) {
+      return 4;
+    }
+
+    $projectDao->createProject($projectName, $desc, $parentId);
+    return (1);
+  }
+
+  /**
+   * \brief Generate the text for this plugin.
+   */
+  public function Output()
+  {
+    /* If this is a POST, then process the request. */
+    $ParentId = GetParm('parentid', PARM_INTEGER);
+    $NewProject = GetParm('newname', PARM_TEXT);
+    $Desc = GetParm('description', PARM_TEXT);
+
+    if (! empty($ParentId) && ! empty($NewProject)) {
+      $rc = $this->create($ParentId, $NewProject, $Desc);
+      if ($rc == 1) {
+        /* Need to refresh the screen */
+        $text = _("Project");
+        $text1 = _("Created");
+        $this->vars['message'] = "$text " . htmlentities($NewProject) . " $text1";
+      } else if ($rc == 4) {
+        $text = _("Project");
+        $text1 = _("Exists");
+        $this->vars['message'] = "$text " . htmlentities($NewProject) . " $text1";
+      }
+    }
+
+    $root_project_pk = GetUserRootProject();
+    $formVars["projectOptions"] = ProjectListOption($root_project_pk, 0);
+
+    return $this->renderString("admin-project-create-form.html.twig",$formVars);
+  }
+}
+
+$NewPlugin = new project_create();
+$NewPlugin->Initialize();

--- a/src/www/ui/admin-project-edit.php
+++ b/src/www/ui/admin-project-edit.php
@@ -1,0 +1,107 @@
+<?php
+/***********************************************************
+ Copyright (C) 2008-2012 Hewlett-Packard Development Company, L.P.
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***********************************************************/
+
+use Fossology\Lib\Db\DbManager;
+
+define("TITLE_PROJECT_PROPERTIES", _("Edit Project Properties"));
+
+class project_properties extends FO_Plugin
+{
+
+  /** @var DbManager */
+  private $dbManager;
+
+  function __construct()
+  {
+    $this->Name = "project_properties";
+    $this->Title = TITLE_PROJECT_PROPERTIES;
+    $this->MenuList = "Organize::Project::Edit Properties";
+    $this->Dependency = array();
+    $this->DBaccess = PLUGIN_DB_WRITE;
+    parent::__construct();
+    $this->dbManager = $GLOBALS['container']->get('db.manager');
+  }
+
+  /**
+   * \brief Given a project's ID and a name, alter
+   * the project properties.
+   * Includes idiot checking since the input comes from stdin.
+   * \return 1 if changed, 0 if failed.
+   */
+  function Edit($ProjectId, $NewName, $NewDesc)
+  {
+    $sql = 'SELECT * FROM project where project_pk = $1;';
+    $Row = $this->dbManager->getSingleRow($sql,array($ProjectId),__METHOD__."Get");
+    /* If the project does not exist. */
+    if ($Row['project_pk'] != $ProjectId) {
+      return (0);
+    }
+    $NewName = trim($NewName);
+    if (! empty($ProjectId)) {
+      // Reuse the old name if no new name was given
+      if (empty($NewName)) {
+        $NewName = $Row['project_name'];
+      }
+      // Reuse the old description if no new description was given
+      if (empty($NewDesc)) {
+        $NewDesc = $Row['project_desc'];
+      }
+    } else {
+      return (0); // $ProjectId is empty
+    }
+    /* Change the properties */
+    $sql = 'UPDATE project SET project_name = $1, project_desc = $2 WHERE project_pk = $3;';
+    $this->dbManager->getSingleRow($sql,array($NewName, $NewDesc, $ProjectId),__METHOD__."Set");
+    return (1);
+  }
+
+  /**
+   * \brief Generate the text for this plugin.
+   */
+  public function Output()
+  {
+    /* If this is a POST, then process the request. */
+    $ProjectSelectId = GetParm('selectprojectid', PARM_INTEGER);
+    if (empty($ProjectSelectId)) {
+      $ProjectSelectId = ProjectGetTop();
+    }
+    $ProjectId = GetParm('oldprojectid', PARM_INTEGER);
+    $NewName = GetParm('newname', PARM_TEXT);
+    $NewDesc = GetParm('newdesc', PARM_TEXT);
+    if (! empty($ProjectId)) {
+      $ProjectSelectId = $ProjectId;
+      $rc = $this->Edit($ProjectId, $NewName, $NewDesc);
+      if ($rc == 1) {
+        /* Need to refresh the screen */
+        $text = _("Project Properties changed");
+        $this->vars["message"] = $text;
+      }
+    }
+    /* Get the project info */
+    $sql = 'SELECT * FROM project WHERE project_pk = $1;';
+    $Project = $this->dbManager->getSingleRow($sql,array($ProjectSelectId),__METHOD__."getProjectRow");
+
+    /* Display the form */
+    $formVars["onchangeURI"] = Traceback_uri() . "?mod=" . $this->Name . "&selectprojectid=";
+    $formVars["projectListOption"] = ProjectListOption(-1, 0, 1, $ProjectSelectId);
+    $formVars["project_name"] = $Project['project_name'];
+    $formVars["project_desc"] = $Project['project_desc'];
+    return $this->renderString("admin-project-edit-form.html.twig",$formVars);
+  }
+}
+$NewPlugin = new project_properties;

--- a/src/www/ui/async/AjaxBrowseProject.php
+++ b/src/www/ui/async/AjaxBrowseProject.php
@@ -1,0 +1,345 @@
+<?php
+/***********************************************************
+ * Copyright (C) 2014-2015 Siemens AG
+ * Author: J.Najjar, S. Weber
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ ***********************************************************/
+
+namespace Fossology\UI\Ajax;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Dao\UserDao;
+use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\Plugin\DefaultPlugin;
+use Fossology\Lib\Proxy\UploadBrowseProxy;
+use Fossology\Lib\UI\MenuHook;
+use Fossology\Lib\UI\MenuRenderer;
+use Fossology\Lib\Util\DataTablesUtility;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AjaxBrowseProject extends DefaultPlugin
+{
+  const NAME = "browseProject-processPost";
+
+  /** @var UploadDao $uploadDao */
+  private $uploadDao;
+  /** @var UserDao $userDao */
+  private $userDao;
+  /** @var DbManager dbManager */
+  private $dbManager;
+  /** @var DataTablesUtility $dataTablesUtility */
+  private $dataTablesUtility;
+  /** @var array */
+  private $filterParams;
+  /** @var int */
+  private $userPerm;
+  /** @var array */
+  private $statusTypes;
+
+  function __construct()
+  {
+    parent::__construct(self::NAME, array(
+      self::REQUIRES_LOGIN => false,
+      self::PERMISSION => Auth::PERM_READ
+    ));
+    global $container;
+    $this->uploadDao = $container->get('dao.upload');
+    $this->userDao = $container->get('dao.user');
+    $this->dbManager = $container->get('db.manager');
+    $this->dataTablesUtility = $container->get('utils.data_tables_utility');
+  }
+
+  /**
+   * @brief Display the loaded menu and plugins.
+   */
+  protected function handle(Request $request)
+  {
+    $groupId = Auth::getGroupId();
+    $gup = $this->dbManager->getSingleRow('SELECT group_perm FROM group_user_member WHERE user_fk=$1 AND group_fk=$2',
+        array(Auth::getUserId(), $groupId), __METHOD__ . '.user_perm');
+    if (!$gup) {
+      throw new \Exception('You are assigned to wrong group.');
+    }
+    $this->userPerm = $gup['group_perm'];
+
+    $uploadId = intval($request->get('uploadId'));
+    if ($uploadId && !$this->uploadDao->isAccessible($uploadId, $groupId)) {
+      throw new \Exception('You cannot access to this upload');
+    }
+
+    $columnName = $request->get('columnName');
+    $statusId = intval($request->get('statusId'));
+    $value = intval($request->get('value'));
+    $moveUpload = intval($request->get("move"));
+    $beyondUpload = intval($request->get("beyond"));
+    $commentText = $request->get('commentText');
+    $direction = $request->get('direction');
+
+    if (! empty($columnName) && ! empty($uploadId) && ! empty($value)) {
+      $uploadBrowseProxy = new UploadBrowseProxy($groupId, $this->userPerm, $this->dbManager);
+      $uploadBrowseProxy->updateTable($columnName, $uploadId, $value);
+    } else if (! empty($moveUpload) && ! empty($beyondUpload)) {
+      $uploadBrowseProxy = new UploadBrowseProxy($groupId, $this->userPerm, $this->dbManager);
+      $uploadBrowseProxy->moveUploadBeyond($moveUpload, $beyondUpload);
+    } else if (! empty($uploadId) && ! empty($direction)) {
+      $uploadBrowseProxy = new UploadBrowseProxy($groupId, $this->userPerm, $this->dbManager);
+      $uploadBrowseProxy->moveUploadToInfinity($uploadId, $direction == 'top');
+    } else if (!empty($uploadId) && !empty($commentText) && !empty($statusId)) {
+      $uploadBrowseProxy = new UploadBrowseProxy($groupId, $this->userPerm, $this->dbManager);
+      $uploadBrowseProxy->setStatusAndComment($uploadId, $statusId, $commentText);
+    } else {
+      return $this->respondProjectGetTableData($request);
+    }
+    return new Response('');
+  }
+
+
+  /**
+   * @param Request $request
+   * @return JsonResponse
+   */
+  protected function respondProjectGetTableData(Request $request)
+  {
+    /* Get list of uploads in this project */
+    list($result, $iTotalDisplayRecords, $iTotalRecords) = $this->getListOfUploadsOfProject($request);
+
+    $uri = Traceback_uri() . "?mod=license";
+    /* Browse-Pfile menu */
+    $menuPfile = menu_find("Browse-Pfile", $menuDepth);
+    /* Browse-Pfile menu without the compare menu item */
+    $menuPfileNoCompare = menu_remove($menuPfile, "Compare");
+
+    $users = $this->userDao->getUserChoices();
+
+    $statusTypesAvailable = $this->uploadDao->getStatusTypeMap();
+    if (!$this->userPerm) {
+      unset($statusTypesAvailable[4]);
+    }
+
+    $output = array();
+    $rowCounter = 0;
+    while ($row = $this->dbManager->fetchArray($result)) {
+      if (empty($row['upload_pk']) || !$this->uploadDao->isAccessible($row['upload_pk'],Auth::getGroupId())) {
+        continue;
+      }
+      $rowCounter++;
+      $output[] = $this->showRow($row, $request, $uri, $menuPfile, $menuPfileNoCompare, $statusTypesAvailable, $users, $rowCounter);
+    }
+    $this->dbManager->freeResult($result);
+    return new JsonResponse(array(
+              'sEcho' => intval($request->get('sEcho')),
+              'aaData' => $output,
+              'iTotalRecords' => $iTotalRecords,
+              'iTotalDisplayRecords' => $iTotalDisplayRecords
+          ));
+  }
+
+
+  /**
+   * @param array $row fetched row
+   * @param Request $request
+   * @param $uri
+   * @param $menuPfile
+   * @param $menuPfileNoCompare
+   * @param array $statusTypesAvailable
+   * @param array $users
+   * @param string (unique)
+   * @return array
+   */
+  private function showRow($row,Request $request, $uri, $menuPfile, $menuPfileNoCompare, $statusTypesAvailable, $users, $rowCounter)
+  {
+    $show = $request->get('show');
+    $project = $request->get('project');
+
+    $uploadId = intval($row['upload_pk']);
+    $description = htmlentities($row['upload_desc']);
+
+    $fileName = $row['ufile_name'];
+    if (empty($fileName)) {
+      $fileName = $row['upload_filename'];
+    }
+
+    $itemId = Isartifact($row['ufile_mode']) ? DirGetNonArtifact($row['uploadtree_pk']) : $row['uploadtree_pk'];
+    if (strlen($fileName) > 20) {
+      $splitFileName = str_split($fileName, 20);
+      $fileName = "";
+      foreach ($splitFileName as $key => $value) {
+        if (strlen($value) > 3 && $key > 0) {
+          $fileName .= "<br/>".$value;
+        } else {
+          $fileName = $fileName.$value;
+        }
+      }
+    }
+    $nameColumn = "<strong class='btn btn-sm font-weight-bold' style='margin-left:10px;font-size:11pt;'>$fileName</strong>";
+    if (IsContainer($row['ufile_mode'])) {
+      $nameColumn = "<a href='$uri&upload=$uploadId&project=$project&item=$itemId&show=$show'>$nameColumn</a>";
+    }
+    $nameColumn .= "<br>";
+    if (!empty($description)) {
+      $nameColumn .= "<i>$description</i><br>";
+    }
+    $Parm = "upload=$uploadId&show=$show&item=" . $row['uploadtree_pk'];
+    if (Iscontainer($row['ufile_mode'])) {
+      $nameAction = MenuRenderer::menuToActiveSelect($menuPfile, $Parm, $uploadId);
+    } else {
+      $nameAction = MenuRenderer::menuToActiveSelect($menuPfileNoCompare, $Parm, $uploadId);
+    }
+
+    $modsUploadMulti = MenuHook::getAgentPluginNames('UploadMulti');
+    if (!empty($modsUploadMulti)) {
+      $nameColumn = '<input type="checkbox" name="uploads[]" class="browse-upload-checkbox" style="width:1.10rem;height:1.10rem;" value="'.$uploadId.'"/>'.$nameColumn;
+    }
+
+    $dateCol = Convert2BrowserTime(substr($row['upload_ts'], 0, 19));
+    if (!$this->userPerm && 4 == $row['status_fk']) {
+      $currentStatus = $this->statusTypes[4];
+    } else {
+      $statusAction = " onchange =\"changeTableEntry(this, $uploadId,'status_fk' )\" ";
+      $currentStatus = $this->createSelect("Status" . $this->userPerm . "Of_$rowCounter", $statusTypesAvailable, $row['status_fk'], $statusAction);
+    }
+    if ($this->userPerm) {
+      $action = " onchange =\"changeTableEntry(this, $uploadId, 'assignee')\"";
+      $currentAssignee = $this->createSelectUsers("AssignedTo_$rowCounter", $users, $row['assignee'], $action );
+    } else {
+      $currentAssignee = array_key_exists($row['assignee'], $users) ? $users[$row['assignee']] : _('Unassigned');
+    }
+    $rejectableUploadId = ($this->userPerm || $row['status_fk'] < 4) ? $uploadId : 0;
+    $tripleComment = array($rejectableUploadId, $row['status_fk'], htmlspecialchars($row['status_comment']));
+
+    $sql = "SELECT rf_pk, rf_shortname FROM upload_clearing_license ucl, license_ref"
+            . " WHERE ucl.group_fk=$1 AND upload_fk=$2 AND ucl.rf_fk=rf_pk";
+    $stmt = __METHOD__.'.collectMainLicenses';
+    $this->dbManager->prepare($stmt, $sql);
+    $res = $this->dbManager->execute($stmt,array(Auth::getGroupId(),$uploadId));
+    $mainLicenses = array();
+    while ($lic=$this->dbManager->fetchArray($res)) {
+      $mainLicenses[] = '<a onclick="javascript:window.open(\''.Traceback_uri()
+              ."?mod=popup-license&rf=$lic[rf_pk]','License text','width=600,height=400,toolbar=no,scrollbars=yes,resizable=yes');"
+              .'" href="javascript:;">'.$lic['rf_shortname'].'</a>'
+              ."<img onclick=\"removeMainLicense($uploadId,$lic[rf_pk]);\" class=\"delete\" src=\"images/space_16.png\" alt=\"\"/></img>";
+    }
+    $this->dbManager->freeResult($res);
+
+    $output = array($nameColumn, $nameAction, $currentStatus, $tripleComment, implode(', ', $mainLicenses), $dateCol, $currentAssignee);
+    return $output;
+  }
+
+  /**
+   * @param string $selectElementName
+   * @param array $databaseMap
+   * @param int $selectedValue
+   * @return array
+   */
+  private function createSelectUsers($selectElementName, $databaseMap, $selectedValue, $action = "")
+  {
+    if (array_key_exists($_SESSION['UserId'], $databaseMap)) {
+      $databaseMap[$_SESSION['UserId']] = _('-- Me --');
+    }
+    $databaseMap[1] = _('Unassigned');
+    return $this->createSelect($selectElementName,$databaseMap, $selectedValue,$action);
+  }
+
+
+  private function createSelect($id,$options,$select='',$action='')
+  {
+    $html = "<select class='form-control-sm' style=\"max-width:250px;\" name=\"$id\" id=\"$id\" $action class=\"ui-render-select2\">";
+    foreach ($options as $key=>$disp) {
+      $html .= '<option value="'.$key.'"';
+      if ($key == $select) {
+        $html .= ' selected';
+      }
+      $html .= ">$disp</option>";
+    }
+    $html .= '</select>';
+    return $html;
+  }
+
+
+  /**
+   * @param Request $request
+   * @return array
+   */
+  private function getListOfUploadsOfProject(Request $request)
+  {
+    $uploadBrowseProxy = new UploadBrowseProxy(Auth::getGroupId(), $this->userPerm, $this->dbManager);
+    $params = array($request->get('project'));
+    $partQuery = $uploadBrowseProxy->getProjectPartialQuery($params);
+
+    $iTotalRecordsRow = $this->dbManager->getSingleRow("SELECT count(*) FROM $partQuery", $params, __METHOD__ . "count.all");
+    $iTotalRecords = $iTotalRecordsRow['count'];
+
+    $this->filterParams = $params;
+    $filter = $this->getSearchString($request->get('sSearch'));
+    $filter .= $this->getIntegerFilter(intval($request->get('assigneeSelected')), 'assignee');
+    $filter .= $this->getIntegerFilter(intval($request->get('statusSelected')), 'status_fk');
+
+    $iTotalDisplayRecordsRow = $this->dbManager->getSingleRow("SELECT count(*) FROM $partQuery $filter",
+        $this->filterParams, __METHOD__ . ".count.". $filter);
+    $iTotalDisplayRecords = $iTotalDisplayRecordsRow['count'];
+
+    $orderString = $this->getOrderString();
+    $stmt = __METHOD__ . "getProjectContents" . $orderString . $filter;
+
+    $statementString = "SELECT upload.*,upload_clearing.*,uploadtree.ufile_name,uploadtree.ufile_mode,uploadtree.uploadtree_pk"
+            . " FROM $partQuery $filter $orderString";
+    $rangedFilterParams = $this->filterParams;
+    $rangedFilterParams[] = intval($request->get('iDisplayStart'));
+    $statementString .= ' OFFSET $' . count($rangedFilterParams);
+    $rangedFilterParams[] = intval($request->get('iDisplayLength'));
+    $statementString .= ' LIMIT $' . count($rangedFilterParams);
+
+    $this->dbManager->prepare($stmt, $statementString);
+    $result = $this->dbManager->execute($stmt, $rangedFilterParams);
+
+    return array($result, $iTotalDisplayRecords, $iTotalRecords);
+  }
+
+  private function getOrderString()
+  {
+    $columnNamesInDatabase = array('upload_filename', 'upload_clearing.status_fk', 'UNUSED', 'UNUSED', 'upload_clearing.assignee', 'upload_ts', 'upload_clearing.priority');
+
+    $orderString = $this->dataTablesUtility->getSortingString($_GET, $columnNamesInDatabase);
+
+    return $orderString;
+  }
+
+  private function getSearchString($searchPattern)
+  {
+    if (empty($searchPattern)) {
+      return '';
+    }
+    $this->filterParams[] = "%$searchPattern%";
+    return ' AND upload_filename ilike $' . count($this->filterParams) . ' ';
+  }
+
+  /**
+   * @param int $var
+   * @param string $columnName in database table
+   */
+  private function getIntegerFilter($var, $columnName)
+  {
+    if (empty($var)) {
+      return '';
+    }
+    $this->filterParams[] = $var;
+    return " AND $columnName=$" . count($this->filterParams) . ' ';
+  }
+}
+
+register_plugin(new AjaxBrowseProject());

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -783,6 +783,26 @@
   $Schema["TABLE"]["folder"]["folder_perm"]["ADD"] = "ALTER TABLE \"folder\" ADD COLUMN \"folder_perm\" int4";
   $Schema["TABLE"]["folder"]["folder_perm"]["ALTER"] = "ALTER TABLE \"folder\" ALTER COLUMN \"folder_perm\" DROP NOT NULL";
 
+  $Schema["TABLE"]["project"]["project_pk"]["DESC"] = "";
+  $Schema["TABLE"]["project"]["project_pk"]["ADD"] = "ALTER TABLE \"project\" ADD COLUMN \"project_pk\" int4 DEFAULT nextval('project_project_pk_seq'::regclass)";
+  $Schema["TABLE"]["project"]["project_pk"]["ALTER"] = "ALTER TABLE \"project\" ALTER COLUMN \"project_pk\" SET NOT NULL, ALTER COLUMN \"project_pk\" SET DEFAULT nextval('project_project_pk_seq'::regclass)";
+
+  $Schema["TABLE"]["project"]["project_name"]["DESC"] = "";
+  $Schema["TABLE"]["project"]["project_name"]["ADD"] = "ALTER TABLE \"project\" ADD COLUMN \"project_name\" text";
+  $Schema["TABLE"]["project"]["project_name"]["ALTER"] = "ALTER TABLE \"project\" ALTER COLUMN \"project_name\" SET NOT NULL";
+
+  $Schema["TABLE"]["project"]["user_fk"]["DESC"] = "";
+  $Schema["TABLE"]["project"]["user_fk"]["ADD"] = "ALTER TABLE \"project\" ADD COLUMN \"user_fk\" int4";
+  $Schema["TABLE"]["project"]["user_fk"]["ALTER"] = "ALTER TABLE \"project\" ALTER COLUMN \"user_fk\" DROP NOT NULL";
+
+  $Schema["TABLE"]["project"]["project_desc"]["DESC"] = "";
+  $Schema["TABLE"]["project"]["project_desc"]["ADD"] = "ALTER TABLE \"project\" ADD COLUMN \"project_desc\" text";
+  $Schema["TABLE"]["project"]["project_desc"]["ALTER"] = "ALTER TABLE \"project\" ALTER COLUMN \"project_desc\" DROP NOT NULL";
+
+  $Schema["TABLE"]["project"]["project_perm"]["DESC"] = "COMMENT ON COLUMN \"project\".\"project_perm\" IS 'future permission'";
+  $Schema["TABLE"]["project"]["project_perm"]["ADD"] = "ALTER TABLE \"project\" ADD COLUMN \"project_perm\" int4";
+  $Schema["TABLE"]["project"]["project_perm"]["ALTER"] = "ALTER TABLE \"project\" ALTER COLUMN \"project_perm\" DROP NOT NULL";
+
 
   $Schema["TABLE"]["foldercontents"]["foldercontents_pk"]["DESC"] = "";
   $Schema["TABLE"]["foldercontents"]["foldercontents_pk"]["ADD"] = "ALTER TABLE \"foldercontents\" ADD COLUMN \"foldercontents_pk\" int4 DEFAULT nextval('foldercontents_foldercontents_pk_seq'::regclass)";
@@ -799,6 +819,22 @@
   $Schema["TABLE"]["foldercontents"]["child_id"]["DESC"] = "";
   $Schema["TABLE"]["foldercontents"]["child_id"]["ADD"] = "ALTER TABLE \"foldercontents\" ADD COLUMN \"child_id\" int4";
   $Schema["TABLE"]["foldercontents"]["child_id"]["ALTER"] = "ALTER TABLE \"foldercontents\" ALTER COLUMN \"child_id\" SET NOT NULL";
+
+  $Schema["TABLE"]["projectcontents"]["projectcontents_pk"]["DESC"] = "";
+  $Schema["TABLE"]["projectcontents"]["projectcontents_pk"]["ADD"] = "ALTER TABLE \"projectcontents\" ADD COLUMN \"projectcontents_pk\" int4 DEFAULT nextval('projectcontents_projectcontents_pk_seq'::regclass)";
+  $Schema["TABLE"]["projectcontents"]["projectcontents_pk"]["ALTER"] = "ALTER TABLE \"projectcontents\" ALTER COLUMN \"projectcontents_pk\" SET NOT NULL, ALTER COLUMN \"projectcontents_pk\" SET DEFAULT nextval('projectcontents_projectcontents_pk_seq'::regclass)";
+
+  $Schema["TABLE"]["projectcontents"]["parent_fk"]["DESC"] = "COMMENT ON COLUMN \"projectcontents\".\"parent_fk\" IS 'parent folder_fk'";
+  $Schema["TABLE"]["projectcontents"]["parent_fk"]["ADD"] = "ALTER TABLE \"projectcontents\" ADD COLUMN \"parent_fk\" int4";
+  $Schema["TABLE"]["projectcontents"]["parent_fk"]["ALTER"] = "ALTER TABLE \"projectcontents\" ALTER COLUMN \"parent_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["projectcontents"]["projectcontents_mode"]["DESC"] = "COMMENT ON COLUMN \"projectcontents\".\"projectcontents_mode\" IS '1<<0 child is folder_fk, 1<<1 child is upload_fk, 1<<2 child is an uploadtree_fk'";
+  $Schema["TABLE"]["projectcontents"]["projectcontents_mode"]["ADD"] = "ALTER TABLE \"projectcontents\" ADD COLUMN \"projectcontents_mode\" int4";
+  $Schema["TABLE"]["projectcontents"]["projectcontents_mode"]["ALTER"] = "ALTER TABLE \"projectcontents\" ALTER COLUMN \"projectcontents_mode\" SET NOT NULL";
+
+  $Schema["TABLE"]["projectcontents"]["child_id"]["DESC"] = "";
+  $Schema["TABLE"]["projectcontents"]["child_id"]["ADD"] = "ALTER TABLE \"projectcontents\" ADD COLUMN \"child_id\" int4";
+  $Schema["TABLE"]["projectcontents"]["child_id"]["ALTER"] = "ALTER TABLE \"projectcontents\" ALTER COLUMN \"child_id\" SET NOT NULL";
 
 
   $Schema["TABLE"]["group_user_member"]["group_user_member_pk"]["DESC"] = "";
@@ -1977,9 +2013,16 @@
   $Schema["TABLE"]["users"]["root_folder_fk"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"root_folder_fk\" int4";
   $Schema["TABLE"]["users"]["root_folder_fk"]["ALTER"] = "ALTER TABLE \"users\" ALTER COLUMN \"root_folder_fk\" SET NOT NULL";
 
+  $Schema["TABLE"]["users"]["root_project_fk"]["DESC"] = "COMMENT ON COLUMN \"users\".\"root_project_fk\" IS 'root project for this user'";
+  $Schema["TABLE"]["users"]["root_project_fk"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"root_project_fk\" int4";
+  
   $Schema["TABLE"]["users"]["default_folder_fk"]["DESC"] = "COMMENT ON COLUMN \"users\".\"default_folder_fk\" IS 'default folder for this user'";
   $Schema["TABLE"]["users"]["default_folder_fk"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"default_folder_fk\" int4 DEFAULT -1";
   $Schema["TABLE"]["users"]["default_folder_fk"]["ALTER"] = "ALTER TABLE \"users\" ALTER COLUMN \"default_folder_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["users"]["default_project_fk"]["DESC"] = "COMMENT ON COLUMN \"users\".\"default_project_fk\" IS 'default project for this user'";
+  $Schema["TABLE"]["users"]["default_project_fk"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"default_project_fk\" int4 DEFAULT -1";
+  $Schema["TABLE"]["users"]["default_project_fk"]["ALTER"] = "ALTER TABLE \"users\" ALTER COLUMN \"default_project_fk\" SET NOT NULL";
 
   $Schema["TABLE"]["users"]["last_connection"]["DESC"] = "";
   $Schema["TABLE"]["users"]["last_connection"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"last_connection\" timestamptz";
@@ -2143,6 +2186,8 @@
 
   $Schema["VIEW"]["folderlist"] = "CREATE VIEW \"folderlist\" AS SELECT folder.folder_pk, folder.folder_name AS name, folder.folder_desc AS description, foldercontents.parent_fk AS parent, foldercontents.foldercontents_mode, NULL::timestamp with time zone AS ts, NULL::integer AS upload_pk, NULL::integer AS pfile_fk, NULL::integer AS ufile_mode FROM folder, foldercontents WHERE ((foldercontents.foldercontents_mode = 1) AND (foldercontents.child_id = folder.folder_pk)) UNION ALL SELECT NULL::integer AS folder_pk, uploadtree.ufile_name AS name, upload.upload_desc AS description, foldercontents.parent_fk AS parent, foldercontents.foldercontents_mode, upload.upload_ts AS ts, upload.upload_pk, uploadtree.pfile_fk, uploadtree.ufile_mode FROM ((upload JOIN uploadtree ON (((upload.upload_pk = uploadtree.upload_fk) AND (uploadtree.parent IS NULL)))) JOIN foldercontents ON (((foldercontents.foldercontents_mode = 2) AND (foldercontents.child_id = upload.upload_pk))));";
 
+  $Schema["VIEW"]["projectlist"] = "CREATE VIEW \"projectlist\" AS SELECT project.project_pk, project.project_name AS name, project.project_desc AS description, projectcontents.parent_fk AS parent, projectcontents.projectcontents_mode, NULL::timestamp with time zone AS ts, NULL::integer AS upload_pk, NULL::integer AS pfile_fk, NULL::integer AS ufile_mode FROM project, projectcontents WHERE ((projectcontents.projectcontents_mode = 1) AND (projectcontents.child_id = project.project_pk)) UNION ALL SELECT NULL::integer AS project_pk, uploadtree.ufile_name AS name, upload.upload_desc AS description, projectcontents.parent_fk AS parent, projectcontents.projectcontents_mode, upload.upload_ts AS ts, upload.upload_pk, uploadtree.pfile_fk, uploadtree.ufile_mode FROM ((upload JOIN uploadtree ON (((upload.upload_pk = uploadtree.upload_fk) AND (uploadtree.parent IS NULL)))) JOIN projectcontents ON (((projectcontents.projectcontents_mode = 2) AND (projectcontents.child_id = upload.upload_pk))));";
+
 
   $Schema["SEQUENCE"]["sysconfig_sysconfig_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"sysconfig_sysconfig_pk_seq\"";
   $Schema["SEQUENCE"]["sysconfig_sysconfig_pk_seq"]["UPDATE"] = "SELECT setval('sysconfig_sysconfig_pk_seq',(SELECT greatest(1,max(sysconfig_pk)) val FROM sysconfig))";
@@ -2201,8 +2246,16 @@
   $Schema["SEQUENCE"]["folder_folder_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"folder_folder_pk_seq\"";
   $Schema["SEQUENCE"]["folder_folder_pk_seq"]["UPDATE"] = "SELECT setval('folder_folder_pk_seq',(SELECT greatest(1,max(folder_pk)) val FROM folder))";
 
+  $Schema["SEQUENCE"]["project_project_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"project_project_pk_seq\"";
+  $Schema["SEQUENCE"]["project_project_pk_seq"]["UPDATE"] = "SELECT setval('project_project_pk_seq',(SELECT greatest(1,max(project_pk)) val FROM project))";
+
+
   $Schema["SEQUENCE"]["foldercontents_foldercontents_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"foldercontents_foldercontents_pk_seq\"";
   $Schema["SEQUENCE"]["foldercontents_foldercontents_pk_seq"]["UPDATE"] = "SELECT setval('foldercontents_foldercontents_pk_seq',(SELECT greatest(1,max(foldercontents_pk)) val FROM foldercontents))";
+
+  $Schema["SEQUENCE"]["projectcontents_projectcontents_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"projectcontents_projectcontents_pk_seq\"";
+  $Schema["SEQUENCE"]["projectcontents_projectcontents_pk_seq"]["UPDATE"] = "SELECT setval('projectcontents_projectcontents_pk_seq',(SELECT greatest(1,max(foldercontents_pk)) val FROM foldercontents))";
+
 
   $Schema["SEQUENCE"]["package_package_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"package_package_pk_seq\"";
   $Schema["SEQUENCE"]["package_package_pk_seq"]["UPDATE"] = "SELECT setval('package_package_pk_seq',(SELECT greatest(1,max(package_pk)) val FROM package))";

--- a/src/www/ui/scripts/tools.js
+++ b/src/www/ui/scripts/tools.js
@@ -48,7 +48,6 @@ function getOptionDefaultTrue(name) {
 
 function failed(jqXHR, textStatus, error) {
   var err = textStatus + ", " + error;
-  console.log("Request Failed: " + err);
   respondTxt = jqXHR.responseText;
   if (respondTxt.indexOf('Module unavailable or your login session timed out.') != 0) {
     $('#dmessage').append(respondTxt);

--- a/src/www/ui/template/admin-project-create-form.html.twig
+++ b/src/www/ui/template/admin-project-create-form.html.twig
@@ -1,0 +1,29 @@
+{# Copyright 2016 Siemens AG
+
+   Copying and distribution of this file, with or without modification,
+   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
+   This file is offered as-is, without any warranty.
+#}
+<form method='POST'>
+    <ol>
+        <li>
+            {{ "Select the parent project:"|trans }}
+            <select name='parentid' class="ui-render-select2">
+                {{ projectOptions }}
+            </select>
+            <P />
+        </li>
+        <li>
+            {{ "Enter the new project name:"|trans }}
+            <br/>
+            <INPUT type='text' name='newname' size=40 />
+            <P />
+        </li>
+        <li>
+            {{ "Enter a meaningful description:"|trans }}
+            <br/>
+            <INPUT type='text' name='description' size=80 />
+        </li>
+    </ol>
+    <input type='submit' value='{{ "Create"|trans }}'>
+</form>

--- a/src/www/ui/template/admin-project-edit-form.html.twig
+++ b/src/www/ui/template/admin-project-edit-form.html.twig
@@ -1,0 +1,27 @@
+<p>
+    {{ "The project properties that can be changed are the project name and description."|trans }}
+    {{ "First select the project to edit. Then enter the new values."|trans }}
+    {{ "If no value is entered, then the corresponding field will not be changed."|trans }}
+</p>
+<form method='post'>
+    <ol>
+        <li> {{ "Select the project to edit:"|trans }}
+            <select name="oldprojectid" onChange="window.location.href='{{ onchangeURI }}' + this.value" class="ui-render-select2">
+                {{ projectListOption }} ProjectListOption(-1, 0, 1, $ProjectSelectId);
+            </select>
+            <P />
+        </li>
+        <li>
+            {{ "Change project name:"|trans }}
+            <br/>
+            <INPUT type="text" name="newname" size=40 value="{{ project_name|e }}" />
+            <P />
+        </li>
+        <li>
+            {{ "Change project description:"|trans }}
+            <br/>
+            <INPUT type="text" name="newdesc" size="60" value="{{ project_desc|e }}" />
+        </li>
+    </ol>
+    <input type="submit" value="{{ "Edit"|trans }}">
+</form>

--- a/src/www/ui/template/ui-browse-project.html.twig
+++ b/src/www/ui/template/ui-browse-project.html.twig
@@ -1,0 +1,107 @@
+{# Copyright 2014-2018 Siemens AG
+
+   Copying and distribution of this file, with or without modification,
+   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
+   This file is offered as-is, without any warranty.
+#}
+{% extends "include/base.html.twig" %}
+{% block styles %}
+  {{ parent() }}
+  <link rel="stylesheet" href="css/jquery.treeview.css"/>
+{% endblock %}
+
+{% block content %}
+  <!-- The browse Modal -->
+  <div class="modal" id="commentModal" tabindex="-1" role="dialog" aria-labelledby="commentModalLabel" aria-hidden="true" data-backdrop="false">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <!-- Modal Header -->
+        <div class="modal-header">
+          <h4 class="modal-title">Enter Comment</h4>
+        </div>
+        <!-- Modal body -->
+        <div class="modal-body">
+          <form name="rejector">
+            <div>{{ 'Please enter a reason for status change'|trans }}</div>
+            <textarea id="commentText" style="overflow:auto;resize:none;width:100%;height:80px;" name="commentText"></textarea>
+          </form>
+        </div>
+        <!-- Modal footer -->
+        <div class="modal-footer">
+          <button type="button" class="btn btn-danger" onclick="closeCommentModal();" data-dismiss="modal">{{ 'Cancel'|trans }}</button>
+          <button type="button" class="btn btn-success" onclick="submitComment();" data-dismiss="modal">{{ 'Ok'|trans }}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <table border="1" width="100%">
+    <tr>
+      <td valign="top" style="width:20%;min-width:280px;" id="nav-cell">
+        <span class="btn btn-outline-danger" id="nav-hider" style="float:right;">X</span>
+        <div style="text-align:center;" class="btn"><strong><u>{{ 'Project Navigation'|trans }}</u></strong></div>
+        {{ projectNav }}
+      </td>
+      <td valign="top" style="background: #efefef; width:1px; font-family:monospace; word-break:break-all;" id="nav-shower" hidden>
+          &raquo;&nbsp;{{ 'Project Navigation'|trans|replace({' ':'&nbsp;'}) }}&nbsp;&raquo;
+      </td>
+      <td valign="top">
+        <div style="text-align:center;font-size:large;"><strong><u>{{ 'Uploads'|trans }} {{ 'in'|trans }} <span id="current-project">{{ projectName }}</span></strong></u></div>
+        <form name="uploadMultiSelect">
+        <table class="semibordered" id="browsetbl" width="100%" cellpadding="0">
+        <thead>
+         <tr>
+           <th id="insert_browsetbl_filter"></th>
+           <th></th>
+           <th>
+             <select id="statusSelector" class="form-control-sm" onchange="filterStatus();">
+               <option value="0" selected> </option>
+            {% for key,disp in statusOptions %}
+              <option value="{{ key }}">{{ disp }}</option>
+            {% endfor %}
+             </select>
+           </th>
+           <th></th>
+           <th></th>
+           <th></th>
+           <th>
+             <select id="assigneeSelector" style="max-width:250px;" class="form-control-sm" onchange="filterAssignee();">
+             {% for key,disp in assigneeOptions %}
+               <option value="{{ key }}" {%if key == 0 %} selected{% endif %}>{{ disp }}</option>
+             {% endfor %}
+             </select>
+           </th>
+         </tr>
+         <tr><th></th> <th></th> <th></th> <th></th> <th></th> <th></th> <th></th></tr>
+        </thead>
+        <tbody></tbody>
+        <tfoot></tfoot>
+        </table>
+        <br/>
+        {% if multiUploadAgents is not empty %}
+          <input type="hidden" name="mod" id="mod" value=""/>
+          {{ 'Select'|trans }}
+          <input type="checkbox" name="project" checked="checked" id="browse-upload-all" value="{{ projectId }}" data-toggle="toggle" data-on="Whole project" data-off="Marked uploads" data-onstyle="outline-success" data-offstyle="outline-success">
+          {{ 'to run'|trans }}:
+          {% for muAgent,muDesc in multiUploadAgents %}
+            <input type="submit" value="{{ muDesc }}" name="{{ muAgent }}" class="multi-upload-agent btn btn-default"/>
+          {% endfor %}
+        {% endif %}
+        </form>
+      </td>
+    </tr>
+  </table>
+{% endblock %}
+
+{% block foot %}
+  {{ parent() }}
+  <script src="scripts/jquery.dataTables.min.js" type="text/javascript"></script>
+  <script src="scripts/jquery.dataTables.select.js" type="text/javascript"></script>
+  <script src="scripts/browse.js" type="text/javascript"></script>
+  <script src="scripts/tools.js" type="text/javascript"></script>
+  <script src="scripts/jquery.treeview.js" type="text/javascript"></script>
+  <script src="scripts/jquery.cookie.js" type="text/javascript"></script>
+  <script src="scripts/bootstrap4-toggle.min.js"></script>
+  <link href="css/bootstrap4-toggle.min.css" rel="stylesheet">
+  <script type="text/javascript"> {% include 'ui-browse-project.js.twig' %}</script>
+{% endblock %}

--- a/src/www/ui/template/ui-browse-project.js.twig
+++ b/src/www/ui/template/ui-browse-project.js.twig
@@ -58,6 +58,7 @@ $(document).ready(function() {
     return false;
   });
   $('#browse-upload-all').button().change(function ( event ){
+    console.log('browse-upload-all change!');
     $('#browse-upload-all-label').removeClass("ui-state-focus ui-state-hover ui-state-active");
     var wholeProject = $(this).prop('checked');
     if(wholeProject) {

--- a/src/www/ui/template/ui-browse-project.js.twig
+++ b/src/www/ui/template/ui-browse-project.js.twig
@@ -1,0 +1,118 @@
+{# Copyright 2014-2018 Siemens AG
+
+   Copying and distribution of this file, with or without modification,
+   are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
+   This file is offered as-is, without any warranty.
+#}
+tableColumns = [
+  {"sTitle": "{{ "Upload Name and Description"|trans }}", "sClass": "left"},
+  {"sTitle": "{{ "Action"|trans }}", "sClass": "center", "bSortable": false, "bSearchable": false},
+  {"sTitle": "{{ "Status"|trans }}", "sClass": "center", "bSortable": false, "bSearchable": false},
+  {"sTitle": "{{ "Comment"|trans }}", "sClass": "center cc", "bSortable": false, "bSearchable": false, "mRender": 2},
+  {"sTitle": "{{ "Main licenses"|trans }}", "sClass": "center", "bSearchable": false, "bSortable": false},
+  {"sTitle": "{{ "Upload Date"|trans }}", "sClass": "center", "sType": "string", "bSearchable": false},
+  {"sTitle": "{{ "Assigned to"|trans }}", "sClass": "center", "bSearchable": false}
+];
+
+tableSorting = [
+  [5, "desc"],
+  [0, "asc"],
+  [6, "desc"]
+];
+
+var project = {{ project }};
+var browseTable;
+
+dataTableConfig =
+    {
+      "bServerSide": true,
+      "sAjaxSource": "?mod=browseProject-processPost",
+      "fnServerData": function (sSource, aoData, fnCallback) {
+          aoData.push({"name": "project", "value": project});
+          aoData.push({"name": "show", "value": "{{ show }}"});
+        aoData.push({"name": "assigneeSelected", "value": assigneeSelected});
+        aoData.push({"name": "statusSelected", "value": statusSelected});
+        $.getJSON(sSource, aoData, fnCallback).fail(failed);
+      },
+      "sPaginationType": "listbox",
+      "aoColumns": tableColumns,
+      "aaSorting": tableSorting,
+      "iDisplayLength": 50,
+      "bProcessing": true,
+      "bStateSave": true,
+      "bRetrieve": true
+    };
+
+function createBrowseTable() {
+  var otable = $('#browsetbl').DataTable(dataTableConfig);
+  return otable;
+}
+
+$(document).ready(function() {
+  browseTable = createBrowseTable();
+  $('.clickable-project').click(function(event){
+    project = $(this).attr('data-project');
+    browseTable.draw();
+    $('#current-project').text($(this).text());
+    $('#browse-upload-all').val(project);
+    return false;
+  });
+  $('#browse-upload-all').button().change(function ( event ){
+    $('#browse-upload-all-label').removeClass("ui-state-focus ui-state-hover ui-state-active");
+    var wholeProject = $(this).prop('checked');
+    if(wholeProject) {
+      $('#wholeProject').switchClass('browse-upload-all-off','browse-upload-all-on');
+      $('#markedUpload').switchClass('browse-upload-all-on','browse-upload-all-off');
+    } else {
+      $('#wholeProject').switchClass('browse-upload-all-on','browse-upload-all-off');
+      $('#markedUpload').switchClass('browse-upload-all-off','browse-upload-all-on');
+    }
+  });
+  $('#browse-upload-all-label').removeClass("ui-state-focus ui-state-hover ui-state-active");
+  $("#searchProjectTree").on('keyup',function(){
+    var projectName = $(this).val().toLowerCase();
+    $("#tree li").each(function(){
+      if ($(this).text().toLowerCase().search(projectName) > -1) {
+        $(this).show();
+      } else {
+        $(this).hide();
+      }
+    });
+  })
+});
+
+$('#nav-hider').click(function() {
+  $('#nav-cell').hide('slow');
+  $('#nav-shower').show('slow');  
+});
+$('#nav-shower').click(function() {
+  $('#nav-shower').hide('slow');
+  $('#nav-cell').show('slow');
+});
+
+function removeMainLicense(uploadId,licenseId) {
+  if(confirm("{{'Remove this license from the main license list?'|trans}}"))
+  {
+    $.getJSON("?mod=conclude-license&do=removeMainLicense&upload=" + uploadId + "&licenseId=" + licenseId)
+      .done(function (data) {
+        var table = createBrowseTable();
+        table.draw(false);
+      })
+      .fail(failed);
+  }
+}
+
+$('.multi-upload-agent').click( function() {
+  $('#mod').val( $(this).attr('name') );
+  return true;
+});
+
+$(function() {
+  $("#tree").treeview({
+    collapsed: false,
+    animated: "fast",
+    control: "#sidetreecontrol",
+    persist: "cookie",
+    cookieId: "fossology_treeview"
+    });
+  });

--- a/src/www/ui/template/upload_file.html.twig
+++ b/src/www/ui/template/upload_file.html.twig
@@ -21,6 +21,7 @@
   </div>
 </li>
 {% endblock %}
+
 {% block filedescription %}
 <li class="mb-4">
   Description(s)

--- a/src/www/ui/ui-browse-folder.php
+++ b/src/www/ui/ui-browse-folder.php
@@ -1,0 +1,354 @@
+<?php
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\FolderDao;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Dao\UserDao;
+use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\UI\FolderNav;
+use Fossology\Lib\UI\MenuHook;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+class ui_browse_folder extends FO_Plugin
+{
+
+    /** @var UploadDao */
+    private $uploadDao;
+    /** @var FolderDao */
+    private $folderDao;
+
+    function __construct()
+    {
+        $this->Name = "BrosweFolder";
+        $this->MenuList = "Browse::Folder view";
+        $this->MenuOrder = 80;
+        $this->MenuTarget = "";
+        $this->MenuTarget = "";
+        $this->DBaccess = PLUGIN_DB_READ;
+        $this->LoginFlag = 0;
+
+        global $container;
+        $this->uploadDao = $container->get('dao.upload');
+        $this->folderDao = $container->get('dao.folder');
+
+        parent::__construct();
+    }
+
+    function RegisterMenus()
+    {
+        menu_insert("Main::" . $this->MenuList, $this->MenuOrder, $this->Name, $this->Name);
+        return ($this->State == PLUGIN_STATE_READY);
+    }
+
+    /**
+     * \brief Given a upload_pk, list every item in it.
+     * If it is an individual file, then list the file contents.
+     */
+    function ShowItem($Upload, $Item, $Show, $Folder, $uploadtree_tablename)
+    {
+        global $container;
+        /** @var DbManager */
+        $dbManager = $container->get('db.manager');
+        $RowStyle1 = "style='background-color:#ecfaff'";  // pale blue
+        $RowStyle2 = "style='background-color:#ffffe3'";  // pale yellow
+        $ColorSpanRows = 3;  // Alternate background color every $ColorSpanRows
+        $RowNum = 0;
+
+        $V = "";
+        /* Use plugin "view" and "download" if they exist. */
+        $Uri = Traceback_uri() . "?mod=" . $this->Name . "&folder=$Folder";
+
+        /* there are three types of Browse-Pfile menus */
+        /* menu as defined by their plugins */
+        $MenuPfile = menu_find("Browse-Pfile", $MenuDepth);
+        /* menu but without Compare */
+        $MenuPfileNoCompare = menu_remove($MenuPfile, "Compare");
+        /* menu with only Tag and Compare */
+        $MenuTag = array();
+        foreach ($MenuPfile as $value) {
+            if (($value->Name == 'Tag') || ($value->Name == 'Compare')) {
+                $MenuTag[] = $value;
+            }
+        }
+
+        $Results = GetNonArtifactChildren($Item, $uploadtree_tablename);
+        $ShowSomething = 0;
+        $V .= "<table class='text' style='border-collapse: collapse' border=0 padding=0>\n";
+        $stmtGetFirstChild = __METHOD__ . '.getFirstChild';
+        $dbManager->prepare($stmtGetFirstChild, "SELECT uploadtree_pk FROM $uploadtree_tablename WHERE parent=$1 limit 1");
+        foreach ($Results as $Row) {
+            if (empty($Row['uploadtree_pk'])) {
+                continue;
+            }
+            $ShowSomething = 1;
+            $Name = $Row['ufile_name'];
+
+            /* Set alternating row background color - repeats every $ColorSpanRows rows */
+            $RowStyle = (($RowNum++ % (2 * $ColorSpanRows)) < $ColorSpanRows) ? $RowStyle1 : $RowStyle2;
+            $V .= "<tr $RowStyle>";
+
+            /* Check for children so we know if the file should by hyperlinked */
+            $result = $dbManager->execute($stmtGetFirstChild, array($Row['uploadtree_pk']));
+            $HasChildren = $dbManager->fetchArray($result);
+            $dbManager->freeResult($result);
+
+            $Parm = "upload=$Upload&show=$Show&item=" . $Row['uploadtree_pk'];
+            $Link = $HasChildren ? "$Uri&show=$Show&upload=$Upload&item=$Row[uploadtree_pk]" : NULL;
+
+            if ($Show == 'detail') {
+                $V .= "<td class='mono'>" . DirMode2String($Row['ufile_mode']) . "</td>";
+                if (!Isdir($Row['ufile_mode'])) {
+                    $V .= "<td align='right'>&nbsp;&nbsp;" . number_format($Row['pfile_size'], 0, "", ",") . "&nbsp;&nbsp;</td>";
+                } else {
+                    $V .= "<td>&nbsp;</td>";
+                }
+            }
+
+            $displayItem = Isdir($Row['ufile_mode']) ? "$Name/" : $Name;
+            if (!empty($Link)) {
+                $displayItem = "<a href=\"$Link\">$displayItem</a>";
+            }
+            if (Iscontainer($Row['ufile_mode'])) {
+                $displayItem = "<b>$displayItem</b>";
+            }
+            $V .= "<td>$displayItem</td>\n";
+
+            if (!Iscontainer($Row['ufile_mode'])) {
+                $V .= menu_to_1list($MenuPfileNoCompare, $Parm, "<td>", "</td>\n", 1, $Upload);
+            } else if (!Isdir($Row['ufile_mode'])) {
+                $V .= menu_to_1list($MenuPfile, $Parm, "<td>", "</td>\n", 1, $Upload);
+            } else {
+                $V .= menu_to_1list($MenuTag, $Parm, "<td>", "</td>\n", 1, $Upload);
+            }
+        } /* foreach($Results as $Row) */
+        $V .= "</table>\n";
+        if (!$ShowSomething) {
+            $text = _("No files");
+            $V .= "<b>$text</b>\n";
+        } else {
+            $V .= "<hr>\n";
+            if (count($Results) == 1) {
+                $text = _("1 item");
+                $V .= "$text\n";
+            } else {
+                $text = _("items");
+                $V .= count($Results) . " $text\n";
+            }
+        }
+        return ($V);
+    }
+
+    /**
+     * @brief Given a folderId, list every item in it.
+     * If it is an individual file, then list the file contents.
+     */
+    private function ShowFolder($folderId)
+    {
+        $rootFolder = $this->folderDao->getDefaultFolder(Auth::getUserId());
+        if ($rootFolder == NULL) {
+            $rootFolder = $this->folderDao->getRootFolder(Auth::getUserId());
+        }
+        /* @var $uiFolderNav FolderNav */
+        $uiFolderNav = $GLOBALS['container']->get('ui.folder.nav');
+
+        $folderNav = '<div id="sidetree" class="container justify-content-center" style="min-width: 234px;">';
+        if ($folderId != $rootFolder->getId()) {
+            $folderNav .= '<div class="treeheader" style="display:inline;"><a class="btn btn-outline-success btn-sm" href="' .
+                Traceback_uri() . '?mod=' . $this->Name . '">Top folder</a> | </div>';
+        }
+        $folderNav .= '<div id="sidetreecontrol" class="treeheader" style="display:inline;">
+                     <a class="btn btn-outline-success btn-sm" href="?#">Collapse All</a> |
+                     <a class="btn btn-outline-success btn-sm" href="?#">Expand All</a>
+                   </div><br/><br/>';
+        $folderNav .= '
+      <div class="col-sm-20" style="margin-top:-10px;">
+        <input id="searchFolderTree" type="text" class="form-control" name="searchFolderTree" placeholder="Search folder" autofocus="autofocus"">
+      </div>';
+        $folderNav .= $uiFolderNav->showFolderTree($folderId) . '</div>';
+
+        $this->vars['folderNav'] = $folderNav;
+
+        $assigneeArray = $this->getAssigneeArray();
+        $this->vars['assigneeOptions'] = $assigneeArray;
+        $this->vars['statusOptions'] = $this->uploadDao->getStatusTypeMap();
+        $this->vars['folder'] = $folderId;
+        $this->vars['folderName'] = $this->folderDao->getFolder($folderId)->getName();
+    }
+
+
+    function Output()
+    {
+        if ($this->State != PLUGIN_STATE_READY) {
+            return 0;
+        }
+
+        $this->folderDao->ensureTopLevelFolder();
+
+        $folder_pk = GetParm("folder", PARM_INTEGER);
+        $Upload = GetParm("upload", PARM_INTEGER);  // upload_pk to browse
+        $Item = GetParm("item", PARM_INTEGER);  // uploadtree_pk to browse
+
+        /* check if $folder_pk is accessible to logged in user */
+        if (!empty($folder_pk) && !$this->folderDao->isFolderAccessible($folder_pk)) {
+            $this->vars['message'] = _("Permission Denied");
+            return $this->render('include/base.html.twig');
+        }
+
+        /* check permission if $Upload is given */
+        if (!empty($Upload) && !$this->uploadDao->isAccessible($Upload, Auth::getGroupId())) {
+            $this->vars['message'] = _("Permission Denied");
+            return $this->render('include/base.html.twig');
+        }
+
+        if (empty($folder_pk)) {
+            try {
+                $folder_pk = $this->getFolderId($Upload);
+            } catch (Exception $exc) {
+                return $exc->getMessage();
+            }
+        }
+
+        $output = $this->outputItemHtml($Item, $folder_pk, $Upload);
+        if ($output instanceof Response) {
+            return $output;
+        }
+
+        $this->vars['content'] = $output;
+        $modsUploadMulti = MenuHook::getAgentPluginNames('UploadMulti');
+        if (!empty($modsUploadMulti)) {
+            $multiUploadAgents = array();
+            foreach ($modsUploadMulti as $mod) {
+                $multiUploadAgents[$mod] = $GLOBALS['Plugins'][$mod]->title;
+            }
+            $this->vars['multiUploadAgents'] = $multiUploadAgents;
+        }
+        $this->vars['folderId'] = $folder_pk;
+
+        return $this->render('ui-browse.html.twig');
+    }
+
+    private function getFolderId($uploadId)
+    {
+        $rootFolder = $this->folderDao->getDefaultFolder(Auth::getUserId());
+        if ($rootFolder == NULL) {
+            $rootFolder = $this->folderDao->getRootFolder(Auth::getUserId());
+        }
+        if (empty($uploadId)) {
+            return $rootFolder->getId();
+        }
+
+        global $container;
+        /* @var $dbManager DbManager */
+        $dbManager = $container->get('db.manager');
+        $uploadExists = $dbManager->getSingleRow(
+            "SELECT count(*) cnt FROM upload WHERE upload_pk=$1 " .
+                "AND (expire_action IS NULL OR expire_action!='d') AND pfile_fk IS NOT NULL",
+            array($uploadId)
+        );
+        if ($uploadExists['cnt'] < 1) {
+            throw new Exception("This upload no longer exists on this system.");
+        }
+
+        $folderTreeCte = $this->folderDao->getFolderTreeCte($rootFolder);
+
+        $parent = $dbManager->getSingleRow(
+            $folderTreeCte .
+                " SELECT ft.folder_pk FROM foldercontents fc LEFT JOIN folder_tree ft ON fc.parent_fk=ft.folder_pk "
+                . "WHERE child_id=$2 AND foldercontents_mode=$3 ORDER BY depth LIMIT 1",
+            array($rootFolder->getId(), $uploadId, FolderDao::MODE_UPLOAD),
+            __METHOD__ . '.parent'
+        );
+        if (!$parent) {
+            throw new Exception("Upload $uploadId missing from foldercontents in your foldertree.");
+        }
+        return $parent['folder_pk'];
+    }
+
+    /**
+     * @param int $uploadTreeId
+     * @param int $Folder
+     * @param int $Upload
+     * @return string
+     */
+    function outputItemHtml($uploadTreeId, $Folder, $Upload)
+    {
+        global $container;
+        $dbManager = $container->get('db.manager');
+        $show = 'quick';
+        $html = '';
+        $uploadtree_tablename = "";
+        if (!empty($uploadTreeId)) {
+            $sql = "SELECT ufile_mode, upload_fk FROM uploadtree WHERE uploadtree_pk = $1";
+            $row = $dbManager->getSingleRow($sql, array($uploadTreeId));
+            $Upload = $row['upload_fk'];
+            if (!$this->uploadDao->isAccessible($Upload, Auth::getGroupId())) {
+                $this->vars['message'] = _("Permission Denied");
+                return $this->render('include/base.html.twig');
+            }
+
+            if (!Iscontainer($row['ufile_mode'])) {
+                $parentItemBounds = $this->uploadDao->getParentItemBounds($Upload);
+                if (!$parentItemBounds->containsFiles()) {
+                    // Upload with a single file, open license view
+                    return new RedirectResponse(Traceback_uri() . '?mod=view-license'
+                        . Traceback_parm_keep(array("upload", "item")));
+                }
+                global $Plugins;
+                $View = &$Plugins[plugin_find_id("view")];
+                if (!empty($View)) {
+                    $this->vars['content'] = $View->ShowView(NULL, "browse");
+                    return $this->render('include/base.html.twig');
+                }
+            }
+            $uploadtree_tablename = $this->uploadDao->getUploadtreeTableName($row['upload_fk']);
+            $html .= Dir2Browse($this->Name, $uploadTreeId, NULL, 1, "Browse", -1, '', '', $uploadtree_tablename) . "\n";
+        } else if (!empty($Upload)) {
+            $uploadtree_tablename = $this->uploadDao->getUploadtreeTableName($Upload);
+            $html .= Dir2BrowseUpload(
+                $this->Name,
+                $Upload,
+                NULL,
+                1,
+                "Browse",
+                $uploadtree_tablename
+            ) . "\n";
+        }
+
+        if (empty($Upload)) {
+            $this->vars['show'] = $show;
+            $this->ShowFolder($Folder);
+            return $html;
+        }
+
+        if (empty($uploadTreeId)) {
+            try {
+                $uploadTreeId = $this->uploadDao->getUploadParent($Upload);
+            } catch (Exception $e) {
+                $this->vars['message'] = $e->getMessage();
+                return $this->render('include/base.html.twig');
+            }
+        }
+        $html .= $this->ShowItem($Upload, $uploadTreeId, $show, $Folder, $uploadtree_tablename);
+        $this->vars['content'] = $html;
+        return $this->render('include/base.html.twig');
+    }
+
+    /**
+     * @return array
+     */
+    private function getAssigneeArray()
+    {
+        global $container;
+        /** @var UserDao $userDao */
+        $userDao = $container->get('dao.user');
+        $assigneeArray = $userDao->getUserChoices();
+        $assigneeArray[Auth::getUserId()] = _('-- Me --');
+        $assigneeArray[1] = _('Unassigned');
+        $assigneeArray[0] = '';
+        return $assigneeArray;
+    }
+}
+
+$NewPlugin = new ui_browse_folder();
+$NewPlugin->Install();

--- a/src/www/ui/ui-browse-project.php
+++ b/src/www/ui/ui-browse-project.php
@@ -54,6 +54,7 @@ class ui_browse_project extends FO_Plugin
     {
         global $container;
         /** @var DbManager */
+        xdebug_break();
         $dbManager = $container->get('db.manager');
         $RowStyle1 = "style='background-color:#ecfaff'";  // pale blue
         $RowStyle2 = "style='background-color:#ffffe3'";  // pale yellow

--- a/src/www/ui/ui-browse-project.php
+++ b/src/www/ui/ui-browse-project.php
@@ -1,0 +1,603 @@
+<?php
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\FolderDao;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Dao\UserDao;
+use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\UI\FolderNav;
+use Fossology\Lib\UI\MenuHook;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+class ui_browse_project extends FO_Plugin
+{
+
+    /** @var UploadDao */
+    private $uploadDao;
+    /** @var FolderDao */
+    private $folderDao;
+
+    /** @var ProjectDao */
+    private $projectDao;
+
+    function __construct()
+    {
+        $this->Name = "BrosweProject";
+        $this->MenuList = "Browse::Project view";
+        $this->MenuOrder = 80;
+        $this->MenuTarget = "";
+        $this->MenuTarget = "";
+        $this->DBaccess = PLUGIN_DB_READ;
+        $this->LoginFlag = 0;
+
+        global $container;
+        $this->uploadDao = $container->get('dao.upload');
+        $this->folderDao = $container->get('dao.folder');
+
+        $this->projectDao = $container->get('dao.project');
+
+        parent::__construct();
+    }
+
+    function RegisterMenus()
+    {
+        menu_insert("Main::" . $this->MenuList, $this->MenuOrder, $this->Name, $this->Name);
+        return ($this->State == PLUGIN_STATE_READY);
+    }
+
+    /**
+     * \brief Given a upload_pk, list every item in it.
+     * If it is an individual file, then list the file contents.
+     */
+    function ShowItem($Upload, $Item, $Show, $Folder, $uploadtree_tablename)
+    {
+        global $container;
+        /** @var DbManager */
+        $dbManager = $container->get('db.manager');
+        $RowStyle1 = "style='background-color:#ecfaff'";  // pale blue
+        $RowStyle2 = "style='background-color:#ffffe3'";  // pale yellow
+        $ColorSpanRows = 3;  // Alternate background color every $ColorSpanRows
+        $RowNum = 0;
+
+        $V = "";
+        /* Use plugin "view" and "download" if they exist. */
+        $Uri = Traceback_uri() . "?mod=" . $this->Name . "&folder=$Folder";
+
+        /* there are three types of Browse-Pfile menus */
+        /* menu as defined by their plugins */
+        $MenuPfile = menu_find("Browse-Pfile", $MenuDepth);
+        /* menu but without Compare */
+        $MenuPfileNoCompare = menu_remove($MenuPfile, "Compare");
+        /* menu with only Tag and Compare */
+        $MenuTag = array();
+        foreach ($MenuPfile as $value) {
+            if (($value->Name == 'Tag') || ($value->Name == 'Compare')) {
+                $MenuTag[] = $value;
+            }
+        }
+
+        $Results = GetNonArtifactChildren($Item, $uploadtree_tablename);
+        $ShowSomething = 0;
+        $V .= "<table class='text' style='border-collapse: collapse' border=0 padding=0>\n";
+        $stmtGetFirstChild = __METHOD__ . '.getFirstChild';
+        $dbManager->prepare($stmtGetFirstChild, "SELECT uploadtree_pk FROM $uploadtree_tablename WHERE parent=$1 limit 1");
+        foreach ($Results as $Row) {
+            if (empty($Row['uploadtree_pk'])) {
+                continue;
+            }
+            $ShowSomething = 1;
+            $Name = $Row['ufile_name'];
+
+            /* Set alternating row background color - repeats every $ColorSpanRows rows */
+            $RowStyle = (($RowNum++ % (2 * $ColorSpanRows)) < $ColorSpanRows) ? $RowStyle1 : $RowStyle2;
+            $V .= "<tr $RowStyle>";
+
+            /* Check for children so we know if the file should by hyperlinked */
+            $result = $dbManager->execute($stmtGetFirstChild, array($Row['uploadtree_pk']));
+            $HasChildren = $dbManager->fetchArray($result);
+            $dbManager->freeResult($result);
+
+            $Parm = "upload=$Upload&show=$Show&item=" . $Row['uploadtree_pk'];
+            $Link = $HasChildren ? "$Uri&show=$Show&upload=$Upload&item=$Row[uploadtree_pk]" : NULL;
+
+            if ($Show == 'detail') {
+                $V .= "<td class='mono'>" . DirMode2String($Row['ufile_mode']) . "</td>";
+                if (!Isdir($Row['ufile_mode'])) {
+                    $V .= "<td align='right'>&nbsp;&nbsp;" . number_format($Row['pfile_size'], 0, "", ",") . "&nbsp;&nbsp;</td>";
+                } else {
+                    $V .= "<td>&nbsp;</td>";
+                }
+            }
+
+            $displayItem = Isdir($Row['ufile_mode']) ? "$Name/" : $Name;
+            if (!empty($Link)) {
+                $displayItem = "<a href=\"$Link\">$displayItem</a>";
+            }
+            if (Iscontainer($Row['ufile_mode'])) {
+                $displayItem = "<b>$displayItem</b>";
+            }
+            $V .= "<td>$displayItem</td>\n";
+
+            if (!Iscontainer($Row['ufile_mode'])) {
+                $V .= menu_to_1list($MenuPfileNoCompare, $Parm, "<td>", "</td>\n", 1, $Upload);
+            } else if (!Isdir($Row['ufile_mode'])) {
+                $V .= menu_to_1list($MenuPfile, $Parm, "<td>", "</td>\n", 1, $Upload);
+            } else {
+                $V .= menu_to_1list($MenuTag, $Parm, "<td>", "</td>\n", 1, $Upload);
+            }
+        } /* foreach($Results as $Row) */
+        $V .= "</table>\n";
+        if (!$ShowSomething) {
+            $text = _("No files");
+            $V .= "<b>$text</b>\n";
+        } else {
+            $V .= "<hr>\n";
+            if (count($Results) == 1) {
+                $text = _("1 item");
+                $V .= "$text\n";
+            } else {
+                $text = _("items");
+                $V .= count($Results) . " $text\n";
+            }
+        }
+        return ($V);
+    }
+
+    /**
+     * \brief Given a upload_pk, list every item in it.
+     * If it is an individual file, then list the file contents.
+     */
+    function ShowItemWithProject($Upload, $Item, $Show, $Project, $uploadtree_tablename)
+    {
+        global $container;
+        /** @var DbManager */
+        $dbManager = $container->get('db.manager');
+        $RowStyle1 = "style='background-color:#ecfaff'";  // pale blue
+        $RowStyle2 = "style='background-color:#ffffe3'";  // pale yellow
+        $ColorSpanRows = 3;  // Alternate background color every $ColorSpanRows
+        $RowNum = 0;
+
+        $V = "";
+        /* Use plugin "view" and "download" if they exist. */
+        $Uri = Traceback_uri() . "?mod=" . $this->Name . "&project=$Project";
+
+        /* there are three types of Browse-Pfile menus */
+        /* menu as defined by their plugins */
+        $MenuPfile = menu_find("Browse-Pfile", $MenuDepth);
+        /* menu but without Compare */
+        $MenuPfileNoCompare = menu_remove($MenuPfile, "Compare");
+        /* menu with only Tag and Compare */
+        $MenuTag = array();
+        foreach ($MenuPfile as $value) {
+            if (($value->Name == 'Tag') || ($value->Name == 'Compare')) {
+                $MenuTag[] = $value;
+            }
+        }
+
+        $Results = GetNonArtifactChildren($Item, $uploadtree_tablename);
+        $ShowSomething = 0;
+        $V .= "<table class='text' style='border-collapse: collapse' border=0 padding=0>\n";
+        $stmtGetFirstChild = __METHOD__ . '.getFirstChild';
+        $dbManager->prepare($stmtGetFirstChild, "SELECT uploadtree_pk FROM $uploadtree_tablename WHERE parent=$1 limit 1");
+        foreach ($Results as $Row) {
+            if (empty($Row['uploadtree_pk'])) {
+                continue;
+            }
+            $ShowSomething = 1;
+            $Name = $Row['ufile_name'];
+
+            /* Set alternating row background color - repeats every $ColorSpanRows rows */
+            $RowStyle = (($RowNum++ % (2 * $ColorSpanRows)) < $ColorSpanRows) ? $RowStyle1 : $RowStyle2;
+            $V .= "<tr $RowStyle>";
+
+            /* Check for children so we know if the file should by hyperlinked */
+            $result = $dbManager->execute($stmtGetFirstChild, array($Row['uploadtree_pk']));
+            $HasChildren = $dbManager->fetchArray($result);
+            $dbManager->freeResult($result);
+
+            $Parm = "upload=$Upload&show=$Show&item=" . $Row['uploadtree_pk'];
+            $Link = $HasChildren ? "$Uri&show=$Show&upload=$Upload&item=$Row[uploadtree_pk]" : NULL;
+
+            if ($Show == 'detail') {
+                $V .= "<td class='mono'>" . DirMode2String($Row['ufile_mode']) . "</td>";
+                if (!Isdir($Row['ufile_mode'])) {
+                    $V .= "<td align='right'>&nbsp;&nbsp;" . number_format($Row['pfile_size'], 0, "", ",") . "&nbsp;&nbsp;</td>";
+                } else {
+                    $V .= "<td>&nbsp;</td>";
+                }
+            }
+
+            $displayItem = Isdir($Row['ufile_mode']) ? "$Name/" : $Name;
+            if (!empty($Link)) {
+                $displayItem = "<a href=\"$Link\">$displayItem</a>";
+            }
+            if (Iscontainer($Row['ufile_mode'])) {
+                $displayItem = "<b>$displayItem</b>";
+            }
+            $V .= "<td>$displayItem</td>\n";
+
+            if (!Iscontainer($Row['ufile_mode'])) {
+                $V .= menu_to_1list($MenuPfileNoCompare, $Parm, "<td>", "</td>\n", 1, $Upload);
+            } else if (!Isdir($Row['ufile_mode'])) {
+                $V .= menu_to_1list($MenuPfile, $Parm, "<td>", "</td>\n", 1, $Upload);
+            } else {
+                $V .= menu_to_1list($MenuTag, $Parm, "<td>", "</td>\n", 1, $Upload);
+            }
+        } /* foreach($Results as $Row) */
+        $V .= "</table>\n";
+        if (!$ShowSomething) {
+            $text = _("No files");
+            $V .= "<b>$text</b>\n";
+        } else {
+            $V .= "<hr>\n";
+            if (count($Results) == 1) {
+                $text = _("1 item");
+                $V .= "$text\n";
+            } else {
+                $text = _("items");
+                $V .= count($Results) . " $text\n";
+            }
+        }
+        return ($V);
+    }
+
+    /**
+     * @brief Given a folderId, list every item in it.
+     * If it is an individual file, then list the file contents.
+     */
+    private function ShowFolder($folderId)
+    {
+        $rootFolder = $this->folderDao->getDefaultFolder(Auth::getUserId());
+        if ($rootFolder == NULL) {
+            $rootFolder = $this->folderDao->getRootFolder(Auth::getUserId());
+        }
+        /* @var $uiFolderNav FolderNav */
+        $uiFolderNav = $GLOBALS['container']->get('ui.folder.nav');
+        // $uiFolderNav = $GLOBALS['container']->get('ui.project.nav');
+        $folderNav = '<div id="sidetree" class="container justify-content-center" style="min-width: 234px;">';
+        if ($folderId != $rootFolder->getId()) {
+            $folderNav .= '<div class="treeheader" style="display:inline;"><a class="btn btn-outline-success btn-sm" href="' .
+                Traceback_uri() . '?mod=' . $this->Name . '">Top folder</a> | </div>';
+        }
+        $folderNav .= '<div id="sidetreecontrol" class="treeheader" style="display:inline;">
+                     <a class="btn btn-outline-success btn-sm" href="?#">Collapse All</a> |
+                     <a class="btn btn-outline-success btn-sm" href="?#">Expand All</a>
+                   </div><br/><br/>';
+        $folderNav .= '
+      <div class="col-sm-20" style="margin-top:-10px;">
+        <input id="searchFolderTree" type="text" class="form-control" name="searchFolderTree" placeholder="Search folder" autofocus="autofocus"">
+      </div>';
+        $folderNav .= $uiFolderNav->showFolderTree($folderId) . '</div>';
+
+        $this->vars['folderNav'] = $folderNav;
+
+        $assigneeArray = $this->getAssigneeArray();
+        $this->vars['assigneeOptions'] = $assigneeArray;
+        $this->vars['statusOptions'] = $this->uploadDao->getStatusTypeMap();
+        $this->vars['folder'] = $folderId;
+        $this->vars['folderName'] = $this->folderDao->getFolder($folderId)->getName();
+    }
+
+    /**
+     * @brief Given a projectId, list every item in it.
+     * If it is an individual file, then list the file contents.
+     */
+    private function ShowProject($projectId)
+    {
+        $rootProject = $this->projectDao->getDefaultProject(Auth::getUserId());
+        if ($rootProject == NULL) {
+            $rootProject = $this->projectDao->getRootProject(Auth::getUserId());
+        }
+        /* @var $uiProjectNav ProjectNav */
+        // $uiProjectNav = $GLOBALS['container']->get('ui.project.nav');
+        $uiProjectNav = $GLOBALS['container']->get('ui.project.nav');
+        $projectNav = '<div id="sidetree" class="container justify-content-center" style="min-width: 234px;">';
+        if ($projectId != $rootProject->getId()) {
+            $projectNav .= '<div class="treeheader" style="display:inline;"><a class="btn btn-outline-success btn-sm" href="' .
+                Traceback_uri() . '?mod=' . $this->Name . '">Top project</a> | </div>';
+        }
+        $projectNav .= '<div id="sidetreecontrol" class="treeheader" style="display:inline;">
+                     <a class="btn btn-outline-success btn-sm" href="?#">Collapse All</a> |
+                     <a class="btn btn-outline-success btn-sm" href="?#">Expand All</a>
+                   </div><br/><br/>';
+        $projectNav .= '
+      <div class="col-sm-20" style="margin-top:-10px;">
+        <input id="searchProjectTree" type="text" class="form-control" name="searchProjectTree" placeholder="Search project" autofocus="autofocus"">
+      </div>';
+        $projectNav .= $uiProjectNav->showProjectTree($projectId) . '</div>';
+
+        $this->vars['projectNav'] = $projectNav;
+
+        $assigneeArray = $this->getAssigneeArray();
+        $this->vars['assigneeOptions'] = $assigneeArray;
+        $this->vars['statusOptions'] = $this->uploadDao->getStatusTypeMap();
+        $this->vars['project'] = $projectId;
+        $this->vars['projectName'] = $this->projectDao->getProject($projectId)->getName();
+    }
+
+    function Output()
+    {
+        if ($this->State != PLUGIN_STATE_READY) {
+            return 0;
+        }
+
+        $this->projectDao->ensureTopLevelProject();
+
+        $project_pk = GetParm("project", PARM_INTEGER);
+        $Upload = GetParm("upload", PARM_INTEGER);  // upload_pk to browse
+        $Item = GetParm("item", PARM_INTEGER);  // uploadtree_pk to browse
+
+        /* check if $project_pk is accessible to logged in user */
+        if (!empty($project_pk) && !$this->projectDao->isProjectAccessible($project_pk)) {
+            $this->vars['message'] = _("Permission Denied");
+            return $this->render('include/base.html.twig');
+        }
+
+        /* check permission if $Upload is given */
+        if (!empty($Upload) && !$this->uploadDao->isAccessible($Upload, Auth::getGroupId())) {
+            $this->vars['message'] = _("Permission Denied");
+            return $this->render('include/base.html.twig');
+        }
+
+        if (empty($project_pk)) {
+            try {
+                $project_pk = $this->getProjectId($Upload);
+            } catch (Exception $exc) {
+                return $exc->getMessage();
+            }
+        }
+
+        $output = $this->outputItemHtmlWithProject($Item, $project_pk, $Upload);
+        if ($output instanceof Response) {
+            return $output;
+        }
+
+        $this->vars['content'] = $output;
+        $modsUploadMulti = MenuHook::getAgentPluginNames('UploadMulti');
+        if (!empty($modsUploadMulti)) {
+            $multiUploadAgents = array();
+            foreach ($modsUploadMulti as $mod) {
+                $multiUploadAgents[$mod] = $GLOBALS['Plugins'][$mod]->title;
+            }
+            $this->vars['multiUploadAgents'] = $multiUploadAgents;
+        }
+        $this->vars['projectId'] = $project_pk;
+
+        return $this->render('ui-browse-project.html.twig');
+    }
+
+    private function getFolderId($uploadId)
+    {
+        $rootFolder = $this->folderDao->getDefaultFolder(Auth::getUserId());
+        if ($rootFolder == NULL) {
+            $rootFolder = $this->folderDao->getRootFolder(Auth::getUserId());
+        }
+        if (empty($uploadId)) {
+            return $rootFolder->getId();
+        }
+
+        global $container;
+        /* @var $dbManager DbManager */
+        $dbManager = $container->get('db.manager');
+        $uploadExists = $dbManager->getSingleRow(
+            "SELECT count(*) cnt FROM upload WHERE upload_pk=$1 " .
+                "AND (expire_action IS NULL OR expire_action!='d') AND pfile_fk IS NOT NULL",
+            array($uploadId)
+        );
+        if ($uploadExists['cnt'] < 1) {
+            throw new Exception("This upload no longer exists on this system.");
+        }
+
+        $folderTreeCte = $this->folderDao->getFolderTreeCte($rootFolder);
+
+        $parent = $dbManager->getSingleRow(
+            $folderTreeCte .
+                " SELECT ft.folder_pk FROM foldercontents fc LEFT JOIN folder_tree ft ON fc.parent_fk=ft.folder_pk "
+                . "WHERE child_id=$2 AND foldercontents_mode=$3 ORDER BY depth LIMIT 1",
+            array($rootFolder->getId(), $uploadId, FolderDao::MODE_UPLOAD),
+            __METHOD__ . '.parent'
+        );
+        if (!$parent) {
+            throw new Exception("Upload $uploadId missing from foldercontents in your foldertree.");
+        }
+        return $parent['folder_pk'];
+    }
+
+    private function getProjectId($uploadId)
+    {
+        $rootProject = $this->projectDao->getDefaultProject(Auth::getUserId());
+        if ($rootProject == NULL) {
+            $rootProject = $this->projectDao->getRootProject(Auth::getUserId());
+        }
+        if (empty($uploadId)) {
+            return $rootProject->getId();
+        }
+
+        global $container;
+        /* @var $dbManager DbManager */
+        $dbManager = $container->get('db.manager');
+        $uploadExists = $dbManager->getSingleRow(
+            "SELECT count(*) cnt FROM upload WHERE upload_pk=$1 " .
+                "AND (expire_action IS NULL OR expire_action!='d') AND pfile_fk IS NOT NULL",
+            array($uploadId)
+        );
+        if ($uploadExists['cnt'] < 1) {
+            throw new Exception("This upload no longer exists on this system.");
+        }
+
+        $projectTreeCte = $this->projectDao->getProjectTreeCte($rootProject);
+
+        $parent = $dbManager->getSingleRow(
+            $projectTreeCte .
+                " SELECT ft.project_pk FROM projectcontents fc LEFT JOIN project_tree ft ON fc.parent_fk=ft.project_pk "
+                . "WHERE child_id=$2 AND projectcontents_mode=$3 ORDER BY depth LIMIT 1",
+            array($rootProject->getId(), $uploadId, ProjectDao::MODE_UPLOAD),
+            __METHOD__ . '.parent'
+        );
+        if (!$parent) {
+            throw new Exception("Upload $uploadId missing from projectcontents in your projecttree.");
+        }
+
+        return $parent['project_pk'];
+    }
+
+    /**
+     * @param int $uploadTreeId
+     * @param int $Folder
+     * @param int $Upload
+     * @return string
+     */
+    function outputItemHtml($uploadTreeId, $Folder, $Upload)
+    {
+        global $container;
+        $dbManager = $container->get('db.manager');
+        $show = 'quick';
+        $html = '';
+        $uploadtree_tablename = "";
+        if (!empty($uploadTreeId)) {
+            $sql = "SELECT ufile_mode, upload_fk FROM uploadtree WHERE uploadtree_pk = $1";
+            $row = $dbManager->getSingleRow($sql, array($uploadTreeId));
+            $Upload = $row['upload_fk'];
+            if (!$this->uploadDao->isAccessible($Upload, Auth::getGroupId())) {
+                $this->vars['message'] = _("Permission Denied");
+                return $this->render('include/base.html.twig');
+            }
+
+            if (!Iscontainer($row['ufile_mode'])) {
+                $parentItemBounds = $this->uploadDao->getParentItemBounds($Upload);
+                if (!$parentItemBounds->containsFiles()) {
+                    // Upload with a single file, open license view
+                    return new RedirectResponse(Traceback_uri() . '?mod=view-license'
+                        . Traceback_parm_keep(array("upload", "item")));
+                }
+                global $Plugins;
+                $View = &$Plugins[plugin_find_id("view")];
+                if (!empty($View)) {
+                    $this->vars['content'] = $View->ShowView(NULL, "browse");
+                    return $this->render('include/base.html.twig');
+                }
+            }
+            $uploadtree_tablename = $this->uploadDao->getUploadtreeTableName($row['upload_fk']);
+            $html .= Dir2Browse($this->Name, $uploadTreeId, NULL, 1, "Browse", -1, '', '', $uploadtree_tablename) . "\n";
+        } else if (!empty($Upload)) {
+            $uploadtree_tablename = $this->uploadDao->getUploadtreeTableName($Upload);
+            $html .= Dir2BrowseUpload(
+                $this->Name,
+                $Upload,
+                NULL,
+                1,
+                "Browse",
+                $uploadtree_tablename
+            ) . "\n";
+        }
+
+        if (empty($Upload)) {
+            $this->vars['show'] = $show;
+            $this->ShowFolder($Folder);
+            // this->ShowProject($Project);
+            return $html;
+        }
+
+        if (empty($uploadTreeId)) {
+            try {
+                $uploadTreeId = $this->uploadDao->getUploadParent($Upload);
+            } catch (Exception $e) {
+                $this->vars['message'] = $e->getMessage();
+                return $this->render('include/base.html.twig');
+            }
+        }
+        $html .= $this->ShowItem($Upload, $uploadTreeId, $show, $Folder, $uploadtree_tablename);
+        $this->vars['content'] = $html;
+        return $this->render('include/base.html.twig');
+    }
+
+        /**
+     * @param int $uploadTreeId
+     * @param int $Project
+     * @param int $Upload
+     * @return string
+     */
+    function outputItemHtmlWithProject($uploadTreeId, $Project, $Upload)
+    {
+
+        global $container;
+        $dbManager = $container->get('db.manager');
+        $show = 'quick';
+        $html = '';
+        $uploadtree_tablename = "";
+        if (!empty($uploadTreeId)) {
+            $sql = "SELECT ufile_mode, upload_fk FROM uploadtree WHERE uploadtree_pk = $1";
+            $row = $dbManager->getSingleRow($sql, array($uploadTreeId));
+            $Upload = $row['upload_fk'];
+            if (!$this->uploadDao->isAccessible($Upload, Auth::getGroupId())) {
+                $this->vars['message'] = _("Permission Denied");
+                return $this->render('include/base.html.twig');
+            }
+
+            if (!Iscontainer($row['ufile_mode'])) {
+                $parentItemBounds = $this->uploadDao->getParentItemBounds($Upload);
+                if (!$parentItemBounds->containsFiles()) {
+                    // Upload with a single file, open license view
+                    return new RedirectResponse(Traceback_uri() . '?mod=view-license'
+                        . Traceback_parm_keep(array("upload", "item")));
+                }
+                global $Plugins;
+                $View = &$Plugins[plugin_find_id("view")];
+                if (!empty($View)) {
+                    $this->vars['content'] = $View->ShowView(NULL, "browse");
+                    return $this->render('include/base.html.twig');
+                }
+            }
+            $uploadtree_tablename = $this->uploadDao->getUploadtreeTableName($row['upload_fk']);
+            $html .= Dir2Browse($this->Name, $uploadTreeId, NULL, 1, "Browse", -1, '', '', $uploadtree_tablename) . "\n";
+        } else if (!empty($Upload)) {
+            $uploadtree_tablename = $this->uploadDao->getUploadtreeTableName($Upload);
+            $html .= Dir2BrowseUpload(
+                $this->Name,
+                $Upload,
+                NULL,
+                1,
+                "Browse",
+                $uploadtree_tablename
+            ) . "\n";
+        }
+
+        if (empty($Upload)) {
+            $this->vars['show'] = $show;
+            $this->ShowProject($Project);
+            // this->ShowProject($Project);
+            return $html;
+        }
+
+        if (empty($uploadTreeId)) {
+            try {
+                $uploadTreeId = $this->uploadDao->getUploadParent($Upload);
+            } catch (Exception $e) {
+                $this->vars['message'] = $e->getMessage();
+                return $this->render('include/base.html.twig');
+            }
+        }
+        $html .= $this->ShowItemWithProject($Upload, $uploadTreeId, $show, $Project, $uploadtree_tablename);
+        $this->vars['content'] = $html;
+        return $this->render('include/base.html.twig');
+    }
+
+    /**
+     * @return array
+     */
+    private function getAssigneeArray()
+    {
+        global $container;
+        /** @var UserDao $userDao */
+        $userDao = $container->get('dao.user');
+        $assigneeArray = $userDao->getUserChoices();
+        $assigneeArray[Auth::getUserId()] = _('-- Me --');
+        $assigneeArray[1] = _('Unassigned');
+        $assigneeArray[0] = '';
+        return $assigneeArray;
+    }
+}
+
+$NewPlugin = new ui_browse_project();
+$NewPlugin->Install();


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This pull request is similar to pull request 2314. But remove the "merge" commit.
add readme_oss reprot generation code in project view

### Changes

I have made some modification of readme_oss generate plugin. For now, it transform a new paramater "type" to schedule.

## How to test

Click the ReadMe_OSS generation button on BrowseFile page or BrowseProject page. Then open the Dbeaver to look at the jobqueue table, you will see the new paramater in jq_cmd_args column.



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2315"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

