### PR TITLE
fix(scanoss): check json-c version for buster

### DIFF
--- a/src/scanoss/agent/main.c
+++ b/src/scanoss/agent/main.c
@@ -286,7 +286,11 @@ int main(int argc, char *argv[])
 
     struct json_object *result_json = json_object_from_file(outputFile);
     if (result_json == NULL) {
+#if JSON_C_MINOR_VERSION > 12
       LOG_ERROR("Unable to parse json output: %s", json_util_get_last_err());
+#else
+      LOG_ERROR("Unable to parse json output.");
+#endif
       return -1;
     }
     sprintf(Cmd, "rm -rf %s", tempFolder);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Check `json-c` version for new feature after version `0.12.1`.
Debian Buster has version `0.12.1` for `json-c`

### Changes

Add pragma check.

## How to test

Build and install on Debian Buster.

Check https://github.com/fossology/fossology/actions/runs/5267072368/jobs/9522109199#step:11:343

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2473"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

