### PR TITLE
fix(spdx): create LicenseRef for custom license text

### DIFF
--- a/src/lib/php/Data/LicenseRef.php
+++ b/src/lib/php/Data/LicenseRef.php
@@ -9,6 +9,7 @@
 namespace Fossology\Lib\Data;
 
 use Fossology\Lib\Dao\LicenseDao;
+use Fossology\Lib\Util\StringOperation;
 
 class LicenseRef
 {
@@ -103,11 +104,14 @@ class LicenseRef
         strcasecmp($shortname, LicenseDao::VOID_LICENSE) === 0) {
       $spdxLicense = $shortname;
     } elseif (empty($spdxId)) {
-      $spdxLicense = self::SPDXREF_PREFIX . $shortname;
+      $spdxLicense = $shortname;
+      if (! StringOperation::stringStartsWith($shortname, self::SPDXREF_PREFIX)) {
+        $spdxLicense = self::SPDXREF_PREFIX . $shortname;
+      }
     } else {
       $spdxLicense = $spdxId;
     }
-    if (strpos($spdxLicense, LicenseRef::SPDXREF_PREFIX) !== false) {
+    if (StringOperation::stringStartsWith($spdxLicense, self::SPDXREF_PREFIX)) {
       // License ref can not end with a '+'
       $spdxLicense = preg_replace('/\+$/', '-or-later', $spdxLicense);
     }

--- a/src/lib/php/Util/StringOperation.php
+++ b/src/lib/php/Util/StringOperation.php
@@ -39,4 +39,16 @@ class StringOperation
     return preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/u', $replace,
       $input);
   }
+
+  /**
+   * Polyfill for PHP8's str_starts_with
+   * https://www.php.net/manual/en/function.str-starts-with.php
+   * @param string $haystack String to search in
+   * @param string $needle   String to search for
+   * @return bool True if haystack starts with needle.
+   */
+  public static function stringStartsWith($haystack, $needle)
+  {
+    return strncmp($haystack, $needle, strlen($needle)) === 0;
+  }
 }

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -442,6 +442,7 @@ class SpdxTwoAgent extends Agent
           $customLicenseText = $clearingEvent->getReportinfo();
           $reportedLicenseShortname = $this->licenseMap->getProjectedSpdxId($this->licenseMap->getProjectedId($clearingLicense->getLicenseId())) .
                                     '-' . md5($customLicenseText);
+          $reportedLicenseShortname = LicenseRef::convertToSpdxId($reportedLicenseShortname, "");
           $this->includedLicenseIds[$reportedLicenseShortname] = $customLicenseText;
           $filesWithLicenses[$clearingDecision->getUploadTreeId()]['concluded'][] = $reportedLicenseShortname;
         } else {
@@ -761,10 +762,10 @@ class SpdxTwoAgent extends Agent
       $hashes = $treeDao->getItemHashes($fileId);
       $fileName = $treeDao->getFullPath($fileId, $treeTableName, 0);
       if (!array_key_exists('concluded', $licenses) || !is_array($licenses['concluded'])) {
-        $licenses['concluded'] = array();
+        $licenses['concluded'] = [];
       }
       if (!array_key_exists('scanner', $licenses) || !is_array($licenses['scanner'])) {
-        $licenses['scanner'] = array();
+        $licenses['scanner'] = [];
       }
       if (!array_key_exists('isCleared', $licenses)) {
         $licenses['isCleared'] = false;
@@ -774,6 +775,9 @@ class SpdxTwoAgent extends Agent
       }
       if (!array_key_exists('acknowledgement', $licenses)) {
         $licenses['acknowledgement'] = [];
+      }
+      if (!array_key_exists('comment', $licenses)) {
+        $licenses['comment'] = [];
       }
       $stateComment = $this->getSPDXReportConf($uploadId, 0);
       $stateWoInfos = $this->getSPDXReportConf($uploadId, 1);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

When using a custom license text for a license, SPDX creates a new license with md5 at end. This makes the license a LicenseRef. This PR is to make sure, it is a LicenseRef.

### Changes

1. While creating a custom license, convert it into LicenseRef.
2. In `convertToSpdxId()` make sure to not have `LicenseRef-fossology-LicenseRef-fossology` for licenses.
3. Add polyfill for `str_starts_with()` available in PHP 8+ in `StringOperation::stringStartsWith()`.

## How to test

1. Clear an upload with a SPDX Listed license like `MIT` and with License ref like `Public-domain`.
2. For both the licenses, add a new decision with custom license text.
3. Check if in the SPDX reports
- [ ] License conclusion for listed license exists.
- [ ] License conclusion for license ref exists.
- [ ] License conclusion for listed license with custom license as a license ref exists.
- [ ] License conclusion for license ref with custom license exists as a license ref (not as `LicenseRef-fossology-LicenseRef-fossology-`)

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2434"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

