### PR TITLE
feat(api): The REST API to export licenses-list as CSV

### DIFF
--- a/src/www/ui/api/Controllers/LicenseController.php
+++ b/src/www/ui/api/Controllers/LicenseController.php
@@ -12,6 +12,7 @@
 
 namespace Fossology\UI\Api\Controllers;
 
+use Fossology\Lib\Application\LicenseCsvExport;
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\LicenseAcknowledgementDao;
 use Fossology\Lib\Dao\LicenseDao;
@@ -894,9 +895,20 @@ class LicenseController extends RestController
       $error = new Info(403, "You are not allowed to access the endpoint.", InfoType::ERROR);
       return $response->withJson($error->getArray(), $error->getCode());
     }
+    $query = $request->getQueryParams();
+    $rf = 0;
+    if (array_key_exists('licenseId', $query)) {
+      $rf = intval($query['licenseId']);
+    }
+    if ($rf != 0 &&
+        (! $this->dbHelper->doesIdExist("license_ref", "rf_pk", $rf) &&
+         ! $this->dbHelper->doesIdExist("license_candidate", "rf_pk", $rf))) {
+      $error = new Info(404, "License not found.", InfoType::ERROR);
+      return $response->withJson($error->getArray(), $error->getCode());
+    }
     $dbManager = $this->dbHelper->getDbManager();
-    $licenseCsvExport = new \Fossology\Lib\Application\LicenseCsvExport($dbManager);
-    $content = $licenseCsvExport->createCsv(0);
+    $licenseCsvExport = new LicenseCsvExport($dbManager);
+    $content = $licenseCsvExport->createCsv($rf);
     $fileName = "fossology-license-export-" . date("YMj-Gis");
     $newResponse = $response->withHeader('Content-type', 'text/csv, charset=UTF-8')
       ->withHeader('Content-Disposition', 'attachment; filename=' . $fileName . '.csv')
@@ -904,9 +916,8 @@ class LicenseController extends RestController
       ->withHeader('Cache-Control', 'no-cache, must-revalidate, maxage=1, post-check=0, pre-check=0')
       ->withHeader('Expires', 'Expires: Thu, 19 Nov 1981 08:52:00 GMT');
     $sf = new StreamFactory();
-    $newResponse = $newResponse->withBody(
+    return $newResponse->withBody(
       $content ? $sf->createStream($content) : $sf->createStream('')
     );
-    return ($newResponse);
   }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -4029,6 +4029,30 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+  /license/export-csv:
+    get:
+      operationId: exportLicense
+      tags:
+        - License
+      summary: Export a csv license
+      description: >
+        Export a csv license
+      responses:
+        '200':
+          description: Successfully exported
+          content:
+            text/plain:
+              schema:
+                type: string
+                format: binary
+        '403':
+          description: Route is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /license/{shortname}:
     parameters:
       - name: shortname

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -4032,6 +4032,14 @@ paths:
   /license/export-csv:
     get:
       operationId: exportLicense
+      parameters:
+        - name: licenseId
+          description: License id to export, 0 for all
+          in: query
+          required: false
+          default: 0
+          schema:
+            type: int
       tags:
         - License
       summary: Export a csv license
@@ -4041,7 +4049,7 @@ paths:
         '200':
           description: Successfully exported
           content:
-            text/plain:
+            text/csv:
               schema:
                 type: string
                 format: binary

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -328,6 +328,7 @@ $app->group('/license',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->get('', LicenseController::class . ':getAllLicenses');
     $app->post('/import-csv', LicenseController::class . ':handleImportLicense');
+    $app->get('/export-csv', LicenseController::class . ':exportAdminLicenseToCSV');
     $app->post('', LicenseController::class . ':createLicense');
     $app->put('/verify/{shortname:.+}', LicenseController::class . ':verifyLicense');
     $app->put('/merge/{shortname:.+}', LicenseController::class . ':mergeLicense');


### PR DESCRIPTION
## Description

Added the API to export licenses' list as a CSV file.

### Changes

1. Added a new method in  `LicenseController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/license/export`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a GET request on the endpoint: `/license/export`,

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/e5ddff4e-8666-4372-9a25-47d37d16f6e1)

### Related Issue:
Fixes #2561  
    
cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2562"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

