### PR TITLE
feat(api): set the clearing decision for a particular item

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -937,6 +937,56 @@ paths:
               schema:
                 $ref: '#/components/schemas/Info'
         default:
+          $ref: '#/components/responses/defaultResponse'  
+  
+  /uploads/{id}/item/{itemId}/clearing-decision:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+      - name: itemId
+        required: true
+        description: Id of the itemId
+        in: path
+        schema:
+          type: integer
+    put:
+      operationId: setClearingDecision
+      tags:
+        - Upload
+      summary: Set the clearing decision for a particular upload tree item.
+      description: >
+        Set the clearing decision for a particular upload tree item.
+      requestBody:
+        description: ClearingDecision payload
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClearingDecision'
+      responses:
+        '200':
+          description: Clearing decision set successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Invalid clearingDecision type or invalid set globalDecision value
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
           $ref: '#/components/responses/defaultResponse'
   /uploads/{id}/licenses/main:
     parameters:
@@ -3444,6 +3494,27 @@ components:
             2: Advisor
           minimum: 0
           maximum: 2
+    ClearingDecision:
+      description: Clearing decision information
+      type: object
+      properties:
+        decisionType:
+          type: integer
+          description: |
+            Type of decision.
+            0: WIP
+            3: To be discussed
+            4: Irrelevant
+            5: Identified
+            6: Do not use
+            7: Non functional
+          example: 3
+          enum: [0, 3, 4, 5, 6, 7]
+        globalDecision:
+          type: boolean
+          description: |
+            Is the decision global?
+            If true, the decision is applied to all occurrence of the file on the server!
     AddMember:
       description: UserMember options
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -152,8 +152,10 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/copyrights', UploadController::class . ':getUploadCopyrights');
     $app->get('/{id:\\d+}/licenses/main', UploadController::class . ':getMainLicenses');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/view', UploadTreeController::class. ':viewLicenseFile');
+    $app->put('/{id:\\d+}/item/{itemId}/clearing-decision', UploadTreeController::class . ':setClearingDecision');
     $app->any('/{params:.*}', BadRequestController::class);
   });
+
 
 ////////////////////////////ADMIN-USERS/////////////////////
 $app->group('/users',

--- a/src/www/ui/ui-clearing-view.php
+++ b/src/www/ui/ui-clearing-view.php
@@ -344,7 +344,7 @@ class ClearingView extends FO_Plugin
    * @param int $lastItem
    * @return array
    */
-  protected function updateLastItem($userId, $groupId, $lastItem, $currentUploadtreeId)
+  public function updateLastItem($userId, $groupId, $lastItem, $currentUploadtreeId)
   {
     $type = GetParm("clearingTypes", PARM_INTEGER);
     $global = GetParm("globalDecision", PARM_STRING) === "on" ? 1 : 0;


### PR DESCRIPTION
## Description

Added the API to set the clearing decision for a particular item.

### Changes

1. Introduced a new group of controllers called `uploadTree` for managing different actions on a particular items and with it's corresponding class  `UploadTreeController`.
2. Created the method in `UploadTreeController` for setting the clearing decision for a particular item.
3. Updated  the main file(`index.php`) by adding a new route `PUT` `/uploadtree/{id}/clearing-decision`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a PUT request on the endpoint: ``/uploadtree/{id}/clearing-decision``, with header variables `decisionType` & `globalDecision`

## Screenshots

### For a successful Request
![clearing_decision_success](https://github.com/fossology/fossology/assets/66276301/d7f41fb4-4e49-4669-8785-150792ced910)

### When the uploadtree id is not FOUND
![clearing_decision_404_1](https://github.com/fossology/fossology/assets/66276301/22197eea-9630-4ca5-8be8-5c12153b0265)


### When the clearing decision type is NOT FOUND

![clearing_decision_404_2](https://github.com/fossology/fossology/assets/66276301/469ec56c-26cc-4613-9d0f-7dc1a78c3c87)

### When globalDecision value is not a boolean

![clearing_decision_404_3](https://github.com/fossology/fossology/assets/66276301/fca4d39a-fcbd-40fe-a144-558470532773)

### Related Issue:
Fixes #2459 

    
cc: @shaheemazmalmmd @GMishx




<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2460"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

