### PR TITLE
feat(api): Get licenses reuse summary API

### DIFF
--- a/src/lib/php/BusinessRules/ReuseReportProcessor.php
+++ b/src/lib/php/BusinessRules/ReuseReportProcessor.php
@@ -46,7 +46,7 @@ class ReuseReportProcessor
    * @return array $vars - array of declearedLicense, clearedLicense, usedLicense,
    *               unusedLicense and missingLicense
    */
-  function getReuseSummary($uploadId)
+  public function getReuseSummary($uploadId)
   {
     $declearedLicenses = $this->detectLicensesFolder->getDeclearedLicenses($uploadId);
     $groupId = Auth::getGroupId();
@@ -71,7 +71,7 @@ class ReuseReportProcessor
     if (empty($declearedLicenses)) {
       $vars["usedLicense"] = "";
       $vars["unusedLicense"] = "";
-      $vars["missingLicense"] = implode($concludedLicenses);
+      $vars["missingLicense"] = implode(", ", $concludedLicenses);
       return $vars;
     }
 

--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -1221,4 +1221,26 @@ class UploadController extends RestController
     }
     return $response->withJson($outputArray, 200);
   }
+
+  /**
+   * Get Reuse report summary for the upload
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function getReuseReportSummary($request, $response, $args)
+  {
+    $uploadId = intval($args['id']);
+
+    if (!$this->dbHelper->doesIdExist("upload", "upload_pk", $uploadId)) {
+      $returnVal = new Info(404, "Upload does not exist", InfoType::ERROR);
+      return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+    }
+
+    $reuseReportProcess = $this->container->get('businessrules.reusereportprocessor');
+    $res = $reuseReportProcess->getReuseSummary($uploadId);
+    return $response->withJson($res, 200);
+  }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1677,6 +1677,43 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+          
+  /uploads/{id}/licenses/reuse:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+    get:
+      operationId: getLicensesReuseSummary
+      tags:
+        - Upload
+      summary: Get the overall licenses reuse summary
+      description: >
+        Get the overall licenses reuse summary for an upload
+      responses:
+        '200':
+          description: Get licenses reuse summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetReuseReportSummary'
+        '404':
+          description: Resource Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /search:
     get:
       operationId: searchFile
@@ -4887,6 +4924,26 @@ components:
           default: 0
           example: 3
       required: ["importerUser"]
+    GetReuseReportSummary:
+      description: Information required by Reuse Report Summary for an upload
+      type: object
+      properties:
+        declearedLicense:
+          type: string
+          description: Decleared license
+          example: "MIT"
+        clearedLicense:
+          type: string
+          description: Cleared license
+          example: "MIT, BSD-3-Clause"
+        unusedLicense:
+          type: string
+          description: Unused license
+          example: "AAL"
+        missingLicense:
+          type: string
+          description: Missing license
+          example: "MIT, BSD-3-Clause"
     SpdxRdfImport:
       description: Information required by SPDX RDF report import agent.
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -153,6 +153,7 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/licenses/histogram', UploadController::class . ':getLicensesHistogram');
     $app->get('/{id:\\d+}/agents', UploadController::class . ':getAllAgents');
     $app->get('/{id:\\d+}/licenses/edited', UploadController::class . ':getEditedLicenses');
+    $app->get('/{id:\\d+}/licenses/reuse', UploadController::class . ':getReuseReportSummary');
     $app->get('/{id:\\d+}/download', UploadController::class . ':uploadDownload');
     $app->get('/{id:\\d+}/copyrights', UploadController::class . ':getUploadCopyrights');
     $app->get('/{id:\\d+}/clearing-progress', UploadController::class . ':getClearingProgressInfo');

--- a/src/www/ui/async/AjaxReuseReport.php
+++ b/src/www/ui/async/AjaxReuseReport.php
@@ -38,7 +38,7 @@ class AjaxReuseReport extends DefaultPlugin
    * @return Response
    * @throws \Exception If upload is not accessible.
    */
-  protected function handle(Request $request)
+  public function handle(Request $request)
   {
     $upload = intval($request->get("upload"));
     $groupId = Auth::getGroupId();


### PR DESCRIPTION
## Description

Added the API to the summary regarding the license reuse summary.

### Changes

1. Added a new method in  `UploadController` to handle the logic.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/uploads/{id}/licenses/reuse`.
3. Updated the `openapi.yaml` file  to introduce a new API.

## How to test

Make a GET request on the endpoint: `/uploads/{id}/licenses/reuse`.

## Screenshots

**UI View:**

![image](https://github.com/fossology/fossology/assets/66276301/3f665e9b-e444-47ef-a33a-41f28a33a939)

**API response:**

![image](https://github.com/fossology/fossology/assets/66276301/0c4be153-1ae0-42cc-9df3-40f2e6b94cd6)


### Related Issue:
Fixes [#2500](https://github.com/fossology/fossology/issues/2500)

cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2501"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

