### PR TITLE
fix(php): remove & to be compatible with PHP 8

### DIFF
--- a/utils/freshmeat/Classes/FreshmeatRdfs.php
+++ b/utils/freshmeat/Classes/FreshmeatRdfs.php
@@ -153,9 +153,7 @@ class FreshmeatRdfs
       );
       foreach ($project->latest_release as $verdata)
       {
-        array_push(& $this->project_info["$project->projectname_short"],
-        $verdata->latest_release_version
-                   );
+        $this->project_info["$project->projectname_short"][] = $verdata->latest_release_version;
       }
     }
     ksort($this->project_info);

--- a/utils/freshmeat/lib_projxml.h.php
+++ b/utils/freshmeat/lib_projxml.h.php
@@ -74,10 +74,10 @@ function get_entry($in_handle, $marker){
   while( false != ($line = fgets($in_handle, 1024))){
     // </project> is the end tag, save it and return, all done.
     if (preg_match('|</project>|', $line)){
-      array_push(&$project, $line);
+      $project[] = $line;
       return($project);
     }
-    array_push(&$project, $line);
+    $project[] = $line;
   }
 }
 
@@ -298,7 +298,7 @@ function read_pfile($xml_file) {
     );
     foreach($project->latest_release as $verdata){
       array_push(
-      &$fmprojs["$project->popularity_rank"] ["$project->projectname_short"],
+      $fmprojs["$project->popularity_rank"] ["$project->projectname_short"],
       $verdata->latest_release_version,
       $verdata->latest_release_id,
       $verdata->latest_release_date

--- a/utils/freshmeat/tests/runGp.php
+++ b/utils/freshmeat/tests/runGp.php
@@ -19,7 +19,7 @@
 require_once ('./GpTestSuite.php');
 
 list($me, $infile) = $argv;
-$test = & new GpClassTestSuite();
+$test = new GpClassTestSuite();
 if (TextReporter :: inCli())
 {
   exit ($test->run(new TextReporter()) ? 0 : 1);


### PR DESCRIPTION
## Description

Fix old PHP syntax to be compatible with PHP 8.

### Changes

Remove ```&``` in ```array_push``` and before ```new```.

