### PR TITLE
fix(php): add missing semicolon

### DIFF
--- a/src/nomos/agent_tests/testdata/NomosTestfiles/GPL/Autoload.php
+++ b/src/nomos/agent_tests/testdata/NomosTestfiles/GPL/Autoload.php
@@ -28,4 +28,4 @@ $wgAutoloadClasses += array(
     'LU_PHPReader' => "$dir/reader/PHPReader.php",
     'LU_Reader' => "$dir/reader/Reader.php",
     'LU_ReaderFactory' => "$dir/reader/ReaderFactory.php"
-)
+);


### PR DESCRIPTION
## Description

PHP 8.2 complains about a syntax error (but PHP 7 does not).

### Changes

Add missing semicolon at end of file.