### PR TITLE
fix(user-add.php): Fixed email is required to add user

### DIFF
--- a/src/www/ui/user-add.php
+++ b/src/www/ui/user-add.php
@@ -77,23 +77,17 @@ class user_add extends DefaultPlugin
       $text .= "<br />" . generate_password_policy_string();
       return ($text);
     }
-
-    if (empty($Email)) {
-      $text = _("Email must be specified. Not added.");
-      return ($text);
-    }
-
     /* Make sure email looks valid */
-    if (! filter_var($Email, FILTER_VALIDATE_EMAIL)) {
+    if (! empty($Email) && ! filter_var($Email, FILTER_VALIDATE_EMAIL)) {
       $text = _("Invalid email address.  Not added.");
       return ($text);
     }
 
-    /* Make sure email is unique */
+    /* Make sure email is unique (If email field not empty)*/
     $email_count = $this->dbManager->getSingleRow(
       "SELECT COUNT(*) as count FROM users WHERE user_email = $1 LIMIT 1;",
       array($Email))["count"];
-    if ($email_count > 0) {
+    if (! empty($Email) && $email_count > 0) {
       $text = _("Email address already exists.  Not added.");
       return ($text);
     }


### PR DESCRIPTION
I have implemented updates to the email validation process, including adjustments to the handling of empty email fields. 

Description
It is not feasible to create a user account without specifying a valid email address, despite the prompt indicating that the field may be left blank.

Changes

- Removed empty($Email) check
- Modified the unique email check to not give an error.


How to test
To verify the recent code changes, kindly attempt to create a new user account with the email field left blank. Previously, an error message would have been displayed. With the updated code, no error message should be displayed when attempting to create a new user without an email address.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2426"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

