### PR TITLE
feat(api): API to return total number of copyrights for a file

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -2099,7 +2099,6 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
             $ref: '#/components/responses/defaultResponse'
-
   /jobs/{id}/{queue}:
     parameters:
       - name: id
@@ -2420,6 +2419,72 @@ paths:
       responses:
         '202':
           description: Folder will be copied/moved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /uploads/{id}/item/{ItemId}/totalcopyrights:
+    parameters:
+      - name: id
+        required: true
+        description: Upload Id
+        in: path
+        schema:
+          type: integer
+      - name: ItemId
+        required: true
+        description: Upload Tree ID
+        in: path
+        schema:
+          type: integer
+      - name: status
+        required: true
+        in: query
+        description: status of the copyright
+        schema:
+          type: string
+          enum:
+              - active
+              - inactive
+    get:
+      operationId: getTotalFileCopyrights
+      tags:
+        - Copyrights
+      summary: Get the total copyrights of the mentioned upload tree ID
+      description: Returns the total number of copyrights associated with the file
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  allOf:
+                    - type: object
+                      properties:
+                        total_copyrights:
+                          type: integer
+                          description: Total Number of copyrights for the uploadtree
+                          example:
+                            125
+        '400':
+          description: "Bad Request. 'upload' is a required query param"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Upload is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Upload does not exist
           content:
             application/json:
               schema:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -166,6 +166,7 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/clearing-history', UploadTreeController::class . ':getClearingHistory');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/highlight', UploadTreeController::class . ':getHighlightEntries');
     $app->patch('/{id:\\d+}/item/{itemId:\\d+}/copyrights/{hash:.*}', CopyrightController::class . ':restoreFileCopyrights');
+    $app->get('/{id:\\d+}/item/{itemId:\\d+}/totalcopyrights', CopyrightController::class . ':getTotalFileCopyrights');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This API returns the total number of copyrights for a UploadTree

## How to test
Send a `GET` request to `/file/upload/{UploadId}/item/{ItemId}/totalcopyrights`

##Screenshots
![Screenshot from 2023-06-21 22-47-51](https://github.com/fossology/fossology/assets/63705023/d0671ea0-53bd-4e2b-97ab-0345e54a3d87)

Fixes #2468

@shaheemazmalmmd Please do have a look as this was requested on priority basis.



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2488"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

