### PR TITLE
fix(ci): add missing dependency to runner image

### DIFF
--- a/utils/automation/Dockerfile.ci
+++ b/utils/automation/Dockerfile.ci
@@ -18,6 +18,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     lsb-release \
     php-cli \
     sudo \
+    libxslt1-dev \
     dpkg-dev \
     cmake \
     ninja-build \


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add the missing `libxslt` dependency to the `utils/automation/Dockerfile.ci`

## How to test

Build the runner image
`docker build -f uilts/automation/Dockerfile.ci -t fossology-runner .`

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2374"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

