### PR TITLE
feat(api): Get all contents of a specific folder

### DIFF
--- a/src/www/ui/api/Controllers/FolderController.php
+++ b/src/www/ui/api/Controllers/FolderController.php
@@ -295,4 +295,42 @@ class FolderController extends RestController
     }
     return $response->withJson($info->getArray(), $info->getCode());
   }
+  /**
+   * Get the all folder contents
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function getAllFolderContents($request, $response, $args)
+  {
+    $folderId = $args['id'];
+    $folderDao = $this->restHelper->getFolderDao();
+
+    if ($folderDao->getFolder($folderId) === null) {
+      $error = new Info(404, "Folder id not found!", InfoType::ERROR);
+    } else if (! $folderDao->isFolderAccessible($folderId, $this->restHelper->getUserId())) {
+      $error = new Info(403, "Folder is not accessible!", InfoType::ERROR);
+    }
+
+    if (isset($error)) {
+      return $response->withJson($error->getArray(), $error->getCode());
+    }
+
+    $folderContents = $this->restHelper->getPlugin('foldercontents');
+    $symfonyRequest = new \Symfony\Component\HttpFoundation\Request();
+    $symfonyRequest->request->set('folder', $folderId);
+    $symfonyRequest->request->set('fromRest', true);
+    $res = $folderContents->handle($symfonyRequest);
+
+    foreach ($folderDao->getRemovableContents($folderId) as $content) {
+      foreach ($res as &$value) {
+        if ($value['id'] == $content) {
+          $value['removable'] = true;
+        }
+      }
+    }
+    return $response->withJson($res, 200);
+  }
 }

--- a/src/www/ui/api/Controllers/FolderController.php
+++ b/src/www/ui/api/Controllers/FolderController.php
@@ -295,6 +295,7 @@ class FolderController extends RestController
     }
     return $response->withJson($info->getArray(), $info->getCode());
   }
+
   /**
    * Get the all folder contents
    *
@@ -318,19 +319,19 @@ class FolderController extends RestController
       return $response->withJson($error->getArray(), $error->getCode());
     }
 
+    /** @var AjaxFolderContents $folderContents */
     $folderContents = $this->restHelper->getPlugin('foldercontents');
     $symfonyRequest = new \Symfony\Component\HttpFoundation\Request();
     $symfonyRequest->request->set('folder', $folderId);
     $symfonyRequest->request->set('fromRest', true);
-    $res = $folderContents->handle($symfonyRequest);
+    $contentList = $folderContents->handle($symfonyRequest);
+    $removableContents = $folderDao->getRemovableContents($folderId);
 
