### PR TITLE
feat(api): verify license as new or variant

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -3981,6 +3981,63 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+  /license/verify/{shortname}:
+    parameters:
+      - name: shortname
+        in: path
+        required: true
+        description: Shortname of the license to be verified
+        schema:
+          type: string
+    put:
+      operationId: verifyLicense
+      tags:
+        - License
+        - Admin
+      summary: Verify a license as new or variant
+      description: >
+        Verify a license as new or variant of another license
+      requestBody:
+        description: The shortname of the parent license |
+           Same name if it's to be verified as a new license
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                parentShortname:
+                  description: Shortname of the parent license
+                  type: string
+                  example:
+                    "MIT"
+      responses:
+        '200':
+          description: License verified successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Given License not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
 components:
   securitySchemes:
     bearerAuth:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -318,6 +318,7 @@ $app->group('/license',
     $app->get('', LicenseController::class . ':getAllLicenses');
     $app->post('/import-csv', LicenseController::class . ':handleImportLicense');
     $app->post('', LicenseController::class . ':createLicense');
+    $app->put('/verify/{shortname:.+}', LicenseController::class . ':verifyLicense');
     $app->get('/admincandidates', LicenseController::class . ':getCandidates');
     $app->get('/adminacknowledgements', LicenseController::class . ':getAllAdminAcknowledgements');
     $app->get('/stdcomments', LicenseController::class . ':getAllLicenseStandardComments');

--- a/src/www/ui/page/AdminLicenseCandidate.php
+++ b/src/www/ui/page/AdminLicenseCandidate.php
@@ -207,7 +207,7 @@ class AdminLicenseCandidate extends DefaultPlugin
    * @param int $rfParent
    * @return bool
    */
-  private function verifyCandidate($rf, $shortname, $rfParent)
+  public function verifyCandidate($rf, $shortname, $rfParent)
   {
     /* @var $licenseDao LicenseDao */
     $licenseDao = $this->getObject('dao.license');


### PR DESCRIPTION
## Description

Added the API to verify a given a license as new one or the variant of another existing license.

### Changes

1. Added a new method in  `LicenseController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `PUT` `/license/verify/{shortname}`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a PUT request on the endpoint:  `/license/verify/{shortname}`,

## Screenshots

#### 1. Verify as new (`shortname in args and body are expected to match`)
![image](https://github.com/fossology/fossology/assets/66276301/dbc8e385-6ea4-441d-878b-bd01570686fe)
![image](https://github.com/fossology/fossology/assets/66276301/073f770f-0487-4545-8ce2-d2dde48ce7e6)

#### 2. Verify as a variant 
![image](https://github.com/fossology/fossology/assets/66276301/777977d5-8abf-4a9b-810a-c4203b1a8308)
![image](https://github.com/fossology/fossology/assets/66276301/c669a47e-ae27-4456-9782-a900cc8de294)

### Related Issue:
Fixes #2510 
    
cc: @shaheemazmalmmd @GMishx



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2528"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

