### PR TITLE
fix(conf): add escape string and fetch raw content

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -204,7 +204,7 @@ jobs:
           ctest --output-on-failure --verbose
 
   php-unit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/src/www/ui/ui-report-conf.php
+++ b/src/www/ui/ui-report-conf.php
@@ -321,7 +321,7 @@ class ui_report_conf extends FO_Plugin
       $columns = "";
       foreach ($this->mapDBColumns as $key => $value) {
         $columns .= $value." = $".$i.", ";
-        $parms[] = GetParm($key, PARM_TEXT);
+        $parms[] = pg_escape_string(GetParm($key, PARM_RAW));
         $i++;
       }
       $parms[] = $this->getCheckBoxSelectionList($this->radioListUR);


### PR DESCRIPTION
Signed-off-by: Shaheem Azmal M MD <shaheem.azmal@siemens.com>

## Description

User was not able to add content with slashes like :  \\xsoftware-1.2.3\\new\\xsoftware.unit.news\\newsforassets\\somemd5.dll to database through conf page.

### Changes

Get raw content from post escape and write it to database.

## How to test

* in conf page add \\xsoftware-1.2.3\\new\\xsoftware.unit.news\\newsforassets\\somemd5.dll to any field. slashes should not get vanished. 


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2346"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

