### PR TITLE
feat(eximporter): add file path for upload tree

### DIFF
--- a/src/decisionimporter/agent/DecisionImporter.php
+++ b/src/decisionimporter/agent/DecisionImporter.php
@@ -34,6 +34,12 @@ require_once "DecisionImporterDataCreator.php";
  */
 class DecisionImporter extends Agent
 {
+  /**
+   * @var int $UPDATE_COUNT
+   * How many rows to update at once to DB
+   */
+  public static $UPDATE_COUNT = 1000;
+
   const REPORT_KEY = "report";          ///< Key used to pass report name
   const LONG_OPT_KEYS = ["userselect"]; ///< Other CLI args required by agents
 

--- a/src/decisionimporter/agent/DecisionImporterDataCreator.php
+++ b/src/decisionimporter/agent/DecisionImporterDataCreator.php
@@ -29,8 +29,6 @@ require_once "FoDecisionData.php";
  */
 class DecisionImporterDataCreator
 {
-  const UPDATE_COUNT = 1000;          ///< How many rows to update at once to DB
-
   /**
    * @var DbManager $dbManager
    * DbManager object
@@ -153,8 +151,8 @@ class DecisionImporterDataCreator
       ], __METHOD__ . ".insertCd", "clearing_decision_pk");
       $clearingDecisionList[$oldDecisionId]["new_decision"] = $newCdId;
       $i++;
-      if ($i == self::UPDATE_COUNT) {
-        $agentObj->heartbeat(self::UPDATE_COUNT);
+      if ($i == DecisionImporter::$UPDATE_COUNT) {
+        $agentObj->heartbeat(DecisionImporter::$UPDATE_COUNT);
         $i = 0;
       }
     }
@@ -179,8 +177,8 @@ class DecisionImporterDataCreator
       ], __METHOD__ . ".insertCe", "clearing_event_pk");
       $clearingEventList[$oldEventId]["new_event"] = $newCeId;
       $i++;
-      if ($i == self::UPDATE_COUNT) {
-        $agentObj->heartbeat(self::UPDATE_COUNT);
+      if ($i == DecisionImporter::$UPDATE_COUNT) {
+        $agentObj->heartbeat(DecisionImporter::$UPDATE_COUNT);
         $i = 0;
       }
     }
@@ -309,8 +307,8 @@ class DecisionImporterDataCreator
       }
       $cxList[$oldId]["new_id"] = $newCp;
       $i++;
-      if ($i == self::UPDATE_COUNT) {
-        $agentObj->heartbeat(self::UPDATE_COUNT);
+      if ($i == DecisionImporter::$UPDATE_COUNT) {
+        $agentObj->heartbeat(DecisionImporter::$UPDATE_COUNT);
         $i = 0;
       }
     }
@@ -325,8 +323,8 @@ class DecisionImporterDataCreator
         $decisionItem['textfinding'], $decisionItem['comment']);
       $decisionList[$oldId]["new_id"] = $newDecision;
       $i++;
-      if ($i == self::UPDATE_COUNT) {
-        $agentObj->heartbeat(self::UPDATE_COUNT);
+      if ($i == DecisionImporter::$UPDATE_COUNT) {
+        $agentObj->heartbeat(DecisionImporter::$UPDATE_COUNT);
         $i = 0;
       }
     }
@@ -357,8 +355,8 @@ class DecisionImporterDataCreator
         ], __METHOD__ . ".insertCe." . $agentName);
       }
       $i++;
-      if ($i == self::UPDATE_COUNT) {
-        $agentObj->heartbeat(self::UPDATE_COUNT);
+      if ($i == DecisionImporter::$UPDATE_COUNT) {
+        $agentObj->heartbeat(DecisionImporter::$UPDATE_COUNT);
         $i = 0;
       }
     }
@@ -443,8 +441,8 @@ class DecisionImporterDataCreator
       $clearingEventList[$oldEventId]["new_lrbid"] = $newLrbId;
       $clearingEventList[$oldEventId]["job_fk"] = $jobId;
       $i++;
-      if ($i == self::UPDATE_COUNT) {
-        $agentObj->heartbeat(self::UPDATE_COUNT);
+      if ($i == DecisionImporter::$UPDATE_COUNT) {
+        $agentObj->heartbeat(DecisionImporter::$UPDATE_COUNT);
         $i = 0;
       }
     }
@@ -461,8 +459,8 @@ class DecisionImporterDataCreator
         $this->dbManager->updateTableRow("clearing_event", $assocParams, "clearing_event_pk",
           $clearingEventItem["new_event"], __METHOD__ . ".updateCeJob");
         $i++;
-        if ($i == self::UPDATE_COUNT) {
-          $agentObj->heartbeat(self::UPDATE_COUNT);
+        if ($i == DecisionImporter::$UPDATE_COUNT) {
+          $agentObj->heartbeat(DecisionImporter::$UPDATE_COUNT);
           $i = 0;
         }
       }
@@ -481,7 +479,7 @@ class DecisionImporterDataCreator
       ];
       $this->dbManager->insertTableRow("highlight_bulk", $assocParams, __METHOD__ . ".insertHighlightBulk");
       $i++;
-      if ($i == self::UPDATE_COUNT) {
+      if ($i == DecisionImporter::$UPDATE_COUNT) {
         $agentObj->heartbeat(0);
         $i = 0;
       }

--- a/src/decisionimporter/agent/FoDecisionData.php
+++ b/src/decisionimporter/agent/FoDecisionData.php
@@ -396,6 +396,7 @@ class FoDecisionData
         "old_pfile" => $uploadTreeItem['pfile_fk'],
         "lft" => $uploadTreeItem['lft'],
         "rgt" => $uploadTreeItem['rgt'],
+        "path" => array_key_exists("path", $uploadTreeItem) ? $uploadTreeItem["path"] : ""
       ];
     }
     return $this;

--- a/src/lib/php/Dao/AllDecisionsDao.php
+++ b/src/lib/php/Dao/AllDecisionsDao.php
@@ -98,10 +98,15 @@ class AllDecisionsDao
    */
   public function getAllAgentUploadTreeDataForUpload($uploadId, $tableName)
   {
-    $sql = "SELECT uploadtree_pk, ut.pfile_fk, ut.lft, ut.rgt FROM uploadtree ut ".
-         " INNER JOIN ".$tableName." ON ".$tableName.".pfile_fk=ut.pfile_fk WHERE upload_fk=$1";
+    $sql = "SELECT DISTINCT ON(uploadtree_pk) " .
+         "uploadtree_pk, ut.pfile_fk, ut.lft, ut.rgt FROM uploadtree ut " .
+         "INNER JOIN ".$tableName." ON ".$tableName.".pfile_fk=ut.pfile_fk WHERE upload_fk=$1";
     $statementName = __METHOD__ . ".allLicEntriesuploadtreeForUpload";
     $rows = $this->dbManager->getRows($sql, array($uploadId), $statementName);
+    foreach ($rows as $index => $row) {
+      $rows[$index]["path"] = implode("/",
+        array_column(Dir2Path($row["uploadtree_pk"]), "ufile_name"));
+    }
     return $rows;
   }
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

While exporting dump, add "path" of file to uploadtree list. This allows matching files even if ununpack version changes over time. (for example, old version of ununpack did not extracted `.dsc` files)

### Changes

1. Add "path" to uploadtree list while creating export dump.
2. While importing, check if item path matches to get new item id. If path does not exist or does not match, then fall back to lft and rgt.