### PR TITLE
fix(php): string offset access with curly braces deprecated in PHP 7.4

### DIFF
--- a/src/nomos/agent_tests/testdata/NomosTestfiles/AGPL/JsonMapper.php
+++ b/src/nomos/agent_tests/testdata/NomosTestfiles/AGPL/JsonMapper.php
@@ -106,7 +106,7 @@ class JsonMapper
         continue;
       }
 
-      if ($type{0} != '\\') {
+      if ($type[0] != '\\') {
         //create a full qualified namespace
         if ($strNs != '') {
           $type = '\\' . $strNs . '\\' . $type;
@@ -130,7 +130,7 @@ class JsonMapper
       }
 
       if ($array !== null) {
-        if ($subtype{0} != '\\') {
+        if ($subtype[0] != '\\') {
           //create a full qualified namespace
           if ($strNs != '') {
             $subtype = $strNs . '\\' . $subtype;


### PR DESCRIPTION
## Description

Array and string offset access syntax with curly braces is deprecated in PHP 7.4. 

https://wiki.php.net/rfc/deprecate_curly_braces_array_access

### Changes

Use square brackets instead. 

