### PR TITLE
fix(user-add.php): Fixed email can be blank but required

### DIFF
--- a/src/www/ui/user-add.php
+++ b/src/www/ui/user-add.php
@@ -78,21 +78,19 @@ class user_add extends DefaultPlugin
       return ($text);
     }
 
-    if (empty($Email)) {
-      $text = _("Email must be specified. Not added.");
-      return ($text);
-    }
-
-    /* Make sure email looks valid */
-    if (! filter_var($Email, FILTER_VALIDATE_EMAIL)) {
+    /* Make sure email looks valid (If email field not empty) */
+    if (! empty($Email) && ! filter_var($Email, FILTER_VALIDATE_EMAIL)) {
       $text = _("Invalid email address.  Not added.");
       return ($text);
     }
 
-    /* Make sure email is unique */
-    $email_count = $this->dbManager->getSingleRow(
-      "SELECT COUNT(*) as count FROM users WHERE user_email = $1 LIMIT 1;",
-      array($Email))["count"];
+    /* Make sure email is unique (If email field not empty) */
+    $email_count = 0;
+    if (! empty($Email)) { 
+      $email_count = $this->dbManager->getSingleRow(
+        "SELECT COUNT(*) as count FROM users WHERE user_email = $1 LIMIT 1;",
+        array($Email))["count"];
+    }
     if ($email_count > 0) {
       $text = _("Email address already exists.  Not added.");
       return ($text);


### PR DESCRIPTION
the empty email checks and modified other email checks to function with an emtpy email field This fixes issue #2391

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix "Email can be blank" but is actually required in the add user page.

### Changes

1. Removed `empty($Email)` check  
2. Modified the other two email checks to not give an error with the email field is empty

## How to test

Try to add a new user with the email field empty. Previously an error message used to be shown, now it doesn't

This fixes #2391 


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2396"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

