### PR TITLE
feat(api): delete a specific license-decision from an uploadtree

### DIFF
--- a/src/www/ui/api/Controllers/UploadTreeController.php
+++ b/src/www/ui/api/Controllers/UploadTreeController.php
@@ -1,0 +1,90 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Samuel Dushimimana <dushsam100@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Controller for uploadtree queries
+ */
+
+namespace Fossology\UI\Api\Controllers;
+
+use Fossology\Lib\Dao\ClearingDao;
+use Fossology\Lib\Dao\LicenseDao;
+use Fossology\Lib\Data\Clearing\ClearingEventTypes;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+
+/**
+ * @class UploadTreeController
+ * @brief Controller for UploadTree model
+ */
+class UploadTreeController extends RestController
+{
+  /**
+   * @var ContainerInterface $container
+   * Slim container
+   */
+  protected $container;
+
+  /** @var ClearingDao */
+  private $clearingDao;
+
+  /**
+   * @var LicenseDao $licenseDao
+   * License Dao object
+   */
+  private $licenseDao;
+
+  public function __construct($container)
+  {
+    parent::__construct($container);
+    $this->container = $container;
+    $this->clearingDao = $this->container->get('dao.clearing');
+    $this->licenseDao = $this->container->get('dao.license');
+  }
+
+
+  /**
+   * Remove the license decision from the upload-tree
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseInterface $response
+   * @param array $args
+   * @return ResponseInterface
+   */
+  public function removeLicenseDecision($request, $response, $args)
+  {
+    try {
+      $uploadTreeId = intval($args['itemId']);
+      $licenseId = intval($args['licenseId']);
+      $returnVal = null;
+      $uploadDao = $this->restHelper->getUploadDao();
+
+      if (!$this->dbHelper->doesIdExist($uploadDao->getUploadtreeTableName($uploadTreeId), "uploadtree_pk", $uploadTreeId)) {
+        $returnVal = new Info(404, "Item does not exist", InfoType::ERROR);
+      } else if (!$this->dbHelper->doesIdExist("license_ref", "rf_pk", $licenseId)) {
+        $returnVal = new Info(404, "License does not exist", InfoType::ERROR);
+      }
+
+      if ($returnVal !== null) {
+        return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+      }
+
+      $this->clearingDao->insertClearingEvent($uploadTreeId, $this->restHelper->getUserId(), $this->restHelper->getGroupId(), $licenseId, true);
+      $returnVal = new Info(200, "Successfully removed license.", InfoType::INFO);
+      return $response->withJson($returnVal->getArray(), 200);
+
+    } catch (\Exception $e) {
+      $returnVal = new Info(500, $e->getMessage(), InfoType::ERROR);
+      return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+    }
+  }
+}

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -867,6 +867,55 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /uploads/{id}/items/{itemId}/licenses/{licenseId}:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+      - name: itemId
+        required: true
+        description: Id of the itemId
+        in: path
+        schema:
+          type: integer
+      - name: licenseId
+        required: true
+        description: Id of the license to be delete
+        in: path
+        schema:
+          type: integer
+    delete:
+      operationId: deleteLicenseDecision
+      tags:
+        - Upload
+      summary: Delete license from an item
+      description: >
+        Delete a particular license for a particular upload tree item
+      responses:
+        '200':
+          description: Successfully removed license.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Resource Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /search:
     get:
       operationId: searchFile

