### PR TITLE
feat(api): REST API to schedule the bulk-scan

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1137,7 +1137,57 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-  
+
+  /uploads/{id}/item/{itemId}/bulk-scan:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+      - name: itemId
+        required: true
+        description: Id of the itemId
+        in: path
+        schema:
+          type: integer
+    post:
+      operationId: scheduleBulkScan
+      tags:
+        - Upload
+      summary: Schedule the bulk scan for the item
+      description: >
+        Schedule the bulk scan for the item
+      requestBody:
+        description: ClearingInfo payload
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScheduleBulkScan'
+      responses:
+        '200':
+          description: Bulk scan scheduled successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Resource Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /uploads/{id}/item/{itemId}/bulk-history:
     parameters:
       - name: id
@@ -5155,6 +5205,48 @@ components:
           description: Date from which to remove older log files from repository.
           nullable: true
           example: "2022-07-16"
+    ScheduleBulkScan:
+      type: object
+      properties:
+        bulkActions:
+          type: array
+          items:
+            type: object
+            properties:
+              licenseShortName:
+                type: string
+                example: MIT
+              licenseText:
+                type: string
+                example: "License text"
+              acknowledgement:
+                type: string
+                example: "Acknowledgement text"
+              comment:
+                type: string
+                example: "Comment text"
+              licenseAction:
+                type: string
+                enum:
+                  - ADD
+                  - REMOVE
+        refText:
+          type: string
+          example: "reference text"
+        bulkScope:
+          type: string
+          enum:
+            - folder
+            - upload
+        forceDecision:
+          type: boolean
+          example: false
+        ignoreIrre:
+          type: boolean
+          example: false
+        delimiters:
+          type: string
+          example: "DEFAULT"
     ScannedEditedLicense:
       type: object
       properties:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -179,6 +179,7 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/totalcopyrights', CopyrightController::class . ':getTotalFileCopyrights');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/tree/view', UploadTreeController::class . ':getTreeView');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/info', FileInfoController::class . ':getItemInfo');
+    $app->post('/{id:\\d+}/item/{itemId:\\d+}/bulk-scan', UploadTreeController::class . ':scheduleBulkScan');
     $app->get('/{id:\\d+}/conf', ConfController::class . ':getConfInfo');
     $app->any('/{params:.*}', BadRequestController::class);
   });

--- a/src/www/ui/change-license-bulk.php
+++ b/src/www/ui/change-license-bulk.php
@@ -40,7 +40,7 @@ class ChangeLicenseBulk extends DefaultPlugin
    * @param Request $request
    * @return Response
    */
-  protected function handle(Request $request)
+  public function handle(Request $request)
   {
     $uploadTreeId = intval($request->get('uploadTreeId'));
     if ($uploadTreeId <= 0) {


### PR DESCRIPTION
## Description

Added the API to schedule the bulk scan for an item, given relevant information in the request body.

### Changes

1. Added a new method in  `UploadTreeController` to handle the logic.
2. Updated  the main file(`index.php`) by adding a new route `POST` `/uploads/{id}/items/{itemId}/bulk-scan`.
3. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a POST request on the endpoint:  `/uploads/{id}/items/{itemId}/bulk-scan`.
This endpoint is expected to return the jobId which corresponds to this bulk scan.

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/d99715c1-ce41-4742-99fd-d876e47b2d3d)

### Related Issue:
Fixes [#2472](https://github.com/fossology/fossology/issues/2472)

cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2483"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

