### PR TITLE
fix(security) Replaced cryptographically insecure PHP rand() function

### DIFF
--- a/install/db/dbmigrate_2.1-2.2.php
+++ b/install/db/dbmigrate_2.1-2.2.php
@@ -56,7 +56,7 @@ function Migrate_21_22($Verbose)
   {
     // No Default User, so create one
     $Perm = 10;  //PLUGIN_DB_ADMIN;
-    $Seed = rand() . rand();
+    $Seed = random_int(0, getrandmax()) . random_int(0, getrandmax());
     $Hash = sha1($Seed . $user_name);
     $sql = "INSERT INTO users (user_name,user_desc,user_seed,user_pass,user_perm,user_email,root_folder_fk)
         VALUES ('$user_name','Default Administrator','$Seed','$Hash',$Perm,'y',1);";

--- a/src/lib/php/common-cache.php
+++ b/src/lib/php/common-cache.php
@@ -42,7 +42,7 @@ function ReportCacheGet($CacheKey)
   global $UserCacheStat;
 
   /* Purge old entries ~ 1/500 of the times this fcn is called */
-  if (rand(1, 500) == 1) {
+  if (random_int(1, 500) == 1) {
     ReportCachePurgeByDate(" now() - interval '365 days'");
   }
 

--- a/src/reportImport/ui/ReportImportAgentPlugin.php
+++ b/src/reportImport/ui/ReportImportAgentPlugin.php
@@ -65,7 +65,7 @@ class ReportImportAgentPlugin extends AgentPlugin
         mkdir($fileBase,0755,true);
       }
       // TODO: validate filename
-      $targetFile = time().'_'.rand().'_'.$report['name'];
+      $targetFile = time().'_'.random_int(0, getrandmax()).'_'.$report['name'];
       if (move_uploaded_file($report['tmp_name'], $fileBase.$targetFile))
       {
         return '--report='.$targetFile;

--- a/src/www/ui/core-smauth.php
+++ b/src/www/ui/core-smauth.php
@@ -313,7 +313,7 @@ class core_smauth extends FO_Plugin
       $_SESSION['UserEmail'] = NULL;
       $_SESSION['Folder'] = NULL;
       $_SESSION['UiPref'] = NULL;
-      $Uri = Traceback_uri() . "logout.html?" . rand();
+      $Uri = Traceback_uri() . "logout.html?" . random_int(0, getrandmax());
       //$Uri = Traceback_uri() . "?mod=refresh&remod=default";
       $V.= "<script language='javascript'>\n";
       $V.= "window.open('$Uri','_top');\n";

--- a/src/www/ui_tests/foss_ui.php
+++ b/src/www/ui_tests/foss_ui.php
@@ -146,7 +146,7 @@ class TestCreateFolder extends WebTestCase {
     $this->assertTrue($this->setField('parentid', 'Software Repository'));
     // Generate a random number so names will not collide with multiple
     // test runs.
-    $tail = rand();
+    $tail = random_int(0, getrandmax());
     $folder_name = 'TestFolder' . "$tail";
     $this->setField('newname', $folder_name);
     $this->clickSubmit('Create!');


### PR DESCRIPTION
Replaced cryptographically insecure PHP rand() function
with built-in for PHP random_int() with secure pseudo-random number generator

## Description
This fixes weak methods of generating pseudo-random values, as detected by a Checkmarx scan of Fossology

### Changes

Fixes 5 randomness generation in php scripts


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2354"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

