### PR TITLE
Added inverse search in Email/ Url / Author Page

### DIFF
--- a/src/copyright/ui/HistogramBase.php
+++ b/src/copyright/ui/HistogramBase.php
@@ -68,7 +68,12 @@ abstract class HistogramBase extends FO_Plugin
       $typeDescriptor = $description;
     }
     $output = "<h4>Activated $typeDescriptor statements:</h4>
-<div><table border=1 width='100%' id='copyright".$type."' class='wordbreaktable'></table></div>
+<div>
+  <div class='btn btn-default' style='float:right; padding:5px; margin:5px;'>
+    <input type='checkbox' style='padding:2px;' id='inverseSearchActivated".$type."' name='inverseSearch'/> 
+    <label class='control-label' for='inverseSearchActivated".$type."'>Inverse Search</label>
+  </div>
+<table border=1 width='100%' id='copyright".$type."' class='wordbreaktable'></table></div>
 <br/><br/>
 <div>
   <table border=0 width='100%' id='searchReplaceTable".$type."'>
@@ -113,6 +118,10 @@ abstract class HistogramBase extends FO_Plugin
   </table>
   <br/><br/>
   <h4>Deactivated $typeDescriptor statements:</h4>
+  <div class='btn btn-default' style='float:right; padding:5px; margin:5px;'>
+  <input type='checkbox' id='inverseSearchDeactivated".$type."' name='inverseSearch'/> 
+  <label class='control-label' for='inverseSearchDeactivated".$type."'>Inverse Search</label>
+  </div>
 </div>
 <div><table border=1 width='100%' id='copyright".$type."deactivated' class='wordbreaktable'></table>
   <br/><br/>

--- a/src/copyright/ui/ajax-copyright-hist.php
+++ b/src/copyright/ui/ajax-copyright-hist.php
@@ -375,10 +375,14 @@ count(*) AS copyright_count " .
   private function addSearchFilter(&$filterParams)
   {
     $searchPattern = GetParm('sSearch', PARM_STRING);
+    $isInverseSearch = GetParm('isInverse', PARM_STRING);
     if (empty($searchPattern)) {
       return '';
     }
     $filterParams[] = "%$searchPattern%";
+    if ($isInverseSearch == 'true') {
+      return 'WHERE mcontent not ilike $'.count($filterParams).' ';
+    }
     return 'WHERE mcontent ilike $'.count($filterParams).' ';
   }
 

--- a/src/copyright/ui/template/histTable.js.twig
+++ b/src/copyright/ui/template/histTable.js.twig
@@ -36,6 +36,23 @@ function createTableBase{{ table.type }}(activated) {
       aoData.push({ "name":"agent", "value": "{{ table.agentId }}" });
       aoData.push({ "name":"type", "value": "{{ table.type }}" });
       aoData.push({ "name":"filter", "value": "{{ table.filter }}" });
+      if(activated)
+      {
+        if($('#inverseSearchActivated{{table.type}}').is(':checked'))
+        {
+          aoData.push( { "name":"isInverse", "value": "true"} );
+        } else {
+          aoData.push( { "name":"isInverse", "value": "false" } );
+        }
+      } else {
+        if($('#inverseSearchDeactivated{{table.type}}').is(':checked'))
+        {
+          aoData.push( { "name":"isInverse", "value": "true"} );
+        } else {
+          aoData.push( { "name":"isInverse", "value": "false" } );
+        }
+      }
+      
       $.getJSON(sSource, aoData, fnCallback).fail(function() {
         if (confirm("You are not logged in. Go to login page?"))
           window.location.href = "?mod=auth";


### PR DESCRIPTION
## Description

Added Inverse Search Option to Search in Email/ Url/ Author Page browse table.

### Changes

- Added Invert checkbox.
- Made addSearchFilter() method to accommodate inverse search parameter.

## How to test

- Go to Email/ URL/ Author Page.
- Click on invert Search checkbox.
- You will get the inverted Search results.

closes #1387 


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2382"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

