### PR TITLE
chore(Dockerfile): add OCI annotations

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -33,6 +33,11 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+    - name: Set build version
+      run: |
+        VERSION_PATTERN='([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+)(-?rc[[:digit:]]+)?-?([[:digit:]]*)-?[[:alnum:]]*'
+        echo VERSION=$(git describe --tags > /dev/null 2>&1 && git describe --tags | head -1 | sed -re "s/${VERSION_PATTERN}/\\1.\\3\\2/" | sed -re 's/\.$/.0/') >> $GITHUB_ENV
+
     - name: Build and push main image
       uses: docker/build-push-action@v3
       with:
@@ -41,6 +46,8 @@ jobs:
         context: .
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        labels: |
+          org.opencontainers.image.version=${VERSION}
 
     - name: Build and push runner image
       uses: docker/build-push-action@v3
@@ -50,3 +57,5 @@ jobs:
         file: utils/automation/Dockerfile.ci
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        labels: |
+          org.opencontainers.image.version=${VERSION}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -131,3 +131,5 @@ jobs:
       with:
         push: true
         tags: fossology/fossology:${{ steps.get_release.outputs.tag_name }}
+        labels: |
+          org.opencontainers.image.version=${{ steps.get_release.outputs.tag_name }}.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@
 # Description: Docker container image recipe
 
 FROM debian:buster-slim as builder
-LABEL maintainer="Fossology <fossology@fossology.org>"
+LABEL org.opencontainers.image.authors="Fossology <fossology@fossology.org>"
+LABEL org.opencontainers.image.source="https://github.com/fossology/fossology"
+LABEL org.opencontainers.image.vendor="FOSSology"
+LABEL org.opencontainers.image.licenses="GPL-2.0-only AND LGPL-2.1-only"
 
 WORKDIR /fossology
 
@@ -51,7 +54,13 @@ RUN make clean install \
 
 FROM debian:buster-slim
 
-LABEL maintainer="Fossology <fossology@fossology.org>"
+LABEL org.opencontainers.image.authors="Fossology <fossology@fossology.org>"
+LABEL org.opencontainers.image.url="https://fossology.org"
+LABEL org.opencontainers.image.source="https://github.com/fossology/fossology"
+LABEL org.opencontainers.image.vendor="FOSSology"
+LABEL org.opencontainers.image.licenses="GPL-2.0-only AND LGPL-2.1-only"
+LABEL org.opencontainers.image.title="FOSSology"
+LABEL org.opencontainers.image.description="FOSSology is an open source license compliance software system and toolkit.  As a toolkit you can run license, copyright and export control scans from the command line.  As a system, a database and web ui are provided to give you a compliance workflow. License, copyright and export scanners are tools used in the workflow."
 
 ### install dependencies
 COPY --from=builder /fossology/dependencies-for-runtime /fossology


### PR DESCRIPTION
## Description

Add annotations from Open Container Initiative to Dockerfile https://github.com/opencontainers/image-spec/blob/main/annotations.md

### Changes

1. Add OCI annotations to `Dockerfile`
2. Add OCI label for Docker Hub images.

## How to test

Build Docker image and check the image labels.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2325"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

