### PR TITLE
feat(api): get a list of scanned licenses for an upload

### DIFF
--- a/src/www/ui/api/Models/ScannedLicense.php
+++ b/src/www/ui/api/Models/ScannedLicense.php
@@ -1,0 +1,159 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Samuel Dushimimana <dushsam100@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * @file
+ * @brief ScannedLicense model
+ */
+namespace Fossology\UI\Api\Models;
+
+class ScannedLicense
+{
+  /**
+   * @var integer $id
+   * License id
+   */
+  private $id;
+  /**
+   * @var string $shortname
+   * License's short name
+   */
+  private $shortname;
+  /**
+   * @var integer $occurence
+   * License's occurrence count
+   */
+  private $occurence;
+  /**
+   * @var integer $unique
+   * License's unique count
+   */
+  private $unique;
+  /**
+   * @var string $spdxName
+   * License's spdx name
+   */
+  private $spdxName;
+
+  /**
+   * @param integer $id
+   * @param string $shortname
+   * @param integer $occurence
+   * @param integer $unique
+   * @param string $spdxName
+   */
+  public function __construct($id, $shortname, $occurence, $unique, $spdxName)
+  {
+    $this->id = $id;
+    $this->shortname = $shortname;
+    $this->occurence = $occurence;
+    $this->unique = $unique;
+    $this->spdxName = $spdxName;
+  }
+
+  /**
+   * @return integer
+   */
+  public function getId()
+  {
+    return $this->id;
+  }
+
+  /**
+   * @return string
+   */
+  public function getShortname()
+  {
+    return $this->shortname;
+  }
+
+  /**
+   * @return integer
+   */
+  public function getOccurence()
+  {
+    return $this->occurence;
+  }
+
+  /**
+   * @return integer
+   */
+  public function getUnique()
+  {
+    return $this->unique;
+  }
+
+  /**
+   * @return string
+   */
+  public function getSpdxName()
+  {
+    return $this->spdxName;
+  }
+
+  /**
+   * JSON representation of current scannedLicense
+   * @return string
+   */
+  public function getJSON()
+  {
+    return json_encode($this->getArray());
+  }
+
+  /**
+   * Get ScannedLicense element as associative array
+   * @return array
+   */
+  public function getArray()
+  {
+    return [
+      'id' => $this->getId(),
+      'shortname' => $this->getShortname(),
+      'occurence' => $this->getOccurence(),
+      'unique' => $this->getUnique(),
+      'spdxName' => $this->getSpdxName()
+    ];
+  }
+
+  /**
+   * @param integer $id
+   */
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+
+  /**
+   * @param string $shortname
+   */
+  public function setShortname($shortname)
+  {
+    $this->shortname = $shortname;
+  }
+
+  /**
+   * @param integer $occurence
+   */
+  public function setOccurence($occurence)
+  {
+    $this->occurence = $occurence;
+  }
+
+  /**
+   * @param integer $unique
+   */
+  public function setUnique($unique)
+  {
+    $this->unique = $unique;
+  }
+
+  /**
+   * @param string $spdxName
+   */
+  public function setSpdxName($spdxName)
+  {
+    $this->spdxName = $spdxName;
+  }
+}

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1604,6 +1604,50 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /uploads/{id}/licenses/scanned:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+      - name: agentId
+        required: false
+        description: Id of the agent
+        in: query
+        schema:
+          type: integer
+    get:
+      operationId: getAllScannedLicenses
+      tags:
+        - Upload
+      summary: Get the scanned licenses list
+      description: >
+        Get the scanned licenses list for a specific upload
+      responses:
+        '200':
+          description: List of the scanned licenses in the upload
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ScannedLicense'
+        '404':
+          description: Resource Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
 
   /uploads/{id}/item/{itemId}/tree/view:
     parameters:
@@ -1693,15 +1737,15 @@ paths:
           default: 50
           minimum: 1
     get:
-      operationId: getLicenseDecisions
+      operationId: getItemTreeView
       tags:
         - Upload
-      summary: Get the license decisions list
+      summary: Get the tree view for the given upload and item id
       description: >
-        Get the license decisions list for the given upload and item id
+        Get the tree view for the given upload and item id
       responses:
         '200':
-          description: List of the license decisions for the upload-tree id
+          description: Tree view for the given upload and item id
           content:
             application/json:
               schema:
@@ -4716,6 +4760,29 @@ components:
               type: integer
               description: The total count of files.
               example: 99
+    ScannedLicense:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Id of the license
+          example: 29
+        shortname:
+          type: string
+          description: Short name of the license
+          example: Apache-2.0
+        occurrence:
+          type: integer
+          description: Number of occurrences of the license
+          example: 1
+        unique:
+          type: integer
+          description: Number of unique occurrences of the license
+          example: 1
+        spdxName:
+          type: string
+          description: SPDX name associated with the license
+          example: Apache-2.0
     UserGroupMember:
       type: object
       properties:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -154,6 +154,7 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/agents', UploadController::class . ':getAllAgents');
     $app->get('/{id:\\d+}/licenses/edited', UploadController::class . ':getEditedLicenses');
     $app->get('/{id:\\d+}/licenses/reuse', UploadController::class . ':getReuseReportSummary');
+    $app->get('/{id:\\d+}/licenses/scanned', UploadController::class . ':getScannedLicenses');
     $app->get('/{id:\\d+}/download', UploadController::class . ':uploadDownload');
     $app->get('/{id:\\d+}/copyrights', UploadController::class . ':getUploadCopyrights');
     $app->get('/{id:\\d+}/clearing-progress', UploadController::class . ':getClearingProgressInfo');


### PR DESCRIPTION
## Description

Added the API to retrieve a list of the scanned licenses for a given upload.

### Changes

1. Added a new method in  `UploadController` to handle the logic.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/uploads/{id}/licenses/scanned`.
3. Updated the `openapi.yaml` file  to introduce a new API.

## How to test

Make a GET request on the endpoint: `/uploads/{id}/licenses/scanned`.

## Screenshots

UI View:

![image](https://github.com/fossology/fossology/assets/66276301/34a4ae0d-1da0-403d-8252-1e746d851111)

API response:

![image](https://github.com/fossology/fossology/assets/66276301/3f9653eb-3533-4fa4-b0d6-f2e50d50de39)

### Related Issue:
Fixes [#2467](https://github.com/fossology/fossology/issues/2467)

cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2495"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

