### PR TITLE
feat(api): Get the database contents for the dashboard overview

### DIFF
--- a/src/www/ui/admin-dashboard-general.php
+++ b/src/www/ui/admin-dashboard-general.php
@@ -32,7 +32,7 @@ class dashboard extends FO_Plugin
    * \brief Return each html row for DatabaseContents()
    * \returns html table row
    */
-  function DatabaseContentsRow($TableName, $TableLabel)
+  function DatabaseContentsRow($TableName, $TableLabel, $fromRest = false)
   {
     $row = $this->dbManager->getSingleRow(
       "select sum(reltuples) as val from pg_class where relname like $1 and reltype !=0",
@@ -60,6 +60,15 @@ class dashboard extends FO_Plugin
     $V .= "<td $mystyle>" . substr($LastAnalyzeTime, 0, 16) . "</td>";
 
     $V .= "</tr>\n";
+
+    if ($fromRest) {
+      return [
+        "metric" => $TableLabel,
+        "total" => intval($item_count),
+        "lastVacuum" => $LastVacTime,
+        "lastAnalyze" => $LastAnalyzeTime
+      ];
+    }
     return $V;
   }
 

--- a/src/www/ui/api/Controllers/OverviewController.php
+++ b/src/www/ui/api/Controllers/OverviewController.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Samuel Dushimimana <dushsam100@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Controller for dashboard overview queries
+ */
+
+namespace Fossology\UI\Api\Controllers;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+
+/**
+ * @class OverviewController
+ * @brief Controller for OverviewController model
+ */
+class OverviewController extends RestController
+{
+  public function getDatabaseContents($request, $response, $args)
+  {
+    $dashboardPlugin = $this->restHelper->getPlugin('dashboard');
+    if (!Auth::isAdmin()) {
+      $error = new Info(403, "Only admin can view database contents.", InfoType::ERROR);
+      return $response->withJson($error->getArray(), $error->getCode());
+    }
+    $res = [
+      /**** Users ****/
+      $dashboardPlugin->DatabaseContentsRow("users", _("Users"), true),
+      /**** Uploads  ****/
+      $dashboardPlugin->DatabaseContentsRow("upload", _("Uploads"), true),
+      /**** Unique pfiles  ****/
+      $dashboardPlugin->DatabaseContentsRow("pfile", _("Unique files referenced in repository"), true),
+      /**** uploadtree recs  ****/
+      $dashboardPlugin->DatabaseContentsRow("uploadtree_%", _("Individual Files"), true),
+      /**** License recs  ****/
+      $dashboardPlugin->DatabaseContentsRow("license_file", _("Discovered Licenses"), true),
+      /**** Copyright recs  ****/
+      $dashboardPlugin->DatabaseContentsRow("copyright", _("Copyrights/URLs/Emails"), true)
+    ];
+    return $response->withJson($res, 200);
+  }
+}

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -53,6 +53,8 @@ tags:
     description: License and obligation management
   - name: Maintenance
     description: Maintenance operations
+  - name: Overview
+    description: Overview of FOSSology operations
 
 paths:
   /tokens:
@@ -4097,6 +4099,39 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /overview/database/contents:
+    get:
+      operationId: getDatabaseContents
+      tags:
+        - Overview
+        - Admin
+      summary: Get database contents
+      description: >
+        Get database contents for the dashboard display.
+      responses:
+        '200':
+          description: List of the database contents
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GetDatabaseContent'
+        '403':
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
 components:
   securitySchemes:
     bearerAuth:
@@ -5889,6 +5924,25 @@ components:
             If TRUE, update the given standard comment.
             if FALSE, add new standard comment.
           example: true
+    GetDatabaseContent:
+      type: object
+      properties:
+        metric:
+          type: string
+          description: The metric associated with the object.
+          example: Users
+        total:
+          type: integer
+          description: The total count associated with the metric.
+          example: 2
+        lastVacuum:
+          type: string
+          description: The date and time of the last vacuum operation. If null, no vacuum operation has been performed.
+          example: null
+        lastAnalyze:
+          type: string
+          description: The date and time of the last analyze operation. If null, no analyze operation has been performed.
+          example: null
   responses:
     defaultResponse:
       description: Some error occurred. Check the "message"

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -33,6 +33,7 @@ use Fossology\UI\Api\Controllers\JobController;
 use Fossology\UI\Api\Controllers\CopyrightController;
 use Fossology\UI\Api\Controllers\LicenseController;
 use Fossology\UI\Api\Controllers\MaintenanceController;
+use Fossology\UI\Api\Controllers\OverviewController;
 use Fossology\UI\Api\Controllers\ReportController;
 use Fossology\UI\Api\Controllers\SearchController;
 use Fossology\UI\Api\Controllers\ConfController;
@@ -332,6 +333,11 @@ $app->group('/license',
     $app->any('/{params:.*}', BadRequestController::class);
   });
 
+////////////////////////////OVERVIEW/////////////////////
+$app->group('/overview',
+  function (\Slim\Routing\RouteCollectorProxy $app) {
+    $app->get('/database/contents', OverviewController::class . ':getDatabaseContents');
+  });
 /////////////////////ERROR HANDLING/////////////////
 // Define Custom Error Handler
 $customErrorHandler = function (


### PR DESCRIPTION
## Description

Added the API to retrieve the database contents with corresponding statuses.

### Changes

1. Added a new method in  `OverviewController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/overview/database/contents`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a GET request on the endpoint:  `/overview/database/contents`,

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/1a5eb645-7aba-4892-9832-e3258d2270a2)

![image](https://github.com/fossology/fossology/assets/66276301/fc5b84c6-a781-4a95-ab6c-3a8bf4921fab)

### Related Issue:
Fixes #2523 
    
cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2530"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

