### PR TITLE
feat(api): get inactive copyright details for a file

### DIFF
--- a/src/copyright/ui/ajax-copyright-hist.php
+++ b/src/copyright/ui/ajax-copyright-hist.php
@@ -226,7 +226,7 @@ class CopyrightHistogramProcessPost extends FO_Plugin
    * @param boolean $activated           True to get activated copyrights, else false
    * @return array[][] Array of table records, filtered records, total records
    */
-  protected function getCopyrights($upload_pk, $item, $uploadTreeTableName, $agentId, $type, $filter, $activated = true)
+  public function getCopyrights($upload_pk, $item, $uploadTreeTableName, $agentId, $type, $filter, $activated = true)
   {
     $offset = GetParm('iDisplayStart', PARM_INTEGER);
     $limit = GetParm('iDisplayLength', PARM_INTEGER);
@@ -365,6 +365,17 @@ count(*) AS copyright_count " .
     $orderString = $this->dataTablesUtility->getSortingString($_GET, $columnNamesInDatabase, $defaultOrder);
 
     return $orderString;
+  }
+
+  /**
+   * @brief Get Agent ID for an upload
+   * @param integer $upload_pk Upload ID
+   * @param string $copyrightType Copyright Type
+   * @return integer Agent ID
+   */
+  public function getAgentId($upload_pk,$copyrightType)
+  {
+    return (LatestAgentpk($upload_pk, $copyrightType));
   }
 
   /**

--- a/src/www/ui/api/Controllers/CopyrightController.php
+++ b/src/www/ui/api/Controllers/CopyrightController.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ Author: Soham Banerjee <sohambanerjee4abc@hotmail.com>
+ SPDX-FileCopyrightText: © 2023 Soham Banerjee <sohambanerjee4abc@hotmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Controller for copyright queries
+ */
+
+namespace Fossology\UI\Api\Controllers;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Db\DbManager;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Psr\Http\Message\ServerRequestInterface;
+
+
+class CopyrightController extends RestController
+{
+  /**
+   * @var ContainerInterface $container
+   * Slim container
+   */
+  protected $container;
+
+  /**
+   * @var copyrightHist $copyrightHist
+   * Copyright Histogram object
+   */
+  private $copyrightHist;
+
+  public function __construct($container)
+  {
+    parent::__construct($container);
+    $this->restHelper = $container->get('helper.restHelper');
+    $this->copyrightHist = $this->restHelper->getPlugin('ajax-copyright-hist');
+  }
+
+  /**
+   * Get inactive copyrights for a particular upload-tree
+   *
+   * @param  ServerRequestInterface $request
+   * @param  ResponseHelper         $response
+   * @param  array                  $args
+   * @return ResponseHelper
+   */
+  public function getInactiveFileCopyrights($request, $response, $args)
+  {
+    $uploadPk = $args["id"];
+    $uploadTreeId = $args["itemId"];
+    $returnVal = null;
+    try {
+      if (!$this->dbHelper->doesIdExist("upload", "upload_pk", $uploadPk)) {
+        $returnVal = new Info(404, "Upload does not exist", InfoType::ERROR);
+      } else if (!$this->dbHelper->doesIdExist($this->restHelper->getUploadDao()->getuploadTreeTableName($uploadPk), "uploadtree_pk", $uploadTreeId)) {
+        $returnVal = new Info(404, "Item does not exist", InfoType::ERROR);
+      }
+      if ($returnVal !== null) {
+        return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+      }
+      $agentId = $this->copyrightHist->getAgentId($uploadPk, 'copyright_ars');
+      $uploadTreeTableName = $this->restHelper->getUploadDao()->getuploadTreeTableName($uploadPk);
+      $returnVal = $this->copyrightHist->getCopyrights($uploadPk, $uploadTreeId, $uploadTreeTableName, $agentId, 'statement', 'inactive', false);
+      return $response->withJson($returnVal, 200);
+    } catch (\Exception $e) {
+      $returnVal = new Info(500, $e->getMessage(), InfoType::ERROR);
+      return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+    }
+  }
+}

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -3,11 +3,11 @@
 
 # SPDX-License-Identifier: GPL-2.0-only
 
