### PR TITLE
feat(api): get list of license decisions for an item

### DIFF
--- a/src/www/ui/ajax-clearing-view.php
+++ b/src/www/ui/ajax-clearing-view.php
@@ -155,10 +155,10 @@ class AjaxClearingView extends FO_Plugin
    * @param $groupId
    * @param $uploadId
    * @param $uploadTreeId
-   * @internal param $itemTreeBounds
    * @return string
+   *@internal param $itemTreeBounds
    */
-  protected function doClearings($orderAscending, $groupId, $uploadId, $uploadTreeId)
+  public function doClearings($orderAscending, $groupId, $uploadId, $uploadTreeId)
   {
     $itemTreeBounds = $this->uploadDao->getItemTreeBoundsFromUploadId($uploadTreeId, $uploadId);
     $aaData = $this->getCurrentSelectedLicensesTableData($itemTreeBounds,

--- a/src/www/ui/api/Controllers/UploadTreeController.php
+++ b/src/www/ui/api/Controllers/UploadTreeController.php
@@ -14,13 +14,22 @@ namespace Fossology\UI\Api\Controllers;
 
 use Fossology\Lib\Data\DecisionScopes;
 use Fossology\Lib\Data\DecisionTypes;
+use Fossology\Lib\BusinessRules\ClearingDecisionProcessor;
+use Fossology\Lib\BusinessRules\LicenseMap;
+use Fossology\Lib\Dao\ClearingDao;
+use Fossology\Lib\Dao\HighlightDao;
+use Fossology\Lib\Dao\LicenseDao;
+use Fossology\Lib\Data\Clearing\ClearingEventTypes;
+use Fossology\Lib\Data\Clearing\ClearingResult;
 use Fossology\UI\Api\Helper\ResponseHelper;
 use Fossology\UI\Api\Models\BulkHistory;
 use Fossology\UI\Api\Models\ClearingHistory;
 use Fossology\UI\Api\Models\Info;
 use Fossology\UI\Api\Models\InfoType;
+use Fossology\UI\Api\Models\LicenseDecision;
+use Fossology\UI\Api\Models\Obligation;
+use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
-
 
 /**
  * @class UploadTreeController
@@ -28,6 +37,29 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class UploadTreeController extends RestController
 {
+  /**
+   * @var ContainerInterface $container
+   * Slim container
+   */
+  protected $container;
+
+  /** @var ClearingDao */
+  private $clearingDao;
+
+  /**
+   * @var LicenseDao $licenseDao
+   * License Dao object
+   */
+  private $licenseDao;
+
+  /**
+   * @var HighlightDao $highlightDao
+   * HighlightDao object
+   */
+  private $highlightDao;
+
+  /** @var ClearingDecisionProcessor */
+  private $clearingDecisionEventProcessor;
 
   /**
    * @var DecisionTypes $decisionTypes
@@ -35,10 +67,13 @@ class UploadTreeController extends RestController
    */
   private $decisionTypes;
 
-
   public function __construct($container)
   {
     parent::__construct($container);
+    $this->clearingDao = $this->container->get('dao.clearing');
+    $this->licenseDao = $this->container->get('dao.license');
+    $this->highlightDao = $container->get("dao.highlight");
+    $this->clearingDecisionEventProcessor = $container->get('businessrules.clearing_decision_processor');
     $this->decisionTypes = $this->container->get('decision.types');
   }
 
@@ -92,6 +127,7 @@ class UploadTreeController extends RestController
       ->withHeader("Etag", md5($response->getBody()));
   }
 
+
   /**
    * Set the clearing decision for a particular upload-tree
    *
@@ -140,6 +176,7 @@ class UploadTreeController extends RestController
       return $response->withJson($returnVal->getArray(), $returnVal->getCode());
     }
   }
+
   /**
    * Get the next and previous item for a given upload and itemId
    *
@@ -275,7 +312,7 @@ class UploadTreeController extends RestController
       }
       ksort($removedLicenses, SORT_STRING);
       ksort($addedLicenses, SORT_STRING);
-      $obj =  new ClearingHistory(date('Y-m-d', $clearingDecision->getTimeStamp()), $clearingDecision->getUserName(), $scope->getTypeName($clearingDecision->getScope()), $this->decisionTypes->getConstantNameFromKey($clearingDecision->getType()), $addedLicenses, $removedLicenses);
+      $obj = new ClearingHistory(date('Y-m-d', $clearingDecision->getTimeStamp()), $clearingDecision->getUserName(), $scope->getTypeName($clearingDecision->getScope()), $this->decisionTypes->getConstantNameFromKey($clearingDecision->getType()), $addedLicenses, $removedLicenses);
       $data[] = $obj->getArray();
     }
     return $response->withJson($data, 200);
@@ -450,5 +487,149 @@ class UploadTreeController extends RestController
     $res = $ajaxExplorerPlugin->handle($symfonyRequest);
 
     return $response->withJson(json_decode($res->getContent(), true)["aaData"], 200);
+  }
+
+  /**
+   * Get all license decisions for a particular upload-tree
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function getLicenseDecisions($request, $response, $args)
+  {
+    $uploadTreeId = intval($args['itemId']);
+    $uploadPk = intval($args['id']);
+    $returnVal = null;
+    $uploadDao = $this->restHelper->getUploadDao();
+    $licenses = [];
+
+    if (!$this->dbHelper->doesIdExist("upload", "upload_pk", $uploadPk)) {
+      $returnVal = new Info(404, "Upload does not exist", InfoType::ERROR);
+    } else if (!$this->dbHelper->doesIdExist($uploadDao->getUploadtreeTableName($uploadPk), "uploadtree_pk", $uploadTreeId)) {
+      $returnVal = new Info(404, "Item does not exist", InfoType::ERROR);
+    }
+
+    if ($returnVal !== null) {
+      return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+    }
+
+    $itemTreeBounds = $uploadDao->getItemTreeBoundsFromUploadId($uploadTreeId, $uploadPk);
+    if ($itemTreeBounds->containsFiles()) {
+      $returnVal = new Info(400, "Item expected to be a file, container sent.", InfoType::ERROR);
+      return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+    }
+
+    list ($addedClearingResults, $removedLicenses) = $this->clearingDecisionEventProcessor->getCurrentClearings(
+      $itemTreeBounds, $this->restHelper->getGroupId(), LicenseMap::CONCLUSION);
+    $licenseEventTypes = new ClearingEventTypes();
+
+    $mergedArray = [];
+
+    foreach ($addedClearingResults as $item) {
+      $mergedArray[] = ['item' => $item, 'isRemoved' => false];
+    }
+
+    foreach ($removedLicenses as $item) {
+      $mergedArray[] = ['item' => $item, 'isRemoved' => true];
+    }
+
+    $mainLicIds = $this->clearingDao->getMainLicenseIds($uploadPk, $this->restHelper->getGroupId());
+
+    foreach ($mergedArray as $item) {
+      $clearingResult = $item['item'];
+      $licenseShortName = $clearingResult->getLicenseShortName();
+      $licenseId = $clearingResult->getLicenseId();
+
+      $types = $this->getAgentInfo($clearingResult);
+      $reportInfo = "";
+      $comment = "";
+      $acknowledgement = "";
+
+      if ($clearingResult->hasClearingEvent()) {
+        $licenseDecisionEvent = $clearingResult->getClearingEvent();
+        $types[] = $this->getEventInfo($licenseDecisionEvent, $licenseEventTypes);
+        $reportInfo = $licenseDecisionEvent->getReportinfo();
+        $comment = $licenseDecisionEvent->getComment();
+        $acknowledgement = $licenseDecisionEvent->getAcknowledgement();
+      }
+
+      $obligations = $this->licenseDao->getLicenseObligations([$licenseId], false);
+      $obligations = array_merge($obligations, $this->licenseDao->getLicenseObligations([$licenseId], true));
+      $obligationList = [];
+      foreach ($obligations as $obligation) {
+        $obligationList[] = new Obligation(
+          $obligation['ob_pk'],
+          $obligation['ob_topic'],
+          $obligation['ob_type'],
+          $obligation['ob_text'],
+          $obligation['ob_classification'],
+          $obligation['ob_comment']
+        );
+      }
+      $license = $this->licenseDao->getLicenseById($licenseId);
+      $licenseObj = new LicenseDecision(
+        $license->getId(),
+        $licenseShortName,
+        $license->getFullName(),
+        $item['isRemoved'] ? '-' : (!empty($reportInfo) ? $reportInfo : $license->getText()),
+        $license->getUrl(),
+        $types,
+        $item['isRemoved'] ? '-' : $acknowledgement,
+        $item['isRemoved'] ? '-' : $comment,
+        in_array($license->getId(), $mainLicIds),
+        $obligationList,
+        $license->getRisk(),
+        $item['isRemoved']
+      );
+      $licenses[] = $licenseObj->getArray();
+    }
+    return $response->withJson($licenses, 200);
+  }
+
+  /**
+   * @param ClearingResult $licenseDecisionResult
+   */
+  private function getAgentInfo(ClearingResult $licenseDecisionResult)
+  {
+    $agentResults = array();
+    foreach ($licenseDecisionResult->getAgentDecisionEvents() as $agentDecisionEvent) {
+      $agentId = $agentDecisionEvent->getAgentId();
+      $matchId = $agentDecisionEvent->getMatchId();
+      $highlightRegion = $this->highlightDao->getHighlightRegion($matchId);
+      $page = null;
+      $percentage = $agentDecisionEvent->getPercentage();
+      if ($highlightRegion[0] != "" && $highlightRegion[1] != "") {
+        $page = $this->highlightDao->getPageNumberOfHighlightEntry($matchId);
+      }
+      $result = array(
+        'name' => $agentDecisionEvent->getAgentName(),
+        'clearingId' => null,
+        'agentId' => $agentId,
+        'highlightId' => $matchId,
+        'page' => intval($page),
+        'percentage' => $percentage
+      );
+      $agentResults[] = $result;
+    }
+    return $agentResults;
+  }
+
+  private function getEventInfo($licenseDecisionEvent, $licenseEventTypes)
+  {
+    $type = $licenseEventTypes->getTypeName($licenseDecisionEvent->getEventType());
+    $eventId = null;
+    if ($licenseDecisionEvent->getEventType() == ClearingEventTypes::BULK) {
+      $eventId = $licenseDecisionEvent->getEventId();
+    }
+    return array(
+      'name' => $type,
+      'clearingId' => $eventId,
+      'agentId' => null,
+      'highlightId' => null,
+      'page' => null,
+      'percentage' => null
+    );
   }
 }

