### PR TITLE
feat(api): Copyright API endpoints

### DIFF
--- a/src/copyright/ui/ajax-copyright-hist.php
+++ b/src/copyright/ui/ajax-copyright-hist.php
@@ -226,7 +226,7 @@ class CopyrightHistogramProcessPost extends FO_Plugin
    * @param boolean $activated           True to get activated copyrights, else false
    * @return array[][] Array of table records, filtered records, total records
    */
-  protected function getCopyrights($upload_pk, $item, $uploadTreeTableName, $agentId, $type, $filter, $activated = true)
+  public function getCopyrights($upload_pk, $item, $uploadTreeTableName, $agentId, $type, $filter, $activated = true)
   {
     $offset = GetParm('iDisplayStart', PARM_INTEGER);
     $limit = GetParm('iDisplayLength', PARM_INTEGER);
@@ -365,6 +365,17 @@ count(*) AS copyright_count " .
     $orderString = $this->dataTablesUtility->getSortingString($_GET, $columnNamesInDatabase, $defaultOrder);
 
     return $orderString;
+  }
+
+  /**
+   * @brief get Agent ID for an upload
+   * @param Integer $upload_pk Upload ID
+   * @param string $copyrightType Copyright Type
+   * @return Integer Agent ID
+   */
+  public function getAgentId($upload_pk,$copyrightType)
+  {
+    return(LatestAgentpk($upload_pk, $copyrightType));
   }
 
   /**

--- a/src/copyright/ui/ajax-copyright-hist.php
+++ b/src/copyright/ui/ajax-copyright-hist.php
@@ -322,7 +322,7 @@ count(*) AS copyright_count " .
    * @param string $type Result type
    * @return string Table name
    */
-  private function getTableName($type)
+  public function getTableName($type)
   {
     switch ($type) {
       case "ipra" :

--- a/src/www/ui/api/Controllers/CopyrightController.php
+++ b/src/www/ui/api/Controllers/CopyrightController.php
@@ -1,0 +1,99 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2018 Siemens AG
+ Author: Gaurav Mishra <mishra.gaurav@siemens.com>
+ SPDX-FileCopyrightText: © 2023 Soham Banerjee <sohambanerjee4abc@hotmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Controller for copyright queries
+ */
+
+namespace Fossology\UI\Api\Controllers;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Db\DbManager;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Psr\Http\Message\ServerRequestInterface;
+
+
+class CopyrightController extends RestController
+{
+  /**
+   * @var ContainerInterface $container
+   * Slim container
+   */
+  protected $container;
+
+  /**
+   * @var ClearingDao
+   */
+  private $clearingDao;
+
+  /**
+   * @var LicenseDao $licenseDao
+   * License Dao object
+   */
+  private $licenseDao;
+
+  /**
+   * @var LicenseDao $licenseDao
+   * Upload Dao object
+   */
+  private $uploadDao;
+
+  /**
+   * @var CopyrightHist $licenseDao
+   * Copyright Histogram object
+   */
+  private $CopyrightHist;
+
+  public function __construct($container)
+  {
+    parent::__construct($container);
+    $this->container = $container;
+    $this->clearingDao = $this->container->get('dao.clearing');
+    $this->licenseDao = $this->container->get('dao.license');
+    $this->uploadDao = $container->get('dao.upload');
+    $this->restHelper = $container->get('helper.restHelper');
+    $this->CopyrightHist = $this->restHelper->getPlugin('ajax-copyright-hist');
+  }
+
+  /**
+   * Get all copyrights for a particular upload-tree
+   *
+   * @param  ServerRequestInterface $request
+   * @param  ResponseHelper         $response
+   * @param  array                  $args
+   * @return ResponseHelper
+   */
+  public function getFileCopyrights($request, $response, $args)
+  {
+    $uploadPk = $args["id"];
+    $uploadTreeId = $args["itemId"];
+    $agentId = $this->CopyrightHist->getAgentId($uploadPk, 'copyright_ars');
+    $UploadTreeTableName = $this->uploadDao->getUploadtreeTableName($uploadPk);
+    $returnVal = null;
+    try {
+      if (!$this->dbHelper->doesIdExist("upload", "upload_pk", $uploadPk)) {
+        $returnVal = new Info(404, "Upload does not exist", InfoType::ERROR);
+      } else if (!$this->dbHelper->doesIdExist($this->uploadDao->getUploadtreeTableName($uploadPk), "uploadtree_pk", $uploadTreeId)) {
+        $returnVal = new Info(404, "Item does not exist", InfoType::ERROR);
+      }
+      if ($returnVal !== null) {
+        return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+      }
+      $returnVal = $this->CopyrightHist->getCopyrights($uploadPk, $uploadTreeId, $UploadTreeTableName, $agentId, 'statement', 'active', true);
+      return $response->withJson($returnVal, 200);
+    } catch (\Exception $e) {
+      $returnVal = new Info(500, $e->getMessage(), InfoType::ERROR);
+      return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+    }
+  }
+}

--- a/src/www/ui/api/Controllers/CopyrightController.php
+++ b/src/www/ui/api/Controllers/CopyrightController.php
@@ -213,4 +213,36 @@ class CopyrightController extends RestController
       return $response->withJson($returnVal->getArray(), $returnVal->getCode());
     }
   }
