### PR TITLE
feat(unifiedreport): support json format for rows and also html break

### DIFF
--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -357,21 +357,22 @@ function Populate_sysconfig()
   $variable = "CommonObligation";
   $contextNamePrompt = _("Common Obligation");
   $contextValue = "";
-  $contextDesc = _("Common Obligation Text, add line break at the end of the line");
+  $commonExObligations = _('you can add HTML line break, Also use json format for table rows');
+  $contextDesc = _("Common Obligation Text,". "$commonExObligations");
   $valueArray[$variable] = array("'$variable'", "'$contextValue'", "'$contextNamePrompt'",
     strval(CONFIG_TYPE_TEXTAREA), "'ReportText'", "2", "'$contextDesc'", "null", "null");
 
   $variable = "AdditionalObligation";
   $contextNamePrompt = _("Additional Obligation");
   $contextValue = "";
-  $contextDesc = _("Additional Obligation Text, add line break at the end of the line");
+  $contextDesc = _("Additional Obligation Text,". "$commonExObligations");
   $valueArray[$variable] = array("'$variable'", "'$contextValue'", "'$contextNamePrompt'",
     strval(CONFIG_TYPE_TEXTAREA), "'ReportText'", "3", "'$contextDesc'", "null", "null");
 
   $variable = "ObligationAndRisk";
   $contextNamePrompt = _("Obligation And Risk Assessment");
   $contextValue = "";
-  $contextDesc = _("Obligations and risk assessment, add line break at the end of the line");
+  $contextDesc = _("Obligations and risk assessment,". "$commonExObligations");
   $valueArray[$variable] = array("'$variable'", "'$contextValue'", "'$contextNamePrompt'",
     strval(CONFIG_TYPE_TEXTAREA), "'ReportText'", "4", "'$contextDesc'", "null", "null");
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

support json format for obligationstext in unified report.

### Changes


## How to test

* go to customize page 
* Add common obligations in json format
```json
{
  "1.a":"All relevant licenses ",
  "1.b":"Add all copyrights",
  "1.c":"Add all acknowledgements"
}
```
* also for additional obligations and Obligation And Risk Assessment

<a href="https://gitpod.io/#https://github.com/fossology/fossology/pull/2588"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

