### PR TITLE
fix(unifiedreport): fix warnings of unified report agent

### DIFF
--- a/src/lib/php/Report/ClearedGetterCommon.php
+++ b/src/lib/php/Report/ClearedGetterCommon.php
@@ -112,10 +112,10 @@ abstract class ClearedGetterCommon
     $findings = array();
     $countLoop = 0;
     foreach ($ungrupedStatements as $statement) {
-      $licenseId = $statement['licenseId'];
-      $content = convertToUTF8($statement['content'], false);
+      $licenseId = (array_key_exists('licenseId', $statement)) ? convertToUTF8($statement['licenseId'], false) : '';
+      $content = (array_key_exists('content', $statement)) ? convertToUTF8($statement['content'], false) : '';
       $content = htmlspecialchars($content, ENT_DISALLOWED);
-      $comments = convertToUTF8($statement['comments'], false);
+      $comments = (array_key_exists('comments', $statement)) ? convertToUTF8($statement['comments'], false) : '';
       $fileName = $statement['fileName'];
       $fileHash = $statement['fileHash'];
       if (array_key_exists('acknowledgement', $statement)) {
@@ -125,8 +125,8 @@ abstract class ClearedGetterCommon
       }
 
       if (!array_key_exists('text', $statement)) {
-        $description = $statement['description'];
-        $textfinding = $statement['textfinding'];
+        $description = (array_key_exists('description', $statement)) ? convertToUTF8($statement['description'], false) : '';
+        $textfinding = (array_key_exists('textfinding', $statement)) ? convertToUTF8($statement['textfinding'], false) : '';
 
         if ($description === null) {
           $text = "";
@@ -169,7 +169,7 @@ abstract class ClearedGetterCommon
         if ($extended) {
           $singleStatement["licenseId"] = $licenseId;
           $singleStatement["comments"] = convertToUTF8($comments, false);
-          $singleStatement["risk"] =  $statement['risk'];
+          $singleStatement["risk"] = (array_key_exists('risk', $statement)) ? convertToUTF8($statement['risk'], false) : 0;
         }
 
         if (empty($comments)) {

--- a/src/lib/php/Report/ObligationsGetter.php
+++ b/src/lib/php/Report/ObligationsGetter.php
@@ -56,25 +56,28 @@ class ObligationsGetter
     $licenseIds = $this->contentOnly($licenseStatements) ?: array();
     $mainLicenseIds = $this->contentOnly($mainLicenseStatements);
 
-    if (! empty($mainLicenseIds)) {
+    if (!empty($mainLicenseIds)) {
       $allLicenseIds = array_unique(array_merge($licenseIds, $mainLicenseIds));
     } else {
       $allLicenseIds = array_unique($licenseIds);
     }
 
     $bulkAddIds = $this->getBulkAddLicenseList($uploadId, $groupId);
+    if (!empty($bulkAddIds)) {
+      $allLicenseIds = array_unique(array_merge($licenseIds, $bulkAddIds));
+    }
+
     $obligationRef = $this->licenseDao->getLicenseObligations($allLicenseIds) ?: array();
     $obligationCandidate = $this->licenseDao->getLicenseObligations($allLicenseIds, true) ?: array();
     $obligations = array_merge($obligationRef, $obligationCandidate);
     $onlyLicenseIdsWithObligation = array_column($obligations, 'rf_fk');
-    if (!empty($bulkAddIds)) {
-      $onlyLicenseIdsWithObligation = array_unique(array_merge($onlyLicenseIdsWithObligation, $bulkAddIds));
-    }
-    $licenseWithoutObligations = array_diff($allLicenseIds, $onlyLicenseIdsWithObligation) ?: array();
+    $licenseWithObligations = array_unique(array_intersect($onlyLicenseIdsWithObligation, $allLicenseIds));
+    $licenseWithoutObligations = array_diff($allLicenseIds, $licenseWithObligations) ?: array();
     foreach ($licenseWithoutObligations as $licenseWithoutObligation) {
       $license = $this->licenseDao->getLicenseById($licenseWithoutObligation);
       if (!empty($license)) {
-        $whiteLists[] = $license->getSpdxId();
+        $whiteLists[] = LicenseRef::convertToSpdxId($license->getShortName(),
+          $license->getSpdxId());
       }
     }
     $newobligations = $this->groupObligations($obligations, $uploadId);
@@ -122,9 +125,15 @@ class ObligationsGetter
     foreach ($obligations as $obligation ) {
       $obTopic = $obligation['ob_topic'];
       $obText = $obligation['ob_text'];
-      $licenseName = $obligation['rf_spdx_id'] ? : LicenseRef::SPDXREF_PREFIX . $obligation['rf_shortname'];
+      $licenseName = LicenseRef::convertToSpdxId($obligation['rf_shortname'],
+        $obligation['rf_spdx_id']);
       $groupBy = $obText;
-      if (!in_array($licenseName,(array) $excludedObligations[$obTopic])) {
+      if (!empty($excludedObligations)) {
+        $obligationLicenseNames = $excludedObligations[$obTopic];
+      } else {
+        $obligationLicenseNames = array();
+      }
+      if (!in_array($licenseName, $obligationLicenseNames)) {
         if (array_key_exists($groupBy, $groupedOb)) {
           $currentLics = &$groupedOb[$groupBy]['license'];
           if (!in_array($licenseName, $currentLics)) {

--- a/src/lib/php/Report/ObligationsGetter.php
+++ b/src/lib/php/Report/ObligationsGetter.php
@@ -52,6 +52,7 @@ class ObligationsGetter
    */
   function getObligations($licenseStatements, $mainLicenseStatements, $uploadId, $groupId)
   {
+    $whiteLists = array();
     $licenseIds = $this->contentOnly($licenseStatements) ?: array();
     $mainLicenseIds = $this->contentOnly($mainLicenseStatements);
 

--- a/src/unifiedreport/agent/reportStatic.php
+++ b/src/unifiedreport/agent/reportStatic.php
@@ -215,8 +215,8 @@ class ReportStatic
     $table->addRow($rowWidth);
     $table->addCell($cellFirstLen)->addText(htmlspecialchars(" Source / binary integration notes"), $leftColStyle, "pStyle");
     $cell = $table->addCell($cellLen);
-    $this->addCheckBoxText($cell, $getCheckboxList[0], $nocriticalfiles);
-    $this->addCheckBoxText($cell, $getCheckboxList[1], $criticalfiles);
+    $this->addCheckBoxText($cell, (array_key_exists(0,$getCheckboxList)) ? $getCheckboxList[0] : '', $nocriticalfiles);
+    $this->addCheckBoxText($cell, (array_key_exists(1,$getCheckboxList)) ? $getCheckboxList[1] : '', $criticalfiles);
 
     $nodependenciesfound = " no dependencies found, neither in source code nor in binaries";
     $dependenciesfoundinsourcecode = " dependencies found in source code (see obligations)";
@@ -224,9 +224,9 @@ class ReportStatic
     $table->addRow($rowWidth);
     $table->addCell($cellFirstLen)->addText(htmlspecialchars(" Dependency notes"), $leftColStyle, "pStyle");
     $cell = $table->addCell($cellLen);
-    $this->addCheckBoxText($cell, $getCheckboxList[2], $nodependenciesfound);
-    $this->addCheckBoxText($cell, $getCheckboxList[3], $dependenciesfoundinsourcecode);
-    $this->addCheckBoxText($cell, $getCheckboxList[4], $dependenciesfoundinbinaries);
+    $this->addCheckBoxText($cell, (array_key_exists(2,$getCheckboxList)) ? $getCheckboxList[2] : '', $nodependenciesfound);
+    $this->addCheckBoxText($cell, (array_key_exists(3,$getCheckboxList)) ? $getCheckboxList[3] : '', $dependenciesfoundinsourcecode);
+    $this->addCheckBoxText($cell, (array_key_exists(4,$getCheckboxList)) ? $getCheckboxList[4] : '', $dependenciesfoundinbinaries);
     if ($otherStatement["ri_depnotes"] != 'NA' && !empty($otherStatement["ri_depnotes"])) {
       $extraNotes = str_replace("\n", "</w:t>\n<w:br />\n<w:t xml:space=\"preserve\">", htmlspecialchars($otherStatement["ri_depnotes"], ENT_DISALLOWED));
       $extraNotes = str_replace("\r", "", $extraNotes);
@@ -238,8 +238,8 @@ class ReportStatic
     $table->addRow($rowWidth);
     $table->addCell($cellFirstLen)->addText(htmlspecialchars(" Export restrictions by copyright owner"), $leftColStyle, "pStyle");
     $cell = $table->addCell($cellLen);
-    $this->addCheckBoxText($cell, $getCheckboxList[5], $noexportrestrictionsfound);
-    $this->addCheckBoxText($cell, $getCheckboxList[6], $exportrestrictionsfound);
+    $this->addCheckBoxText($cell, (array_key_exists(5,$getCheckboxList)) ? $getCheckboxList[5] : '', $noexportrestrictionsfound);
+    $this->addCheckBoxText($cell, (array_key_exists(6,$getCheckboxList)) ? $getCheckboxList[6] : '', $exportrestrictionsfound);
     if ($otherStatement["ri_exportnotes"] != 'NA' && !empty($otherStatement["ri_exportnotes"])) {
       $extraNotes = str_replace("\n", "</w:t>\n<w:br />\n<w:t xml:space=\"preserve\">", htmlspecialchars($otherStatement["ri_exportnotes"], ENT_DISALLOWED));
       $extraNotes = str_replace("\r", "", $extraNotes);
@@ -252,8 +252,8 @@ class ReportStatic
     $table->addCell($cellFirstLen)->addText(htmlspecialchars(" Restrictions for use (e.g. not for Nuclear Power) by copyright owner"),
       $leftColStyle, "pStyle");
     $cell = $table->addCell($cellLen);
-    $this->addCheckBoxText($cell, $getCheckboxList[7], $norestrictionsforusefound);
-    $this->addCheckBoxText($cell, $getCheckboxList[8], $restrictionsforusefound);
+    $this->addCheckBoxText($cell, (array_key_exists(7,$getCheckboxList)) ? $getCheckboxList[7] : '', $norestrictionsforusefound);
+    $this->addCheckBoxText($cell, (array_key_exists(8,$getCheckboxList)) ? $getCheckboxList[8] : '', $restrictionsforusefound);
     if ($otherStatement["ri_copyrightnotes"] != 'NA' && !empty($otherStatement["ri_copyrightnotes"])) {
       $extraNotes = str_replace("\n", "</w:t>\n<w:br />\n<w:t xml:space=\"preserve\">", htmlspecialchars($otherStatement["ri_copyrightnotes"], ENT_DISALLOWED));
       $extraNotes = str_replace("\r", "", $extraNotes);


### PR DESCRIPTION
## Description

fix warnings of unified report agent

### Changes

Use array_key_exists function to check if the key exist.

## How to test

* Switch on warnings in your development machine and generate unified report.
* You should not see any warnings in job log.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2372"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

