### PR TITLE
fix(package): use prefix /usr for Debian packages

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -89,7 +89,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -GNinja ..
+        cmake -GNinja -DCMAKE_INSTALL_PREFIX=/usr -DFO_SYSCONFDIR=/etc/fossology ..
 
     - name: Build Debs
       run: ninja -C build package


### PR DESCRIPTION
## Description

CMake by default uses `/usr/local` as install prefix. This works fine for local setup but fails for Debian package installations.

While creating release packages, fix the install prefix.

### Changes

Use `-DCMAKE_INSTALL_PREFIX=/usr` while creating release packages.


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2351"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

