### PR TITLE
feat(api): Search & suggest license from the reference text

### DIFF
--- a/src/monk/ui/oneshot.php
+++ b/src/monk/ui/oneshot.php
@@ -65,7 +65,7 @@ class OneShot extends DefaultPlugin
     return $this->render('include/base.html.twig', $vars);
   }
 
-  public function scanMonkRendered($text)
+  public function scanMonkRendered($text, $fromRest = false)
   {
     $tmpFileName = tempnam("/tmp", "monk");
     if (!$tmpFileName) {
@@ -82,7 +82,9 @@ class OneShot extends DefaultPlugin
     $textFragment = new TextFragment(0, $text);
 
     $rendered = $this->textRenderer->renderText($textFragment, $splitPositions);
-
+    if ( $fromRest ) {
+      return array($licenseIds, $highlights);
+    }
     return array($licenseIds, $rendered);
   }
 

--- a/src/monk/ui/oneshot.php
+++ b/src/monk/ui/oneshot.php
@@ -78,13 +78,14 @@ class OneShot extends DefaultPlugin
     unlink($tmpFileName);
 
     $this->highlightProcessor->addReferenceTexts($highlights);
+    if ($fromRest) {
+      return array($licenseIds, $highlights);
+    }
+
     $splitPositions = $this->highlightProcessor->calculateSplitPositions($highlights);
     $textFragment = new TextFragment(0, $text);
 
     $rendered = $this->textRenderer->renderText($textFragment, $splitPositions);
-    if ( $fromRest ) {
-      return array($licenseIds, $highlights);
-    }
     return array($licenseIds, $rendered);
   }
 

--- a/src/www/ui/api/Controllers/LicenseController.php
+++ b/src/www/ui/api/Controllers/LicenseController.php
@@ -852,8 +852,10 @@ class LicenseController extends RestController
 
     list ($suggestIds, $rendered) = $adminLicenseCandidate->suggestLicenseId($rfText, true);
 
