### PR TITLE
chore(ci): tag scanner image on release

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -148,3 +148,12 @@ jobs:
         labels: |
           org.opencontainers.image.version=${{ steps.get_release.outputs.tag_name }}.0
         context: .
+
+    - name: Build and push runner image
+      uses: docker/build-push-action@v3
+      with:
+        push: true
+        tags: fossology/fossology:${{ steps.get_release.outputs.tag_name }}-scanner
+        file: utils/automation/Dockerfile.ci
+        labels: |
+          org.opencontainers.image.version=${{ steps.get_release.outputs.tag_name }}.0


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This adds an explicit tag to the `scanner` docker tag on releases, just like the main image, so that people can explicitly version it.

### Changes

Adds a release build similar to the main build:

https://github.com/fossology/fossology/blob/master/.github/workflows/docker-build.yml#L46-L66

The tag scheme is similar to kaniko's debug tags, which should be picked up by renovate and similar tools. See https://github.com/GoogleContainerTools/kaniko/releases/tag/v1.17.0 for example.
