### PR TITLE
fix(clixml): use license full name in clixml report

### DIFF
--- a/src/clixml/agent/template/clixml-file.xml.twig
+++ b/src/clixml/agent/template/clixml-file.xml.twig
@@ -41,7 +41,7 @@
   {%- if licensesMain %}
     {%- for ids in licensesMain %}
       {%~ if ids.textMain %}
-  <License type="global" name="{{ids.contentMain|e}}" spdxidentifier="{{ids.contentMain|e}}">
+  <License type="global" name="{{ids.nameMain|e}}" spdxidentifier="{{ids.contentMain|e}}">
     <Content><![CDATA[{{ ids.textMain }}
 ]]></Content>
     <Files><![CDATA[
@@ -75,7 +75,7 @@
   {%- if licenses %}
     {%- for ids in licenses %}
       {%~ if ids.text %}
-  <License type="{{ids.risk}}" name="{{ids.content|e}}" spdxidentifier="{{ids.content|e}}">
+  <License type="{{ids.risk}}" name="{{ids.name|e}}" spdxidentifier="{{ids.content|e}}">
     <Content><![CDATA[{{ ids.text }}
 ]]></Content>
     <Files><![CDATA[

--- a/src/lib/php/BusinessRules/test/LicenseMapTest.php
+++ b/src/lib/php/BusinessRules/test/LicenseMapTest.php
@@ -164,16 +164,16 @@ class LicenseMapTest extends \PHPUnit\Framework\TestCase
   {
     $licenseMap = new LicenseMap($this->dbManager, $this->groupId+1, LicenseMap::CONCLUSION, true);
     $map = \Fossology\Lib\Test\Reflectory::getObjectsProperty($licenseMap, 'map');
-    assertThat($map,hasItemInArray(array('rf_fk'=>1,'parent_shortname'=>'One','parent_spdx_id'=>'One','rf_parent'=>1)));
-    assertThat($map,hasItemInArray(array('rf_fk'=>2,'parent_shortname'=>'One','parent_spdx_id'=>'One','rf_parent'=>1)));
+    assertThat($map,hasItemInArray(array('rf_fk'=>1,'parent_shortname'=>'One','parent_spdx_id'=>'One','rf_parent'=>1,'parent_fullname'=>'One-1')));
+    assertThat($map,hasItemInArray(array('rf_fk'=>2,'parent_shortname'=>'One','parent_spdx_id'=>'One','rf_parent'=>1,'parent_fullname'=>'One-1')));
   }
 
   public function testFullMapWithCandidates()
   {
     $licenseMap = new LicenseMap($this->dbManager, $this->groupId, LicenseMap::CONCLUSION, true);
     $map = \Fossology\Lib\Test\Reflectory::getObjectsProperty($licenseMap, 'map');
-    assertThat($map,hasItemInArray(array('rf_fk'=>1,'parent_shortname'=>'One','parent_spdx_id'=>'One','rf_parent'=>1)));
-    assertThat($map,hasItemInArray(array('rf_fk'=>2,'parent_shortname'=>'One','parent_spdx_id'=>'One','rf_parent'=>1)));
-    assertThat($map,hasItemInArray(array('rf_fk'=>3,'parent_shortname'=>'Three','parent_spdx_id'=>'Three','rf_parent'=>3)));
+    assertThat($map,hasItemInArray(array('rf_fk'=>1,'parent_shortname'=>'One','parent_spdx_id'=>'One','rf_parent'=>1,'parent_fullname'=>'One-1')));
+    assertThat($map,hasItemInArray(array('rf_fk'=>2,'parent_shortname'=>'One','parent_spdx_id'=>'One','rf_parent'=>1,'parent_fullname'=>'One-1')));
+    assertThat($map,hasItemInArray(array('rf_fk'=>3,'parent_shortname'=>'Three','parent_spdx_id'=>'Three','rf_parent'=>3,'parent_fullname'=>'Three-3')));
   }
 }

--- a/src/lib/php/Data/LicenseRef.php
+++ b/src/lib/php/Data/LicenseRef.php
@@ -111,6 +111,18 @@ class LicenseRef
       // License ref can not end with a '+'
       $spdxLicense = preg_replace('/\+$/', '-or-later', $spdxLicense);
     }
-    return $spdxLicense;
+    return self::replaceSpaces($spdxLicense);
+  }
+
+  /**
+   * Replace all spaces with '-' if they are not surrounding 'AND', 'WITH' or
+   * 'OR'
+   * @param string $licenseName SPDX expression
+   * @return string SPDX expression with space replaced with dash
+   */
+  public static function replaceSpaces($licenseName): string
+  {
+    $licenseName = str_replace(' ', '-', $licenseName);
+    return preg_replace('/-(OR|AND|WITH)-(?!later)/i', ' $1 ', $licenseName);
   }
 }

