### PR TITLE
feat(api): Get clearing-history API for an item

### DIFF
--- a/src/lib/php/Data/DecisionTypes.php
+++ b/src/lib/php/Data/DecisionTypes.php
@@ -29,6 +29,17 @@ class DecisionTypes extends Types
     );
   }
 
+  public function getConstantNameFromKey($key)
+  {
+    return array(
+        self::TO_BE_DISCUSSED => "TO_BE_DISCUSSED",
+        self::IRRELEVANT => "IRRELEVANT",
+        self::IDENTIFIED => "IDENTIFIED",
+        self::DO_NOT_USE => "DO_NOT_USE",
+        self::NON_FUNCTIONAL => "NON_FUNCTIONAL"
+    )[$key];
+  }
+
   public function getExtendedMap()
   {
     $map = $this->map;

--- a/src/www/ui/api/Models/ClearingHistory.php
+++ b/src/www/ui/api/Models/ClearingHistory.php
@@ -1,0 +1,180 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Samuel Dushimimana <dushsam100@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * @file
+ * @brief Info model
+ */
+namespace Fossology\UI\Api\Models;
+
+/**
+ * @class Info
+ * @brief Info model to contain general error and return values
+ */
+class ClearingHistory
+{
+  /**
+   * @var string $date
+   * HTTP response code
+   */
+  private $date;
+    /**
+     * @var string $username
+     * Reponse message
+     */
+  private $username;
+    /**
+     * @var string $scope
+     * Response type
+     */
+  private $scope;
+    /**
+     * @var string $type
+     * Response type
+     */
+  private $type;
+
+  /**
+   * @var array $addedLicenses
+   * Response type
+   */
+  private $addedLicenses;
+  /**
+   * @var array $removedLicenses
+   * Response type
+   */
+  private $removedLicenses;
+
+  /**
+   * @param string $date
+   * @param string $username
+   * @param string $scope
+   * @param string $type
+   * @param array $addedLicenses
+   * @param array $removedLicenses
+   */
+  public function __construct($date, $username, $scope, $type, $addedLicenses, $removedLicenses)
+  {
+    $this->date = $date;
+    $this->username = $username;
+    $this->scope = $scope;
+    $this->type = $type;
+    $this->addedLicenses = $addedLicenses;
+    $this->removedLicenses = $removedLicenses;
+  }
+
+  ////// Getters /////
+  /**
+   * Get info as associative array
+   * @return array
+   */
+  public function getArray()
+  {
+    return [
+      'date' => $this->date,
+      'username' => $this->username,
+      'scope' => $this->scope,
+      'type' => $this->type,
+      'addedLicenses' => $this->addedLicenses,
+      'removedLicenses' => $this->removedLicenses
+    ];
+  }
+
+  /**
+   * @return string
+   */
+  public function getDate()
+  {
+    return $this->date;
+  }
+
+  /**
+   * @param string $date
+   */
+  public function setDate(string $date)
+  {
+    $this->date = $date;
+  }
+
+  /**
+   * @return string
+   */
+  public function getUsername()
+  {
+    return $this->username;
+  }
+
+  /**
+   * @param string $username
+   */
+  public function setUsername(string $username)
+  {
+    $this->username = $username;
+  }
+
+  /**
+   * @return string
+   */
+  public function getScope()
+  {
+    return $this->scope;
+  }
+
+  /**
+   * @param string $scope
+   */
+  public function setScope($scope)
+  {
+    $this->scope = $scope;
+  }
+
+  /**
+   * @return string
+   */
+  public function getType()
+  {
+    return $this->type;
+  }
+
+  /**
+   * @param string $type
+   */
+  public function setType($type)
+  {
+    $this->type = $type;
+  }
+
+  /**
+   * @return array
+   */
+  public function getAddedLicenses()
+  {
+    return $this->addedLicenses;
+  }
+
+  /**
+   * @param array $addedLicenses
+   */
+  public function setAddedLicenses($addedLicenses)
+  {
+    $this->addedLicenses = $addedLicenses;
+  }
+
+  /**
+   * @return array
+   */
+  public function getRemovedLicenses()
+  {
+    return $this->removedLicenses;
+  }
+
+  /**
+   * @param array $removedLicenses
+   */
+  public function setRemovedLicenses(array $removedLicenses)
+  {
+    $this->removedLicenses = $removedLicenses;
+  }
+}

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1244,6 +1244,50 @@ paths:
           $ref: '#/components/responses/defaultResponse'
 
 
+  /uploads/{id}/item/{itemId}/clearing-history:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+      - name: itemId
+        required: true
+        description: Id of the itemId
+        in: path
+        schema:
+          type: integer
+    get:
+      operationId: getClearingHistory
+      tags:
+        - Upload
+      summary: Get the clearing history
+      description: >
+        Get the clearing history for a specific upload item
+      responses:
+        '200':
+          description: List of the data about clearing history
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetClearingHistory'
+        '404':
+          description: Resource Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+
   /search:
     get:
       operationId: searchFile
@@ -3725,7 +3769,7 @@ components:
           type: integer
           example:
             3
-            
+                       
     GetBulkHistory:
       type: object
       properties:
@@ -3758,6 +3802,47 @@ components:
         removedLicenses:
           type: array
           description: List of license shortnames removed from the scan
+          items:
+            type: string
+            example: "GPL-2.0"
+
+    GetClearingHistory:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date
+          description: Date of the clearing history
+          example: "2023-06-15"
+        username:
+          type: string
+          description: Username of the user who created the decision.
+          example: "fossy"
+        scope:
+          type: string
+          description: Scope of the clearing
+          enum:
+            - local
+            - package
+            - global
+        type:
+          type: string
+          description: Type of the clearing
+          enum:
+            - TO_BE_DISCUSSED
+            - IRRELEVANT
+            - IDENTIFIED
+            - DO_NOT_USE
+            - NON_FUNCTIONAL
+        addedLicenses:
+          type: array
+          description: List of license shortnames added to the decision
+          items:
+            type: string
+            example: "MIT"
+        removedLicenses:
+          type: array
+          description: List of license shortnames removed from the decision
           items:
             type: string
             example: "GPL-2.0"

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -161,6 +161,7 @@ $app->group('/uploads',
     $app->put('/{id:\\d+}/item/{itemId:\\d+}/copyrights/{hash:.*}', CopyrightController::class . ':updateFileCopyrights');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/prev-next', UploadTreeController::class . ':getNextPreviousItem');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/bulk-history', UploadTreeController::class . ':getBulkHistory');
+    $app->get('/{id:\\d+}/item/{itemId:\\d+}/clearing-history', UploadTreeController::class . ':getClearingHistory');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 


### PR DESCRIPTION
## Description

Added the API to a get a list of the clearing history for a particular item.

### Changes

1. Added a new method in  `UploadTreeController` to handle the logic.
2. Created the method in `UploadTreeController` for retrieve the list of the data.
3. Updated  the main file(`index.php`) by adding a new route `GET` `/uploads/{id}/items/{itemId}/clearing-history`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a GET request on the endpoint: `GET` `/uploads/{id}/items/{itemId}/clearing-history`.,

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/36765d84-1c4e-4d2d-ac2f-4a629677acc3)

### Related Issue:
Fixes [#2472](https://github.com/fossology/fossology/issues/2472)

    
cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2477"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

