### PR TITLE
feat(api): Get the clearing-progress info for an upload.

### DIFF
--- a/src/lib/php/Proxy/UploadTreeProxy.php
+++ b/src/lib/php/Proxy/UploadTreeProxy.php
@@ -61,7 +61,7 @@ class UploadTreeProxy extends DbViewProxy
    * @param string $uploadTreeTableName
    * @return string
    */
-  private function createUploadTreeViewQuery($options, $uploadTreeTableName)
+  public function createUploadTreeViewQuery($options, $uploadTreeTableName)
   {
     if (empty($options)) {
       return self::getDefaultUploadTreeView($this->uploadId, $uploadTreeTableName);

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1140,7 +1140,6 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
-
   /uploads/{id}/licenses/main:
     parameters:
       - name: id
@@ -1316,7 +1315,6 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
-
   /uploads/{id}/item/{itemId}/clearing-history:
     parameters:
       - name: id
@@ -1360,6 +1358,42 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /uploads/{id}/clearing-progress:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+    get:
+      operationId: getClearingProgressInfo
+      tags:
+        - Upload
+      summary: Get the clearing progress info
+      description: >
+        Get the clearing progress information for an upload
+      responses:
+        '200':
+          description: Get clearing progress info
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClearingProgressInfo'
+        '404':
+          description: Resource Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
 
   /search:
     get:
@@ -3991,6 +4025,19 @@ components:
           example: "MIT: 'MIT License\n\nCopyright (c) <year> <copyright holders>'"
         htmlElement:
           type: string
+    ClearingProgressInfo:
+      type: object
+      properties:
+        totalFilesOfInterest:
+          description: Total number of targeted files to be cleared
+          type: integer
+          example:
+            234
+        totalFilesCleared:
+          description: Total number of files cleared
+          type: integer
+          example:
+            200
     UserGroupMember:
       type: object
       properties:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -151,6 +151,7 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/licenses', UploadController::class . ':getUploadLicenses');
     $app->get('/{id:\\d+}/download', UploadController::class . ':uploadDownload');
     $app->get('/{id:\\d+}/copyrights', UploadController::class . ':getUploadCopyrights');
+    $app->get('/{id:\\d+}/clearing-progress', UploadController::class . ':getClearingProgressInfo');
     $app->get('/{id:\\d+}/licenses/main', UploadController::class . ':getMainLicenses');
     $app->post('/{id:\\d+}/licenses/main', UploadController::class . ':setMainLicense');
     $app->delete('/{id:\\d+}/licenses/{shortName:[\\w\\- \\.]+}/main', UploadController::class . ':removeMainLicense');


### PR DESCRIPTION
## Description

Added the API to get retrieve the rows that makes a tree-view from a specific upload and item.

### Changes

1. Added a new method in  `UploadController` to handle the logic.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/uploads/{id}/clearing/progress`.
3. Updated the `openapi.yaml` file  to introduce a new API.

## How to test

Make a GET request on the endpoint: `/uploads/{id}/clearing/progress`

## Screenshots

UI View:
![image](https://github.com/fossology/fossology/assets/66276301/4f21b3ee-0337-49ed-8ec9-3fb6ace36840)

Corresponding API Object:

![image](https://github.com/fossology/fossology/assets/66276301/27173fc6-9c66-49eb-9a4c-de6eff60beb4)

### Related Issue:
Fixes [#2459](https://github.com/fossology/fossology/issues/2459)


cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2494"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