--- a/src/www/ui/api/Models/LicenseDecision.php
+++ b/src/www/ui/api/Models/LicenseDecision.php
@@ -1,0 +1,197 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Samuel Dushimimana <dushsam100@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief License
+ */
+
+namespace Fossology\UI\Api\Models;
+
+use PhpOffice\PhpSpreadsheet\Calculation\Logical\Boolean;
+
+/**
+ * @class LicenseDecision
+ * @package Fossology\UI\Api\Models
+ * @brief LicenseDecision model to hold license decision related info
+ */
+class LicenseDecision extends License
+{
+  /**
+   * @var array $ALLOWED_KEYS
+   * Allowed keys from user to parse
+   */
+  const ALLOWED_KEYS = ['shortName', 'fullName', 'text', 'url', 'risk',
+    'isCandidate', 'mergeRequest', 'source', 'acknowledgement', 'comment'];
+
+  /**
+   * @var array $sources
+   * source of the license
+   */
+  private $sources;
+  /**
+   * @var string $acknowledgement
+   * acknowledgement of the license
+   */
+  private $acknowledgement;
+  /**
+   * @var string $comment
+   * The comment of the license
+   */
+  private $comment;
+
+  /**
+   * @var bool $isMainLicense
+   * The main license
+   */
+  private $isMainLicense;
+
+  /**
+   * @var bool $isRemoved
+   * The removed license
+   */
+  private $isRemoved;
+
+  /**
+   * @param array $sources
+   * @param string $acknowledgement
+   * @param string $comment
+   */
+  public function __construct($id,
+                              $shortName = "",
+                              $fullName = "",
+                              $text = "",
+                              $url = "",
+                              $sources = [], $acknowledgement = "", $comment = "",
+                              $isMainLicense = false,
+                              $obligations = null,
+                              $risk = null,
+                              $isRemoved = false,
+                              $isCandidate = false)
+  {
+    parent::__construct(
+      $id,
+      $shortName,
+      $fullName,
+      $text,
+      $url,
+      $obligations,
+      $risk,
+      $isCandidate
+    );
+    $this->setSources($sources);
+    $this->setAcknowledgement($acknowledgement);
+    $this->setComment($comment);
+    $this->setIsMainLicense($isMainLicense);
+    $this->setIsRemoved($isRemoved);
+  }
+
+
+  /**
+   * JSON representation of the license
+   * @return string
+   */
+  public function getJSON()
+  {
+    return json_encode($this->getArray());
+  }
+
+  /**
+   * Array representation of the license
+   * @return array
+   */
+  public function getArray()
+  {
+    $data = parent::getArray();
+    $data['sources'] = $this->getSources();
+    $data['acknowledgement'] = $this->getAcknowledgement();
+    $data['comment'] = $this->getComment();
+    $data['isMainLicense'] = $this->getIsMainLicense();
+    $data['isRemoved'] = $this->getIsRemoved();
+    return $data;
+  }
+
+  /**
+   * @return array
+   */
+  public function getSources(): array
+  {
+    return $this->sources;
+  }
+
+  /**
+   * @param array $sources
+   */
+  public function setSources(array $sources): void
+  {
+    $this->sources = $sources;
+  }
+
+  /**
+   * @return string
+   */
+  public function getAcknowledgement(): string
+  {
+    return $this->acknowledgement;
+  }
+
+  /**
+   * @param string $acknowledgement
+   */
+  public function setAcknowledgement(string $acknowledgement): void
+  {
+    $this->acknowledgement = $acknowledgement;
+  }
+
+  /**
+   * @return string
+   */
+  public function getComment(): string
+  {
+    return $this->comment;
+  }
+
+  /**
+   * @param string $comment
+   */
+  public function setComment(string $comment): void
+  {
+    $this->comment = $comment;
+  }
+
+  /**
+   * @param bool $isRemoved
+   */
+  public function setIsRemoved(bool $isRemoved): void
+  {
+    $this->isRemoved = $isRemoved;
+  }
+
+  /**
+   * @return bool
+   */
+  public function getIsRemoved(): bool
+  {
+    return $this->isRemoved;
+  }
+
+  /**
+   * @return bool
+   */
+  public function getIsMainLicense(): bool
+  {
+    return $this->isMainLicense;
+  }
+
+  /**
+   * @param bool $isMainLicense
+   */
+  public function setIsMainLicense(bool $isMainLicense): void
+  {
+    $this->isMainLicense = $isMainLicense;
+  }
+}

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1183,6 +1183,51 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /uploads/{id}/item/{itemId}/licenses:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+      - name: itemId
+        required: true
+        description: Id of the itemId
+        in: path
+        schema:
+          type: integer
+    get:
+      operationId: getLicenseDecisions
+      tags:
+        - Upload
+      summary: Get the license decisions list
+      description: >
+        Get the license decisions list for the given upload and item id
+      responses:
+        '200':
+          description: List of the license decisions for the upload-tree id
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LicenseDecision'
+        '404':
+          description: Resource Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /uploads/{id}/licenses/main:
     parameters:
       - name: id
