### PR TITLE
feat(api): add new license decision

### DIFF
--- a/src/www/ui/api/Controllers/UploadTreeController.php
+++ b/src/www/ui/api/Controllers/UploadTreeController.php
@@ -1,0 +1,101 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Samuel Dushimimana <dushsam100@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Controller for uploadtree queries
+ */
+
+namespace Fossology\UI\Api\Controllers;
+
+use Fossology\Lib\Dao\ClearingDao;
+use Fossology\Lib\Dao\LicenseDao;
+use Fossology\Lib\Data\Clearing\ClearingEventTypes;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+
+/**
+ * @class UploadTreeController
+ * @brief Controller for UploadTree model
+ */
+class UploadTreeController extends RestController
+{
+  /**
+   * @var ContainerInterface $container
+   * Slim container
+   */
+  protected $container;
+
+  /** @var ClearingDao */
+  private $clearingDao;
+
+  /**
+   * @var LicenseDao $licenseDao
+   * License Dao object
+   */
+  private $licenseDao;
+
+  public function __construct($container)
+  {
+    parent::__construct($container);
+    $this->container = $container;
+    $this->clearingDao = $this->container->get('dao.clearing');
+    $this->licenseDao = $this->container->get('dao.license');
+  }
+
+  /**
+   * Add a new license to a particular upload-tree
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function addLicenseDecision($request, $response, $args)
+  {
+    $body = $this->getParsedBody($request);
+    $uploadTreeId = intval($args['itemId']);
+    $shortName = $body['shortName'];
+    $returnVal = null;
+    $license = null;
+    $uploadDao = $this->restHelper->getUploadDao();
+
+    try {
+      // check if the license and the uploadTreeId exist
+      if (!$this->dbHelper->doesIdExist($uploadDao->getUploadtreeTableName($uploadTreeId), "uploadtree_pk", $uploadTreeId)) {
+        $returnVal = new Info(404, "Item does not exist", InfoType::ERROR);
+      } else if (empty($shortName)) {
+        $returnVal = new Info(400, "Short name missing from request.",
+          InfoType::ERROR);
+      } else {
+        $license = $this->licenseDao->getLicenseByShortName($shortName,
+          $this->restHelper->getGroupId());
+
+        if ($license === null) {
+          $returnVal = new Info(404, "License file with short name '$shortName' not found.",
+            InfoType::ERROR);
+        }
+      }
+
+      if ($returnVal !== null) {
+        return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+      }
+
+      $this->clearingDao->insertClearingEvent($uploadTreeId, $this->restHelper->getUserId(), $this->restHelper->getGroupId(), $license->getId(), false);
+      $returnVal = new Info(200, "Successfully added license decision.", InfoType::INFO);
+      return $response->withJson($returnVal->getArray(), 200);
+
+    } catch (\Exception $e) {
+      $returnVal = new Info(500, $e->getMessage(), InfoType::ERROR);
+      return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+    }
+  }
+}

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -867,6 +867,62 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /uploads/{id}/items/{itemId}/licenses:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+      - name: itemId
+        required: true
+        description: Id of the itemId
+        in: path
+        schema:
+          type: integer
+    post:
+      operationId: addLicenseDecision
+      tags:
+        - Upload
+      summary: Add new license decision
+      description: >
+        Add a license decision for a particular upload tree item
+      requestBody:
+        description: ClearingDecision payload
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddNewLicenseDecision'
+      responses:
+        '200':
+          description: Successfully added license decision
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Short name missing from the request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Resource Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /search:
     get:
       operationId: searchFile
@@ -3286,6 +3342,14 @@ components:
             2: Advisor
           minimum: 0
           maximum: 2
+    AddNewLicenseDecision:
+      description: New license decision
+      type: object
+      properties:
+        shortName:
+          type: string
+          description: Short name of the license
+          example: MIT
     AddMember:
       description: UserMember options
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -33,6 +33,7 @@ use Fossology\UI\Api\Controllers\MaintenanceController;
 use Fossology\UI\Api\Controllers\ReportController;
 use Fossology\UI\Api\Controllers\SearchController;
 use Fossology\UI\Api\Controllers\UploadController;
+use Fossology\UI\Api\Controllers\UploadTreeController;
 use Fossology\UI\Api\Controllers\UserController;
 use Fossology\UI\Api\Helper\ResponseFactoryHelper;
 use Fossology\UI\Api\Helper\ResponseHelper;
@@ -149,6 +150,7 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/licenses', UploadController::class . ':getUploadLicenses');
     $app->get('/{id:\\d+}/download', UploadController::class . ':uploadDownload');
     $app->get('/{id:\\d+}/copyrights', UploadController::class . ':getUploadCopyrights');
+    $app->post('/{id:\\d+}/items/{itemId:\\d+}/licenses', UploadTreeController::class . ':addLicenseDecision');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui_tests/api/Controllers/UploadTreeControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadTreeControllerTest.php
@@ -1,0 +1,204 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Samuel Dushimimana <dushsam100@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for UploadTreeController
+ */
+
+namespace Fossology\UI\Api\Test\Controllers;
+
+use ClearingView;
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\ClearingDao;
+use Fossology\Lib\Dao\LicenseDao;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Data\DecisionTypes;
+use Fossology\Lib\Data\UploadStatus;
+use Fossology\Lib\Db\DbManager;
+use Fossology\UI\Api\Controllers\UploadTreeController;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Fossology\UI\Api\Models\License;
+use Slim\Psr7\Factory\StreamFactory;
+use Mockery as M;
+use Slim\Psr7\Headers;
+use Slim\Psr7\Request;
+use Slim\Psr7\Uri;
+
+/**
+ * @class UploadControllerTest
+ * @brief Unit tests for UploadController
+ */
+class UploadTreeControllerTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @var DbHelper $dbHelper
+   * DbHelper mock
+   */
+  private $dbHelper;
+
+  /**
+   * @var DbManager $dbManager
+   * Dbmanager mock
+   */
+  private $dbManager;
+
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+
+  /**
+   * @var UploadTreeController $uploadTreeController
+   * UploadTreeController mock
+   */
+  private $uploadTreeController;
+
+  /**
+   * @var UploadDao $uploadDao
+   * UploadDao mock
+   */
+  private $uploadDao;
+
+  /**
+   * @var LicenseDao $licenseDao
+   * LicenseDao mock
+   */
+  private $licenseDao;
+
+  /**
+   * @var ClearingDao $clearingDao
+   * ClearingDao mock
+   */
+  private $clearingDao;
+
+  /**
+   * @var StreamFactory $streamFactory
+   * Stream factory to create body streams.
+   */
+  private $streamFactory;
+
+  /**
+   * @var M\MockInterface $viewLicensePlugin
+   * ViewFilePlugin mock
+   */
+  private $viewLicensePlugin;
+
+  /**
+   * @var DecisionTypes $decisionTypes
+   * Decision types object
+   */
+  private $decisionTypes;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp(): void
+  {
+    global $container;
+    $this->userId = 2;
+    $this->groupId = 2;
+    $container = M::mock('ContainerBuilder');
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->dbManager = M::mock(DbManager::class);
+    $this->restHelper = M::mock(RestHelper::class);
+    $this->uploadDao = M::mock(UploadDao::class);
+    $this->clearingDao = M::mock(ClearingDao::class);
+    $this->viewLicensePlugin = M::mock(ClearingView::class);
+    $this->decisionTypes = M::mock(DecisionTypes::class);
+    $this->licenseDao = M::mock(LicenseDao::class);
+
+//    $twitterMock = \Mockery::mock(TwitterClient::class);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+
+    $this->restHelper->shouldReceive('getPlugin')
+      ->withArgs(array('view-license'))->andReturn($this->viewLicensePlugin);
+
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs([M::any(), [$this->groupId, UploadStatus::OPEN,
+        Auth::PERM_READ]]);
+    $this->dbHelper->shouldReceive('getDbManager')->andReturn($this->dbManager);
+
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+    $this->restHelper->shouldReceive('getGroupId')->andReturn($this->groupId);
+    $this->restHelper->shouldReceive('getUserId')->andReturn($this->userId);
+    $this->restHelper->shouldReceive('getUploadDao')
+      ->andReturn($this->uploadDao);
+    $container->shouldReceive('get')->withArgs(['decision.types'])->andReturn($this->decisionTypes);
+    $container->shouldReceive('get')->withArgs(['dao.license'])->andReturn($this->licenseDao);
+    $container->shouldReceive('get')->withArgs(['dao.clearing'])->andReturn($this->clearingDao);
+    $this->uploadTreeController = new UploadTreeController($container);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+    $this->streamFactory = new StreamFactory();
+  }
+
+  /**
+   * Helper function to get JSON array from response
+   *
+   * @param Response $response
+   * @return array Decoded response
+   */
+  private function getResponseJson($response)
+  {
+    $response->getBody()->seek(0);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+
+
+  /**
+   * @test
+   * -# Test for UploadTreeController::setClearingDecision() for setting a clearing decision
+   * -# Check if response status is 200 and response body matches
+   */
+  public function testAddLicenseDecision()
+  {
+    $uploadId = 1;
+    $itemId = 200;
+    $shortName = "MIT";
+    $licenseId = 23;
+    $license = new License($licenseId, "MIT", "MIT License", "risk", "texts", [],
+      'type', false);
+
+    $rq = [
+      "shortName" => $shortName,
+    ];
+
+    $this->uploadDao->shouldReceive("getUploadtreeTableName")->withArgs([$itemId])->andReturn("uploadtree");
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["uploadtree", "uploadtree_pk", $itemId])->andReturn(true);
+    $this->licenseDao->shouldReceive('getLicenseByShortName')
+      ->withArgs([$shortName, $this->groupId])->andReturn($license);
+    $this->clearingDao->shouldReceive('insertClearingEvent')
+      ->withArgs([$itemId, $this->userId, $this->groupId, $licenseId, false])->andReturn(null);
+
+    $info = new Info(200, "Successfully added license decision.", InfoType::INFO);
+
+    $expectedResponse = (new ResponseHelper())->withJson($info->getArray(), $info->getCode());
+    $reqBody = $this->streamFactory->createStream(json_encode(
+      $rq
+    ));
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    $request = new Request("POST", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $reqBody);
+    $actualResponse = $this->uploadTreeController->addLicenseDecision($request, new ResponseHelper(), ['id' => $uploadId, 'itemId' => $itemId]);
+
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+}


### PR DESCRIPTION
## Description

Added the API to set the clearing decision for a particular item.

### Changes

1. Added a new method in  `UploadTreeController` to handle the logic.
2. Created the method in `UploadTreeController` for adding the new license on the selected item.
3. Updated  the main file(`index.php`) by adding a new route `POST` `/uploads/{id}/items/{itemId}/licenses`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a POST request on the endpoint: ``/uploads/{id}/items/{itemId}/licenses``,

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/5cc896df-663e-410e-842c-daaa1aab2a31)

### Related Issue:
Fixes #2459 

    
cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2466"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

