### PR TITLE
feat(os): add support for Debian Bookworm (12)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,7 +23,7 @@ jobs:
       DEBIAN_FRONTEND: "noninteractive"
     services:
       postgres:
-        image: postgres:13
+        image: postgres:15
         env:
           POSTGRES_DB: postgres
           POSTGRES_USER: postgres
@@ -142,7 +142,7 @@ jobs:
           }
     services:
       postgres:
-        image: postgres:14
+        image: postgres:15
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -20,6 +20,7 @@ jobs:
         os:
           - 'debian:buster'
           - 'debian:bullseye'
+          - 'debian:bookworm'
           - 'ubuntu:focal'
           - 'ubuntu:jammy'
 

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -22,7 +22,7 @@ RUN install-packages --option Dpkg::Options::="--force-confold" \
     libssl-dev libtext-template-perl libxml2-dev lsb-release ninja-build p7zip \
     p7zip-full poppler-utils postgresql-14 postgresql-contrib-14 \
     postgresql-server-dev-all rpm sleuthkit s-nail sqlite3 subversion tar \
-    unrar-free unzip upx-ucl wget zip
+    unrar-free unzip wget zip
 
 # Fix PHP for FOSSology
 RUN PHP_PATH=$(php --ini | awk '/\/etc\/php.*\/cli$/{print $5}') \

--- a/cmake/FoPackaging.cmake
+++ b/cmake/FoPackaging.cmake
@@ -207,8 +207,8 @@ resources.")
 
 set(CPACK_DEBIAN_FOSSOLOGY-UNUNPACK_PACKAGE_DEPENDS
     "fossology-common, binutils, bzip2, cabextract, cpio, sleuthkit,
-    genisoimage, poppler-utils, rpm, upx-ucl, unrar-free, unzip, p7zip-full,
-    p7zip, zstd")
+    genisoimage, poppler-utils, rpm, unrar-free, unzip, p7zip-full, p7zip,
+    zstd")
 
 set(CPACK_DEBIAN_FOSSOLOGY-UNUNPACK_PACKAGE_SECTION "utils")
 else()
@@ -224,8 +224,7 @@ This package contains the ununpack agent program and resources.")
 
 set(CPACK_DEBIAN_UNUNPACK_PACKAGE_DEPENDS
     "fossology-common, binutils, bzip2, cabextract, cpio, sleuthkit,
-    genisoimage, poppler-utils, rpm, upx-ucl, unrar-free, unzip, p7zip-full,
-    p7zip")
+    genisoimage, poppler-utils, rpm, unrar-free, unzip, p7zip-full, p7zip")
 
 set(CPACK_DEBIAN_UNUNPACK_PACKAGE_SECTION "utils")
 
@@ -240,8 +239,7 @@ This package contains the adj2nest agent program and resources.")
 
 set(CPACK_DEBIAN_ADJ2NEST_PACKAGE_DEPENDS
     "fossology-common, binutils, bzip2, cabextract, cpio, sleuthkit,
-    genisoimage, poppler-utils, rpm, upx-ucl, unrar-free, unzip, p7zip-full,
-    p7zip")
+    genisoimage, poppler-utils, rpm, unrar-free, unzip, p7zip-full, p7zip")
 
 set(CPACK_DEBIAN_ADJ2NEST_PACKAGE_SECTION "utils")
 endif()

--- a/debian/control
+++ b/debian/control
@@ -113,8 +113,8 @@ Description: architecture for analyzing software, database
 Package: fossology-ununpack
 Architecture: any
 Depends: fossology-common, binutils, bzip2, cabextract, cpio, sleuthkit,
- genisoimage, poppler-utils, rpm, upx-ucl, unrar-free, unzip, p7zip-full,
- p7zip, ${shlibs:Depends}, ${misc:Depends}
+ genisoimage, poppler-utils, rpm, unrar-free, unzip, p7zip-full, p7zip,
+ ${shlibs:Depends}, ${misc:Depends}
 Conflicts: fossology-agents-single
 Description: architecture for analyzing software, ununpack and adj2nest
  The FOSSology project is a web based framework that allows you to

--- a/pbconf/fossology/deb/control
+++ b/pbconf/fossology/deb/control
@@ -96,7 +96,7 @@ Description: architecture for analyzing software, database
 
 Package: fossology-ununpack
 Architecture: any
-Depends: fossology-common, binutils, bzip2, cabextract, cpio, sleuthkit, genisoimage, poppler-utils, rpm, upx-ucl, unrar-free, unzip, p7zip-full, p7zip, ${shlibs:Depends}, ${misc:Depends}
+Depends: fossology-common, binutils, bzip2, cabextract, cpio, sleuthkit, genisoimage, poppler-utils, rpm, unrar-free, unzip, p7zip-full, p7zip, ${shlibs:Depends}, ${misc:Depends}
 Conflicts: fossology-agents-single
 Description: architecture for analyzing software, ununpack and adj2nest
  The FOSSology project is a web based framework that allows you to

--- a/src/copyright/mod_deps
+++ b/src/copyright/mod_deps
@@ -91,8 +91,10 @@ if [[ $RUNTIME ]]; then
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.62.0;;
         buster)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.67.0;;
-        bullseye|sid)
+        bullseye)
           apt-get $YesOpt install libjsoncpp24 libboost-filesystem1.74.0;;