+
+  /**
+   * Get all inactive copyrights for a particular upload-tree
+   *
+   * @param  ServerRequestInterface $request
+   * @param  ResponseHelper         $response
+   * @param  array                  $args
+   * @return ResponseHelper
+   */
+  public function getInactiveFileCopyrights($request, $response, $args)
+  {
+    $uploadPk = $args["id"];
+    $uploadTreeId = $args["itemId"];
+    $agentId = $this->CopyrightHist->getAgentId($uploadPk, 'copyright_ars');
+    $UploadTreeTableName = $this->uploadDao->getUploadtreeTableName($uploadPk);
+    $returnVal = null;
+    try {
+      if (!$this->dbHelper->doesIdExist("upload", "upload_pk", $uploadPk)) {
+        $returnVal = new Info(404, "Upload does not exist", InfoType::ERROR);
+      } else if (!$this->dbHelper->doesIdExist($this->uploadDao->getUploadtreeTableName($uploadPk), "uploadtree_pk", $uploadTreeId)) {
+        $returnVal = new Info(404, "Item does not exist", InfoType::ERROR);
+      }
+      if ($returnVal !== null) {
+        return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+      }
+      $returnVal = $this->CopyrightHist->getCopyrights($uploadPk, $uploadTreeId, $UploadTreeTableName, $agentId, 'statement', 'inactive', false);
+      return $response->withJson($returnVal, 200);
+    } catch (\Exception $e) {
+      $returnVal = new Info(500, $e->getMessage(), InfoType::ERROR);
+      return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+    }
+  }
 }

--- a/src/www/ui/api/Controllers/CopyrightController.php
+++ b/src/www/ui/api/Controllers/CopyrightController.php
@@ -141,4 +141,41 @@ class CopyrightController extends RestController
       return $response->withJson($returnVal->getArray(), $returnVal->getCode());
     }
   }
+
+  /**
+   * Delete copyrights for a particular file
+   *
+   * @param  ServerRequestInterface $request
+   * @param  ResponseHelper         $response
+   * @param  array                  $args
+   * @return ResponseHelper
+   */
+
+
+  public function DeleteFileCopyrights($request, $response, $args)
+  {
+    try {
+      $uploadDao = $this->restHelper->getUploadDao();
+      $uploadTreeId = intval($args['itemId']);
+      $copyrightHash = ($args['hash']);
+      $userId = $this->restHelper->getUserId();
+      $UploadTreeTableName = $uploadDao->getUploadtreeTableName($uploadTreeId);
+      $cpTable = $this->CopyrightHist->getTableName('statement');
+      $returnVal = null;
+      $item = $uploadDao->getItemTreeBounds($uploadTreeId, $UploadTreeTableName);
+
+      if (!$this->dbHelper->doesIdExist($uploadDao->getUploadtreeTableName($uploadTreeId), "uploadtree_pk", $uploadTreeId)) {
+        $returnVal = new Info(404, "Item does not exist", InfoType::ERROR);
+      }
+      if ($returnVal !== null) {
+        return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+      }
+      $this->copyrightDao->updateTable($item, $copyrightHash, '', $userId, $cpTable, 'delete');
+      $returnVal = new Info(200, "Successfully removed Copyright.", InfoType::INFO);
+      return $response->withJson($returnVal->getArray(), 200);
+    } catch (\Exception $e) {
+      $returnVal = new Info(500, $e->getMessage(), InfoType::ERROR);
+      return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+    }
+  }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -804,6 +804,34 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+    delete:
+      operationId: DeleteFileCopyrights
+      tags:
+        - Copyrights
+      summary: Deletes a copyright for a file
+      description: Deletes a copyright statement for a particular file
+      responses:
+        '200':
+          description: OK
+          headers:
+            X-Total-Pages:
+              description: Total number of pages which can be generated based on limit
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/deleteCopyright'
+        '403':
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'    
 
   /uploads/{id}/copyrights:
     parameters:
