### PR TITLE
hotfix(ui): fix User object accessing

### DIFF
--- a/src/www/ui/api/Helper/DbHelper.php
+++ b/src/www/ui/api/Helper/DbHelper.php
@@ -91,15 +91,15 @@ class DbHelper
     $uploadProxy = new UploadBrowseProxy($groupId, 0, $this->dbManager);
     $folderId = $options["folderId"];
     if ($folderId === null) {
-      $user = $this->getUsers($userId);
-      $folderId = $user[0]['rootFolderId'];
+      $users = $this->getUsers($userId);
+      $folderId = $users[0]->getRootFolderId();
     }
     $folders = [$folderId];
 
     if ($uploadId !== null) {
       $recursive = true;
-      $user = $this->getUsers($userId);
-      $folderId = $user[0]->getArray()['rootFolderId'];
+      $users = $this->getUsers($userId);
+      $folderId = $users[0]->getRootFolderId();
       $folders = [$folderId];
     }
 
@@ -250,10 +250,9 @@ FROM $tableName WHERE $idRowName = $1", [$id],
     }
     $users = [];
     if ($id === null) {
-      $result = $result = $this->dbManager->getRows($usersSQL, [], $statement);
+      $result = $this->dbManager->getRows($usersSQL, [], $statement);
     } else {
-      $result = $result = $this->dbManager->getRows($usersSQL, [$id],
-        $statement);
+      $result = $this->dbManager->getRows($usersSQL, [$id], $statement);
     }
     $currentUser = Auth::getUserId();
     $userIsAdmin = Auth::isAdmin();

--- a/src/www/ui/api/Helper/UploadHelper.php
+++ b/src/www/ui/api/Helper/UploadHelper.php
@@ -24,6 +24,7 @@ use Fossology\Lib\Proxy\UploadTreeProxy;
 use Fossology\Lib\Dao\AgentDao;
 use Fossology\UI\Api\Models\Findings;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use UIExportList;
 
 /**
  * @class UploadHelper
@@ -679,11 +680,12 @@ class UploadHelper
 
     if ($boolLicense) {
       foreach ($licenseList as $license) {
+        $copyrightContent = null;
         if ($boolCopyright) {
-          $copyrightContent = array();
+          $copyrightContent = [];
           foreach ($copyrightList as $copy) {
             if (($license['filePath'] == $copy['filePath']) !== false ) {
-              array_push($copyrightContent,$copy['content']);
+              $copyrightContent[] = $copy['content'];
             }
           }
           if (count($copyrightContent)==0) {
@@ -703,13 +705,13 @@ class UploadHelper
         $copyrightContent = array();
         foreach ($copyrightList as $copy) {
           if (($copyFilepath['filePath'] == $copy['filePath']) === true) {
-            array_push($copyrightContent,$copy['content']);
+            $copyrightContent[] = $copy['content'];
           }
         }
         $findings = new Findings();
         $findings->setCopyright($copyrightContent);
         $responseRow = array();
-        $responseRow['filePath'] = $copy['filePath'];
+        $responseRow['filePath'] = $copyFilepath['filePath'];
         $responseRow['copyright'] = $findings->getCopyright();
         $responseList[] = $responseRow;
       }

--- a/src/www/ui/api/Middlewares/RestAuthMiddleware.php
+++ b/src/www/ui/api/Middlewares/RestAuthMiddleware.php
@@ -53,8 +53,14 @@ class RestAuthMiddleware
       stristr($request->getMethod(), "post") !== false) {
       $response = $handler->handle($request);
     } else {
+      /** @var AuthHelper $authHelper */
       $authHelper = $GLOBALS['container']->get('helper.authHelper');
-      $jwtToken = $request->getHeader('Authorization')[0];
+      $authHeaders = $request->getHeader('Authorization');
+      if (!empty($authHeaders)) {
+        $jwtToken = $authHeaders[0];
+      } else {
+        $jwtToken = "";
+      }
       $userId = -1;
       $tokenScope = false;
       $tokenValid = $authHelper->verifyAuthToken($jwtToken, $userId,

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -20,6 +20,7 @@ require_once dirname(dirname(dirname(__DIR__))) . "/vendor/autoload.php";
 require_once dirname(dirname(dirname(dirname(__FILE__)))) .
   "/lib/php/bootstrap.php";
 
+use Fossology\Lib\Util\TimingLogger;
 use Fossology\UI\Api\Controllers\AuthController;
 use Fossology\UI\Api\Controllers\BadRequestController;
 use Fossology\UI\Api\Controllers\FolderController;
@@ -41,6 +42,7 @@ use Fossology\UI\Api\Models\Info;
 use Fossology\UI\Api\Models\InfoType;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
+use Slim\Exception\HttpMethodNotAllowedException;
 use Slim\Exception\HttpNotFoundException;
 use Slim\Factory\AppFactory;
 use Slim\Middleware\ContentLengthMiddleware;
@@ -97,8 +99,8 @@ $app->setBasePath(BASE_PATH);
  * 1. The call enters from Rest Auth and initialize session variables.
  * 2. It then goes to FOSSology Init and initialize all plugins
  * 3. The normal flow continues.
- * 4. The call now enteres FOSSology Init again and plugins are unloaded.
- * 5. Then call then enters Rest Auth and leaves as is.
+ * 4. The call now enters FOSSology Init again and plugins are unloaded.
+ * 5. The call then enters Rest Auth and leaves as is.
  */
 if ($dbConnected) {
   // Middleware for plugin initialization

--- a/src/www/ui/async/ScheduleAgent.php
+++ b/src/www/ui/async/ScheduleAgent.php
@@ -48,6 +48,10 @@ class ScheduleAgent extends DefaultPlugin
       $upload = $this->uploadDao->getUpload($uploadId);
       $uploadName = $upload->getFilename();
       $ourPlugin = plugin_find($agentName);
+      if ($ourPlugin === null) {
+        return new Response(json_encode(["error" => "Unable to find $agentName"]),
+          Response::HTTP_INTERNAL_SERVER_ERROR, ["Content-type" => "text/json"]);
+      }
 
       $jobqueueId = isAlreadyRunning($ourPlugin->AgentName, $uploadId);
       if ($jobqueueId == 0) {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Apply hotfix to REST API to patch access to `User` object.
Other fixes like importing missing classes and handling other PHP Errors and Notices also applied to this PR.

### Changes

1. Use `$users[0]->getRootFolderId();` for object instead of `$user[0]['rootFolderId'];`
2. Fix missing variables in `UploadHelper`
3. Check if `Authorization` header exists in `RestAuthMiddleware` before getting its value.
4. Import missing classes in `index.php`
5. Add a null check in `ScheduleAgent.php`

## How to test

1. List out all uploads using REST API.
2. List out specific upload using REST API.