### PR TITLE
fix(import): ignore missing utree in dump import

### DIFF
--- a/src/decisionexporter/agent/decisionexporter.php
+++ b/src/decisionexporter/agent/decisionexporter.php
@@ -58,10 +58,9 @@ class DecisionExporter extends Agent
     $tableName = "decision_exporter_pfile_" . $uploadId;
 
     $pfileData = $this->allDecisionsDao->getAllAgentPfileIdsForUpload($uploadId, $groupId, $userId);
-    if (!empty($pfileData)) {
-      $this->createPfileTable($uploadId, $tableName);
-    }
+    $this->createPfileTable($uploadId, $tableName);
     $this->heartbeat(count($pfileData));
+
     $this->insertPfileData($uploadId, $pfileData, $tableName);
     $this->heartbeat(1);
     $uploadTreeData = $this->allDecisionsDao->getAllAgentUploadTreeDataForUpload($uploadId, $tableName);
@@ -124,9 +123,8 @@ class DecisionExporter extends Agent
       'licenses'=>$licenseData,
       'upload_clearing_license'=>array_values($mainLicenseData)
     );
-    if (!empty($pfileData)) {
-      $this->dropPfileTable($uploadId, $tableName);
-    }
+
+    $this->dropPfileTable($uploadId, $tableName);
     $this->writeReport($contents, $uploadId);
 
     return true;

--- a/src/decisionimporter/agent/DecisionImporterDataCreator.php
+++ b/src/decisionimporter/agent/DecisionImporterDataCreator.php
@@ -141,15 +141,19 @@ class DecisionImporterDataCreator
 
     $i = 0;
     foreach ($clearingDecisionList as $oldDecisionId => $decisionItem) {
-      $newCdId = $this->dbManager->insertTableRow("clearing_decision", [
-        "uploadtree_fk" => $decisionItem["new_itemid"],
-        "pfile_fk" => $decisionItem["new_pfile"],
-        "decision_type" => $decisionItem["decision_type"],
-        "group_fk" => $this->groupId,
-        "user_fk" => $this->userId,
-        "scope" => $decisionItem["scope"],
-        "date_added" => $decisionItem["date_added"]
-      ], __METHOD__ . ".insertCd", "clearing_decision_pk");
+      if ($decisionItem["new_itemid"] !== null) {
+        $newCdId = $this->dbManager->insertTableRow("clearing_decision", [
+          "uploadtree_fk" => $decisionItem["new_itemid"],
+          "pfile_fk" => $decisionItem["new_pfile"],
+          "decision_type" => $decisionItem["decision_type"],
+          "group_fk" => $this->groupId,
+          "user_fk" => $this->userId,
+          "scope" => $decisionItem["scope"],
+          "date_added" => $decisionItem["date_added"]
+        ], __METHOD__ . ".insertCd", "clearing_decision_pk");
+      } else {
+        $newCdId = null;
+      }
       $clearingDecisionList[$oldDecisionId]["new_decision"] = $newCdId;
       $i++;
       if ($i == DecisionImporterAgent::$UPDATE_COUNT) {
@@ -163,19 +167,23 @@ class DecisionImporterDataCreator
 
     $i = 0;
     foreach ($clearingEventList as $oldEventId => $eventItem) {
-      $newCeId = $this->dbManager->insertTableRow("clearing_event", [
-        "uploadtree_fk" => $eventItem["new_itemid"],
-        "rf_fk" => $eventItem["new_rfid"],
-        "removed" => $eventItem["removed"],
-        "user_fk" => $this->userId,
-        "group_fk" => $this->groupId,
-        "job_fk" => null,
-        "type_fk" => $eventItem["type_fk"],
-        "comment" => $eventItem["comment"],
-        "reportinfo" => $eventItem["reportinfo"],
-        "acknowledgement" => $eventItem["acknowledgement"],
-        "date_added" => $eventItem["date_added"]
-      ], __METHOD__ . ".insertCe", "clearing_event_pk");
+      if ($eventItem["new_itemid"] !== null) {
+        $newCeId = $this->dbManager->insertTableRow("clearing_event", [
+          "uploadtree_fk" => $eventItem["new_itemid"],
+          "rf_fk" => $eventItem["new_rfid"],
+          "removed" => $eventItem["removed"],
+          "user_fk" => $this->userId,
+          "group_fk" => $this->groupId,
+          "job_fk" => null,
+          "type_fk" => $eventItem["type_fk"],
+          "comment" => $eventItem["comment"],
+          "reportinfo" => $eventItem["reportinfo"],
+          "acknowledgement" => $eventItem["acknowledgement"],
+          "date_added" => $eventItem["date_added"]
+        ], __METHOD__ . ".insertCe", "clearing_event_pk");
+      } else {
+        $newCeId = null;
+      }
       $clearingEventList[$oldEventId]["new_event"] = $newCeId;
       $i++;
       if ($i == DecisionImporterAgent::$UPDATE_COUNT) {
@@ -189,6 +197,9 @@ class DecisionImporterDataCreator
 
     foreach ($clearingDecisionEventList as $oldCdId => $ceList) {
       $newCdId = $clearingDecisionList[$oldCdId]["new_decision"];
+      if ($newCdId === null) {
+        continue;
+      }
       foreach ($ceList as $oldCeId) {
         $newCeId = $clearingEventList[$oldCeId]["new_event"];
         $this->dbManager->insertTableRow("clearing_decision_event", [


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

If an uploadtree is missing from the decision dump, simply ignore it rather than raising an exception.
As this error is not solvable.
For example, if between versions of FOSSology (where dump is created and where it is imported), ununpack decides to extract a new archive type, there will be at least 1 missing uploadtree of the unextracted archive which cannot be found.

### Changes

Set `new_itemid` for uploadtree to `null` if it is not found.

Closes #2402 

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2408"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

