### PR TITLE
feat(api): Get active queries for Dashboard overview

### DIFF
--- a/src/www/ui/admin-dashboard-general.php
+++ b/src/www/ui/admin-dashboard-general.php
@@ -13,7 +13,7 @@ use Fossology\Lib\Db\DbManager;
 
 class dashboard extends FO_Plugin
 {
-  protected $pgVersion;
+  public $pgVersion;
 
   /** @var DbManager */
   private $dbManager;
@@ -252,13 +252,14 @@ class dashboard extends FO_Plugin
    * \brief Database queries
    * \returns html table containing query strings, pid, and start time
    */
-  function DatabaseQueries()
+  function DatabaseQueries($fromRest = false)
   {
     $V = "<table border=1 id='databaseTable'>\n";
     $head1 = _("PID");
     $head2 = _("Query");
     $head3 = _("Started");
     $head4 = _("Elapsed");
+    $restRes = [];
     $V .= "<tr><th>$head1</th><th>$head2</th><th>$head3</th><th>$head4</th></tr>\n";
     $getCurrentVersion = explode(" ", $this->pgVersion['server']);
     $currentVersion = str_replace(".", "", $getCurrentVersion[0]);
@@ -285,6 +286,12 @@ class dashboard extends FO_Plugin
         $V .= "<td class='dashboard'>$StartTime</td>";
         $V .= "<td class='dashboard'>$row[elapsed]</td>";
         $V .= "</tr>\n";
+        $restRes[] = [
+          "pid" => $row['processid'],
+          "query" => htmlspecialchars($row[$current_query]),
+          "startTime" => $row['query_start'],
+          "elapsed" => $row['elapsed']
+        ];
       }
     } else {
       $V .= "<tr><td class='dashboard' colspan=4>There are no active FOSSology queries</td></tr>";
@@ -293,6 +300,9 @@ class dashboard extends FO_Plugin
     pg_free_result($result);
     $V .= "</table>\n";
 
+    if ($fromRest) {
+      return $restRes;
+    }
     return $V;
   }
 

--- a/src/www/ui/api/Controllers/OverviewController.php
+++ b/src/www/ui/api/Controllers/OverviewController.php
@@ -104,4 +104,29 @@ class OverviewController extends RestController
     $res = $dashboardPlugin->DatabaseMetrics(true);
     return $response->withJson($res, 200);
   }
+
+  /**
+   * Get active queries
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function getActiveQueries($request, $response, $args)
+  {
+    if (!Auth::isAdmin()) {
+      $error = new Info(403, "Only Admin can access the endpoint.", InfoType::ERROR);
+      return $response->withJson($error->getArray(), $error->getCode());
+    }
+    $dashboardPlugin = $this->restHelper->getPlugin('dashboard');
+    global $PG_CONN;
+    $dashboardPlugin->pgVersion = pg_version($PG_CONN);
+    $res = $dashboardPlugin->DatabaseQueries(true);
+
+    foreach ($res as &$value) {
+      $value['pid'] = intval($value['pid']);
+    }
+    return $response->withJson($res, 200);
+  }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -4266,7 +4266,6 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
-
   /overview/database/metrics:
     get:
       operationId: getDatabaseMetrics
@@ -4300,6 +4299,38 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /overview/queries/active:
+    get:
+      operationId: getActiveQueries
+      tags:
+        - Overview
+        - Admin
+      summary: Get active queries
+      description: >
+        Get a list of active queries from the database.
+      responses:
+        '200':
+          description: List of active queries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GetActiveQuery'
+        '403':
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
 components:
   securitySchemes:
     bearerAuth:
@@ -6262,6 +6293,23 @@ components:
           type: string
           description: The total count associated with the metric.
           example: "36"
+    GetActiveQuery:
+      properties:
+        pid:
+          type: integer
+          example: 1831
+        query:
+          type: string
+          enum:
+            - idle
+            - active
+        startTime:
+          type: string
+          format: date-time
+          example: "023-08-31 15:04:58.162799+02"
+        elapsed:
+          type: string
+          example: "00:01:06.961334"
   responses:
     defaultResponse:
       description: Some error occurred. Check the "message"

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -342,6 +342,7 @@ $app->group('/overview',
     $app->get('/disk/usage', OverviewController::class . ':getDiskSpaceUsage');
     $app->get('/info/php', OverviewController::class . ':getPhpInfo');
     $app->get('/database/metrics', OverviewController::class . ':getDatabaseMetrics');
+    $app->get('/queries/active', OverviewController::class . ':getActiveQueries');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 


### PR DESCRIPTION
## Description

Added the API to retrieve the active queries for the Admin Dashboard overview.

### Changes

1. Added a new method in  `OverviewController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/overview/queries/active`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a GET request on the endpoint:  `/overview/queries/active`,

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/0b27e973-f5a8-492f-ba7e-dd2b29385670)
![image](https://github.com/fossology/fossology/assets/66276301/0ea9be96-6428-4976-89f2-26a55621d292)

### Related Issue:
Fixes #2523 
    
cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2533"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

