### PR TITLE
fix(spdx-rdf): use CDATA for attributionText

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,6 +9,7 @@ concurrency:
 
 on:
   push:
+    branches: [master]
   pull_request:
     branches: [master]
   workflow_dispatch:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -22,7 +22,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y git doxygen graphviz
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
 

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt-get update
           echo PATH="/usr/lib/ccache/:$PATH" >> $GITHUB_ENV
           echo COMPOSER_HOME="$HOME/.composer/" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - name: Syntax Check
@@ -54,7 +54,7 @@ jobs:
           sudo apt-get install -y cppcheck
           echo PATH="/usr/lib/ccache/:$PATH" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - name: Static Code Analysis
@@ -68,7 +68,7 @@ jobs:
         with:
           php-version: '8.1'
           extensions: gettext, mbstring, gd, json, xml, zip, pgsql, curl, uuid, posix, sqlite3
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - name: PHP Codesniffer
@@ -87,7 +87,7 @@ jobs:
           php-version: '8.1'
           extensions: gettext, mbstring, gd, json, xml, zip, pgsql, curl, uuid, posix, sqlite3, dom
           tools: sebastian/phpcpd:6.0.3
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - name: Copy/Paste detector
@@ -100,7 +100,7 @@ jobs:
   openapi-lint:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup default rules
         run: |
           echo '{"extends": ["spectral:oas"]}' > .spectral.json

--- a/src/lib/php/Proxy/UploadTreeProxy.php
+++ b/src/lib/php/Proxy/UploadTreeProxy.php
@@ -8,10 +8,10 @@
 namespace Fossology\Lib\Proxy;
 
 use Fossology\Lib\BusinessRules\LicenseMap;
+use Fossology\Lib\Data\AgentRef;
 use Fossology\Lib\Data\DecisionScopes;
 use Fossology\Lib\Data\DecisionTypes;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
-use Fossology\Lib\Data\AgentRef;
 
 class UploadTreeProxy extends DbViewProxy
 {
@@ -241,7 +241,9 @@ class UploadTreeProxy extends DbViewProxy
       case "noLicense":
       case self::OPT_SKIP_ALREADY_CLEARED:
       case "noCopyright":
+      case "noIpra":
       case "noEcc":
+      case "noKeyword":
 
         $queryCondition = self::getQueryCondition($skipThese, $options, $groupId, $agentFilter, $applyGlobal)." ".$additionalCondition;
         if ('uploadtree' === $uploadTreeTableName || 'uploadtree_a' == $uploadTreeTableName) {
@@ -320,6 +322,9 @@ ORDER BY cd.clearing_decision_pk DESC LIMIT 1";
       case "noCopyright":
         return "EXISTS (SELECT copyright_pk FROM copyright cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null )".
               " OR EXISTS (SELECT 1 FROM copyright_decision AS cd WHERE ut.pfile_fk = cd.pfile_fk)";
+      case "noIpra":
+        return "EXISTS (SELECT ipra_pk FROM ipra cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null )".
+              " OR EXISTS (SELECT 1 FROM ipra_decision AS cd WHERE ut.pfile_fk = cd.pfile_fk)";
       case "noEcc":
         return "EXISTS (SELECT ecc_pk FROM ecc cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null )".
               " OR EXISTS (SELECT 1 FROM ecc_decision AS cd WHERE ut.pfile_fk = cd.pfile_fk)";

--- a/src/lib/php/View/HighlightRenderer.php
+++ b/src/lib/php/View/HighlightRenderer.php
@@ -35,7 +35,8 @@ class HighlightRenderer
             Highlight::AUTHOR => 'hi-author',
             Highlight::BULK => 'hi-bulk',
             Highlight::IPRA => 'hi-ipra',
-            Highlight::ECC => 'hi-mediumorchid'
+            Highlight::ECC => 'hi-mediumorchid',
+            Highlight::KEYWORDOTHERS => 'hi-teal'
           );
 
   /**

--- a/src/spdx2/agent/template/spdx2-package.xml.twig
+++ b/src/spdx2/agent/template/spdx2-package.xml.twig
@@ -89,7 +89,8 @@
         ]]></rdfs:comment>
         {%- endif ~%}
 {% for obligation in obligations  %}
-        <spdx:attributionText>{{ obligation }}</spdx:attributionText>
+        <spdx:attributionText><![CDATA[{{ obligation|replace({'\f':''})
+                |replace({']]>':']]]]><![CDATA[>'}) }}]]></spdx:attributionText>
 {% endfor %}
         {{ fileNodes|replace({'\n':'\n        '}) }}
       </spdx:Package>

--- a/src/www/ui/css/highlights.css
+++ b/src/www/ui/css/highlights.css
@@ -79,3 +79,7 @@
 .hi-mediumorchid {
   background-color: #BA55D3;
 }
+
+.hi-teal {
+  background-color: #008080;
+}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

1. Since RDF files are XML, putting unescaped text in `<spdx:attributionText>` can cause failures. To prevent, put text in `<![CDATA[ ]]>`
2. Prevent running build-test.yml on pushes other than `master` branch.
3. Add missing keyword other highlight.
4. Update workflows to use checkout v3.

### Changes

1. Update `<spdx:attributionText>` to use `<![CDATA[ ]]>`.
2. Update `actions/checkout@v2` to `actions/checkout@v3`
3. Prevent dual run of `build-test.yml`

## How to test

1. Clear an upload with some license.
2. Add an obligation to the license with `&` and `<>` characters in text.
3. Generate SPDX RDF and validate it.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2386"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

