### PR TITLE
feat(api): get licenses histogram for an upload

### DIFF
--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -16,6 +16,7 @@ namespace Fossology\UI\Api\Controllers;
 
 use Fossology\DelAgent\UI\DeleteMessages;
 use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Data\AgentRef;
 use Fossology\Lib\Data\UploadStatus;
 use Fossology\Lib\Proxy\ScanJobProxy;
@@ -96,6 +97,11 @@ class UploadController extends RestController
    * Valid status inputs
    */
   const VALID_STATUS = ["open", "inprogress", "closed", "rejected"];
+
+  /**
+   * Agent names list
+   */
+  private $agentNames = AgentRef::AGENT_LIST;
 
   public function __construct($container)
   {
@@ -1047,5 +1053,79 @@ class UploadController extends RestController
       "totalFilesCleared" => intval($filesAlreadyCleared),
     ];
     return $response->withJson($res, 200);
+  }
+
+  /**
+   * Get all licenses histogram for the entire upload
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function getLicensesHistogram($request, $response, $args)
+  {
+    $agentDao = $this->container->get('dao.agent');
+    $clearingDao = $this->container->get('dao.clearing');
+    $licenseDao = $this->container->get('dao.license');
+
+    $uploadId = intval($args['id']);
+    $uploadDao = $this->restHelper->getUploadDao();
+    $query = $request->getQueryParams();
+    $selectedAgentId = $query['agentId'];
+
+    if (!$this->dbHelper->doesIdExist("upload", "upload_pk", $uploadId)) {
+      $returnVal = new Info(404, "Upload does not exist.", InfoType::ERROR);
+    } else if ($selectedAgentId !== null && !$this->dbHelper->doesIdExist("agent", "agent_pk", $selectedAgentId)) {
+      $returnVal = new Info(404, "Agent does not exist.", InfoType::ERROR);
+    }
+    if (isset($returnVal)) {
+      return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+    }
+
+    $scannerAgents = array_keys($this->agentNames);
+    $scanJobProxy = new ScanJobProxy($agentDao, $uploadId);
+    $scanJobProxy->createAgentStatus($scannerAgents);
+    $uploadTreeTableName = $uploadDao->getUploadtreeTableName($uploadId);
+    $itemTreeBounds = $uploadDao->getParentItemBounds($uploadId, $uploadTreeTableName);
+    $editedLicenses = $clearingDao->getClearedLicenseIdAndMultiplicities($itemTreeBounds, $this->restHelper->getGroupId());
+    $selectedAgentIds = empty($selectedAgentId) ? $scanJobProxy->getLatestSuccessfulAgentIds() : $selectedAgentId;
+    $scannedLicenses = $licenseDao->getLicenseHistogram($itemTreeBounds, $selectedAgentIds);
+    $allScannerLicenseNames = array_keys($scannedLicenses);
+    $allEditedLicenseNames = array_keys($editedLicenses);
+    $allLicNames = array_unique(array_merge($allScannerLicenseNames, $allEditedLicenseNames));
+    $realLicNames = array_diff($allLicNames, array(LicenseDao::NO_LICENSE_FOUND));
+    $totalScannerLicenseCount = 0;
+    $editedTotalLicenseCount = 0;
+
+    $res = array();
+    foreach ($realLicNames as $licenseShortName) {
+      $count = 0;
+      if (array_key_exists($licenseShortName, $scannedLicenses)) {
+        $count = $scannedLicenses[$licenseShortName]['unique'];
+        $rfId = $scannedLicenses[$licenseShortName]['rf_pk'];
+      } else {
+        $rfId = $editedLicenses[$licenseShortName]['rf_pk'];
+      }
+      $editedCount = array_key_exists($licenseShortName, $editedLicenses) ? $editedLicenses[$licenseShortName]['count'] : 0;
+      $totalScannerLicenseCount += $count;
+      $editedTotalLicenseCount += $editedCount;
+      $scannerCountLink = $count;
+      $editedLink = $editedCount;
+
+      $res[] = array($scannerCountLink, $editedLink, array($licenseShortName, $rfId));
+    }
+
+    $outputArray = [];
+
+    foreach ($res as $item) {
+      $outputArray[] = [
+        "id" => intval($item[2][1]),
+        "name" => $item[2][0],
+        "scannerCount" => intval($item[0]),
+        "concludedCount" => intval($item[1]),
+      ];
+    }
+    return $response->withJson($outputArray, 200);
   }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1395,6 +1395,50 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /uploads/{id}/licenses/histogram:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+      - name: agentId
+        required: false
+        description: Id of the agent
+        in: query
+        schema:
+          type: integer
+    get:
+      operationId: getLicensesHistogram
+      tags:
+        - Upload
+      summary: Get the licenses histogram
+      description: >
+        Get the licenses histogram for a specific upload
+      responses:
+        '200':
+          description: Get the licenses histogram for the upload
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LicenseHistogram'
+        '404':
+          description: Resource Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /search:
     get:
       operationId: searchFile
@@ -4038,6 +4082,21 @@ components:
           type: integer
           example:
             200
+    LicenseHistogram:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 357
+        name:
+          type: string
+          example: "ACE"
+        scannerCount:
+          type: integer
+          example: 0
+        concludedCount:
+          type: integer
+          example: 1
     UserGroupMember:
       type: object
       properties:
@@ -4186,6 +4245,30 @@ components:
           description: Date from which to remove older log files from repository.
           nullable: true
           example: "2022-07-16"
+    ScannedEditedLicense:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 29
+        name:
+          type: string
+          example: Apache-2.0
+        details:
+          type: object
+          properties:
+            count:
+              type: integer
+              example: 1
+            unique:
+              type: integer
+              example: 1
+            rf_pk:
+              type: integer
+              example: 29
+            spdx_id:
+              type: string
+              example: Apache-2.0
     NewGroupPermission:
       description: User Group permission update
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -149,6 +149,7 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/perm-groups', UploadController::class . ':getGroupsWithPermissions');
     $app->get('/{id:\\d+}/summary', UploadController::class . ':getUploadSummary');
     $app->get('/{id:\\d+}/licenses', UploadController::class . ':getUploadLicenses');
+    $app->get('/{id:\\d+}/licenses/histogram', UploadController::class . ':getLicensesHistogram');
     $app->get('/{id:\\d+}/download', UploadController::class . ':uploadDownload');
     $app->get('/{id:\\d+}/copyrights', UploadController::class . ':getUploadCopyrights');
     $app->get('/{id:\\d+}/clearing-progress', UploadController::class . ':getClearingProgressInfo');


### PR DESCRIPTION
## Description

Added the API to retrieve the license histogram for a given upload.

### Changes

1. Added a new method in  `UploadController` to handle the logic.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/uploads/{id}/licenses/histogram`.
3. Updated the `openapi.yaml` file  to introduce a new API.

## How to test

Make a GET request on the endpoint: `/uploads/{id}/licenses/histogram`.

## Screenshots

UI View:
![image](https://github.com/fossology/fossology/assets/66276301/9f229413-e634-4d3a-83f0-179d689437dd)

API response:

![image](https://github.com/fossology/fossology/assets/66276301/88b02159-cfb2-41d4-9526-f657c6f30b37)


### Related Issue:
Fixes [#2467](https://github.com/fossology/fossology/issues/2467)

cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2497"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

