### PR TITLE
fix(php): Using ${var} in strings is deprecated

### DIFF
--- a/src/lib/php/common-active.php
+++ b/src/lib/php/common-active.php
@@ -98,7 +98,7 @@ function ActiveHTTPscript($RequestName,$IncludeScriptTags=1)
 
   $HTML .= "var $RequestName=null;\n";
   /* Check for browser support. */
-  $HTML .= "function ${RequestName}_Get(Url)\n";
+  $HTML .= "function {$RequestName}_Get(Url)\n";
   $HTML .= "{\n";
   $HTML .= "if (window.XMLHttpRequest)\n";
   $HTML .= "  {\n";
@@ -112,7 +112,7 @@ function ActiveHTTPscript($RequestName,$IncludeScriptTags=1)
 
   $HTML .= "if ($RequestName!=null)\n";
   $HTML .= "  {\n";
-  $HTML .= "  $RequestName.onreadystatechange=${RequestName}_Reply;\n";
+  $HTML .= "  $RequestName.onreadystatechange={$RequestName}_Reply;\n";
   /*
    'true' means asynchronous request.
   Rather than waiting for the reply, the reply is

--- a/src/www/ui/upload-instructions.php
+++ b/src/www/ui/upload-instructions.php
@@ -56,12 +56,12 @@ class UploadInstructions extends DefaultPlugin
     $V .= "<td bgcolor='white'>&nbsp;</td>";
     $V .= "<td bgcolor='blue'>&nbsp;</td>";
     $text = _("Your computer");
-    $V .= "<td bgcolor='white' align='center'><a href='${Uri}?mod=upload_file'>$text</a></td>";
+    $V .= "<td bgcolor='white' align='center'><a href='{$Uri}?mod=upload_file'>$text</a></td>";
     $V .= "<td bgcolor='blue'>&nbsp;</td>";
     $V .= "<td bgcolor='white'> &rarr; </td>";
     $V .= "<td bgcolor='blue'>&nbsp;</td>";
     $text = _("FOSSology web server");
-    $V .= "<td bgcolor='white' align='center'><a href='${Uri}?mod=upload_srv_files'>$text</a></td>";
+    $V .= "<td bgcolor='white' align='center'><a href='{$Uri}?mod=upload_srv_files'>$text</a></td>";
     $V .= "<td bgcolor='blue'>&nbsp;</td>";
     $V .= "<td bgcolor='white'>&nbsp;</td>";
     $V .= "</tr><tr>";
@@ -102,7 +102,7 @@ class UploadInstructions extends DefaultPlugin
     $V .= "<td bgcolor='white'>&nbsp;</td>";
     $V .= "<td bgcolor='blue'>&nbsp;</td>";
     $text = _("Remote web or FTP server");
-    $V .= "<td bgcolor='white' align='center'><a href='${Uri}?mod=upload_url'>$text</a></td>";
+    $V .= "<td bgcolor='white' align='center'><a href='{$Uri}?mod=upload_url'>$text</a></td>";
     $V .= "<td bgcolor='blue'>&nbsp;</td>";
     $V .= "<td bgcolor='white'>&nbsp;</td>";
     $V .= "</tr><tr>";


### PR DESCRIPTION
## Description

Using ${var} in strings is deprecated

### Changes

Use {$var} instead 
