### PR TITLE
feat(api): Get the summary statistics for all Jobs

### DIFF
--- a/src/www/ui/admin-dashboard-stats.php
+++ b/src/www/ui/admin-dashboard-stats.php
@@ -29,12 +29,12 @@ class dashboardReporting extends FO_Plugin
   /**
    * \brief Lists number of ever quequed jobs per job type (agent)..
    */
-  function CountAllJobs()
+  function CountAllJobs($fromRest = false)
   {
     $query = "SELECT ag.agent_name,ag.agent_desc,count(jq.*) AS fired_jobs ";
     $query.= "FROM agent ag LEFT OUTER JOIN jobqueue jq ON (jq.jq_type = ag.agent_name) ";
     $query.= "GROUP BY ag.agent_name,ag.agent_desc ORDER BY fired_jobs DESC;";
-
+    $restRes = [];
     $rows = $this->dbManager->getRows($query);
 
     $V = "<table border=1>";
@@ -42,10 +42,18 @@ class dashboardReporting extends FO_Plugin
 
     foreach ($rows as $agData) {
       $V .= "<tr><td>".$agData['agent_name']."</td><td>".$agData['agent_desc']."</td><td align='right'>".$agData['fired_jobs']."</td></tr>";
+      $restRes[] = [
+        'agentName' => $agData['agent_name'],
+        'agentDesc' => $agData['agent_desc'],
+        'firedJobs' => intval($agData['fired_jobs']),
+      ];
     }
 
     $V .= "</table>";
 
+    if ($fromRest) {
+      return $restRes;
+    }
     return $V;
   }
 

--- a/src/www/ui/api/Controllers/JobController.php
+++ b/src/www/ui/api/Controllers/JobController.php
@@ -510,4 +510,22 @@ class JobController extends RestController
   {
     return $JobsInfo2["job"]["job_pk"] - $JobsInfo1["job"]["job_pk"];
   }
+
+  /**
+   * @brief Get the summary statistics of all the jobs
+   * @param Request $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function getJobStatistics($request, $response, $args)
+  {
+    if (!Auth::isAdmin()) {
+      $error = new Info(403, "Only Admin can access the endpoint.", InfoType::ERROR);
+      return $response->withJson($error->getArray(), $error->getCode());
+    }
+    $statisticsPlugin = $this->restHelper->getPlugin('dashboard-statistics');
+    $res = $statisticsPlugin->CountAllJobs(true);
+    return $response->withJson($res, 200);
+  }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -2609,6 +2609,31 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
             $ref: '#/components/responses/defaultResponse'
+  /jobs/dashboard/statistics:
+    get:
+      operationId: getJobStatistics
+      tags:
+        - Job
+      summary: Get the statistics of all the jobs
+      description: Returns the statistics of all the jobs for the Admin Dashboard
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GetJobStatistics'
+        '403':
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /jobs/{id}/{queue}:
     parameters:
       - name: id
@@ -5663,6 +5688,21 @@ components:
           type: boolean
           example: true
           description: Indicates whether the comment is enabled or not.
+    GetJobStatistics:
+      type: object
+      properties:
+        agentName:
+          type: string
+          description: "Name of the agent"
+          example: "monkbulk"
+        agentDesc:
+          type: string
+          description: "Description of the agent"
+          example: "monkbulk agent"
+        firedJobs:
+          type: integer
+          description: "Number of fired jobs"
+          example: 23
   responses:
     defaultResponse:
       description: Some error occurred. Check the "message"

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -240,6 +240,7 @@ $app->group('/jobs',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->get('[/{id:\\d+}]', JobController::class . ':getJobs');
     $app->get('/all', JobController::class . ':getAllJobs');
+    $app->get('/dashboard/statistics', JobController::class . ':getJobStatistics');
     $app->post('', JobController::class . ':createJob');
     $app->get('/history', JobController::class . ':getJobsHistory');
     $app->delete('/{id:\\d+}/{queue:\\d+}', JobController::class . ':deleteJob');


### PR DESCRIPTION
## Description

Added the API to retrieve the server jobs for the Admin Dashboard overview.

### Changes

1. Added a new method in  `JobController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/jobs/dashboard/statistics`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a GET request on the endpoint:  `/jobs/dashboard/statistics`,

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/7b0e513c-0ae0-4d7a-868f-0101c361623d)
![image](https://github.com/fossology/fossology/assets/66276301/94620102-8c0c-467d-924e-d21bc6df66e3)

### Related Issue:
Fixes #2523 
    
cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2537"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

