### PR TITLE
fix(php) Optional parameter declared before required parameter

### DIFF
--- a/src/readmeoss/agent/readmeoss.php
+++ b/src/readmeoss/agent/readmeoss.php
@@ -183,7 +183,7 @@ class ReadmeOssAgent extends Agent
    * @param string $break         Line break string
    * @return string Formated report
    */
-  private function createReadMeOSSFormat($addSeparator, $dataForReadME, $extract='text', $break)
+  private function createReadMeOSSFormat($addSeparator, $dataForReadME, $extract, $break)
   {
     $outData = "";
     foreach ($dataForReadME as $statements) {

--- a/src/testing/lib/fossologyTestCase.php
+++ b/src/testing/lib/fossologyTestCase.php
@@ -173,7 +173,7 @@ class fossologyTestCase extends fossologyTest
    * @return exists with failure or returns folder id.
    *
    */
-  public function createFolder($parent = null, $name, $description = null)
+  public function createFolder($parent, $name, $description = null)
   {
 
     global $URL;
@@ -790,7 +790,7 @@ class fossologyTestCase extends fossologyTest
   * @TODO determine if setting alpha folders is worth it.  Right now this routine
   * does not use them.....
   */
-  public function uploadServer($parentFolder = 1, $uploadPath, $description = null, $uploadName = null, $agents = null)
+  public function uploadServer($parentFolder, $uploadPath, $description = null, $uploadName = null, $agents = null)
   {
     global $URL;
     global $PROXY;
@@ -865,7 +865,7 @@ class fossologyTestCase extends fossologyTest
    *
    * @return pass or fail
    */
-  public function uploadUrl($parentFolder = 1, $url, $description = null, $uploadName = null, $agents = null)
+  public function uploadUrl($parentFolder, $url, $description = null, $uploadName = null, $agents = null)
   {
     global $URL;
     global $PROXY;
@@ -1002,4 +1002,3 @@ class fossologyTestCase extends fossologyTest
     return TRUE;
   }
 }
-?>

--- a/src/testing/lib/libTestDB.php
+++ b/src/testing/lib/libTestDB.php
@@ -143,7 +143,7 @@ function SetRepo($sysConfPath,$repoPath)
  * Created on Sep 15, 2011 by Mark Donohoe
  */
 
-function TestDBInit($path=NULL, $dbName)
+function TestDBInit($path, $dbName)
 {
   if(empty($path))
   {


### PR DESCRIPTION
## Description

You cannot have an optional parameter declared before a required parameter

### Changes

Remove default value
