### PR TITLE
fix(spdx): de-duplicate licenses with same SPDX ID

### DIFF
--- a/src/lib/php/Data/Clearing/ClearingEvent.php
+++ b/src/lib/php/Data/Clearing/ClearingEvent.php
@@ -104,8 +104,9 @@ class ClearingEvent implements LicenseClearing
   }
 
   /**
+   * Get modified license text.
+   *
    * @return string
-   * @deprecated
    */
   public function getReportinfo()
   {
@@ -113,8 +114,9 @@ class ClearingEvent implements LicenseClearing
   }
 
   /**
+   * Get acknowledgement
+   *
    * @return string
-   * @deprecated
    */
   public function getAcknowledgement()
   {

--- a/src/lib/php/Data/License.php
+++ b/src/lib/php/Data/License.php
@@ -62,7 +62,7 @@ class License extends LicenseRef
    */
   public function getSpdxId()
   {
-    return $this->spdxId;
+    return LicenseRef::convertToSpdxId($this->getShortName(), $this->spdxId);
   }
 
   /**

--- a/src/lib/php/Data/Report/FileNode.php
+++ b/src/lib/php/Data/Report/FileNode.php
@@ -1,0 +1,187 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Siemens AG
+ SPDX-FileContributor: Gaurav Mishra <mishra.gaurav@siemens.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+ */
+
+namespace Fossology\Lib\Data\Report;
+
+class FileNode
+{
+  /**
+   * @var string[] $comments
+   * Comments on file.
+   */
+  private $comments = [];
+  /**
+   * @var string[] $acknowledgements
+   * Acknowledgements on file.
+   */
+  private $acknowledgements = [];
+  /**
+   * @var string[] $concludedLicenses
+   * Concluded licenses on file (rf_pk + md5(text)).
+   */
+  private $concludedLicenses = [];
+  /**
+   * @var bool $isCleared
+   * Is file cleared.
+   */
+  private $isCleared = false;
+  /**
+   * @var string[] $scanners
+   * Scanner findings (rf_pk + md5(text)).
+   */
+  private $scanners = [];
+  /**
+   * @var string[] $copyrights
+   * Copyrights on file.
+   */
+  private $copyrights = [];
+
+  /**
+   * Add comment to file.
+   *
+   * @param string $comment
+   * @return FileNode
+   */
+  public function addComment(string $comment): FileNode
+  {
+    $this->comments[] = $comment;
+    return $this;
+  }
+
+  /**
+   * Replace comments.
+   *
+   * @param string[] $comments
+   * @return FileNode
+   */
+  public function setComments(array $comments): FileNode
+  {
+    $this->comments = $comments;
+    return $this;
+  }
+
+  /**
+   * Add acknowledgement to file.
+   *
+   * @param string $acknowledgement
+   * @return FileNode
+   */
+  public function addAcknowledgement(string $acknowledgement): FileNode
+  {
+    $this->acknowledgements[] = $acknowledgement;
+    return $this;
+  }
+
+  /**
+   * Replace acknowledgement array.
+   *
+   * @param string[] $acknowledgements
+   * @return FileNode
+   */
+  public function setAcknowledgements(array $acknowledgements): FileNode
+  {
+    $this->acknowledgements = $acknowledgements;
+    return $this;
+  }
+
+  /**
+   * Add concluded license to file.
+   *
+   * @param string $concludedLicense
+   * @return FileNode
+   */
+  public function addConcludedLicense(string $concludedLicense): FileNode
+  {
+    $this->concludedLicenses[] = $concludedLicense;
+    return $this;
+  }
+
+  /**
+   * Set if file is cleared.
+   *
+   * @param bool $isCleared
+   * @return FileNode
+   */
+  public function setIsCleared(bool $isCleared): FileNode
+  {
+    $this->isCleared = $isCleared;
+    return $this;
+  }
+
+  /**
+   * Add scanner finding to file.
+   *
+   * @param string $scanner
+   * @return FileNode
+   */
+  public function addScanner(string $scanner): FileNode
+  {
+    $this->scanners[] = $scanner;
+    return $this;
+  }
+
+  /**
+   * Add copyright to file.
+   *
+   * @param string $copyright
+   * @return FileNode
+   */
+  public function addCopyright(string $copyright): FileNode
+  {
+    $this->copyrights[] = $copyright;
+    return $this;
+  }
+
+  /**
+   * @return string[]
+   */
+  public function getComments(): array
+  {
+    return $this->comments;
+  }
+
+  /**
+   * @return string[]
+   */
+  public function getAcknowledgements(): array
+  {
+    return $this->acknowledgements;
+  }
+
+  /**
+   * @return string[]
+   */
+  public function getConcludedLicenses(): array
+  {
+    return $this->concludedLicenses;
+  }
+
+  /**
+   * @return bool
+   */
+  public function isCleared(): bool
+  {
+    return $this->isCleared;
+  }
+
+  /**
+   * @return string[]
+   */
+  public function getScanners(): array
+  {
+    return $this->scanners;
+  }
+
+  /**
+   * @return string[]
+   */
+  public function getCopyrights(): array
+  {
+    return $this->copyrights;
+  }
+}

--- a/src/lib/php/Data/Report/SpdxLicenseInfo.php
+++ b/src/lib/php/Data/Report/SpdxLicenseInfo.php
@@ -1,0 +1,107 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Siemens AG
+ SPDX-FileContributor: Gaurav Mishra <mishra.gaurav@siemens.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+ */
+
+namespace Fossology\Lib\Data\Report;
+
+use Fossology\Lib\Data\License;
+
+class SpdxLicenseInfo
+{
+  /**
+   * @var License $licenseObj
+   * License object to get data from.
+   */
+  private $licenseObj;
+  /**
+   * @var bool $listedLicense
+   * Is a SPDX listed license?
+   */
+  private $listedLicense = false;
+  /**
+   * @var bool $customText
+   * Is a custom text license?
+   */
+  private $customText = false;
+
+  /**
+   * @return bool
+   */
+  public function isTextPrinted(): bool
+  {
+    return $this->textPrinted;
+  }
+
+  /**
+   * @param bool $textPrinted
+   * @return SpdxLicenseInfo
+   */
+  public function setTextPrinted(bool $textPrinted): SpdxLicenseInfo
+  {
+    $this->textPrinted = $textPrinted;
+    return $this;
+  }
+  /**
+   * @var bool $textPrinted
+   * Is the license text already printed?
+   */
+  private $textPrinted = false;
+
+  /**
+   * @return License
+   */
+  public function getLicenseObj(): License
+  {
+    return $this->licenseObj;
+  }
+
+  /**
+   * @param License $licenseObj
+   * @return SpdxLicenseInfo
+   */
+  public function setLicenseObj(License $licenseObj): SpdxLicenseInfo
+  {
+    $this->licenseObj = $licenseObj;
+    return $this;
+  }
+
+  /**
+   * @return bool
+   */
+  public function isListedLicense(): bool
+  {
+    return $this->listedLicense;
+  }
+
+  /**
+   * @param bool $listedLicense
+   * @return SpdxLicenseInfo
+   */
+  public function setListedLicense(bool $listedLicense): SpdxLicenseInfo
+  {
+    $this->listedLicense = $listedLicense;
+    return $this;
+  }
+
+  /**
+   * @return bool
+   */
+  public function isCustomText(): bool
+  {
+    return $this->customText;
+  }
+
+  /**
+   * @param bool $customText
+   * @return SpdxLicenseInfo
+   */
+  public function setCustomText(bool $customText): SpdxLicenseInfo
+  {
+    $this->customText = $customText;
+    return $this;
+  }
+}

--- a/src/lib/php/Report/ObligationsGetter.php
+++ b/src/lib/php/Report/ObligationsGetter.php
@@ -76,8 +76,7 @@ class ObligationsGetter
     foreach ($licenseWithoutObligations as $licenseWithoutObligation) {
       $license = $this->licenseDao->getLicenseById($licenseWithoutObligation);
       if (!empty($license)) {
-        $whiteLists[] = LicenseRef::convertToSpdxId($license->getShortName(),
-          $license->getSpdxId());
+        $whiteLists[] = $license->getSpdxId();
       }
     }
     $newobligations = $this->groupObligations($obligations, $uploadId);

--- a/src/spdx2/agent/template/listedlicense.xml.twig
+++ b/src/spdx2/agent/template/listedlicense.xml.twig
@@ -1,0 +1,17 @@
+{# SPDX-FileCopyrightText: © 2023 Siemens AG
+
+   SPDX-License-Identifier: FSFAP
+#}
+{% macro listedLicenseFull(licenseObj) %}
+<spdx:ListedLicense rdf:about="http://spdx.org/licenses/{{ licenseObj.spdxId|replace({' ': '-'})|url_encode }}">
+  <spdx:name>{{ licenseObj.fullName|e }}</spdx:name>
+  <spdx:licenseId>{{ licenseObj.spdxId|replace({' ': '-'})|e }}</spdx:licenseId>
+  <spdx:licenseText><![CDATA[
+{{ licenseObj.text|replace({'\f':''})
+    |replace({']]>':']]]]><![CDATA[>'}) }}
+  ]]></spdx:licenseText>
+{%~ if licenseObj.url is not empty %}
+  <rdfs:seeAlso>{{ licenseObj.url }}</rdfs:seeAlso>
+{%~ endif %}
+</spdx:ListedLicense>
+{% endmacro %}

--- a/src/spdx2/agent/template/spdx2-document.xml.twig
+++ b/src/spdx2/agent/template/spdx2-document.xml.twig
@@ -1,7 +1,8 @@
-{# SPDX-FileCopyrightText: © 2015 Siemens AG
+{# SPDX-FileCopyrightText: © 2015,2023 Siemens AG
 
    SPDX-License-Identifier: FSFAP
 #}
+{%- from "listedlicense.xml.twig" import listedLicenseFull -%}
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     xmlns:spdx="http://spdx.org/rdf/terms#"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -9,17 +10,7 @@
 <spdx:SpdxDocument rdf:about="{{ uri }}#SPDXRef-DOCUMENT">
   <spdx:specVersion>SPDX-2.3</spdx:specVersion>
   <spdx:dataLicense>
-    <spdx:ListedLicense rdf:about="http://spdx.org/licenses/{{ dataLicense.id|replace({' ': '-'})|url_encode }}">
-      <spdx:name>{{ dataLicense.name|e }}</spdx:name>
-      <spdx:licenseId>{{ dataLicense.id|replace({' ': '-'})|e }}</spdx:licenseId>
-      <spdx:licenseText><![CDATA[
-{{ dataLicense.text|replace({'\f':''})
-                   |replace({']]>':']]]]><![CDATA[>'}) }}
-      ]]></spdx:licenseText>
-{% if dataLicense.url is not empty %}
-      <rdfs:seeAlso>{{ dataLicense.url }}</rdfs:seeAlso>
-{% endif %}
-    </spdx:ListedLicense>
+    {{ listedLicenseFull(licenseList[dataLicense].licenseObj) -}}
   </spdx:dataLicense>
   <spdx:creationInfo>
     <spdx:CreationInfo>
@@ -34,21 +25,21 @@
   <rdfs:comment>
     This document was created using license information and a generator from Fossology.
   </rdfs:comment>
-  {%- for licenseData in licenseTexts %}{% if licenseData.id starts with 'LicenseRef-' ~%}
+  {%- for licenseData in licenseList %}{% if licenseData.licenseObj.spdxId starts with 'LicenseRef-' or licenseData.licenseObj.shortName starts with 'LicenseRef-' ~%}
   <spdx:hasExtractedLicensingInfo>
-{% if licenseData.id starts with 'LicenseRef-' %}
-    <spdx:ExtractedLicensingInfo rdf:about="#{{ licenseData.id|replace({' ': '-'})|url_encode }}">
-{% else %}
-    <spdx:ExtractedLicensingInfo rdf:about="http://spdx.org/licenses/{{ licenseData.id|replace({' ': '-'})|url_encode }}">
-{% endif %}
-      <spdx:licenseId>{{ licenseData.id|replace({' ': '-'})|e }}</spdx:licenseId>
-      <spdx:name>{{ licenseData.name|e }}</spdx:name>
+    {%- set licId=licenseData.licenseObj.spdxId %}
+    {% if licenseData.licenseObj.shortName starts with 'LicenseRef-' %}
+      {% set licId=licenseData.licenseObj.shortName %}
+    {%- endif ~%}
+    <spdx:ExtractedLicensingInfo rdf:about="#{{ licId|replace({' ': '-'})|url_encode }}">
+      <spdx:licenseId>{{ licenseData.licenseObj.spdxId|replace({' ': '-'})|e }}</spdx:licenseId>
+      <spdx:name>{{ licenseData.licenseObj.fullName|e }}</spdx:name>
       <spdx:extractedText><![CDATA[
-{{ licenseData.text|replace({'\f':''})
-                   |replace({']]>':']]]]><![CDATA[>'}) }}
+{{ licenseData.licenseObj.text|replace({'\f':''})
+        |replace({']]>':']]]]><![CDATA[>'}) }}
       ]]></spdx:extractedText>
-{% if licenseData.url is not empty %}
-      <rdfs:seeAlso>{{ licenseData.url }}</rdfs:seeAlso>
+{% if licenseData.licenseObj.url is not empty %}
+      <rdfs:seeAlso>{{ licenseData.licenseObj.url }}</rdfs:seeAlso>
 {% endif %}
     </spdx:ExtractedLicensingInfo>
   </spdx:hasExtractedLicensingInfo>

--- a/src/spdx2/agent/template/spdx2-file.xml.twig
+++ b/src/spdx2/agent/template/spdx2-file.xml.twig
@@ -1,7 +1,16 @@
-{# SPDX-FileCopyrightText: © 2015 Siemens AG
+{# SPDX-FileCopyrightText: © 2015,2023 Siemens AG
 
    SPDX-License-Identifier: FSFAP
 #}
+{%- from "listedlicense.xml.twig" import listedLicenseFull -%}
+{% set dualLicense = false %}
+{% if fileData.concludedLicenses|length > 2 %}
+  {% for res in fileData.concludedLicenses %}
+    {% if 'Dual-license' == licenseList[res].licenseObj.shortName %}
+      {% set dualLicense = true %}
+    {% endif %}
+  {% endfor %}
+{%- endif -%}
 <spdx:hasFile>
   <spdx:File rdf:about="#SPDXRef-item{{ fileId|url_encode }}">
     <spdx:fileName>{{ fileName|e }}</spdx:fileName>
@@ -23,119 +32,101 @@
         <spdx:checksumValue>{{ md5 | lower }}</spdx:checksumValue>
       </spdx:Checksum>
     </spdx:checksum>
-{%~ if isCleared %}
-  {%~ if concludedLicenses|default is empty %}
+{%~ if fileData.isCleared() %}{# File clearing decisions #}
+  {%~ if fileData.concludedLicenses|default is empty %}
     <spdx:licenseConcluded rdf:resource="http://spdx.org/rdf/terms#none" />
-  {%~ elseif concludedLicenses|length > 1 %}
+  {%~ elseif fileData.concludedLicenses|length > 1 %}
     <spdx:licenseConcluded>
-    {%~ if 'Dual-license' in concludedLicenses and concludedLicenses|length > 2 %}
+    {%~ if dualLicense %}
       <spdx:DisjunctiveLicenseSet>
     {%~ else %}
       <spdx:ConjunctiveLicenseSet>
     {%~ endif %}{# End dual license check #}
-    {%~ for res in concludedLicenses %}
-      {%~ if res starts with 'LicenseRef-' %}
-        <spdx:member rdf:resource="#{{ res|replace({' ': '-'})|url_encode }}" />
+    {%~ for res in fileData.concludedLicenses %}
+      {%~ if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' or licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+        {%- set licId=licenseList[res].licenseObj.spdxId %}
+        {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+          {% set licId=licenseList[res].licenseObj.shortName %}
+        {%- endif ~%}
+        <spdx:member rdf:resource="#{{ licId|replace({' ': '-'})|url_encode }}" />
       {%~ else %}
-        {%~ if licenseInfoConcluded[res] is defined %}{# License defined first time #}
+        {%~ if not licenseList[res].isTextPrinted() %}{# License to be printed #}
         <spdx:member>
-          <spdx:ListedLicense rdf:about="http://spdx.org/licenses/{{ licenseInfoConcluded[res].id|replace({' ': '-'})|url_encode }}">
-            <spdx:name>{{ licenseInfoConcluded[res].name|e }}</spdx:name>
-            <spdx:licenseId>{{ licenseInfoConcluded[res].id|replace({' ': '-'})|e }}</spdx:licenseId>
-            <spdx:licenseText><![CDATA[
-{{ licenseInfoConcluded[res].text|replace({'\f':''})
-                                 |replace({']]>':']]]]><![CDATA[>'}) }}
-            ]]></spdx:licenseText>
-          {%~ if licenseInfoConcluded[res].url is not empty %}
-            <rdfs:seeAlso>{{ licenseInfoConcluded[res].url }}</rdfs:seeAlso>
-          {%~ endif %}
-          </spdx:ListedLicense>
+          {{ listedLicenseFull(licenseList[res].licenseObj) }}
         </spdx:member>
-        {%~ else %}
-        <spdx:member rdf:resource="http://spdx.org/licenses/{{ res|replace({' ': '-'})|url_encode }}" />
+        {%~ else %}{# License already printed #}
+        <spdx:member rdf:resource="http://spdx.org/licenses/{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}" />
         {%~ endif %}
       {%~ endif %}{# End printing license conclusion #}
     {%~ endfor %}
-    {%~ if 'Dual-license' in concludedLicenses and concludedLicenses|length > 2 %}
+    {%~ if dualLicense %}
       </spdx:DisjunctiveLicenseSet>
     {%~ else %}
       </spdx:ConjunctiveLicenseSet>
     {%~ endif %}
     </spdx:licenseConcluded>
-  {%~ elseif concludedLicenses|length == 1 %}
-    {%- set res = concludedLicenses[0] %}
-    {%- if res starts with 'LicenseRef-' %}
-    <spdx:licenseConcluded rdf:resource="#{{ res|replace({' ': '-'})|url_encode }}" />
+  {%~ elseif fileData.concludedLicenses|length == 1 %}
+    {%- set res = fileData.concludedLicenses[0] %}
+    {%- if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' or licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+      {%- set licId=licenseList[res].licenseObj.spdxId %}
+      {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+        {% set licId=licenseList[res].licenseObj.shortName %}
+      {%- endif ~%}
+    <spdx:licenseConcluded rdf:resource="#{{ licId|replace({' ': '-'})|url_encode }}" />
     {%~ else %}
-      {%~ if licenseInfoConcluded[res] is defined %}{# License defined first time #}
+      {%~ if not licenseList[res].isTextPrinted() %}{# License to be printed #}
     <spdx:licenseConcluded>
-      <spdx:ListedLicense rdf:about="http://spdx.org/licenses/{{ licenseInfoConcluded[res].id|replace({' ': '-'})|url_encode }}">
-        <spdx:name>{{ licenseInfoConcluded[res].name|e }}</spdx:name>
-        <spdx:licenseId>{{ licenseInfoConcluded[res].id|replace({' ': '-'})|e }}</spdx:licenseId>
-        <spdx:licenseText><![CDATA[
-{{ licenseInfoConcluded[res].text|replace({'\f':''})
-          |replace({']]>':']]]]><![CDATA[>'}) }}
-        ]]></spdx:licenseText>
-        {%~ if licenseInfoConcluded[res].url is not empty %}
-        <rdfs:seeAlso>{{ licenseInfoConcluded[res].url }}</rdfs:seeAlso>
-        {%~ endif %}
-      </spdx:ListedLicense>
+      {{ listedLicenseFull(licenseList[res].licenseObj) }}
     </spdx:licenseConcluded>
       {%~ else %}
-    <spdx:licenseConcluded rdf:resource="http://spdx.org/licenses/{{ res|replace({' ': '-'})|url_encode }}" />
+    <spdx:licenseConcluded rdf:resource="http://spdx.org/licenses/{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}" />
       {%~ endif %}
     {%~ endif %}{# End printing single conclusion #}
   {%~ endif %}
-{%~ else %}
+{%~ else %}{# End file clearing decisions #}
     <spdx:licenseConcluded rdf:resource="http://spdx.org/rdf/terms#noassertion" />
 {%~ endif %}{# End license conclusion block #}
 {%~ if licenseCommentState %}{# License comments to be printed #}
-  {%~ if licenseComment is empty %}
+  {%~ if fileData.comments is empty %}
     <spdx:licenseComments rdf:resource="http://spdx.org/rdf/terms#noassertion" />
   {%~ else %}
-    <spdx:licenseComments><![CDATA[{{ licenseComment|e }}]]></spdx:licenseComments>
+    <spdx:licenseComments><![CDATA[{{ fileData.comments|join("\n")|e }}]]></spdx:licenseComments>
   {%~ endif %}
-{% endif %}
-{%~ if scannerLicenses|default is empty %}
+{%~ endif %}
+{%~ if fileData.scanners|default is empty %}
     <spdx:licenseInfoInFile rdf:resource="http://spdx.org/rdf/terms#noassertion" />
 {%~ else %}
-  {%~ for res in scannerLicenses %}
-    {%~ if res starts with 'LicenseRef-' %}
-    <spdx:licenseInfoInFile rdf:resource="#{{ res|replace({' ': '-'})|url_encode }}" />
+  {%~ for res in fileData.scanners %}
+    {%~ if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' or licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+      {%- set licId=licenseList[res].licenseObj.spdxId %}
+      {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+        {% set licId=licenseList[res].licenseObj.shortName %}
+      {%- endif ~%}
+    <spdx:licenseInfoInFile rdf:resource="#{{ licId|replace({' ': '-'})|url_encode }}" />
     {%~ else %}
-      {%~ if licenseInfoScanner[res] is defined %}{# License defined first time #}
+      {%~ if not licenseList[res].isTextPrinted() %}{# License to be printed #}
     <spdx:licenseInfoInFile>
-      <spdx:ListedLicense rdf:about="http://spdx.org/licenses/{{ licenseInfoScanner[res].id|replace({' ': '-'})|url_encode }}">
-        <spdx:name>{{ licenseInfoScanner[res].name|e }}</spdx:name>
-        <spdx:licenseId>{{ licenseInfoScanner[res].id|replace({' ': '-'})|e }}</spdx:licenseId>
-        <spdx:licenseText><![CDATA[
-{{ licenseInfoScanner[res].text|replace({'\f':''})
-                              |replace({']]>':']]]]><![CDATA[>'}) }}
-        ]]></spdx:licenseText>
-        {%~ if licenseInfoScanner[res].url is not empty %}
-        <rdfs:seeAlso>{{ licenseInfoScanner[res].url }}</rdfs:seeAlso>
-        {%~ endif %}
-      </spdx:ListedLicense>
+      {{ listedLicenseFull(licenseList[res].licenseObj) }}
     </spdx:licenseInfoInFile>
       {%~ else %}
     <spdx:licenseInfoInFile>
-      <spdx:ListedLicense rdf:about="http://spdx.org/licenses/{{ res|replace({' ': '-'})|url_encode }}" />
+      <spdx:ListedLicense rdf:about="http://spdx.org/licenses/{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}" />
     </spdx:licenseInfoInFile>
       {%~ endif %}
     {%- endif %}
   {%- endfor %}{# End printing license infos in file #}
 {%- endif %}
-{%~ if copyrights|default is empty %}
+{%~ if fileData.copyrights|default is empty %}
     <spdx:copyrightText rdf:resource="http://spdx.org/rdf/terms#noassertion" />
 {%~ else %}
     <spdx:copyrightText><![CDATA[
-  {%~ for cp in copyrights %}
+  {%~ for cp in fileData.copyrights %}
       {{ cp|replace({'\f':''})
            |replace({']]>':']]]]><![CDATA[>'}) }}
   {%~ endfor %}
     ]]></spdx:copyrightText>
 {%~ endif %}
-{%~ for ack in acknowledgements %}
+{%~ for ack in fileData.acknowledgements %}
     <spdx:attributionText><![CDATA[{{ ack|replace({'\f':''})
             |replace({']]>':']]]]><![CDATA[>'}) }}]]></spdx:attributionText>
 {%~ endfor %}

--- a/src/spdx2/agent/template/spdx2-package.xml.twig
+++ b/src/spdx2/agent/template/spdx2-package.xml.twig
@@ -1,7 +1,15 @@
-{# SPDX-FileCopyrightText: © 2015 Siemens AG
+{# SPDX-FileCopyrightText: © 2015,2023 Siemens AG
 
    SPDX-License-Identifier: FSFAP
 #}
+{%- set dualLicense = false -%}
+{% if mainLicenses|length > 2 %}
+  {% for res in mainLicenses %}
+    {% if 'Dual-license' == licenseList[res].licenseObj.shortName %}
+      {% set dualLicense = true %}
+    {% endif %}
+  {% endfor %}
+{%- endif -%}
 <spdx:relationship>
   <spdx:Relationship>
     <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes" />
@@ -51,19 +59,23 @@
         </spdx:checksum>
 {% if mainLicenses|length > 1 %}
         <spdx:licenseConcluded>
-{% if 'Dual-license' in mainLicenses and mainLicenses|length > 2 %}
+{% if dualLicense %}
           <spdx:DisjunctiveLicenseSet>
 {% else %}
           <spdx:ConjunctiveLicenseSet>
 {% endif %}
 {% for res in mainLicenses %}
-{% if res starts with 'LicenseRef-' %}
-            <spdx:member rdf:resource="#{{ res|replace({' ': '-'})|url_encode }}" />
+{% if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' %}
+  {% set licId=licenseList[res].licenseObj.spdxId %}
+  {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+    {% set licId=licenseList[res].licenseObj.shortName %}
+  {% endif %}
+            <spdx:member rdf:resource="#{{ licId|replace({' ': '-'})|url_encode }}" />
 {% else %}
-            <spdx:member rdf:resource="http://spdx.org/licenses/{{ res|replace({' ': '-'})|url_encode }}" />
+            <spdx:member rdf:resource="http://spdx.org/licenses/{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}" />
 {% endif %}
 {% endfor %}
-{% if 'Dual-license' in concludedLicenses and concludedLicenses|length > 2 %}
+{% if dualLicense %}
           </spdx:DisjunctiveLicenseSet>
 {% else %}
           </spdx:ConjunctiveLicenseSet>
@@ -71,10 +83,14 @@
         </spdx:licenseConcluded>
 {% elseif mainLicenses|length == 1 %}
 {% set res = mainLicenses[0] %}
-{% if res starts with 'LicenseRef-' %}
-        <spdx:licenseConcluded rdf:resource="#{{ res|replace({' ': '-'})|url_encode }}" />
+{% if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' %}
+  {% set licId=licenseList[res].licenseObj.spdxId %}
+  {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+    {% set licId=licenseList[res].licenseObj.shortName %}
+  {% endif %}
+        <spdx:licenseConcluded rdf:resource="#{{ licId|replace({' ': '-'})|url_encode }}" />
 {% else %}
-        <spdx:licenseConcluded rdf:resource="http://spdx.org/licenses/{{ res|replace({' ': '-'})|url_encode }}" />
+        <spdx:licenseConcluded rdf:resource="http://spdx.org/licenses/{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}" />
 {% endif %}
 {% endif %}
         {% if licenseComments %}<spdx:licenseComments><![CDATA[

--- a/src/spdx2/agent/template/spdx2csv-file.twig
+++ b/src/spdx2/agent/template/spdx2csv-file.twig
@@ -3,33 +3,36 @@
    SPDX-License-Identifier: FSFAP
 #}
 {{- fileName -}},SPDXRef-item{{- fileId -}},
-{%- if isCleared -%}
-{%- if concludedLicenses|default is empty -%}
+{%- if fileData.isCleared() -%}
+{%- if fileData.concludedLicenses|default is empty -%}
 NONE,
 {%- else -%}
-"{{- concludedLicense -}}",
+"{{- concludedLicensesString -}}",
 {%- endif -%}
 {%- else -%}
 NOASSERTION,
 {%- endif -%}
-{%- if licenseComment != null -%}
-"{{ licenseComment
-                                       |replace({ '\r\n': ' ', '\n': ' ', '\r': ' ' })
-                                       |replace({'\f':''})
-                                       |replace({'"':'""'}) }}"
+{%- if fileData.comments is not empty -%}
+"{{ fileData.comments|join('\n')
+|replace({ '\r\n': ' ', '\n': ' ', '\r': ' ' })
+|replace({'\f':'', '"':'""'}) }}"
 {%- endif -%},
-{%- if scannerLicenses|default is empty -%}
+{%- if fileData.scanners|default is empty -%}
 NOASSERTION,
 {%- else -%}
-"{{- scannerLicenses|join('AND')
-                    |replace({' ':'-'})
-                    |replace({'AND':' AND '}) -}}",
+"{% for res in fileData.scanners %}
+  {%- set licId=licenseList[res].licenseObj.spdxId %}
+  {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+    {% set licId=licenseList[res].licenseObj.shortName %}
+  {%- endif ~%}
+  {{ licId }}{% if res != fileData.scanners|last %} AND {% endif %}
+{% endfor %}",
 {%- endif -%}
-{%- if copyrights|default is empty -%}
+{%- if fileData.copyrights|default is empty -%}
 NOASSERTION
 {%- else -%}
-"{{- copyrights |join(';')
+"{{- fileData.copyrights|join(';')
                 |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
                 |replace({ '\r\n': ' ', '\n': ' ', '\r': ' ' })
                 |replace({'\f':''})
-                |replace({'"':'""'}) }}" {% endif %}                                    
+                |replace({'"':'""'}) }}"{% endif %}{{ "" }}

--- a/src/spdx2/agent/template/spdx2tv-document.twig
+++ b/src/spdx2/agent/template/spdx2tv-document.twig
@@ -3,7 +3,7 @@
    SPDX-License-Identifier: FSFAP
 #}
 SPDXVersion: SPDX-2.3
-DataLicense: {{ dataLicense.id|replace({' ': '-'}) }}
+DataLicense: {{ licenseList[dataLicense].licenseObj.spdxId|replace({' ': '-'}) }}
 
 ##-------------------------
 ## Document Information
@@ -42,10 +42,14 @@ LicenseListVersion: 3.19
 ## License Information
 ##-------------------------
 
-{% for licenseData in licenseTexts %}{% if licenseData.id starts with 'LicenseRef-' %}
-LicenseID: {{ licenseData.id|replace({' ': '-'}) }}
-LicenseName: {{ licenseData.name }}
-ExtractedText: <text> {{ licenseData.text|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
-                                         |replace({'\f':''}) }} </text>
+{% for licenseData in licenseList %}{% if licenseData.licenseObj.spdxId starts with 'LicenseRef-' or licenseData.licenseObj.shortName starts with 'LicenseRef-' ~%}
+{%- set licId=licenseData.licenseObj.spdxId %}
+{% if licenseData.licenseObj.shortName starts with 'LicenseRef-' %}
+  {% set licId=licenseData.licenseObj.shortName %}
+{%- endif ~%}
+LicenseID: {{ licId|replace({' ': '-'}) }}
+LicenseName: {{ licenseData.licenseObj.fullName }}
+ExtractedText: <text> {{ licenseData.licenseObj.text|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
+    |replace({'\f':''}) }} </text>
 
 {% endif %}{% endfor %}

--- a/src/spdx2/agent/template/spdx2tv-file.twig
+++ b/src/spdx2/agent/template/spdx2tv-file.twig
@@ -11,38 +11,43 @@ SPDXID: SPDXRef-item{{ fileId }}
 FileChecksum: SHA1: {{ sha1 | lower }}
 FileChecksum: SHA256: {{ sha256 | lower }}
 FileChecksum: MD5: {{ md5 | lower }}
-{% if isCleared %}
-{% if concludedLicenses|default is empty %}
+{% if fileData.isCleared() %}
+{% if fileData.concludedLicenses|default is empty %}
 LicenseConcluded: NONE
 {% else %}
-LicenseConcluded: {{ concludedLicense }}
+LicenseConcluded: {{ concludedLicensesString }}
 {% endif%}
 {% else %}
 LicenseConcluded: NOASSERTION
 {% endif %}
 {% if licenseCommentState %}
-{% if licenseComment is not empty %}
-LicenseComments: <text>{{ licenseComment |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
-                                         |replace({'\f':''}) }} </text>
+{% if fileData.comments is not empty %}
+LicenseComments: <text> {{ fileData.comments|join('\n')
+  |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
+  |replace({'\f':''}) }} </text>
 {% endif %}
 {% endif %}
-{% if scannerLicenses|default is empty %}
+{% if fileData.scanners|default is empty %}
 LicenseInfoInFile: NOASSERTION
 {% else %}
-{% for lic in  scannerLicenses %}
-LicenseInfoInFile: {{ lic|replace({' ':'-'})}}
+{% for res in fileData.scanners %}
+{%- set licId=licenseList[res].licenseObj.spdxId %}
+{% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+  {% set licId=licenseList[res].licenseObj.shortName %}
+{%- endif ~%}
+LicenseInfoInFile: {{ licId|replace({' ':'-'})}}
 {% endfor %}
 {% endif %}
 {# FileSize: 48 Kb (49173 bytes) #}
-{% if copyrights|default is empty %}
+{% if fileData.copyrights|default is empty %}
 FileCopyrightText: NOASSERTION
 {% else %}
-FileCopyrightText: <text> {{ copyrights|join('\n')
-                                       |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
-                                       |replace({'\f':''}) }} </text>
+FileCopyrightText: <text> {{ fileData.copyrights|join('\n')
+  |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
+  |replace({'\f':''}) }} </text>
 {% endif %}
-{% if acknowledgements|default is not empty %}
-FileAttributionText: <text> {{ acknowledgements|join('\n')
-                                               |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
-                                               |replace({'\f':''}) }} </text>
+{% if fileData.acknowledgements|default is not empty %}
+FileAttributionText: <text> {{ fileData.acknowledgements|join('\n')
+  |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
+  |replace({'\f':''}) }} </text>
 {% endif %}

--- a/src/spdx2/agent/template/spdx2tv-package.twig
+++ b/src/spdx2/agent/template/spdx2tv-package.twig
@@ -23,8 +23,8 @@ PackageChecksum: MD5: {{ md5 | lower }}
 PackageLicenseConcluded: NOASSERTION
 PackageLicenseDeclared: NOASSERTION
 {% else %}
-PackageLicenseConcluded: {{ mainLicense }}
-PackageLicenseDeclared: {{ mainLicense }}
+PackageLicenseConcluded: {{ mainLicenseString }}
+PackageLicenseDeclared: {{ mainLicenseString }}
 {% endif %}
 {% if licenseComments %}PackageLicenseComments: <text> {{ licenseComments|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'}) }} </text>
 {% endif %}

--- a/src/spdx2/agent_tests/Functional/fo_report.sql
+++ b/src/spdx2/agent_tests/Functional/fo_report.sql
@@ -549,6 +549,11 @@ INSERT INTO license_ref (rf_pk, rf_shortname, rf_spdx_id, rf_text, rf_url, rf_ad
 and new line.', NULL, NULL, NULL, NULL, 'License C', NULL, NULL, NULL, NULL, NULL, false, true, false, NULL, 2, NULL);
 INSERT INTO license_ref (rf_pk, rf_shortname, rf_spdx_id, rf_text, rf_url, rf_add_date, rf_copyleft, "rf_OSIapproved", rf_fullname, "rf_FSFfree", "rf_GPLv2compatible", "rf_GPLv3compatible", rf_notes, "rf_Fedora", marydone, rf_active, rf_text_updatable, rf_md5, rf_detector_type, rf_source) VALUES (560, 'lic Cpp', 'LicenseRef-fossology-lic-Cpp', 'License by Nomos plus plus.', NULL, NULL, NULL, NULL, 'License Cpp', NULL, NULL, NULL, NULL, NULL, false, true, false, NULL, 2, NULL);
 INSERT INTO license_ref (rf_pk, rf_shortname, rf_spdx_id, rf_text, rf_url, rf_add_date, rf_copyleft, "rf_OSIapproved", rf_fullname, "rf_FSFfree", "rf_GPLv2compatible", "rf_GPLv3compatible", rf_notes, "rf_Fedora", marydone, rf_active, rf_text_updatable, rf_md5, rf_detector_type, rf_source) VALUES (561, 'lic D', 'LicenseRef-fossology-lic-D', 'License by Nomos.', NULL, NULL, NULL, NULL, 'License D', NULL, NULL, NULL, NULL, NULL, false, true, false, NULL, 2, NULL);
+INSERT INTO license_ref (rf_pk, rf_shortname, rf_spdx_id, rf_text, rf_url, rf_add_date, rf_copyleft, "rf_OSIapproved",
+                         rf_fullname, "rf_FSFfree", "rf_GPLv2compatible", "rf_GPLv3compatible", rf_notes, "rf_Fedora",
+                         marydone, rf_active, rf_text_updatable, rf_md5, rf_detector_type, rf_source)
+VALUES (561, 'CC0-1.0', 'CC0-1.0', 'CC0-1.0', NULL, NULL, NULL, NULL, 'CC0 1.0', NULL, NULL, NULL, NULL, NULL, false,
+        true, false, '407014723b7e45b6ee534a20cd7542a2', 2, NULL);
 
 
 INSERT INTO monk_ars VALUES (4, 8, 1, true, NULL, '2015-05-04 11:43:17.619778+02', '2015-05-04 11:43:17.863761+02');

--- a/src/www/ui/page/AdminLicenseFromCSV.php
+++ b/src/www/ui/page/AdminLicenseFromCSV.php
@@ -52,6 +52,7 @@ class AdminLicenseFromCSV extends DefaultPlugin
 
     $vars[self::KEY_UPLOAD_MAX_FILESIZE] = ini_get(self::KEY_UPLOAD_MAX_FILESIZE);
     $vars['baseUrl'] = $request->getBaseUrl();
+    $vars['license_csv_import'] = true;
 
     return $this->render("admin_license_from_csv.html.twig", $this->mergeWithDefault($vars));
   }

--- a/src/www/ui/page/AdminObligationFromCSV.php
+++ b/src/www/ui/page/AdminObligationFromCSV.php
@@ -8,12 +8,12 @@
 
 namespace Fossology\UI\Page;
 
+use Fossology\Lib\Application\LicenseCsvImport;
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Plugin\DefaultPlugin;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Fossology\Lib\Application\LicenseCsvImport;
 
 /**
  * \brief Upload a file from the users computer using the UI.
@@ -51,6 +51,7 @@ class AdminObligationFromCSV extends DefaultPlugin
 
     $vars[self::KEY_UPLOAD_MAX_FILESIZE] = ini_get(self::KEY_UPLOAD_MAX_FILESIZE);
     $vars['baseUrl'] = $request->getBaseUrl();
+    $vars['license_csv_import'] = false;
 
     return $this->render("admin_license_from_csv.html.twig", $this->mergeWithDefault($vars));
   }

--- a/src/www/ui/template/admin_license_from_csv.html.twig
+++ b/src/www/ui/template/admin_license_from_csv.html.twig
@@ -16,13 +16,15 @@
     </label>
     <input name="file_input" type="file"/><br/>
     {{ 'Delimiter'|trans }}: <input type="text" name="delimiter" value="," size="1" maxlength="1" /><br/>
-    {{ 'Enclosure'|trans }}: <input type="text" name="enclosure" value="&quot;" size="1" maxlength="1" /><br/>         
+    {{ 'Enclosure'|trans }}: <input type="text" name="enclosure" value="&quot;" size="1" maxlength="1" /><br/>
     <br/>
     <p>&nbsp;&nbsp;&nbsp;&nbsp;<input type="submit" value="{{ 'Upload'| trans }}"/>
     </p>
+    {% if not(license_csv_import is empty) %}
     <p>
       {{ 'NOTE: Obligations will not get imported, To import go to Admin -> Obligation Admin -> CSV Import'| trans }} <br/>
     </p>
+    {% endif %}
 
   </form>
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

If 2 or more licenses share the same SPDX ID, this commit de-duplicates them.
In the same process, change the data structure sent to twig files from arrays to `FileNode` and `SpdxLicenseInfo`.

### Changes

1. Create 2 new Data structures `FileNode` and `SpdxLicenseInfo`.
2. Use new data structures to send data to SPDX twig files instead of plain arrays.
3. De-Duplicate licenses to each get a unique IRI.
  1. First sort licenses by SPDX ID + shortname
  2. Check consecutive licenses if they have the same SPDX ID. If yes, then second license is duplicate.
  3. Change the license's shortname with `LicenseRef-<shortname>-<md5(text)>` to generate a unique ID.
  4. This new ID will then be used as IRI and `<licenseId>` will still point to the SPDX ID.

## How to test

1. Create variants of a license and give them all same SPDX ID (for example BSD-3-Clause).
2. Add these variants to different files.
3. In some of the files, update the license text at decision level.
4. Add other license clearing information like comments and acknowledgements.
5. Generate SPDX and DEP5 reports.
6. Validate the SPDX reports with https://tools.spdx.org/app/validate/ or https://github.com/spdx/tools-java

- [x] Todo: Fix CycloneDX report generator as common code was updated.