### PR TITLE
chore(pythondeps): preserve proxy env with su

### DIFF
--- a/install/fo-install-pythondeps
+++ b/install/fo-install-pythondeps
@@ -146,27 +146,27 @@ if [[ $RUNTIME && -z "$DEBIAN" ]]; then
 fi
 if [[ $RUNTIME ]]; then
   if id "$TARGETUSER" &>/dev/null; then
-    su "$TARGETUSER" -c 'mkdir -p $HOME/pythondeps && touch $HOME/.bashrc'
-    su "$TARGETUSER" -c 'grep -qF pythondeps $HOME/.bashrc || printf "export PATH=\"$PATH:$HOME/pythondeps/bin\"\nexport PYTHONPATH=\"$HOME/pythondeps\"" >> $HOME/.bashrc'
+    su $TARGETUSER -c 'mkdir -p $HOME/pythondeps && touch $HOME/.bashrc'
+    su $TARGETUSER -c 'grep -qF pythondeps $HOME/.bashrc || printf "export PATH=\"$PATH:$HOME/pythondeps/bin\"\nexport PYTHONPATH=\"$HOME/pythondeps\"" >> $HOME/.bashrc'
     ###########################################################################
     # Install pip dependencies together.
     # Using --target causes conflict in bin dir, using --upgrade overwrites it.
     # See https://github.com/pypa/pip/issues/8063
     # Dependencies for scancode
-    su "$TARGETUSER" -c 'python3 -m pip install --target=$HOME/pythondeps --no-input setuptools wheel'
+    su --login --whitelist-environment="http_proxy,HTTP_PROXY,https_proxy,HTTPS_PROXY" $TARGETUSER -c 'python3 -m pip install --target=$HOME/pythondeps --no-input setuptools wheel'
     ###########################################################################
     if [[ $EXPERIMENTAL ]]; then
       # Include experimental dependencies
-      su "$TARGETUSER" -c 'PYTHONPATH="$HOME/pythondeps" python3 -m pip install\
-      --target=$HOME/pythondeps --no-input --upgrade \
-      spacy pandas scancode-toolkit==31.2.4 scanoss==1.5.1'
-      su "$TARGETUSER" -c 'PYTHONPATH="$HOME/pythondeps" python3 -m spacy \
-      download en_core_web_sm --target=$HOME/pythondeps'
+      su --login --whitelist-environment="http_proxy,HTTP_PROXY,https_proxy,HTTPS_PROXY" $TARGETUSER -c 'PYTHONPATH="$HOME/pythondeps" python3 -m pip install \
+        --target=$HOME/pythondeps --no-input --upgrade \
+        spacy pandas scancode-toolkit==31.2.4 scanoss==1.5.1'
+      su --login --whitelist-environment="http_proxy,HTTP_PROXY,https_proxy,HTTPS_PROXY" $TARGETUSER -c 'PYTHONPATH="$HOME/pythondeps" python3 -m spacy \
+        download en_core_web_sm --target=$HOME/pythondeps'
     else
       # Only non-experimental dependencies
-      su "$TARGETUSER" -c 'PYTHONPATH="$HOME/pythondeps" python3 -m pip install\
-       --target=$HOME/pythondeps --no-input --upgrade \
-       scancode-toolkit==31.2.4 scanoss==1.5.1'
+      su --login --whitelist-environment="http_proxy,HTTP_PROXY,https_proxy,HTTPS_PROXY" $TARGETUSER -c 'PYTHONPATH="$HOME/pythondeps" python3 -m pip install\
+        --target=$HOME/pythondeps --no-input --upgrade \
+        scancode-toolkit==31.2.4 scanoss==1.5.1'
     fi
     ###########################################################################
   else


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Preserve proxy environments while doing `su` in `fo-install-pythondeps` for `pip install` commands.

### Changes

Use `--login --whitelist-environment="http_proxy,HTTP_PROXY,https_proxy,HTTPS_PROXY"` flags with `su`.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2571"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

