### PR TITLE
feat(api): Update Upload Summary API to add more info

### DIFF
--- a/src/www/ui/api/Models/UploadSummary.php
+++ b/src/www/ui/api/Models/UploadSummary.php
@@ -79,6 +79,26 @@ class UploadSummary
    * No of files with copyrights
    */
   private $copyrightCount;
+  /**
+   * @var integer $concludedNoLicenseFoundCount
+   * No of concluded files with no license found
+   */
+  private $concludedNoLicenseFoundCount;
+  /**
+   * @var integer $fileCount
+   * No of files in upload
+   */
+  private $fileCount;
+  /**
+   * @var integer $noScannerLicenseFoundCount
+   * No of files with no license found by scanner
+   */
+  private $noScannerLicenseFoundCount;
+  /**
+   * @var integer $scannerUniqueLicenseCount
+   * No of unique licenses found by scanner
+   */
+  private $scannerUniqueLicenseCount;
 
   public function __construct()
   {
@@ -94,6 +114,10 @@ class UploadSummary
     $this->clearingStatus = UploadStatus::OPEN;
     $this->copyrightCount = 0;
     $this->assignee = null;
+    $this->concludedNoLicenseFoundCount = 0;
+    $this->fileCount = 0;
+    $this->noScannerLicenseFoundCount = 0;
+    $this->scannerUniqueLicenseCount = 0;
   }
 
   /**
@@ -123,7 +147,11 @@ class UploadSummary
       "filesToBeCleared"        => $this->filesToBeCleared,
       "filesCleared"            => $this->filesCleared,
       "clearingStatus"          => self::statusToString($this->clearingStatus),
-      "copyrightCount"          => $this->copyrightCount
+      "copyrightCount"          => $this->copyrightCount,
+      "concludedNoLicenseFoundCount" => $this->concludedNoLicenseFoundCount,
+      "fileCount"               => $this->fileCount,
+      "noScannerLicenseFoundCount" => $this->noScannerLicenseFoundCount,
+      "scannerUniqueLicenseCount" => $this->scannerUniqueLicenseCount
     ];
   }
 
@@ -221,6 +249,38 @@ class UploadSummary
   public function setCopyrightCount($copyrightCount)
   {
     $this->copyrightCount = intval($copyrightCount);
+  }
+
+  /**
+   * @param number $concludedNoLicenseFoundCount
+   */
+  public function setConcludedNoLicenseFoundCount($concludedNoLicenseFoundCount)
+  {
+    $this->concludedNoLicenseFoundCount = intval($concludedNoLicenseFoundCount);
+  }
+
+  /**
+   * @param number $fileCount
+   */
+  public function setFileCount($fileCount)
+  {
+    $this->fileCount = intval($fileCount);
+  }
+
+  /**
+   * @param number $noScannerLicenseFoundCount
+   */
+  public function setNoScannerLicenseFoundCount($noScannerLicenseFoundCount)
+  {
+    $this->noScannerLicenseFoundCount = intval($noScannerLicenseFoundCount);
+  }
+
+  /**
+   * @param number $scannerUniqueLicenseCount
+   */
+  public function setScannerUniqueLicenseCount($scannerUniqueLicenseCount)
+  {
+    $this->scannerUniqueLicenseCount = intval($scannerUniqueLicenseCount);
   }
 
   /**

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -604,6 +604,12 @@ paths:
         schema:
           type: string
           description: Group name, from last login if not provided
+      - name: agentId
+        required: false
+        description: Id of the agent
+        in: query
+        schema:
+          type: integer
     get:
       operationId: getSummaryByUploadId
       tags:
@@ -3410,6 +3416,18 @@ components:
         content:
           type: string
           description: Copyright text
+        concludedNoLicenseFoundCount:
+          type: integer
+          description: No. of concluded no license found.
+        fileCount:
+          type: integer
+          description: No. of files in the upload.
+        noScannerLicenseFoundCount:
+          type: integer
+          description: No. of no scanner license found.
+        scannerUniqueLicenseCount:
+          type: integer
+          description: No. of unique licenses found by scanner.
     Job:
       type: object
       properties:

--- a/src/www/ui/page/BrowseLicense.php
+++ b/src/www/ui/page/BrowseLicense.php
@@ -225,7 +225,7 @@ class BrowseLicense extends DefaultPlugin
    * @param ClearingDecision []
    * @return array
    */
-  private function createLicenseHistogram($uploadTreeId, $tagId, ItemTreeBounds $itemTreeBounds, $agentIds, $groupId)
+  public function createLicenseHistogram($uploadTreeId, $tagId, ItemTreeBounds $itemTreeBounds, $agentIds, $groupId)
   {
     $fileCount = $this->uploadDao->countPlainFiles($itemTreeBounds);
     $licenseHistogram = $this->licenseDao->getLicenseHistogram($itemTreeBounds, $agentIds);

--- a/src/www/ui_tests/api/Models/UploadSummaryTest.php
+++ b/src/www/ui_tests/api/Models/UploadSummaryTest.php
@@ -39,7 +39,11 @@ class UploadSummaryTest extends \PHPUnit\Framework\TestCase
       "filesToBeCleared"        => 0,
       "filesCleared"            => 25,
       "clearingStatus"          => "Closed",
-      "copyrightCount"          => 10
+      "copyrightCount"          => 10,
+      "fileCount"               => 25,
+      "noScannerLicenseFoundCount" => 0,
+      "scannerUniqueLicenseCount" => 0,
+      'concludedNoLicenseFoundCount' => 0
     ];
 
     $actual = new UploadSummary();
@@ -55,6 +59,10 @@ class UploadSummaryTest extends \PHPUnit\Framework\TestCase
     $actual->setFilesCleared(25);
     $actual->setClearingStatus(UploadStatus::CLOSED);
     $actual->setCopyrightCount(10);
+    $actual->setFileCount(25);
+    $actual->setNoScannerLicenseFoundCount(0);
+    $actual->setScannerUniqueLicenseCount(0);
+    $actual->setConcludedNoLicenseFoundCount(0);
 
     $this->assertEquals($expected, $actual->getArray());
   }


### PR DESCRIPTION
## Description

Update the current API to for getting the upload's summary to add more information related to licenses.

### Changes

1. Updated the method `getUploadSummary` in  `UploadController` to make the changes.
2. Updated the `openapi.yaml` file  to introduce a new changes for the API.

## How to test

Make a GET request on the endpoint: `/uploads/{id}/summary`.

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/7ec33f78-bf1c-4fd3-a72b-ce691eafca4e)

### Related Issue:

Fixes [#2467](https://github.com/fossology/fossology/issues/2467)

cc: @shaheemazmalmmd @GMishx

