### PR TITLE
feat(api): migrate `/tokens` endpoints to v2

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -18,6 +18,7 @@
         "ext-pgsql": "*",
         "ext-curl": "*",
         "ext-uuid": "*",
+        "ext-openssl": "*",
         "composer/spdx-licenses": "1.5.7",
         "firebase/php-jwt": "v6.3.0",
         "monolog/monolog" : "2.8.0",

--- a/src/composer.json.in
+++ b/src/composer.json.in
@@ -18,6 +18,7 @@
         "ext-pgsql": "*",
         "ext-curl": "*",
         "ext-uuid": "*",
+        "ext-openssl": "*",
         "composer/spdx-licenses": "1.5.7",
         "firebase/php-jwt": "v6.3.0",
         "monolog/monolog" : "2.8.0",

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5ea7283f575eddb7499576aa651f543b",
+    "content-hash": "ce29a0a18b2680e7ad7204a3e0451d8e",
     "packages": [
         {
             "name": "composer/spdx-licenses",
@@ -470,16 +470,16 @@
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.5.2",
+            "version": "1.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "b94b2807d85443f9719887892882d0329d1e2598"
+                "reference": "67ab6e18aaa14d753cc148911d273f6e6cb6721e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/b94b2807d85443f9719887892882d0329d1e2598",
-                "reference": "b94b2807d85443f9719887892882d0329d1e2598",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/67ab6e18aaa14d753cc148911d273f6e6cb6721e",
+                "reference": "67ab6e18aaa14d753cc148911d273f6e6cb6721e",
                 "shasum": ""
             },
             "require": {
@@ -489,11 +489,6 @@
                 "symfony/phpunit-bridge": "^4.4 || ^5.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.5-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "src/functions_include.php"
@@ -534,7 +529,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/1.5.2"
+                "source": "https://github.com/guzzle/promises/tree/1.5.3"
             },
             "funding": [
                 {
@@ -550,20 +545,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-28T14:55:35+00:00"
+            "time": "2023-05-21T12:31:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.5.0",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "b635f279edd83fc275f822a1188157ffea568ff6"
+                "reference": "be45764272e8873c72dbe3d2edcfdfcc3bc9f727"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/b635f279edd83fc275f822a1188157ffea568ff6",
-                "reference": "b635f279edd83fc275f822a1188157ffea568ff6",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/be45764272e8873c72dbe3d2edcfdfcc3bc9f727",
+                "reference": "be45764272e8873c72dbe3d2edcfdfcc3bc9f727",
                 "shasum": ""
             },
             "require": {
@@ -650,7 +645,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.5.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.6.1"
             },
             "funding": [
                 {
@@ -666,7 +661,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-17T16:11:26+00:00"
+            "time": "2023-08-27T10:13:57+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
@@ -1562,16 +1557,16 @@
         },
         {
             "name": "psr/http-client",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-client.git",
-                "reference": "0955afe48220520692d2d09f7ab7e0f93ffd6a31"
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/0955afe48220520692d2d09f7ab7e0f93ffd6a31",
-                "reference": "0955afe48220520692d2d09f7ab7e0f93ffd6a31",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
                 "shasum": ""
             },
             "require": {
@@ -1608,9 +1603,9 @@
                 "psr-18"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-client/tree/1.0.2"
+                "source": "https://github.com/php-fig/http-client"
             },
-            "time": "2023-04-10T20:12:12+00:00"
+            "time": "2023-09-23T14:17:50+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -2586,16 +2581,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.23",
+            "version": "v5.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "b2f79d86cd9e7de0fff6d03baa80eaed7a5f38b5"
+                "reference": "0ce3a62c9579a53358d3a7eb6b3dfb79789a6364"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b2f79d86cd9e7de0fff6d03baa80eaed7a5f38b5",
-                "reference": "b2f79d86cd9e7de0fff6d03baa80eaed7a5f38b5",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/0ce3a62c9579a53358d3a7eb6b3dfb79789a6364",
+                "reference": "0ce3a62c9579a53358d3a7eb6b3dfb79789a6364",
                 "shasum": ""
             },
             "require": {
@@ -2630,7 +2625,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.23"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.25"
             },
             "funding": [
                 {
@@ -2646,7 +2641,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-02T11:38:35+00:00"
+            "time": "2023-05-31T13:04:02+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -2809,16 +2804,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a"
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
                 "shasum": ""
             },
             "require": {
@@ -2833,7 +2828,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2871,7 +2866,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -2887,20 +2882,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "639084e360537a19f9ee352433b84ce831f3d2da"
+                "reference": "ecaafce9f77234a6a449d29e49267ba10499116d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/639084e360537a19f9ee352433b84ce831f3d2da",
-                "reference": "639084e360537a19f9ee352433b84ce831f3d2da",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/ecaafce9f77234a6a449d29e49267ba10499116d",
+                "reference": "ecaafce9f77234a6a449d29e49267ba10499116d",
                 "shasum": ""
             },
             "require": {
@@ -2914,7 +2909,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2958,7 +2953,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -2974,20 +2969,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:30:37+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6"
+                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/19bd1e4fcd5b91116f14d8533c57831ed00571b6",
-                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
+                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
                 "shasum": ""
             },
             "require": {
@@ -2999,7 +2994,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3042,7 +3037,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -3058,20 +3053,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534"
+                "reference": "42292d99c55abe617799667f454222c54c60e229"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
+                "reference": "42292d99c55abe617799667f454222c54c60e229",
                 "shasum": ""
             },
             "require": {
@@ -3086,7 +3081,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3125,7 +3120,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -3141,20 +3136,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-07-28T09:04:16+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "869329b1e9894268a8a61dabb69153029b7a8c97"
+                "reference": "70f4aebd92afca2f865444d30a4d2151c13c3179"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/869329b1e9894268a8a61dabb69153029b7a8c97",
-                "reference": "869329b1e9894268a8a61dabb69153029b7a8c97",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/70f4aebd92afca2f865444d30a4d2151c13c3179",
+                "reference": "70f4aebd92afca2f865444d30a4d2151c13c3179",
                 "shasum": ""
             },
             "require": {
@@ -3163,7 +3158,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3201,7 +3196,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -3217,20 +3212,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9"
+                "reference": "fe2f306d1d9d346a7fee353d0d5012e401e984b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
-                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fe2f306d1d9d346a7fee353d0d5012e401e984b5",
+                "reference": "fe2f306d1d9d346a7fee353d0d5012e401e984b5",
                 "shasum": ""
             },
             "require": {
@@ -3239,7 +3234,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3280,7 +3275,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -3296,20 +3291,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
+                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
+                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
                 "shasum": ""
             },
             "require": {
@@ -3318,7 +3313,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3363,7 +3358,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -3379,20 +3374,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "707403074c8ea6e2edaf8794b0157a0bfa52157a"
+                "reference": "7581cd600fa9fd681b797d00b02f068e2f13263b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/707403074c8ea6e2edaf8794b0157a0bfa52157a",
-                "reference": "707403074c8ea6e2edaf8794b0157a0bfa52157a",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/7581cd600fa9fd681b797d00b02f068e2f13263b",
+                "reference": "7581cd600fa9fd681b797d00b02f068e2f13263b",
                 "shasum": ""
             },
             "require": {
@@ -3401,7 +3396,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3442,7 +3437,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -3458,7 +3453,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3720,16 +3715,16 @@
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v5.4.21",
+            "version": "v5.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "be74908a6942fdd331554b3cec27ff41b45ccad4"
+                "reference": "11401fe94f960249b3c63a488c63ba73091c1e4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/be74908a6942fdd331554b3cec27ff41b45ccad4",
-                "reference": "be74908a6942fdd331554b3cec27ff41b45ccad4",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/11401fe94f960249b3c63a488c63ba73091c1e4a",
+                "reference": "11401fe94f960249b3c63a488c63ba73091c1e4a",
                 "shasum": ""
             },
             "require": {
@@ -3773,7 +3768,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v5.4.21"
+                "source": "https://github.com/symfony/var-exporter/tree/v5.4.26"
             },
             "funding": [
                 {
@@ -3789,7 +3784,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-21T19:46:44+00:00"
+            "time": "2023-07-20T07:21:16+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -5232,16 +5227,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "de036ec91d55d2a9e0db2ba975b512cdb1c23921"
+                "reference": "66783ce213de415b451b904bfef9dda0cf9aeae0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/de036ec91d55d2a9e0db2ba975b512cdb1c23921",
-                "reference": "de036ec91d55d2a9e0db2ba975b512cdb1c23921",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/66783ce213de415b451b904bfef9dda0cf9aeae0",
+                "reference": "66783ce213de415b451b904bfef9dda0cf9aeae0",
                 "shasum": ""
             },
             "require": {
@@ -5284,7 +5279,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/3.0.3"
             },
             "funding": [
                 {
@@ -5292,7 +5287,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-10T06:55:38+00:00"
+            "time": "2023-08-02T09:23:32+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -5682,16 +5677,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.23",
+            "version": "v5.4.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "90f21e27d0d88ce38720556dd164d4a1e4c3934c"
+                "reference": "f4f71842f24c2023b91237c72a365306f3c58827"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/90f21e27d0d88ce38720556dd164d4a1e4c3934c",
-                "reference": "90f21e27d0d88ce38720556dd164d4a1e4c3934c",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f4f71842f24c2023b91237c72a365306f3c58827",
+                "reference": "f4f71842f24c2023b91237c72a365306f3c58827",
                 "shasum": ""
             },
             "require": {
@@ -5761,7 +5756,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.23"
+                "source": "https://github.com/symfony/console/tree/v5.4.28"
             },
             "funding": [
                 {
@@ -5777,20 +5772,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-24T18:47:29+00:00"
+            "time": "2023-08-07T06:12:30+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354"
+                "reference": "875e90aeea2777b6f135677f618529449334a612"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/511a08c03c1960e08a883f4cffcacd219b758354",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/875e90aeea2777b6f135677f618529449334a612",
+                "reference": "875e90aeea2777b6f135677f618529449334a612",
                 "shasum": ""
             },
             "require": {
@@ -5802,7 +5797,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5842,7 +5837,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -5858,7 +5853,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -5924,16 +5919,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.22",
+            "version": "v5.4.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "8036a4c76c0dd29e60b6a7cafcacc50cf088ea62"
+                "reference": "e41bdc93def20eaf3bfc1537c4e0a2b0680a152d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/8036a4c76c0dd29e60b6a7cafcacc50cf088ea62",
-                "reference": "8036a4c76c0dd29e60b6a7cafcacc50cf088ea62",
+                "url": "https://api.github.com/repos/symfony/string/zipball/e41bdc93def20eaf3bfc1537c4e0a2b0680a152d",
+                "reference": "e41bdc93def20eaf3bfc1537c4e0a2b0680a152d",
                 "shasum": ""
             },
             "require": {
@@ -5990,7 +5985,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.22"
+                "source": "https://github.com/symfony/string/tree/v5.4.29"
             },
             "funding": [
                 {
@@ -6006,7 +6001,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-14T06:11:53+00:00"
+            "time": "2023-09-13T11:47:41+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -6071,7 +6066,8 @@
         "ext-xml": "*",
         "ext-pgsql": "*",
         "ext-curl": "*",
-        "ext-uuid": "*"
+        "ext-uuid": "*",
+        "ext-openssl": "*"
     },
     "platform-dev": {
         "ext-posix": "*",

--- a/src/lib/php/Util/ArrayOperation.php
+++ b/src/lib/php/Util/ArrayOperation.php
@@ -56,4 +56,22 @@ class ArrayOperation
     }
     return false;
   }
+
+  /**
+   * @brief Check if a list of keys exists in associative array.
+   *
+   * This function takes a list of keys which should appear in an associative
+   * array. The function flips the key array to make it as an associative array.
+   * It then uses the array_diff_key() to compare the two arrays.
+   *
+   * @param array $array Associative array to check keys against
+   * @param array $keys  Array of keys to check
+   * @return boolean True if all keys exists, false otherwise.
+   * @uses array_flip()
+   * @uses array_diff_key()
+   */
+  public static function arrayKeysExists(array $array, array $keys): bool
+  {
+    return !array_diff_key(array_flip($keys), $array);
+  }
 }

--- a/src/lib/php/Util/test/ArrayOperationTest.php
+++ b/src/lib/php/Util/test/ArrayOperationTest.php
@@ -79,4 +79,14 @@ class ArrayOperationTest extends \PHPUnit\Framework\TestCase
     assertThat(ArrayOperation::multiSearch(array(200),$haystack),is(false));
     assertThat(ArrayOperation::multiSearch(array(200,102),$haystack),is(2));
   }
+
+  public function testArrayKeyExists()
+  {
+    $haystack = ["Key1" => "Value1", "Key2" => "Value2", "Key3" => "Value3"];
+    $this->assertTrue(ArrayOperation::arrayKeysExists($haystack, ["Key1", "Key2", "Key3"]));
+    $this->assertTrue(ArrayOperation::arrayKeysExists($haystack, ["Key1", "Key2"]));
+    $this->assertTrue(ArrayOperation::arrayKeysExists($haystack, ["Key3"]));
+    $this->assertFalse(ArrayOperation::arrayKeysExists($haystack, ["Key11", "Key2", "Key3"]));
+    $this->assertFalse(ArrayOperation::arrayKeysExists($haystack, ["Key11"]));
+  }
 }

--- a/src/www/CMakeLists.txt
+++ b/src/www/CMakeLists.txt
@@ -35,7 +35,7 @@ install(DIRECTORY ui
     PATTERN "*.html"
     PATTERN "*.ico"
     PATTERN "*.js"
-    PATTERN "*openapi.yaml"
+    PATTERN "*openapi*.yaml"
     PATTERN "*.php"
     PATTERN "*.png"
     PATTERN "*.twig"

--- a/src/www/ui/api/Controllers/AuthController.php
+++ b/src/www/ui/api/Controllers/AuthController.php
@@ -16,12 +16,15 @@ use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Exceptions\DuplicateTokenKeyException;
 use Fossology\Lib\Exceptions\DuplicateTokenNameException;
 use Fossology\UI\Api\Exceptions\HttpBadRequestException;
+use Fossology\UI\Api\Exceptions\HttpConflictException;
 use Fossology\UI\Api\Exceptions\HttpErrorException;
 use Fossology\UI\Api\Exceptions\HttpInternalServerErrorException;
 use Fossology\UI\Api\Exceptions\HttpNotFoundException;
 use Fossology\UI\Api\Exceptions\HttpTooManyRequestException;
 use Fossology\UI\Api\Helper\ResponseHelper;
 use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Models\ApiVersion;
+use Fossology\UI\Api\Models\TokenRequest;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -52,7 +55,6 @@ class AuthController extends RestController
    * @param array $args
    * @return ResponseHelper
    * @throws HttpErrorException
-   * @throws DuplicateTokenNameException
    */
   public function createNewJwtToken($request, $response, $args)
   {
@@ -61,77 +63,50 @@ class AuthController extends RestController
         "Use OAuth clients.");
     }
     $tokenRequestBody = $this->getParsedBody($request);
-    $paramsRequired = [
-      "username",
-      "password",
-      "token_name",
-      "token_scope",
-      "token_expire"
-    ];
+    $tokenRequest = TokenRequest::fromArray($tokenRequestBody,
+      ApiVersion::getVersion($request));
 
-    if (! $this->arrayKeysExists($tokenRequestBody, $paramsRequired)) {
-      throw new HttpBadRequestException("Following parameters are required " .
-        "in the request body: " . join(",", $paramsRequired));
-    }
-    $this->restHelper->validateTokenRequest(
-      $tokenRequestBody["token_expire"], $tokenRequestBody["token_name"],
-      $tokenRequestBody["token_scope"]);
+    $this->restHelper->validateTokenRequest($tokenRequest->getTokenExpire(),
+      $tokenRequest->getTokenName(), $tokenRequest->getTokenScope());
     // Request is in correct format.
     $authHelper = $this->restHelper->getAuthHelper();
-    if (!$authHelper->checkUsernameAndPassword($tokenRequestBody["username"],
-      $tokenRequestBody["password"])) {
+    if (!$authHelper->checkUsernameAndPassword($tokenRequest->getUsername(),
+      $tokenRequest->getPassword())) {
       throw new HttpNotFoundException("Username or password incorrect.");
     }
 
     $userId = $this->restHelper->getUserId();
-    $expire = $tokenRequestBody["token_expire"];
-    $scope  = $tokenRequestBody["token_scope"];
-    $name   = $tokenRequestBody["token_name"];
     $key    = bin2hex(
       openssl_random_pseudo_bytes(RestHelper::TOKEN_KEY_LENGTH / 2));
     try {
-      $jti = $this->dbHelper->insertNewTokenKey($userId, $expire,
-        RestHelper::SCOPE_DB_MAP[$scope], $name, $key);
+      $jti = $this->dbHelper->insertNewTokenKey($userId,
+        $tokenRequest->getTokenExpire(), $tokenRequest->getTokenScope(),
+        $tokenRequest->getTokenName(), $key);
     } catch (DuplicateTokenKeyException $e) {
       // Key already exists, try again.
       $key = bin2hex(
         openssl_random_pseudo_bytes(RestHelper::TOKEN_KEY_LENGTH / 2));
       try {
-        $jti = $this->dbHelper->insertNewTokenKey($userId, $expire,
-          RestHelper::SCOPE_DB_MAP[$scope], $name, $key);
+        $jti = $this->dbHelper->insertNewTokenKey($userId,
+          $tokenRequest->getTokenExpire(), $tokenRequest->getTokenScope(),
+          $tokenRequest->getTokenName(), $key);
       } catch (DuplicateTokenKeyException $e) {
         // New key also failed, give up!
         throw new HttpTooManyRequestException("Please try again later.");
+      } catch (DuplicateTokenNameException $e) {
+        throw new HttpConflictException($e->getMessage(), $e);
       }
     } catch (DuplicateTokenNameException $e) {
-      throw new HttpErrorException($e->getMessage(), $e->getCode(), $e);
+      throw new HttpConflictException($e->getMessage(), $e);
     }
     if (! empty($jti['jti'])) {
       $theJwtToken = $this->restHelper->getAuthHelper()->generateJwtToken(
-        $expire, $jti['created_on'], $jti['jti'], $scope, $key);
+        $tokenRequest->getTokenExpire(), $jti['created_on'], $jti['jti'],
+        $tokenRequest->getTokenScope(), $key);
       return $response->withJson([
         "Authorization" => "Bearer " . $theJwtToken
       ], 201);
     }
     throw new HttpInternalServerErrorException("Please try again later.");
   }
-
-  /**
-   * @brief Check if a list of keys exists in associative array.
-   *
-   * This function takes a list of keys which should appear in an associative
-   * array. The function flips the key array to make it as an associative array.
-   * It then uses the array_diff_key() to compare the two arrays.
-   *
-   * @param array $array Associative array to check keys against
-   * @param array $keys  Array of keys to check
-   * @return boolean True if all keys exists, false otherwise.
-   * @uses array_flip()
-   * @uses array_diff_key()
-   */
-  private function arrayKeysExists($array, $keys)
-  {
-    return !array_diff_key(array_flip($keys), $array);
-  }
 }
-

--- a/src/www/ui/api/Helper/AuthHelper.php
+++ b/src/www/ui/api/Helper/AuthHelper.php
@@ -211,12 +211,13 @@ class AuthHelper
    * @param string $expire   When the token will expire ('YYYY-MM-DD')
    * @param string $created  When the token was created ('YYYY-MM-DD')
    * @param string $jti      Token id (`pat_pk.user_pk`)
-   * @param string $scope    User friendly token scope
+   * @param string $scope    Token scope key
    * @param string $key      Token secret key
    * @return string New JWT token
    */
   public function generateJwtToken($expire, $created, $jti, $scope, $key)
   {
+    $scope = array_search($scope, RestHelper::SCOPE_DB_MAP);
     $newJwtToken = [
       "exp" => strtotime($expire . " +1 day -1 second"),  // To allow day level granularity
       "nbf" => strtotime($created),

--- a/src/www/ui/api/Helper/RestHelper.php
+++ b/src/www/ui/api/Helper/RestHelper.php
@@ -272,7 +272,7 @@ class RestHelper
       throw new HttpBadRequestException(
         "The token should have at least 1 day and max $tokenValidity days " .
         "of validity and should follow YYYY-MM-DD format.");
-    } elseif (! in_array($tokenScope, RestHelper::VALID_SCOPES)) {
+    } elseif (! in_array($tokenScope, RestHelper::SCOPE_DB_MAP)) {
       throw new HttpBadRequestException(
         "Invalid token scope, allowed only " .
         join(",", RestHelper::VALID_SCOPES));

--- a/src/www/ui/api/Models/ApiVersion.php
+++ b/src/www/ui/api/Models/ApiVersion.php
@@ -10,6 +10,8 @@
  */
 namespace Fossology\UI\Api\Models;
 
+use Psr\Http\Message\ServerRequestInterface;
+
 /**
  * @class ApiVersion
  * @brief ApiVersion enum
@@ -18,4 +20,14 @@ class ApiVersion
 {
   const V1 = 1;
   const V2 = 2;
+  const ATTRIBUTE_NAME = 'apiVersion';
+
+  /**
+   * @param ServerRequestInterface $request
+   * @return int
+   */
+  public static function getVersion(ServerRequestInterface $request): int
+  {
+    return $request->getAttribute(self::ATTRIBUTE_NAME, self::V1);
+  }
 }

--- a/src/www/ui/api/Models/TokenRequest.php
+++ b/src/www/ui/api/Models/TokenRequest.php
@@ -1,0 +1,216 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Siemens AG
+ SPDX-FileContributor: Gaurav Mishra <mishra.gaurav@siemens.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+ */
+
+namespace Fossology\UI\Api\Models;
+
+use DateTime;
+use Fossology\Lib\Util\ArrayOperation;
+use Fossology\UI\Api\Exceptions\HttpBadRequestException;
+use Fossology\UI\Api\Helper\RestHelper;
+
+class TokenRequest
+{
+  /**
+   * @var array $VERSION_1_KEYS
+   * Keys for version 1 of the API
+   */
+  const VERSION_1_KEYS = ["username", "password", "token_name", "token_scope",
+    "token_expire"];
+  /**
+   * @var array $VERSION_2_KEYS
+   * Keys for version 2 of the API
+   */
+  const VERSION_2_KEYS = ["username", "password", "tokenName", "tokenScope",
+    "tokenExpire"];
+  /**
+   * @var string $tokenName
+   * Token Name
+   */
+  private $tokenName;
+  /**
+   * @var string $tokenScope
+   * Token Scope
+   */
+  private $tokenScope;
+  /**
+   * @var DateTime $tokenExpire
+   * Token Expiry
+   */
+  private $tokenExpire;
+  /**
+   * @var string $username
+   * Username
+   */
+  private $username;
+  /**
+   * @var string $password
+   * Password
+   */
+  private $password;
+
+  /**
+   * @param string $tokenName   Token Name
+   * @param string $tokenScope  Token Scope
+   * @param string $tokenExpire Token Expiry
+   * @param string $username    Username
+   * @param string $password    Password
+   * @throws HttpBadRequestException If request is invalid
+   */
+  public function __construct(string $tokenName, string $tokenScope,
+                              string $tokenExpire, string $username="",
+                              string $password="")
+  {
+    $this->setTokenName($tokenName);
+    $this->setTokenScope($tokenScope);
+    $this->setTokenExpire($tokenExpire);
+    $this->setUsername($username);
+    $this->setPassword($password);
+  }
+
+  /**
+   * @param string $tokenName
+   * @return TokenRequest
+   * @throws HttpBadRequestException
+   */
+  public function setTokenName(string $tokenName): TokenRequest
+  {
+    if (empty($tokenName)) {
+      throw new HttpBadRequestException("Token name cannot be empty");
+    }
+    $this->tokenName = $tokenName;
+    return $this;
+  }
+
+  /**
+   * @param string $tokenScope On of `RestHelper::VALID_SCOPES`
+   * @return TokenRequest
+   * @throws HttpBadRequestException
+   */
+  public function setTokenScope(string $tokenScope): TokenRequest
+  {
+    $tokenScope = strtolower($tokenScope);
+    if (!in_array($tokenScope, RestHelper::VALID_SCOPES)) {
+      throw new HttpBadRequestException("Invalid scope provided");
+    }
+    $this->tokenScope = RestHelper::SCOPE_DB_MAP[$tokenScope];
+    return $this;
+  }
+
+  /**
+   * @param string $tokenExpire
+   * @return TokenRequest
+   * @throws HttpBadRequestException
+   */
+  public function setTokenExpire(string $tokenExpire): TokenRequest
+  {
+    $this->tokenExpire = DateTime::createFromFormat("Y-m-d", $tokenExpire);
+    if ($this->tokenExpire === false) {
+      throw new HttpBadRequestException("Invalid date format provided");
+    }
+    return $this;
+  }
+
+  /**
+   * @param string $username
+   * @return TokenRequest
+   */
+  public function setUsername(string $username): TokenRequest
+  {
+    $this->username = $username;
+    return $this;
+  }
+
+  /**
+   * @param string $password
+   * @return TokenRequest
+   */
+  public function setPassword(string $password): TokenRequest
+  {
+    $this->password = $password;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getTokenName(): string
+  {
+    return $this->tokenName;
+  }
+
+  /**
+   * @return string
+   */
+  public function getTokenScope(): string
+  {
+    return $this->tokenScope;
+  }
+
+  /**
+   * @return string
+   */
+  public function getTokenExpire(): string
+  {
+    return $this->tokenExpire->format('Y-m-d');
+  }
+
+  /**
+   * @return string
+   */
+  public function getUsername(): string
+  {
+    return $this->username;
+  }
+
+  /**
+   * @return string
+   */
+  public function getPassword(): string
+  {
+    return $this->password;
+  }
+
+  /**
+   * @param array $input Request body
+   * @param int $version Version
+   * @return TokenRequest
+   * @throws HttpBadRequestException
+   */
+  public static function fromArray(array $input, int $version): TokenRequest
+  {
+    if (! array_key_exists("username", $input)) {
+      $input["username"] = "";
+    }
+    if (! array_key_exists("password", $input)) {
+      $input["password"] = "";
+    }
+    if ($version == ApiVersion::V1) {
+      if (! ArrayOperation::arrayKeysExists($input, self::VERSION_1_KEYS)) {
+        throw new HttpBadRequestException("Not all required parameters sent.");
+      }
+      return new TokenRequest(
+        $input["token_name"],
+        $input["token_scope"],
+        $input["token_expire"],
+        $input["username"],
+        $input["password"]
+      );
+    } else {
+      if (! ArrayOperation::arrayKeysExists($input, self::VERSION_2_KEYS)) {
+        throw new HttpBadRequestException("Not all required parameters sent.");
+      }
+      return new TokenRequest(
+        $input["tokenName"],
+        $input["tokenScope"],
+        $input["tokenExpire"],
+        $input["username"],
+        $input["password"]
+      );
+    }
+  }
+}

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -7,7 +7,7 @@ openapi: 3.1.0
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.6.0
+  version: 2.0.0
   contact:
     email: fossology@fossology.org
   license:
@@ -15,7 +15,7 @@ info:
     url: https://github.com/fossology/fossology/blob/master/LICENSE
 servers:
   - url: http://localhost/repo/api/v1
-    description: Localhost instance
+    description: Localhost instance (deprecated)
   - url: http://localhost/repo/api/v2
     description: Localhost instance (Version 2)
 security:
@@ -203,7 +203,7 @@ paths:
               example:
                 {"Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJsb2NhbGhvc3QiLCJhdWQiOiJsb2NhbGhvc3QiLCJleHAiOjE1NTEyOTIyMDAsIm5iZiI6MTU1MTIwNTgwMCwianRpIjoiTmk0eiIsInNjb3BlIjoicmVhZCJ9.71D6xTD2QE45t9AVCwbrQwSSae5lC4yzKCMpZWXoC2Q"}
         '404':
-          description: UserName or password incorrect
+          description: Username or password incorrect
           content:
             application/json:
               schema:
@@ -5424,26 +5424,24 @@ components:
     TokenRequest:
       type: object
       properties:
-        token_name:
+        tokenName:
           type: string
           maxLength: 40
           description: Friendly name of the token
-        token_scope:
+        tokenScope:
           type: string
           enum:
             - read
             - write
           description: The scope of the token.
-        token_expire:
+        tokenExpire:
           type: string
           format: date
           description: Date when the token must expire (default max 30 days).
       required:
-        - username
-        - password
-        - token_name
-        - token_scope
-        - token_expire
+        - tokenName
+        - tokenScope
+        - tokenExpire
     VcsUpload:
       description: To create an upload from a version control system
       type: object
@@ -7079,3 +7077,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Info'
+
+  parameters:
+    groupName:
+      description: The group name to chose
+      in: query
+      name: groupName
+      schema:
+        type: string
+      required: false

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -116,7 +116,7 @@ $app->setBasePath($BASE_PATH);
 
 // Custom middleware to set the API version as a request attribute
 $apiVersionMiddleware = function (Request $request, $handler) use ($apiVersion) {
-  $request = $request->withAttribute('apiVersion', $apiVersion);
+  $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, $apiVersion);
   return $handler->handle($request);
 };
 
@@ -342,10 +342,6 @@ $app->group('/customise',
   });
 
 ////////////////////////////INFO/////////////////////
-$app->group('/version',
-  function (\Slim\Routing\RouteCollectorProxy $app) {
-    $app->get('', InfoController::class . ':getInfo');
-  });
 $app->group('/info',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->get('', InfoController::class . ':getInfo');

--- a/src/www/ui/user-edit.php
+++ b/src/www/ui/user-edit.php
@@ -446,9 +446,10 @@ class UserEditPage extends DefaultPlugin
    * Generate new token based on the request sent by user.
    *
    * @param Request $request
-   * @return string The new token if no error occured.
+   * @return string The new token if no error occurred.
    * @throws \UnexpectedValueException Throws an exception if the request is
-   * @throws DuplicateTokenKeyException
+   * @throws DuplicateTokenKeyException Unable to generate new key.
+   * @throws DuplicateTokenNameException Duplicate token name in DB.
    * @uses Fossology::UI::Api::Helper::RestHelper::validateTokenRequest()
    * @uses Fossology::UI::Api::Helper::DbHelper::insertNewTokenKey()
    */
@@ -495,7 +496,8 @@ class UserEditPage extends DefaultPlugin
       throw new \UnexpectedValueException($e->getMessage());
     }
     return $this->authHelper->generateJwtToken($tokenExpiry,
-      $jti['created_on'], $jti['jti'], $tokenScope, $key);
+      $jti['created_on'], $jti['jti'], RestHelper::SCOPE_DB_MAP[$tokenScope],
+      $key);
   }
 
   /**

--- a/src/www/ui_tests/api/Controllers/InfoControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/InfoControllerTest.php
@@ -136,7 +136,9 @@ class InfoControllerTest extends \PHPUnit\Framework\TestCase
       ],
       "fossology" => $fossInfo
     ), 200);
-    $actualResponse = $this->infoController->getInfo(null,
+    $request = new Request("POST", new Uri("HTTP", "localhost"), new Headers(),
+      [], [], (new StreamFactory())->createStream());
+    $actualResponse = $this->infoController->getInfo($request,
       new ResponseHelper());
     $this->assertEquals($expectedResponse->getStatusCode(),
       $actualResponse->getStatusCode());

--- a/src/www/ui_tests/api/Helper/AuthHelperTest.php
+++ b/src/www/ui_tests/api/Helper/AuthHelperTest.php
@@ -109,7 +109,7 @@ class AuthHelperTest extends \PHPUnit\Framework\TestCase
     $createdOn = strftime('%Y-%m-%d');
     $expire = strftime('%Y-%m-%d', strtotime('+3 day'));
     $authToken = $this->authHelper->generateJwtToken($expire, $createdOn, $jti,
-      "write", $key);
+      "w", $key);
     $authHeader = "Bearer " . $authToken;
     $tokenRow = [
       "token_key" => $key,
@@ -152,7 +152,7 @@ class AuthHelperTest extends \PHPUnit\Framework\TestCase
     $createdOn = strftime('%Y-%m-%d');
     $expire = strftime('%Y-%m-%d', strtotime('+3 day'));
     $authToken = $this->authHelper->generateJwtToken($expire, $createdOn, $jti,
-      "write", $key);
+      "w", $key);
     $authHeader = "Bearer " . $authToken;
     $tokenRow = [
       "token_key" => $key,

--- a/src/www/ui_tests/api/Helper/RestHelperTest.php
+++ b/src/www/ui_tests/api/Helper/RestHelperTest.php
@@ -212,7 +212,7 @@ class RestHelperTest extends \PHPUnit\Framework\TestCase
   {
     $tokenExpire = strftime('%Y-%m-%d', strtotime('+3 day'));
     $tokenName = "myTok";
-    $tokenScope = "read";
+    $tokenScope = "r";
     $tokenValidity = 30;
 
     $this->authHelper->shouldReceive('getMaxTokenValidity')
@@ -270,7 +270,7 @@ class RestHelperTest extends \PHPUnit\Framework\TestCase
   {
     $tokenExpire = strftime('%Y-%m-%d', strtotime('+10 day'));
     $tokenName = "myTok";
-    $tokenScope = "r";
+    $tokenScope = "rread";
     $tokenValidity = 30;
 
     $this->authHelper->shouldReceive('getMaxTokenValidity')


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Create a new `openapiv2.yaml` file to store the v2 related changes.
The idea is to keep using this file to store the changes related to only v2 migration like camelCasing changes, moving parameters from header to query, etc. Other changes like adding new endpoint need to be updated in both `openapi.yaml` and `openapiv2.yaml`.
Once every endpoint is migrated, the original file `openapi.yaml` can be replaced with this. This will allow to let everyone know v1 is deprecated from that point of time and v2 can be released with version `2.0.0`.

Update the `TokenRequest` component to use camelCasing and update endpoints accordingly.

## !Breaking
Remove the deprecated `/version` endpoint.

### Changes

1. Update `TokenRequest` component to use camelCasing.
2. Create new file `openapiv2.yaml`.
3. Remove deprecated `/version` endpoint.

## How to test

Test the `GET /api/tokens` and `POST /users/tokens` endpoints with both V1 and V2 to see if they are working as expected.

/cc @dushimsam 