### PR TITLE
feat(api): Get database metrics overview for dashboard

### DIFF
--- a/src/www/ui/api/Controllers/OverviewController.php
+++ b/src/www/ui/api/Controllers/OverviewController.php
@@ -85,4 +85,23 @@ class OverviewController extends RestController
     $res = $dashboardPlugin->GetPHPInfoTable(true);
     return $response->withJson($res, 200);
   }
+
+  /**
+   * Get the database for the dashboard overview
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function getDatabaseMetrics($request, $response, $args)
+  {
+    if (!Auth::isAdmin()) {
+      $error = new Info(403, "Only admin can view database metrics.", InfoType::ERROR);
+      return $response->withJson($error->getArray(), $error->getCode());
+    }
+    $dashboardPlugin = $this->restHelper->getPlugin('dashboard');
+    $res = $dashboardPlugin->DatabaseMetrics(true);
+    return $response->withJson($res, 200);
+  }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -4266,6 +4266,40 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+
+  /overview/database/metrics:
+    get:
+      operationId: getDatabaseMetrics
+      tags:
+        - Overview
+        - Admin
+      summary: Get database metrics
+      description: >
+        Get database metrics for the dashboard display.
+      responses:
+        '200':
+          description: List of the database metrics
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GetDatabaseMetric'
+        '403':
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
 components:
   securitySchemes:
     bearerAuth:
@@ -6217,6 +6251,17 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/HighlightInfo'
+    GetDatabaseMetric:
+      type: object
+      properties:
+        metric:
+          type: string
+          description: The metric associated with the object.
+          example: FOSSology database size
+        total:
+          type: string
+          description: The total count associated with the metric.
+          example: "36"
   responses:
     defaultResponse:
       description: Some error occurred. Check the "message"

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -341,6 +341,7 @@ $app->group('/overview',
     $app->get('/database/contents', OverviewController::class . ':getDatabaseContents');
     $app->get('/disk/usage', OverviewController::class . ':getDiskSpaceUsage');
     $app->get('/info/php', OverviewController::class . ':getPhpInfo');
+    $app->get('/database/metrics', OverviewController::class . ':getDatabaseMetrics');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 


### PR DESCRIPTION
## Description

Added the API to retrieve the database metrics with corresponding statuses.

### Changes

1. Added a new method in  `OverviewController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/overview/database/metrics`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a GET request on the endpoint:  `/overview/database/metrics`,

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/466fafdb-76a9-47c6-a38b-19bf02c08d7e)
![image](https://github.com/fossology/fossology/assets/66276301/74da523e-1556-4a6f-8dcf-3a1ba2814839)

### Related Issue:
Fixes #2523 
    
cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2532"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

