### PR TITLE
fix(bulkReuse): concider folder level and package level bulk

### DIFF
--- a/src/decider/agent/BulkReuser.php
+++ b/src/decider/agent/BulkReuser.php
@@ -51,34 +51,54 @@ class BulkReuser
      * UploadDao from container
      */
     $uploadDao = $GLOBALS['container']->get('dao.upload');
-    $topItem = $uploadDao->getUploadParent($uploadId);
-    /** @var DeciderJobAgentPlugin $deciderPlugin
-     * DeciderJobAgentPlugin object to add deciderjob
-     */
-    $deciderPlugin = plugin_find("agent_deciderjob");
-    $dependecies = array();
-    $sql = "INSERT INTO license_ref_bulk (user_fk,group_fk,rf_text,upload_fk,uploadtree_fk,ignore_irrelevant,bulk_delimiters) "
-            . "SELECT $1 AS user_fk, $2 AS group_fk,rf_text,$3 AS upload_fk, $4 as uploadtree_fk, ignore_irrelevant, bulk_delimiters
-              FROM license_ref_bulk WHERE lrb_pk=$5 RETURNING lrb_pk, $5 as lrb_origin";
-    $sqlLic = "INSERT INTO license_set_bulk (lrb_fk, rf_fk, removing, comment, reportinfo, acknowledgement) "
-            ."SELECT $1 as lrb_fk, rf_fk, removing, comment, reportinfo, acknowledgement FROM license_set_bulk WHERE lrb_fk=$2";
-    $this->dbManager->prepare($stmt=__METHOD__.'cloneBulk', $sql);
-    $this->dbManager->prepare($stmtLic=__METHOD__.'cloneBulkLic', $sqlLic);
-    $res = $this->dbManager->execute($stmt,array($userId,$groupId,$uploadId,$topItem, $bulkId));
-    $row = $this->dbManager->fetchArray($res);
-    $this->dbManager->freeResult($res);
-    $resLic = $this->dbManager->execute($stmtLic,array($row['lrb_pk'],$row['lrb_origin']));
-    $this->dbManager->freeResult($resLic);
-    $upload = $uploadDao->getUpload($uploadId);
-    $uploadName = $upload->getFilename();
-    $job_pk = \JobAddJob($userId, $groupId, $uploadName, $uploadId);
-    $dependecies = array(array('name' => 'agent_monk_bulk', 'args' => $row['lrb_pk']));
-    $errorMsg = '';
-    $jqId = $deciderPlugin->AgentAdd($job_pk, $uploadId, $errorMsg, $dependecies);
-
-    if (!empty($errorMsg)) {
-      throw new Exception(str_replace('<br>', "\n", $errorMsg));
+    $nTopItem = $uploadDao->getUploadParent($uploadId);
+    $pUTree = $this->dbManager->getSingleRow("SELECT uploadtree_fk FROM license_ref_bulk WHERE lrb_pk=$1",
+      array($bulkId), __METHOD__);
+    $uploadEntry = $uploadDao->getUploadEntry($pUTree['uploadtree_fk']);
+    $pUID = intval($uploadEntry['upload_fk']);
+    $pTopItem = $uploadDao->getUploadParent($pUID);
+    if ($pTopItem == $pUTree['uploadtree_fk']) {
+      $topItem = $nTopItem;
+    } else {
+      $pfUTree = $this->dbManager->getSingleRow("SELECT uploadtree_pk FROM uploadtree WHERE upload_fk=$1 AND ufile_name=$2 AND ufile_mode=$3",
+        array($uploadId, $uploadEntry['ufile_name'], $uploadEntry['ufile_mode']), __METHOD__.'getRealUploadtreeEntry');
+      if (!empty($pfUTree) && count($pfUTree) <= 1) {
+        $topItem = $pfUTree['uploadtree_pk'];
+      } else {
+        $topItem = "";
+      }
     }
-    return $jqId;
+    if (!empty($topItem)) {
+      /** @var DeciderJobAgentPlugin $deciderPlugin
+       * DeciderJobAgentPlugin object to add deciderjob
+       */
+      $deciderPlugin = plugin_find("agent_deciderjob");
+      $dependecies = array();
+      $sql = "INSERT INTO license_ref_bulk (user_fk,group_fk,rf_text,upload_fk,uploadtree_fk,ignore_irrelevant,bulk_delimiters) "
+              . "SELECT $1 AS user_fk, $2 AS group_fk,rf_text,$3 AS upload_fk, $4 as uploadtree_fk, ignore_irrelevant, bulk_delimiters
+                FROM license_ref_bulk WHERE lrb_pk=$5 RETURNING lrb_pk, $5 as lrb_origin";
+      $sqlLic = "INSERT INTO license_set_bulk (lrb_fk, rf_fk, removing, comment, reportinfo, acknowledgement) "
+              ."SELECT $1 as lrb_fk, rf_fk, removing, comment, reportinfo, acknowledgement FROM license_set_bulk WHERE lrb_fk=$2";
+      $this->dbManager->prepare($stmt=__METHOD__.'cloneBulk', $sql);
+      $this->dbManager->prepare($stmtLic=__METHOD__.'cloneBulkLic', $sqlLic);
+      $res = $this->dbManager->execute($stmt,array($userId,$groupId,$uploadId,$topItem, $bulkId));
+      $row = $this->dbManager->fetchArray($res);
+      $this->dbManager->freeResult($res);
+      $resLic = $this->dbManager->execute($stmtLic,array($row['lrb_pk'],$row['lrb_origin']));
+      $this->dbManager->freeResult($resLic);
+      $upload = $uploadDao->getUpload($uploadId);
+      $uploadName = $upload->getFilename();
+      $job_pk = \JobAddJob($userId, $groupId, $uploadName, $uploadId);
+      $dependecies = array(array('name' => 'agent_monk_bulk', 'args' => $row['lrb_pk']));
+      $errorMsg = '';
+      $jqId = $deciderPlugin->AgentAdd($job_pk, $uploadId, $errorMsg, $dependecies);
+
+      if (!empty($errorMsg)) {
+        throw new Exception(str_replace('<br>', "\n", $errorMsg));
+      }
+      return $jqId;
+    } else {
+      return 0;
+    }
   }
 }

