### PR TITLE
fix(README): Fix broken Travis SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/fossology/fossology)
 [![GPL-2.0](https://img.shields.io/github/license/fossology/fossology)](LICENSE)
-[![Travis-CI Build Status](https://travis-ci.org/fossology/fossology.svg?branch=master)](https://travis-ci.org/fossology/fossology)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2395/badge)](https://bestpractices.coreinfrastructure.org/projects/2395)
 [![Coverage Status](https://coveralls.io/repos/github/fossology/fossology/badge.svg?branch=master)](https://coveralls.io/github/fossology/fossology?branch=master)
 [![Slack Channel](https://img.shields.io/badge/slack-fossology-blue.svg?longCache=true&logo=slack)](https://join.slack.com/t/fossology/shared_invite/enQtNzI0OTEzMTk0MjYzLTYyZWQxNDc0N2JiZGU2YmI3YmI1NjE4NDVjOGYxMTVjNGY3Y2MzZmM1OGZmMWI5NTRjMzJlNjExZGU2N2I5NGY)


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This is a possible solution to #2432, the link where the badge should point to still needs to be edited, because currently it points to a page which does not exist

### Changes

The badge was rendered via an SVG, changed to a badge from `image shields`.

`Link still needs to be added`

## How to test

Badge can be viewed in the README.md of the project.


Might close issue #2432 .


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2433"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

