### PR TITLE
feat(api): get the contents of the file

### DIFF
--- a/src/www/ui/api/Controllers/UploadTreeController.php
+++ b/src/www/ui/api/Controllers/UploadTreeController.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Samuel Dushimimana <dushsam100@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Controller for uploadtree queries
+ */
+
+namespace Fossology\UI\Api\Controllers;
+
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Psr\Http\Message\ServerRequestInterface;
+
+
+/**
+ * @class UploadTreeController
+ * @brief Controller for UploadTree model
+ */
+class UploadTreeController extends RestController
+{
+
+  /**
+   * Get the contents of a specific file
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function viewLicenseFile($request, $response, $args)
+  {
+    $uploadId = intval($args['id']);
+    $itemId = intval($args['itemId']);
+
+    $uploadDao = $this->restHelper->getUploadDao();
+    $returnVal = null;
+
+    if (!$this->dbHelper->doesIdExist("upload", "upload_pk", $uploadId)) {
+      $returnVal = new Info(404, "Upload does not exist", InfoType::ERROR);
+    } else if (!$this->dbHelper->doesIdExist($uploadDao->getUploadtreeTableName($uploadId), "uploadtree_pk", $itemId)) {
+      $returnVal = new Info(404, "Item does not exist", InfoType::ERROR);
+    }
+
+    if ($returnVal !== null) {
+      return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+    }
+
+    $view = $this->restHelper->getPlugin('view');
+
+    $inputFile = @fopen(RepPathItem($itemId), "rb");
+    if (empty($inputFile)) {
+      global $Plugins;
+      $reunpackPlugin = &$Plugins[plugin_find_id("ui_reunpack")];
+      $state = $reunpackPlugin->CheckStatus($uploadId, "reunpack", "ununpack");
+      if ($state != 0 && $state != 2) {
+        $errorMess = _("Reunpack job is running: you can see it in");
+      } else {
+        $errorMess = _("File contents are not available in the repository.");
+      }
+      $info = new Info(500, $errorMess, InfoType::ERROR);
+      return $response->withJson($info->getArray(), $info->getCode());
+    }
+    rewind($inputFile);
+
+    $res = $view->getText($inputFile, 0, 0, -1, null, false, true);
+    $response->getBody()->write($res);
+    return $response->withHeader("Content-Type", "text/plain")
+      ->withHeader("Cache-Control", "max-age=1296000, must-revalidate")
+      ->withHeader("Etag", md5($response->getBody()));
+  }
+}

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -866,7 +866,51 @@ paths:
                   $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-
+  /uploads/{id}/item/{itemId}/view:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+      - name: itemId
+        required: true
+        description: Id of the item
+        in: path
+        schema:
+          type: integer
+    get:
+      operationId: viewTheContentOfTheFile
+      tags:
+        - Upload
+        - License
+      summary: Get the contents of the file
+      description:
+        Returns the contents of a specific file
+      responses:
+        '200':
+          description: Get contents
+          content:
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: Upload or Item does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal Server Error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /uploads/{id}/licenses/main:
     parameters:
       - name: id

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -33,6 +33,7 @@ use Fossology\UI\Api\Controllers\MaintenanceController;
 use Fossology\UI\Api\Controllers\ReportController;
 use Fossology\UI\Api\Controllers\SearchController;
 use Fossology\UI\Api\Controllers\UploadController;
+use Fossology\UI\Api\Controllers\UploadTreeController;
 use Fossology\UI\Api\Controllers\UserController;
 use Fossology\UI\Api\Helper\ResponseFactoryHelper;
 use Fossology\UI\Api\Helper\ResponseHelper;
@@ -150,6 +151,7 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/download', UploadController::class . ':uploadDownload');
     $app->get('/{id:\\d+}/copyrights', UploadController::class . ':getUploadCopyrights');
     $app->get('/{id:\\d+}/licenses/main', UploadController::class . ':getMainLicenses');
+    $app->get('/{id:\\d+}/item/{itemId:\\d+}/view', UploadTreeController::class. ':viewLicenseFile');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui/ui-view.php
+++ b/src/www/ui/ui-view.php
@@ -163,7 +163,7 @@ class ui_view extends FO_Plugin
    * \brief Given a file handle, display "strings" of the file.
    */
   function getText($inputFile, $startOffset, $Flowed, $outputLength = -1,
-    $splitPositions = null, $insertBacklink = false)
+    $splitPositions = null, $insertBacklink = false, $fromRest = false)
   {
     if (! ($outputLength = $this->checkAndPrepare($inputFile, $startOffset,
       $outputLength))) {
@@ -183,7 +183,7 @@ class ui_view extends FO_Plugin
     $output .= ($Flowed ? nl2br($renderedText) : $renderedText) .
       (! $Flowed ? "</pre>" : "") . "</div>\n";
 
-    return $output;
+    return $fromRest ? $renderedText : $output;
   } // ShowText()
 
   /**

--- a/src/www/ui_tests/api/Controllers/UploadTreeControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadTreeControllerTest.php
@@ -1,0 +1,147 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Samuel Dushimimana <dushsam100@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for UploadTreeController
+ */
+
+namespace {
+  if (!function_exists('RepPathItem')) {
+    function RepPathItem($Item, $Repo = "files")
+    {
+      return dirname(__DIR__) . "/tests.xml";
+    }
+  }
+}
+
+namespace Fossology\UI\Api\Test\Controllers {
+
+  use Fossology\Lib\Auth\Auth;
+  use Fossology\Lib\Dao\UploadDao;
+  use Fossology\Lib\Data\UploadStatus;
+  use Fossology\Lib\Db\DbManager;
+  use Fossology\UI\Api\Controllers\UploadTreeController;
+  use Fossology\UI\Api\Helper\DbHelper;
+  use Fossology\UI\Api\Helper\ResponseHelper;
+  use Fossology\UI\Api\Helper\RestHelper;
+  use Mockery as M;
+  use Slim\Psr7\Factory\StreamFactory;
+
+  /**
+   * @class UploadControllerTest
+   * @brief Unit tests for UploadController
+   */
+  class UploadTreeControllerTest extends \PHPUnit\Framework\TestCase
+  {
+    /**
+     * @var DbHelper $dbHelper
+     * DbHelper mock
+     */
+    private $dbHelper;
+
+    /**
+     * @var DbManager $dbManager
+     * Dbmanager mock
+     */
+    private $dbManager;
+
+    /**
+     * @var RestHelper $restHelper
+     * RestHelper mock
+     */
+    private $restHelper;
+
+    /**
+     * @var UploadTreeController $uploadTreeController
+     * UploadTreeController mock
+     */
+    private $uploadTreeController;
+
+    /**
+     * @var UploadDao $uploadDao
+     * UploadDao mock
+     */
+    private $uploadDao;
+
+    /**
+     * @var StreamFactory $streamFactory
+     * Stream factory to create body streams.
+     */
+    private $streamFactory;
+
+    /**
+     * @var M\MockInterface $viewFilePlugin
+     * ViewFilePlugin mock
+     */
+    private $viewFilePlugin;
+
+    /**
+     * @brief Setup test objects
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    protected function setUp(): void
+    {
+      global $container;
+      $this->userId = 2;
+      $this->groupId = 2;
+      $container = M::mock('ContainerBuilder');
+      $this->dbHelper = M::mock(DbHelper::class);
+      $this->dbManager = M::mock(DbManager::class);
+      $this->restHelper = M::mock(RestHelper::class);
+      $this->uploadDao = M::mock(UploadDao::class);
+
+      $this->viewFilePlugin = M::mock('ui_view');
+
+      $this->restHelper->shouldReceive('getPlugin')
+        ->withArgs(array('view'))->andReturn($this->viewFilePlugin);
+
+      $this->dbManager->shouldReceive('getSingleRow')
+        ->withArgs([M::any(), [$this->groupId, UploadStatus::OPEN,
+          Auth::PERM_READ]]);
+      $this->dbHelper->shouldReceive('getDbManager')->andReturn($this->dbManager);
+
+      $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+      $this->restHelper->shouldReceive('getGroupId')->andReturn($this->groupId);
+      $this->restHelper->shouldReceive('getUserId')->andReturn($this->userId);
+      $this->restHelper->shouldReceive('getUploadDao')
+        ->andReturn($this->uploadDao);
+      $container->shouldReceive('get')->withArgs(array(
+        'helper.restHelper'))->andReturn($this->restHelper);
+
+      $this->uploadTreeController = new UploadTreeController($container);
+      $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+      $this->streamFactory = new StreamFactory();
+    }
+
+    /**
+     * @test
+     * -# Test for UploadController::viewLicenseFile() with valid status
+     * -# Check if response status is 200 and the body has the expected contents
+     */
+    public function testViewLicenseFile()
+    {
+      $upload_pk = 1;
+      $item_pk = 200;
+      $expectedContent = file_get_contents(dirname(__DIR__) . "/tests.xml");
+
+      $this->dbHelper->shouldReceive('doesIdExist')
+        ->withArgs(["upload", "upload_pk", $upload_pk])->andReturn(true);
+      $this->uploadDao->shouldReceive("getUploadtreeTableName")->withArgs([$upload_pk])->andReturn("uploadtree");
+      $this->dbHelper->shouldReceive('doesIdExist')
+        ->withArgs(["uploadtree", "uploadtree_pk", $item_pk])->andReturn(true);
+
+      $this->viewFilePlugin->shouldReceive('getText')->withArgs([M::any(), 0, 0, -1, null, false, true])->andReturn($expectedContent);
+
+      $expectedResponse = new ResponseHelper();
+      $expectedResponse->getBody()->write($expectedContent);
+      $actualResponse = $this->uploadTreeController->viewLicenseFile(null, new ResponseHelper(), ['id' => $upload_pk, 'itemId' => $item_pk]);
+      $this->assertEquals($expectedResponse->getStatusCode(), $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getBody()->getContents(), $actualResponse->getBody()->getContents());
+    }
+  }
+}


### PR DESCRIPTION
## Description

Added the API to retrieve the contents of a specific file.

### Changes

1. Added a new method in  `UploadController` to handle the logic.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/uploads/{id}/item/{itemId}/view`.
3. Updated the `openapi.yaml` file  to introduce a new API.

## How to test

Make a GET request on the endpoint: ``/uploads/{id}/item/{itemId}/view``

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/315d528f-3f2b-4c2f-a646-4a9a3bfdb025)


### Related Issue:
Fixes #2454  

    
cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2456"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

