### PR TITLE
fix(user-edit.php): Fixed editing emails allows for duplicate emails …

### DIFF
--- a/src/www/ui/user-edit.php
+++ b/src/www/ui/user-edit.php
@@ -265,6 +265,17 @@ class UserEditPage extends DefaultPlugin
       $Errors .= "<li>" . _("Invalid email address.") . "</li>";
     }
 
+    /* Make sure email is unique */
+    $email_count = 0;
+    if (!empty($UserRec['user_email'])) {
+      $email_count = $this->dbManager->getSingleRow(
+        "SELECT COUNT(*) as count FROM users WHERE user_email = $1 LIMIT 1;",
+        array($UserRec['user_email']))["count"];
+    }
+    if ($email_count > 0) {
+      $Errors .= "<li>" . _("Email address already exists.") . "</li>";
+    }
+
     /* Make sure user can't ask for blank password if policy is enabled */
     if (passwordPolicyEnabled() && !empty($UserRec['_blank_pass'])) {
       $Errors .= "<li>" . _("Password policy enabled, can't have a blank password.") . "</li>";


### PR DESCRIPTION
…for multiple users

Added a check to see if the new email is unique or not This fixes #2397

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Users can't edit their email with an email that's not unique.

### Changes

Added a uniqueness check for the email field

## How to test

- Create two new users with different emails.
- Try to edit the email value of one of the users to the other's email value.
- Previously, this would have worked, now it displays an error message and the email isn't changed.

This fixes #2397


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2398"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

