### PR TITLE
feat(api): restore deleted copyrights

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -2112,6 +2112,29 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+    patch:
+      operationId: restoreFileCopyrights
+      tags:
+        - Copyrights
+      summary: Restores a copyright for a file
+      description: Restores a copyright statement for a particular file
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Info'
+        '403':
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
     put:
       operationId: updateFileCopyrights
       tags:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -163,6 +163,7 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/bulk-history', UploadTreeController::class . ':getBulkHistory');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/clearing-history', UploadTreeController::class . ':getClearingHistory');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/highlight', UploadTreeController::class . ':getHighlightEntries');
+    $app->patch('/{id:\\d+}/item/{itemId:\\d+}/copyrights/{hash:.*}', CopyrightController::class . ':restoreFileCopyrights');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Restores deleted copyright statements for a file

## How to test

send a `patch` request to the endpoint `file/upload/{uploadId}/item/{itemid}/copyright{copyrightHash}`

## Screenshots

![Screenshot from 2023-06-21 11-58-18](https://github.com/fossology/fossology/assets/63705023/47bd0d03-6cbc-4a81-a785-81c3571fd84c)

closes #2468

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2486"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

