### PR TITLE
changed varchar(32) to text

### DIFF
--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -16,7 +16,7 @@
   $Schema["TABLE"]["agent"]["agent_name"]["ALTER"] = "ALTER TABLE \"agent\" ALTER COLUMN \"agent_name\" SET NOT NULL";
 
   $Schema["TABLE"]["agent"]["agent_rev"]["DESC"] = "COMMENT ON COLUMN \"agent\".\"agent_rev\" IS 'revision string'";
-  $Schema["TABLE"]["agent"]["agent_rev"]["ADD"] = "ALTER TABLE \"agent\" ADD COLUMN \"agent_rev\" varchar(32)";
+  $Schema["TABLE"]["agent"]["agent_rev"]["ADD"] = "ALTER TABLE \"agent\" ADD COLUMN \"agent_rev\" text";
   $Schema["TABLE"]["agent"]["agent_rev"]["ALTER"] = "ALTER TABLE \"agent\" ALTER COLUMN \"agent_rev\" DROP NOT NULL";
 
   $Schema["TABLE"]["agent"]["agent_desc"]["DESC"] = "COMMENT ON COLUMN \"agent\".\"agent_desc\" IS 'short description'";


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

With latest master branch, some build produces very long Fossology Version,  longer than 32 chars. This is because in table agent, column agent_rev is too short i.e only 32 characters long.

### Changes
I have changed 'varchar(32)' in table agent, cloumn agent_rev to 'text' which would easily accomodate longer Fossology version.

closes #2579
