### PR TITLE
feat(API): `POST report/import?upload={id}` route for initiating a reportImport job for a given upload

### DIFF
--- a/src/reportImport/ui/ReportImportPlugin.php
+++ b/src/reportImport/ui/ReportImportPlugin.php
@@ -101,7 +101,7 @@ class ReportImportPlugin extends DefaultPlugin
     return $this->render('ReportImportPlugin.html.twig', $this->mergeWithDefault($vars));
   }
 
-  protected function runImport($uploadId, $report, $request)
+  public function runImport($uploadId, $report, $request)
   {
     $reportImportAgent = plugin_find('agent_reportImport');
 

--- a/src/www/ui/api/Controllers/ReportController.php
+++ b/src/www/ui/api/Controllers/ReportController.php
@@ -12,6 +12,7 @@
 
 namespace Fossology\UI\Api\Controllers;
 
+use Exception;
 use Fossology\CliXml\UI\CliXmlGeneratorUi;
 use Fossology\DecisionExporter\UI\FoDecisionExporter;
 use Fossology\DecisionImporter\UI\AgentDecisionImporterPlugin;
@@ -24,6 +25,7 @@ use Fossology\UnifiedReport\UI\FoUnifiedReportGenerator;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\Psr7\Factory\StreamFactory;
 use Slim\Psr7\Request as SlimRequest;
+use Slim\Psr7\UploadedFile as SlimUploadedFile;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -55,7 +57,8 @@ class ReportController extends RestController
    * Allowed report types to be imported.
    */
   private $importAllowed = [
-    'decisionimporter'
+    'decisionimporter',
+    'spdxrdf'
   ];
 
   /**
@@ -123,7 +126,7 @@ class ReportController extends RestController
           $error = new Info(500, "Some error occured!", InfoType::ERROR);
           return $response->withJson($error->getArray(), $error->getCode());
       }
-    } catch (\Exception $e) {
+    } catch (Exception $e) {
       $error = new Info(500, $e->getMessage(), InfoType::ERROR);
       return $response->withJson($error->getArray(), $error->getCode());
     }
@@ -237,7 +240,7 @@ class ReportController extends RestController
       );
 
       return $newResponse;
-    } catch (\Exception $e) {
+    } catch (Exception $e) {
       $error = new Info(500, $e->getMessage(), InfoType::ERROR);
       return $response->withJson($error->getArray(), $error->getCode());
     }
@@ -284,38 +287,57 @@ class ReportController extends RestController
    * @param array $args
    * @return ResponseHelper
    */
-  public function importReport(ServerRequestInterface $request, ResponseHelper $response, array $args): ResponseHelper
+  public function importReport(ServerRequestInterface $request,
+                               ResponseHelper $response, array $args): ResponseHelper
   {
     $returnVal = null;
     $query = $request->getQueryParams();
     if (!array_key_exists("upload", $query)) {
-      $returnVal = new Info(400, "Bad Request. **upload** is a required query param", InfoType::INFO);
-    } elseif (!array_key_exists("reportFormat", $query) || !in_array($query["reportFormat"], $this->importAllowed)) {
-      $returnVal = new Info(400, "Bad Request. Missing or wrong query param 'reportFormat'", InfoType::ERROR);
+      $returnVal = new Info(400,
+        "Bad Request. **upload** is a required query param", InfoType::INFO);
+    } elseif (!array_key_exists("reportFormat", $query) ||
+        !in_array($query["reportFormat"], $this->importAllowed)) {
+      $returnVal = new Info(400,
+        "Bad Request. Missing or wrong query param 'reportFormat'", InfoType::ERROR);
     }
     if ($returnVal !== null) {
       return $response->withJson($returnVal->getArray(), $returnVal->getCode());
     }
     $upload_pk = intval($query['upload']);
     // checking if the scheduler is running or not
-    $commu_status = fo_communicate_with_scheduler('status', $response_from_scheduler, $error_info);
+    $commu_status = fo_communicate_with_scheduler('status',
+      $response_from_scheduler, $error_info);
     if ($commu_status) {
-      $reqBody = $this->getParsedBody($request);
+      $files = $request->getUploadedFiles();
+
       $res = true;
-      if (! $this->dbHelper->doesIdExist("upload", "upload_pk", $upload_pk)) {
+      if (!$this->dbHelper->doesIdExist("upload", "upload_pk", $upload_pk)) {
         $returnVal = new Info(404, "Upload does not exist", InfoType::ERROR);
         $res = false;
-      } else if (! $this->restHelper->getUploadDao()->isAccessible($upload_pk, $this->restHelper->getGroupId())) {
+      } elseif (!$this->restHelper->getUploadDao()->isAccessible($upload_pk, $this->restHelper->getGroupId())) {
         $returnVal = new Info(403, "Upload is not accessible", InfoType::ERROR);
+        $res = false;
+      } elseif (empty($files['report'])) {
+        $returnVal = new Info(400, "No file uploaded", InfoType::ERROR);
         $res = false;
       }
       if (!$res) {
-        return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+        return $response->withJson($returnVal->getArray(),
+          $returnVal->getCode());
       }
+      /** @var SlimUploadedFile $slimFile */
+      $slimFile = $files['report'];
+
       $reportFormat = $query["reportFormat"];
       switch ($reportFormat) {
         case $this->importAllowed[0]:
-          $returnVal = $this->importDecisionJson($request, $response, $reqBody, $upload_pk);
+          $returnVal = $this->importDecisionJson($request, $response,
+            $upload_pk, $slimFile);
+          break;
+        case $this->importAllowed[1]:
+          $returnVal = $this->importSpdxReport($request, $response, $upload_pk,
+            $slimFile);
+          break;
       }
       return $returnVal;
     }
@@ -325,24 +347,24 @@ class ReportController extends RestController
 
   /**
    * Run decision importer agent for JSON report.
+   *
    * @param ServerRequestInterface $request
    * @param ResponseHelper $response
-   * @param array $reqBody
    * @param int $uploadId
+   * @param SlimUploadedFile $slimFile
    * @return ResponseHelper
    */
-  private function importDecisionJson(ServerRequestInterface $request, ResponseHelper $response, array $reqBody, int $uploadId): ResponseHelper
+  private function importDecisionJson(ServerRequestInterface $request,
+                                      ResponseHelper $response, int $uploadId,
+                                      SlimUploadedFile $slimFile): ResponseHelper
   {
     /** @var AgentDecisionImporterPlugin $decisionImporter */
     $decisionImporter = $this->restHelper->getPlugin("ui_fodecisionimporter");
     $symfonyRequest = new Request();
 
-    $files = $request->getUploadedFiles();
+    $reqBody = $this->getParsedBody($request);
 
-    if (empty($files['report'])) {
-      $info = new Info(400, "No file uploaded", InfoType::ERROR);
-      return $response->withJson($info->getArray(), $info->getCode());
-    } elseif (!array_key_exists("importerUser", $reqBody)) {
+    if (!array_key_exists("importerUser", $reqBody)) {
       $info = new Info(400, "Missing parameter 'importerUser'", InfoType::ERROR);
       return $response->withJson($info->getArray(), $info->getCode());
     }
@@ -352,10 +374,8 @@ class ReportController extends RestController
       $importerUser = $this->restHelper->getUserId();
     }
 
-    /** @var \Slim\Psr7\UploadedFile $slimFile */
-    $slimFile = $files['report'];
-
-    $uploadedFile = new UploadedFile($slimFile->getFilePath(), $slimFile->getClientFilename(), $slimFile->getClientMediaType());
+    $uploadedFile = new UploadedFile($slimFile->getFilePath(),
+      $slimFile->getClientFilename(), $slimFile->getClientMediaType());
 
     $symfonyRequest->files->set('report', $uploadedFile);
     $symfonyRequest->request->set('uploadselect', $uploadId);
@@ -363,7 +383,7 @@ class ReportController extends RestController
 
     try {
       $agentResp = $decisionImporter->handleRequest($symfonyRequest);
-    } catch (\Exception $e) {
+    } catch (Exception $e) {
       $error = new Info(500, $e->getMessage(), InfoType::ERROR);
       return $response->withJson($error->getArray(), $error->getCode());
     }
@@ -377,75 +397,83 @@ class ReportController extends RestController
   }
 
   /**
-   * Import a report
+   * Import a SPDX RDF report
    *
    * @param ServerRequestInterface $request
    * @param ResponseHelper $response
-   * @param array $args
+   * @param int $upload_pk
+   * @param SlimUploadedFile $slimFile
    * @return ResponseHelper
    */
-  public function importReport($request, $response, $args)
+  public function importSpdxReport(ServerRequestInterface $request,
+                                   ResponseHelper $response, int $upload_pk,
+                                   SlimUploadedFile $slimFile): ResponseHelper
   {
-    $returnVal = null;
-    $query = $request->getQueryParams();
-    if (!array_key_exists("upload", $query)) {
-      $returnVal = new Info(400, "Bad Request. **upload** is a required query param", InfoType::INFO);
-      return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+    $reqBody = $this->getParsedBody($request);
+    /** @var \ReportImportPlugin $reportImport */
+    $reportImport = $this->restHelper->getPlugin('ui_reportImport');
+    $symfonyRequest = new Request();
+
+    // moving the uploaded file to the ReportImport Directory
+    global $SysConf;
+    $fileBase = $SysConf['FOSSOLOGY']['path'] . "/ReportImport/";
+    if (!is_dir($fileBase)) {
+      mkdir($fileBase, 0755, true);
     }
-    $upload_pk = intval($query['upload']);
-    // checking if the scheduler is running or not
-    $commu_status = fo_communicate_with_scheduler('status', $response_from_scheduler, $error_info);
-    if ($commu_status) {
-      // parsing the request body
-      $reqBody = $this->getParsedBody($request);
-      // checking if the upload exists and if yes, whether it is accessible
-      $res = true;
-      if (! $this->dbHelper->doesIdExist("upload", "upload_pk", $upload_pk)) {
-        $returnVal = new Info(404, "Upload does not exist", InfoType::ERROR);
-        $res = false;
-      } else if (! $this->restHelper->getUploadDao()->isAccessible($upload_pk, $this->restHelper->getGroupId())) {
-        $returnVal = new Info(403, "Upload is not accessible", InfoType::ERROR);
-        $res = false;
-      }
-      if ($res !== true) {
-        return $response->withJson($returnVal->getArray(), $returnVal->getCode());
-      }
-      $reportImport = $this->restHelper->getPlugin('ui_reportImport');
-      $symfonyRequest = new \Symfony\Component\HttpFoundation\Request();
+    $targetFile = time() . '_' . rand() . '_' . $slimFile->getClientFilename();
+    $slimFile->moveTo($fileBase . $targetFile);
 
-      $files = $request->getUploadedFiles();
-
-      if (empty($files['report'])) {
-        $info = new Info(400, "No file uploaded", InfoType::ERROR);
-        return $response->withJson($info->getArray(), $info->getCode());
-      }
-      // Extracting file from uploaded files
-      /** @var \Psr\Http\Message\UploadedFileInterface $file */
-      $file = $files['report'];
-
-      // moving the uploaded file to the ReportImport Directory
-      global $SysConf;
-      $fileBase = $SysConf['FOSSOLOGY']['path'] . "/ReportImport/";
-      if (!is_dir($fileBase)) {
-        mkdir($fileBase, 0755, true);
-      }
-      $targetFile = time() . '_' . rand() . '_' . $file->getClientFilename();
-      $file->moveTo($fileBase . $targetFile);
-
-      // translating values for symfony request
-      $symfonyRequest->request->set('addConcludedAsDecisions', filter_var($reqBody['addConcludedAsDecisions'], FILTER_VALIDATE_BOOLEAN) ? 'true' : 'false');
-      $symfonyRequest->request->set('addLicenseInfoFromInfoInFile', filter_var($reqBody['addLicenseInfoFromInfoInFile'], FILTER_VALIDATE_BOOLEAN) ? 'true' : 'false');
-      $symfonyRequest->request->set('addLicenseInfoFromConcluded', filter_var($reqBody['addLicenseInfoFromConcluded'], FILTER_VALIDATE_BOOLEAN) ? 'true' : 'false');
-      $symfonyRequest->request->set('addConcludedAsDecisionsOverwrite', filter_var($reqBody['addConcludedAsDecisionsOverwrite'], FILTER_VALIDATE_BOOLEAN) ? 'true' : 'false');
-      $symfonyRequest->request->set('addConcludedAsDecisionsTBD', filter_var($reqBody['addConcludedAsDecisionsTBD'], FILTER_VALIDATE_BOOLEAN) ? 'true' : 'false');
-      $symfonyRequest->request->set('addCopyrights', filter_var($reqBody['addCopyrights'], FILTER_VALIDATE_BOOLEAN) ? 'true' : 'false');
-      $symfonyRequest->request->set('addNewLicensesAs', $reqBody['addNewLicensesAs']);
-
-      $reportImport->runImport($upload_pk, $targetFile, $symfonyRequest);
-      $returnVal = new Info(202, "ReportImport job is scheduled successfully for the given upload.", InfoType::INFO);
-    } else {
-      $returnVal = new Info(503, "Scheduler is not running!", InfoType::ERROR);
+    // Get default values for parameters
+    $addNewLicensesAs = "candidate";
+    $addLicenseInfoFromInfoInFile = "true";
+    $addLicenseInfoFromConcluded = "false";
+    $addConcludedAsDecisions = "true";
+    $addConcludedAsDecisionsTBD = "true";
+    $addCopyrights = "false";
+    if (array_key_exists("addNewLicensesAs", $reqBody) &&
+        $reqBody["addNewLicensesAs"] === "license") {
+      $addNewLicensesAs = "license";
     }
+    if (array_key_exists("addLicenseInfoFromInfoInFile", $reqBody) &&
+          !filter_var($reqBody["addLicenseInfoFromInfoInFile"],
+            FILTER_VALIDATE_BOOLEAN)) {
+      $addLicenseInfoFromInfoInFile = "false";
+    }
+    if (array_key_exists("addLicenseInfoFromConcluded", $reqBody) &&
+        filter_var($reqBody["addLicenseInfoFromConcluded"],
+          FILTER_VALIDATE_BOOLEAN)) {
+      $addLicenseInfoFromConcluded = "true";
+    }
+    if (array_key_exists("addConcludedAsDecisions", $reqBody) &&
+        !filter_var($reqBody["addConcludedAsDecisions"],
+          FILTER_VALIDATE_BOOLEAN)) {
+      $addConcludedAsDecisions = "false";
+    }
+    if (array_key_exists("addConcludedAsDecisionsTBD", $reqBody) &&
+        !filter_var($reqBody["addConcludedAsDecisionsTBD"],
+          FILTER_VALIDATE_BOOLEAN)) {
+      $addConcludedAsDecisionsTBD = "false";
+    }
+    if (array_key_exists("addCopyrights", $reqBody) &&
+        filter_var($reqBody["addCopyrights"],
+          FILTER_VALIDATE_BOOLEAN)) {
+      $addCopyrights = "true";
+    }
+
+    // translating values for symfony request
+    $symfonyRequest->request->set('addNewLicensesAs', $addNewLicensesAs);
+    $symfonyRequest->request->set('addLicenseInfoFromInfoInFile',
+      $addLicenseInfoFromInfoInFile);
+    $symfonyRequest->request->set('addLicenseInfoFromConcluded',
+      $addLicenseInfoFromConcluded);
+    $symfonyRequest->request->set('addConcludedAsDecisions',
+      $addConcludedAsDecisions);
+    $symfonyRequest->request->set('addConcludedAsDecisionsTBD',
+      $addConcludedAsDecisionsTBD);
+    $symfonyRequest->request->set('addCopyrights', $addCopyrights);
+
+    $agentResp = $reportImport->runImport($upload_pk, $targetFile, $symfonyRequest);
+    $returnVal = new Info(201, intval($agentResp[0]), InfoType::INFO);
     return $response->withJson($returnVal->getArray(), $returnVal->getCode());
   }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -7,7 +7,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.5.0
+  version: 1.5.1
   contact:
     email: fossology@fossology.org
   license:
@@ -2016,6 +2016,7 @@ paths:
         schema:
           enum:
             - decisionimporter
+            - spdxRdf
     post:
       operationId: uploadReport
       tags:
@@ -2029,6 +2030,53 @@ paths:
             schema:
               oneOf:
                 - $ref: '#/components/schemas/DecisionImporter'
+          multipart/form-dataa:
+            schema:
+              type: object
+              properties:
+                addLicenseInfoFromInfoInFile:
+                  type: boolean
+                  description: SPDX tag of type licenseInfoInFile
+                  default: false
+                  required: false
+                addConcludedAsDecisions:
+                  type: boolean
+                  description: Add concluded licenses as decisions
+                  required: false
+                  default: false
+                addLicenseInfoFromConcluded:
+                  type: boolean
+                  description: SPDX tag of type licenseConcluded
+                  default: false
+                  required: false
+                addConcludedAsDecisionsOverwrite:
+                  type: boolean
+                  description: also overwrite existing decissions
+                  default: false
+                  required: false
+                addConcludedAsDecisionsTBD:
+                  type: boolean
+                  description: import as "to be discussed"
+                  default: false
+                  required: false
+                addCopyrights:
+                  type: boolean
+                  description: Add the copyright information as textfindings
+                  default: false
+                  required: false
+                addNewLicensesAs:
+                  type: string
+                  description: Create new licenses as
+                  enum:
+                    - candidate
+                    - license
+                  required: true
+                  default: candidate
+                report:
+                  type: string
+                  format: binary
+                  description: Select report to upload
+                  required: true
       responses:
         '201':
           description: ReportImport job is scheduled successfully for the given upload.

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1425,7 +1425,7 @@ paths:
     get:
       operationId: getJobsHistoryPerUpload
       tags:
-      - Job
+        - Job
       summary: Get the history of all the jobs queued based on an upload
       description: Returns the history of all the jobs queued based on an upload
       responses:
@@ -1456,7 +1456,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Info'
         default:
-            $ref: '#/components/responses/defaultResponse'
+          $ref: '#/components/responses/defaultResponse'
 
   /folders:
     parameters:
@@ -2016,7 +2016,7 @@ paths:
         schema:
           enum:
             - decisionimporter
-            - spdxRdf
+            - spdxrdf
     post:
       operationId: uploadReport
       tags:
@@ -2025,58 +2025,20 @@ paths:
       description: >
         Import a report to an existing upload
       requestBody:
+        required: true
         content:
           multipart/form-data:
             schema:
-              oneOf:
-                - $ref: '#/components/schemas/DecisionImporter'
-          multipart/form-dataa:
-            schema:
               type: object
               properties:
-                addLicenseInfoFromInfoInFile:
-                  type: boolean
-                  description: SPDX tag of type licenseInfoInFile
-                  default: false
-                  required: false
-                addConcludedAsDecisions:
-                  type: boolean
-                  description: Add concluded licenses as decisions
-                  required: false
-                  default: false
-                addLicenseInfoFromConcluded:
-                  type: boolean
-                  description: SPDX tag of type licenseConcluded
-                  default: false
-                  required: false
-                addConcludedAsDecisionsOverwrite:
-                  type: boolean
-                  description: also overwrite existing decissions
-                  default: false
-                  required: false
-                addConcludedAsDecisionsTBD:
-                  type: boolean
-                  description: import as "to be discussed"
-                  default: false
-                  required: false
-                addCopyrights:
-                  type: boolean
-                  description: Add the copyright information as textfindings
-                  default: false
-                  required: false
-                addNewLicensesAs:
-                  type: string
-                  description: Create new licenses as
-                  enum:
-                    - candidate
-                    - license
-                  required: true
-                  default: candidate
                 report:
+                  description: Report file to be imported
                   type: string
                   format: binary
-                  description: Select report to upload
-                  required: true
+              oneOf:
+                - $ref: '#/components/schemas/DecisionImporter'
+                - $ref: '#/components/schemas/SpdxRdfImport'
+              required: ["report"]
       responses:
         '201':
           description: ReportImport job is scheduled successfully for the given upload.
@@ -2429,7 +2391,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Info'
         default:
-            $ref: '#/components/responses/defaultResponse'
+          $ref: '#/components/responses/defaultResponse'
   /license/admincandidates/{id}:
     parameters:
       - name: id
@@ -2690,8 +2652,8 @@ components:
           type: string
           description: group_name of the license-candidate.
         group_id:
-            type: integer
-            description: group_id of the license-candidate.
+          type: integer
+          description: group_id of the license-candidate.
     User:
       type: object
       properties:
@@ -3375,13 +3337,42 @@ components:
           description: User ID on which to tag imported decisions. Use '0' for self.
           default: 0
           example: 3
-        report:
-          $ref: '#/components/schemas/ReportImportFile'
-      required: ["importerUser", "report"]
-    ReportImportFile:
-      description: Report file to be imported
-      type: string
-      format: binary
+      required: ["importerUser"]
+    SpdxRdfImport:
+      description: Information required by SPDX RDF report import agent.
+      type: object
+      properties:
+        addNewLicensesAs:
+          type: string
+          description: Create new licenses as
+          enum:
+            - candidate
+            - license
+          default: candidate
+        addLicenseInfoFromInfoInFile:
+          type: boolean
+          description: >
+            Add the License Info as findings from SPDX tag of type
+            licenseInfoInFile
+          default: true
+        addLicenseInfoFromConcluded:
+          type: boolean
+          description: >
+            Add the License Info as findings from SPDX tag of type
+            licenseConcluded
+          default: false
+        addConcludedAsDecisions:
+          type: boolean
+          description: Add concluded licenses as decisions
+          default: true
+        addConcludedAsDecisionsTBD:
+          type: boolean
+          description: Add concluded licenses imported as "to be discussed"
+          default: true
+        addCopyrights:
+          type: boolean
+          description: Add the copyright information as text findings
+          default: false
   responses:
     defaultResponse:
       description: Some error occurred. Check the "message"


### PR DESCRIPTION
Signed-off-by: Krishna Mahato <krishhtrishh9304@gmail.com>

## Description
There is a new POST route which is available at `/report/import?upload={id}` which will initiate a reportImport job for a given upload.

## How to test
- Use any API platform like postman.
- Pull the changes from this PR.

### Testing `POST /report/import?upload={id}` . Refer the below example ----

- Provide the request body as the following. (_Make sure the type is multipart/form-data_)
<img width="887" alt="Screenshot 2022-09-14 at 12 22 47 PM" src="https://user-images.githubusercontent.com/71918441/190082100-326ec60c-84e5-4e08-84cd-f939e4278208.png">

- You can expect a response like this 
<img width="603" alt="Screenshot 2022-09-14 at 12 23 27 PM" src="https://user-images.githubusercontent.com/71918441/190082249-bd5e7df3-b225-484f-b7a1-2013734be19f.png">

This fixes #2308 .
@GMishx @shaheemazmalmmd @Shruti3004 PTAL.



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2317"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