-openapi: 3.0.2
+openapi: 3.0.3
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.5.1
+  version: 1.5.2
   contact:
     email: fossology@fossology.org
   license:
@@ -138,6 +138,33 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiInfo'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /openapi:
+    get:
+      operationId: getOpenApi
+      tags:
+        - info
+      security: []
+      summary: Get the current openapi.yaml file
+      description: >
+        Get the current API documentation as a response with content negotiation.
+      responses:
+        '200':
+          description: The API documentation
+          content:
+            application/vnd.oai.openapi:
+              schema:
+                $ref: '#/components/schemas/APIinfo'
+            application/yaml:
+              schema:
+                $ref: '#/components/schemas/APIinfo'
+            application/vnd.oai.openapi+json:
+              schema:
+                $ref: '#/components/schemas/APIinfo'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIinfo'
         default:
           $ref: '#/components/responses/defaultResponse'
   /maintenance:
@@ -654,6 +681,23 @@ paths:
         schema:
           type: boolean
           default: false
+      - name: page
+        description: Page number (starts from 1)
+        required: false
+        in: header
+        schema:
+          type: integer
+          default: 1
+          minimum: 1
+      - name: limit
+        description: Limits of responses per request
+        required: false
+        in: header
+        schema:
+          type: integer
+          default: 50
+          minimum: 1
+          maximum: 1000
       - name: groupName
         description: The group name to chose while accessing the package
         in: header
@@ -671,10 +715,23 @@ paths:
       responses:
         '200':
           description: Get licenses
+          headers:
+            X-Total-Pages:
+              description: Total number of pages which can be generated based on limit
+              schema:
+                type: integer
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/UploadLicenses'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Info'
         '503':
           description: >
             The ununpack agent or queried agents have not started yet. Please
@@ -864,6 +921,139 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /uploads/{id}/item/{itemId}/view:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+      - name: itemId
+        required: true
+        description: Id of the item
+        in: path
+        schema:
+          type: integer
+    get:
+      operationId: viewTheContentOfTheFile
+      tags:
+        - Upload
+        - License
+      summary: Get the contents of the file
+      description:
+        Returns the contents of a specific file
+      responses:
+        '200':
+          description: Get contents
+          content:
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: Upload or Item does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal Server Error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'  
+  
+  /uploads/{id}/item/{itemId}/clearing-decision:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+      - name: itemId
+        required: true
+        description: Id of the itemId
+        in: path
+        schema:
+          type: integer
+    put:
+      operationId: setClearingDecision
+      tags:
+        - Upload
+      summary: Set the clearing decision for a particular upload tree item.
+      description: >
+        Set the clearing decision for a particular upload tree item.
+      requestBody:
+        description: ClearingDecision payload
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClearingDecision'
+      responses:
+        '200':
+          description: Clearing decision set successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Invalid clearingDecision type or invalid set globalDecision value
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /uploads/{id}/licenses/main:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+    get:
+      operationId: getMainLicenses
+      tags:
+        - Upload
+      summary: Get main licenses on the upload
+      description: >
+        Get main licenses assigned on a particular upload
+      responses:
+        '200':
+          description: All main licenses from an upload
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/License'
+        '404':
+          description: Upload not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
 
@@ -1456,6 +1646,54 @@ paths:
               schema:
                 $ref: '#/components/schemas/Info'
         default:
+            $ref: '#/components/responses/defaultResponse'
+
+  /jobs/{id}/{queue}:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the Job
+        in: path
+        schema:
+          type: integer
+      - name: queue
+        required: true
+        description: Id of the job queue to be deleted
+        in: path
+        schema:
+          type: integer
+    delete:
+      operationId: deleteJob
+      tags:
+        - Job
+      summary: Deletes a job using its Id and Queue
+      description: Deletes a job queue and all the other job queues depending on it
+      responses:
+        '200':
+          description: Job deleted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: You don't have permission to delete this job.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Job/JobQueue not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Failed to kill job.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
           $ref: '#/components/responses/defaultResponse'
 
   /folders:
@@ -1634,6 +1872,56 @@ paths:
       responses:
         '202':
           description: Folder will be copied/moved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /uploads/{id}/items/{itemId}/copyrights:
+    parameters:
+      - name: id
+        required: true
+        description: Upload Id
+        in: path
+        schema:
+          type: integer
+      - name: ItemId
+        required: true
+        description: Upload Tree ID
+        in: path
+        schema:
+          type: integer
+    get:
+      operationId: getInactiveFileCopyrights
+      tags:
+        - Copyrights
+      summary: Get the inactive copyrights of the mentioned upload tree ID
+      description: Returns the list of inactive copyrights associated with the file
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GetFileCopyrights'
+        '400':
+          description: "Bad Request. 'upload' is a required query param"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Upload is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Upload does not exist
           content:
             application/json:
               schema:
@@ -2959,6 +3247,19 @@ components:
         uploadId:
           type: integer
           description: Upload ID to which the job belongs to.
+    GetFileCopyrights:
+      description: Copyright details of a file
+      type: object
+      properties:
+        content:
+          type: string
+          description: Copyright content
+        hash:
+          type: string
+          description: copyright hash
+        copyright_count:
+          type: integer
+          description: count of the copyrights
     UrlUpload:
       description: To create an upload from a URL
       type: object
@@ -3286,6 +3587,27 @@ components:
             2: Advisor
           minimum: 0
           maximum: 2
+    ClearingDecision:
+      description: Clearing decision information
+      type: object
+      properties:
+        decisionType:
+          type: integer
+          description: |
+            Type of decision.
+            0: WIP
+            3: To be discussed
+            4: Irrelevant
+            5: Identified
+            6: Do not use
+            7: Non functional
+          example: 3
+          enum: [0, 3, 4, 5, 6, 7]
+        globalDecision:
+          type: boolean
+          description: |
+            Is the decision global?
+            If true, the decision is applied to all occurrence of the file on the server!
     AddMember:
       description: UserMember options
       type: object
@@ -3328,6 +3650,28 @@ components:
               enum:
                 - OK
                 - ERROR
+    APIinfo:
+      description: Api Documentation
+      type: object
+      properties:
+        openapi:
+          type: string
+          description: version
+        info:
+          type: string
+          description: version info
+        servers:
+          type: string
+          description: server info
+        security:
+          type: string
+          description: security info
+        tags:
+          type: string
+          description: API tags
+        paths:
+          type: string
+          description: API endpoints
     DecisionImporter:
       description: Information required by Decision Importer agent
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -28,11 +28,13 @@ use Fossology\UI\Api\Controllers\FolderController;
 use Fossology\UI\Api\Controllers\GroupController;
 use Fossology\UI\Api\Controllers\InfoController;
 use Fossology\UI\Api\Controllers\JobController;
+use Fossology\UI\Api\Controllers\CopyrightController;
 use Fossology\UI\Api\Controllers\LicenseController;
 use Fossology\UI\Api\Controllers\MaintenanceController;
 use Fossology\UI\Api\Controllers\ReportController;
 use Fossology\UI\Api\Controllers\SearchController;
 use Fossology\UI\Api\Controllers\UploadController;
+use Fossology\UI\Api\Controllers\UploadTreeController;
 use Fossology\UI\Api\Controllers\UserController;
 use Fossology\UI\Api\Helper\ResponseFactoryHelper;
 use Fossology\UI\Api\Helper\ResponseHelper;