--- a/src/decider/agent_tests/Functional/schedulerTest.php
+++ b/src/decider/agent_tests/Functional/schedulerTest.php
@@ -585,7 +585,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
     $this->dbManager->queryOnce("INSERT INTO job (job_pk, job_queued, job_priority, job_upload_fk, job_user_fk, job_group_fk)"
             . " VALUES ($otherJob, '2014-08-07 09:22:22.718312+00', 0, 1, 2, $groupId)");
 
-    $this->dbManager->queryOnce("INSERT INTO license_ref_bulk (lrb_pk, user_fk, group_fk, rf_text, upload_fk, uploadtree_fk) VALUES (123456, 2, $groupId, 'foo bar', 1, 7)");
+    $this->dbManager->queryOnce("INSERT INTO license_ref_bulk (lrb_pk, user_fk, group_fk, rf_text, upload_fk, uploadtree_fk) VALUES (123456, 2, $groupId, 'foo bar', 1, 1)");
     $this->dbManager->queryOnce("INSERT INTO license_set_bulk (lrb_fk, rf_fk, removing) VALUES (123456, $licId1, 'f')");
 
     $this->dbManager->queryOnce("INSERT INTO upload_reuse (upload_fk, reused_upload_fk, group_fk, reused_group_fk, reuse_mode)"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Consider folder level bulk while reuse. 

### Changes

Search for folder uploadtreeID and schedule a bulk scan.

## How to test

* upload package x.
* schedule a bulk scan for package x for a folder.
* upload package x.1 and reuse bulk decisions from package x.
* bulk should only be applied to folder level.


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2448"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