--- a/src/lib/php/Report/LicenseMainGetter.php
+++ b/src/lib/php/Report/LicenseMainGetter.php
@@ -43,7 +43,9 @@ class LicenseMainGetter extends ClearedGetterCommon
         'licenseId' => $originLicenseId,
         'risk' => $allLicenseCols->getRisk(),
         'content' => $licenseMap->getProjectedSpdxId($originLicenseId),
-        'text' => $allLicenseCols->getText()
+        'text' => $allLicenseCols->getText(),
+        'name' => $licenseMap->getProjectedName($originLicenseId,
+            $allLicenseCols->getFullName())
       );
     }
     return $allStatements;

--- a/src/www/ui/admin-license-file.php
+++ b/src/www/ui/admin-license-file.php
@@ -258,7 +258,6 @@ class admin_license_file extends FO_Plugin
     $vars['actionUri'] = "?mod=" . $this->Name . "&rf_pk=$rf_pk_update";
     $vars['req_marydone'] = array_key_exists('req_marydone', $_POST) ? $_POST['req_marydone'] : '';
     $vars['req_shortname'] = array_key_exists('req_shortname', $_POST) ? $_POST['req_shortname'] : '';
-    $vars['req_marydone'] = array_key_exists('req_marydone', $_POST) ? $_POST['req_marydone'] : '';
     $vars['rf_shortname'] = array_key_exists('rf_shortname', $_POST) ? $_POST['rf_shortname'] : '';
     $vars['rf_fullname'] = array_key_exists('rf_fullname', $_POST) ? $_POST['rf_fullname'] : '';
     $vars['rf_text'] = array_key_exists('rf_text', $_POST) ? $_POST['rf_text'] : '';
@@ -411,6 +410,10 @@ class admin_license_file extends FO_Plugin
     } elseif (empty($spdxId)) {
       $spdxId = null;
     }
+    if (! empty($spdxId)) {
+      $spdxId = LicenseRef::replaceSpaces($spdxId);
+    }
+
     if (empty($shortname)) {
       $text = _("ERROR: The license shortname is empty. License not added.");
       return "<b>$text</b><p>";
@@ -520,6 +523,9 @@ class admin_license_file extends FO_Plugin
       }
     } elseif (empty($rf_spdx_id)) {
       $rf_spdx_id = null;
+    }
+    if (! empty($rf_spdx_id)) {
+      $rf_spdx_id = LicenseRef::replaceSpaces($rf_spdx_id);
     }
 
     if (empty($rf_shortname)) {

--- a/src/www/ui/page/AdviceLicense.php
+++ b/src/www/ui/page/AdviceLicense.php
@@ -184,6 +184,9 @@ class AdviceLicense extends DefaultPlugin
     } elseif (empty($spdxId)) {
       $spdxId = null;
     }
+    if (! empty($spdxId)) {
+      $spdxId = LicenseRef::replaceSpaces($spdxId);
+    }
 
     $licenseDao->updateCandidate($oldRow['rf_pk'], $shortname, $fullname,
       $rfText, $url, $note, $lastmodified, $userIdmodified, !empty($marydone),


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Extract license fullname while generating CLIXML reports and use them to fill the `name` attribute.

### Changes

1. Extract `name` from `LicenseMainGetter` for main licenses.
2. New function `addLicenseNames()` for license decisions.
3. Change the `name` attribute in twig file.
4. Add new function `LicenseRef::replaceSpaces()` to replace spaces with dash in SPDX ID.

## How to test

Generate new CLIXML for an upload and check the `name` attribute of `<License>`.

Closes #2399 

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2400"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

