### PR TITLE
feat(api): get all agents for the upload

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1439,6 +1439,45 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+  /uploads/{id}/agents:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+    get:
+      operationId: getAgentsByUploadId
+      tags:
+        - Upload
+      summary: Get agents for a upload
+      description: >
+        Returns the list of agents for a upload.
+      responses:
+        '200':
+          description: Get agents
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AgentOfUpload'
+        '404':
+          description: Resource Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /search:
     get:
       operationId: searchFile
@@ -4162,6 +4201,37 @@ components:
         concludedCount:
           type: integer
           example: 1
+    AgentOfUpload:
+      type: object
+      properties:
+        successfulAgents:
+          type: array
+          items:
+              properties:
+                agent_id:
+                  type: integer
+                  example: 20
+                agent_rev:
+                  type: string
+                  example: "4.1.0.282-rc1.ffb851"
+                agent_name:
+                  type: string
+                  example: "reso"
+        uploadId:
+          type: integer
+          example: 10
+        agentName:
+          type: string
+          example: "reso"
+        currentAgentId:
+          type: integer
+          example: 20
+        currentAgentRev:
+          type: string
+          example: "4.1.0.282-rc1.ffb851"
+        isAgentRunning:
+          type: boolean
+          example: false
     UserGroupMember:
       type: object
       properties:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -150,6 +150,7 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/summary', UploadController::class . ':getUploadSummary');
     $app->get('/{id:\\d+}/licenses', UploadController::class . ':getUploadLicenses');
     $app->get('/{id:\\d+}/licenses/histogram', UploadController::class . ':getLicensesHistogram');
+    $app->get('/{id:\\d+}/agents', UploadController::class . ':getAllAgents');
     $app->get('/{id:\\d+}/download', UploadController::class . ':uploadDownload');
     $app->get('/{id:\\d+}/copyrights', UploadController::class . ':getUploadCopyrights');
     $app->get('/{id:\\d+}/clearing-progress', UploadController::class . ':getClearingProgressInfo');


### PR DESCRIPTION
## Description

Added the API to the retrieve the list of the agents associated with the upload.

### Changes

1. Added a new method in  `UploadController` to handle the logic.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/uploads/{id}/agents`.
3. Updated the `openapi.yaml` file  to introduce a new API.

## How to test

Make a GET request on the endpoint: `/uploads/{id}/agents`.

## Screenshots
![image](https://github.com/fossology/fossology/assets/66276301/abc10bb9-dc56-4d76-8178-5933cc1ffcf9)

### Related Issue:
Fixes [#2500](https://github.com/fossology/fossology/issues/2500)

cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2502"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