@@ -3089,6 +3117,21 @@ components:
           type: string
           description: Success message
           example: "Successfully Updated Copyright."
+        type:
+          type: string
+          description: type of message
+          example: "INFO"
+    deleteCopyright:
+      type: object
+      properties:
+        code:
+          type: integer
+          description: Status code
+          example: 200
+        content:
+          type: string
+          description: Success message
+          example: "Successfully removed Copyright."
         type:
           type: string
           description: type of message

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -749,6 +749,62 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /file/upload{id}/item/{itemId}/copyright/{hash}:
+    parameters:
+      - name: id
+        required: true
+        description: upload ID
+        in: path
+        schema:
+          type: integer
+      - name: itemId
+        required: true
+        description: Upload tree ID
+        in: path
+        schema:
+          type: integer
+      - name: hash
+        required: true
+        description: copyright hash
+        in: path
+        schema:
+          type: string
+    put:
+      operationId: UpdateFileCopyrights
+      tags:
+        - Copyrights
+      summary: Updates a copyright for a file
+      description: Updates a copyright statement for a particular file
+      requestBody:
+        description: ClearingInfo payload
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetCopyrightInfo'
+      responses:
+        '200':
+          description: OK
+          headers:
+            X-Total-Pages:
+              description: Total number of pages which can be generated based on limit
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/updateCopyright'
+        '403':
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /uploads/{id}/copyrights:
     parameters:
       - name: id
@@ -3022,6 +3078,27 @@ components:
         copyright_count:
           type: integer
           description: count of the copyrights
+    updateCopyright:
+      type: object
+      properties:
+        code:
+          type: integer
+          description: Status code
+          example: 200
+        content:
+          type: string
+          description: Success message
+          example: "Successfully Updated Copyright."
+        type:
+          type: string
+          description: type of message
+          example: "INFO"
+    SetCopyrightInfo:
+      type: object
+      properties:
+        content:
+          type: string
+          description: Copyright text
     UrlUpload:
       description: To create an upload from a URL
       type: object

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -831,7 +831,27 @@ paths:
               schema:
                 $ref: '#/components/schemas/Info'
         default:
-          $ref: '#/components/responses/defaultResponse'    
+          $ref: '#/components/responses/defaultResponse'
+    patch:
+      operationId: RestoreFileCopyrights
+      tags:
+        - Copyrights
+      summary: Restores a copyright for a file
+      description: Restores a copyright statement for a particular file
+      responses:
+        '200':
+          description: OK
+          headers:
+            X-Total-Pages:
+              description: Total number of pages which can be generated based on limit
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/restoreCopyright'
 
   /uploads/{id}/copyrights:
     parameters:
@@ -3132,6 +3152,21 @@ components:
           type: string
           description: Success message
           example: "Successfully removed Copyright."
+        type:
+          type: string
+          description: type of message
+          example: "INFO"
+    restoreCopyright:
+      type: object
+      properties:
+        code:
+          type: integer
+          description: Status code
+          example: 200
+        content:
+          type: string
+          description: Success message
+          example: "Successfully restored Copyright."
         type:
           type: string
           description: type of message

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -699,6 +699,56 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /file/upload/{id}/item/{ItemId}/copyrights:
+    parameters:
+      - name: id
+        required: true
+        description: Upload Id
+        in: path
+        schema:
+          type: integer
+      - name: ItemId
+        required: true
+        description: Upload Tree ID
+        in: path
+        schema:
+          type: integer
+    get:
+      operationId: getFileCopyrights
+      tags:
+        - Copyrights
+      summary: Get the copyrights of the mentioned upload tree ID
+      description: Returns the list of copyrights associated with the file
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GetFileCopyrights'
+        '400':
+          description: "Bad Request. 'upload' is a required query param"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Upload is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Upload does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /uploads/{id}/copyrights:
     parameters:
       - name: id