--- a/src/www/ui_tests/api/Controllers/UploadTreeControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadTreeControllerTest.php
@@ -1,0 +1,185 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Samuel Dushimimana <dushsam100@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for UploadTreeController
+ */
+
+namespace Fossology\UI\Api\Test\Controllers;
+
+use ClearingView;
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\ClearingDao;
+use Fossology\Lib\Dao\LicenseDao;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Data\DecisionTypes;
+use Fossology\Lib\Data\UploadStatus;
+use Fossology\Lib\Db\DbManager;
+use Fossology\UI\Api\Controllers\UploadTreeController;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Slim\Psr7\Factory\StreamFactory;
+use Mockery as M;
+
+/**
+ * @class UploadControllerTest
+ * @brief Unit tests for UploadController
+ */
+class UploadTreeControllerTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @var DbHelper $dbHelper
+   * DbHelper mock
+   */
+  private $dbHelper;
+
+  /**
+   * @var DbManager $dbManager
+   * Dbmanager mock
+   */
+  private $dbManager;
+
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+
+  /**
+   * @var UploadTreeController $uploadTreeController
+   * UploadTreeController mock
+   */
+  private $uploadTreeController;
+
+  /**
+   * @var UploadDao $uploadDao
+   * UploadDao mock
+   */
+  private $uploadDao;
+
+  /**
+   * @var LicenseDao $licenseDao
+   * LicenseDao mock
+   */
+  private $licenseDao;
+
+  /**
+   * @var ClearingDao $clearingDao
+   * ClearingDao mock
+   */
+  private $clearingDao;
+
+  /**
+   * @var StreamFactory $streamFactory
+   * Stream factory to create body streams.
+   */
+  private $streamFactory;
+
+  /**
+   * @var M\MockInterface $viewLicensePlugin
+   * ViewFilePlugin mock
+   */
+  private $viewLicensePlugin;
+
+  /**
+   * @var DecisionTypes $decisionTypes
+   * Decision types object
+   */
+  private $decisionTypes;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp(): void
+  {
+    global $container;
+    $this->userId = 2;
+    $this->groupId = 2;
+    $container = M::mock('ContainerBuilder');
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->dbManager = M::mock(DbManager::class);
+    $this->restHelper = M::mock(RestHelper::class);
+    $this->uploadDao = M::mock(UploadDao::class);
+    $this->clearingDao = M::mock(ClearingDao::class);
+    $this->viewLicensePlugin = M::mock(ClearingView::class);
+    $this->decisionTypes = M::mock(DecisionTypes::class);
+    $this->licenseDao = M::mock(LicenseDao::class);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+
+    $this->restHelper->shouldReceive('getPlugin')
+      ->withArgs(array('view-license'))->andReturn($this->viewLicensePlugin);
+
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs([M::any(), [$this->groupId, UploadStatus::OPEN,
+        Auth::PERM_READ]]);
+    $this->dbHelper->shouldReceive('getDbManager')->andReturn($this->dbManager);
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+    $this->restHelper->shouldReceive('getGroupId')->andReturn($this->groupId);
+    $this->restHelper->shouldReceive('getUserId')->andReturn($this->userId);
+    $this->restHelper->shouldReceive('getUploadDao')
+      ->andReturn($this->uploadDao);
+    $container->shouldReceive('get')->withArgs(['decision.types'])->andReturn($this->decisionTypes);
+    $container->shouldReceive('get')->withArgs(['dao.license'])->andReturn($this->licenseDao);
+    $container->shouldReceive('get')->withArgs(['dao.clearing'])->andReturn($this->clearingDao);
+    $this->uploadTreeController = new UploadTreeController($container);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+    $this->streamFactory = new StreamFactory();
+  }
+
+  /**
+   * Helper function to get JSON array from response
+   *
+   * @param Response $response
+   * @return array Decoded response
+   */
+  private function getResponseJson($response)
+  {
+    $response->getBody()->seek(0);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+
+
+  /**
+   * @test
+   * -# Test for UploadTreeController::removeLicenseDecision() for delete a license decision
+   * -# Check if response status is 200 and response body matches
+   */
+  public function testRemoveLicenseDecision()
+  {
+    $uploadId = 1;
+    $itemId = 200;
+    $licenseId = 23;
+
+    $this->uploadDao->shouldReceive("getUploadtreeTableName")->withArgs([$itemId])->andReturn("uploadtree");
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["uploadtree", "uploadtree_pk", $itemId])->andReturn(true);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["license_ref", "rf_pk", $licenseId])->andReturn(true);
+
+    $this->clearingDao->shouldReceive('insertClearingEvent')
+      ->withArgs([$itemId, $this->userId, $this->groupId, $licenseId, true])->andReturn(null);
+
+    $info = new Info(200, "Successfully removed license.", InfoType::INFO);
+
+    $expectedResponse = (new ResponseHelper())->withJson($info->getArray(),
+      $info->getCode());
+    $actualResponse = $this->uploadTreeController->removeLicenseDecision(null,
+      new ResponseHelper(), ['id' => $uploadId, 'licenseId' => $licenseId, 'itemId' => $itemId]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+}


### PR DESCRIPTION
## Description

Added the API to delete the license decision from an uploadtree

### Changes

1. Added a new method in  `UploadTreeController` to handle the logic.
2. Created the method in `UploadTreeController` for adding the new license on the selected item.
3. Updated  the main file(`index.php`) by adding a new route `DELETE` `/uploads/{id}/items/{itemId}/licenses/{licenseId}`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a DELETE request on the endpoint: `/uploads/{id}/items/{itemId}/licenses/{licenseId}`

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/efae763b-e2f5-4d7d-816f-0fe6ef7872ca)

### Related Issue:
Fixes #2459 

    
cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2469"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

