### PR TITLE
feat(docker): update images to Debian 11 (bullseye)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Install Dependencies

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -90,7 +90,7 @@ jobs:
         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DFO_SYSCONFDIR=/etc/fossology -DFO_LOCALSTATEDIR=/var -S. -B./build -G Ninja
 
     - name: Build Debs
-      run: ninja -C build package
+      run: cd build && cpack --config CPackConfig.cmake
 
     - name: Rename package
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 #
 # Description: Docker container image recipe
 
-FROM debian:buster-slim as builder
+FROM debian:bullseye-slim as builder
 LABEL org.opencontainers.image.authors="Fossology <fossology@fossology.org>"
 LABEL org.opencontainers.image.source="https://github.com/fossology/fossology"
 LABEL org.opencontainers.image.vendor="FOSSology"
@@ -21,7 +21,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       git \
       lsb-release \
-      php7.3-cli \
+      php7.4-cli \
       sudo \
       cmake \
       ninja-build \
@@ -53,9 +53,9 @@ COPY . .
 
 RUN cmake -DCMAKE_BUILD_TYPE=MinSizeRel -S. -B./build -G Ninja \
  && cmake --build ./build --parallel \
- && ninja -C ./build install
+ && cmake --install build
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 LABEL org.opencontainers.image.authors="Fossology <fossology@fossology.org>"
 LABEL org.opencontainers.image.url="https://fossology.org"

--- a/utils/automation/Dockerfile.ci
+++ b/utils/automation/Dockerfile.ci
@@ -6,9 +6,9 @@
 # SPDX-License-Identifier: FSFAP
 #
 # Description: Gitlab CI runner image recipie
-# Using Debian 10
+# Using Debian 11
 
-FROM debian:buster-slim as builder
+FROM debian:bullseye-slim as builder
 
 WORKDIR /fossology
 
@@ -52,7 +52,7 @@ RUN dpkg-shlibdeps -Orun-deps -ebuild/src/nomos/agent/nomossa \
                               -ebuild/src/ojo/agent/ojo \
  && sed -E -i -e 's/(shlibs:Depends=)|(\(>=?[ 0-9\:\.\~\-]*\))|(,)//g' run-deps
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 LABEL maintainer="Fossology <fossology@fossology.org>"
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Update Docker images to use new Debian 11 as base.

### Changes

1. Update Dockerfile base images to [debian:bullseye-slim](https://hub.docker.com/_/debian/tags?page=1&name=bullseye-slim)
2. Update building and packaging commands from ninja to cmake/cpack
3. Update Document build to use Ubuntu-22.04

## How to test

Build and run a docker container.