### PR TITLE
feat(api): add pagination to license browser

### DIFF
--- a/src/www/ui/api/Helper/UploadHelper.php
+++ b/src/www/ui/api/Helper/UploadHelper.php
@@ -737,7 +737,7 @@ class UploadHelper
    * @return array Array containing `filePath`, `agentFindings` and
    * `conclusions` for each upload tree item
    */
-  public function getUploadLicenseList($uploadId, $agents, $printContainers, $boolLicense, $boolCopyright)
+  public function getUploadLicenseList($uploadId, $agents, $printContainers, $boolLicense, $boolCopyright, $page = 0, $limit = 50)
   {
     global $container;
     $restHelper = $container->get('helper.restHelper');
@@ -821,6 +821,9 @@ class UploadHelper
         $responseList[] = $responseRow->getArray();
       }
     }
-    return $responseList;
+    $offset = $page * $limit;
+    $paginatedResponseList = array_slice($responseList, $offset, $limit);
+    $paginatedResponseListSize = sizeof($responseList);
+    return array($paginatedResponseList, $paginatedResponseListSize);
   }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -654,6 +654,23 @@ paths:
         schema:
           type: boolean
           default: false
+      - name: page
+        description: Page number (starts from 1)
+        required: false
+        in: header
+        schema:
+          type: integer
+          default: 1
+          minimum: 1
+      - name: limit
+        description: Limits of responses per request
+        required: false
+        in: header
+        schema:
+          type: integer
+          default: 50
+          minimum: 1
+          maximum: 1000
       - name: groupName
         description: The group name to chose while accessing the package
         in: header
@@ -671,10 +688,23 @@ paths:
       responses:
         '200':
           description: Get licenses
+          headers:
+            X-Total-Pages:
+              description: Total number of pages which can be generated based on limit
+              schema:
+                type: integer
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/UploadLicenses'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Info'
         '503':
           description: >
             The ununpack agent or queried agents have not started yet. Please

--- a/src/www/ui_tests/api/Controllers/UploadControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadControllerTest.php
@@ -794,8 +794,8 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
 
     $uploadHelper = M::mock('overload:Fossology\UI\Api\Helper\UploadHelper');
     $uploadHelper->shouldReceive('getUploadLicenseList')
-      ->withArgs([$uploadId, ['nomos', 'monk'], false, true, false])
-      ->andReturn($licenseResponse);
+      ->withArgs([$uploadId, ['nomos', 'monk'], false, true, false, 0, 50])
+      ->andReturn(([[$licenseResponse], 1]));
 
     $expectedResponse = (new ResponseHelper())->withJson($licenseResponse, 200);
 
@@ -804,7 +804,9 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     $this->assertEquals($expectedResponse->getStatusCode(),
       $actualResponse->getStatusCode());
     $this->assertEquals($this->getResponseJson($expectedResponse),
-      $this->getResponseJson($actualResponse));
+      $this->getResponseJson($actualResponse)[0]);
+    $this->assertEquals('1',
+      $actualResponse->getHeaderLine('X-Total-Pages'));
   }
 
   /**


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

# Description

As mentioned in the issue #2404, pagination feature needed to be added to the endpoint "uploads/{id}/license".
Hence, this PR aims to solve the same. 

## Changes

Additional fields ( i.e. limits and page ) can be passed to UploadController, which calls for UploadHelper. While receiving response from UploadHelper, the response array is modified using `array_slice` according to the needed page and limit fields. 

Also updated the `open-api.yaml` to display the changes.



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2430"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>


## Testing
1.) Using an auth token send a get request to `uploads/{id}/license` . This will display all the results.
2.) Include page and limit in the headers of the request. This will display the paginated results.




### Results

### Before :

![Screenshot from 2023-04-06 23-31-05](https://user-images.githubusercontent.com/97532378/230462624-4a848859-3bb6-44eb-bc7f-4a68ae4c81ec.png)

### After : 

![Screenshot from 2023-04-06 23-31-18](https://user-images.githubusercontent.com/97532378/230462724-f22f7f46-7858-4968-9377-226d73eea118.png)



