### PR TITLE
feat(api): update admin license acknowledgement

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -2752,6 +2752,50 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+
+  /license/adminacknowledgements/{ackId}:
+    parameters:
+      - name: ackId
+        required: true
+        description: Id of the admin-license-acknowledgement
+        in: path
+        schema:
+          type: integer
+    put:
+      operationId: updateAdminLicenseAcknowledgement
+      tags:
+        - License
+      summary: Update admin license acknowledgement
+      description: >
+        Update admin license acknowledgement to the list.
+      requestBody:
+        description: Information to be updated
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewAdminLicenseAcknowledgement'
+      responses:
+        '200':
+          description: Request is successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
 components:
   securitySchemes:
     bearerAuth:
@@ -3747,6 +3791,17 @@ components:
           type: boolean
           description: Add the copyright information as text findings
           default: false
+    NewAdminLicenseAcknowledgement:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the AdminAcknowledgement
+          example: ackName
+        ack:
+          type: string
+          description: The acknowledgement text of the AdminAcknowledgement
+          example: ack text
   responses:
     defaultResponse:
       description: Some error occurred. Check the "message"

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -267,6 +267,7 @@ $app->group('/license',
     $app->patch('/{shortname:.+}', LicenseController::class . ':updateLicense');
     $app->delete('/admincandidates/{id:\\d+}',
       LicenseController::class . ':deleteAdminLicenseCandidate');
+    $app->put('/adminacknowledgements/{ackId:\\d+}', LicenseController::class . ':updateAdminAcknowledgement');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
@@ -13,6 +13,7 @@
 namespace Fossology\UI\Api\Test\Controllers;
 
 use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\LicenseAcknowledgementDao;
 use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Dao\UserDao;
 use Fossology\Lib\Db\DbManager;
@@ -86,6 +87,12 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
   private $licenseDao;
 
   /**
+   * @var LicenseAcknowledgementDao $adminLicenseAckDao
+   * LicenseAcknowledgementDao mock
+   */
+  private $adminLicenseAckDao;
+
+  /**
    * @var UserDao $userDao
    * UserDao mock
    */
@@ -134,6 +141,7 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
     $this->userDao = M::mock(UserDao::class);
     $this->adminLicensePlugin = M::mock('admin_license_from_csv');
     $this->licenseCandidatePlugin = M::mock('admin_license_candidate');
+    $this->adminLicenseAckDao = M::mock(LicenseAcknowledgementDao::class);
 
     $this->dbHelper->shouldReceive('getDbManager')->andReturn($this->dbManager);
 
@@ -146,7 +154,8 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
 
     $this->restHelper->shouldReceive('getPlugin')
       ->withArgs(array('admin_license_from_csv'))->andReturn($this->adminLicensePlugin);
-
+    $container->shouldReceive('get')->withArgs(array(
+      'dao.license.acknowledgement'))->andReturn($this->adminLicenseAckDao);
     $container->shouldReceive('get')->withArgs(array(
       'helper.restHelper'))->andReturn($this->restHelper);
     $container->shouldReceive('get')->withArgs(array(


### PR DESCRIPTION
## Description

Added the API to retrieve a list of the licenses' admin acknowledgments.

### Changes

1. Added a new method in  `LicenseController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `PUT` `/licenses/adminacknowlegments/{id}`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a PUT request on the endpoint:  `/licenses/adminacknowlegments/{id}`,

## Screenshots

#### 1. Successful Req

![image](https://github.com/fossology/fossology/assets/66276301/6ab9843f-2657-4848-853f-8e47f0c7675f)


#### 2. Name Exists (Handle duplicates- Updated name matches with another existing one)

![image](https://github.com/fossology/fossology/assets/66276301/2d0d5b6f-6b87-43b1-b6bd-29f466c6f01f)


### Related Issue:
Fixes #2511 

cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2515"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