@@ -4241,6 +4286,56 @@ components:
           example:
             - "Copyright (C) 2017-2020 Free Software Foundation, Inc."
             - "Copyright (C) 1991-2020 Free Software Foundation, Inc."
+    LicenseDecision:
+      description: Extended License model with additional fields
+      allOf:
+        - $ref: '#/components/schemas/License'
+      properties:
+        sources:
+          description: Array of sources
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                description: The name of the agent.
+                example: nomos
+              clearingId:
+                type: integer
+                description: The clearing ID.
+                example: 200
+              agentId:
+                type: integer
+                description: The agent ID.
+                example: 61
+              highlightId:
+                type: integer
+                description: The highlight ID.
+                example: 2297
+              page:
+                type: integer
+                description: The page number.
+                example: 0
+              percentage:
+                type: integer
+                description: The percentage value.
+                example: 78
+        comment:
+          description: Comment for the license decision
+          type: string
+          example: "This is a comment"
+        acknowledgement:
+          description: License acknowledgement
+          type: string
+        isMainLicense:
+          description: Is the license the main license?
+          type: boolean
+          example: true
+        isRemoved:
+          description: Is the license removed?
+          type: boolean
+          example: false
     License:
       description: License from the database
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -160,11 +160,12 @@ $app->group('/uploads',
     $app->post('/{id:\\d+}/licenses/main', UploadController::class . ':setMainLicense');
     $app->delete('/{id:\\d+}/licenses/{shortName:[\\w\\- \\.]+}/main', UploadController::class . ':removeMainLicense');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/view', UploadTreeController::class. ':viewLicenseFile');
-    $app->put('/{id:\\d+}/item/{itemId}/clearing-decision', UploadTreeController::class . ':setClearingDecision');
+    $app->get('/{id:\\d+}/item/{itemId:\\d+}/prev-next', UploadTreeController::class . ':getNextPreviousItem');
+    $app->get('/{id:\\d+}/item/{itemId:\\d+}/licenses', UploadTreeController::class . ':getLicenseDecisions');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/copyrights', CopyrightController::class . ':getFileCopyrights');
     $app->delete('/{id:\\d+}/item/{itemId:\\d+}/copyrights/{hash:.*}', CopyrightController::class . ':deleteFileCopyrights');
     $app->put('/{id:\\d+}/item/{itemId:\\d+}/copyrights/{hash:.*}', CopyrightController::class . ':updateFileCopyrights');
-    $app->get('/{id:\\d+}/item/{itemId:\\d+}/prev-next', UploadTreeController::class . ':getNextPreviousItem');
+    $app->put('/{id:\\d+}/item/{itemId}/clearing-decision', UploadTreeController::class . ':setClearingDecision');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/bulk-history', UploadTreeController::class . ':getBulkHistory');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/clearing-history', UploadTreeController::class . ':getClearingHistory');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/highlight', UploadTreeController::class . ':getHighlightEntries');

