### PR TITLE
feat(api): Import obligation list from CSV

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -4101,7 +4101,7 @@ paths:
           required: false
           default: 0
           schema:
-            type: int
+            type: integer
       tags:
         - License
       summary: Export a csv license
@@ -4717,6 +4717,51 @@ paths:
                 $ref: '#/components/schemas/Info'
         '500':
           description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /license/obligation/import-csv:
+    post:
+      operationId: importObligationCsv
+      tags:
+        - License
+      summary: Import an obligation csv file
+      description: >
+        Import an obligation csv file
+      requestBody:
+        description: Information about delimiters, inclosure and csv file.
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                enclosure:
+                  type: string
+                  description: Enclosure for string in CSV
+                  default: '"'
+                delimiter:
+                  type: string
+                  description: Delimiters for fields in CSV
+                  default: ','
+                file_input:
+                  type: string
+                  format: binary
+                  description: CSV to be imported
+              required:
+                - file_input
+      responses:
+        '400':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '200':
+          description: Successfully imported
           content:
             application/json:
               schema:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -352,6 +352,7 @@ $app->group('/license',
     $app->delete('/admincandidates/{id:\\d+}',
       LicenseController::class . ':deleteAdminLicenseCandidate');
     $app->put('/adminacknowledgements', LicenseController::class . ':handleAdminLicenseAcknowledgement');
+    $app->post('/obligation/import-csv', LicenseController::class . ':importObligationsFromCSV');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 


### PR DESCRIPTION
## Description

Added the API to import obligation list from a CSV file.

### Changes

1. Added a new method in  `LicenseController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `POST` `/license/obligation/import-csv`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a POST request on the endpoint: `/license/obligation/import-csv`,

## Screenshots

![image](https://github.com/fossology/fossology/assets/66276301/0e7964f9-cd26-426d-8c65-47480fbe9788)

### Related Issue:
Fixes #2560 
    
cc: @shaheemazmalmmd @GMishx



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2563"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