+        bookworm|sid)
+          apt-get $YesOpt install libjsoncpp25 libboost-filesystem1.74.0;;
         focal)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.71.0;;
         jammy)

--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -13,7 +13,6 @@ use Fossology\Lib\Data\Tree\ItemTreeBounds;
 use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Proxy\ScanJobProxy;
 use Fossology\Lib\Util\StringOperation;
-use Fossology\Lib\Data\AgentRef;
 use Monolog\Logger;
 
 class CopyrightDao
@@ -349,7 +348,7 @@ ORDER BY copyright_pk, UT.uploadtree_pk, content DESC";
     $statementName .= ".".$joinType."Join";
 
     if ($extrawhere !== null) {
-      $whereClause .= "AND ". $extrawhere;
+      $whereClause .= " AND ". $extrawhere;
       $statementName .= "._".$extrawhere."_";
     }
     $decisionTableKey = $tableNameDecision . "_pk";

--- a/src/lib/php/Dao/LicenseStdCommentDao.php
+++ b/src/lib/php/Dao/LicenseStdCommentDao.php
@@ -161,7 +161,7 @@ class LicenseStdCommentDao
       }
       $sql = "UPDATE license_std_comment " .
         "SET updated = NOW(), user_fk = $2, " . join(",", $updateStatement) .
-        "WHERE lsc_pk = $1 " .
+        " WHERE lsc_pk = $1 " .
         "RETURNING 1 AS updated;";
       $retVal = $this->dbManager->getSingleRow($sql, $params, $statement);
       $updated += intval($retVal);

--- a/src/nomos/mod_deps
+++ b/src/nomos/mod_deps
@@ -83,7 +83,9 @@ if [[ $RUNTIME ]]; then
       case "$CODENAME" in
         stretch|buster|cosmic)
           apt-get $YesOpt install libjson-c3;;
-        bullseye|sid)
+        bullseye)
+          apt-get $YesOpt install libjson-c5;;
+        bookworm|sid)
           apt-get $YesOpt install libjson-c5;;
         focal)
           apt-get $YesOpt install libjson-c4;;

--- a/src/ojo/mod_deps
+++ b/src/ojo/mod_deps
@@ -93,6 +93,8 @@ if [[ $RUNTIME ]]; then
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.67.0 libboost-program-options1.67.0 libboost-regex1.67.0;;
         bullseye)
           apt-get $YesOpt install libjsoncpp24 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0;;
+        bookworm)
+          apt-get $YesOpt install libjsoncpp25 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0;;
         sid)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0;;
         focal)

--- a/src/scancode/mod_deps
+++ b/src/scancode/mod_deps
@@ -96,6 +96,8 @@ if [[ $RUNTIME ]]; then
           apt-get $YesOpt install libjsoncpp1 libboost-program-options1.67.0;;
         bullseye)
           apt-get $YesOpt install libjsoncpp24 libboost-program-options1.74.0;;
+        bookworm)
+          apt-get $YesOpt install libjsoncpp25 libboost-program-options1.74.0;;
         sid)
           apt-get $YesOpt install libjsoncpp1 libboost-program-options1.74.0;;
         focal)

--- a/src/ununpack/agent/CMakeLists.txt
+++ b/src/ununpack/agent/CMakeLists.txt
@@ -5,6 +5,8 @@ SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 
 set(FO_CWD ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FO_C_FLAGS}")
