### PR TITLE
chore(UploadTreeProxy): optimize license file query

### DIFF
--- a/src/lib/php/Proxy/UploadTreeProxy.php
+++ b/src/lib/php/Proxy/UploadTreeProxy.php
@@ -8,6 +8,8 @@
 namespace Fossology\Lib\Proxy;
 
 use Fossology\Lib\BusinessRules\LicenseMap;
+use Fossology\Lib\Dao\LicenseDao;
+use Fossology\Lib\Dao\UploadDao;
 use Fossology\Lib\Data\AgentRef;
 use Fossology\Lib\Data\DecisionScopes;
 use Fossology\Lib\Data\DecisionTypes;
@@ -288,6 +290,20 @@ class UploadTreeProxy extends DbViewProxy
    */
   private static function getQueryCondition($skipThese, $options, $groupId = null, $agentFilter='', $applyGlobal = false)
   {
+    global $container;
+    /** @var LicenseDao $licenseDao */
+    $licenseDao = $container->get('dao.license');
+    $licensesToRemove = [];
+    foreach (['No_license_found', 'Void'] as $licenseName) {
+      $license = $licenseDao->getLicenseByShortName($licenseName);
+      if ($license) {
+        $licensesToRemove[] = "lf.rf_fk != " . $license->getId();
+      }
+    }
+    $licensesToRemove = implode(' AND ', $licensesToRemove);
+    if (!empty($licensesToRemove)) {
+      $licensesToRemove = "($licensesToRemove) AND ";
+    }
     if ($applyGlobal) {
       $globalSql = "(
         ut.uploadtree_pk = cd.uploadtree_fk AND cd.group_fk = $groupId
@@ -299,12 +315,8 @@ class UploadTreeProxy extends DbViewProxy
       $globalSql = "ut.uploadtree_pk = cd.uploadtree_fk AND cd.group_fk = $groupId";
     }
     $conditionQueryHasLicense = "(EXISTS (SELECT 1 FROM license_file lf " .
-      "LEFT JOIN ONLY license_ref lr ON lf.rf_fk = lr.rf_pk " .
-      "LEFT JOIN license_candidate lc ON lf.rf_fk = lc.rf_pk " .
-      "AND lc.group_fk = $groupId " .
-      "WHERE (lr.rf_shortname NOT IN ('No_license_found', 'Void') " .
-      "OR (lr.rf_pk IS NULL AND lc.rf_pk IS NOT NULL)) " .
-      "AND lf.pfile_fk = ut.pfile_fk $agentFilter)" .
+      "WHERE ($licensesToRemove" .
+      "lf.pfile_fk = ut.pfile_fk $agentFilter))" .
       "OR EXISTS (SELECT 1 FROM clearing_decision AS cd " .
       "WHERE cd.group_fk = $groupId AND ut.uploadtree_pk = cd.uploadtree_fk))";
 

--- a/src/www/ui_tests/api/Controllers/UploadControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadControllerTest.php
@@ -1128,6 +1128,10 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     $this->dbManager->shouldReceive("getSingleRow")
       ->withArgs([M::any(), [], 'already_cleared_uploadtree' . $uploadId])
       ->andReturn(['count' => 0]);
+    $this->licenseDao->shouldReceive('getLicenseByShortName')
+      ->withArgs(['No_license_found'])->andReturn(null);
+    $this->licenseDao->shouldReceive('getLicenseByShortName')
+      ->withArgs(['Void'])->andReturn(null);
     $res = [
       "totalFilesOfInterest" => 1,
       "totalFilesCleared" => 1,


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Replace the use of JOINs with `license_ref` and `license_candidate` by getting license ID of 'No_license_found' and 'Void' licenses and filter the IDs directly.

Also, no agent currently scans with candidate license and thus, there should be no candidate license ID in `license_file` table. Thus, we can remove join with `license_candidate` as well.

### Changes

Removing following join:
```
->  Nested Loop Left Join  (cost=0.85..5.82 rows=1 width=0) (actual time=0.008..0.008 rows=1 loops=3908)
      Filter: ((lr.rf_shortname <> ALL ('{No_license_found,Void}'::text[])) OR (lr.rf_pk IS NULL))
      Rows Removed by Filter: 1
      ->  Index Only Scan using lf_pfile_agent_rf_lf_idx on license_file lf  (cost=0.57..3.31 rows=1 width=8) (actual time=0.006..0.006 rows=1 loops=3908)
            Index Cond: (pfile_fk = ut.pfile_fk)
            Filter: (agent_fk = ANY ('{1897,1900}'::integer[]))
            Rows Removed by Filter: 19
            Heap Fetches: 35
      ->  Index Scan using rf_pkpk on license_ref lr  (cost=0.28..2.50 rows=1 width=25) (actual time=0.001..0.001 rows=1 loops=5711)
            Index Cond: (rf_pk = lf.rf_fk)
```

## How to test

Load the License Browser view for a large component and notice the difference in loading speed.

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2577"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

