### PR TITLE
fix(clixml.php): Fixed the issue of PHP 8 Warning

### DIFF
--- a/src/clixml/agent/clixml.php
+++ b/src/clixml/agent/clixml.php
@@ -106,7 +106,7 @@ class CliXml extends Agent
   protected function preWorkOnArgsFlp($args,$key1,$key2)
   {
     $needle = ' --'.$key2.'=';
-    if (strpos($args[$key1],$needle) !== false) {
+    if (array_key_exists($key1,$args) && strpos($args[$key1],$needle) !== false) {
       $exploded = explode($needle,$args[$key1]);
       $args[$key1] = trim($exploded[0]);
       $args[$key2] = trim($exploded[1]);


### PR DESCRIPTION
## Description

Fixed the issue on PHP8.1 warning while exporting CLIXML.

## How to test

1. Install FOSSology on PHP8
2. Upload a package
3. Export CLIXML report
4. Check the agent logs

Fixed #2324 

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2417"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