+# Set to 1 if using upx-ucl package to support .upx files
+set(UPX_INSTALLED 0)
 
 include_directories(
     ${glib_INCLUDE_DIRS}
@@ -24,6 +26,7 @@ foreach(FO_UNP_LIB ununpack ununpack_cov ununpack-sa)
         _FILE_OFFSET_BITS=64
         VERSION_S="${FO_VERSION}"
         COMMIT_HASH_S="${FO_COMMIT_HASH}"
+        UPX_SUPPORT=${UPX_INSTALLED}
     )
     target_sources(${FO_UNP_LIB}
         PRIVATE
@@ -61,6 +64,7 @@ foreach(FO_UNP_EXEC departition departition-coverage ununpack_exec ununpack-cove
         _FILE_OFFSET_BITS=64
         VERSION_S="${FO_VERSION}"
         COMMIT_HASH_S="${FO_COMMIT_HASH}"
+        UPX_SUPPORT=${UPX_INSTALLED}
     )
     if(${FO_UNP_EXEC} MATCHES "^departition")
         set(UNP_XSRC "${FO_CWD}/departition.c")

--- a/src/ununpack/agent/ununpack_globals.h
+++ b/src/ununpack/agent/ununpack_globals.h
@@ -67,7 +67,9 @@ cmdlist CMD[] =
 /* 3 */ { "application/x-compress","zcat","","> '%s' 2>/dev/null","",CMD_PACK,1,0177000,0177000, },
 /* 4 */ { "application/x-bzip","bzcat","","> '%s' 2>/dev/null","",CMD_PACK,1,0177000,0177000, },
 /* 5 */ { "application/x-bzip2","bzcat","","> '%s' 2>/dev/null","",CMD_PACK,1,0177000,0177000, },
+#if UPX_SUPPORT
 /* 6 */ { "application/x-upx","upx","-d -o'%s'",">/dev/null 2>&1","",CMD_PACK,1,0177000,0177000, },
+#endif
 /* 7 */ { "application/pdf","pdftotext","-htmlmeta","'%s' >/dev/null 2>&1","",CMD_PACK,1,0100000,0100000, },
 /* 8 */ { "application/x-pdf","pdftotext","-htmlmeta","'%s' >/dev/null 2>&1","",CMD_PACK,1,0100000,0100000, },
 /* 9 */ { "application/x-zip","unzip","-q -P none -o","-x / >/dev/null 2>&1","unzip -Zhzv '%s' > '%s'",CMD_ARC,1,0177000,0177000, },

--- a/src/ununpack/mod_deps
+++ b/src/ununpack/mod_deps
@@ -80,7 +80,7 @@ if [ $RUNTIME ]; then
   case "$DISTRO" in
     Debian|Ubuntu)
       apt-get $YesOpt install \
-        bzip2 cabextract cpio genisoimage p7zip poppler-utils rpm tar upx-ucl \
+        bzip2 cabextract cpio genisoimage p7zip poppler-utils rpm tar \
         unzip gzip sleuthkit p7zip-full unrar-free libgcrypt20 zstd
       ;;
     RedHatEnterprise*|CentOS)
@@ -91,7 +91,7 @@ if [ $RUNTIME ]; then
     Fedora)
       yum $YesOpt install \
         bzip2 cabextract cpio genisoimage p7zip p7zip-plugins poppler-utils rpm\
-        tar upx unzip gzip sleuthkit unrar libgcrypt zstd
+        tar unzip gzip sleuthkit unrar libgcrypt zstd
       ;;
   esac
 fi

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -98,17 +98,19 @@ if [[ $BUILDTIME ]]; then
             libdistro-info-perl libcppunit-dev libomp-dev cmake ninja-build
          case "$CODENAME" in
            stretch)
-             apt-get $YesOpt install php-mbstring php7.0-cli php7.0-xml php7.0-zip php7.0-gd php7.0-pgsql php7.0-curl php7.0-uuid;;
+             apt-get $YesOpt install php-mbstring php7.0-cli php7.0-xml php7.0-zip php7.0-gd php7.0-pgsql php7.0-curl php7.0-uuid php7.0-sqlite3;;
            buster)
-             apt-get $YesOpt install php-mbstring php7.3-cli php7.3-xml php7.3-zip php7.3-gd php7.3-pgsql php7.3-curl php7.3-uuid;;
+             apt-get $YesOpt install php-mbstring php7.3-cli php7.3-xml php7.3-zip php7.3-gd php7.3-pgsql php7.3-curl php7.3-uuid php7.3-sqlite3;;
            bullseye)
