### PR TITLE
fix(unifiedReport): fix table distortion for component link

### DIFF
--- a/src/unifiedreport/agent/reportStatic.php
+++ b/src/unifiedreport/agent/reportStatic.php
@@ -10,6 +10,8 @@ use PhpOffice\PhpWord\Element\Section;
 use PhpOffice\PhpWord\Element\TextRun;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Element\Cell;
+use PhpOffice\PhpWord\SimpleType\JcTable;
+use PhpOffice\PhpWord\Style\Table;
 
 /**
  * @class ReportStatic
@@ -36,7 +38,9 @@ class ReportStatic
   private $tablestyle = array("borderSize" => 2,
                               "name" => "Arial",
                               "borderColor" => "000000",
-                              "cellSpacing" => 5
+                              "cellSpacing" => 5,
+                              "alignment"   => JcTable::START,
+                              "layout"      => Table::LAYOUT_FIXED
                              );
 
   /**

--- a/src/unifiedreport/agent/reportSummary.php
+++ b/src/unifiedreport/agent/reportSummary.php
@@ -7,7 +7,9 @@
 
 use Fossology\Lib\Data\Package\ComponentType;
 use PhpOffice\PhpWord\Element\Section;
-use \PhpOffice\PhpWord\Style;
+use PhpOffice\PhpWord\Style;
+use PhpOffice\PhpWord\SimpleType\JcTable;
+use PhpOffice\PhpWord\Style\Table;
 
 /**
  * @class ReportSummary
@@ -26,7 +28,9 @@ class ReportSummary
   private $tablestyle = array("borderSize" => 2,
                               "name" => "Arial",
                               "borderColor" => "000000",
-                              "cellSpacing" => 5
+                              "cellSpacing" => 5,
+                              "alignment"   => JcTable::START,
+                              "layout"      => Table::LAYOUT_FIXED
                              );
 
   /** @var array $subHeadingStyle

--- a/src/unifiedreport/agent/unifiedreport.php
+++ b/src/unifiedreport/agent/unifiedreport.php
@@ -102,6 +102,8 @@ use Fossology\Lib\Report\XpClearedGetter;
 use PhpOffice\PhpWord\Element\Section;
 use PhpOffice\PhpWord\IOFactory;
 use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\SimpleType\JcTable;
+use PhpOffice\PhpWord\Style\Table;
 
 include_once(__DIR__ . "/version.php");
 include_once(__DIR__ . "/reportStatic.php");
@@ -195,7 +197,9 @@ class UnifiedReport extends Agent
   private $tablestyle = array("borderSize" => 2,
                               "name" => "Arial",
                               "borderColor" => "000000",
-                              "cellSpacing" => 5
+                              "cellSpacing" => 5,
+                              "alignment"   => JcTable::START,
+                              "layout"      => Table::LAYOUT_FIXED
                              );
 
   /** @var array $subHeadingStyle


### PR DESCRIPTION
## Description

When creating the unified report, the cell get extremely large which holds the component link.

### Changes

Added fixed width using existing table classes.

## How to test

* Add large URL into component link column from conf page.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2373"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

