### PR TITLE
feat(api): Get list of bulk-history API

### DIFF
--- a/src/www/ui/api/Models/BulkHistory.php
+++ b/src/www/ui/api/Models/BulkHistory.php
@@ -1,0 +1,154 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Samuel Dushimimana <dushsam100@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * @file
+ * @brief BulkHistory model
+ */
+namespace Fossology\UI\Api\Models;
+
+class BulkHistory
+{
+
+  /**
+   * @var int $bulkId ID of the Bulk
+   */
+  private $bulkId;
+
+  /**
+   * @var int $clearingEventId ID of the associated clearing event
+   */
+  private $clearingEventId;
+
+  /**
+   * @var string $text Scan reference text
+   */
+  private $text;
+
+  /**
+   * @var boolean $matched Whether matched or not
+   */
+  private $matched;
+
+  /**
+   * @var boolean $tried Whether tried or not
+   */
+  private $tried;
+
+  /**
+   * @var array $addedLicenses Added licenses
+   */
+  private $addedLicenses;
+
+  /**
+   * @var array $removedLicenses Removed licenses
+   */
+  private $removedLicenses;
+
+  /**
+   * BulkHistory constructor.
+   *
+   * @param int $bulkId
+   * @param int $clearingEventId
+   * @param string $text
+   * @param boolean $matched
+   * @param boolean $tried
+   * @param array $addedLicenses
+   * @param array $removedLicenses
+   */
+  public function __construct($bulkId, $clearingEventId, $text, $matched, $tried, $addedLicenses, $removedLicenses)
+  {
+    $this->bulkId = intval($bulkId);
+    $this->clearingEventId = intval($clearingEventId);
+    $this->text = $text;
+    $this->matched = $matched;
+    $this->tried = $tried;
+    $this->addedLicenses = $addedLicenses;
+    $this->removedLicenses = $removedLicenses;
+  }
+
+  public function getBulkId()
+  {
+    return $this->bulkId;
+  }
+
+  public function getClearingEventId()
+  {
+    return $this->clearingEventId;
+  }
+
+  public function getText()
+  {
+    return $this->text;
+  }
+
+  public function getMatched()
+  {
+    return $this->matched;
+  }
+
+  public function getTried()
+  {
+    return $this->tried;
+  }
+
+  public function getAddedLicenses()
+  {
+    return $this->addedLicenses;
+  }
+
+  public function getRemovedLicenses()
+  {
+    return $this->removedLicenses;
+  }
+
+  public function setBulkId($bulkId)
+  {
+    $this->bulkId = $bulkId;
+  }
+
+  public function setClearingEventId($clearingEventId)
+  {
+    $this->clearingEventId = $clearingEventId;
+  }
+
+  public function setText($text)
+  {
+    $this->text = $text;
+  }
+
+  public function setMatched($matched)
+  {
+    $this->matched = $matched;
+  }
+
+  public function setTried($tried)
+  {
+    $this->tried = $tried;
+  }
+
+  public function setAddedLicenses($addedLicenses)
+  {
+    $this->addedLicenses = $addedLicenses;
+  }
+
+  public function setRemovedLicenses($removedLicenses)
+  {
+    $this->removedLicenses = $removedLicenses;
+  }
+
+  public function getArray()
+  {
+    return [
+      "bulkId" => $this->bulkId,
+      "clearingEventId" => $this->clearingEventId,
+      "text" => $this->text,
+      "matched" => $this->matched,
+      "tried" => $this->tried,
+      "addedLicenses" => $this->addedLicenses,
+      "removedLicenses" => $this->removedLicenses
+    ];
+  }
+}

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1021,6 +1021,52 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+  
+  /uploads/{id}/item/{itemId}/bulk-history:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+      - name: itemId
+        required: true
+        description: Id of the itemId
+        in: path
+        schema:
+          type: integer
+    get:
+      operationId: getBulkHistory
+      tags:
+        - Upload
+      summary: Get the bulk history
+      description: >
+        Get the bulk history for a specific upload item
+      responses:
+        '200':
+          description: List of the data about the bulk history
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GetBulkHistory'
+        '404':
+          description: Resource Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
 
   /uploads/{id}/licenses/main:
     parameters:
@@ -1196,6 +1242,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+
 
   /search:
     get:
@@ -3678,6 +3725,42 @@ components:
           type: integer
           example:
             3
+            
+    GetBulkHistory:
+      type: object
+      properties:
+        bulkId:
+          type: integer
+          description: The bulk id
+          example: 1
+        clearingEventId:
+          type: integer
+          description: The event id associated with the bulk
+          example: 1
+        text:
+          type: string
+          description: Scan reference text
+          example: "Licensed under MIT"
+        matched:
+          type: boolean
+          description: Whether matched or not
+          example: false
+        tried:
+          type: boolean
+          description: Whether tried or not
+          example: true
+        addedLicenses:
+          type: array
+          description: List of license shortnames added to the scan
+          items:
+            type: string
+            example: "MIT"
+        removedLicenses:
+          type: array
+          description: List of license shortnames removed from the scan
+          items:
+            type: string
+            example: "GPL-2.0"
     UserGroupMember:
       type: object
       properties:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -160,6 +160,7 @@ $app->group('/uploads',
     $app->delete('/{id:\\d+}/item/{itemId:\\d+}/copyrights/{hash:.*}', CopyrightController::class . ':deleteFileCopyrights');
     $app->put('/{id:\\d+}/item/{itemId:\\d+}/copyrights/{hash:.*}', CopyrightController::class . ':updateFileCopyrights');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/prev-next', UploadTreeController::class . ':getNextPreviousItem');
+    $app->get('/{id:\\d+}/item/{itemId:\\d+}/bulk-history', UploadTreeController::class . ':getBulkHistory');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 


### PR DESCRIPTION
## Description

Added the API to a get a list of the bulk history for a particular item.

### Changes

1. Added a new method in  `UploadTreeController` to handle the logic.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/uploads/{id}/items/{itemId}/bulk-history`.
3. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a GET request on the endpoint: `GET` `/uploads/{id}/items/{itemId}/bulk-history`.,

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/8400e18b-4e59-4ee8-ac8e-5733f28365f2)

### Related Issue:
Fixes [#2472](https://github.com/fossology/fossology/issues/2472)

cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2481"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

