### PR TITLE
feat(highlightRows):Highlighted deleted rows on copyright/URL/Author/…

### DIFF
--- a/src/copyright/ui/ajax-copyright-hist.php
+++ b/src/copyright/ui/ajax-copyright-hist.php
@@ -429,7 +429,7 @@ count(*) AS copyright_count " .
   private function fillTableRow($row, $uploadTreeId, $upload, $agentId, $type,$listPage, $filter = "", $activated = true, $rw = true)
   {
     $hash = $row['hash'];
-    $output = array('DT_RowId' => "$upload,$uploadTreeId,$hash,$type" );
+    $output = array('DT_RowId' => "$upload,$uploadTreeId,$hash,$type", "DT_RowClass" => "row$hash");
 
     $link = "<a href='";
     $link .= Traceback_uri();

--- a/src/copyright/ui/template/histTable.js.twig
+++ b/src/copyright/ui/template/histTable.js.twig
@@ -236,6 +236,7 @@ function delete{{ table.type }}(upload, item, hash, kind) {
       success: function(data) {
         $("#delete{{ table.type }}" + hash).hide();
         $("#update{{ table.type }}" + hash).attr("style","display:inline !important;");
+        $("tr.row"+hash+" td").attr("style","background-color:#fdff32 !important");
       },
       error: function(errorResponse) {
         alert(errorResponse.responseText);
@@ -253,6 +254,7 @@ function undo{{ table.type }}(upload, item, hash, kind) {
         $("#delete{{ table.type }}" + hash).show();
         $("#update{{ table.type }}" + hash).hide();
         $("#deleteBySelect{{ table.type }}" + hash).prop('checked', false);
+        $("tr.row"+hash+" td").attr("style","background-color:''");
       },
       error: function(errorResponse) {
         alert(errorResponse.responseText);


### PR DESCRIPTION
…Email tables

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

The proposed change highlights the deleted row in Copyright/Url/Author/Email Table.

### Changes

Added an unique class to the row consisting of row hash.
Changed the style of the row on delete.

## How to test

Delete a Copyright/Email/Url/author and you can see the row highlighted.
When you undo the row become normal again.

closes #797 

[Screencast from 07-03-23 09:31:17 PM IST.webm](https://user-images.githubusercontent.com/68627768/223489177-af9c73ca-344f-476c-bc2b-dfbe497f03b7.webm)



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2388"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

