### PR TITLE
fix(debian): prevent duplication of bootstrap

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -96,10 +96,15 @@ composer_install:
 	@echo "current dir: '$${PWD}'"
 	$(INSTALL_DATA) composer.json composer.lock $(DESTDIR)$(MODDIR)
 	(cd $(DESTDIR)$(MODDIR); export COMPOSER_HOME=/dev/null; export COMPOSER_ALLOW_SUPERUSER=1; $(COMPOSER_PHAR) install --no-plugins --no-scripts --no-dev)
-	rm -rf $(DESTDIR)$(MODDIR)/www/ui/css/bootstrap
-	rm -rf $(DESTDIR)$(MODDIR)/www/ui/scripts/bootstrap
-	$(INSTALL_DATA) $(DESTDIR)$(MODDIR)/vendor/twbs/bootstrap/dist/css/* -t $(DESTDIR)$(MODDIR)/www/ui/css/bootstrap
-	$(INSTALL_DATA) $(DESTDIR)$(MODDIR)/vendor/twbs/bootstrap/dist/js/* -t $(DESTDIR)$(MODDIR)/www/ui/scripts/bootstrap
+	@if expr "$(DESTDIR)" : ".*fossology-common" >/dev/null; then \
+	  echo "Not duplicating bootstrap in Debian packaging"; \
+	else \
+	  echo "Copying bootstrap files to www"; \
+		rm -rf $(DESTDIR)$(MODDIR)/www/ui/css/bootstrap; \
+		rm -rf $(DESTDIR)$(MODDIR)/www/ui/scripts/bootstrap; \
+		$(INSTALL_DATA) $(DESTDIR)$(MODDIR)/vendor/twbs/bootstrap/dist/css/* -t $(DESTDIR)$(MODDIR)/www/ui/css/bootstrap; \
+		$(INSTALL_DATA) $(DESTDIR)$(MODDIR)/vendor/twbs/bootstrap/dist/js/* -t $(DESTDIR)$(MODDIR)/www/ui/scripts/bootstrap; \
+  fi
 
 .PHONY: subdirs $(BUILDDIRS)
 .PHONY: subdirs $(DIRS)

--- a/utils/fo-debuild
+++ b/utils/fo-debuild
@@ -60,21 +60,21 @@ while true; do
 done
 
 # Get the version
-VERSION=$(eval ${VERSION_COMMAND})
+VERSION=$(eval "${VERSION_COMMAND}")
 VERSION="${VERSION/-rc/~rc}-1"
 DISTRO=$(lsb_release --codename --short)
 
 # Update debian/changelog
 echo "Updating changelog with ${DISTRO} distro and ${VERSION} version."
-debchange --distribution ${DISTRO} \
-  --newversion ${VERSION} \
+debchange --distribution "${DISTRO}" \
+  --newversion "${VERSION}" \
   --urgency low --maintmaint "New patch build"
 
 utils/fo-mktar
 
 # Clean and build packages
 echo "Building packages..."
-make clean phpvendors
+make clean
 dpkg-buildpackage ${NOSIGN}
 
 # Discard changelog changes

--- a/utils/utils.sh
+++ b/utils/utils.sh
@@ -43,4 +43,4 @@ EOF
 }
 
 VERSION_PATTERN='([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+)(-?rc[[:digit:]]+)?-?([[:digit:]]*)-?[[:alnum:]]*'
-VERSION_COMMAND="git describe --tags > /dev/null 2>&1 && git describe --tags | head -1 | sed -re 's/${VERSION_PATTERN}/\\1.\\3\\2/' | sed -re 's/\.$/.0/'"
+VERSION_COMMAND="git describe --tags > /dev/null 2>&1 && git describe --tags | head -1 | sed -re 's/${VERSION_PATTERN}/\\1.\\3\\2/' | sed -re 's/\.(-rc[[:digit:]])?$/.0\1/'"


### PR DESCRIPTION
## Description

Prevent duplication of bootstrap folders in `fossology-common` and `fossology-web` Debian packages.
Also, fix regex for `-rc` tag versioning.

### More info
While creating Debian packages, `fossology-common` and `fossology-web` both contain files under `/usr/share/fossology/www/ui/css/bootstrap` and `/usr/share/fossology/www/ui/scripts/bootstrap` which causes following warning during installation:
```
Preparing to unpack fossology-common_4.2.0.~rc1-1_amd64.deb ...
Unpacking fossology-common (4.2.0.~rc1-1) over (4.2.0.10~rc1-1) ...
dpkg: error processing archive fossology-common_4.2.0.~rc1-1_amd64.deb (--install):
 trying to overwrite '/usr/share/fossology/www/ui/css/bootstrap/bootstrap-grid.css', which is also in package fossology-web 4.2.0.~rc1-1
```

### Changes

1. In `composer_install` target, check if building `fossology-common` package, then do not copy bootstrap folders.
2. Fix the version regex for rc tags to replace string `4.2.0.-rc1` to `4.2.0.0-rc1`.

## How to test

1. Remove installed bootstrap folders from `/usr/local/share/fossology/www/ui/scripts` and `css` and install the branch.
  1. UI should load properly with bootstrap working.
2. Create Debian packages using `./utils/fo-debuild --no-sign` and install them.
  1. The warning shown above should not appear.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2339"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

