### PR TITLE
feat(SETUP-V2): Support Multiple Versions (V1 & V2)

### DIFF
--- a/src/www/ui/api/Models/ApiVersion.php
+++ b/src/www/ui/api/Models/ApiVersion.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Samuel Dushimimana <dushsam100@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * @file
+ * @brief ApiVersion enum
+ */
+namespace Fossology\UI\Api\Models;
+
+/**
+ * @class ApiVersion
+ * @brief ApiVersion enum
+ */
+class ApiVersion
+{
+  const V1 = 1;
+  const V2 = 2;
+}

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -16,6 +16,8 @@ info:
 servers:
   - url: http://localhost/repo/api/v1
     description: Localhost instance
+  - url: http://localhost/repo/api/v2
+    description: Localhost instance (Version 2)
 security:
   - bearerAuth: []
   - oauth: []

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -2,6 +2,7 @@
 /*
  SPDX-FileCopyrightText: © 2017-2018,2021 Siemens AG
  SPDX-FileCopyrightText: © 2021 Orange by Piotr Pszczola <piotr.pszczola@orange.com>
+ SPDX-FileCopyrightText: © 2023 Samuel Dushimimana <dushsam100@gmail.com>
 
  SPDX-License-Identifier: GPL-2.0-only
 */
@@ -43,6 +44,7 @@ use Fossology\UI\Api\Helper\ResponseFactoryHelper;
 use Fossology\UI\Api\Helper\ResponseHelper;
 use Fossology\UI\Api\Middlewares\FossologyInitMiddleware;
 use Fossology\UI\Api\Middlewares\RestAuthMiddleware;
+use Fossology\UI\Api\Models\ApiVersion;
 use Fossology\UI\Api\Models\Info;
 use Fossology\UI\Api\Models\InfoType;
 use Psr\Http\Message\ServerRequestInterface;
@@ -51,16 +53,28 @@ use Slim\Exception\HttpMethodNotAllowedException;
 use Slim\Exception\HttpNotFoundException;
 use Slim\Factory\AppFactory;
 use Slim\Middleware\ContentLengthMiddleware;
+use Slim\Psr7\Request;
 use Slim\Psr7\Response;
 use Throwable;
 
-const REST_VERSION = "1";
+// Extracts the version from the URL
+function getVersionFromUri ($uri)
+{
+  $matches = [];
+  preg_match('/\/repo\/api\/v(\d+)/', $uri, $matches);
+  return isset($matches[1]) ? intval($matches[1]) : null;
+}
 
-const BASE_PATH   = "/repo/api/v" . REST_VERSION;
+// Determine the API version based on the URL
+$requestedVersion = isset($_SERVER['REQUEST_URI']) ? getVersionFromUri($_SERVER['REQUEST_URI']) : null;
+$apiVersion = in_array($requestedVersion, [ApiVersion::V1, ApiVersion::V2]) ? $requestedVersion : ApiVersion::V1; // Default to "1"
+
+// Construct the base path
+$BASE_PATH = "/repo/api/v" .$apiVersion;
 
 const AUTH_METHOD = "JWT_TOKEN";
 
-$GLOBALS['apiBasePath'] = BASE_PATH;
+$GLOBALS['apiBasePath'] = $BASE_PATH;
 
 $startTime = microtime(true);
 
@@ -95,9 +109,15 @@ if ($dbConnected) {
 AppFactory::setContainer($container);
 AppFactory::setResponseFactory(new ResponseFactoryHelper());
 $app = AppFactory::create();
-$app->setBasePath(BASE_PATH);
+$app->setBasePath($BASE_PATH);
 
-/*
+// Custom middleware to set the API version as a request attribute
+$apiVersionMiddleware = function (Request $request, $handler) use ($apiVersion) {
+  $request = $request->withAttribute('apiVersion', $apiVersion);
+  return $handler->handle($request);
+};
+
+/*./
  * To check the order of middlewares, refer
  * https://www.slimframework.com/docs/v4/concepts/middleware.html
  *
@@ -108,6 +128,7 @@ $app->setBasePath(BASE_PATH);
  * 3. The normal flow continues.
  * 4. The call now enters FOSSology Init again and plugins are unloaded.
  * 5. The call then enters Rest Auth and leaves as is.
+ * 6. Added ApiVersion middleware to set 'apiVersion' attribute in request.
  */
 if ($dbConnected) {
   // Middleware for plugin initialization
@@ -116,6 +137,8 @@ if ($dbConnected) {
   $app->add(new RestAuthMiddleware());
   // Content length middleware
   $app->add(new ContentLengthMiddleware());
+  // Api version middleware
+  $app->add($apiVersionMiddleware);
 } else {
   // DB not connected
   // Respond to health request as expected


### PR DESCRIPTION
## Description

This pull request (PR) focuses on enhancing the functionality of the API configuration to accommodate the routes of Version 2.

### Changes

#### 1. Dynamic Base URL Support:

The i`index.php` file has been revised to facilitate the dynamic base URL, capable of accommodating both V1 and V2 versions of the API. 

#### 2. OpenAPI Specification Update:

The `openapi.yml` file has been updated to incorporate the server URL specific to Version 2 of the API. 

## How to test

**1. Add this block of code in the `getInfo` method from `InfoController`:**
  
![image](https://github.com/fossology/fossology/assets/66276301/f66601dd-8024-4f9c-bb89-5d9b4b336893)

**2. Call the Version 1 API** 

![image](https://github.com/fossology/fossology/assets/66276301/ab615f85-3821-48b8-a183-f28c20125ae7)

**3. Call the Version 2 API**

![image](https://github.com/fossology/fossology/assets/66276301/0abf5832-ce21-40fd-a2a5-cef8c848fc8c)

**4. Other Cases**

![image](https://github.com/fossology/fossology/assets/66276301/261afe85-9058-4ae9-b75a-ae8c6d39141c)

### Related Issue:
Fixes #2575 
    
cc: @shaheemazmalmmd @GMishx



<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2576"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