@@ -2959,6 +3009,19 @@ components:
         uploadId:
           type: integer
           description: Upload ID to which the job belongs to.
+    GetFileCopyrights:
+      description: Copyright details of a file
+      type: object
+      properties:
+        content:
+          type: string
+          description: Copyright content
+        hash:
+          type: string
+          description: copyright hash
+        copyright_count:
+          type: integer
+          description: count of the copyrights
     UrlUpload:
       description: To create an upload from a URL
       type: object

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -749,6 +749,56 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /file/upload/{id}/item/{ItemId}/copyrights/inactive:
+    parameters:
+      - name: id
+        required: true
+        description: Upload Id
+        in: path
+        schema:
+          type: integer
+      - name: ItemId
+        required: true
+        description: Upload Tree ID
+        in: path
+        schema:
+          type: integer
+    get:
+      operationId: getInactiveFileCopyrights
+      tags:
+        - Copyrights
+      summary: Get the inactive copyrights of the mentioned upload tree ID
+      description: Returns the list of inactive copyrights associated with the file
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GetFileCopyrights'
+        '400':
+          description: "Bad Request. 'upload' is a required query param"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Upload is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Upload does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /file/upload{id}/item/{itemId}/copyright/{hash}:
     parameters:
       - name: id

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -248,6 +248,7 @@ $app->group('/file',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->get('/upload/{id:\\d+}/item/{itemId:\\d+}/copyrights', CopyrightController::class . ':getFileCopyrights');
     $app->put('/upload/{id:\\d+}/item/{itemId:\\d+}/copyright/{hash:.*}', CopyrightController::class . ':UpdateFileCopyrights');
+    $app->delete('/upload/{id:\\d+}/item/{itemId:\\d+}/copyright/{hash:.*}', CopyrightController::class . ':DeleteFileCopyrights');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -244,9 +244,12 @@ $app->group('/filesearch',
     $app->post('', FileSearchController::class . ':getFiles');
     $app->any('/{params:.*}', BadRequestController::class);
   });