-             apt-get $YesOpt install php7.4-mbstring php7.4-cli php7.4-xml php7.4-zip php7.4-gd php7.4-pgsql php7.4-curl php7.4-uuid;;
+             apt-get $YesOpt install php7.4-mbstring php7.4-cli php7.4-xml php7.4-zip php7.4-gd php7.4-pgsql php7.4-curl php7.4-uuid php7.4-sqlite3;;
+           bookworm)
+             apt-get $YesOpt install php8.2-mbstring php8.2-cli php8.2-xml php8.2-zip php8.2-gd php8.2-pgsql php8.2-curl php8.2-uuid php8.2-sqlite3;;
            sid)
-             apt-get $YesOpt install php-mbstring php-cli php-xml php-zip php-gd php-pgsql php-curl php-uuid;;
+             apt-get $YesOpt install php-mbstring php-cli php-xml php-zip php-gd php-pgsql php-curl php-uuid php-sqlite3;;
            focal)
-             apt-get $YesOpt install php-mbstring php-cli php-xml php-zip php-gd php-pgsql php-curl php-uuid;;
+             apt-get $YesOpt install php-mbstring php-cli php-xml php-zip php-gd php-pgsql php-curl php-uuid php-sqlite3;;
            jammy)
-             apt-get $YesOpt install php-mbstring php-cli php-xml php-zip php-gd php-pgsql php-curl php-uuid;;
+             apt-get $YesOpt install php-mbstring php-cli php-xml php-zip php-gd php-pgsql php-curl php-uuid php-sqlite3;;
          esac
          if ! dpkg --get-selections | grep -q postgresql-server-dev; then  ## if postgresql-server-dev is not installed
            case "$CODENAME" in
@@ -118,8 +120,10 @@ if [[ $BUILDTIME ]]; then
                 apt-get $YesOpt install postgresql-server-dev-11;;
               bullseye)
                 apt-get $YesOpt install postgresql-server-dev-13;;
+              bookworm)
+                apt-get $YesOpt install postgresql-server-dev-15;;
               sid)
-                apt-get $YesOpt install postgresql-server-dev-11;;
+                apt-get $YesOpt install postgresql-server-dev-16;;
               focal)
                 apt-get $YesOpt install postgresql-server-dev-12;;
               jammy)
@@ -182,6 +186,11 @@ if [[ $RUNTIME ]]; then
                libapache2-mod-php7.4 php7.4-pgsql php7.4-cli php7.4-curl \
                php7.4-xml php7.4-zip php7.4-mbstring php7.4-uuid php-php-gettext s-nail \
                libboost-program-options1.74.0 libboost-regex1.74.0 libicu67;;
+            bookworm)
+               apt-get $YesOpt install postgresql-15 php8.2 php8.2-pgsql \
+               libapache2-mod-php8.2 php8.2-pgsql php8.2-cli php8.2-curl \
+               php8.2-xml php8.2-zip php8.2-mbstring php8.2-uuid php-php-gettext s-nail \
+               libboost-program-options1.74.0 libboost-regex1.74.0 libicu72;;
             sid)
                apt-get $YesOpt install postgresql php php-pgsql php-cli php-curl php-xml php-zip php-mbstring php-uuid php-gettext s-nail \
                  libboost-program-options1.74.0 libboost-regex1.74.0 libicu67;;

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -168,7 +168,7 @@ if [[ $RUNTIME ]]; then
             libxml2 libzstd1 \
             binutils \
             cabextract cpio sleuthkit genisoimage \
-            poppler-utils upx-ucl \
+            poppler-utils \
             unrar-free unzip p7zip-full p7zip wget \
             subversion git \
             dpkg-dev php-uuid


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add support for Debian Bookworm which was released on 2023-06-10.

Note: The package `upx-ucl` used by `ununpack` to extract `upx` files is no longer available on Debian package repositories. It appears to have failing a CI test https://ci.debian.net/packages/u/upx-ucl/
Keeping this PR as a WIP until the package is available. If it takes long, we would have to disable extraction of `upx` files from ununpack agent and go ahead with merge of this PR.

### Changes

Add packages for `bookworm` in dependency installer scripts.

## How to test

Build and install FOSSology on Debian Bookworm (12).

Closes #2596