### PR TITLE
feat(api): Add, edit & delete license decision

### DIFF
--- a/src/www/ui/ajax-clearing-view.php
+++ b/src/www/ui/ajax-clearing-view.php
@@ -277,7 +277,7 @@ class AjaxClearingView extends FO_Plugin
    * @param boolean $orderAscending
    * @return array
    */
-  protected function getCurrentSelectedLicensesTableData(ItemTreeBounds $itemTreeBounds, $groupId, $orderAscending)
+  public function getCurrentSelectedLicensesTableData(ItemTreeBounds $itemTreeBounds, $groupId, $orderAscending)
   {
     $uploadTreeId = $itemTreeBounds->getItemId();
     $uploadId = $itemTreeBounds->getUploadId();

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1227,7 +1227,61 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-
+    put:
+      operationId: addEditDeleteLicenseDecision
+      tags:
+        - Upload
+      summary: Add, update or delete a license decision.
+      description: >
+        Add, update or delete a license decision for a particular upload tree item.
+      requestBody:
+        description: Add, update or delete
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/AddEditDeleteLicenseDecision'
+      responses:
+        '200':
+          description: Request processed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: array
+                    description: List of the items' responses whose requests processed successfully.
+                    items:
+                      $ref: '#/components/schemas/Info'
+                  errors:
+                    type: array
+                    description: List of the errors found.
+                    items:
+                      $ref: '#/components/schemas/Info'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Resource Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+          
   /uploads/{id}/licenses/main:
     parameters:
       - name: id
@@ -5128,6 +5182,31 @@ components:
         paths:
           type: string
           description: API endpoints
+    AddEditDeleteLicenseDecision:
+      type: object
+      properties:
+        shortName:
+          type: string
+          description: Short name of the license
+          example: "MIT"
+        add:
+          type: boolean
+          description: |
+            If true, add the license if not on the list, otherwise update it's properties.
+            If false, remove the license from the list.
+          example: true
+        text:
+          type: string
+          description: Clearing info text
+          example: "This is a license decision text"
+        ack:
+          type: string
+          description: Acknowledgement of license decision
+          example:  "This is a license decision acknowledgement text"
+        comment:
+          type: string
+          description: Comment for the license decision
+          example: "This is a license decision comment"
     DecisionImporter:
       description: Information required by Decision Importer agent
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -156,6 +156,7 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/licenses/reuse', UploadController::class . ':getReuseReportSummary');
     $app->get('/{id:\\d+}/licenses/scanned', UploadController::class . ':getScannedLicenses');
     $app->get('/{id:\\d+}/agents/revision', UploadController::class . ':getAgentsRevision');
+    $app->put('/{id:\\d+}/item/{itemId:\\d+}/licenses', UploadTreeController::class . ':handleAddEditAndDeleteLicenseDecision');
     $app->get('/{id:\\d+}/download', UploadController::class . ':uploadDownload');
     $app->get('/{id:\\d+}/copyrights', UploadController::class . ':getUploadCopyrights');
     $app->get('/{id:\\d+}/clearing-progress', UploadController::class . ':getClearingProgressInfo');


### PR DESCRIPTION
## Description

Added the API to handle add, edit, and delete of the license decisions in one request.

### Changes

1. Added a new method in  `UploadTreeController` to handle the logic.
2. Created the method in `UploadTreeController` for handling add, edit and delete of the items given in the request body.
3. Updated  the main file(`index.php`) by adding a new route `PUT` `/uploads/{id}/item/{itemId}/licenses`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a PUT request on the endpoint: ``/uploads/{id}/item/{itemId}/licenses``,

## Screenshots

### Request
![image](https://github.com/fossology/fossology/assets/66276301/345c9f4a-1376-4f1f-988e-8436b8c29c14)

### Response
![image](https://github.com/fossology/fossology/assets/66276301/16931d5c-e649-4be1-a6e8-04b1e4d7efce)

### Related Issue:
Fixes #2459 

    
cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2509"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

