### PR TITLE
fix(oauth): update username if oauth email matches

### DIFF
--- a/src/lib/php/Dao/UserDao.php
+++ b/src/lib/php/Dao/UserDao.php
@@ -273,7 +273,7 @@ class UserDao
         array($userId, $groupId), __FUNCTION__);
   }
 
-  public function getUserAndDefaultGroupByUserName($userName, $oauth=false)
+  public function getUserAndDefaultGroupByUserName(&$userName, $oauth=false)
   {
     $searchEmail = " ";
     $statement = __METHOD__;
@@ -286,6 +286,9 @@ class UserDao
         array($userName), $statement);
     if (empty($userRow)) {
       throw new \Exception('invalid user name');
+    }
+    if ($oauth) {
+      $userName = $userRow['user_name'];
     }
     $userRow['oauth'] = $oauth;
     if ($userRow['group_fk']) {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

While using OIDC, if user is matched using `user_email` field, update the username from DB for following checks.

### Changes

In `getUserAndDefaultGroupByUserName()` make parameter `$userName` as pass-by-reference and update it to `user_name` from DB in case of OAuth.

## How to test

1. Setup OIDC.
2. Create a user with different username but keep email field to match oidc.
3. Login with the new user using OIDC. The login should succeed.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2349"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

