### PR TITLE
chore(scancode): fix the version to 31.2.4

### DIFF
--- a/install/db/dbmigrate_bulk_license.php
+++ b/install/db/dbmigrate_bulk_license.php
@@ -14,9 +14,14 @@
  * This should be called after fossinit calls apply_schema.
  **/
 
-echo "Transform bulk licenses into bulk license sets...";
-$dbManager->queryOnce('
+$rf_fkExists = $dbManager->existsColumn("license_ref_bulk", "rf_fk");
+$removingExists = $dbManager->existsColumn("license_ref_bulk", "removing");
+
+if ($rf_fkExists && $removingExists) {
+  echo "Transform bulk licenses into bulk license sets...";
+  $dbManager->queryOnce('
   INSERT INTO license_set_bulk (lrb_fk, rf_fk, removing)
   SELECT lrb_pk lrb_fk, rf_fk, removing FROM license_ref_bulk');
-echo "...and drop the old columns\n";
-$libschema->dropColumnsFromTable(array('rf_fk','removing'), 'license_ref_bulk');
+  echo "...and drop the old columns\n";
+  $libschema->dropColumnsFromTable(array('rf_fk', 'removing'), 'license_ref_bulk');
+}

--- a/install/fo-install-pythondeps
+++ b/install/fo-install-pythondeps
@@ -146,22 +146,27 @@ if [[ $RUNTIME && -z "$DEBIAN" ]]; then
 fi
 if [[ $RUNTIME ]]; then
   if id "$TARGETUSER" &>/dev/null; then
-    su $TARGETUSER -c 'mkdir -p $HOME/pythondeps && touch $HOME/.bashrc'
-    su $TARGETUSER -c 'grep -qF pythondeps $HOME/.bashrc || printf "export PATH=\"$PATH:$HOME/pythondeps/bin\"\nexport PYTHONPATH=\"$HOME/pythondeps\"" >> $HOME/.bashrc'
+    su "$TARGETUSER" -c 'mkdir -p $HOME/pythondeps && touch $HOME/.bashrc'
+    su "$TARGETUSER" -c 'grep -qF pythondeps $HOME/.bashrc || printf "export PATH=\"$PATH:$HOME/pythondeps/bin\"\nexport PYTHONPATH=\"$HOME/pythondeps\"" >> $HOME/.bashrc'
     ###########################################################################
     # Install pip dependencies together.
     # Using --target causes conflict in bin dir, using --upgrade overwrites it.
     # See https://github.com/pypa/pip/issues/8063
     # Dependencies for scancode
-    su $TARGETUSER -c 'python3 -m pip install --target=$HOME/pythondeps --no-input setuptools wheel'
+    su "$TARGETUSER" -c 'python3 -m pip install --target=$HOME/pythondeps --no-input setuptools wheel'
     ###########################################################################
     if [[ $EXPERIMENTAL ]]; then
       # Include experimental dependencies
-      su $TARGETUSER -c 'PYTHONPATH="$HOME/pythondeps" python3 -m pip install --target=$HOME/pythondeps --no-input --upgrade spacy pandas scancode-toolkit scanoss'
-      su $TARGETUSER -c 'PYTHONPATH="$HOME/pythondeps" python3 -m spacy download en_core_web_sm --target=$HOME/pythondeps'
+      su "$TARGETUSER" -c 'PYTHONPATH="$HOME/pythondeps" python3 -m pip install\
+      --target=$HOME/pythondeps --no-input --upgrade \
+      spacy pandas scancode-toolkit==31.2.4 scanoss==1.5.1'
+      su "$TARGETUSER" -c 'PYTHONPATH="$HOME/pythondeps" python3 -m spacy \
+      download en_core_web_sm --target=$HOME/pythondeps'
     else
       # Only non-experimental dependencies
-      su $TARGETUSER -c 'PYTHONPATH="$HOME/pythondeps" python3 -m pip install --target=$HOME/pythondeps --no-input --upgrade scancode-toolkit scanoss'
+      su "$TARGETUSER" -c 'PYTHONPATH="$HOME/pythondeps" python3 -m pip install\
+       --target=$HOME/pythondeps --no-input --upgrade \
+       scancode-toolkit==31.2.4 scanoss==1.5.1'
     fi
     ###########################################################################
   else

--- a/src/lib/php/Data/AgentRef.php
+++ b/src/lib/php/Data/AgentRef.php
@@ -21,10 +21,10 @@ class AgentRef
     'ninka' => 'Nk',
     'reportImport' => 'I',
     'ojo' => 'O',
-    'scancode' => 'S',
+    'scancode' => 'Sc',
     'spasht' => 'Sp',
     'reso' => 'Rs',
-    'scanoss' => 'Sc'
+    'scanoss' => 'So'
   );
   /**
    * @var int

--- a/src/lib/php/UI/template/include/base.html.twig
+++ b/src/lib/php/UI/template/include/base.html.twig
@@ -4,7 +4,7 @@
 #}
 {# Set common list of agents. Displayed by various pages #}
 {%
-  set agent_list = "(N: nomos, M: monk, Nk: ninka, I: reportImport, O: ojo, S: scancode, Sp: spasht, Rs: reso, Sc: scanoss)"
+  set agent_list = "(N: nomos, M: monk, Nk: ninka, I: reportImport, O: ojo, Sc: scancode, Sp: spasht, Rs: reso, So: scanoss)"
 %}
 <!DOCTYPE html>
 <html lang="en">

--- a/src/scancode/agent/scancode_dbhandler.cc
+++ b/src/scancode/agent/scancode_dbhandler.cc
@@ -214,7 +214,7 @@ void ScancodeDatabaseHandler::insertOrCacheLicenseIdForName(string const& rfShor
  */
 unsigned long ScancodeDatabaseHandler::getCachedLicenseIdForName(string const& rfShortName) const
 {
-  std::unordered_map<string,long>::const_iterator findIterator = licenseRefCache.find(rfShortName);
+  auto findIterator = licenseRefCache.find(rfShortName);
   if (findIterator != licenseRefCache.end())
   {
     return findIterator->second;
@@ -419,7 +419,7 @@ bool ScancodeDatabaseHandler::insertInDatabase(DatabaseEntry& entry) const
 
 /**
  * @brief create tables to save copyright and author informations
- * @return  true on sucessful creation, false otherwise
+ * @return  true on successful creation, false otherwise
  */
 bool ScancodeDatabaseHandler::createTables() const
 {
@@ -444,7 +444,7 @@ bool ScancodeDatabaseHandler::createTables() const
     }
   }
   if (tablesChecked && (failedCounter > 0))
-    LOG_NOTICE("table creation succeded on try %d/%d \n", failedCounter, MAX_TABLE_CREATION_RETRIES);
+    LOG_NOTICE("table creation succeeded on try %d/%d \n", failedCounter, MAX_TABLE_CREATION_RETRIES);
   dbManager.ignoreWarnings(false);
   return tablesChecked;
 }

--- a/src/scancode/agent/scancode_template.html
+++ b/src/scancode/agent/scancode_template.html
@@ -20,36 +20,39 @@
                     "start_line": {{ license.start_line }},
                     "matched_text": {{ license.matched_text|tojson }}
                 }
