### PR TITLE
fix(api): check if hist has required keys

### DIFF
--- a/src/www/ui/api/Helper/UploadHelper.php
+++ b/src/www/ui/api/Helper/UploadHelper.php
@@ -33,6 +33,7 @@ use Fossology\UI\Api\Models\Reuser;
 use Fossology\UI\Api\Models\Scancode;
 use Fossology\UI\Api\Models\ScanOptions;
 use Fossology\UI\Api\Models\UploadSummary;
+use Fossology\UI\Page\BrowseLicense;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use UIExportList;
 
@@ -592,8 +593,16 @@ class UploadHelper
 
     $mainLicenses = $this->getMainLicenses($dbManager, $uploadId, $groupId);
 
+    /** @var BrowseLicense $uiLicense */
     $uiLicense = $restHelper->getPlugin("license");
     $hist = $uiLicense->getUploadHist($itemTreeBounds);
+    if (!is_array($hist) || !array_key_exists('uniqueLicenseCount', $hist)) {
+      $hist = [];
+      $hist['uniqueLicenseCount'] = 0;
+      $hist['scannerLicenseCount'] = 0;
+      $hist['editedUniqueLicenseCount'] = 0;
+      $hist['editedLicenseCount'] = 0;
+    }
 
     $summary = new UploadSummary();
     $summary->setUploadId($uploadId);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

If no agent has been scheduled on an upload, the `/summary` endpoint throws warnings in logs.

### Changes

1. Check if the response from `getUploadHist()` contains the required keys.

## How to test

1. Upload a package (id: 1) and run scanners on it.
2. Upload second package (id: 2) and do not run any scanners on it.
3. Upload a single file, no archive (id: 3) and run scanners on it.
4. Upload a single file (id: 4) and do not run any scanners on it.

On all uploads, do `GET /uploads/{id}/summary` and check Apache error log. There should be no warning like following:
```
PHP Notice:  Undefined index: uniqueLicenseCount in /usr/share/fossology/www/ui/api/Helper/UploadHelper.php on line 608 
PHP Notice:  Undefined index: scannerLicenseCount in /usr/share/fossology/www/ui/api/Helper/UploadHelper.php on line 609 
PHP Notice:  Undefined index: editedUniqueLicenseCount in /usr/share/fossology/www/ui/api/Helper/UploadHelper.php on line 610 
PHP Notice:  Undefined index: editedLicenseCount in /usr/share/fossology/www/ui/api/Helper/UploadHelper.php on line 611 
PHP Notice:  Undefined index: uniqueLicenseCount in /usr/share/fossology/www/ui/api/Helper/UploadHelper.php on line 608 
```

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2425"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

