### PR TITLE
feat(api): API to handle three filters to get prev & next item

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1142,6 +1142,59 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+          
+  /uploads/{id}/item/{itemId}/prev-next:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+      - name: itemId
+        required: true
+        description: Id of the itemId
+        in: path
+        schema:
+          type: integer
+      - name: selection
+        required: false
+        schema:
+          type: string
+          enum:
+            - withLicenses
+            - noClearing
+        in: query
+        description: Return jobs for the given upload id only
+    get:
+      operationId: getPreviousAndNextItem
+      tags:
+        - Upload
+      summary: Get previous and next item for an upload
+      description: >
+        Get the index of the previous and the next time for an upload
+      responses:
+        '200':
+          description: List of the data about clearing history
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPrevNextItem'
+        '404':
+          description: Resource Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /search:
     get:
       operationId: searchFile
@@ -3605,6 +3658,19 @@ components:
           type: string
           example:
             "Main group"
+    GetPrevNextItem:
+      type: object
+      properties:
+        prevItemId:
+          description: Previous item Id
+          type: integer
+          example:
+            1
+        nextItemId:
+          description: Next item Id
+          type: integer
+          example:
+            3
     UserGroupMember:
       type: object
       properties:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -159,6 +159,7 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/copyrights', CopyrightController::class . ':getFileCopyrights');
     $app->delete('/{id:\\d+}/item/{itemId:\\d+}/copyrights/{hash:.*}', CopyrightController::class . ':deleteFileCopyrights');
     $app->put('/{id:\\d+}/item/{itemId:\\d+}/copyrights/{hash:.*}', CopyrightController::class . ':updateFileCopyrights');
+    $app->get('/{id:\\d+}/item/{itemId:\\d+}/prev-next', UploadTreeController::class . ':getNextPreviousItem');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 


### PR DESCRIPTION
## Description

Added the API to get the what should be the next and the previous item, given the current Item Id.

### Changes

1. Added a new method in  `UploadTreeController` to handle the logic.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/uploads/{id}/items/{itemId}/prev-next`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a GET request on the endpoint: `GET`  `/uploads/{id}/items/{itemId}/prev-next`.

## Screenshots

### 1. Without any filter

![image](https://github.com/fossology/fossology/assets/66276301/c72d2f9a-809f-4da1-a8d6-5365bd971e12)

### 2. WithLicenses filter

![image](https://github.com/fossology/fossology/assets/66276301/7588914c-a938-4e0f-b299-d3b5cc5c0cba)

### 3. noClearing Filter

![image](https://github.com/fossology/fossology/assets/66276301/5ca9416a-1358-402f-af9d-110e4a6c06ff)


### Related Issue:
Fixes [#2472](https://github.com/fossology/fossology/issues/2472)

    
cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2480"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

