### PR TITLE
feat(licenseCsv): export spdx id in license CSV

### DIFF
--- a/src/lib/php/Application/test/LicenseCsvExportTest.php
+++ b/src/lib/php/Application/test/LicenseCsvExportTest.php
@@ -8,6 +8,7 @@
 namespace Fossology\Lib\Application;
 
 use Fossology\Lib\BusinessRules\LicenseMap;
+use Fossology\Lib\Data\LicenseRef;
 use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Test\TestPgDb;
 use Mockery as M;
@@ -60,6 +61,7 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
       $licenses[$i] = array(
         'rf_pk' => $i,
         'rf_shortname' => 'lic' . $i,
+        'rf_spdx_id' => 'lrf-lic' . $i,
         'rf_fullname' => 'lice' . $i,
         'rf_text' => 'text' . $i,
         'rf_url' => $i . $i,
@@ -75,6 +77,7 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
         'rf_pk' => $i + 4,
         'rf_shortname' => 'candlic' . $i,
         'rf_fullname' => 'candlice' . $i,
+        'rf_spdx_id' => null,
         'rf_text' => 'text' . $i,
         'rf_url' => $i . $i,
         'rf_notes' => 'note' . $i,
@@ -94,7 +97,7 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
     $dbManager->insertTableRow('license_map', array('rf_fk'=>3,'rf_parent'=>2,'usage'=>LicenseMap::REPORT));
 
     $licenseCsvExport = new LicenseCsvExport($dbManager);
-    $head = array('shortname','fullname','text','parent_shortname','report_shortname','url','notes','source','risk','group', 'obligations');
+    $head = array('shortname','fullname', 'spdx_id','text','parent_shortname','report_shortname','url','notes','source','risk','group', 'obligations');
     $out = fopen('php://output', 'w');
 
     $csv = $licenseCsvExport->createCsv();
@@ -102,6 +105,7 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
     fputcsv($out, $head);
     fputcsv($out, array($licenses[1]['rf_shortname'],
         $licenses[1]['rf_fullname'],
+        $licenses[1]['rf_spdx_id'],
         $licenses[1]['rf_text'],
         null,
         null,
@@ -113,6 +117,7 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
 
     fputcsv($out, array($licenses[2]['rf_shortname'],
         $licenses[2]['rf_fullname'],
+        $licenses[2]['rf_spdx_id'],
         $licenses[2]['rf_text'],
         null,
         null,
@@ -124,6 +129,7 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
 
     fputcsv($out, array($licenses[3]['rf_shortname'],
         $licenses[3]['rf_fullname'],
+        $licenses[3]['rf_spdx_id'],
         $licenses[3]['rf_text'],
         $licenses[1]['rf_shortname'],
         $licenses[2]['rf_shortname'],
@@ -135,6 +141,7 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
 
     fputcsv($out, array($candLicenses[2]['rf_shortname'],
       $candLicenses[2]['rf_fullname'],
+      LicenseRef::convertToSpdxId($candLicenses[2]['rf_shortname'], $candLicenses[2]['rf_spdx_id']),
       $candLicenses[2]['rf_text'],
       null,
       null,
@@ -146,6 +153,7 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
 
     fputcsv($out, array($candLicenses[4]['rf_shortname'],
       $candLicenses[4]['rf_fullname'],
+      LicenseRef::convertToSpdxId($candLicenses[4]['rf_shortname'], $candLicenses[4]['rf_spdx_id']),
       $candLicenses[4]['rf_text'],
       null,
       null,
@@ -166,6 +174,7 @@ class LicenseCsvExportTest extends \PHPUnit\Framework\TestCase
     fputcsv($out, $head, $delimiter);
     fputcsv($out, array($licenses[3]['rf_shortname'],
           $licenses[3]['rf_fullname'],
+          $licenses[3]['rf_spdx_id'],
           $licenses[3]['rf_text'],
           $licenses[1]['rf_shortname'],
           $licenses[2]['rf_shortname'],

--- a/src/www/ui/page/AdminLicenseFromCSV.php
+++ b/src/www/ui/page/AdminLicenseFromCSV.php
@@ -8,14 +8,12 @@
 
 namespace Fossology\UI\Page;
 
+use Fossology\Lib\Application\LicenseCsvImport;
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Plugin\DefaultPlugin;
-use Fossology\UI\Api\Models\Info;
-use Fossology\UI\Api\Models\InfoType;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Fossology\Lib\Application\LicenseCsvImport;
 
 /**
  * \brief Upload a file from the users computer using the UI.
@@ -81,7 +79,7 @@ class AdminLicenseFromCSV extends DefaultPlugin
     if (! empty($errMsg)) {
       return array(false, $errMsg,400);
     }
-    /** @var LicenseCsvImport */
+    /** @var LicenseCsvImport $licenseCsvImport */
     $licenseCsvImport = $this->getObject('app.license_csv_import');
     $licenseCsvImport->setDelimiter($delimiter);
     $licenseCsvImport->setEnclosure($enclosure);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

While generating License CSV export, export SPDX ID of license as well.
Also while importing, import SPDX ID as optional column.

### Changes

1. Export `rf_spdx_id` as `spdx_id`.
2. Import `spdx_id` as optional column.

## How to test

1. Export a license CSV.
2. Edit the SPDX ID.
3. Import the CSV.
4. License should be updated.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2401"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

