### PR TITLE
feat(deleteFileInBrowse):ability to delete file from browser

### DIFF
--- a/src/delagent/ui/Page/AdminUploadDelete.php
+++ b/src/delagent/ui/Page/AdminUploadDelete.php
@@ -168,7 +168,7 @@ class AdminUploadDelete extends DefaultPlugin
    * @param $folderId The folder(folder_id) containing the uploads
    * @return string with the message.
    */
-  private function TryToDelete($uploadpk, $folderId)
+  public function TryToDelete($uploadpk, $folderId)
   {
     if (!$this->uploadDao->isEditable($uploadpk, Auth::getGroupId())) {
       $returnMessage = DeleteMessages::NO_PERMISSION;

--- a/src/delagent/ui/delete-file-browse.php
+++ b/src/delagent/ui/delete-file-browse.php
@@ -1,0 +1,81 @@
+<?php
+/*
+/*
+ SPDX-FileCopyrightText: © 2023 Simran Nigam <nigamsimran14@gmail.com>
+ SPDX-FileContributor: Simran Nigam <nigamsimran14@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @namespace Fossology::DelAgent::UI::Page
+ * @brief UI namespace for DelAgent
+ */
+namespace Fossology\DelAgent\UI\Page;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Dao\FolderDao;
+use Fossology\Lib\Plugin\DefaultPlugin;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * @class BrowseUploadDelete
+ * @brief UI plugin to delete uploaded files
+ */
+class BrowseUploadDelete extends DefaultPlugin
+{
+  const NAME = "browse_upload_delete";
+
+  /** @var UploadDao */
+  private $uploadDao;
+
+  /** @var FolderDao */
+  private $folderDao;
+
+  function __construct()
+  {
+    parent::__construct(self::NAME, array(
+        self::TITLE => _("Delete Uploaded File"),
+        self::PERMISSION => Auth::PERM_ADMIN,
+        self::REQUIRES_LOGIN => true
+    ));
+
+    global $container;
+    $this->uploadDao = $container->get('dao.upload');
+    $this->folderDao = $container->get('dao.folder');
+  }
+
+    /**
+   * \brief Customize submenus.
+   */
+  function RegisterMenus()
+  {
+    $text = _("Delete Browse File");
+    menu_insert("Browse-Pfile::Delete",0,$this->Name,$text);
+  } // RegisterMenus()
+
+  /**
+   * @copydoc Fossology::Lib::Plugin::DefaultPlugin::handle()
+   * @see Fossology::Lib::Plugin::DefaultPlugin::handle()
+   */
+  protected function handle(Request $request)
+  {
+    $vars = array();
+
+    $uploadpk = $request->get('upload');
+    $folderId = $request->get('folder');
+
+    if (!empty($uploadpk)) {
+      /**
+      * @var AdminUploadDelete $adminUploadDelete
+      */
+      $adminUploadDelete = plugin_find("admin_upload_delete");
+      $adminUploadDelete->TryToDelete($uploadpk, $folderId);
+    }
+    return new RedirectResponse(Traceback_uri() . '?mod=' . 'showjobs');
+  }
+}
+
+register_plugin(new BrowseUploadDelete());

--- a/src/www/ui/scripts/browse.js
+++ b/src/www/ui/scripts/browse.js
@@ -33,8 +33,15 @@ $(document).ready(function () {
         openCommentModal(source[0],source[1],source[2]);
     } );
     $('select.goto-active-option').change(function() {
-      var url = $(this).val();
-      if(url){ window.location = url;}
+      const url = $(this).val();
+      const optionText = $(this).find("option:selected").text();
+      let userResponse = true
+      if (optionText === "Delete") {
+        userResponse = confirm("Are you sure you want to delete this upload ?")
+      } 
+      if(url && userResponse) {
+        window.location = url;
+      }
     });
   });
   commentModal = $('#commentModal').modal('hide');


### PR DESCRIPTION
## Description

Added delete file algorithm in Browse Page.

### Changes

Added delete file algorithm in Browse Page
## How to test

1. Create new file
2. Go to browse page
3. Go to actions of the corresponding file
4. Select Delete
5. It will add to the job queue,  

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)

Closing #1657 

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2381"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

[Screencast from 13-03-23 06:20:32 AM IST.webm](https://user-images.githubusercontent.com/95395832/224585641-1e38db5c-6046-4525-97ad-cef5c0caa717.webm)
