### PR TITLE
feat(delete-job-endpoint): Added a delete job endpoint to the Fossolo…

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1456,6 +1456,54 @@ paths:
               schema:
                 $ref: '#/components/schemas/Info'
         default:
+            $ref: '#/components/responses/defaultResponse'
+  
+  /jobs/{id}/{queue}:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the Job
+        in: path
+        schema:
+          type: integer
+      - name: queue
+        required: true
+        description: Id of the job queue to be deleted
+        in: path
+        schema:
+          type: integer
+    delete:
+      operationId: deleteJob
+      tags:
+        - Job
+      summary: Deletes a job using its Id and Queue
+      description: Deletes a job queue and all the other job queues depending on it
+      responses:
+        '200':
+          description: Job deleted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: You don't have permission to delete this job.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Job/JobQueue not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Failed to kill job.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
           $ref: '#/components/responses/defaultResponse'
 
   /folders:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -186,6 +186,7 @@ $app->group('/jobs',
     $app->get('/all', JobController::class . ':getAllJobs');
     $app->post('', JobController::class . ':createJob');
     $app->get('/history', JobController::class . ':getJobsHistory');
+    $app->delete('/{id:\\d+}/{queue:\\d+}', JobController::class . ':deleteJob');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 


### PR DESCRIPTION
…gy API

It works based on Job ID and Job Queue ID. It also deletes Job Queues that depend ond the Job Queue to be deleted This fixes #1787

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Added a delete endpoint to the fossology API

### Changes

Added a new endpoint `/jobs/{id}/{queue}` that deletes a job queue given the job queue and it's ID. It also deletes all queues depending on this job queue.

Also Added documentation to the `openapi.yaml` file and changed the version number.

Also modified the `index.php` file to add the endpoint to the list of routes.

## How to test

- Schedule a new Job
- Send a request to the localhost/repo/jobs/{id}/{queue} with the job id and job queue you'd like to delete

This fixes #1787 


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2407"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

