### PR TITLE
feat(api): add new admin-license acknowledgment

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -2709,6 +2709,42 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+  /license/adminacknowledgements:
+    post:
+      operationId: addAdminLicenseAcknowledgement
+      tags:
+        - License
+      summary: Add a new admin license acknowledgement
+      description: >
+        Add a new admin license acknowledgement to the list.
+      requestBody:
+        description: Information to be added
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewAdminLicenseAcknowledgement'
+      responses:
+        '200':
+          description: Request is successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
 components:
   securitySchemes:
     bearerAuth:
@@ -3704,6 +3740,17 @@ components:
           type: boolean
           description: Add the copyright information as text findings
           default: false
+    NewAdminLicenseAcknowledgement:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the AdminAcknowledgement
+          example: ackName
+        ack:
+          type: string
+          description: The acknowledgement text of the AdminAcknowledgement
+          example: ack text
   responses:
     defaultResponse:
       description: Some error occurred. Check the "message"

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -266,6 +266,7 @@ $app->group('/license',
     $app->patch('/{shortname:.+}', LicenseController::class . ':updateLicense');
     $app->delete('/admincandidates/{id:\\d+}',
       LicenseController::class . ':deleteAdminLicenseCandidate');
+    $app->post('/adminacknowledgements', LicenseController::class . ':addNewAdminAcknowledgement');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
@@ -13,6 +13,7 @@
 namespace Fossology\UI\Api\Test\Controllers;
 
 use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\LicenseAcknowledgementDao;
 use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Dao\UserDao;
 use Fossology\Lib\Db\DbManager;
@@ -86,6 +87,12 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
   private $licenseDao;
 
   /**
+   * @var LicenseAcknowledgementDao $adminLicenseAckDao
+   * LicenseAcknowledgementDao mock
+   */
+  private $adminLicenseAckDao;
+
+  /**
    * @var UserDao $userDao
    * UserDao mock
    */
@@ -132,6 +139,7 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
     $this->restHelper = M::mock(RestHelper::class);
     $this->licenseDao = M::mock(LicenseDao::class);
     $this->userDao = M::mock(UserDao::class);
+    $this->adminLicenseAckDao = M::mock(LicenseAcknowledgementDao::class);
     $this->adminLicensePlugin = M::mock('admin_license_from_csv');
     $this->licenseCandidatePlugin = M::mock('admin_license_candidate');
 
@@ -151,6 +159,10 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
       'helper.restHelper'))->andReturn($this->restHelper);
     $container->shouldReceive('get')->withArgs(array(
       'dao.license'))->andReturn($this->licenseDao);
+    $container->shouldReceive('get')->withArgs(array(
+      'auth'))->andReturn($this->auth);
+    $container->shouldReceive('get')->withArgs(array(
+      'dao.license.acknowledgement'))->andReturn($this->adminLicenseAckDao);
     $this->licenseController = new LicenseController($container);
     $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
     $this->streamFactory = new StreamFactory();


### PR DESCRIPTION
## Description

Added the API to retrieve a list of the licenses' admin acknowledgments.

### Changes

1. Added a new method in  `LicenseController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `POST` `/licenses/adminacknowlegments`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a POST request on the endpoint:  `/licenses/adminacknowlegments`,

## Screenshots

#### 1. Successful Req

![image](https://github.com/fossology/fossology/assets/66276301/860f434b-6c41-4716-b489-7f9c7bf1d8d9)


#### 2. Name Exists (Handle duplicates)

![image](https://github.com/fossology/fossology/assets/66276301/2d0d5b6f-6b87-43b1-b6bd-29f466c6f01f)


### Related Issue:
Fixes #2511 

    
cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2513"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