+
+/////////////////////////COPYRIGHTS////////////////////
 $app->group('/file',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->get('/upload/{id:\\d+}/item/{itemId:\\d+}/copyrights', CopyrightController::class . ':getFileCopyrights');
+    $app->get('/upload/{id:\\d+}/item/{itemId:\\d+}/copyrights/inactive', CopyrightController::class . ':getInactiveFileCopyrights');
     $app->put('/upload/{id:\\d+}/item/{itemId:\\d+}/copyright/{hash:.*}', CopyrightController::class . ':UpdateFileCopyrights');
     $app->delete('/upload/{id:\\d+}/item/{itemId:\\d+}/copyright/{hash:.*}', CopyrightController::class . ':DeleteFileCopyrights');
     $app->patch('/upload/{id:\\d+}/item/{itemId:\\d+}/copyright/{hash:.*}', CopyrightController::class . ':RestoreFileCopyrights');

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -249,6 +249,7 @@ $app->group('/file',
     $app->get('/upload/{id:\\d+}/item/{itemId:\\d+}/copyrights', CopyrightController::class . ':getFileCopyrights');
     $app->put('/upload/{id:\\d+}/item/{itemId:\\d+}/copyright/{hash:.*}', CopyrightController::class . ':UpdateFileCopyrights');
     $app->delete('/upload/{id:\\d+}/item/{itemId:\\d+}/copyright/{hash:.*}', CopyrightController::class . ':DeleteFileCopyrights');
+    $app->patch('/upload/{id:\\d+}/item/{itemId:\\d+}/copyright/{hash:.*}', CopyrightController::class . ':RestoreFileCopyrights');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -247,6 +247,7 @@ $app->group('/filesearch',
 $app->group('/file',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->get('/upload/{id:\\d+}/item/{itemId:\\d+}/copyrights', CopyrightController::class . ':getFileCopyrights');
+    $app->put('/upload/{id:\\d+}/item/{itemId:\\d+}/copyright/{hash:.*}', CopyrightController::class . ':UpdateFileCopyrights');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -28,6 +28,7 @@ use Fossology\UI\Api\Controllers\FolderController;
 use Fossology\UI\Api\Controllers\GroupController;
 use Fossology\UI\Api\Controllers\InfoController;
 use Fossology\UI\Api\Controllers\JobController;
+use Fossology\UI\Api\Controllers\CopyrightController;
 use Fossology\UI\Api\Controllers\LicenseController;
 use Fossology\UI\Api\Controllers\MaintenanceController;
 use Fossology\UI\Api\Controllers\ReportController;
@@ -241,6 +242,11 @@ $app->group('/health',
 $app->group('/filesearch',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->post('', FileSearchController::class . ':getFiles');
+    $app->any('/{params:.*}', BadRequestController::class);
+  });
+$app->group('/file',
+  function (\Slim\Routing\RouteCollectorProxy $app) {
+    $app->get('/upload/{id:\\d+}/item/{itemId:\\d+}/copyrights', CopyrightController::class . ':getFileCopyrights');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

# Copyright endpoints

This PR introduces copyright endpoints
  
The endpoints and their functionalities are explained below

closes #2468 

- ## getFileCopyrights
  
  ## Description
  Copyright info for file is exposed through `/file/upload/{UploadId}/item/{ItemId}/copyrights` endpoint
  
  ## Screenshots
  
  
  ![Screenshot from 2023-06-15 12-27-40](https://github.com/fossology/fossology/assets/63705023/219ea736-9036-407b-9c0a-b643e53e7874)
  
  ## How to test
  Send a GET request to `/file/upload/{UploadId}/item/{ItemId}/copyrights` endpoint to see the result.

- ## UpdateFileCopyrights
  ## Description
  
  API to update File copyright is added  in this PR
  
  
  ## How to test
  
  Send a `PUT` request to the endpoint `/file/upload/{Upload_id}/item/{Item_id}/copyright/{Copyright_hash}`
  
  with a body :
  ```
  {
    "content": "New Test copyright text"
  }
  ```
  ##Screenshots:
  - Before sending the API request:
  
  ![Screenshot from 2023-06-18 18-09-36](https://github.com/fossology/fossology/assets/63705023/f34151a0-b24b-4c23-bc16-d05a9bbdc0dc)
  
  - The API Request:
  
  ![Screenshot from 2023-06-18 18-09-50](https://github.com/fossology/fossology/assets/63705023/4a3b5507-044f-43ae-9bb5-7560a8c3da9b)
  
  - After the API request:
  
  ![Screenshot from 2023-06-18 18-10-01](https://github.com/fossology/fossology/assets/63705023/2662a03e-5367-4678-ba25-f621458cdd93)

- ## DeleteFileCopyrights
  ## Description
  
  Deletes a copyright for a file using `/file/upload/<uploadId>/item/<ItemId>/copyright/<Hash>`
  
  ## Screenshot
  ![Screenshot from 2023-06-17 16-49-34](https://github.com/fossology/fossology/assets/63705023/4a0f395c-6627-414c-8e7f-87e2c7d7482d)

- ## RestoreFileCopyrights

  ## Description
  
  Restores deleted copyright statements for a file
  
  ## How to test
  
  send a `patch` request to the endpoint `file/upload/{uploadId}/item/{itemid}/copyright{copyrightHash}`
  
  ## Screenshots
  
  ![Screenshot from 2023-06-21 11-58-18](https://github.com/fossology/fossology/assets/63705023/47bd0d03-6cbc-4a81-a785-81c3571fd84c)

- ## getInactiveFileCopyrights
  ## Description
  Inactive copyright info for file is exposed through `/file/upload/{UploadId}/item/{ItemId}/copyrights/inactive` endpoint
  
  ## Screenshots
  
  
  ![Screenshot from 2023-06-20 20-50-25](https://github.com/fossology/fossology/assets/63705023/3f1717c7-5c5a-4191-b64f-5122d9da4c7a)
  
  ## How to test
  Send a GET request to `/file/upload/{UploadId}/item/{ItemId}/copyrights/inactive` endpoint to see the result. 

This PR is a merged PR for #2475 #2478 #2479 #2485 #2486
done to avoid merge conflicts as discussed with @shaheemazmalmmd 

#2488 is kept separate due to its high priority as informed by @shaheemazmalmmd 


 
Please do have a look @shaheemazmalmmd @GMishx @avinal 

separate PR will be issued for testcases of these endpoints soon.


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2490"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

