### PR TITLE
feat(api): Merge a license into an existing one

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -3981,6 +3981,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+
   /license/verify/{shortname}:
     parameters:
       - name: shortname
@@ -4038,6 +4039,64 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+
+  /license/merge/{shortname}:
+    parameters:
+      - name: shortname
+        in: path
+        required: true
+        description: Shortname of the license to be merged
+        schema:
+          type: string
+    put:
+      operationId: mergeLicense
+      tags:
+        - License
+        - Admin
+      summary: Merge a license with another
+      description: >
+        Merge a license to another existing license
+      requestBody:
+        description: The shortname of the parent license to be merged into
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                parentShortname:
+                  description: Shortname of the parent license
+                  type: string
+                  example:
+                    "MIT"
+      responses:
+        '200':
+          description: License merged successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Given License not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
 components:
   securitySchemes:
     bearerAuth:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -319,6 +319,7 @@ $app->group('/license',
     $app->post('/import-csv', LicenseController::class . ':handleImportLicense');
     $app->post('', LicenseController::class . ':createLicense');
     $app->put('/verify/{shortname:.+}', LicenseController::class . ':verifyLicense');
+    $app->put('/merge/{shortname:.+}', LicenseController::class . ':mergeLicense');
     $app->get('/admincandidates', LicenseController::class . ':getCandidates');
     $app->get('/adminacknowledgements', LicenseController::class . ':getAllAdminAcknowledgements');
     $app->get('/stdcomments', LicenseController::class . ':getAllLicenseStandardComments');

--- a/src/www/ui/page/AdminLicenseCandidate.php
+++ b/src/www/ui/page/AdminLicenseCandidate.php
@@ -231,7 +231,7 @@ class AdminLicenseCandidate extends DefaultPlugin
     return true;
   }
 
-  private function mergeCandidate($candidate, $suggest, $vars)
+  public function mergeCandidate($candidate, $suggest, $vars)
   {
     /** @var DbManager */
     $dbManager = $this->getObject('db.manager');


### PR DESCRIPTION
## Description

Added the API to merge a given candidate license into another existing one.

### Changes

1. Added a new method in  `LicenseController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `PUT` `/license/merge/{shortname}`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a PUT request on the endpoint:  `/license/merge/{shortname}`,

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/e0c8068b-c3fa-4d4e-b9c9-2dbf900e495f)

![image](https://github.com/fossology/fossology/assets/66276301/65d0c78e-2b1a-4d5d-9003-4acd49862002)

### Related Issue:
Fixes #2510 
    
cc: @shaheemazmalmmd @GMishx



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2529"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

