### PR TITLE
fix(dao): getLicenseByCondition set statement name on condition

### DIFF
--- a/src/lib/php/Dao/LicenseDao.php
+++ b/src/lib/php/Dao/LicenseDao.php
@@ -508,17 +508,20 @@ ORDER BY lft asc
         $param, __METHOD__ . ".$condition.only");
     if (false === $row && isset($groupId)) {
       $userId = (isset($_SESSION) && array_key_exists('UserId', $_SESSION)) ? $_SESSION['UserId'] : 0;
+      $statementName = __METHOD__ . ".$condition";
       if (!empty($userId)) {
         $param[] = $userId;
         $extraCondition = "AND group_fk IN (SELECT group_fk FROM group_user_member WHERE user_fk=$".count($param).")";
+        $statementName .= ".userId";
       }
       if (is_int($groupId) && empty($userId)) {
         $param[] = $groupId;
         $extraCondition = "AND group_fk=$".count($param);
+        $statementName .= ".groupId";
       }
       $row = $this->dbManager->getSingleRow(
         "SELECT rf_pk, rf_shortname, rf_spdx_id, rf_fullname, rf_text, rf_url, rf_risk, rf_detector_type FROM license_candidate WHERE $condition $extraCondition",
-        $param, __METHOD__ . ".$condition.group");
+        $param, $statementName);
     }
     if (false === $row) {
       return null;


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

In `LicenseDao::getLicenseByCondition()`, set the statement name based on condition.

In `ObligationsGetter::getObligations()`, the function `getLicenseById()` is called without group id and the function is generally called by CLIs. In this special case, the function `getLicenseByCondition()` ends up without the user id and group id.
This results in a prepared statement `Fossology\Lib\Dao\LicenseDao::getLicenseByCondition.rf_pk=$1.group` without group parameter.

### Changes

Add `.userId` and `.groupId` to statement name based on condition in `LicenseDao::getLicenseByCondition()`.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2437"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

