### PR TITLE
feat(api): Get disk space usage overview

### DIFF
--- a/src/www/ui/admin-dashboard-general.php
+++ b/src/www/ui/admin-dashboard-general.php
@@ -266,10 +266,12 @@ class dashboard extends FO_Plugin
   /**
    * \brief Determine amount of free disk space.
    */
-  function DiskFree()
+  function DiskFree($fromRest = false)
   {
     global $SYSCONFDIR;
     global $SysConf;
+
+    $restRes = [];
 
     $Cmd = "df -hP";
     $Buf = $this->DoCmd($Cmd);
@@ -332,6 +334,15 @@ class dashboard extends FO_Plugin
       $V .= "<td align='right' $mystyle>$List[4]</td>";
 
       $V .= "<td align='left'>" . htmlentities($List[5]) . "</td></tr>\n";
+
+      $restRes["data"][] = [
+        "filesystem" => htmlentities($List[0]),
+        "capacity" => $List[1],
+        "used" => $List[2],
+        "available" => $List[3],
+        "percentFull" => $List[4],
+        "mountPoint" => htmlentities($List[5])
+      ];
     }
     $V .= "</table>\n";
 
@@ -357,7 +368,16 @@ class dashboard extends FO_Plugin
     // FOSSology config location
     $V .= $Indent . _("FOSSology config") . ": " . $SYSCONFDIR . "<br>";
 
-    return($V);
+    $restRes["notes"] = [
+      "database" => $DargArray[0],
+      "repository" => $SysConf['FOSSOLOGY']['path'],
+      "fossologyConfig" => $SYSCONFDIR
+    ];
+
+    if ($fromRest) {
+      return $restRes;
+    }
+    return ($V);
   }
 
   public function Output()

--- a/src/www/ui/api/Controllers/OverviewController.php
+++ b/src/www/ui/api/Controllers/OverviewController.php
@@ -13,8 +13,10 @@
 namespace Fossology\UI\Api\Controllers;
 
 use Fossology\Lib\Auth\Auth;
+use Fossology\UI\Api\Helper\ResponseHelper;
 use Fossology\UI\Api\Models\Info;
 use Fossology\UI\Api\Models\InfoType;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * @class OverviewController
@@ -43,6 +45,25 @@ class OverviewController extends RestController
       /**** Copyright recs  ****/
       $dashboardPlugin->DatabaseContentsRow("copyright", _("Copyrights/URLs/Emails"), true)
     ];
+    return $response->withJson($res, 200);
+  }
+
+  /**
+   * Get disk space usage overview
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function getDiskSpaceUsage($request, $response, $args)
+  {
+    if (!Auth::isAdmin()) {
+      $error = new Info(403, "Only Admin can access the endpoint.", InfoType::ERROR);
+      return $response->withJson($error->getArray(), $error->getCode());
+    }
+    $dashboardPlugin = $this->restHelper->getPlugin('dashboard');
+    $res = $dashboardPlugin->DiskFree(true);
     return $response->withJson($res, 200);
   }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -4132,6 +4132,39 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /overview/disk/usage:
+    get:
+      operationId: getDiskUsage
+      tags:
+        - Overview
+        - Admin
+      summary: Get disk usage
+      description: >
+        Get disk usage
+      responses:
+        '200':
+          description: Disk usage response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DiskUsage'
+        '403':
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
 components:
   securitySchemes:
     bearerAuth:
@@ -5943,6 +5976,55 @@ components:
           type: string
           description: The date and time of the last analyze operation. If null, no analyze operation has been performed.
           example: null
+    DiskUsage:
+      type: object
+      properties:
+        data:
+          type: array
+          description: "List of filesystem information"
+          items:
+            type: object
+            properties:
+              filesystem:
+                type: string
+                description: "Filesystem path"
+                example: "/dev/nvme0n1p6"
+              capacity:
+                type: string
+                description: "Total capacity of the filesystem"
+                example: "192G"
+              used:
+                type: string
+                description: "Used space in the filesystem"
+                example: "173G"
+              available:
+                type: string
+                description: "Available space in the filesystem"
+                example: "8.8G"
+              percentFull:
+                type: string
+                description: "Percentage of the filesystem used"
+                example: "96%"
+              mountPoint:
+                type: string
+                description: "Mount point of the filesystem"
+                example: "/"
+        notes:
+          type: object
+          description: "Additional notes"
+          properties:
+            database:
+              type: string
+              description: "Database location"
+              example: "/var/lib/postgresql/12/main"
+            repository:
+              type: string
+              description: "Repository location"
+              example: "/srv/fossology/repository"
+            fossologyConfig:
+              type: string
+              description: "Fossology configuration location"
+              example: "/usr/local/etc/fossology"
   responses:
     defaultResponse:
       description: Some error occurred. Check the "message"

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -337,7 +337,10 @@ $app->group('/license',
 $app->group('/overview',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->get('/database/contents', OverviewController::class . ':getDatabaseContents');
+    $app->get('/disk/usage', OverviewController::class . ':getDiskSpaceUsage');
+    $app->any('/{params:.*}', BadRequestController::class);
   });
+
 /////////////////////ERROR HANDLING/////////////////
 // Define Custom Error Handler
 $customErrorHandler = function (


### PR DESCRIPTION
## Description

Added the API to retrieve the disk space usage for the Admin Dashboard overview.

### Changes

1. Added a new method in  `OverviewController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/overview/disk/usage`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a GET request on the endpoint:  `/overview/disk/usage`,

## Screenshots
![image](https://github.com/fossology/fossology/assets/66276301/fd704b29-1f1d-44f2-bb07-eb25c22284ff)
![image](https://github.com/fossology/fossology/assets/66276301/b1ab95fa-7570-436f-b907-3288eab91066)
![image](https://github.com/fossology/fossology/assets/66276301/e9f85aec-ad94-4982-a802-1bedecf75850)

### Related Issue:
Fixes #2523 
    
cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2534"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

