### PR TITLE
docs(openapi): fix spectral lint warnings/errors

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -47,6 +47,8 @@ tags:
   description: Upload's report
 - name: License
   description: License and obligation management
+- name: Maintenance
+  description: Maintenance operations
 
 paths:
   /tokens:
@@ -2064,7 +2066,8 @@ paths:
                   type: string
                   format: binary
                   description: CSV to be imported
-                  
+              required:
+                - file_input
       responses:
           '400':
             description: Validation Error
@@ -2588,9 +2591,7 @@ components:
           filePath:
             description: Path of the files for which the copyright information is provided
             type: string
-            example: 
-            - "path/to/file1"
-            - "path/to/file2"
+            example: "path/to/file1"
     UploadPermGroups:
       description: Groups with their respective permissions for a upload
       type: object


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

I've fixed spectral linting warnings/errors related to the `openapi.yaml` file.

### Changes

Only changes in the `openapi.yaml` spec:
- The `Maintenance` tag was not declared in global tags
- The `required` property for `multipart/form-data` properties needed to be an array, see https://github.com/OAI/OpenAPI-Specification/issues/1954#issuecomment-502946287

## How to test

With the following spectral ruleset `.spectral.yml`:

```
extends: "spectral:oas"
```

Before this MR:

```sh
$ spectral lint src/www/ui/api/documentation/openapi.yaml

src/www/ui/api/documentation/openapi.yaml
  145:11  warning  operation-tag-defined      Operation tags must be defined in global tags.  paths./maintenance.post.tags[0]
 2058:28    error  oas3-valid-schema-example  schema is invalid: data/required must be array  paths./license/import-csv.post.requestBody.content.multipart/form-data.schema.properties.enclosure.default
 2059:29    error  oas3-schema                "required" property type must be array.         paths./license/import-csv.post.requestBody.content.multipart/form-data.schema.properties.enclosure.required
 2063:28    error  oas3-valid-schema-example  schema is invalid: data/required must be array  paths./license/import-csv.post.requestBody.content.multipart/form-data.schema.properties.delimiter.default
 2064:29    error  oas3-schema                "required" property type must be array.         paths./license/import-csv.post.requestBody.content.multipart/form-data.schema.properties.delimiter.required
 2069:29    error  oas3-schema                "required" property type must be array.         paths./license/import-csv.post.requestBody.content.multipart/form-data.schema.properties.file_input.required

✖ 6 problems (5 errors, 1 warning, 0 infos, 0 hints)
```

After this MR:

```sh
$ spectral lint src/www/ui/api/documentation/openapi.yaml

No results with a severity of 'error' or higher found!
```

:hammer_and_wrench: with :heart: by [Siemens](https://opensource.siemens.com/)

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2320"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