@@ -149,6 +151,10 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/licenses', UploadController::class . ':getUploadLicenses');
     $app->get('/{id:\\d+}/download', UploadController::class . ':uploadDownload');
     $app->get('/{id:\\d+}/copyrights', UploadController::class . ':getUploadCopyrights');
+    $app->get('/{id:\\d+}/licenses/main', UploadController::class . ':getMainLicenses');
+    $app->get('/{id:\\d+}/item/{itemId:\\d+}/view', UploadTreeController::class. ':viewLicenseFile');
+    $app->put('/{id:\\d+}/item/{itemId}/clearing-decision', UploadTreeController::class . ':setClearingDecision');
+    $app->get('/{id:\\d+}/item/{itemId:\\d+}/copyrights/inactive', CopyrightController::class . ':getInactiveFileCopyrights');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 
@@ -243,6 +249,11 @@ $app->group('/filesearch',
     $app->post('', FileSearchController::class . ':getFiles');
     $app->any('/{params:.*}', BadRequestController::class);
   });
+$app->group('/file',
+function (\Slim\Routing\RouteCollectorProxy $app) {
+  
+  $app->any('/{params:.*}', BadRequestController::class);
+});
 
 /////////////////////////LICENSE SEARCH/////////////////
 $app->group('/license',

--- a/src/www/ui_tests/api/Controllers/CopyrightControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/CopyrightControllerTest.php
@@ -1,0 +1,197 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Soham Banerjee <sohambanerjee4abc@hotmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for CopyrightController
+ */
+
+namespace Fossology\UI\Api\Test\Controllers;
+
+use CopyrightHistogramProcessPost;
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\ClearingDao;
+use Fossology\Lib\Dao\LicenseDao;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Data\DecisionTypes;
+use Fossology\Lib\Data\UploadStatus;
+use Fossology\Lib\Db\DbManager;
+use Fossology\UI\Api\Controllers\CopyrightController;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Fossology\UI\Api\Models\License;
+use Slim\Psr7\Factory\StreamFactory;
+use Mockery as M;
+use Slim\Psr7\Headers;
+use Slim\Psr7\Request;
+use Slim\Psr7\Uri;
+
+/**
+ * @class UploadControllerTest
+ * @brief Unit tests for UploadController
+ */
+class CopyrightControllerTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @var DbHelper $dbHelper
+   * DbHelper mock
+   */
+  private $dbHelper;
+
+  /**
+   * @var DbManager $dbManager
+   * Dbmanager mock
+   */
+  private $dbManager;
+
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+
+  /**
+   * @var CopyrightController $CopyrightController
+   * CopyrightController mock
+   */
+  private $CopyrightController;
+
+  /**
+   * @var UploadDao $uploadDao
+   * UploadDao mock
+   */
+  private $uploadDao;
+
+  /**
+   * @var CopyrightHistogramProcessPost $CopyrightHistPlugin
+   * CopyrightHistogramProcessPost mock
+   */
+  private $CopyrightHistPlugin;
+
+  /**
+   * @var LicenseDao $licenseDao
+   * LicenseDao mock
+   */
+  private $licenseDao;
+
+  /**
+   * @var ClearingDao $clearingDao
+   * ClearingDao mock
+   */
+  private $clearingDao;
+
+  /**
+   * @var StreamFactory $streamFactory
+   * Stream factory to create body streams.
+   */
+  private $streamFactory;
+
+
+  /**
+   * @var DecisionTypes $decisionTypes
+   * Decision types object
+   */
+  private $decisionTypes;
+
+  /**
+   * @var AssertCountBefore $assertCountBefore
+   * Assert count object
+   */
+  private $assertCountBefore;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp(): void
+  {
+    global $container;
+    $this->userId = 2;
+    $this->groupId = 2;
+    $container = M::mock('ContainerBuilder');
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->dbManager = M::mock(DbManager::class);
+    $this->restHelper = M::mock(RestHelper::class);
+    $this->uploadDao = M::mock(UploadDao::class);
+    $this->clearingDao = M::mock(ClearingDao::class);
+    $this->CopyrightHistPlugin = M::mock(CopyrightHistogramProcessPost::class);
+    $this->decisionTypes = M::mock(DecisionTypes::class);
+    $this->licenseDao = M::mock(LicenseDao::class);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'
+    ))->andReturn($this->restHelper);
+
+    $this->restHelper->shouldReceive('getPlugin')
+      ->withArgs(array('ajax-copyright-hist'))->andReturn($this->CopyrightHistPlugin);
+
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs([M::any(), [
+        $this->groupId, UploadStatus::OPEN,
+        Auth::PERM_READ
+      ]]);
+    $this->dbHelper->shouldReceive('getDbManager')->andReturn($this->dbManager);
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+    $this->restHelper->shouldReceive('getGroupId')->andReturn($this->groupId);
+    $this->restHelper->shouldReceive('getUserId')->andReturn($this->userId);
+    $container->shouldReceive('get')->withArgs(['decision.types'])->andReturn($this->decisionTypes);
+    $container->shouldReceive('get')->withArgs(['dao.license'])->andReturn($this->licenseDao);
+    $container->shouldReceive('get')->withArgs(['dao.clearing'])->andReturn($this->clearingDao);
+    $container->shouldReceive('get')->withArgs(['dao.upload'])->andReturn($this->uploadDao);
+    $this->CopyrightController = new CopyrightController($container);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+    $this->streamFactory = new StreamFactory();
+  }
+
+  /**
+   * Helper function to get JSON array from response
+   *
+   * @param Response $response
+   * @return array Decoded response
+   */
+  private function getResponseJson($response)
+  {
+    $response->getBody()->seek(0);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+
+
+  /**
+   * @test
+   * -# Test for CopyrightController::getInactiveFileCopyrights()
+   * -# Check if response status is 200 and RES body matches
+   */
+  public function testGetFileCopyrights()
+  {
+    $itemId = 68;
+    $uploadId = 4;
+    $agentId = 6;
+    $UploadTreeTableName = 'uploadtree_a';
+    $rows = array(
+      'content' => "Copyright (C) 2020 Siemens AG Author: Gaurav Mishra <mishra.gaurav@siemens.com>", 'hash' => "16f93a4e03cf6b9218fa03ca5a8ee88e",
+      'copyright_count' => "1"
+    );
+
+    $res = array($rows, 1, 1);
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+
+    $this->uploadDao->shouldReceive('getUploadtreeTableName')->withArgs([$uploadId])->andReturn("uploadtree");
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["uploadtree", "uploadtree_pk", $itemId])->andReturn(true);
+    $this->CopyrightHistPlugin->shouldReceive('getAgentId')->withArgs([$uploadId, 'copyright_ars'])->andReturn($agentId);
+    $this->CopyrightHistPlugin->shouldReceive('getCopyrights')->withArgs([$uploadId, $itemId, $UploadTreeTableName, $agentId, 'statement', 'inactive', true])->andReturn($res);
+    $expectedResponse = (new ResponseHelper())->withJson($res, 200);
+    $actualResponse = $this->CopyrightController->getInactiveFileCopyrights(null, new ResponseHelper(), ['id' => $uploadId, 'itemId' => $itemId]);
+    $this->assertEquals($expectedResponse->getStatusCode(), $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($actualResponse), $this->getResponseJson($expectedResponse));
+  }
+}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
Inactive copyright info for file is exposed through `/file/upload/{UploadId}/item/{ItemId}/copyrights/inactive` endpoint

## Screenshots


![Screenshot from 2023-06-20 20-50-25](https://github.com/fossology/fossology/assets/63705023/3f1717c7-5c5a-4191-b64f-5122d9da4c7a)

## How to test
Send a GET request to `/file/upload/{UploadId}/item/{ItemId}/copyrights/inactive` endpoint to see the result.

closes #2468



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2485"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

