### PR TITLE
feat(api): Unlink folder contents

### DIFF
--- a/src/lib/php/Dao/FolderDao.php
+++ b/src/lib/php/Dao/FolderDao.php
@@ -389,7 +389,9 @@ WHERE fc.parent_fk = $1 AND fc.foldercontents_mode = " . self::MODE_UPLOAD . " A
     if ($this->isRemovableContent($content['child_id'], $content['foldercontents_mode'])) {
       $sql = "DELETE FROM foldercontents WHERE foldercontents_pk=$1";
       $this->dbManager->getSingleRow($sql, array($folderContentId), __METHOD__);
+      return true;
     }
+    return false;
   }
 
   public function removeContentById($uploadpk, $folderId)

--- a/src/www/ui/api/Controllers/FolderController.php
+++ b/src/www/ui/api/Controllers/FolderController.php
@@ -12,7 +12,7 @@
 
 namespace Fossology\UI\Api\Controllers;
 
-use Exception;
+use Fossology\Lib\Dao\FolderDao;
 use Fossology\UI\Ajax\AjaxFolderContents;
 use Fossology\UI\Api\Helper\ResponseHelper;
 use Fossology\UI\Api\Models\Folder;
@@ -285,14 +285,13 @@ class FolderController extends RestController
     if (!$this->dbHelper->doesIdExist("foldercontents", "foldercontents_pk", $folderContentId)) {
       $info = new Info(404, "Folder content id not found!", InfoType::ERROR);
     } else {
-      try {
-        $folderDao = $this->container->get('dao.folder');
-        $folderDao->removeContent($folderContentId);
-      } catch (Exception $ex) {
-        $info = new Info(500, $ex->getMessage(), InfoType::ERROR);
-        return $response->withJson($info->getArray(), $info->getCode());
+      /** @var FolderDao $folderDao */
+      $folderDao = $this->container->get('dao.folder');
+      if ($folderDao->removeContent($folderContentId)) {
+        $info = new Info(200, "Folder unlinked successfully.", InfoType::INFO);
+      } else {
+        $info = new Info(400, "Content cannot be unlinked.", InfoType::ERROR);
       }
-      $info = new Info(200, "Folder unlinked successfully.", InfoType::INFO);
     }
     return $response->withJson($info->getArray(), $info->getCode());
   }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -3101,6 +3101,37 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /folders/contents/{contentId}/unlink:
+    parameters:
+      - name: contentId
+        in: path
+        required: true
+        description: ID of the content
+        schema:
+          type: integer
+    put:
+      operationId: unlinkContent
+      tags:
+        - Folders
+      summary: Unlink a content from a folder
+      description:
+        Unlink a content from a folder
+      responses:
+        '200':
+          description: Content is unlinked from the folder
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Folder content does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /uploads/{id}/item/{ItemId}/totalcopyrights:
     parameters:
       - name: id

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -275,6 +275,7 @@ $app->group('/folders',
     $app->patch('/{id:\\d+}', FolderController::class . ':editFolder');
     $app->put('/{id:\\d+}', FolderController::class . ':copyFolder');
     $app->get('/{id:\\d+}/contents/unlinkable', FolderController::class . ':getUnlinkableFolderContents');
+    $app->put('/contents/{contentId:\\d+}/unlink', FolderController::class . ':unlinkFolder');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 


### PR DESCRIPTION
## Description

Added the API to unlink the folder contents.

### Changes

1. Added a new method in  `JobController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `PUT` `/folders/contents/{contentId}/unlink`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a PUT request on the endpoint: `/folders/contents/{contentId}/unlink`,

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/f11f0c30-a838-4303-a6b1-e9d3ac1a41c5)

### Related Issue:
Fixes #2540  
    
cc: @shaheemazmalmmd @GMishx


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2552"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

