### PR TITLE
feat(api): Get all licenses-admin acknowlegments

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -3325,6 +3325,31 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+  /license/adminacknowledgements:
+    get:
+      operationId: getAdminLicenseAcknowledgements
+      tags:
+        - License
+      summary: Get all admin license acknowledgements
+      description: >
+        Get a list of the admin license acknowledgements
+      responses:
+        '200':
+          description: Request is successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AdminLicenseAcknowledgement'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
 components:
   securitySchemes:
     bearerAuth:
@@ -4573,6 +4598,25 @@ components:
           type: boolean
           description: Add the copyright information as text findings
           default: false
+    AdminLicenseAcknowledgement:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: The primary key of the AdminAcknowledgement
+          example: 2
+        name:
+          type: string
+          description: The name of the AdminAcknowledgement
+          example: ackupdated
+        acknowledgement:
+          type: string
+          description: The acknowledgement text of the AdminAcknowledgement
+          example: updated Ack text
+        is_enabled:
+          type: boolean
+          description: Indicates if the AdminAcknowledgement is enabled
+          example: true
   responses:
     defaultResponse:
       description: Some error occurred. Check the "message"

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -276,6 +276,7 @@ $app->group('/license',
     $app->post('/import-csv', LicenseController::class . ':handleImportLicense');
     $app->post('', LicenseController::class . ':createLicense');
     $app->get('/admincandidates', LicenseController::class . ':getCandidates');
+    $app->get('/adminacknowledgements', LicenseController::class . ':getAllAdminAcknowledgements');
     $app->get('/{shortname:.+}', LicenseController::class . ':getLicense');
     $app->patch('/{shortname:.+}', LicenseController::class . ':updateLicense');
     $app->delete('/admincandidates/{id:\\d+}',

--- a/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
@@ -13,6 +13,7 @@
 namespace Fossology\UI\Api\Test\Controllers;
 
 use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\LicenseAcknowledgementDao;
 use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Dao\UserDao;
 use Fossology\Lib\Db\DbManager;
@@ -92,6 +93,12 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
   private $userDao;
 
   /**
+   * @var LicenseAcknowledgementDao $adminLicenseAckDao
+   * LicenseAcknowledgementDao mock
+   */
+  private $adminLicenseAckDao;
+
+  /**
    * @var M\MockInterface $adminLicensePlugin
    * admin_license_from_csv mock
    */
@@ -132,6 +139,7 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
     $this->restHelper = M::mock(RestHelper::class);
     $this->licenseDao = M::mock(LicenseDao::class);
     $this->userDao = M::mock(UserDao::class);
+    $this->adminLicenseAckDao = M::mock(LicenseAcknowledgementDao::class);
     $this->adminLicensePlugin = M::mock('admin_license_from_csv');
     $this->licenseCandidatePlugin = M::mock('admin_license_candidate');
 
@@ -151,6 +159,8 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
       'helper.restHelper'))->andReturn($this->restHelper);
     $container->shouldReceive('get')->withArgs(array(
       'dao.license'))->andReturn($this->licenseDao);
+    $container->shouldReceive('get')->withArgs(array(
+      'dao.license.acknowledgement'))->andReturn($this->adminLicenseAckDao);
     $this->licenseController = new LicenseController($container);
     $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
     $this->streamFactory = new StreamFactory();


### PR DESCRIPTION
## Description

Added the API to retrieve a list of the licenses' admin acknowledgments.

### Changes

1. Added a new method in  `LicenseController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/licenses/adminacknowlegments`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a GET request on the endpoint:  `/licenses/adminacknowlegments`,

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/53743f5a-ffec-4f51-a3e4-16d98113629d)

### Related Issue:
Fixes #2511 

    
cc: @shaheemazmalmmd @GMishx



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2512"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

