### PR TITLE
feat(api): REST API to get keywords and highlight-entries from content

### DIFF
--- a/src/lib/php/Data/Highlight.php
+++ b/src/lib/php/Data/Highlight.php
@@ -195,6 +195,23 @@ class Highlight
     return $this->htmlElement;
   }
 
+  /**
+   * Get Highlight element as associative array
+   * @return array
+   */
+  public function getArray()
+  {
+    return array(
+      "start" => $this->start,
+      "end" => $this->end,
+      "type" => $this->type,
+      "licenseId" => $this->licenseId,
+      "refStart" => $this->refStart,
+      "refEnd" => $this->refEnd,
+      "infoText" => $this->infoText,
+      "htmlElement" => $this->htmlElement
+    );
+  }
 
   public function __toString()
   {

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -925,7 +925,81 @@ paths:
                   $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-
+  /uploads/{id}/item/{itemId}/highlight:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+      - name: itemId
+        required: true
+        description: Id of the item
+        in: path
+        schema:
+          type: integer
+      - name: clearingId
+        required: false
+        description: Id of the clearing event
+        in: query
+        schema:
+          type: integer
+      - name: licenseId
+        required: false
+        description: Id of the license
+        in: query
+        schema:
+          type: integer
+      - name: highlightId
+        required: false
+        description: Id of the highlight
+        in: query
+        schema:
+          type: integer
+      - name: agentId
+        required: false
+        description: Id of the agent
+        in: query
+        schema:
+          type: integer
+    get:
+      operationId: getHighlightEntries
+      tags:
+        - Upload
+      summary: Get highlight entries of the content.
+      description: >
+        Get highlight entries of the content for the given upload and item id.
+      responses:
+        '200':
+          description: List of the data about highlight entries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HighlightInfo'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Resource Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+          
   /uploads/{id}/item/{itemId}/view:
     parameters:
       - name: id
@@ -3846,6 +3920,55 @@ components:
           items:
             type: string
             example: "GPL-2.0"
+            
+    HighlightInfo:
+      type: object
+      properties:
+        start:
+          type: integer
+          description: Start position of the highlight in file
+          example: 68
+        end:
+          type: integer
+          description: End position of the highlight in file
+          example: 70
+        type:
+          type: string
+          description: Type of highlight
+          enum:
+            - M | Match
+            - MC | Changed
+            - MA | Added
+            - MD | Deleted
+            - S | Signature
+            - K | Keyword
+            - B | Bulk
+            - C | Copyright
+            - U | Url
+            - E | Email
+            - A | Author
+            - I | IPRA
+            - X | ECC
+            - KW | Keyword others
+            - any | Undefined
+        shortName:
+          type: string
+          description: License shortname
+          example: MIT
+        refStart:
+          type: integer
+          description: Start of monk diff highlight (relative)
+          example: 0
+        refEnd:
+          type: integer
+          description: End of monk diff highlight (relative)
+          example: 53
+        infoText:
+          type: string
+          description: Tooltip text
+          example: "MIT: 'MIT License\n\nCopyright (c) <year> <copyright holders>'"
+        htmlElement:
+          type: string
     UserGroupMember:
       type: object
       properties:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -162,6 +162,7 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/prev-next', UploadTreeController::class . ':getNextPreviousItem');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/bulk-history', UploadTreeController::class . ':getBulkHistory');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/clearing-history', UploadTreeController::class . ':getClearingHistory');
+    $app->get('/{id:\\d+}/item/{itemId:\\d+}/highlight', UploadTreeController::class . ':getHighlightEntries');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui/ui-clearing-view.php
+++ b/src/www/ui/ui-clearing-view.php
@@ -98,7 +98,7 @@ class ClearingView extends FO_Plugin
    * @param int $uploadId
    * @return Highlight[]
    */
-  private function getSelectedHighlighting(ItemTreeBounds $itemTreeBounds, $licenseId, $selectedAgentId, $highlightId, $clearingId, $uploadId)
+  public function getSelectedHighlighting(ItemTreeBounds $itemTreeBounds, $licenseId, $selectedAgentId, $highlightId, $clearingId, $uploadId)
   {
     $unmaskAgents = $selectedAgentId;
     if (empty($selectedAgentId)) {


### PR DESCRIPTION
## Description

Added the API to get the index of the keywords and the highlight-entries from the given file's content.

### Changes

1. Added a new method in  `UploadController` to handle the logic.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/uploads/{id}/item/{itemId}/highlight`.
3. Updated the `openapi.yaml` file  to introduce a new API.

## How to test

Make a GET request on the endpoint: `/uploads/{id}/item/{itemId}/highlight`

## Screenshots
![image](https://github.com/fossology/fossology/assets/66276301/48b73325-764f-4e05-b917-afb2d9444fd2)

### Related Issue:
Fixes [#2459](https://github.com/fossology/fossology/issues/2459)


cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2484"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

