### PR TITLE
fix(rest): swap upload and folder id to create job

### DIFF
--- a/src/www/ui/api/Controllers/JobController.php
+++ b/src/www/ui/api/Controllers/JobController.php
@@ -160,7 +160,7 @@ class JobController extends RestController
         return $response->withJson($error->getArray(), $error->getCode());
       }
       $uploadHelper = new UploadHelper();
-      $info = $uploadHelper->handleScheduleAnalysis($folder, $upload,
+      $info = $uploadHelper->handleScheduleAnalysis($upload, $folder,
         $scanOptionsJSON);
       return $response->withJson($info->getArray(), $info->getCode());
     }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

In PR #2287 the upload ID and folder ID got swapped for creating new jobs.

### Changes

Fix function call to `UploadHelper::handleScheduleAnalysis()` in `JobController`

## How to test

Schedule agents using REST API.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2411"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

