### PR TITLE
feat(api): Remove a particular main license from an upload

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1098,6 +1098,49 @@ paths:
               schema:
                 $ref: '#/components/schemas/Info'
         default:
+          $ref: '#/components/responses/defaultResponse'  
+  
+  /uploads/{id}/licenses/{shortName}/main:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+      - name: shortName
+        required: true
+        description: shortName of the main license to be deleted
+        in: path
+        schema:
+          type: string
+    delete:
+      operationId: deleteMainLicense
+      tags:
+        - Upload
+      summary: Delete a main license from an upload
+      description: >
+        Delete a main license from an upload.
+      responses:
+        '200':
+          description: License is removed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
           $ref: '#/components/responses/defaultResponse'
   /search:
     get:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -152,6 +152,7 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/copyrights', UploadController::class . ':getUploadCopyrights');
     $app->get('/{id:\\d+}/licenses/main', UploadController::class . ':getMainLicenses');
     $app->post('/{id:\\d+}/licenses/main', UploadController::class . ':setMainLicense');
+    $app->delete('/{id:\\d+}/licenses/{shortName:[\\w\\- \\.]+}/main', UploadController::class . ':removeMainLicense');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/view', UploadTreeController::class. ':viewLicenseFile');
     $app->put('/{id:\\d+}/item/{itemId}/clearing-decision', UploadTreeController::class . ':setClearingDecision');
     $app->any('/{params:.*}', BadRequestController::class);


### PR DESCRIPTION
## Description

Added the API to delete a specific main license from an upload.

### Changes

1. Added a new method in  `UploadController` to handle the logic.
2. Updated  the main file(`index.php`) by adding a new route `DELETE` `/uploads/{id}/licenses/{licenseId}/main`.
3. Updated the `openapi.yaml` file  to introduce a new API.

## How to test

Make a DELETE request on the endpoint: `/uploads/{id}/licenses/{licenseId}/main`.

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/12cf5cd9-ed1a-49c4-965c-4e75e8a00f60)


### Related Issue:
Fixes #2459   

    
cc: @shaheemazmalmmd @GMishx



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2463"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