-    foreach ($rendered as $key => $value) {
-      $rendered[$key] = $value->getArray();
+    $highlights = [];
+
+    foreach ($rendered as $value) {
+      $highlights[] = $value->getArray();
     }
 
     if (! empty($suggestIds)) {
@@ -868,7 +870,7 @@ class LicenseController extends RestController
         'url' => $suggestLicense['rf_url'],
         'notes' => $suggestLicense['rf_notes'],
         'risk' => intval($suggestLicense['rf_risk']),
-        'highlights' => $rendered,
+        'highlights' => $highlights,
       ];
     }
     if (empty($suggestLicense)) {

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -237,6 +237,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HealthInfo'
+        default:
+          $ref: '#/components/responses/defaultResponse'
 
   /uploads/{id}:
     parameters:
@@ -5199,21 +5201,21 @@ components:
           type: string
           description: Type of highlight
           enum:
-            - M | Match
-            - MC | Changed
-            - MA | Added
-            - MD | Deleted
-            - S | Signature
-            - K | Keyword
-            - B | Bulk
-            - C | Copyright
-            - U | Url
-            - E | Email
-            - A | Author
-            - I | IPRA
-            - X | ECC
-            - KW | Keyword others
-            - any | Undefined
+            - M  # Match
+            - MC # Changed
+            - MA # Added
+            - MD # Deleted
+            - S  # Signature
+            - K  # Keyword
+            - B  # Bulk
+            - C  # Copyright
+            - U  # Url
+            - E  # Email
+            - A  # Author
+            - I  # IPRA
+            - X  # ECC
+            - KW # Keyword others
+            - any # Undefined
         shortName:
           type: string
           description: License shortname
@@ -6214,41 +6216,7 @@ components:
         highlights:
           type: array
           items:
-            type: object
-            properties:
-              start:
-                type: integer
-                example: 0
-              end:
-                type: integer
-                example: 161
-              type:
-                type: string
-                example: M
-              licenseId:
-                type: integer
-                example: 126
-              refStart:
-                type: integer
-                example: 0
-              refEnd:
-                type: integer
-                example: 163
-              infoText:
-                type: string
-                example: MIT
-              htmlElement:
-                type: string
-                example: null
-          example:
-            - start: 0
-              end: 161
-              type: M
-              licenseId: 126
-              refStart: 0
-              refEnd: 163
-              infoText: MIT
-              htmlElement: null
+            $ref: '#/components/schemas/HighlightInfo'
   responses:
     defaultResponse:
       description: Some error occurred. Check the "message"

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -643,7 +643,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-  /uploads/{id}/item/{itemId}/info:    
+  /uploads/{id}/item/{itemId}/info:
     parameters:
       - name: id
         required: true
@@ -1045,7 +1045,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-          
+
   /uploads/{id}/item/{itemId}/view:
     parameters:
       - name: id
@@ -1335,7 +1335,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-          
+
   /uploads/{id}/licenses/main:
     parameters:
       - name: id
@@ -1458,7 +1458,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-          
+
   /uploads/{id}/item/{itemId}/prev-next:
     parameters:
       - name: id
@@ -1553,7 +1553,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-  
+
   /uploads/{id}/clearing-progress:
     parameters:
       - name: id
@@ -1874,7 +1874,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-          
+
   /uploads/{id}/licenses/reuse:
     parameters:
       - name: id
@@ -2659,6 +2659,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+
   /jobs/{id}/{queue}:
     parameters:
       - name: id
@@ -4219,6 +4220,50 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /license/suggest:
+    post:
+      operationId: getSuggestedLicense
+      tags:
+        - License
+        - Admin
+      summary: Get suggested license by reference text.
+      description: >
+        Get a single suggested license by the given reference text.
+      requestBody:
+        description: Reference text to get suggested license
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                referenceText:
+                  description: Reference text to get suggested license
+                  type: string
+                  example:
+                    "According to MIT license, add some modifications"
+      responses:
+        '200':
+          description: Request is successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetSuggestedLicense'
+        '403':
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
 components:
   securitySchemes:
     bearerAuth:
@@ -5006,7 +5051,7 @@ components:
       properties:
         key:
           description: field key
-          type: string          
+          type: string
         value:
           description: field value
           type: string
@@ -5033,7 +5078,7 @@ components:
           description: If type is 'dropdown', provide options in format op1{val1}|op2{val2}|...
           type: string
 
-            
+
     Group:
       description: Group object
       type: object
@@ -5061,7 +5106,7 @@ components:
           type: integer
           example:
             3
-                       
+
     GetBulkHistory:
       type: object
       properties:
@@ -5138,7 +5183,7 @@ components:
           items:
             type: string
             example: "GPL-2.0"
-            
+
     HighlightInfo:
       type: object
       properties:
@@ -6131,6 +6176,79 @@ components:
           enum:
             - "Running"
             - "Stopped"
+    GetSuggestedLicense:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: The primary key of the suggested license.
+          example: 1329
+        spdxName:
+          type: string
+          description: The SPDX identifier of the suggested license.
+          example: "LicenseRef-fossology-testmerge"
+        shortname:
+          type: string
+          description: The short name of the suggested license.
+          example: "MIT"
+        fullname:
+          type: string
+          description: The full name of the suggested license.
+          example: "MIT license"
+        text:
+          type: string
+          description: The text content of the suggested license.
+          example: "Copyright (c) 2002 by AUTHOR PROFESSIONAL IDENTIFICATION * URL \"PROMOTIONAL SLOGAN FOR AUTHOR'S PROFESSIONAL PRACTICE\"\r\n"
+        url:
+          type: string
+          description: The URL associated with the suggested license.
+          example: "https://www.google.com/"
+        notes:
+          type: string
+          description: Additional notes or comments about the suggested license.
+          example: "public notes"
+        risk:
+          type: integer
+          description: The risk level associated with the suggested license.
+          example: 2
+        highlights:
+          type: array
+          items:
+            type: object
+            properties:
+              start:
+                type: integer
+                example: 0
+              end:
+                type: integer
+                example: 161
+              type:
+                type: string
+                example: M
+              licenseId:
+                type: integer
+                example: 126
+              refStart:
+                type: integer
+                example: 0
+              refEnd:
+                type: integer
+                example: 163
+              infoText:
+                type: string
+                example: MIT
+              htmlElement:
+                type: string
+                example: null
+          example:
+            - start: 0
+              end: 161
+              type: M
+              licenseId: 126
+              refStart: 0
+              refEnd: 163
+              infoText: MIT
+              htmlElement: null
   responses:
     defaultResponse:
       description: Some error occurred. Check the "message"

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -326,6 +326,7 @@ $app->group('/license',
     $app->get('/adminacknowledgements', LicenseController::class . ':getAllAdminAcknowledgements');
     $app->get('/stdcomments', LicenseController::class . ':getAllLicenseStandardComments');
     $app->put('/stdcomments', LicenseController::class . ':handleLicenseStandardComment');
+    $app->post('/suggest', LicenseController::class . ':getSuggestedLicense');
     $app->get('/{shortname:.+}', LicenseController::class . ':getLicense');
     $app->patch('/{shortname:.+}', LicenseController::class . ':updateLicense');
     $app->delete('/admincandidates/{id:\\d+}',

--- a/src/www/ui/page/AdminLicenseCandidate.php
+++ b/src/www/ui/page/AdminLicenseCandidate.php
@@ -189,13 +189,13 @@ class AdminLicenseCandidate extends DefaultPlugin
     return $row;
   }
 
-  private function suggestLicenseId($str)
+  public function suggestLicenseId($str, $fromRest = false)
   {
     /* @var $monkOneShotPlugin \Fossology\Monk\UI\Oneshot */
     $monkOneShotPlugin = plugin_find("oneshot-monk");
 
     if (null !== $monkOneShotPlugin) {
-      return $monkOneShotPlugin->scanMonkRendered($str);
+      return $monkOneShotPlugin->scanMonkRendered($str, $fromRest);
     } else {
       return array(array(), $str);
     }


### PR DESCRIPTION
## Description

Added the API to search and the suggested license from the given reference text.

### Changes

1. Added a new method in  `LicenseController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `POST` `/license/suggest`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a POST request on the endpoint:  `/license/suggest`,

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/c5015c72-2baa-40cc-8e76-b6931f1979bc)

### Related Issue:
Fixes #2510 
    
cc: @shaheemazmalmmd @GMishx




<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2524"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

