### PR TITLE
feat(api): add the new main license for the upload

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -923,6 +923,7 @@ paths:
                   $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+
   /uploads/{id}/item/{itemId}/view:
     parameters:
       - name: id
@@ -1018,6 +1019,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+          
   /uploads/{id}/licenses/main:
     parameters:
       - name: id
@@ -1056,7 +1058,47 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-
+    post:
+      operationId: setMainLicense
+      tags:
+        - Upload
+      summary: Set the main license for the upload
+      description: >
+        Set the main license for a particular upload.
+      requestBody:
+        description: MainLicense payload
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetMainLicense'
+      responses:
+        '200':
+          description: Main license set successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Short name missing from request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /search:
     get:
       operationId: searchFile
@@ -3545,6 +3587,14 @@ components:
           description: |
             Is the decision global?
             If true, the decision is applied to all occurrence of the file on the server!
+    SetMainLicense:
+      description: Set Main License information
+      type: object
+      properties:
+        shortName:
+          type: string
+          description: short name of the license
+          example: MIT
     AddMember:
       description: UserMember options
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -151,6 +151,7 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/download', UploadController::class . ':uploadDownload');
     $app->get('/{id:\\d+}/copyrights', UploadController::class . ':getUploadCopyrights');
     $app->get('/{id:\\d+}/licenses/main', UploadController::class . ':getMainLicenses');
+    $app->post('/{id:\\d+}/licenses/main', UploadController::class . ':setMainLicense');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/view', UploadTreeController::class. ':viewLicenseFile');
     $app->put('/{id:\\d+}/item/{itemId}/clearing-decision', UploadTreeController::class . ':setClearingDecision');
     $app->any('/{params:.*}', BadRequestController::class);


### PR DESCRIPTION
## Description

Added the API to set a specific license as the main license for the given Upload

### Changes

1. Added a new method in  `UploadController` to handle the logic.
2. Updated  the main file(`index.php`) by adding a new route `POST` `/uploads/{id}/licenses/main`.
3. Updated the `openapi.yaml` file  to introduce a new API.

## How to test

Make a POST request on the endpoint: `/uploads/{id}/licenses/main`.

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/5226a5e6-86a1-44a3-9796-9fc8f0016bc1)



### Related Issue:
Fixes #2459   

    
cc: @shaheemazmalmmd @GMishx



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2462"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

