### PR TITLE
chore(build): fix building of monkbulk package

### DIFF
--- a/src/monk/agent/CMakeLists.txt
+++ b/src/monk/agent/CMakeLists.txt
@@ -70,4 +70,4 @@ install(TARGETS monk_exec
 install(TARGETS monkbulk
     RUNTIME
     DESTINATION ${FO_MODDIR}/${PROJECT_NAME}bulk/agent 
-    COMPONENT monk)
+    COMPONENT monkbulk)

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -981,7 +981,7 @@
   $Schema["TABLE"]["jobqueue"]["jq_host"]["ALTER"] = "ALTER TABLE \"jobqueue\" ALTER COLUMN \"jq_host\" DROP NOT NULL";
 
   $Schema["TABLE"]["jobqueue"]["jq_cmd_args"]["DESC"] = "COMMENT ON COLUMN \"jobqueue\".\"jq_cmd_args\" IS 'command line arguments, i.e. \"-ab -u 123 -c /my/dir\"'";
-  $Schema["TABLE"]["jobqueue"]["jq_cmd_args"]["ADD"] = "ALTER TABLE \"jobqueue\" ADD COLUMN \"jq_cmd_args\" varchar(1024)";
+  $Schema["TABLE"]["jobqueue"]["jq_cmd_args"]["ADD"] = "ALTER TABLE \"jobqueue\" ADD COLUMN \"jq_cmd_args\" text";
   $Schema["TABLE"]["jobqueue"]["jq_cmd_args"]["ALTER"] = "ALTER TABLE \"jobqueue\" ALTER COLUMN \"jq_cmd_args\" DROP NOT NULL";
 
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

1. Fix installation target for monkbulk agent in CMake.
2. Change data type of `jobqueue::jq_cmd_args` to `text` from `varchar(1024)` to allow longer arguments, used by report agents.

### Changes

In `src/monk/agent/CMakeLists.txt`, fix the component name for monkbulk.

## How to test

Build packages and check the contents of monk and monkbulk packages.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2359"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

