### PR TITLE
feat(API): Create Admin-License API

### DIFF
--- a/src/www/ui/admin-license-file.php
+++ b/src/www/ui/admin-license-file.php
@@ -72,7 +72,7 @@ class admin_license_file extends FO_Plugin
 
     // Add new rec to db
     if (@$_POST["addit"]) {
-      $resultstr = $this->Adddb();
+      $resultstr = $this->Adddb($_POST);
       $this->vars['message'] = $resultstr;
       if (strstr($resultstr, $errorstr)) {
         return $this->Updatefm(0);
@@ -349,7 +349,7 @@ class admin_license_file extends FO_Plugin
   }
 
   /** @brief check if shortname or license text of this license is existing */
-  private function isShortnameBlocked($rfId, $shortname, $text)
+  public function isShortnameBlocked($rfId, $shortname, $text)
   {
     $sql = "SELECT count(*) from license_ref where rf_pk <> $1 and (LOWER(rf_shortname) = LOWER($2) or (rf_text <> ''
       and rf_text = $3 and LOWER(rf_text) NOT LIKE 'license by nomos.'))";
@@ -478,18 +478,18 @@ class admin_license_file extends FO_Plugin
    *
    * \return An add status string
    */
-  function Adddb()
+  public function Adddb($REQ)
   {
-    $rf_shortname = StringOperation::replaceUnicodeControlChar(trim($_POST['rf_shortname']));
-    $rf_fullname = StringOperation::replaceUnicodeControlChar(trim($_POST['rf_fullname']));
-    $rf_url = $_POST['rf_url'];
-    $rf_notes = $_POST['rf_notes'];
-    $rf_text = StringOperation::replaceUnicodeControlChar(trim($_POST['rf_text']));
-    $parent = $_POST['rf_parent'];
-    $report = $_POST['rf_report'];
-    $riskLvl = intval($_POST['risk_level']);
+    $rf_shortname = StringOperation::replaceUnicodeControlChar(trim($REQ['rf_shortname']));
+    $rf_fullname = StringOperation::replaceUnicodeControlChar(trim($REQ['rf_fullname']));
+    $rf_url = $REQ['rf_url'];
+    $rf_notes = $REQ['rf_notes'];
+    $rf_text = StringOperation::replaceUnicodeControlChar(trim($REQ['rf_text']));
+    $parent = $REQ['rf_parent'];
+    $report = $REQ['rf_report'];
+    $riskLvl = intval($REQ['risk_level']);
     $selectedObligations = array_key_exists($this->obligationSelectorName,
-      $_POST) ? $_POST[$this->obligationSelectorName] : [];
+      $REQ) ? $REQ[$this->obligationSelectorName] : [];
 
     if (empty($rf_shortname)) {
       $text = _("ERROR: The license shortname is empty. License not added.");
@@ -512,17 +512,17 @@ class admin_license_file extends FO_Plugin
     $this->dbManager->prepare($stmt,$sql);
     $res = $this->dbManager->execute($stmt,
       array(
-        $_POST['rf_active'],
-        $_POST['marydone'],
+        $REQ['rf_active'],
+        $REQ['marydone'],
         $rf_shortname,
         $rf_fullname,
         $rf_url,
         $rf_notes,
         $rf_text,
-        $_POST['rf_text_updatable'],
-        $_POST['rf_detector_type'],
+        $REQ['rf_text_updatable'],
+        $REQ['rf_detector_type'],
         $riskLvl,
-        $_POST['rf_spdx_compatible']
+        $REQ['rf_spdx_compatible']
       ));
     $row = $this->dbManager->fetchArray($res);
     $rfId = $row['rf_pk'];
@@ -554,7 +554,7 @@ class admin_license_file extends FO_Plugin
       $obligationMap->associateLicenseWithObligation($obligation, $rfId);
     }
 
-    return "License $_POST[rf_shortname] (id=$rfId) added.<p>";
+    return "License $REQ[rf_shortname] (id=$rfId) added.<p>";
   }
 
 

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -2036,6 +2036,49 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
             $ref: '#/components/responses/defaultResponse'
+  /license/admin:
+    post:
+      operationId: createAdminLicense
+      tags:
+        - License
+      summary: Create a new admin license
+      description: >
+        Add a new admin license to the database
+      requestBody:
+        description: Information about new Admin license
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AdminLicense'
+      responses:
+        '201':
+          description: License added successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /license/import-csv:
     post:
       operationId: importLicense
@@ -2762,6 +2805,76 @@ components:
         isCandidate:
           description: Is the license a candidate?
           type: boolean
+    AdminLicense:
+      description: AdminLicense from the database
+      type: object
+      properties:
+        rf_active:
+          description: Is the license active?
+          type: boolean
+          example:
+           true
+        marydone:
+          description: Is the license done?
+          type: boolean
+          example:
+            true
+        rf_shortname:
+          description: Short name
+          type: string
+          example:
+            "MIT"
+        rf_fullname:
+          description: Full name
+          type: string
+          example:
+            "MIT License"
+        rf_url:
+          description: URL of the license text
+          type: string
+          example:
+            "https://opensource.org/licenses/MIT"
+        rf_notes:
+          description: Notes
+          type: string
+          example:
+            "Short Notes about license"
+        rf_text:
+          description: License text
+          type: string
+          example:
+            "MIT License Copyright (c) <year> <copyright holders> ..."
+        rf_parent:
+          description: Parent license
+          type: string
+          example:
+            "MIT"
+        rf_report:
+          description: Report info
+          type: string
+          example:
+            "Report Info"
+        risk_level:
+          description: Risk level
+          type: integer
+          nullable: true
+          example:
+            3
+        rf_text_updatable:
+          description: Is the license text updatable?
+          type: boolean
+          example:
+            true
+        rf_detector_type:
+          description: Detector type
+          type: integer
+          example:
+            1
+        rf_spdx_compatible:
+          description: Is the license SPDX compatible?
+          type: boolean
+          example:
+            true
     Group:
       description: Group object
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -243,6 +243,7 @@ $app->group('/license',
     $app->get('', LicenseController::class . ':getAllLicenses');
     $app->post('/import-csv', LicenseController::class . ':handleImportLicense');
     $app->post('', LicenseController::class . ':createLicense');
+    $app->post('/admin', LicenseController::class . ':createAdminLicense');
     $app->get('/{shortname:.+}', LicenseController::class . ':getLicense');
     $app->patch('/{shortname:.+}', LicenseController::class . ':updateLicense');
     $app->any('/{params:.*}', BadRequestController::class);


### PR DESCRIPTION
Signed-off-by: dushimsam <dushsam@gmail.com>


## Description

An endpoint to add new admin-license .

### Changes

1. Added a new controller file and the function to handle the logic in `LicenseController`.
2. Updated some functions from `admin-license-file.php` to be reusable by the outside callers.
3. Updated  the main file(`index.php`) by adding a new route `POST` `/license/admin`.
4. Updated the `openapi.yaml` file  to introduce a new API.

## How to test

Make a POST request on the endpoint accessed at "/license/admin"

## Example

 #### 1. FIRST CASE  
 
The creation of the license text
![image](https://user-images.githubusercontent.com/66276301/190174335-23391f31-8089-4985-bd11-61f241cea95d.png)


 #### 2. SECOND CASE

Handling the tendency of generating duplicate records from the database.

![image](https://user-images.githubusercontent.com/66276301/190174495-2c86b104-1562-4f3c-9f6c-a8d48d212af1.png)

### Related Issue:
Fixes #2318 

    
cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2298"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2319"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

