### PR TITLE
feat(api): openapi.yaml exposed through API

### DIFF
--- a/src/www/ui/api/Controllers/InfoController.php
+++ b/src/www/ui/api/Controllers/InfoController.php
@@ -1,7 +1,7 @@
 <?php
 /*
  SPDX-FileCopyrightText: © 2019, 2021 Siemens AG
- Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ Author: Gaurav Mishra <mishra.gaurav@siemens.com>, Soham Banerjee <sohambanerjee4abc@hotmail.com>
 
  SPDX-License-Identifier: GPL-2.0-only
 */
@@ -117,5 +117,25 @@ class InfoController extends RestController
         "status" => $dbStatus
       ]
     ), $statusCode);
+  }
+
+  /**
+   * Get the current OpenAPI info
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @return ResponseHelper
+   */
+  public function getOpenApi($request, $response)
+  {
+    global $SysConf;
+    try {
+      $yaml = new Parser();
+      $yamlDocArray = $yaml->parse(file_get_contents(__DIR__ ."/../documentation/openapi.yaml"));
+    } catch (ParseException $exception) {
+      printf("Unable to parse the YAML string: %s", $exception->getMessage());
+      return $response->withStatus(500, "Unable to read openapi.yaml");
+    }
+    return $response->withJson(array($yamlDocArray), 200);
   }
 }

--- a/src/www/ui/api/Middlewares/RestAuthMiddleware.php
+++ b/src/www/ui/api/Middlewares/RestAuthMiddleware.php
@@ -14,10 +14,10 @@
 
 namespace Fossology\UI\Api\Middlewares;
 
-use Fossology\UI\Api\Models\Info;
-use Fossology\UI\Api\Models\InfoType;
 use Fossology\UI\Api\Helper\AuthHelper;
 use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
@@ -41,16 +41,23 @@ class RestAuthMiddleware
   {
     global $SysConf;
     $requestUri = $request->getUri();
+    $requestPath = strtolower($requestUri->getPath());
+    $authFreePaths = ["/version", "/info", "/openapi", "/health"];
+
+    $isPassThroughPath = false;
+    foreach ($authFreePaths as $authFreePath) {
+      if (strpos($requestPath, $authFreePath) !== false) {
+        $isPassThroughPath = true;
+        break;
+      }
+    }
+
     if (stristr($request->getMethod(), "options") !== false) {
       $response = $handler->handle($request);
-    } elseif (stristr($requestUri->getPath(), "/version") !== false) {
-      $response = $handler->handle($request);
-    } elseif (stristr($requestUri->getPath(), "/info") !== false) {
-      $response = $handler->handle($request);
-    } elseif (stristr($requestUri->getPath(), "/health") !== false) {
+    } elseif ($isPassThroughPath) {
       $response = $handler->handle($request);
     } elseif (stristr($requestUri->getPath(), "/tokens") !== false &&
-      stristr($request->getMethod(), "post") !== false) {
+        stristr($request->getMethod(), "post") !== false) {
       $response = $handler->handle($request);
     } else {
       /** @var AuthHelper $authHelper */

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -148,11 +148,20 @@ paths:
       security: []
       summary: Get the current openapi.yaml file
       description: >
-        Get the current API documentation as a API response
+        Get the current API documentation as a response with content negotiation.
       responses:
         '200':
           description: The API documentation
           content:
+            application/vnd.oai.openapi:
+              schema:
+                $ref: '#/components/schemas/APIinfo'
+            application/yaml:
+              schema:
+                $ref: '#/components/schemas/APIinfo'
+            application/vnd.oai.openapi+json:
+              schema:
+                $ref: '#/components/schemas/APIinfo'
             application/json:
               schema:
                 $ref: '#/components/schemas/APIinfo'
@@ -1514,7 +1523,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
             $ref: '#/components/responses/defaultResponse'
-  
+
   /jobs/{id}/{queue}:
     parameters:
       - name: id

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -3,7 +3,7 @@
 
 # SPDX-License-Identifier: GPL-2.0-only
 
-openapi: 3.0.2
+openapi: 3.0.3
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
@@ -138,6 +138,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiInfo'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /openapi:
+    get:
+      operationId: getOpenApi
+      tags:
+        - info
+      security: []
+      summary: Get the current openapi.yaml file
+      description: >
+        Get the current API documentation as a API response
+      responses:
+        '200':
+          description: The API documentation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIinfo'
         default:
           $ref: '#/components/responses/defaultResponse'
   /maintenance:
@@ -3415,6 +3433,28 @@ components:
               enum:
                 - OK
                 - ERROR
+    APIinfo:
+      description: Api Documentation
+      type: object
+      properties:
+        openapi:
+          type: string
+          description: version
+        info:
+          type: string
+          description: version info
+        servers:
+          type: string
+          description: server info
+        security:
+          type: string
+          description: security info
+        tags:
+          type: string
+          description: API tags
+        paths:
+          type: string
+          description: API endpoints
     DecisionImporter:
       description: Information required by Decision Importer agent
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -238,6 +238,10 @@ $app->group('/health',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->get('', InfoController::class . ':getHealth');
   });
+$app->group('/openapi',
+  function (\Slim\Routing\RouteCollectorProxy $app) {
+    $app->get('', InfoController::class . ':getOpenApi');
+  });
 
 /////////////////////////FILE SEARCH////////////////////
 $app->group('/filesearch',

--- a/src/www/ui_tests/api/Controllers/InfoControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/InfoControllerTest.php
@@ -139,4 +139,17 @@ class InfoControllerTest extends \PHPUnit\Framework\TestCase
     $this->assertEquals($this->getResponseJson($expectedResponse),
       $this->getResponseJson($actualResponse));
   }
+
+  public function testGetOpenApi()
+  {
+    $yaml = new Parser();
+    $yamlDocArray = $yaml->parseFile(self::YAML_LOC);
+    $expectedResponse = (new ResponseHelper())->withJson(array($yamlDocArray), 200);
+    $actualResponse = $this->infoController->getOpenApi(null,
+      new ResponseHelper(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This Pull request exposes the `openapi.yaml` file through the new `/openapi` endpoint.
### Changes
`src/www/ui/api/Controllers/InfoController.php`
`src/www/ui/api/index.php`


## How to test
use the `/openapi` endpoint in postman.

##Screenshots:
![Screenshot from 2023-06-14 21-37-19](https://github.com/fossology/fossology/assets/63705023/552719a2-0bcf-4b0d-b1fb-9c0f832c0396)

Closes #2452 




<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2474"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

