### PR TITLE
feat(api): update clearing info (TEXT, ACK & COMMENT) for a license

### DIFF
--- a/src/www/ui/ajax-clearing-view.php
+++ b/src/www/ui/ajax-clearing-view.php
@@ -158,7 +158,7 @@ class AjaxClearingView extends FO_Plugin
    * @internal param $itemTreeBounds
    * @return string
    */
-  protected function doClearings($orderAscending, $groupId, $uploadId, $uploadTreeId)
+  public function doClearings($orderAscending, $groupId, $uploadId, $uploadTreeId)
   {
     $itemTreeBounds = $this->uploadDao->getItemTreeBoundsFromUploadId($uploadTreeId, $uploadId);
     $aaData = $this->getCurrentSelectedLicensesTableData($itemTreeBounds,

--- a/src/www/ui/api/Controllers/UploadTreeController.php
+++ b/src/www/ui/api/Controllers/UploadTreeController.php
@@ -1,0 +1,120 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Samuel Dushimimana <dushsam100@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Controller for uploadtree queries
+ */
+
+namespace Fossology\UI\Api\Controllers;
+
+use Fossology\Lib\Dao\ClearingDao;
+use Fossology\Lib\Dao\LicenseDao;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+
+/**
+ * @class UploadTreeController
+ * @brief Controller for UploadTree model
+ */
+class UploadTreeController extends RestController
+{
+  /**
+   * @var ContainerInterface $container
+   * Slim container
+   */
+  protected $container;
+
+  /** @var ClearingDao */
+  private $clearingDao;
+
+  /**
+   * @var LicenseDao $licenseDao
+   * License Dao object
+   */
+  private $licenseDao;
+
+  public function __construct($container)
+  {
+    parent::__construct($container);
+    $this->container = $container;
+    $this->clearingDao = $this->container->get('dao.clearing');
+    $this->licenseDao = $this->container->get('dao.license');
+  }
+
+  /**
+   * Set clearing info for a particular upload-tree
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function updateClearingInfo($request, $response, $args)
+  {
+    try {
+      $uploadTreeId = intval($args['itemId']);
+      $licenseId = intval($args['licenseId']);
+      $uploadPk = intval($args['id']);
+      $body = $this->getParsedBody($request);
+      $column = $body['column'];
+      $text = $body['text'];
+      $columnIdMap = [
+        'TEXT' => 'reportinfo',
+        'ACK' => 'acknowledgement',
+        'COMMENT' => 'comment',
+      ];
+
+      $returnVal = null;
+      $uploadDao = $this->restHelper->getUploadDao();
+
+      if (!$this->dbHelper->doesIdExist("upload", "upload_pk", $uploadPk)) {
+        $returnVal = new Info(404, "Upload does not exist", InfoType::ERROR);
+      } else if (!$this->dbHelper->doesIdExist($uploadDao->getUploadtreeTableName($uploadPk), "uploadtree_pk", $uploadTreeId)) {
+        $returnVal = new Info(404, "Item does not exist", InfoType::ERROR);
+      } else if (!isset($body['column'])) {
+        $returnVal =  new Info(400, "The property 'column' is required", InfoType::ERROR);
+      } else if (!array_key_exists($column, $columnIdMap)) {
+        $returnVal = new Info(400, "Invalid columnKey. Allowed values are 'TEXT', 'ACK', 'COMMENT'", InfoType::ERROR);
+      } else if (!$this->dbHelper->doesIdExist("license_ref", "rf_pk", $licenseId)) {
+        $returnVal = new Info(404, "License does not exist", InfoType::ERROR);
+      }
+
+      if ($returnVal !== null) {
+        return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+      }
+
+      $concludeLicensePlugin = $this->restHelper->getPlugin('conclude-license');
+
+      // Get the existing licenseIds and check if the given license is among them
+      $res = $concludeLicensePlugin->doClearings(true, $this->restHelper->getGroupId(), $uploadPk, $uploadTreeId);
+      $existingLicenseIds = array();
+
+      foreach ($res['aaData'] as $license) {
+        $currId = $license['DT_RowId'];
+        $currId = explode(',', $currId)[1];
+        $existingLicenseIds[] = intval($currId);
+      }
+
+      if (!in_array($licenseId, $existingLicenseIds)) {
+        $returnVal = new Info(404, "Given License does not exist on this item", InfoType::ERROR);
+        return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+      }
+
+      $this->clearingDao->updateClearingEvent($uploadTreeId, $this->restHelper->getUserId(), $this->restHelper->getGroupId(), $licenseId, $columnIdMap[$column], $text);
+      $returnVal = new Info(200, "Successfully updated " . ($column == "TEXT" ? "License text": ($column == "ACK" ? "Acknowledgement": "Comment")). ".", InfoType::INFO);
+      return $response->withJson($returnVal->getArray(), 200);
+    } catch (\Exception $e) {
+      $returnVal = new Info(500, $e->getMessage(), InfoType::ERROR);
+      return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+    }
+  }
+}

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -867,6 +867,68 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /uploads/{id}/items/{itemId}/licenses/{licenseId}/clearing-info:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+      - name: itemId
+        required: true
+        description: Id of the Item
+        in: path
+        schema:
+          type: integer
+      - name: licenseId
+        required: true
+        description: Id of the license
+        in: path
+        schema:
+          type: integer
+    put:
+      operationId: setClearingInfo
+      tags:
+        - Upload
+      summary: Set text, comment or the acknowledgement
+      description: >
+        Set text, comment or the acknowledgement for a license
+      requestBody:
+        description: ClearingInfo payload
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetClearingInfo'
+      responses:
+        '200':
+          description: Successfully updated the clearing info
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Invalid ColumnId
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Resource Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /search:
     get:
       operationId: searchFile
@@ -2455,6 +2517,18 @@ components:
         filename:
           type: string
           description: Filename of the treeItem
+    SetClearingInfo:
+      type: object
+      properties:
+        text:
+          type: string
+          description: Clearing info text
+        column:
+          type: string
+          enum:
+            - TEXT
+            - ACK
+            - COMMENT
     LicenseDecider:
       type: object
       properties:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -33,6 +33,7 @@ use Fossology\UI\Api\Controllers\MaintenanceController;
 use Fossology\UI\Api\Controllers\ReportController;
 use Fossology\UI\Api\Controllers\SearchController;
 use Fossology\UI\Api\Controllers\UploadController;
+use Fossology\UI\Api\Controllers\UploadTreeController;
 use Fossology\UI\Api\Controllers\UserController;
 use Fossology\UI\Api\Helper\ResponseFactoryHelper;
 use Fossology\UI\Api\Helper\ResponseHelper;
@@ -149,6 +150,7 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/licenses', UploadController::class . ':getUploadLicenses');
     $app->get('/{id:\\d+}/download', UploadController::class . ':uploadDownload');
     $app->get('/{id:\\d+}/copyrights', UploadController::class . ':getUploadCopyrights');
+    $app->put('/{id:\\d+}/items/{itemId:\\d+}/licenses/{licenseId:\\d+}/clearing-info', UploadTreeController::class . ':updateClearingInfo');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui_tests/api/Controllers/UploadTreeControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadTreeControllerTest.php
@@ -1,0 +1,265 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Samuel Dushimimana <dushsam100@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for UploadTreeController
+ */
+
+namespace Fossology\UI\Api\Test\Controllers;
+
+use AjaxClearingView;
+use ClearingView;
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\ClearingDao;
+use Fossology\Lib\Dao\LicenseDao;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Data\DecisionTypes;
+use Fossology\Lib\Data\UploadStatus;
+use Fossology\Lib\Db\DbManager;
+use Fossology\UI\Api\Controllers\UploadTreeController;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Fossology\UI\Api\Models\License;
+use Slim\Psr7\Factory\StreamFactory;
+use Mockery as M;
+use Slim\Psr7\Headers;
+use Slim\Psr7\Request;
+use Slim\Psr7\Uri;
+
+/**
+ * @class UploadControllerTest
+ * @brief Unit tests for UploadController
+ */
+class UploadTreeControllerTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @var DbHelper $dbHelper
+   * DbHelper mock
+   */
+  private $dbHelper;
+
+  /**
+   * @var DbManager $dbManager
+   * Dbmanager mock
+   */
+  private $dbManager;
+
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+
+  /**
+   * @var UploadTreeController $uploadTreeController
+   * UploadTreeController mock
+   */
+  private $uploadTreeController;
+
+  /**
+   * @var UploadDao $uploadDao
+   * UploadDao mock
+   */
+  private $uploadDao;
+
+  /**
+   * @var AjaxClearingView $clearingViewPlugin
+   * AjaxClearingView mock
+   */
+  private $clearingViewPlugin;
+
+  /**
+   * @var LicenseDao $licenseDao
+   * LicenseDao mock
+   */
+  private $licenseDao;
+
+  /**
+   * @var ClearingDao $clearingDao
+   * ClearingDao mock
+   */
+  private $clearingDao;
+
+  /**
+   * @var StreamFactory $streamFactory
+   * Stream factory to create body streams.
+   */
+  private $streamFactory;
+
+
+  /**
+   * @var DecisionTypes $decisionTypes
+   * Decision types object
+   */
+  private $decisionTypes;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp(): void
+  {
+    global $container;
+    $this->userId = 2;
+    $this->groupId = 2;
+    $container = M::mock('ContainerBuilder');
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->dbManager = M::mock(DbManager::class);
+    $this->restHelper = M::mock(RestHelper::class);
+    $this->uploadDao = M::mock(UploadDao::class);
+    $this->clearingDao = M::mock(ClearingDao::class);
+    $this->clearingViewPlugin = M::mock(AjaxClearingView::class);
+    $this->decisionTypes = M::mock(DecisionTypes::class);
+    $this->licenseDao = M::mock(LicenseDao::class);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+
+    $this->restHelper->shouldReceive('getPlugin')
+      ->withArgs(array('conclude-license'))->andReturn($this->clearingViewPlugin);
+
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs([M::any(), [$this->groupId, UploadStatus::OPEN,
+        Auth::PERM_READ]]);
+    $this->dbHelper->shouldReceive('getDbManager')->andReturn($this->dbManager);
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+    $this->restHelper->shouldReceive('getGroupId')->andReturn($this->groupId);
+    $this->restHelper->shouldReceive('getUserId')->andReturn($this->userId);
+    $this->restHelper->shouldReceive('getUploadDao')
+      ->andReturn($this->uploadDao);
+    $container->shouldReceive('get')->withArgs(['decision.types'])->andReturn($this->decisionTypes);
+    $container->shouldReceive('get')->withArgs(['dao.license'])->andReturn($this->licenseDao);
+    $container->shouldReceive('get')->withArgs(['dao.clearing'])->andReturn($this->clearingDao);
+    $this->uploadTreeController = new UploadTreeController($container);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+    $this->streamFactory = new StreamFactory();
+  }
+
+  /**
+   * Helper function to get JSON array from response
+   *
+   * @param Response $response
+   * @return array Decoded response
+   */
+  private function getResponseJson($response)
+  {
+    $response->getBody()->seek(0);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+
+
+  /**
+   * @test
+   * -# Test for UploadTreeController::updateClearingInfo()
+   * -# Check if response status is 200 and RES body matches
+   */
+  public function testUpdateClearingInfo()
+  {
+    $itemId = 200;
+    $uploadId = 1;
+    $licenseId = 123;
+    $column = "TEXT";
+    $text = "text";
+
+    $aaData = array(['DT_RowId' => "$itemId,$licenseId", 'DT_RowClass' => 'removed']);
+
+    $res = array(
+      'aaData' => $aaData,
+    );
+
+    $rq = [
+      "text" => $text,
+      "column" => $column,
+    ];
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+
+    $this->uploadDao->shouldReceive('getUploadtreeTableName')->withArgs([$uploadId])->andReturn("uploadtree");
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["uploadtree", "uploadtree_pk", $itemId])->andReturn(true);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["license_ref", "rf_pk", $licenseId])->andReturn(true);
+
+    $this->clearingViewPlugin->shouldReceive('doClearings')->withArgs([true, $this->groupId, $uploadId, $itemId])->andReturn($res);
+    $this->clearingDao->shouldReceive('updateClearingEvent')->withArgs([$itemId, $this->userId, $this->groupId, $licenseId, "reportinfo", $text])->andReturn(null);
+
+    $info = new Info(200, "Successfully updated License text.", InfoType::INFO);
+    $expectedResponse = (new ResponseHelper())->withJson($info->getArray(), $info->getCode());
+    $reqBody = $this->streamFactory->createStream(json_encode(
+      $rq
+    ));
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    $request = new Request("PUT", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $reqBody);
+    $actualResponse = $this->uploadTreeController->updateClearingInfo($request, new ResponseHelper(), ['id' => $uploadId, 'itemId' => $itemId, 'licenseId' => $licenseId]);
+
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for UploadTreeController::updateClearingInfo()
+   * -# Check if response status is 400 when Column Id is invalid
+   */
+  public function testUpdateClearingInfo_BadRequest()
+  {
+    $itemId = 200;
+    $uploadId = 1;
+    $licenseId = 123;
+    $column = "ANY";
+    $text = "text";
+
+    $aaData = array(['DT_RowId' => "$itemId,$licenseId", 'DT_RowClass' => 'removed']);
+
+    $res = array(
+      'aaData' => $aaData,
+    );
+
+    $rq = [
+      "text" => $text,
+      "column" => $column,
+    ];
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+
+    $this->uploadDao->shouldReceive('getUploadtreeTableName')->withArgs([$uploadId])->andReturn("uploadtree");
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["uploadtree", "uploadtree_pk", $itemId])->andReturn(true);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["license_ref", "rf_pk", $licenseId])->andReturn(true);
+
+    $this->clearingViewPlugin->shouldReceive('doClearings')->withArgs([true, $this->groupId, $uploadId, $itemId])->andReturn($res);
+    $this->clearingDao->shouldReceive('updateClearingEvent')->withArgs([$itemId, $this->userId, $this->groupId, $licenseId, "reportinfo", $text])->andReturn(null);
+
+    $info = new Info(400, "Invalid columnKey. Allowed values are 'TEXT', 'ACK', 'COMMENT'", InfoType::ERROR);
+    $expectedResponse = (new ResponseHelper())->withJson($info->getArray(), $info->getCode());
+    $reqBody = $this->streamFactory->createStream(json_encode(
+      $rq
+    ));
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    $request = new Request("PUT", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $reqBody);
+    $actualResponse = $this->uploadTreeController->updateClearingInfo($request, new ResponseHelper(), ['id' => $uploadId, 'itemId' => $itemId, 'licenseId' => $licenseId]);
+
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+}


### PR DESCRIPTION
## Description

Added the API to update the clearing info (LICENSE TEXT, ACKNOWLEDGMENT, OR COMMENT) for a specific license decision.

### Changes

1. Added a new method in  `UploadTreeController` to handle the logic.
2. Created the method in `UploadTreeController` for adding the new license on the selected item.
3. Updated  the main file(`index.php`) by adding a new route `PUT` `/uploads/{id}/items/{itemId}/licenses/{licenseId}/clearing-info`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a PUT request on the endpoint: `/uploads/{id}/items/{itemId}/licenses/{licenseId}/clearing-info`,

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/a18fb314-a13a-4f0b-aa56-85cb889bc285)

### Related Issue:
Fixes #2459 

    
cc: @shaheemazmalmmd @GMishx



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2471"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

