### PR TITLE
fix(unifiedReport): fix line break issue in libre office

### DIFF
--- a/src/unifiedreport/agent/reportStatic.php
+++ b/src/unifiedreport/agent/reportStatic.php
@@ -198,7 +198,8 @@ class ReportStatic
 
     $table->addRow($rowWidth);
     $table->addCell($cellFirstLen)->addText(htmlspecialchars(" General assessment"), $leftColStyle, "pStyle");
-    $generalAssessment = str_replace("\n", "<w:br/>", htmlspecialchars($otherStatement["ri_general_assesment"], ENT_DISALLOWED));
+    $generalAssessment = str_replace("\n", "</w:t>\n<w:br />\n<w:t xml:space=\"preserve\">", htmlspecialchars($otherStatement["ri_general_assesment"], ENT_DISALLOWED));
+    $generalAssessment = str_replace("\r", "", $generalAssessment);
     $table->addCell($cellLen)->addText($generalAssessment, $rightColStyleBlue, "pStyle");
 
     $table->addRow($rowWidth);
@@ -223,7 +224,8 @@ class ReportStatic
     $this->addCheckBoxText($cell, $getCheckboxList[3], $dependenciesfoundinsourcecode);
     $this->addCheckBoxText($cell, $getCheckboxList[4], $dependenciesfoundinbinaries);
     if ($otherStatement["ri_depnotes"] != 'NA' && !empty($otherStatement["ri_depnotes"])) {
-      $extraNotes = str_replace("\n", "<w:br/>", htmlspecialchars($otherStatement["ri_depnotes"], ENT_DISALLOWED));
+      $extraNotes = str_replace("\n", "</w:t>\n<w:br />\n<w:t xml:space=\"preserve\">", htmlspecialchars($otherStatement["ri_depnotes"], ENT_DISALLOWED));
+      $extraNotes = str_replace("\r", "", $extraNotes);
       $cell->addText($extraNotes, $rightColStyleBlue, "pStyle");
     }
 
@@ -235,7 +237,8 @@ class ReportStatic
     $this->addCheckBoxText($cell, $getCheckboxList[5], $noexportrestrictionsfound);
     $this->addCheckBoxText($cell, $getCheckboxList[6], $exportrestrictionsfound);
     if ($otherStatement["ri_exportnotes"] != 'NA' && !empty($otherStatement["ri_exportnotes"])) {
-      $extraNotes = str_replace("\n", "<w:br/>", htmlspecialchars($otherStatement["ri_exportnotes"], ENT_DISALLOWED));
+      $extraNotes = str_replace("\n", "</w:t>\n<w:br />\n<w:t xml:space=\"preserve\">", htmlspecialchars($otherStatement["ri_exportnotes"], ENT_DISALLOWED));
+      $extraNotes = str_replace("\r", "", $extraNotes);
       $cell->addText($extraNotes, $rightColStyleBlue, "pStyle");
     }
 
@@ -248,18 +251,21 @@ class ReportStatic
     $this->addCheckBoxText($cell, $getCheckboxList[7], $norestrictionsforusefound);
     $this->addCheckBoxText($cell, $getCheckboxList[8], $restrictionsforusefound);
     if ($otherStatement["ri_copyrightnotes"] != 'NA' && !empty($otherStatement["ri_copyrightnotes"])) {
-      $extraNotes = str_replace("\n", "<w:br/>", htmlspecialchars($otherStatement["ri_copyrightnotes"], ENT_DISALLOWED));
+      $extraNotes = str_replace("\n", "</w:t>\n<w:br />\n<w:t xml:space=\"preserve\">", htmlspecialchars($otherStatement["ri_copyrightnotes"], ENT_DISALLOWED));
+      $extraNotes = str_replace("\r", "", $extraNotes);
       $cell->addText($extraNotes, $rightColStyleBlue, "pStyle");
     }
 
     $table->addRow($rowWidth, "pStyle");
     $table->addCell($cellFirstLen)->addText(htmlspecialchars(" Additional notes"), $leftColStyle, "pStyle");
-    $additionalNotes = str_replace("\n", "<w:br/>", htmlspecialchars($otherStatement["ri_ga_additional"], ENT_DISALLOWED));
+    $additionalNotes = str_replace("\n", "</w:t>\n<w:br />\n<w:t xml:space=\"preserve\">", htmlspecialchars($otherStatement["ri_ga_additional"], ENT_DISALLOWED));
+    $additionalNotes = str_replace("\r", "", $additionalNotes);
     $cell = $table->addCell($cellLen)->addText($additionalNotes, $rightColStyleBlue, "pStyle");
 
     $table->addRow($rowWidth);
     $cell = $table->addCell($cellFirstLen)->addText(htmlspecialchars(" General Risks (optional)"), $leftColStyle, "pStyle");
