### PR TITLE
feat(api): Get removable folder contents

### DIFF
--- a/src/www/ui/api/Controllers/FolderController.php
+++ b/src/www/ui/api/Controllers/FolderController.php
@@ -12,11 +12,12 @@
 
 namespace Fossology\UI\Api\Controllers;
 
+use Fossology\UI\Ajax\AjaxFolderContents;
 use Fossology\UI\Api\Helper\ResponseHelper;
-use Psr\Http\Message\ServerRequestInterface;
 use Fossology\UI\Api\Models\Folder;
 use Fossology\UI\Api\Models\Info;
 use Fossology\UI\Api\Models\InfoType;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * @class FolderController
@@ -235,15 +236,16 @@ class FolderController extends RestController
     }
     return $response->withJson($info->getArray(), $info->getCode());
   }
+
   /**
-   * Get the removable folder contents
+   * Get the unlinkable folder contents (contents which are copied)
    *
    * @param ServerRequestInterface $request
    * @param ResponseHelper $response
    * @param array $args
    * @return ResponseHelper
    */
-  public function getRemovableFolderContents($request, $response, $args)
+  public function getUnlinkableFolderContents($request, $response, $args)
   {
     $folderId = $args['id'];
     $folderDao = $this->restHelper->getFolderDao();
@@ -258,6 +260,7 @@ class FolderController extends RestController
       return $response->withJson($error->getArray(), $error->getCode());
     }
 
+    /** @var AjaxFolderContents $folderContents */
     $folderContents = $this->restHelper->getPlugin('foldercontents');
     $symfonyRequest = new \Symfony\Component\HttpFoundation\Request();
     $symfonyRequest->request->set('folder', $folderId);

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -3222,6 +3222,42 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+  /folders/{id}/contents/removable:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: ID of the folder
+        schema:
+          type: integer
+    get:
+      operationId: getRemovableContents
+      tags:
+        - Folders
+      summary: Get removable contents of a folder
+      description:
+        Get removable contents of a folder by id
+      responses:
+        '200':
+          description: Removable contents of the given folder
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetFolderContent'
+        '403':
+          description: Folder is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Folder does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /groups:
     get:
       operationId: getGroups
@@ -4916,6 +4952,18 @@ components:
         parent:
           type: integer
           description: Id of the parent folder (if any, null otherwise).
+    GetFolderContent:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Id of the folder content.
+        content:
+          type: string
+          description: Content of the folder.
+        removable:
+          type: boolean
+          description: Is the folder removable.
     TokenRequest:
       type: object
       properties:

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -3222,7 +3222,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-  /folders/{id}/contents/removable:
+  /folders/{id}/contents/unlinkable:
     parameters:
       - name: id
         in: path
@@ -3231,15 +3231,15 @@ paths:
         schema:
           type: integer
     get:
-      operationId: getRemovableContents
+      operationId: getUnlinkableContents
       tags:
         - Folders
-      summary: Get removable contents of a folder
+      summary: Get contents of a folder which can be unlinked
       description:
-        Get removable contents of a folder by id
+        Get unlinkable contents of a folder by id. These contents are copied.
       responses:
         '200':
-          description: Removable contents of the given folder
+          description: Unlinkable contents of the given folder
           content:
             application/json:
               schema:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -274,6 +274,7 @@ $app->group('/folders',
     $app->delete('/{id:\\d+}', FolderController::class . ':deleteFolder');
     $app->patch('/{id:\\d+}', FolderController::class . ':editFolder');
     $app->put('/{id:\\d+}', FolderController::class . ':copyFolder');
+    $app->get('/{id:\\d+}/contents/removable', FolderController::class . ':getRemovableFolderContents');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -274,7 +274,7 @@ $app->group('/folders',
     $app->delete('/{id:\\d+}', FolderController::class . ':deleteFolder');
     $app->patch('/{id:\\d+}', FolderController::class . ':editFolder');
     $app->put('/{id:\\d+}', FolderController::class . ':copyFolder');
-    $app->get('/{id:\\d+}/contents/removable', FolderController::class . ':getRemovableFolderContents');
+    $app->get('/{id:\\d+}/contents/unlinkable', FolderController::class . ':getUnlinkableFolderContents');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui/async/AjaxFolderContents.php
+++ b/src/www/ui/async/AjaxFolderContents.php
@@ -62,21 +62,20 @@ class AjaxFolderContents extends DefaultPlugin
       $filterResults[$content] = $results[$content];
     }
 
-    $restRes = array_map(function($key, $value) {
-      return array(
-        'id' => $key,
-        'content' => $value,
-        'removable' => true
-      );
-    }, array_keys($filterResults), $filterResults);
+    if ($request->get('fromRest')) {
+      return array_map(function ($key, $value) {
+        return array(
+          'id' => $key,
+          'content' => $value,
+          'removable' => true
+        );
+      }, array_keys($filterResults), $filterResults);
+    }
 
     if (empty($filterResults)) {
       $filterResults["-1"] = "No removable content found";
     }
 
-    if ($request->get('fromRest')) {
-      return $restRes;
-    }
     return new JsonResponse($filterResults);
   }
 

--- a/src/www/ui/async/AjaxFolderContents.php
+++ b/src/www/ui/async/AjaxFolderContents.php
@@ -33,7 +33,7 @@ class AjaxFolderContents extends DefaultPlugin
     $this->folderDao = $this->getObject('dao.folder');
   }
 
-  protected function handle(Request $request)
+  public function handle(Request $request)
   {
     $folderId = intval($request->get('folder'));
     $uploadName = $request->get('upload');
@@ -61,8 +61,21 @@ class AjaxFolderContents extends DefaultPlugin
     foreach ($this->folderDao->getRemovableContents($folderId) as $content) {
       $filterResults[$content] = $results[$content];
     }
+
+    $restRes = array_map(function($key, $value) {
+      return array(
+        'id' => $key,
+        'content' => $value,
+        'removable' => true
+      );
+    }, array_keys($filterResults), $filterResults);
+
     if (empty($filterResults)) {
       $filterResults["-1"] = "No removable content found";
+    }
+
+    if ($request->get('fromRest')) {
+      return $restRes;
     }
     return new JsonResponse($filterResults);
   }


### PR DESCRIPTION
## Description

Added the API to retrieve the get a list of removable contents in a folder.

### Changes

1. Added a new method in  `FolderController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/folders/{id}/contents/removable`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a GET request on the endpoint:  `/folders/{id}/contents/removable`.

## Screenshots
![image](https://github.com/fossology/fossology/assets/66276301/3f73480c-efab-4621-b57e-3d8da78ee13e)

### Related Issue:
Fixes #2540 
    
cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2538"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2551"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

