### PR TITLE
feat(api): Get all standard comments

### DIFF
--- a/src/www/ui/api/Controllers/LicenseController.php
+++ b/src/www/ui/api/Controllers/LicenseController.php
@@ -15,6 +15,7 @@ namespace Fossology\UI\Api\Controllers;
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\LicenseAcknowledgementDao;
 use Fossology\Lib\Dao\LicenseDao;
+use Fossology\Lib\Dao\LicenseStdCommentDao;
 use Fossology\Lib\Exception;
 use Fossology\Lib\Util\StringOperation;
 use Fossology\UI\Api\Helper\ResponseHelper;
@@ -61,6 +62,11 @@ class LicenseController extends RestController
    */
   private $adminLicenseAckDao;
 
+  /**
+   * @var LicenseStdCommentDao $licenseStdCommentDao
+   * License Dao object
+   */
+  private $licenseStdCommentDao;
 
   /**
    * @param ContainerInterface $container
@@ -70,6 +76,7 @@ class LicenseController extends RestController
     parent::__construct($container);
     $this->licenseDao = $this->container->get('dao.license');
     $this->adminLicenseAckDao = $this->container->get('dao.license.acknowledgement');
+    $this->licenseStdCommentDao = $this->container->get('dao.license.stdc');
   }
 
   /**
@@ -584,5 +591,24 @@ class LicenseController extends RestController
       'success' => $success,
       'errors' => $errors
     ], 200);
+  }
+
+  /**
+   * Get all license standard comments
+   *
+   * @param Request $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function getAllLicenseStandardComments($request, $response, $args)
+  {
+    $res = $this->licenseStdCommentDao->getAllComments();
+    foreach ($res as $key => $ack) {
+      $res[$key]['id'] = intval($ack['lsc_pk']);
+      $res[$key]['is_enabled'] = $ack['is_enabled'] == "t";
+      unset($res[$key]['lsc_pk']);
+    }
+    return $response->withJson($res, 200);
   }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -3814,7 +3814,6 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-
     put:
       operationId: mutateAdminLicenseAcknowledgement
       tags:
@@ -3845,6 +3844,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /license/stdcomments:
+    get:
+      operationId: getAllStandardLicenseComments
+      tags:
+        - License
+      summary: Get all standard license comments
+      description: >
+        Get a list of all standard license comments.
+      responses:
+        '200':
+          description: Request is successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StandardComment'
         default:
           $ref: '#/components/responses/defaultResponse'
 components:
@@ -5531,6 +5550,25 @@ components:
             If true, update the given admin acknowledgement.
             if false, add new admin acknowledgement.
           example: true
+    StandardComment:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 2
+          description: The primary key of the comment.
+        name:
+          type: string
+          example: firstComment
+          description: The name of the comment.
+        comment:
+          type: string
+          example: The comment's text
+          description: The text content of the comment.
+        is_enabled:
+          type: boolean
+          example: true
+          description: Indicates whether the comment is enabled or not.
   responses:
     defaultResponse:
       description: Some error occurred. Check the "message"

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -295,6 +295,7 @@ $app->group('/license',
     $app->post('', LicenseController::class . ':createLicense');
     $app->get('/admincandidates', LicenseController::class . ':getCandidates');
     $app->get('/adminacknowledgements', LicenseController::class . ':getAllAdminAcknowledgements');
+    $app->get('/stdcomments', LicenseController::class . ':getAllLicenseStandardComments');
     $app->get('/{shortname:.+}', LicenseController::class . ':getLicense');
     $app->patch('/{shortname:.+}', LicenseController::class . ':updateLicense');
     $app->delete('/admincandidates/{id:\\d+}',

--- a/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
@@ -15,6 +15,7 @@ namespace Fossology\UI\Api\Test\Controllers;
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\LicenseAcknowledgementDao;
 use Fossology\Lib\Dao\LicenseDao;
+use Fossology\Lib\Dao\LicenseStdCommentDao;
 use Fossology\Lib\Dao\UserDao;
 use Fossology\Lib\Db\DbManager;
 use Fossology\UI\Api\Controllers\LicenseController;
@@ -99,6 +100,12 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
   private $adminLicenseAckDao;
 
   /**
+   * @var LicenseStdCommentDao $licenseStdCommentDao
+   * LicenseStdCommentDao mock
+   */
+  private $licenseStdCommentDao;
+
+  /**
    * @var M\MockInterface $adminLicensePlugin
    * admin_license_from_csv mock
    */
@@ -142,6 +149,7 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
     $this->adminLicenseAckDao = M::mock(LicenseAcknowledgementDao::class);
     $this->adminLicensePlugin = M::mock('admin_license_from_csv');
     $this->licenseCandidatePlugin = M::mock('admin_license_candidate');
+    $this->licenseStdCommentDao = M::mock(LicenseStdCommentDao::class);
 
     $this->dbHelper->shouldReceive('getDbManager')->andReturn($this->dbManager);
 
@@ -154,7 +162,8 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
 
     $this->restHelper->shouldReceive('getPlugin')
       ->withArgs(array('admin_license_from_csv'))->andReturn($this->adminLicensePlugin);
-
+    $container->shouldReceive('get')->withArgs(array(
+      'dao.license.stdc'))->andReturn($this->licenseStdCommentDao);
     $container->shouldReceive('get')->withArgs(array(
       'helper.restHelper'))->andReturn($this->restHelper);
     $container->shouldReceive('get')->withArgs(array(


### PR DESCRIPTION
## Description

Added the API to retrieve a list of the standard comments.

### Changes

1. Added a new method in  `LicenseController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/licenses/stdcomments`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a GET request on the endpoint:  `/licenses/stdcomments`,

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/e86abcf1-2d91-4d4c-8575-b9c558655c0e)

### Related Issue:
Fixes #2511 

    
cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2517"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