-    $generalRisks = str_replace("\n", "<w:br/>", htmlspecialchars($otherStatement["ri_ga_risk"], ENT_DISALLOWED));
+    $generalRisks = str_replace("\n", "</w:t>\n<w:br />\n<w:t xml:space=\"preserve\">", htmlspecialchars($otherStatement["ri_ga_risk"], ENT_DISALLOWED));
+    $generalRisks = str_replace("\r", "", $generalRisks);
     $cell = $table->addCell($cellLen)->addText($generalRisks, $rightColStyleBlue, "pStyle");
     if ($otherStatement["includeDNU"]) {
       $table->addRow($rowWidth);
@@ -421,7 +427,8 @@ class ReportStatic
           $firstRowTextStyle);
           $table->addCell($secondColLen, $this->secondColStyle)->addText(htmlspecialchars(implode(",",
             $obligation["license"])));
-          $obligationText = str_replace("\n", "<w:br/>", htmlspecialchars($obligation["text"], ENT_DISALLOWED));
+          $obligationText = str_replace("\n", "</w:t>\n<w:br />\n<w:t xml:space=\"preserve\">", htmlspecialchars($obligation["text"], ENT_DISALLOWED));
+          $obligationText = str_replace("\r", "", $obligationText);
           $table->addCell($thirdColLen)->addText($obligationText);
       }
     } else {

--- a/src/unifiedreport/agent/unifiedreport.php
+++ b/src/unifiedreport/agent/unifiedreport.php
@@ -421,7 +421,8 @@ class UnifiedReport extends Agent
         $cell1->addText(htmlspecialchars($licenseMain["content"], ENT_DISALLOWED), $this->licenseColumn, "pStyle");
         $cell2 = $table->addCell($secondColLen);
         // replace new line character
-        $licenseText = str_replace("\n", "<w:br/>\n", htmlspecialchars($licenseMain["text"], ENT_DISALLOWED));
+        $licenseText = str_replace("\n", "</w:t>\n<w:br />\n<w:t xml:space=\"preserve\">", htmlspecialchars($licenseMain["text"], ENT_DISALLOWED));
+        $licenseText = str_replace("\r", "", $licenseText);
         $cell2->addText($licenseText, $this->licenseTextColumn, "pStyle");
         if (!empty($licenseMain["files"])) {
           $cell3 = $table->addCell($thirdColLen, $styleColumn);
@@ -468,7 +469,8 @@ class UnifiedReport extends Agent
         $cell1->addText(htmlspecialchars($licenseStatement["content"], ENT_DISALLOWED), $this->licenseColumn, "pStyle");
         $cell2 = $table->addCell($secondColLen, "pStyle");
         // replace new line character
-        $licenseText = str_replace("\n", "<w:br/>\n", htmlspecialchars($licenseStatement["text"], ENT_DISALLOWED));
+        $licenseText = str_replace("\n", "</w:t>\n<w:br />\n<w:t xml:space=\"preserve\">", htmlspecialchars($licenseStatement["text"], ENT_DISALLOWED));
+        $licenseText = str_replace("\r", "", $licenseText);
         $cell2->addText($licenseText, $this->licenseTextColumn, "pStyle");
         $cell3 = $table->addCell($thirdColLen, "pStyle");
         asort($licenseStatement["files"]);
@@ -513,7 +515,8 @@ class UnifiedReport extends Agent
           $cell1->addText(htmlspecialchars($licenseStatement["content"], ENT_DISALLOWED), $this->licenseColumn, "pStyle");
           $cell2 = $table->addCell($secondColLen);
           // replace new line character
-          $licenseText = str_replace("\n", "<w:br/>\n", htmlspecialchars($licenseStatement["text"], ENT_DISALLOWED));
+          $licenseText = str_replace("\n", "</w:t>\n<w:br />\n<w:t xml:space=\"preserve\">", htmlspecialchars($licenseStatement["text"], ENT_DISALLOWED));
+          $licenseText = str_replace("\r", "", $licenseText);
           $cell2->addText($licenseText, $this->licenseTextColumn, "pStyle");
           $cell3 = $table->addCell($thirdColLen, $riskarray['color']);
           asort($licenseStatement["files"]);


### PR DESCRIPTION
## Description

replace '\n' with '</w:t>\n<w:br />\n<w:t xml:space=\"preserve\">' to make it compatible with windows and Linux versions.

closes https://github.com/fossology/fossology/issues/2211

## How to test
 see https://github.com/fossology/fossology/issues/2211


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2333"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

