### PR TITLE
feat(api): Get PHP-Info for the Dasbhoard Overview

### DIFF
--- a/src/www/ui/admin-dashboard-general.php
+++ b/src/www/ui/admin-dashboard-general.php
@@ -122,10 +122,12 @@ class dashboard extends FO_Plugin
     return $this->GetLastAnalyzeTimeOrVacTime("last_vacuum, last_autovacuum",$TableName);
   }
 
-  function GetPHPInfoTable()
+  function GetPHPInfoTable($fromRest = false)
   {
     $PHP_VERSION = phpversion();
     $loadedModules = get_loaded_extensions();
+
+    $restRes = [];
 
     $table = "
 <table class='infoTable' border=1>
@@ -151,9 +153,16 @@ class dashboard extends FO_Plugin
       Loaded Extensions
       </td>
       <td><div class='infoTable'>";
+
+    $restRes['phpVersion'] = $PHP_VERSION;
+    $restRes['loadedExtensions'] = [];
     foreach ($loadedModules as $currentExtensionName) {
       $currentVersion = phpversion($currentExtensionName);
       $table .= $currentExtensionName . ": " . $currentVersion . "<br />";
+      $restRes['loadedExtensions'][] = [
+        'name' => $currentExtensionName,
+        'version' => $currentVersion
+      ];
     }
 
     $table .="</div></td>
@@ -162,6 +171,10 @@ class dashboard extends FO_Plugin
 </table>
 
   ";
+
+    if ($fromRest) {
+      return $restRes;
+    }
     return $table;
   }
 

--- a/src/www/ui/api/Controllers/OverviewController.php
+++ b/src/www/ui/api/Controllers/OverviewController.php
@@ -66,4 +66,23 @@ class OverviewController extends RestController
     $res = $dashboardPlugin->DiskFree(true);
     return $response->withJson($res, 200);
   }
+
+  /**
+   * Get PHP info overview
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function getPhpInfo($request, $response, $args)
+  {
+    if (!Auth::isAdmin()) {
+      $error = new Info(403, "Only Admin can access the endpoint.", InfoType::ERROR);
+      return $response->withJson($error->getArray(), $error->getCode());
+    }
+    $dashboardPlugin = $this->restHelper->getPlugin('dashboard');
+    $res = $dashboardPlugin->GetPHPInfoTable(true);
+    return $response->withJson($res, 200);
+  }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -4132,6 +4132,37 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /overview/info/php:
+    get:
+      operationId: getPhpInfo
+      tags:
+        - Overview
+        - Admin
+      summary: Get PHP info
+      description: >
+        Get PHP info
+      responses:
+        '200':
+          description: PHP info
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/GetPHPInfo'
+        '403':
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /overview/disk/usage:
     get:
       operationId: getDiskUsage
@@ -6025,6 +6056,27 @@ components:
               type: string
               description: "Fossology configuration location"
               example: "/usr/local/etc/fossology"
+    GetPHPInfo:
+      type: object
+      properties:
+        phpVersion:
+          type: string
+          description: "Version of PHP"
+          example: "7.4.3-4ubuntu2.18"
+        loadedExtensions:
+          type: array
+          description: "List of loaded extensions in PHP"
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                description: "Name of the loaded extension"
+                example: "Core"
+              version:
+                type: string
+                description: "Version of the loaded extension"
+                example: "7.4.3-4ubuntu2.18"
   responses:
     defaultResponse:
       description: Some error occurred. Check the "message"

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -338,6 +338,7 @@ $app->group('/overview',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->get('/database/contents', OverviewController::class . ':getDatabaseContents');
     $app->get('/disk/usage', OverviewController::class . ':getDiskSpaceUsage');
+    $app->get('/info/php', OverviewController::class . ':getPhpInfo');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 


### PR DESCRIPTION
## Description

Added the API to retrieve the PHP-Info for the Admin Dashboard overview.

### Changes

1. Added a new method in  `OverviewController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/overview/info/php`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a GET request on the endpoint:  `/overview/info/php`,

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/58593982-ae1c-4121-b00f-3ae2dd1a3e8f)
![image](https://github.com/fossology/fossology/assets/66276301/1b714ee6-18c8-4fb1-84cc-1095380ce026)

### Related Issue:
Fixes #2523 
    
cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2535"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

