### PR TITLE
fix(test): fix wrong test according to comment

### DIFF
--- a/src/buckets/ui/bucket-diff.php
+++ b/src/buckets/ui/bucket-diff.php
@@ -251,7 +251,7 @@ return;
     /* If both $Child and $OtherChild are specified,
      * reassemble bucketstr and highlight the differences
      */
-    if ($OtherChild and $OtherChild)
+    if ($Child and $OtherChild)
     {
       $bucketstr = "";
       foreach ($Child['bucketarray'] as $bucket_pk)

--- a/src/nomos/agent_tests/testdata/NomosTestfiles/GPL/nomos-diff-GPLv2.php
+++ b/src/nomos/agent_tests/testdata/NomosTestfiles/GPL/nomos-diff-GPLv2.php
@@ -187,7 +187,7 @@ class ui_nomos_diff extends FO_Plugin
     /* If both $Child and $OtherChild are specified,
      * reassemble licstr and highlight the differences
      */
-    if ($OtherChild and $OtherChild)
+    if ($Child and $OtherChild)
     {
       $licstr = "";
       $DiffLicStyle = "style='background-color:#ffa8a8'";  // mid red pastel

--- a/src/nomos/ui/nomos-diff.php
+++ b/src/nomos/ui/nomos-diff.php
@@ -240,7 +240,7 @@ class ui_nomos_diff extends FO_Plugin
      * If both $Child and $OtherChild are specified,
      * reassemble licstr and highlight the differences
      */
-    if ($OtherChild and $OtherChild) {
+    if ($Child and $OtherChild) {
       $licstr = "";
       $DiffLicStyle = "style='background-color:#ffa8a8'"; // mid red pastel
       foreach ($Child['licarray'] as $rf_pk => $rf_shortname) {


### PR DESCRIPTION
## Description

test
```
if ($OtherChild and $OtherChild)
```
makes no sense

### Changes

fix test according to comment:
```
      /* If both $Child and $OtherChild are specified,
      * reassemble licstr and highlight the differences
      */
```


<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2586"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

