### PR TITLE
feat(api): Run scheduler based on the given operation

### DIFF
--- a/src/www/ui/admin-scheduler.php
+++ b/src/www/ui/admin-scheduler.php
@@ -82,7 +82,7 @@ class admin_scheduler extends FO_Plugin
    * \param $operation operation name, e.g. 'status'
    * \return one operation text
    **/
-  function GetOperationText($operation)
+  public function GetOperationText($operation)
   {
     $operation_text = '';
     $job_id = GetParm('job_list', PARM_TEXT);
@@ -155,7 +155,7 @@ class admin_scheduler extends FO_Plugin
    * \param $level_id selected level id
    * \return return response from the scheduler
    **/
-  function OperationSubmit($operation, $job_id, $priority_id, $level_id)
+  public function OperationSubmit($operation, $job_id, $priority_id, $level_id)
   {
     if ("start" === $operation) {
       // start the scheduler

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -2578,7 +2578,77 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: '#/components/schemas/GetSchedulerOption'
+                $ref: '#/components/schemas/GetSchedulerOption'
+        '403':
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /jobs/scheduler/operation/run:
+    parameters:
+      - name: job
+        required: false
+        description: Name of the selected job
+        in: query
+        schema:
+          type: string
+      - name: level
+        required: false
+        description: Level of the selected verbose
+        in: query
+        schema:
+          type: string
+      - name: priority
+        required: false
+        description: Priority option selected
+        in: query
+        schema:
+          type: string
+    post:
+      operationId: handleSchedulerRun
+      tags:
+        - Job
+        - Admin
+      summary: Run the scheduler
+      description: Run the scheduler with the selected options from a specific operation
+      requestBody:
+        description: Scheduler operation
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                operation:
+                  type: string
+                  description: Operation to be run by the scheduler
+                  enum:
+                    - status
+                    - database
+                    - reload
+                    - agents
+                    - verbose
+                    - stop
+                    - restart
+                    - pause
+                    - priority
+      responses:
+        '200':
+          description: Scheduler run successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
         '403':
           description: Access denied
           content:

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -6418,7 +6418,7 @@ components:
         startTime:
           type: string
           format: date-time
-          example: "023-08-31 15:04:58.162799+02"
+          example: "2023-09-28T05:15:05.227Z"
         elapsed:
           type: string
           example: "00:01:06.961334"

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -243,6 +243,7 @@ $app->group('/jobs',
     $app->get('/all', JobController::class . ':getAllJobs');
     $app->get('/dashboard/statistics', JobController::class . ':getJobStatistics');
     $app->get('/scheduler/operation/{operationName:[\\w\\- \\.]+}', JobController::class . ':getSchedulerJobOptionsByOperation');
+    $app->post('/scheduler/operation/run', JobController::class . ':handleRunSchedulerOption');
     $app->post('', JobController::class . ':createJob');
     $app->get('/history', JobController::class . ':getJobsHistory');
     $app->get('/dashboard', JobController::class . ':getAllServerJobsStatus');


### PR DESCRIPTION
## Description

Added the API to run the scheduler of an operation based on the selected option.

### Changes

1. Added a new method in  `JobController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `POST` `/jobs/scheduler/operation/run`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a POST request on the endpoint:  `/jobs/scheduler/operation/run`,

## Screenshots
![image](https://github.com/fossology/fossology/assets/66276301/5db93c84-a1e7-495b-936a-87aa71e0a9cd)
![image](https://github.com/fossology/fossology/assets/66276301/f9e959c3-f4d0-42c9-b117-ab441b891bee)
![image](https://github.com/fossology/fossology/assets/66276301/5a9ec4ed-79cc-4a92-b37f-bf21634b222a)


### Related Issue:
Fixes #2526 
    
cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2539"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

