### PR TITLE
feat(api): Add, Edit & toggle standard-license comment

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -3943,6 +3943,44 @@ paths:
                   $ref: '#/components/schemas/StandardComment'
         default:
           $ref: '#/components/responses/defaultResponse'
+    put:
+      operationId: mutateStdComments
+      tags:
+        - License
+      summary: Add, Edit, Enable & Disable
+      description: >
+        Add, edit and toggle standard comments
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/MutateStdComment'
+      responses:
+        '200':
+          description: Request is successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Info'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
 components:
   securitySchemes:
     bearerAuth:
@@ -5703,6 +5741,38 @@ components:
           type: integer
           description: "Number of fired jobs"
           example: 23
+    MutateStdComment:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: |
+            The ID of the standard comment.
+            Required if update is TRUE.
+          example: 2
+        name:
+          type: string
+          description: |
+            The name of the standard comment.
+            Required if update is FALSE.
+          example: commentName
+        comment:
+          type: string
+          description: |
+            The standard comment text.
+            Required if update is FALSE.
+          example: comment text
+        toggle:
+          type: boolean
+          description: A boolean indicating the toggle state.
+          example: true
+        update:
+          type: boolean
+          description: |
+            A boolean indicating if an update is needed.
+            If TRUE, update the given standard comment.
+            if FALSE, add new standard comment.
+          example: true
   responses:
     defaultResponse:
       description: Some error occurred. Check the "message"

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -321,6 +321,7 @@ $app->group('/license',
     $app->get('/admincandidates', LicenseController::class . ':getCandidates');
     $app->get('/adminacknowledgements', LicenseController::class . ':getAllAdminAcknowledgements');
     $app->get('/stdcomments', LicenseController::class . ':getAllLicenseStandardComments');
+    $app->put('/stdcomments', LicenseController::class . ':handleLicenseStandardComment');
     $app->get('/{shortname:.+}', LicenseController::class . ':getLicense');
     $app->patch('/{shortname:.+}', LicenseController::class . ':updateLicense');
     $app->delete('/admincandidates/{id:\\d+}',

--- a/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
@@ -159,7 +159,6 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
     $this->restHelper->shouldReceive('getUserId')->andReturn($this->userId);
     $this->restHelper->shouldReceive('getUserDao')->andReturn($this->userDao);
 
-
     $this->restHelper->shouldReceive('getPlugin')
       ->withArgs(array('admin_license_from_csv'))->andReturn($this->adminLicensePlugin);
     $container->shouldReceive('get')->withArgs(array(


### PR DESCRIPTION
## Description

Added the API to add new, edit and toggle standard-license comments.

### Changes

1. Added a new method in  `LicenseController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `PUT` `/licenses/stdcomments`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a PUT request on the endpoint: ``/licenses/stdcomments``,

## Screenshots

### Request
![image](https://github.com/fossology/fossology/assets/66276301/fc1b0a66-699d-4103-856e-de00719d3cf2)

### Response
![image](https://github.com/fossology/fossology/assets/66276301/2eb52d49-5447-4c46-9780-8ee7635c4884)

### Related Issue:
Fixes #2511 

cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2518"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

