### PR TITLE
feat(api): Add, Edit & toggle admin license acknowledgement

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -3709,6 +3709,39 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+
+    put:
+      operationId: mutateAdminLicenseAcknowledgement
+      tags:
+        - License
+      summary: Add, Edit, Enable & Disable
+      description: >
+        Add, edit and toggle admin-license acknowledgement
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/MutateAdminAcknowledgement'
+      responses:
+        '200':
+          description: Request is successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
 components:
   securitySchemes:
     bearerAuth:
@@ -5211,6 +5244,38 @@ components:
         is_enabled:
           type: boolean
           description: Indicates if the AdminAcknowledgement is enabled
+          example: true
+    MutateAdminAcknowledgement:
+      type: object
+      properties:
+        id:
+          type: integer
+          description:  |
+            The ID of the acknowledgement.
+            Required if update is TRUE.
+          example: 2
+        name:
+          type: string
+          description: |
+            The name of the acknowledgement.
+            Not required if update is TRUE and toggle is set.
+          example: ackName
+        ack:
+          type: string
+          description: |
+            The acknowledgement text.
+            Not required if update is TRUE and toggle is set.
+          example: acknowledgement text
+        toggle:
+          type: boolean
+          description: A boolean indicating the toggle state.
+          example: true
+        update:
+          type: boolean
+          description: |
+            A boolean indicating if an update is needed.
+            If true, update the given admin acknowledgement.
+            if false, add new admin acknowledgement.
           example: true
   responses:
     defaultResponse:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -289,6 +289,7 @@ $app->group('/license',
     $app->patch('/{shortname:.+}', LicenseController::class . ':updateLicense');
     $app->delete('/admincandidates/{id:\\d+}',
       LicenseController::class . ':deleteAdminLicenseCandidate');
+    $app->put('/adminacknowledgements', LicenseController::class . ':handleAdminLicenseAcknowledgement');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
@@ -158,6 +158,8 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
     $container->shouldReceive('get')->withArgs(array(
       'helper.restHelper'))->andReturn($this->restHelper);
     $container->shouldReceive('get')->withArgs(array(
+      'dao.license.acknowledgement'))->andReturn($this->adminLicenseAckDao);
+    $container->shouldReceive('get')->withArgs(array(
       'dao.license'))->andReturn($this->licenseDao);
     $container->shouldReceive('get')->withArgs(array(
       'dao.license.acknowledgement'))->andReturn($this->adminLicenseAckDao);


### PR DESCRIPTION
## Description

Added the API to add new, edit and toggle admin license acknowledgement.

### Changes

1. Added a new method in  `LicenseController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `PUT` `/licenses/adminacknowlegments`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a PUT request on the endpoint: ``/licenses/adminacknowlegments``,

## Screenshots

### Request
![image](https://github.com/fossology/fossology/assets/66276301/214f5e25-073d-4d59-affc-fd7b1ecb6aaf)

### Response
![image](https://github.com/fossology/fossology/assets/66276301/0f604e2e-3c17-4a53-b473-b6340d8dd9cd)

### Related Issue:
Fixes #2511 

    
cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2509"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2516"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

