### PR TITLE
feat(spdx): update reports to v-2.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,7 +174,7 @@ variable.list
 /src/copyright/VERSION-keyword
 /src/copyright/VERSION-copyright
 /src/copyright/VERSION-ipra
-/src/spdx2/agent_tests/Functional/spdx-tools-2.2.2-jar-with-dependencies.jar*
+/src/spdx2/agent_tests/Functional/tools-java-1.1.3-jar-with-dependencies.jar*
 /src/spdx2/agent/version.php
 /src/unifiedreport/agent/unifiedreport
 /src/unifiedreport/agent/version.php

--- a/.gitignore
+++ b/.gitignore
@@ -174,7 +174,7 @@ variable.list
 /src/copyright/VERSION-keyword
 /src/copyright/VERSION-copyright
 /src/copyright/VERSION-ipra
-/src/spdx2/agent_tests/Functional/tools-java-1.1.3-jar-with-dependencies.jar*
+/src/spdx2/agent_tests/Functional/tools-java-*-jar-with-dependencies.jar
 /src/spdx2/agent/version.php
 /src/unifiedreport/agent/unifiedreport
 /src/unifiedreport/agent/version.php

--- a/install/scripts/install-spdx-tools.sh
+++ b/install/scripts/install-spdx-tools.sh
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: © Fossology contributors
 
 # SPDX-License-Identifier: GPL-2.0-only
-VERSION="1.1.3"
+VERSION="1.1.4"
 TAG="v${VERSION}"
 DOWNLOAD_LOC=$(dirname $0)/../../src/spdx2/agent_tests/Functional
 

--- a/src/composer.json
+++ b/src/composer.json
@@ -18,6 +18,7 @@
         "ext-pgsql": "*",
         "ext-curl": "*",
         "ext-uuid": "*",
+        "composer/spdx-licenses": "1.5.7",
         "firebase/php-jwt": "v6.3.0",
         "monolog/monolog" : "2.8.0",
         "phpoffice/phpword" : "0.18.3",

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,8 +4,88 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "69828c7301c9e9d903ea9d3749a953b5",
+    "content-hash": "1514432812f9747206392705b627a9cd",
     "packages": [
+        {
+            "name": "composer/spdx-licenses",
+            "version": "1.5.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/spdx-licenses.git",
+                "reference": "c848241796da2abf65837d51dce1fae55a960149"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/c848241796da2abf65837d51dce1fae55a960149",
+                "reference": "c848241796da2abf65837d51dce1fae55a960149",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Spdx\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "SPDX licenses list and validation library.",
+            "keywords": [
+                "license",
+                "spdx",
+                "validator"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/spdx-licenses/issues",
+                "source": "https://github.com/composer/spdx-licenses/tree/1.5.7"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-23T07:37:50+00:00"
+        },
         {
             "name": "easyrdf/easyrdf",
             "version": "1.1.1",

--- a/src/lib/php/Data/LicenseRef.php
+++ b/src/lib/php/Data/LicenseRef.php
@@ -101,10 +101,16 @@ class LicenseRef
   {
     if (strcasecmp($shortname, LicenseDao::NO_LICENSE_FOUND) === 0 ||
         strcasecmp($shortname, LicenseDao::VOID_LICENSE) === 0) {
-      return $shortname;
+      $spdxLicense = $shortname;
     } elseif (empty($spdxId)) {
-      return self::SPDXREF_PREFIX . $shortname;
+      $spdxLicense = self::SPDXREF_PREFIX . $shortname;
+    } else {
+      $spdxLicense = $spdxId;
     }
-    return $spdxId;
+    if (strpos($spdxLicense, LicenseRef::SPDXREF_PREFIX) !== false) {
+      // License ref can not end with a '+'
+      $spdxLicense = preg_replace('/\+$/', '-or-later', $spdxLicense);
+    }
+    return $spdxLicense;
   }
 }

--- a/src/spdx2/CMakeLists.txt
+++ b/src/spdx2/CMakeLists.txt
@@ -42,6 +42,8 @@ foreach(SPDX_INSTALL spdx2 spdx2tv dep5 spdx2csv)
 endforeach()
 
 if(TESTING)
+    configure_file(${FO_CMAKEDIR}/TestInstall.make.in ${CMAKE_CURRENT_BINARY_DIR}/TestInstall.make
+        NEWLINE_STYLE LF @ONLY)
     enable_testing()
     add_subdirectory(agent_tests)
 endif(TESTING)

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -828,7 +828,7 @@ class SpdxTwoAgent extends Agent
           'acknowledgements' => SpdxTwoUtils::cleanTextArray($licenses['acknowledgement'])
         );
         if ($stateComment) {
-          $dataTemplate['licenseComment'] = SpdxTwoUtils::implodeLicenses(
+          $dataTemplate['licenseComment'] = implode("\n",
                     SpdxTwoUtils::removeEmptyLicenses($licenses['comment']));
         }
         $content .= $this->renderString($this->getTemplateFile('file'),$dataTemplate);

--- a/src/spdx2/agent/spdx2utils.php
+++ b/src/spdx2/agent/spdx2utils.php
@@ -109,4 +109,46 @@ class SpdxTwoUtils
       return implode(" AND ", $licenses);
     }
   }
+
+  /**
+   * Clean an array of strings by trimming the elements and removing empty
+   * strings.
+   * @param string[] $texts Array of texts to be concatenated.
+   * @return string[] String array with all trimmed string elements.
+   */
+  static public function cleanTextArray($texts): array
+  {
+    if (!$texts || !is_array($texts) || sizeof($texts) == 0) {
+      return [];
+    }
+
+    sort($texts, SORT_NATURAL | SORT_FLAG_CASE);
+
+    $cleanArray = [];
+    foreach ($texts as $text) {
+      $text = trim($text);
+      if (empty($text)) {
+        continue;
+      }
+      $cleanArray[] = $text;
+    }
+    return $cleanArray;
+  }
+
+  /**
+   * Remove empty and 'NOASSERTION' licenses from list.
+   * @param string[] $licenses List of licenses.
+   * @return array List of licenses removing empty and 'NOASSERTION's.
+   */
+  public static function removeEmptyLicenses(array $licenses): array
+  {
+    $newList = [];
+    foreach ($licenses as $license) {
+      if (empty($license) || $license === "NOASSERTION") {
+        continue;
+      }
+      $newList[] = $license;
+    }
+    return $newList;
+  }
 }

