### PR TITLE
fix(api): jti not required for oauth tokens

### DIFF
--- a/src/www/ui/api/Helper/AuthHelper.php
+++ b/src/www/ui/api/Helper/AuthHelper.php
@@ -114,9 +114,6 @@ class AuthHelper
       $jwtTokenPayloadDecoded = JWT::jsonDecode(
         JWT::urlsafeB64Decode($jwtTokenPayload));
 
-      if ($jwtTokenPayloadDecoded->{'jti'} === null) {
-        $returnValue = new Info(403, "Invalid token sent.", InfoType::ERROR);
-      }
       $restToken = Auth::getRestTokenType();
       if (($restToken & Auth::TOKEN_OAUTH) == Auth::TOKEN_OAUTH &&
         property_exists($jwtTokenPayloadDecoded, 'iss') &&


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

In case of using OAuth tokens for REST API, the check for jti is unnecessary. jti is not a required claim is not used any where.

(Azure does not send `jti` in bearer tokens).

### Changes

Remove check for `jti` claim if client has sent bearer token from OAuth.

## How to test

1. Setup OAuth for server.
2. Send a request with OAuth token.
3. Send a request with FOSSology token.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2420"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

