### PR TITLE
fix(manualCopyright):Made Disabled Manual Copyrights Visible in UI

### DIFF
--- a/src/copyright/ui/template/ui-xp-view_rhs.html.twig
+++ b/src/copyright/ui/template/ui-xp-view_rhs.html.twig
@@ -72,11 +72,11 @@
           {% endif %}
         </td>
         <td id='actionsOf{{ row["#{decisionsTable}_pk"] }}'>
-          <span class="basicActions">
+          <span class="basicActions" {% if row.is_enabled == 'f' %} hidden {% endif %}>
             <img src="images/button_edit.png" onclick="editDecision({{ row["#{decisionsTable}_pk"] }}, '{{ row.textfinding|e('js') }}', '{{ row.description|e('js') }}', '{{ row.comment|e('js') }}', {{ row.clearing_decision_type_fk }});">
             <img class="delete" src="images/space_16.png" onclick="deleteDecision({{ row["#{decisionsTable}_pk"] }});">
           </span>
-          <span class="undoActions" hidden>
+          <span class="undoActions" {% if row.is_enabled == 't' %} hidden {% endif %}>
             deleted [<a href="#" onclick="event.preventDefault();undoDecision({{ row["#{decisionsTable}_pk"] }});">undo</a>]
           </span>
         </td>

--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -394,7 +394,7 @@ ORDER BY copyright_pk, UT.uploadtree_pk, content DESC";
   {
     $statementName = __METHOD__.$tableName;
     $orderTablePk = $tableName.'_pk';
-    $sql = "SELECT * FROM $tableName where pfile_fk = $1 and is_enabled order by $orderTablePk desc";
+    $sql = "SELECT * FROM $tableName where pfile_fk = $1 order by $orderTablePk desc";
     $params = array($pfileId);
 
     return $this->dbManager->getRows($sql, $params, $statementName);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Made the disabled Manual Copyrights Visible in Current Decision section in `?mod=copyright-view` page.

### Changes

- Removed `is_enabled` from query to get current decisions data.
- Displayed Options based on whether it is disabled or not.

## How to test

1. Add a manual copyright
2. Disable the copyright
3. Reload the page
4. Check whether the disabled copyright is visible in Current decisions section.

closes #1344 

![image](https://user-images.githubusercontent.com/68627768/224496210-6cd36d85-e049-4eb6-ab68-6a0949e0b41a.png)




<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2389"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

