### PR TITLE
feat(scanner): support github in scanner

### DIFF
--- a/utils/automation/.github-workflow.yml
+++ b/utils/automation/.github-workflow.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: © 2020 Siemens AG
+# SPDX-FileCopyrightText: © anupam.ghosh@siemens.com
+# SPDX-FileCopyrightText: © gaurav.mishra@siemens.com
+
+# SPDX-License-Identifier: FSFAP
+
+name: Check diff for license with Fossology
+
+on:
+  pull_request:
+
+jobs:
+  check-license:
+    name: Check license
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          docker run --rm --name "fossologyscanner" -w "/opt/repo" -v ${PWD}:/opt/repo \
+            -e GITHUB_TOKEN=${{ github.token }} \
+            -e GITHUB_PULL_REQUEST=${{ github.event.number }} \
+            -e GITHUB_REPOSITORY=${{ github.repository }} \
+            -e GITHUB_ACTIONS \
+            fossology/fossology:scanner "/bin/fossologyscanner" nomos ojo
+
+  check-copyright:
+    name: Check copyright
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          docker run --rm --name "fossologyscanner" -w "/opt/repo" -v ${PWD}:/opt/repo \
+            -e GITHUB_TOKEN=${{ github.token }} \
+            -e GITHUB_PULL_REQUEST=${{ github.event.number }} \
+            -e GITHUB_REPOSITORY=${{ github.repository }} \
+            -e GITHUB_ACTIONS \
+            fossology/fossology:scanner "/bin/fossologyscanner" copyright keyword

--- a/utils/automation/.github-workflow.yml
+++ b/utils/automation/.github-workflow.yml
@@ -1,6 +1,4 @@
-# SPDX-FileCopyrightText: © 2020 Siemens AG
-# SPDX-FileCopyrightText: © anupam.ghosh@siemens.com
-# SPDX-FileCopyrightText: © gaurav.mishra@siemens.com
+# SPDX-FileCopyrightText: © 2023 igor.mishchuk@carbonhealth.com
 
 # SPDX-License-Identifier: FSFAP
 


### PR DESCRIPTION
## Description

Add support of Github actions in `scanner`

### Changes

* Add logic to execute `scanner` in Github actions

## How to test

```
- name: Fossology scanner
  run: |
    docker run --name "fossologyscanner" -w "/opt/repo" -v ${PWD}:/opt/repo \
      -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
      -e GITHUB_PULL_REQUEST=${{ github.event.number }} \
      fossology/fossology:scanner "/bin/fossologyscanner" nomos ojo
```

Note, `GITHUB_REPOSITORY` and `GITHUB_ACTIONS` are provided by Github action itself, so we do not need to specify it explicitly.
   

This closes #2450 


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2451"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

