### PR TITLE
feat(api): Get all server jobs for Admin Dashboard

### DIFF
--- a/src/www/ui/api/Controllers/JobController.php
+++ b/src/www/ui/api/Controllers/JobController.php
@@ -528,4 +528,24 @@ class JobController extends RestController
     $res = $statisticsPlugin->CountAllJobs(true);
     return $response->withJson($res, 200);
   }
+
+  /**
+   * Get all the server jobs with status
+   *
+   * @param Request $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function getAllServerJobsStatus($request, $response, $args)
+  {
+    if (!Auth::isAdmin()) {
+      $error = new Info(403, "Only Admin can access the endpoint.", InfoType::ERROR);
+      return $response->withJson($error->getArray(), $error->getCode());
+    }
+    $allJobStatusPlugin = $this->restHelper->getPlugin('ajax_all_job_status');
+    $symfonyRequest = new \Symfony\Component\HttpFoundation\Request();
+    $res = $allJobStatusPlugin->handle($symfonyRequest);
+    return $response->withJson(json_decode($res->getContent(), true), 200);
+  }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -2611,6 +2611,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
             $ref: '#/components/responses/defaultResponse'
+
   /jobs/dashboard/statistics:
     get:
       operationId: getJobStatistics
@@ -2636,6 +2637,28 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /jobs/dashboard:
+    get:
+      operationId: getAllServerJobs
+      tags:
+        - Job
+      summary: Gets all jobs server jobs with scheduler status
+      description: Returns all jobs with the scheduler status for the Admin Dashboard. This API returns a response only if the requesting user is an Admin.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllServerJobs'
+        '403':
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /jobs/{id}/{queue}:
     parameters:
       - name: id
@@ -6002,11 +6025,11 @@ components:
         lastVacuum:
           type: string
           description: The date and time of the last vacuum operation. If null, no vacuum operation has been performed.
-          example: null
+          example: "null"
         lastAnalyze:
           type: string
           description: The date and time of the last analyze operation. If null, no analyze operation has been performed.
-          example: null
+          example: "null"
     DiskUsage:
       type: object
       properties:
@@ -6077,6 +6100,37 @@ components:
                 type: string
                 description: "Version of the loaded extension"
                 example: "7.4.3-4ubuntu2.18"
+    AllServerJobs:
+      type: object
+      properties:
+        data:
+          type: array
+          description: "List of agents"
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                description: "Name of the agent"
+                example: "decider"
+              running:
+                type: integer
+                description: "Number of running instances"
+                example: 0
+              pending:
+                type: integer
+                description: "Number of pending instances"
+                example: 1
+              eta:
+                type: string
+                description: "Estimated time of arrival"
+                example: "N/A"
+        scheduler:
+          type: string
+          description: "Current scheduler status"
+          enum:
+            - "Running"
+            - "Stopped"
   responses:
     defaultResponse:
       description: Some error occurred. Check the "message"

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -244,6 +244,7 @@ $app->group('/jobs',
     $app->get('/dashboard/statistics', JobController::class . ':getJobStatistics');
     $app->post('', JobController::class . ':createJob');
     $app->get('/history', JobController::class . ':getJobsHistory');
+    $app->get('/dashboard', JobController::class . ':getAllServerJobsStatus');
     $app->delete('/{id:\\d+}/{queue:\\d+}', JobController::class . ':deleteJob');
     $app->any('/{params:.*}', BadRequestController::class);
   });

--- a/src/www/ui/async/AjaxAllJobStatus.php
+++ b/src/www/ui/async/AjaxAllJobStatus.php
@@ -50,7 +50,7 @@ class AjaxAllJobStatus extends DefaultPlugin
    * @param Request $request
    * @return Response
    */
-  protected function handle(Request $request)
+  public function handle(Request $request)
   {
     $results = $this->showJobDao->getJobsForAll();
     $uniqueTypes = array_unique(array_column($results, 'job'));


### PR DESCRIPTION
## Description

Added the API to retrieve the server jobs for the Admin Dashboard overview.

### Changes

1. Added a new method in  `JobController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/jobs/dashboard`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a GET request on the endpoint:  `/jobs/dashboard`,

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/8e2e6db5-9c6a-4b8b-89c9-bc549a847802)
![image](https://github.com/fossology/fossology/assets/66276301/e153fde4-5f3c-41fe-97d3-82d3cb66315f)

### Related Issue:
Fixes #2523 
    
cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2536"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