-    foreach ($folderDao->getRemovableContents($folderId) as $content) {
-      foreach ($res as &$value) {
-        if ($value['id'] == $content) {
-          $value['removable'] = true;
-        }
+    foreach ($contentList as &$value) {
+      if (in_array($value['id'], $removableContents)) {
+        $value['removable'] = true;
       }
     }
-    return $response->withJson($res, 200);
+    return $response->withJson($contentList, 200);
   }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -3132,6 +3132,43 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /folders/{id}/contents:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: ID of the folder
+        schema:
+          type: integer
+    get:
+      operationId: getAllFolderContents
+      tags:
+        - Folders
+      summary: Get all contents of a folder
+      description:
+        Get all contents of a folder by id
+      responses:
+        '200':
+          description: Contents of the given folder
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetFolderContent'
+        '403':
+          description: Folder is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Folder does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /uploads/{id}/item/{ItemId}/totalcopyrights:
     parameters:
       - name: id
@@ -4669,6 +4706,18 @@ components:
           nullable: true
         hash:
           $ref: '#/components/schemas/Hash'
+    GetFolderContent:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Id of the folder content.
+        content:
+          type: string
+          description: Content of the folder.
+        removable:
+          type: boolean
+          description: Is the folder removable.
     UploadSummary:
       type: object
       properties:

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -2371,8 +2371,8 @@ paths:
         schema:
           type: string
           enum:
-              - active
-              - inactive
+            - active
+            - inactive
       - name: limit
         description: Limits of responses per request
         required: false
@@ -2724,7 +2724,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Info'
         default:
-            $ref: '#/components/responses/defaultResponse'
+          $ref: '#/components/responses/defaultResponse'
 
   /jobs/dashboard/statistics:
     get:
@@ -3153,7 +3153,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetFolderContent'
+                type: array
+                items:
+                  $ref: '#/components/schemas/GetFolderContent'
         '403':
           description: Folder is not accessible
           content:
@@ -3190,8 +3192,8 @@ paths:
         schema:
           type: string
           enum:
-              - active
-              - inactive
+            - active
+            - inactive
     get:
       operationId: getTotalFileCopyrights
       tags:
@@ -4324,7 +4326,7 @@ paths:
         Verify a license as new or variant of another license
       requestBody:
         description: The shortname of the parent license |
-           Same name if it's to be verified as a new license
+          Same name if it's to be verified as a new license
         required: true
         content:
           application/json:
@@ -4469,7 +4471,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: '#/components/schemas/GetPHPInfo'
+                $ref: '#/components/schemas/GetPHPInfo'
         '403':
           description: Access denied
           content:
@@ -5051,18 +5053,6 @@ components:
         parent:
           type: integer
           description: Id of the parent folder (if any, null otherwise).
-    GetFolderContent:
-      type: object
-      properties:
-        id:
-          type: integer
-          description: Id of the folder content.
-        content:
-          type: string
-          description: Content of the folder.
-        removable:
-          type: boolean
-          description: Is the folder removable.
     TokenRequest:
       type: object
       properties:
@@ -5466,12 +5456,12 @@ components:
           description: field type
           type: string
           enum:
-          - int
-          - text
-          - textarea
-          - password
-          - dropdown
-          - boolean
+            - int
+            - text
+            - textarea
+            - password
+            - dropdown
+            - boolean
         label:
           description: field label
           type: string
@@ -5671,16 +5661,16 @@ components:
         successfulAgents:
           type: array
           items:
-              properties:
-                agent_id:
-                  type: integer
-                  example: 20
-                agent_rev:
-                  type: string
-                  example: "4.1.0.282-rc1.ffb851"
-                agent_name:
-                  type: string
-                  example: "reso"
+            properties:
+              agent_id:
+                type: integer
+                example: 20
+              agent_rev:
+                type: string
+                example: "4.1.0.282-rc1.ffb851"
+              agent_name:
+                type: string
+                example: "reso"
         uploadId:
           type: integer
           example: 10

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -276,6 +276,7 @@ $app->group('/folders',
     $app->put('/{id:\\d+}', FolderController::class . ':copyFolder');
     $app->get('/{id:\\d+}/contents/unlinkable', FolderController::class . ':getUnlinkableFolderContents');
     $app->put('/contents/{contentId:\\d+}/unlink', FolderController::class . ':unlinkFolder');
+    $app->get('/{id:\\d+}/contents', FolderController::class . ':getAllFolderContents');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui/async/AjaxFolderContents.php
+++ b/src/www/ui/async/AjaxFolderContents.php
@@ -52,17 +52,16 @@ class AjaxFolderContents extends DefaultPlugin
       $uploadStatus = " (" . $uploadStatus->getTypeName($upload['status_fk']) . ")";
       $results[$upload['foldercontents_pk']] = $upload['upload_filename'] . _(" from ") . Convert2BrowserTime($uploadDate) . $uploadStatus;
     }
-    $restRes = array_map(function($key, $value) {
-      return array(
-        'id' => $key,
-        'content' => $value,
-        'removable' => false
-      );
-    }, array_keys($results), $results);
 
     if (!$request->get('removable')) {
       if ($request->get('fromRest')) {
-        return $restRes;
+        return array_map(function($key, $value) {
+          return array(
+            'id' => $key,
+            'content' => $value,
+            'removable' => false
+          );
+        }, array_keys($results), $results);
       }
       return new JsonResponse($results);
     }

--- a/src/www/ui/async/AjaxFolderContents.php
+++ b/src/www/ui/async/AjaxFolderContents.php
@@ -48,12 +48,22 @@ class AjaxFolderContents extends DefaultPlugin
     $childUploads = $this->folderDao->getFolderChildUploads($folderId, Auth::getGroupId());
     foreach ($childUploads as $upload) {
       $uploadStatus = new UploadStatus();
-      $uploadDate = explode(".",$upload['upload_ts'])[0];
+      $uploadDate = explode(".", $upload['upload_ts'])[0];
       $uploadStatus = " (" . $uploadStatus->getTypeName($upload['status_fk']) . ")";
       $results[$upload['foldercontents_pk']] = $upload['upload_filename'] . _(" from ") . Convert2BrowserTime($uploadDate) . $uploadStatus;
     }
+    $restRes = array_map(function($key, $value) {
+      return array(
+        'id' => $key,
+        'content' => $value,
+        'removable' => false
+      );
+    }, array_keys($results), $results);
 
     if (!$request->get('removable')) {
+      if ($request->get('fromRest')) {
+        return $restRes;
+      }
       return new JsonResponse($results);
     }
 


### PR DESCRIPTION
## Description

Added the API to retrieve the get a list of removable contents in a folder.

### Changes

1. Added a new method in  `FolderController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/folders/{id}/contents`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a GET request on the endpoint:  `/folders/{id}/contents`.

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/56bd5055-f342-4615-9ec2-471c53d09b95)

### Related Issue:
Fixes #2554 
    
cc: @shaheemazmalmmd @GMishx 



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2555"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