--- a/src/spdx2/agent/spdx2utils.php
+++ b/src/spdx2/agent/spdx2utils.php
@@ -7,14 +7,14 @@
 
 namespace Fossology\SpdxTwo;
 
+use Fossology\Lib\Data\LicenseRef;
+
 /**
  * @class SpdxTwoUtils
  * @brief Utilities for SPDX2
  */
 class SpdxTwoUtils
 {
-  static public $prefix = "LicenseRef-";      ///< Prefix to be used
-
   /**
    * @brief For a given set of arguments assign $args[$key1] and $args[$key2]
    *
@@ -54,6 +54,10 @@ class SpdxTwoUtils
     }
 
     $license = preg_replace('/[^a-zA-Z0-9\-\_\.\+]/','-',$license);
+    if (strpos($license, LicenseRef::SPDXREF_PREFIX) !== false) {
+      // License ref can not end with a '+'
+      $license = preg_replace('/\+$/', '-or-later', $license);
+    }
     return preg_replace('/\+(?!$)/','-',$license);
   }
 
@@ -102,7 +106,7 @@ class SpdxTwoUtils
        ($index = array_search("Dual-license",$licenses)) !== false) {
       return $licenses[$index===0?1:0] . " OR " . $licenses[$index===2?1:2];
     } elseif (count($licenses) == 3 &&
-        ($index = array_search(self::$prefix . "Dual-license", $licenses)) !== false) {
+        ($index = array_search(LicenseRef::SPDXREF_PREFIX . "Dual-license", $licenses)) !== false) {
       return $licenses[$index===0?1:0] . " OR " . $licenses[$index===2?1:2];
     } else {
       // Add prefixes where needed, enclose statements containing ' OR ' with parentheses
@@ -140,7 +144,7 @@ class SpdxTwoUtils
    * @param string[] $licenses List of licenses.
    * @return array List of licenses removing empty and 'NOASSERTION's.
    */
-  public static function removeEmptyLicenses(array $licenses): array
+  public static function removeEmptyLicenses($licenses): array
   {
     $newList = [];
     foreach ($licenses as $license) {

--- a/src/spdx2/agent/template/dep5-copyright-document.twig
+++ b/src/spdx2/agent/template/dep5-copyright-document.twig
@@ -17,11 +17,11 @@ Comment: {% if licenseComments %}
 {# File Paragraphes: #}
 {{ packageNodes }}
 {# Stand-alone License Paragraphes: #}
-{% for licenseId,licenseData in licenseTexts %}{% if licenseId starts with 'LicenseRef-' %}
+{% for licenseData in licenseTexts %}{% if licenseData.id starts with 'LicenseRef-' %}
 
-License: {{ licenseId }}
- {{ licenseData['text']|replace({'\f':''})|replace({'\r\n':'\n'})
-                                          |replace({'\n\n':'\n.\n'})
-                                          |replace({'\n\n':'\n.\n'})
-                                          |replace({'\n':'\n '}) }}
+License: {{ licenseData.id }}
+ {{ licenseData.text|replace({'\f':''})|replace({'\r\n':'\n'})
+                                       |replace({'\n\n':'\n.\n'})
+                                       |replace({'\n\n':'\n.\n'})
+                                       |replace({'\n':'\n '}) }}
 {% endif %}{% endfor %}

--- a/src/spdx2/agent/template/spdx2-document.xml.twig
+++ b/src/spdx2/agent/template/spdx2-document.xml.twig
@@ -8,7 +8,19 @@
     xml:base="{{ uri }}">
 <spdx:SpdxDocument rdf:about="{{ uri }}#SPDXRef-DOCUMENT">
   <spdx:specVersion>SPDX-2.3</spdx:specVersion>
-  <spdx:dataLicense rdf:resource="http://spdx.org/licenses/CC0-1.0" />
+  <spdx:dataLicense>
+    <spdx:ListedLicense rdf:about="http://spdx.org/licenses/{{ dataLicense.id|replace({' ': '-'})|url_encode }}">
+      <spdx:name>{{ dataLicense.name|e }}</spdx:name>
+      <spdx:licenseId>{{ dataLicense.id|replace({' ': '-'})|e }}</spdx:licenseId>
+      <spdx:licenseText><![CDATA[
+{{ dataLicense.text|replace({'\f':''})
+                   |replace({']]>':']]]]><![CDATA[>'}) }}
+      ]]></spdx:licenseText>
+{% if dataLicense.url is not empty %}
+      <rdfs:seeAlso>{{ dataLicense.url }}</rdfs:seeAlso>
+{% endif %}
+    </spdx:ListedLicense>
+  </spdx:dataLicense>
   <spdx:creationInfo>
     <spdx:CreationInfo>
       <spdx:licenseListVersion>3.19</spdx:licenseListVersion>
@@ -22,19 +34,22 @@
   <rdfs:comment>
     This document was created using license information and a generator from Fossology.
   </rdfs:comment>
-  {% for licenseId,licenseData in licenseTexts %}{% if licenseId starts with 'LicenseRef-' %}
+  {% for licenseData in licenseTexts %}{% if licenseData.id starts with 'LicenseRef-' %}
   <spdx:hasExtractedLicensingInfo>
-{% if licenseId starts with 'LicenseRef-' %}
-    <spdx:ExtractedLicensingInfo rdf:about="#{{ licenseId|replace({' ': '-'})|url_encode }}">
+{% if licenseData.id starts with 'LicenseRef-' %}
+    <spdx:ExtractedLicensingInfo rdf:about="#{{ licenseData.id|replace({' ': '-'})|url_encode }}">
 {% else %}
-    <spdx:ExtractedLicensingInfo rdf:about="http://spdx.org/licenses/{{ licenseId|replace({' ': '-'})|url_encode }}">
+    <spdx:ExtractedLicensingInfo rdf:about="http://spdx.org/licenses/{{ licenseData.id|replace({' ': '-'})|url_encode }}">
 {% endif %}
-      <spdx:licenseId>{{ licenseId|replace({' ': '-'})|e }}</spdx:licenseId>
-      <spdx:name>{{ licenseData['name']|e }}</spdx:name>
+      <spdx:licenseId>{{ licenseData.id|replace({' ': '-'})|e }}</spdx:licenseId>
+      <spdx:name>{{ licenseData.name|e }}</spdx:name>
       <spdx:extractedText><![CDATA[
-{{ licenseData['text']|replace({'\f':''})
-                      |replace({']]>':']]]]><![CDATA[>'}) }}
+{{ licenseData.text|replace({'\f':''})
+                   |replace({']]>':']]]]><![CDATA[>'}) }}
       ]]></spdx:extractedText>
+{% if licenseData.url is not empty %}
+      <rdfs:seeAlso>{{ licenseData.url }}</rdfs:seeAlso>
+{% endif %}
     </spdx:ExtractedLicensingInfo>
   </spdx:hasExtractedLicensingInfo>
 {% endif %}{% endfor %}

--- a/src/spdx2/agent/template/spdx2-document.xml.twig
+++ b/src/spdx2/agent/template/spdx2-document.xml.twig
@@ -4,17 +4,18 @@
 #}
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     xmlns:spdx="http://spdx.org/rdf/terms#"
-    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xml:base="{{ uri }}">
 <spdx:SpdxDocument rdf:about="{{ uri }}#SPDXRef-DOCUMENT">
-  <spdx:specVersion>SPDX-2.2</spdx:specVersion>
+  <spdx:specVersion>SPDX-2.3</spdx:specVersion>
   <spdx:dataLicense rdf:resource="http://spdx.org/licenses/CC0-1.0" />
   <spdx:creationInfo>
     <spdx:CreationInfo>
-      <spdx:licenseListVersion>2.6</spdx:licenseListVersion>
+      <spdx:licenseListVersion>3.19</spdx:licenseListVersion>
       <spdx:creator>Person: {{ userName|e }}</spdx:creator>
       <spdx:creator>Organization: {{ organisation|e }}</spdx:creator>
-      <spdx:creator>Tool: spdx2</spdx:creator>
-      <spdx:created>{{ 'now'|date('Y-m-d\\TH:i:s\\Z')}}{# date('c') for ISO 8601 is not parsed by spdxTool #}</spdx:created>
+      <spdx:creator>Tool: {{ toolVersion|e }}</spdx:creator>
+      <spdx:created>{{ 'now'|date('Y-m-d\\TH:i:s\\Z', 'UTC') }}{# date('c') for ISO 8601 is not parsed by spdxTool #}</spdx:created>
     </spdx:CreationInfo>
   </spdx:creationInfo>
   <spdx:name>{{ documentName|e }}</spdx:name>
@@ -24,7 +25,7 @@
   {% for licenseId,licenseData in licenseTexts %}{% if licenseId starts with 'LicenseRef-' %}
   <spdx:hasExtractedLicensingInfo>
 {% if licenseId starts with 'LicenseRef-' %}
-    <spdx:ExtractedLicensingInfo rdf:about="{{ uri }}#{{ licenseId|replace({' ': '-'})|url_encode }}">
+    <spdx:ExtractedLicensingInfo rdf:about="#{{ licenseId|replace({' ': '-'})|url_encode }}">
 {% else %}
     <spdx:ExtractedLicensingInfo rdf:about="http://spdx.org/licenses/{{ licenseId|replace({' ': '-'})|url_encode }}">
 {% endif %}

--- a/src/spdx2/agent/template/spdx2-document.xml.twig
+++ b/src/spdx2/agent/template/spdx2-document.xml.twig
@@ -34,7 +34,7 @@
   <rdfs:comment>
     This document was created using license information and a generator from Fossology.
   </rdfs:comment>
-  {% for licenseData in licenseTexts %}{% if licenseData.id starts with 'LicenseRef-' %}
+  {%- for licenseData in licenseTexts %}{% if licenseData.id starts with 'LicenseRef-' ~%}
   <spdx:hasExtractedLicensingInfo>
 {% if licenseData.id starts with 'LicenseRef-' %}
     <spdx:ExtractedLicensingInfo rdf:about="#{{ licenseData.id|replace({' ': '-'})|url_encode }}">
@@ -52,7 +52,7 @@
 {% endif %}
     </spdx:ExtractedLicensingInfo>
   </spdx:hasExtractedLicensingInfo>
-{% endif %}{% endfor %}
+{%- endif %}{% endfor ~%}
   {{ packageNodes|replace({'\n':'\n  '}) }}
 </spdx:SpdxDocument>
 </rdf:RDF>

--- a/src/spdx2/agent/template/spdx2-file.xml.twig
+++ b/src/spdx2/agent/template/spdx2-file.xml.twig
@@ -23,22 +23,21 @@
         <spdx:checksumValue>{{ md5 | lower }}</spdx:checksumValue>
       </spdx:Checksum>
     </spdx:checksum>
-{% if isCleared %}
-{% if concludedLicenses|default is empty %}
+{%~ if isCleared %}
+  {%~ if concludedLicenses|default is empty %}
     <spdx:licenseConcluded rdf:resource="http://spdx.org/rdf/terms#none" />
-{% elseif concludedLicenses|length > 1 %}
+  {%~ elseif concludedLicenses|length > 1 %}
     <spdx:licenseConcluded>
-{% if 'Dual-license' in concludedLicenses and concludedLicenses|length > 2 %}
+    {%~ if 'Dual-license' in concludedLicenses and concludedLicenses|length > 2 %}
       <spdx:DisjunctiveLicenseSet>
-{% else %}
+    {%~ else %}
       <spdx:ConjunctiveLicenseSet>
-{% endif %}
-{% for res in concludedLicenses %}
-{% if res starts with 'LicenseRef-' %}
+    {%~ endif %}{# End dual license check #}
+    {%~ for res in concludedLicenses %}
+      {%~ if res starts with 'LicenseRef-' %}
         <spdx:member rdf:resource="#{{ res|replace({' ': '-'})|url_encode }}" />
-{% else %}
-{% if licenseInfoConcluded[res] is defined %}
-{# License defined first time #}
+      {%~ else %}
+        {%~ if licenseInfoConcluded[res] is defined %}{# License defined first time #}
         <spdx:member>
           <spdx:ListedLicense rdf:about="http://spdx.org/licenses/{{ licenseInfoConcluded[res].id|replace({' ': '-'})|url_encode }}">
             <spdx:name>{{ licenseInfoConcluded[res].name|e }}</spdx:name>
@@ -47,29 +46,28 @@
 {{ licenseInfoConcluded[res].text|replace({'\f':''})
                                  |replace({']]>':']]]]><![CDATA[>'}) }}
             ]]></spdx:licenseText>
-{% if licenseInfoConcluded[res].url is not empty %}
+          {%~ if licenseInfoConcluded[res].url is not empty %}
             <rdfs:seeAlso>{{ licenseInfoConcluded[res].url }}</rdfs:seeAlso>
-{% endif %}
+          {%~ endif %}
           </spdx:ListedLicense>
         </spdx:member>
-{% else %}
+        {%~ else %}
         <spdx:member rdf:resource="http://spdx.org/licenses/{{ res|replace({' ': '-'})|url_encode }}" />
-{% endif %}
-{% endif %}
-{% endfor %}
-{% if 'Dual-license' in concludedLicenses and concludedLicenses|length > 2 %}
+        {%~ endif %}
+      {%~ endif %}{# End printing license conclusion #}
+    {%~ endfor %}
+    {%~ if 'Dual-license' in concludedLicenses and concludedLicenses|length > 2 %}
       </spdx:DisjunctiveLicenseSet>
-{% else %}
+    {%~ else %}
       </spdx:ConjunctiveLicenseSet>
-{% endif %}
+    {%~ endif %}
     </spdx:licenseConcluded>
-{% elseif concludedLicenses|length == 1 %}
-{% set res = concludedLicenses[0] %}
-{% if res starts with 'LicenseRef-' %}
+  {%~ elseif concludedLicenses|length == 1 %}
+    {%- set res = concludedLicenses[0] %}
+    {%- if res starts with 'LicenseRef-' %}
     <spdx:licenseConcluded rdf:resource="#{{ res|replace({' ': '-'})|url_encode }}" />
-{% else %}
-{% if licenseInfoConcluded[res] is defined %}
-{# License defined first time #}
+    {%~ else %}
+      {%~ if licenseInfoConcluded[res] is defined %}{# License defined first time #}
     <spdx:licenseConcluded>
       <spdx:ListedLicense rdf:about="http://spdx.org/licenses/{{ licenseInfoConcluded[res].id|replace({' ': '-'})|url_encode }}">
         <spdx:name>{{ licenseInfoConcluded[res].name|e }}</spdx:name>
@@ -78,34 +76,34 @@
 {{ licenseInfoConcluded[res].text|replace({'\f':''})
           |replace({']]>':']]]]><![CDATA[>'}) }}
         ]]></spdx:licenseText>
-        {% if licenseInfoConcluded[res].url is not empty %}
-          <rdfs:seeAlso>{{ licenseInfoConcluded[res].url }}</rdfs:seeAlso>
-        {% endif %}
+        {%~ if licenseInfoConcluded[res].url is not empty %}
+        <rdfs:seeAlso>{{ licenseInfoConcluded[res].url }}</rdfs:seeAlso>
+        {%~ endif %}
       </spdx:ListedLicense>
     </spdx:licenseConcluded>
-{% else %}
+      {%~ else %}
     <spdx:licenseConcluded rdf:resource="http://spdx.org/licenses/{{ res|replace({' ': '-'})|url_encode }}" />
-{% endif %}
-{% endif %}
-{% endif %}
-{% else %}
+      {%~ endif %}
+    {%~ endif %}{# End printing single conclusion #}
+  {%~ endif %}
+{%~ else %}
     <spdx:licenseConcluded rdf:resource="http://spdx.org/rdf/terms#noassertion" />
-{% endif %}
-{% if licenseCommentState %}
-{% if licenseComment is empty %}
+{%~ endif %}{# End license conclusion block #}
+{%~ if licenseCommentState %}{# License comments to be printed #}
+  {%~ if licenseComment is empty %}
     <spdx:licenseComments rdf:resource="http://spdx.org/rdf/terms#noassertion" />
-{% else %}
+  {%~ else %}
     <spdx:licenseComments><![CDATA[{{ licenseComment|e }}]]></spdx:licenseComments>
+  {%~ endif %}
 {% endif %}
-{% endif %}
-{% if scannerLicenses|default is empty %}
+{%~ if scannerLicenses|default is empty %}
     <spdx:licenseInfoInFile rdf:resource="http://spdx.org/rdf/terms#noassertion" />
-{% else %}{% for res in scannerLicenses %}
-{% if res starts with 'LicenseRef-' %}
+{%~ else %}
+  {%~ for res in scannerLicenses %}
+    {%~ if res starts with 'LicenseRef-' %}
     <spdx:licenseInfoInFile rdf:resource="#{{ res|replace({' ': '-'})|url_encode }}" />
-{% else %}
-{% if licenseInfoScanner[res] is defined %}
-{# License defined first time #}
+    {%~ else %}
+      {%~ if licenseInfoScanner[res] is defined %}{# License defined first time #}
     <spdx:licenseInfoInFile>
       <spdx:ListedLicense rdf:about="http://spdx.org/licenses/{{ licenseInfoScanner[res].id|replace({' ': '-'})|url_encode }}">
         <spdx:name>{{ licenseInfoScanner[res].name|e }}</spdx:name>
@@ -114,30 +112,32 @@
 {{ licenseInfoScanner[res].text|replace({'\f':''})
                               |replace({']]>':']]]]><![CDATA[>'}) }}
         ]]></spdx:licenseText>
-{% if licenseInfoScanner[res].url is not empty %}
+        {%~ if licenseInfoScanner[res].url is not empty %}
         <rdfs:seeAlso>{{ licenseInfoScanner[res].url }}</rdfs:seeAlso>
-{% endif %}
+        {%~ endif %}
       </spdx:ListedLicense>
     </spdx:licenseInfoInFile>
-{% else %}
+      {%~ else %}
     <spdx:licenseInfoInFile>
       <spdx:ListedLicense rdf:about="http://spdx.org/licenses/{{ res|replace({' ': '-'})|url_encode }}" />
     </spdx:licenseInfoInFile>
-{% endif %}
-{% endif %}
-{% endfor %}{% endif %}
-{% if copyrights|default is empty %}
+      {%~ endif %}
+    {%- endif %}
+  {%- endfor %}{# End printing license infos in file #}
+{%- endif %}
+{%~ if copyrights|default is empty %}
     <spdx:copyrightText rdf:resource="http://spdx.org/rdf/terms#noassertion" />
-{% else %}    <spdx:copyrightText><![CDATA[
-{% for cp in copyrights %}
+{%~ else %}
+    <spdx:copyrightText><![CDATA[
+  {%~ for cp in copyrights %}
       {{ cp|replace({'\f':''})
            |replace({']]>':']]]]><![CDATA[>'}) }}
-{% endfor %}
+  {%~ endfor %}
     ]]></spdx:copyrightText>
-{% endif %}
-{% for ack in acknowledgements %}
+{%~ endif %}
+{%~ for ack in acknowledgements %}
     <spdx:attributionText><![CDATA[{{ ack|replace({'\f':''})
             |replace({']]>':']]]]><![CDATA[>'}) }}]]></spdx:attributionText>
-{% endfor %}
+{%~ endfor %}
   </spdx:File>
 </spdx:hasFile>

--- a/src/spdx2/agent/template/spdx2-file.xml.twig
+++ b/src/spdx2/agent/template/spdx2-file.xml.twig
@@ -37,7 +37,24 @@
 {% if res starts with 'LicenseRef-' %}
         <spdx:member rdf:resource="#{{ res|replace({' ': '-'})|url_encode }}" />
 {% else %}
+{% if licenseInfoConcluded[res] is defined %}
+{# License defined first time #}
+        <spdx:member>
+          <spdx:ListedLicense rdf:about="http://spdx.org/licenses/{{ licenseInfoConcluded[res].id|replace({' ': '-'})|url_encode }}">
+            <spdx:name>{{ licenseInfoConcluded[res].name|e }}</spdx:name>
+            <spdx:licenseId>{{ licenseInfoConcluded[res].id|replace({' ': '-'})|e }}</spdx:licenseId>
+            <spdx:licenseText><![CDATA[
+{{ licenseInfoConcluded[res].text|replace({'\f':''})
+                                 |replace({']]>':']]]]><![CDATA[>'}) }}
+            ]]></spdx:licenseText>
+{% if licenseInfoConcluded[res].url is not empty %}
+            <rdfs:seeAlso>{{ licenseInfoConcluded[res].url }}</rdfs:seeAlso>
+{% endif %}
+          </spdx:ListedLicense>
+        </spdx:member>
+{% else %}
         <spdx:member rdf:resource="http://spdx.org/licenses/{{ res|replace({' ': '-'})|url_encode }}" />
+{% endif %}
 {% endif %}
 {% endfor %}
 {% if 'Dual-license' in concludedLicenses and concludedLicenses|length > 2 %}
@@ -51,7 +68,24 @@
 {% if res starts with 'LicenseRef-' %}
     <spdx:licenseConcluded rdf:resource="#{{ res|replace({' ': '-'})|url_encode }}" />
 {% else %}
+{% if licenseInfoConcluded[res] is defined %}
+{# License defined first time #}
+    <spdx:licenseConcluded>
+      <spdx:ListedLicense rdf:about="http://spdx.org/licenses/{{ licenseInfoConcluded[res].id|replace({' ': '-'})|url_encode }}">
+        <spdx:name>{{ licenseInfoConcluded[res].name|e }}</spdx:name>
+        <spdx:licenseId>{{ licenseInfoConcluded[res].id|replace({' ': '-'})|e }}</spdx:licenseId>
+        <spdx:licenseText><![CDATA[
+{{ licenseInfoConcluded[res].text|replace({'\f':''})
+          |replace({']]>':']]]]><![CDATA[>'}) }}
+        ]]></spdx:licenseText>
+        {% if licenseInfoConcluded[res].url is not empty %}
+          <rdfs:seeAlso>{{ licenseInfoConcluded[res].url }}</rdfs:seeAlso>
+        {% endif %}
+      </spdx:ListedLicense>
+    </spdx:licenseConcluded>
+{% else %}
     <spdx:licenseConcluded rdf:resource="http://spdx.org/licenses/{{ res|replace({' ': '-'})|url_encode }}" />
+{% endif %}
 {% endif %}
 {% endif %}
 {% else %}
@@ -70,7 +104,26 @@
 {% if res starts with 'LicenseRef-' %}
     <spdx:licenseInfoInFile rdf:resource="#{{ res|replace({' ': '-'})|url_encode }}" />
 {% else %}
-    <spdx:licenseInfoInFile rdf:resource="http://spdx.org/licenses/{{ res|replace({' ': '-'})|url_encode }}" />
+{% if licenseInfoScanner[res] is defined %}
+{# License defined first time #}
+    <spdx:licenseInfoInFile>
+      <spdx:ListedLicense rdf:about="http://spdx.org/licenses/{{ licenseInfoScanner[res].id|replace({' ': '-'})|url_encode }}">
+        <spdx:name>{{ licenseInfoScanner[res].name|e }}</spdx:name>
+        <spdx:licenseId>{{ licenseInfoScanner[res].id|replace({' ': '-'})|e }}</spdx:licenseId>
+        <spdx:licenseText><![CDATA[
+{{ licenseInfoScanner[res].text|replace({'\f':''})
+                              |replace({']]>':']]]]><![CDATA[>'}) }}
+        ]]></spdx:licenseText>
+{% if licenseInfoScanner[res].url is not empty %}
+        <rdfs:seeAlso>{{ licenseInfoScanner[res].url }}</rdfs:seeAlso>
+{% endif %}
+      </spdx:ListedLicense>
+    </spdx:licenseInfoInFile>
+{% else %}
+    <spdx:licenseInfoInFile>
+      <spdx:ListedLicense rdf:about="http://spdx.org/licenses/{{ res|replace({' ': '-'})|url_encode }}" />
+    </spdx:licenseInfoInFile>
+{% endif %}
 {% endif %}
 {% endfor %}{% endif %}
 {% if copyrights|default is empty %}

--- a/src/spdx2/agent/template/spdx2-file.xml.twig
+++ b/src/spdx2/agent/template/spdx2-file.xml.twig
@@ -2,9 +2,8 @@
 
    SPDX-License-Identifier: FSFAP
 #}
-
 <spdx:hasFile>
-  <spdx:File rdf:about="{{ uri }}#SPDXRef-item{{ fileId|url_encode }}">
+  <spdx:File rdf:about="#SPDXRef-item{{ fileId|url_encode }}">
     <spdx:fileName>{{ fileName|e }}</spdx:fileName>
     <spdx:checksum>
       <spdx:Checksum>
@@ -27,18 +26,33 @@
 {% if isCleared %}
 {% if concludedLicenses|default is empty %}
     <spdx:licenseConcluded rdf:resource="http://spdx.org/rdf/terms#none" />
-{% else %}
+{% elseif concludedLicenses|length > 1 %}
     <spdx:licenseConcluded>
+{% if 'Dual-license' in concludedLicenses and concludedLicenses|length > 2 %}
       <spdx:DisjunctiveLicenseSet>
+{% else %}
+      <spdx:ConjunctiveLicenseSet>
+{% endif %}
 {% for res in concludedLicenses %}
 {% if res starts with 'LicenseRef-' %}
-        <spdx:member rdf:resource="{{ uri }}#{{ res|replace({' ': '-'})|url_encode }}" />
+        <spdx:member rdf:resource="#{{ res|replace({' ': '-'})|url_encode }}" />
 {% else %}
         <spdx:member rdf:resource="http://spdx.org/licenses/{{ res|replace({' ': '-'})|url_encode }}" />
 {% endif %}
 {% endfor %}
+{% if 'Dual-license' in concludedLicenses and concludedLicenses|length > 2 %}
       </spdx:DisjunctiveLicenseSet>
+{% else %}
+      </spdx:ConjunctiveLicenseSet>
+{% endif %}
     </spdx:licenseConcluded>
+{% elseif concludedLicenses|length == 1 %}
+{% set res = concludedLicenses[0] %}
+{% if res starts with 'LicenseRef-' %}
+    <spdx:licenseConcluded rdf:resource="#{{ res|replace({' ': '-'})|url_encode }}" />
+{% else %}
+    <spdx:licenseConcluded rdf:resource="http://spdx.org/licenses/{{ res|replace({' ': '-'})|url_encode }}" />
+{% endif %}
 {% endif %}
 {% else %}
     <spdx:licenseConcluded rdf:resource="http://spdx.org/rdf/terms#noassertion" />
@@ -54,7 +68,7 @@
     <spdx:licenseInfoInFile rdf:resource="http://spdx.org/rdf/terms#noassertion" />
 {% else %}{% for res in scannerLicenses %}
 {% if res starts with 'LicenseRef-' %}
-    <spdx:licenseInfoInFile rdf:resource="{{ uri }}#{{ res|replace({' ': '-'})|url_encode }}" />
+    <spdx:licenseInfoInFile rdf:resource="#{{ res|replace({' ': '-'})|url_encode }}" />
 {% else %}
     <spdx:licenseInfoInFile rdf:resource="http://spdx.org/licenses/{{ res|replace({' ': '-'})|url_encode }}" />
 {% endif %}
@@ -68,5 +82,9 @@
 {% endfor %}
     ]]></spdx:copyrightText>
 {% endif %}
+{% for ack in acknowledgements %}
+    <spdx:attributionText><![CDATA[{{ ack|replace({'\f':''})
+            |replace({']]>':']]]]><![CDATA[>'}) }}]]></spdx:attributionText>
+{% endfor %}
   </spdx:File>
 </spdx:hasFile>

--- a/src/spdx2/agent/template/spdx2-package.xml.twig
+++ b/src/spdx2/agent/template/spdx2-package.xml.twig
@@ -6,10 +6,15 @@
   <spdx:Relationship>
     <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes" />
     <spdx:relatedSpdxElement>
-      <spdx:Package rdf:about="{{ uri }}#SPDXRef-upload{{ packageId|url_encode }}">
+      <spdx:Package rdf:about="#SPDXRef-upload{{ packageId|url_encode }}">
         <spdx:name>{{ packageName }}</spdx:name>
         <spdx:packageFileName>{{ uploadName }}</spdx:packageFileName>
         <spdx:downloadLocation rdf:resource="http://spdx.org/rdf/terms#noassertion" />
+        <spdx:versionInfo>{{ packageVersion|e }}</spdx:versionInfo>
+        {%- if releaseDate is not empty ~%}
+        <spdx:releaseDate>{{ releaseDate }}</spdx:releaseDate>
+        {%- endif ~%}
+        <spdx:filesAnalyzed>true</spdx:filesAnalyzed>
         {%- if componentId is not empty ~%}
         <spdx:externalRef>
           <spdx:ExternalRef>
@@ -44,23 +49,48 @@
             <spdx:checksumValue>{{ md5 | lower }}</spdx:checksumValue>
           </spdx:Checksum>
         </spdx:checksum>
+{% if mainLicenses|length > 1 %}
         <spdx:licenseConcluded>
+{% if 'Dual-license' in mainLicenses and mainLicenses|length > 2 %}
           <spdx:DisjunctiveLicenseSet>
-  {% for res in mainLicenses %}
-  {% if res starts with 'LicenseRef-' %}
-            <spdx:member rdf:resource="{{ uri }}#{{ res|replace({' ': '-'})|url_encode }}" />
-  {% else %}
+{% else %}
+          <spdx:ConjunctiveLicenseSet>
+{% endif %}
+{% for res in mainLicenses %}
+{% if res starts with 'LicenseRef-' %}
+            <spdx:member rdf:resource="#{{ res|replace({' ': '-'})|url_encode }}" />
+{% else %}
             <spdx:member rdf:resource="http://spdx.org/licenses/{{ res|replace({' ': '-'})|url_encode }}" />
-  {% endif %}
-  {% endfor %}
+{% endif %}
+{% endfor %}
+{% if 'Dual-license' in concludedLicenses and concludedLicenses|length > 2 %}
           </spdx:DisjunctiveLicenseSet>
+{% else %}
+          </spdx:ConjunctiveLicenseSet>
+{% endif %}
         </spdx:licenseConcluded>
+{% elseif mainLicenses|length == 1 %}
+{% set res = mainLicenses[0] %}
+{% if res starts with 'LicenseRef-' %}
+        <spdx:licenseConcluded rdf:resource="#{{ res|replace({' ': '-'})|url_encode }}" />
+{% else %}
+        <spdx:licenseConcluded rdf:resource="http://spdx.org/licenses/{{ res|replace({' ': '-'})|url_encode }}" />
+{% endif %}
+{% endif %}
         {% if licenseComments %}<spdx:licenseComments><![CDATA[
           {{ licenseComments|replace({']]>':']]><![CDATA[>'}) }}
         ]]></spdx:licenseComments>
         {% endif %}<spdx:licenseDeclared rdf:resource="http://spdx.org/rdf/terms#noassertion" />
         <spdx:licenseInfoFromFiles rdf:resource="http://spdx.org/rdf/terms#noassertion" />
         <spdx:copyrightText rdf:resource="http://spdx.org/rdf/terms#noassertion" />
+        {%- if generalAssessment is not empty ~%}
+        <rdfs:comment><![CDATA[
+          {{ generalAssessment|replace({']]>':']]><![CDATA[>'}) }}
+        ]]></rdfs:comment>
+        {%- endif ~%}
+{% for obligation in obligations  %}
+        <spdx:attributionText>{{ obligation }}</spdx:attributionText>
+{% endfor %}
         {{ fileNodes|replace({'\n':'\n          '}) }}
       </spdx:Package>
     </spdx:relatedSpdxElement>

--- a/src/spdx2/agent/template/spdx2-package.xml.twig
+++ b/src/spdx2/agent/template/spdx2-package.xml.twig
@@ -91,7 +91,7 @@
 {% for obligation in obligations  %}
         <spdx:attributionText>{{ obligation }}</spdx:attributionText>
 {% endfor %}
-        {{ fileNodes|replace({'\n':'\n          '}) }}
+        {{ fileNodes|replace({'\n':'\n        '}) }}
       </spdx:Package>
     </spdx:relatedSpdxElement>
   </spdx:Relationship>

--- a/src/spdx2/agent/template/spdx2tv-document.twig
+++ b/src/spdx2/agent/template/spdx2tv-document.twig
@@ -2,7 +2,7 @@
 
    SPDX-License-Identifier: FSFAP
 #}
-SPDXVersion: SPDX-2.2
+SPDXVersion: SPDX-2.3
 DataLicense: CC0-1.0
 
 ##-------------------------
@@ -17,7 +17,9 @@ SPDXID: SPDXRef-DOCUMENT
 ## Creation Information
 ##-------------------------
 
-Creator: Tool: spdx2
+{% if toolVersion is not empty %}
+Creator: Tool: {{ toolVersion }}
+{% endif %}
 {% if userName is not empty %}
 Creator: Person: {{ userName }}
 {% endif %}
@@ -27,8 +29,8 @@ Creator: Organization: {{ organisation }}
 CreatorComment: <text>
 This document was created using license information and a generator from Fossology.
 </text>
-Created: {{ 'now'|date('Y-m-d\\TH:i:s\\Z')}}
-LicenseListVersion: 2.6
+Created: {{ 'now'|date('Y-m-d\\TH:i:s\\Z', 'UTC') }}
+LicenseListVersion: 3.19
 
 ##-------------------------
 ## Package Information

--- a/src/spdx2/agent/template/spdx2tv-document.twig
+++ b/src/spdx2/agent/template/spdx2tv-document.twig
@@ -3,7 +3,7 @@
    SPDX-License-Identifier: FSFAP
 #}
 SPDXVersion: SPDX-2.3
-DataLicense: CC0-1.0
+DataLicense: {{ dataLicense.id|replace({' ': '-'}) }}
 
 ##-------------------------
 ## Document Information
@@ -42,10 +42,10 @@ LicenseListVersion: 3.19
 ## License Information
 ##-------------------------
 
-{% for licenseId,licenseData in licenseTexts %}{% if licenseId starts with 'LicenseRef-' %}
-LicenseID: {{ licenseId|replace({' ': '-'}) }}
-LicenseName: {{ licenseData['name'] }}
-ExtractedText: <text> {{ licenseData['text']|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
-                                            |replace({'\f':''}) }} </text>
+{% for licenseData in licenseTexts %}{% if licenseData.id starts with 'LicenseRef-' %}
+LicenseID: {{ licenseData.id|replace({' ': '-'}) }}
+LicenseName: {{ licenseData.name }}
+ExtractedText: <text> {{ licenseData.text|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
+                                         |replace({'\f':''}) }} </text>
 
 {% endif %}{% endfor %}

--- a/src/spdx2/agent/template/spdx2tv-file.twig
+++ b/src/spdx2/agent/template/spdx2tv-file.twig
@@ -40,4 +40,9 @@ FileCopyrightText: NOASSERTION
 FileCopyrightText: <text> {{ copyrights|join('\n')
                                        |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
                                        |replace({'\f':''}) }} </text>
-{% endif %} 
+{% endif %}
+{% if acknowledgements|default is not empty %}
+FileAttributionText: <text> {{ acknowledgements|join('\n')
+                                               |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
+                                               |replace({'\f':''}) }} </text>
+{% endif %}

--- a/src/spdx2/agent/template/spdx2tv-package.twig
+++ b/src/spdx2/agent/template/spdx2tv-package.twig
@@ -7,6 +7,13 @@ PackageName: {{ packageName }}
 PackageFileName: {{ uploadName }}
 SPDXID: SPDXRef-upload{{ packageId }}
 PackageDownloadLocation: NOASSERTION
+{% if packageVersion is not empty %}
+PackageVersion: {{ packageVersion }}
+{% endif %}
+{% if releaseDate is not empty %}
+ReleaseDate: {{ releaseDate }}
+{% endif %}
+FilesAnalyzed: true
 PackageVerificationCode: {{ verificationCode }}
 PackageChecksum: SHA1: {{ sha1 | lower }}
 PackageChecksum: SHA256: {{ sha256 | lower }}
@@ -23,6 +30,14 @@ PackageLicenseDeclared: {{ mainLicense }}
 {% endif %}
 PackageLicenseInfoFromFiles: NOASSERTION
 PackageCopyrightText: NOASSERTION
+{%- if generalAssessment is not empty ~%}
+PackageComment: <text> {{ generalAssessment|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'}) }} </text>
+{%- endif ~%}
+{% if obligations|default is not empty %}
+PackageAttributionText: <text> {{ obligations|join('\n')
+                                             |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
+                                             |replace({'\f':''}) }} </text>
+{% endif %}
 
 Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-upload{{ packageId }}
 {# RelationshipComment: #}

--- a/src/spdx2/agent_tests/Functional/schedulerTest.php
+++ b/src/spdx2/agent_tests/Functional/schedulerTest.php
@@ -246,15 +246,15 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
    * @brief Pull SPDX toolkit from github if not found
    *
    * -# Verify if Java is installed
-   * -# Pull version 1.1.3
-   * -# Store only tools-java-1.1.3-jar-with-dependencies.jar
+   * -# Pull version 1.1.4
+   * -# Store only tools-java-1.1.4-jar-with-dependencies.jar
    * @return string Jar file path
    */
   protected function pullSpdxTools()
   {
     $this-> verifyJavaIsInstalled();
 
-    $version='1.1.3';
+    $version='1.1.4';
     $tag='v'.$version;
 
     $jarFileBasename = 'tools-java-'.$version.'-jar-with-dependencies.jar';

--- a/src/spdx2/agent_tests/Functional/schedulerTest.php
+++ b/src/spdx2/agent_tests/Functional/schedulerTest.php
@@ -68,7 +68,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
     $this->runnerCli = new SchedulerTestRunnerCli($this->testDb);
     $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
 
-    $this->agentDir = dirname(dirname(__DIR__));
+    $this->agentDir = dirname(__DIR__, 4) . '/build/src/spdx2';
   }
 
   /**
@@ -175,7 +175,6 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
   public function runJobFromJobque($uploadId, $jobId)
   {
     list($success,$output,$retCode) = $this->runnerCli->run($uploadId, $this->userId, $this->groupId, $jobId);
-    var_dump([$success,$output,$retCode]);
 
     assertThat('cannot run runner', $success, equalTo(true));
     assertThat('report failed: "'.$output.'"', $retCode, equalTo(0));
@@ -196,7 +195,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
     assertThat($row, hasKeyValuePair('job_fk', $jobId));
     $filepath = $row['filepath'];
     assertThat($filepath, endsWith('.rdf'));
-    assertThat(file_exists($filepath),equalTo(true));
+    $this->assertFileExists($filepath, "RDF report does not exists.");
 
     return $filepath;
   }


### PR DESCRIPTION
## Description

Update SPDX RDF and tag:value reports to specification version 2.3.

### Changes

1. General:
    1. Use organization name from "Report Header Text" filed from customize page.
    2. Use tool version as `fossology-<version>` where version is build version (e.g. `4.2.1.19`)
    3. Fix report creation timestamp to use UTC timezone.
    4. Fix verification checksum by excluding parent file from calculation (parent file = uploaded file).
    5. Include obligations and acknowledgements in reports.
    6. Update license list version to 3.19
2. RDF files:
    1. Change extension from `-spdx.rdf` to `.spdx.rdf`
    2. Use `xml:base` to reduce URI lengths.
    3. If concluded licenses include `Dual-license`, then use `DisjunctiveLicenseSet` (to denote `OR`), otherwise use `ConjunctiveLicenseSet` (to denote `AND`).
    4. If there is only one concluded license, do not use any set.
    5. Print license acknowledgements in `<spdx:File>` using `<spdx:attributionText>`.
    6. Use general assessment as `<rdfs:comment>` in `<spdx:Package>`.
    7. Use license obligations in `<spdx:Package>` using `<spdx:attributionText>`.
3. Tag-value files:
    1. Print license acknowledgements using `FileAttributionText: <text> ... </text>`.
    2. Print `PackageVersion:` and `ReleaseDate:` from report conf.
    3. Print general assessment as `PackageComment: <text> ... </text>`.
    4. Print license obligations using `PackageAttributionText: <text> ... </text>`.

## How to test

1. Generate SPDX reports in RDF and tag value format.
2. Check if the reports looks good.
3. Validate reports using SPDX tools or online validator at: https://tools.spdx.org/app/validate/
4. Check if other reports are not broken (DEP5 and SPDX CSV).
5. Check for issues reported in #1894

Depends on #2363

Closes #1968
Closes #1894

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2368"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

