### PR TITLE
feat(api): Get scheduler options for a given operation

### DIFF
--- a/src/www/ui/admin-scheduler.php
+++ b/src/www/ui/admin-scheduler.php
@@ -19,7 +19,7 @@ define("TITLE_ADMIN_SCHEDULER", _("Scheduler Administration"));
 class admin_scheduler extends FO_Plugin
 {
   var $error_info = "";
-  var $operation_array;
+  public $operation_array;
 
   function __construct()
   {
@@ -27,6 +27,20 @@ class admin_scheduler extends FO_Plugin
     $this->Title      = TITLE_ADMIN_SCHEDULER;
     $this->MenuList   = "Admin::Scheduler";
     $this->DBaccess   = PLUGIN_DB_ADMIN;
+    $this->operation_array = array
+    (
+      "status" => array(_("Status"), _("Display job or scheduler status.")),
+      "database" => array(_("Check job queue"),_("Check for new jobs.")),
+      "reload" => array(_("Reload"), _("Reload fossology.conf.")),
+      "agents" => array(_("Agents"), _("Show a list of enabled agents.")),
+      "verbose" => array(_("Verbose"), _("Change the verbosity level of the scheduler or a job.")),
+      "stop" => array(_("Shutdown Scheduler"), _("Shutdown the scheduler gracefully and stop all background processing.  This can take a while for all the agents to quit.")),
+      //    "start" => array(_("Start Scheduler"), _("Start Scheduler.")),
+      //    "restarts" => array(_("Restart Scheduler"), _("Restart Scheduler.")),
+      "restart" => array(_("Unpause a job"), _("Unpause a job.")),
+      "pause" => array(_("Pause a running job"), _("Pause a running job.")),
+      "priority" => array(_("Priority"), _("Change the priority of a job."))
+    );
     parent::__construct();
   }
 
@@ -197,21 +211,6 @@ class admin_scheduler extends FO_Plugin
   {
     $V="";
     $status_msg = "";
-
-    $this->operation_array = array
-    (
-    "status" => array(_("Status"), _("Display job or scheduler status.")),
-    "database" => array(_("Check job queue"),_("Check for new jobs.")),
-    "reload" => array(_("Reload"), _("Reload fossology.conf.")),
-    "agents" => array(_("Agents"), _("Show a list of enabled agents.")),
-    "verbose" => array(_("Verbose"), _("Change the verbosity level of the scheduler or a job.")),
-    "stop" => array(_("Shutdown Scheduler"), _("Shutdown the scheduler gracefully and stop all background processing.  This can take a while for all the agents to quit.")),
-    //    "start" => array(_("Start Scheduler"), _("Start Scheduler.")),
-    //    "restarts" => array(_("Restart Scheduler"), _("Restart Scheduler.")),
-    "restart" => array(_("Unpause a job"), _("Unpause a job.")),
-    "pause" => array(_("Pause a running job"), _("Pause a running job.")),
-    "priority" => array(_("Priority"), _("Change the priority of a job."))
-    );
 
     $operation = GetParm('operation', PARM_TEXT);
     $job_id = GetParm('job_list', PARM_TEXT);

--- a/src/www/ui/api/Controllers/JobController.php
+++ b/src/www/ui/api/Controllers/JobController.php
@@ -548,4 +548,34 @@ class JobController extends RestController
     $res = $allJobStatusPlugin->handle($symfonyRequest);
     return $response->withJson(json_decode($res->getContent(), true), 200);
   }
+
+  /**
+   * @brief Get the scheduler job options for a given operation
+   * @param Request $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function getSchedulerJobOptionsByOperation($request, $response, $args)
+  {
+    $operation = $args['operationName'];
+    $adminSchedulerPlugin = $this->restHelper->getPlugin('admin_scheduler');
+    if (!Auth::isAdmin()) {
+      $error = new Info(403, "Only Admin can access the endpoint.", InfoType::ERROR);
+      return $response->withJson($error->getArray(), $error->getCode());
+    }
+
+    if (!in_array($operation, array_keys($adminSchedulerPlugin->operation_array))) {
+      $allowedOperations = implode(', ', array_keys($adminSchedulerPlugin->operation_array));
+      $error = new Info(400, "Operation '$operation' not allowed. Allowed operations are: $allowedOperations", InfoType::ERROR);
+      return $response->withJson($error->getArray(), $error->getCode());
+    }
+
+    $schedulerPlugin = $this->restHelper->getPlugin('ajax_admin_scheduler');
+    $symfonyRequest = new \Symfony\Component\HttpFoundation\Request();
+    $symfonyRequest->request->set('operation', $operation);
+    $symfonyRequest->request->set('fromRest', true);
+    $res = $schedulerPlugin->handle($symfonyRequest);
+    return $response->withJson($res, 200);
+  }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -2546,6 +2546,48 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+
+  /jobs/scheduler/operation/{operationName}:
+    parameters:
+      - name: operationName
+        required: true
+        description: Name of the operation
+        in: path
+        schema:
+          type: string
+          enum:
+            - status
+            - database
+            - reload
+            - agents
+            - verbose
+            - stop
+            - restart
+            - pause
+            - priority
+    get:
+      operationId: getSchedulerOptionsByOperation
+      tags:
+        - Job
+        - Admin
+      summary: get scheduler options by operation
+      description: Returns the scheduler options for a specific operation
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/GetSchedulerOption'
+        '403':
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /jobs/{id}:
     parameters:
       - name: id
@@ -6310,6 +6352,33 @@ components:
         elapsed:
           type: string
           example: "00:01:06.961334"
+    GetSchedulerOption:
+      type: object
+      properties:
+        jobList:
+          type: array
+          description: "List of jobs"
+          items:
+            type: string
+          example: [ "scheduler" ]
+        priorityList:
+          type: array
+          description: "List of priorities"
+          items:
+            type: integer
+          example: [ -20, -19, -18 ]
+        verboseList:
+          type: array
+          description: "List of verbose levels"
+          items:
+            type: integer
+          example: [ 1, 3 ]
+        agentList:
+          type: array
+          description: "List of agents"
+          items:
+            type: string
+          example: [ "clixml", "pkgagent", "maintagent", "deciderjob" ]
   responses:
     defaultResponse:
       description: Some error occurred. Check the "message"

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -242,6 +242,7 @@ $app->group('/jobs',
     $app->get('[/{id:\\d+}]', JobController::class . ':getJobs');
     $app->get('/all', JobController::class . ':getAllJobs');
     $app->get('/dashboard/statistics', JobController::class . ':getJobStatistics');
+    $app->get('/scheduler/operation/{operationName:[\\w\\- \\.]+}', JobController::class . ':getSchedulerJobOptionsByOperation');
     $app->post('', JobController::class . ':createJob');
     $app->get('/history', JobController::class . ':getJobsHistory');
     $app->get('/dashboard', JobController::class . ':getAllServerJobsStatus');

--- a/src/www/ui/async/AjaxAdminScheduler.php
+++ b/src/www/ui/async/AjaxAdminScheduler.php
@@ -32,25 +32,32 @@ class AjaxAdminScheduler extends DefaultPlugin
 
   /**
    * @param Request $request
-   * @return Response
+   * @return Response | array
    */
-  protected function handle(Request $request)
+  public function handle(Request $request)
   {
     $V = '';
     $operation = $request->get('operation');
     $vars['jobOptions'] = $this->jobListOption($operation);
     $vars['operation'] = $operation;
-    $vars['priorityList'] = $this->priorityListOption();
+    $vars['priorityList'] = $this->priorityListOption($request->get('fromRest'));
     $content = $this->renderer->load('ajax-admin-scheduler.html.twig')->render($vars);
+    $restRes = [
+      'jobList' => $vars['jobOptions'] ?? [],
+      'priorityList' => $vars['priorityList'] ?? [],
+      'verboseList' => [],
+      'agentList' => [],
+    ];
 
     if ('pause' == $operation || 'restart' == $operation ||
       'status' == $operation || 'priority' == $operation) {
       $V = $content;
     } else if ('verbose' == $operation) {
-      $verbose_list_option = $this->verboseListOption();
+      $verbose_list_option = $this->verboseListOption($request->get('fromRest'));
       $text2 = _("Select a verbosity level");
       $V = $content .
         "<br>$text2: <select name='level_list' id='level_list'>$verbose_list_option</select>";
+      $restRes['verboseList'] = $verbose_list_option;
     } else if ('agents' == $operation) {
       /** @var DbManager */
       $dbManager = $this->getObject('db.manager');
@@ -59,10 +66,15 @@ class AjaxAdminScheduler extends DefaultPlugin
       $res = $dbManager->execute($stmt);
       $V = '<ul>';
       while ($row = $dbManager->fetchArray($res)) {
+        $restRes['agentList'][] = $row['agent_name'];
         $V .= "<li>$row[agent_name]</li>";
       }
       $V .= '</ul>';
       $dbManager->freeResult($res);
+    }
+
+    if ($request->get('fromRest')) {
+      return $restRes;
     }
     return new Response($V, Response::HTTP_OK, array('content-type'=>'text/htm')); // not 'text/html' while console-logging
   }
@@ -96,31 +108,41 @@ class AjaxAdminScheduler extends DefaultPlugin
 
   /**
    * @brief get the verbose list:  if the value of verbose is 1, set verbose as 1
-   * @return string
+   * @return string | array
    **/
-  function verboseListOption()
+  function verboseListOption($fromRest = false)
   {
     $verbose_list_option = "";
     $min = 1;
     $max = 3;
+    $restRes = [];
     for ($i = $min; $i <= $max; $i++) {
       $bitmask= (1<<$i) - 1;
       $verbose_list_option .= "<option value='$bitmask'>$i</option>";
+      $restRes[] = $bitmask;
+    }
+    if ($fromRest) {
+      return $restRes;
     }
     return $verbose_list_option;
   }
 
   /**
    * @brief get the priority list for setting, -20..20
-   * @return string of priority options
+   * @return string | array of priority options
    **/
-  function priorityListOption()
+  function priorityListOption($fromRest = false)
   {
     $min = -20;
     $max = 20;
+    $resRes = [];
     $priority_list = array();
     for ($i = $min; $i <= $max; $i++) {
       $priority_list[$i]=$i;
+      $resRes[] = $i;
+    }
+    if ($fromRest) {
+      return $resRes;
     }
     return $priority_list;
   }


### PR DESCRIPTION
## Description

Added the API to retrieve the scheduler options for the given operation.

### Changes

1. Added a new method in  `JobController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/jobs/scheduler/operation/{operationName}`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a GET request on the endpoint:  `/jobs/scheduler/operation/{operationName}`,

## Screenshots
![image](https://github.com/fossology/fossology/assets/66276301/5ca71865-0fac-4207-addd-3fdc10b1df56)
![image](https://github.com/fossology/fossology/assets/66276301/227e6beb-460b-4161-9065-05d3e3c20305)
![image](https://github.com/fossology/fossology/assets/66276301/f7079133-c6dd-4280-a653-bb8523ac138e)

### Related Issue:
Fixes #2526 
    
cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2538"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

