### PR TITLE
feat(api): get edited licenses list for an upload

### DIFF
--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -1186,4 +1186,39 @@ class UploadController extends RestController
     }
     return $response->withJson($res, 200);
   }
+
+  /**
+   * Get all edited licenses for the entire upload
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function getEditedLicenses($request, $response, $args)
+  {
+    $clearingDao = $this->container->get('dao.clearing');
+    $licenseDao = $this->container->get('dao.license');
+
+    $uploadId = intval($args['id']);
+    if (!$this->dbHelper->doesIdExist("upload", "upload_pk", $uploadId)) {
+      $returnVal = new Info(404, "Upload does not exist", InfoType::ERROR);
+      return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+    }
+    $uploadDao = $this->restHelper->getUploadDao();
+    $uploadTreeTableName = $uploadDao->getUploadtreeTableName($uploadId);
+    $itemTreeBounds = $uploadDao->getParentItemBounds($uploadId, $uploadTreeTableName);
+    $res = $clearingDao->getClearedLicenseIdAndMultiplicities($itemTreeBounds, $this->restHelper->getGroupId());
+    $outputArray = [];
+
+    foreach ($res as $key => $value) {
+      $outputArray[] = [
+        "id" => intval($value["rf_pk"]),
+        "shortName" => $key,
+        "count" =>intval($value["count"]),
+        "spdx_id" => $value["spdx_id"],
+      ];
+    }
+    return $response->withJson($outputArray, 200);
+  }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1363,7 +1363,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-
+  
   /uploads/{id}/clearing-progress:
     parameters:
       - name: id
@@ -1469,6 +1469,44 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/AgentOfUpload'
+        '404':
+          description: Resource Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /uploads/{id}/licenses/edited:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+    get:
+      operationId: getAllEditedLicenses
+      tags:
+        - Upload
+      summary: Get the edited licenses list
+      description: >
+        Get the edited licenses list for a specific upload
+      responses:
+        '200':
+          description: List of the edited licenses in the upload
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EditedLicense'
         '404':
           description: Resource Not Found
           content:
@@ -4464,6 +4502,21 @@ components:
           type: string
           description: short name of the license
           example: MIT
+    EditedLicense:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 29
+        shortName:
+          type: string
+          example: Apache-2.0
+        count:
+          type: integer
+          example: 1
+        spdx_id:
+          type: string
+          example: LicenseRef-fossology-ACE
     AddMember:
       description: UserMember options
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -151,6 +151,7 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/licenses', UploadController::class . ':getUploadLicenses');
     $app->get('/{id:\\d+}/licenses/histogram', UploadController::class . ':getLicensesHistogram');
     $app->get('/{id:\\d+}/agents', UploadController::class . ':getAllAgents');
+    $app->get('/{id:\\d+}/licenses/edited', UploadController::class . ':getEditedLicenses');
     $app->get('/{id:\\d+}/download', UploadController::class . ':uploadDownload');
     $app->get('/{id:\\d+}/copyrights', UploadController::class . ':getUploadCopyrights');
     $app->get('/{id:\\d+}/clearing-progress', UploadController::class . ':getClearingProgressInfo');


### PR DESCRIPTION
## Description

Added the API to retrieve a list of the edited licenses for a given upload.

### Changes

1. Added a new method in  `UploadController` to handle the logic.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/uploads/{id}/licenses/edited`.
3. Updated the `openapi.yaml` file  to introduce a new API.

## How to test

Make a GET request on the endpoint: `/uploads/{id}/licenses/edited`.

## Screenshots

**UI View:**

![image](https://github.com/fossology/fossology/assets/66276301/a6d62fa2-59f8-481a-8731-b2068c5145a0)

**API response:**

![image](https://github.com/fossology/fossology/assets/66276301/26c0f91e-104d-4cd1-b756-51d3bf869da2)

### Related Issue:
Fixes [#2467](https://github.com/fossology/fossology/issues/2467)

cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2495"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2498"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

