### PR TITLE
feat(api): get main licenses assigned on an upload

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -7,7 +7,7 @@ openapi: 3.0.2
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.5.1
+  version: 1.5.2
   contact:
     email: fossology@fossology.org
   license:
@@ -864,6 +864,45 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /uploads/{id}/licenses/main:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+    get:
+      operationId: getMainLicenses
+      tags:
+        - Upload
+      summary: Get main licenses on the upload
+      description: >
+        Get main licenses assigned on a particular upload
+      responses:
+        '200':
+          description: All main licenses from an upload
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/License'
+        '404':
+          description: Upload not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
 

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -149,6 +149,7 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/licenses', UploadController::class . ':getUploadLicenses');
     $app->get('/{id:\\d+}/download', UploadController::class . ':uploadDownload');
     $app->get('/{id:\\d+}/copyrights', UploadController::class . ':getUploadCopyrights');
+    $app->get('/{id:\\d+}/licenses/main', UploadController::class . ':getMainLicenses');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui_tests/api/Controllers/UploadControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadControllerTest.php
@@ -15,7 +15,9 @@ namespace Fossology\UI\Api\Test\Controllers;
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\AgentDao;
+use Fossology\Lib\Dao\ClearingDao;
 use Fossology\Lib\Dao\FolderDao;
+use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Dao\UploadDao;
 use Fossology\Lib\Dao\UserDao;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
@@ -28,6 +30,7 @@ use Fossology\UI\Api\Helper\RestHelper;
 use Fossology\UI\Api\Models\Hash;
 use Fossology\UI\Api\Models\Info;
 use Fossology\UI\Api\Models\InfoType;
+use Fossology\UI\Api\Models\License;
 use Fossology\UI\Api\Models\Upload;
 use Mockery as M;
 use Slim\Psr7\Factory\StreamFactory;
@@ -114,6 +117,19 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
   private $agentDao;
 
   /**
+   * @var ClearingDao $clearingDao
+   * ClearingDao mock
+   */
+  private $clearingDao;
+
+  /**
+   * @var LicenseDao $licenseDao
+   * LicenseDao mock
+   */
+  private $licenseDao;
+
+
+  /**
    * @var StreamFactory $streamFactory
    * Stream factory to create body streams.
    */
@@ -137,6 +153,8 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     $this->folderDao = M::mock(FolderDao::class);
     $this->agentDao = M::mock(AgentDao::class);
     $this->userDao = M::mock(UserDao::class);
+    $this->clearingDao = M::mock(ClearingDao::class);
+    $this->licenseDao = M::mock(LicenseDao::class);
 
     $this->dbManager->shouldReceive('getSingleRow')
       ->withArgs([M::any(), [$this->groupId, UploadStatus::OPEN,
@@ -154,9 +172,12 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
       ->andReturn($this->userDao);
 
     $container->shouldReceive('get')->withArgs(array(
+      'dao.clearing'))->andReturn($this->clearingDao);
+    $container->shouldReceive('get')->withArgs(array(
       'helper.restHelper'))->andReturn($this->restHelper);
     $container->shouldReceive('get')->withArgs(array(
       'dao.agent'))->andReturn($this->agentDao);
+    $container->shouldReceive('get')->withArgs(array('dao.license'))->andReturn($this->licenseDao);
     $this->uploadController = new UploadController($container);
     $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
     $this->streamFactory = new StreamFactory();
@@ -916,5 +937,33 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
       $actualResponse->getStatusCode());
     $this->assertEquals($this->getResponseJson($expectedResponse),
       $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for UploadController::getMainLicenses()
+   * -# Check if response status is 200 and RES body matches
+   */
+  public function testGetMainLicenses()
+  {
+    $uploadId = 1;
+    $licenseIds = array();
+    $licenseId = 123;
+    $licenseIds[$licenseId] = $licenseId;
+    $license = new License($licenseId, "MIT", "MIT License", "risk", "texts", [],
+      'type', false);
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+    $this->clearingDao->shouldReceive('getMainLicenseIds')->withArgs([$uploadId, $this->groupId])->andReturn($licenseIds);
+    $this->licenseDao->shouldReceive('getLicenseObligations')->withArgs([[$licenseId], false])->andReturn([]);
+    $this->licenseDao->shouldReceive('getLicenseObligations')->withArgs([[$licenseId], true])->andReturn([]);
+    $this->licenseDao->shouldReceive('getLicenseById')->withArgs([$licenseId])->andReturn($license);
+
+    $licenses[] = $license->getArray();
+    $expectedResponse = (new ResponseHelper())->withJson($licenses, 200);
+    $actualResponse = $this->uploadController->getMainLicenses(null, new ResponseHelper(), ['id' => $uploadId]);
+    $this->assertEquals($expectedResponse->getStatusCode(), $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse), $this->getResponseJson($actualResponse));
   }
 }


### PR DESCRIPTION
## Description

Added the API to get a list of the main licenses assigned on an upload.

### Changes

1. Added a new method in  `UploadController` to handle the logic.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/uploads/{id}/licenses/main`.
3. Updated the `openapi.yaml` file  to introduce a new API.

## How to test

Make a GET request on the endpoint: `/uploads/{id}/licenses/main`.

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/c63dfd79-3b5e-466f-9b85-d30c3c1de614)


### Related Issue:
Fixes #2459   

    
cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2465"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