--- a/src/www/ui_tests/api/Controllers/UploadTreeControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadTreeControllerTest.php
@@ -24,6 +24,10 @@ namespace Fossology\UI\Api\Test\Controllers {
   use ClearingView;
   use Fossology\Lib\Auth\Auth;
   use Fossology\Lib\Dao\ClearingDao;
+  use Fossology\Lib\BusinessRules\ClearingDecisionProcessor;
+  use Fossology\Lib\BusinessRules\LicenseMap;
+  use Fossology\Lib\Dao\HighlightDao;
+  use Fossology\Lib\Dao\LicenseDao;
   use Fossology\Lib\Dao\UploadDao;
   use Fossology\Lib\Data\ClearingDecision;
   use Fossology\Lib\Data\DecisionScopes;
@@ -31,6 +35,11 @@ namespace Fossology\UI\Api\Test\Controllers {
   use Fossology\Lib\Data\Tree\Item;
   use Fossology\Lib\Data\Tree\ItemTreeBounds;
   use Fossology\Lib\Data\Highlight;
+  use Fossology\Lib\Data\Clearing\ClearingEvent;
+  use Fossology\Lib\Data\Clearing\ClearingEventTypes;
+  use Fossology\Lib\Data\Clearing\ClearingLicense;
+  use Fossology\Lib\Data\Clearing\ClearingResult;
+  use Fossology\Lib\Data\LicenseRef;
   use Fossology\Lib\Data\UploadStatus;
   use Fossology\Lib\Db\DbManager;
   use Fossology\UI\Api\Controllers\UploadTreeController;
@@ -41,6 +50,8 @@ namespace Fossology\UI\Api\Test\Controllers {
   use Fossology\UI\Api\Models\ClearingHistory;
   use Fossology\UI\Api\Models\Info;
   use Fossology\UI\Api\Models\InfoType;
+  use Fossology\UI\Api\Models\License;
+  use Fossology\UI\Api\Models\LicenseDecision;
   use Mockery as M;
   use Psr\Http\Message\ServerRequestInterface;
   use Slim\Psr7\Factory\StreamFactory;
@@ -86,14 +97,26 @@ namespace Fossology\UI\Api\Test\Controllers {
     private $uploadDao;
 
     /**
-     * @var ClearingDao $clearingDao
-     * ClearingDao mock
+     * @var LicenseDao $licenseDao
+     * LicenseDao mock
      */
-    private $clearingDao;
+    private $licenseDao;
 
     /**
-     * @var StreamFactory $streamFactory
-     * Stream factory to create body streams.
+     * @var HighlightDao $highlightDao
+     * ClearingDao mock
+     */
+    private $highlightDao;
+
+    /**
+     * @var ClearingEventTypes $clearingEventTypes
+     * ClearingDao mock
+     */
+    private $clearingEventTypes;
+
+    /**
+     * @var ClearingDao $clearingDao
+     * ClearingDao mock
      */
     private $streamFactory;
 
@@ -122,6 +145,17 @@ namespace Fossology\UI\Api\Test\Controllers {
     private $decisionTypes;
 
     /**
+     * @var ItemTreeBounds $itemTreeBoundsMock
+     * ItemTreeBounds Mock
+     */
+    private $itemTreeBoundsMock;
+
+    /** @var ClearingDecisionProcessor $clearingDecisionEventProcessor
+     * ClearingDecisionProcessor Mock
+     */
+    private $clearingDecisionEventProcessor;
+
+    /**
      * @brief Setup test objects
      * @see PHPUnit_Framework_TestCase::setUp()
      */
@@ -135,11 +169,16 @@ namespace Fossology\UI\Api\Test\Controllers {
       $this->dbManager = M::mock(DbManager::class);
       $this->restHelper = M::mock(RestHelper::class);
       $this->uploadDao = M::mock(UploadDao::class);
-      $this->decisionTypes = M::mock(DecisionTypes::class);
+      $this->decisionTypes = M::mock(DecisionTypes::class);      $this->clearingDao = M::mock(ClearingDao::class);
+      $this->licenseDao = M::mock(LicenseDao::class);
+      $this->clearingDecisionEventProcessor = M::mock(ClearingDecisionProcessor::class);
       $this->viewFilePlugin = M::mock('ui_view');
       $this->viewLicensePlugin = M::mock(ClearingView::class);
       $this->clearingDao = M::mock(ClearingDao::class);
       $this->decisionScopes = M::mock(DecisionScopes::class);
+      $this->highlightDao = M::mock(HighlightDao::class);
+      $this->clearingEventTypes = M::mock(ClearingEventTypes::class);
+      $this->itemTreeBoundsMock = M::mock(ItemTreeBounds::class);
 
       $this->restHelper->shouldReceive('getPlugin')
         ->withArgs(array('view'))->andReturn($this->viewFilePlugin);
@@ -161,7 +200,9 @@ namespace Fossology\UI\Api\Test\Controllers {
       $container->shouldReceive('get')->withArgs(['decision.types'])->andReturn($this->decisionTypes);
       $container->shouldReceive('get')->withArgs(['dao.clearing'])->andReturn($this->clearingDao);
 
-      $container->shouldReceive('get')->withArgs(['decision.types'])->andReturn($this->decisionTypes);
+      $container->shouldReceive('get')->withArgs(['businessrules.clearing_decision_processor'])->andReturn($this->clearingDecisionEventProcessor);
+      $container->shouldReceive('get')->withArgs(['dao.highlight'])->andReturn($this->highlightDao);
+      $container->shouldReceive('get')->withArgs(['dao.license'])->andReturn($this->licenseDao);
       $this->uploadTreeController = new UploadTreeController($container);
       $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
       $this->streamFactory = new StreamFactory();
@@ -500,6 +541,65 @@ namespace Fossology\UI\Api\Test\Controllers {
         ->willReturn($queryParams);
 
       $actualResponse = $this->uploadTreeController->getHighlightEntries($request, new ResponseHelper(), ['id' => $uploadId, 'itemId' => $itemId]);
+      $this->assertEquals($expectedResponse->getStatusCode(), $actualResponse->getStatusCode());
+      $this->assertEquals($this->getResponseJson($expectedResponse), $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test for UploadTreeController::getLicenseDecisions()
+     * -# Check if response status is 200 and RES body matches
+     * @throws \Fossology\Lib\Exception
+     */
+    public function testGetLicenseDecisions()
+    {
+      $itemId = 200;
+      $uploadId = 1;
+      $licenseId = 123;
+      $licenses = array();
+
+      $itemTreeBounds = new ItemTreeBounds($itemId, 'uploadtree_a', $uploadId, 0, 1);
+      $addedClearingResults = [];
+
+      $result = array(
+        'name' => 'Imported decision',
+        'clearingId' => null,
+        'agentId' => null,
+        'highlightId' => null,
+        'page' => 0,
+        'percentage' => null
+      );
+
+      $license = new License($licenseId, "MIT", "MIT License", "text", "url", [],
+        null, false);
+      $licenseDecision = new LicenseDecision($licenseId, "MIT", "MIT License", 'text', "url", array($result),
+        '', '', false, [], null, false);
+
+      $licenseRef = new LicenseRef($licenseId, "MIT", "MIT LICENSE", "spx");
+      $clearingEvent = new ClearingEvent(1, $itemId, 12, $this->userId, $this->groupId, 4, new ClearingLicense($licenseRef, false, "", "", "", ""));
+      $licenseDecisionResult = new ClearingResult($clearingEvent, []);
+      $addedClearingResults[$licenseId] = $licenseDecisionResult;
+
+      $this->dbHelper->shouldReceive('doesIdExist')
+        ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+
+      $this->uploadDao->shouldReceive('getUploadtreeTableName')->withArgs([$uploadId])->andReturn("uploadtree");
+      $this->dbHelper->shouldReceive('doesIdExist')
+        ->withArgs(["uploadtree", "uploadtree_pk", $itemId])->andReturn(true);
+
+      $this->uploadDao->shouldReceive("getItemTreeBoundsFromUploadId")->withArgs([$itemId, $uploadId])->andReturn($itemTreeBounds);
+      $this->itemTreeBoundsMock->shouldReceive("containsFiles")->andReturn(false);
+      $this->clearingDao->shouldReceive('getMainLicenseIds')->andReturn([]);
+      $this->clearingEventTypes->shouldReceive('getTypeName')->withArgs([$clearingEvent->getEventType()])->andReturn($result['name']);
+      $this->highlightDao->shouldReceive('getHighlightRegion')->withArgs([1])->andReturn([""]);
+      $this->clearingDecisionEventProcessor->shouldReceive("getCurrentClearings")->withArgs([$itemTreeBounds, $this->groupId, LicenseMap::CONCLUSION])->andReturn([$addedClearingResults, []]);
+      $this->licenseDao->shouldReceive('getLicenseObligations')->withArgs([[$licenseId], false])->andReturn([]);
+      $this->licenseDao->shouldReceive('getLicenseObligations')->withArgs([[$licenseId], true])->andReturn([]);
+      $this->licenseDao->shouldReceive('getLicenseById')->withArgs([$licenseId])->andReturn($license);
+      $licenses[] = $licenseDecision->getArray();
+
+      $expectedResponse = (new ResponseHelper())->withJson($licenses, 200);
+      $actualResponse = $this->uploadTreeController->getLicenseDecisions(null, new ResponseHelper(), ['id' => $uploadId, 'itemId' => $itemId]);
       $this->assertEquals($expectedResponse->getStatusCode(), $actualResponse->getStatusCode());
       $this->assertEquals($this->getResponseJson($expectedResponse), $this->getResponseJson($actualResponse));
     }


### PR DESCRIPTION
## Description

Added the API to retrieve a list of license decisions for a particular item.

### Changes

1. Added a new method in  `UploadTreeController` to handle the logic.
2. Created the method in `UploadTreeController` for adding the new license on the selected item.
3. Updated  the main file(`index.php`) by adding a new route `GET` `/uploads/{id}/items/{itemId}/licenses`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a GET request on the endpoint: ``/uploads/{id}/items/{itemId}/licenses``,

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/606a35c2-6348-4c6b-9f34-84cc168985c3)

### Related Issue:
Fixes #2459 

    
cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2470"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

