### PR TITLE
fix(php): replace deprecated split by explode

### DIFF
--- a/src/testing/lib/TestRun.php
+++ b/src/testing/lib/TestRun.php
@@ -136,7 +136,7 @@ class TestRun
 		{
 		  return(NULL);
 		}
-		$parts = split(' ', $psLast);
+		$parts = explode(' ', $psLast);
 		//print "parts is:\n"; print_r($parts) . "\n";
 		return ($parts[5]);
 	}

--- a/src/testing/lib/fossologyTest.php
+++ b/src/testing/lib/fossologyTest.php
@@ -467,7 +467,7 @@ class fossologyTest extends WebTestCase
         continue;
       }
 
-      list($upId, $file) = split(' ', $upload);
+      list($upId, $file) = explode(' ', $upload);
       if($upId == '#') {
         continue;
       }

--- a/src/testing/lib/reportClass.php
+++ b/src/testing/lib/reportClass.php
@@ -315,7 +315,7 @@ class TestReport {
 			//print "parsed suite name:$suiteName\n";
 
 			$pfe_results = $this->parseResults($moData[$suite +1]);
-			$pfe = split(':', $pfe_results);
+			$pfe = explode(':', $pfe_results);
 			array_push($results, $pfe[0]);
 			array_push($results, $pfe[1]);
 			array_push($results, $pfe[2]);
@@ -378,17 +378,17 @@ class TestReport {
 
 		while($line = $this->getResult($FD)){
 			//$line = getResult($FD);
-			$resultParts = split(';',$line);
-			list($lKey,$licenseType) = split('=',$resultParts[0]);
-			list($fnKey,$fileName)   = split('=',$resultParts[1]);
+			$resultParts = explode(';',$line);
+			list($lKey,$licenseType) = explode('=',$resultParts[0]);
+			list($fnKey,$fileName)   = explode('=',$resultParts[1]);
 			$FileName[] = rtrim($fileName,'.txt');
 			$LicenseType[$licenseType] = $FileName;
-			//print "PLR: before = split results is:{$resultParts[1]}\n<br>";
-			list($fnKey,$std) = split('=',$resultParts[1]);
+			//print "PLR: before = explode results is:{$resultParts[1]}\n<br>";
+			list($fnKey,$std) = explode('=',$resultParts[1]);
 			$VettedName[]     = str_replace(',',",<br>",$std);
-			list($pKey,$pass) = split('=',$resultParts[2]);
+			list($pKey,$pass) = explode('=',$resultParts[2]);
 			$results[]        = str_replace(',',",<br>",$pass);
-			list($fKey,$fail) = split('=',$resultParts[3]);
+			list($fKey,$fail) = explode('=',$resultParts[3]);
 			$results[]        = str_replace(',',",<br>",$fail);
 		}
 		$All[] = $LicenseType;
@@ -497,8 +497,8 @@ class TestReport {
 		$pat = '.+took\s(.*?)\sto\srun$';
 		$matches = preg_match("/$pat/", $string, $matched);
 		//print "the array looks like:\n"; print_r($matched) . "\n";
-		$parts = split(' ', $matched[1]);
-		//print "split array looks like:\n"; print_r($parts) . "\n";
+		$parts = explode(' ', $matched[1]);
+		//print "explode array looks like:\n"; print_r($parts) . "\n";
 		//$time = 'infinity';
 		$sizep = count($parts);
 		$etime = NULL;

--- a/src/testing/utils/createUIUsers.php
+++ b/src/testing/utils/createUIUsers.php
@@ -92,7 +92,7 @@ class createUIUsers extends fossologyTestCase {
     print "Using Svn Version:$Svn\n";
     foreach($Users as $user => $params) {
       list($description, $email, $access, $folder,
-      $block, $blank, $password, $Enote, $bucket, $ui ) = split(',',$Users[$user]);
+      $block, $blank, $password, $Enote, $bucket, $ui ) = explode(',',$Users[$user]);
       $added = $this->addUser($user, $description, $email, $access, $folder,
         $password, $Enote, $bucket, $ui);
       if(preg_match('/User already exists/',$added, $matches)) {

--- a/src/testing/utils/simpleUi-users.php
+++ b/src/testing/utils/simpleUi-users.php
@@ -48,7 +48,7 @@ class createSuiUsers extends fossologyTestCase {
     foreach($Users as $user => $parms)
     {
       list($description, $email, $access, $folder,
-      $pass1, $pass2, $Enote, $Bucketpool, $Ui) = split(',',$parms);
+      $pass1, $pass2, $Enote, $Bucketpool, $Ui) = explode(',',$parms);
       $created = $this->createFolder(1, $user, $description);
       if($created == 0)
       {


### PR DESCRIPTION
## Description

Function ```split``` was DEPRECATED in PHP 5.3.0, and REMOVED in PHP 7.0.0.

### Changes

Replace ```split``` by ```explode```.

Partial fix for #2584
