### PR TITLE
feat(api): Export Obligation list as CSV

### DIFF
--- a/src/lib/php/Application/ObligationCsvExport.php
+++ b/src/lib/php/Application/ObligationCsvExport.php
@@ -7,7 +7,6 @@
 
 namespace Fossology\Lib\Application;
 
-use Fossology\Lib\BusinessRules\LicenseMap;
 use Fossology\Lib\Db\DbManager;
 
 /**
@@ -68,18 +67,17 @@ class ObligationCsvExport
   {
     $csvarray = array();
     $sql = "SELECT ob_pk,ob_type,ob_topic,ob_text,ob_classification,ob_modifications,ob_comment
-            FROM obligation_ref;";
+            FROM obligation_ref";
     if ($ob>0) {
       $stmt = __METHOD__.'.ob';
-      $sql .= ' WHERE ob_pk=$'.$ob;
-      $row = $this->dbManager->getSingleRow($sql,$stmt);
-      $vars = $row ? array( $row ) : array();
+      $sql .= ' WHERE ob_pk=$1;';
+      $row = $this->dbManager->getSingleRow($sql, [$ob], $stmt);
       $liclist = $this->obligationMap->getLicenseList($ob);
       $candidatelist = $this->obligationMap->getLicenseList($ob, True);
-      array_shift($vars);
-      array_push($vars,$liclist);
-      array_push($vars,$candidatelist);
-      $csvarray = $vars;
+      array_shift($row);
+      array_push($row,$liclist);
+      array_push($row,$candidatelist);
+      array_push($csvarray,$row);
     } else {
       $stmt = __METHOD__;
       $this->dbManager->prepare($stmt,$sql);

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -4786,6 +4786,31 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+
+  /license/obligation/export-csv:
+    get:
+      operationId: exportLicenseObligations
+      tags:
+        - License
+      summary: Export a csv obligation list
+      description: >
+        Export a csv license obligation list
+      responses:
+        '200':
+          description: Successfully exported
+          content:
+            text/plain:
+              schema:
+                type: string
+                format: binary
+        '403':
+          description: Route is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
 components:
   securitySchemes:
     bearerAuth:

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -300,6 +300,85 @@ paths:
                   $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+  /obligations/import-csv:
+    post:
+      operationId: importObligationCsv
+      tags:
+        - License
+      summary: Import an obligation csv file
+      description: >
+        Import an obligation csv file
+      requestBody:
+        description: Information about delimiters, inclosure and csv file.
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                enclosure:
+                  type: string
+                  description: Enclosure for string in CSV
+                  default: '"'
+                delimiter:
+                  type: string
+                  description: Delimiters for fields in CSV
+                  default: ','
+                file_input:
+                  type: string
+                  format: binary
+                  description: CSV to be imported
+              required:
+                - file_input
+      responses:
+        '400':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '200':
+          description: Successfully imported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /obligations/export-csv:
+    get:
+      operationId: exportLicenseObligations
+      parameters:
+        - name: id
+          description: Obligation id to export, 0 for all
+          in: query
+          required: false
+          default: 0
+          schema:
+            type: integer
+      tags:
+        - License
+      summary: Export a csv obligation list
+      description: >
+        Export a csv license obligation list
+      responses:
+        '200':
+          description: Successfully exported
+          content:
+            text/plain:
+              schema:
+                type: string
+                format: binary
+        '403':
+          description: Route is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /obligations:
     get:
       operationId: getAllObligationsData
@@ -4113,7 +4192,7 @@ paths:
     get:
       operationId: exportLicense
       parameters:
-        - name: licenseId
+        - name: id
           description: License id to export, 0 for all
           in: query
           required: false
@@ -4741,76 +4820,7 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-  /license/obligation/import-csv:
-    post:
-      operationId: importObligationCsv
-      tags:
-        - License
-      summary: Import an obligation csv file
-      description: >
-        Import an obligation csv file
-      requestBody:
-        description: Information about delimiters, inclosure and csv file.
-        required: true
-        content:
-          multipart/form-data:
-            schema:
-              type: object
-              properties:
-                enclosure:
-                  type: string
-                  description: Enclosure for string in CSV
-                  default: '"'
-                delimiter:
-                  type: string
-                  description: Delimiters for fields in CSV
-                  default: ','
-                file_input:
-                  type: string
-                  format: binary
-                  description: CSV to be imported
-              required:
-                - file_input
-      responses:
-        '400':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Info'
-        '200':
-          description: Successfully imported
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Info'
-        default:
-          $ref: '#/components/responses/defaultResponse'
 
-  /license/obligation/export-csv:
-    get:
-      operationId: exportLicenseObligations
-      tags:
-        - License
-      summary: Export a csv obligation list
-      description: >
-        Export a csv license obligation list
-      responses:
-        '200':
-          description: Successfully exported
-          content:
-            text/plain:
-              schema:
-                type: string
-                format: binary
-        '403':
-          description: Route is not accessible
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Info'
-        default:
-          $ref: '#/components/responses/defaultResponse'
 components:
   securitySchemes:
     bearerAuth:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -231,6 +231,8 @@ $app->group('/obligations',
     $app->get('/{id:\\d+}', ObligationController::class . ':obligationsDetails');
     $app->get('', ObligationController::class . ':obligationsAllDetails');
     $app->delete('/{id:\\d+}', ObligationController::class . ':deleteObligation');
+    $app->get('/export-csv', ObligationController::class . ':exportObligationsToCSV');
+    $app->post('/import-csv', ObligationController::class . ':importObligationsFromCSV');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 
@@ -348,13 +350,11 @@ $app->group('/license',
     $app->get('/stdcomments', LicenseController::class . ':getAllLicenseStandardComments');
     $app->put('/stdcomments', LicenseController::class . ':handleLicenseStandardComment');
     $app->post('/suggest', LicenseController::class . ':getSuggestedLicense');
-    $app->get('/obligation/export-csv', LicenseController::class . ':exportObligationsToCSV');
     $app->get('/{shortname:.+}', LicenseController::class . ':getLicense');
     $app->patch('/{shortname:.+}', LicenseController::class . ':updateLicense');
     $app->delete('/admincandidates/{id:\\d+}',
       LicenseController::class . ':deleteAdminLicenseCandidate');
     $app->put('/adminacknowledgements', LicenseController::class . ':handleAdminLicenseAcknowledgement');
-    $app->post('/obligation/import-csv', LicenseController::class . ':importObligationsFromCSV');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -348,6 +348,7 @@ $app->group('/license',
     $app->get('/stdcomments', LicenseController::class . ':getAllLicenseStandardComments');
     $app->put('/stdcomments', LicenseController::class . ':handleLicenseStandardComment');
     $app->post('/suggest', LicenseController::class . ':getSuggestedLicense');
+    $app->get('/obligation/export-csv', LicenseController::class . ':exportObligationsToCSV');
     $app->get('/{shortname:.+}', LicenseController::class . ':getLicense');
     $app->patch('/{shortname:.+}', LicenseController::class . ':updateLicense');
     $app->delete('/admincandidates/{id:\\d+}',


### PR DESCRIPTION
## Description

Added the API to export Obligations' list as a CSV file.

### Changes

1. Added a new method in  `LicenseController` to build the functionality.
2. Updated  the main file(`index.php`) by adding a new route `GET` `/license/obligation/export-csv`.
4. Updated the `openapi.yaml` file  to write the new API's documentation.

## How to test

Make a GET request on the endpoint: `/license/obligation/export-csv`,

## Screenshots
![image](https://github.com/fossology/fossology/assets/66276301/1e254510-7b71-4046-9013-a4b2a8cd67c4)

### Related Issue:
Fixes #2560 
    
cc: @shaheemazmalmmd @GMishx

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2574"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