-                {%- if loop.nextitem and not loop.lastitem -%},{%- endif -%}
+                {%- if loop.nextitem and not loop.last -%},{%- endif -%}
             {%- endfor -%}
         {%- endif -%}
     ],
     "copyrights": 
     [
     {%- if files.license_copyright -%}
+        {%- set copyright_ns = namespace(print=false) -%}
         {%- for path, data in files.license_copyright.items() -%}
             {%- for row in data -%}
                 {%- if row.what != 'license' -%}
+                    {%- if copyright_ns.print -%},{%- else -%}{%- set copyright_ns.print = true -%}{%- endif -%}
                     {
                          "value": {{ row.value|tojson }},
                          "start": {{ row.start }}
-                     }
+                    }
                 {%- endif -%}
-            {%- endfor -%} {%- if loop.nextitem and not loop.lastitem -%},{%- endif -%}
+            {%- endfor -%}
         {%- endfor -%}
     {%- endif -%}
     ],
     "holders": 
     [
         {%- if files.infos -%}
+            {%- set holder_ns = namespace(print=false) -%}
             {%- for path, row in files.infos.items() -%}
                 {%- if row.holders -%}
                     {%- for data in row.holders -%}
+                        {%- if holder_ns.print -%},{%- else -%}{%- set holder_ns.print = true -%}{%- endif -%}
                         {
-                             "value": {{ data.value|tojson }},
+                             "value": {{ data.holder|tojson }},
                              "start": {{ data.start_line }}
                         }
-                        {%- if loop.nextitem and not loop.lastitem -%},{%- endif -%}
                     {%- endfor -%}
                 {%- endif -%}
             {%- endfor -%}

--- a/src/scancode/agent/scancode_utils.cc
+++ b/src/scancode/agent/scancode_utils.cc
@@ -188,9 +188,7 @@ bool saveLicenseMatchesToDatabase(const State &state,
                                   unsigned long pFileId,
                                   ScancodeDatabaseHandler &databaseHandler) 
                                   {
-  for (vector<Match>::const_iterator it = matches.begin();
-       it != matches.end(); ++it) {
-    const Match &match = *it;
+  for (const auto & match : matches) {
     databaseHandler.insertOrCacheLicenseIdForName(
         match.getMatchName(), match.getLicenseFullName(), match.getTextUrl());
   }
@@ -198,9 +196,7 @@ bool saveLicenseMatchesToDatabase(const State &state,
   if (!databaseHandler.begin()) {
     return false;
   }
-  for (vector<Match>::const_iterator it = matches.begin(); it != matches.end();
-       ++it) {
-    const Match &match = *it;
+  for (const auto & match : matches) {
     int agentId = state.getAgentId();
     string rfShortname = match.getMatchName();
     int percent = match.getPercentage();
@@ -257,9 +253,7 @@ bool saveOtherMatchesToDatabase(const State &state,
   if (!databaseHandler.begin())
     return false;
 
-  for (vector<Match>::const_iterator it = matches.begin();
-       it != matches.end(); ++it) {
-    const Match &match = *it;
+  for (const auto & match : matches) {
     DatabaseEntry entry(match,state.getAgentId(),pFileId);
 
     if (!databaseHandler.insertInDatabase(entry))

--- a/src/scancode/agent/scancode_wrapper.cc
+++ b/src/scancode/agent/scancode_wrapper.cc
@@ -9,14 +9,14 @@
 #define MINSCORE 50
 
 /**
- * @brief convertes start line to start byte of the matched text
+ * @brief converts start line to start byte of the matched text
  *
  * count number of characters before start line and add it to the
  * characters before the matched text in the start line.
  *
  * @param filename name of the file uploaded
  * @param start_line  start line of the matched text by scancode
- * @param match_text  text inthe codefile matched by scancode
+ * @param match_text  text in the codefile matched by scancode
  * @return  start byte of the matched text on success, -1 on failure
  */
 unsigned getFilePointer(const string &filename, size_t start_line,
@@ -78,8 +78,9 @@ string scanFileWithScancode(const State &state, const fo::File &file) {
       state.getCliOptions() +
       " --custom-output - --custom-template scancode_template.html " +
       file.getFileName() + " --quiet " +
-      ((state.getCliOptions().find('l') != string::npos) ? " --license-text --license-score " + to_string(MINSCORE): "");
-  string result = "";
+      ((state.getCliOptions().find('l') != string::npos) ? " --license-text --license-score " +
+      to_string(MINSCORE): "");
+  string result;
 
   if (!(in = popen(command.c_str(), "r"))) {
     LOG_FATAL("could not execute scancode command: %s \n", command.c_str());
@@ -94,9 +95,9 @@ string scanFileWithScancode(const State &state, const fo::File &file) {
     LOG_FATAL("could not execute scancode command: %s \n", command.c_str());
     bail(1);
   }
-  unsigned int startjson = result.find("{");
-  result=result.substr(startjson, string::npos);
-return result;
+  unsigned int startjson = result.find('{');
+  result = result.substr(startjson, string::npos);
+  return result;
 }
 
 /**
@@ -134,16 +135,14 @@ map<string, vector<Match>> extractDataFromScancodeResult(const string& scancodeR
   vector<Match> licenses;
   if (isSuccessful) {
     Json::Value licensearrays = scancodevalue["licenses"];
-    if(!licensearrays.size())
+    if(licensearrays.empty())
     {
-      LOG_NOTICE("No license found\n");
       result["scancode_license"].push_back(Match("No_license_found"));
     }
     else
     {
-      for (unsigned int i = 0; i < licensearrays.size(); i++)
+      for (auto oneresult : licensearrays)
       {
-          Json::Value oneresult = licensearrays[i];
           string licensename = oneresult["key"].asString();
           int percentage = (int)oneresult["score"].asFloat();
           string full_name=oneresult["name"].asString();
@@ -158,8 +157,7 @@ map<string, vector<Match>> extractDataFromScancodeResult(const string& scancodeR
     }
 
     Json::Value copyarrays = scancodevalue["copyrights"];
-    for (unsigned int i = 0; i < copyarrays.size(); i++) {
-        Json::Value oneresult = copyarrays[i];
+    for (auto oneresult : copyarrays) {
         string copyrightname = oneresult["value"].asString();
         unsigned long start_line=oneresult["start"].asUInt();
         string temp_text= copyrightname.substr(0,copyrightname.find("[\n\t]"));
@@ -170,8 +168,7 @@ map<string, vector<Match>> extractDataFromScancodeResult(const string& scancodeR
     }
 
     Json::Value holderarrays = scancodevalue["holders"];
-    for (unsigned int i = 0; i < holderarrays.size(); i++) {
-        Json::Value oneresult = holderarrays[i];
+    for (auto oneresult : holderarrays) {
         string holdername = oneresult["value"].asString();
         unsigned long start_line=oneresult["start"].asUInt();
         string temp_text= holdername.substr(0,holdername.find("\n"));


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

1. Fix the `scancode-toolkit` Python dependency to version 31.2.4 to eliminate possible cases of failures.
2. Update scancode code to use modern loops and auto variables.
3. Fix template to handle cases where a single contains multiple copyright and author information.

## How to test

Run the scancode agent from UI.

Possible fixes for: #2348
Closes #2375
Closes #2329
Closes #2277

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2436"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

