### PR TITLE
feat(upload): track assignee and closing events

### DIFF
--- a/src/lib/php/Data/Upload/UploadEvents.php
+++ b/src/lib/php/Data/Upload/UploadEvents.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Siemens AG
+ SPDX-FileContributor: Gaurav Mishra <mishra.gaurav@siemens.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+ */
+
+namespace Fossology\Lib\Data\Upload;
+
+/**
+ * @class UploadEvents
+ * @brief This class contains the events for the upload_events table
+ */
+class UploadEvents
+{
+  /**
+   * @var int ASSIGNEE_EVENT
+   * Event when upload assignee is changed
+   */
+  const ASSIGNEE_EVENT = 1;
+  /**
+   * @var int UPLOAD_CLOSED_EVENT
+   * Event when upload is closed
+   */
+  const UPLOAD_CLOSED_EVENT = 2;
+}

--- a/src/lib/php/Proxy/test/UploadBrowseProxyTest.php
+++ b/src/lib/php/Proxy/test/UploadBrowseProxyTest.php
@@ -21,7 +21,7 @@ class UploadBrowseProxyTest extends \PHPUnit\Framework\TestCase
   protected function setUp() : void
   {
     $this->testDb = new TestPgDb();
-    $this->testDb->createPlainTables( array('upload','upload_clearing','perm_upload') );
+    $this->testDb->createPlainTables( array('upload','upload_clearing','perm_upload','upload_events') );
     $this->testDb->getDbManager()->insertTableRow('upload', array('upload_pk'=>1,'upload_filename'=>'for.all','user_fk'=>1,'upload_mode'=>1,'public_perm'=>Auth::PERM_READ,'pfile_fk'=>31415));
     $this->testDb->getDbManager()->insertTableRow('upload', array('upload_pk'=>2,'upload_filename'=>'for.this','user_fk'=>1,'upload_mode'=>1,'public_perm'=>Auth::PERM_NONE));
     $this->testDb->getDbManager()->insertTableRow('perm_upload', array('perm_upload_pk'=>1, 'upload_fk'=>2,'group_fk'=>$this->groupId,'perm'=>Auth::PERM_READ));

--- a/src/lib/php/common-ui.php
+++ b/src/lib/php/common-ui.php
@@ -7,6 +7,7 @@
 
  SPDX-License-Identifier: LGPL-2.1-only
 */
+
 use Symfony\Component\HttpFoundation\Session\Session;
 
 /**
@@ -105,6 +106,30 @@ function HumanSize( $bytes )
     $bytes /= 1024;
   }
   return(round($bytes, 2) . ' PB');
+}
+
+/**
+ * @brief Convert DateInterval to Human readable format
+ *
+ * If DateInterval is more than 1 year, then return years, else return months,
+ * else return days. If duration is less than 1 day, then return hours and
+ * minutes.
+ * @param DateInterval $duration Duration to convert
+ * @return string Formatted duration
+ */
+function HumanDuration(DateInterval $duration): string
+{
+  $humanDuration = "";
+  if ($duration->y > 0) {
+    $humanDuration .= $duration->y . " y";
+  } elseif ($duration->m > 0) {
+    $humanDuration .= $duration->m . " m";
+  } elseif ($duration->days > 0) {
+    $humanDuration .= $duration->days . " d";
+  } else {
+    $humanDuration .= $duration->h . "h " . $duration->i . "m";
+  }
+  return $humanDuration;
 }
 
 /**

--- a/src/lib/php/services.xml.in
+++ b/src/lib/php/services.xml.in
@@ -211,6 +211,7 @@ SPDX-License-Identifier: FSFAP
         <service id="helper.dbHelper" class="Fossology\UI\Api\Helper\DbHelper" public="true">
             <argument type="service" id="db.manager"/>
             <argument type="service" id="dao.folder"/>
+            <argument type="service" id="dao.upload"/>
         </service>
         <service id="helper.fileHelper" class="Fossology\UI\Api\Helper\FileHelper" public="true">
             <argument type="service" id="dao.pfile"/>

--- a/src/www/ui/api/Models/Upload.php
+++ b/src/www/ui/api/Models/Upload.php
@@ -52,6 +52,16 @@ class Upload
    */
   private $assignee;
   /**
+   * @var string $assigneeDate
+   * Date when a user was assigned to the upload.
+   */
+  private $assigneeDate;
+  /**
+   * @var string $closingDate
+   * Date when the upload was closed or rejected.
+   */
+  private $closingDate;
+  /**
    * @var Hash $hash
    * Hash information of the upload
    */
@@ -77,6 +87,8 @@ class Upload
     $this->uploadName = $uploadName;
     $this->uploadDate = $uploadDate;
     $this->assignee = $assignee == 1 ? null : intval($assignee);
+    $this->assigneeDate = null;
+    $this->closingDate = null;
     $this->hash = $hash;
   }
 
@@ -103,7 +115,29 @@ class Upload
       "uploadname"  => $this->uploadName,
       "uploaddate"  => $this->uploadDate,
       "assignee"    => $this->assignee,
+      "assigneeDate" => $this->assigneeDate,
+      "closingDate" => $this->closingDate,
       "hash"        => $this->hash->getArray()
     ];
+  }
+
+  /**
+   * @param string|null $assigneeDate
+   * @return Upload
+   */
+  public function setAssigneeDate(?string $assigneeDate): Upload
+  {
+    $this->assigneeDate = $assigneeDate;
+    return $this;
+  }
+
+  /**
+   * @param string|null $closingDate
+   * @return Upload
+   */
+  public function setClosingDate(?string $closingDate): Upload
+  {
+    $this->closingDate = $closingDate;
+    return $this;
   }
 }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -7,7 +7,7 @@ openapi: 3.1.0
 info:
   title: FOSSology API
   description: Automate your fossology instance using REST API
-  version: 1.6.0
+  version: 1.6.1
   contact:
     email: fossology@fossology.org
   license:
@@ -5085,6 +5085,16 @@ components:
         assignee:
           type: integer
           description: assignee id of the upload.
+          nullable: true
+        assigneeDate:
+          type: string
+          format: date-time
+          description: Date, when a user was assigned to the upload.
+          nullable: true
+        closingDate:
+          type: string
+          format: date-time
+          description: Date, when the upload was closed or rejected.
           nullable: true
         hash:
           $ref: '#/components/schemas/Hash'

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -5086,6 +5086,16 @@ components:
           type: integer
           description: assignee id of the upload.
           nullable: true
+        assigneeDate:
+          type: string
+          format: date-time
+          description: Date, when a user was assigned to the upload.
+          nullable: true
+        closingDate:
+          type: string
+          format: date-time
+          description: Date, when the upload was closed or rejected.
+          nullable: true
         hash:
           $ref: '#/components/schemas/Hash'
     GetFolderContent:

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -2099,6 +2099,19 @@
   $Schema["TABLE"]["uploadtree"]["ufile_name"]["ALTER"] = "ALTER TABLE \"uploadtree\" ALTER COLUMN \"ufile_name\" DROP NOT NULL";
 
 
+  $Schema["TABLE"]["upload_events"]["upload_fk"]["DESC"] = "COMMENT ON COLUMN \"upload_events\".\"upload_fk\" IS 'upload that generated this event'";
+  $Schema["TABLE"]["upload_events"]["upload_fk"]["ADD"] = "ALTER TABLE \"upload_events\" ADD COLUMN \"upload_fk\" int4";
+  $Schema["TABLE"]["upload_events"]["upload_fk"]["ALTER"] = "ALTER TABLE \"upload_events\" ALTER COLUMN \"upload_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["upload_events"]["event_ts"]["DESC"] = "COMMENT ON COLUMN \"upload_events\".\"event_ts\" IS 'timestamp when event happened'";
+  $Schema["TABLE"]["upload_events"]["event_ts"]["ADD"] = "ALTER TABLE \"upload_events\" ADD COLUMN \"event_ts\" timestamptz DEFAULT now()";
+  $Schema["TABLE"]["upload_events"]["event_ts"]["ALTER"] = "ALTER TABLE \"upload_events\" ALTER COLUMN \"event_ts\" SET NOT NULL, ALTER COLUMN \"event_ts\" SET DEFAULT now()";
+
+  $Schema["TABLE"]["upload_events"]["event_type"]["DESC"] = "COMMENT ON COLUMN \"upload_events\".\"event_type\" IS 'type of event, see Fossology::Lib::Data::Upload::UploadEvents'";
+  $Schema["TABLE"]["upload_events"]["event_type"]["ADD"] = "ALTER TABLE \"upload_events\" ADD COLUMN \"event_type\" int4";
+  $Schema["TABLE"]["upload_events"]["event_type"]["ALTER"] = "ALTER TABLE \"upload_events\" ALTER COLUMN \"event_type\" SET NOT NULL";
+
+
   $Schema["TABLE"]["users"]["user_pk"]["DESC"] = "";
   $Schema["TABLE"]["users"]["user_pk"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"user_pk\" int4 DEFAULT nextval('users_user_pk_seq'::regclass)";
   $Schema["TABLE"]["users"]["user_pk"]["ALTER"] = "ALTER TABLE \"users\" ALTER COLUMN \"user_pk\" SET NOT NULL, ALTER COLUMN \"user_pk\" SET DEFAULT nextval('users_user_pk_seq'::regclass)";
@@ -2276,6 +2289,7 @@
   $Schema["TABLE"]["report_info"]["ri_globaldecision"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_globaldecision\" int2 DEFAULT 1";
   $Schema["TABLE"]["report_info"]["ri_globaldecision"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_globaldecision\" SET NOT NULL, ALTER COLUMN \"ri_globaldecision\" SET DEFAULT 1";
 
+
   $Schema["VIEW"]["license_file_ref"] = "CREATE VIEW \"license_file_ref\" AS SELECT license_ref.rf_fullname, license_ref.rf_shortname, license_ref.rf_pk, license_file.fl_end_byte, license_file.rf_match_pct, license_file.rf_timestamp, license_file.fl_start_byte, license_file.fl_ref_end_byte, license_file.fl_ref_start_byte, license_file.fl_pk, license_file.agent_fk, license_file.pfile_fk FROM (license_file JOIN license_ref ON ((license_file.rf_fk = license_ref.rf_pk)));";
 
   $Schema["VIEW"]["uploadtree_tag_file_inner"] = "CREATE VIEW \"uploadtree_tag_file_inner\" AS SELECT uploadtree.pfile_fk, uploadtree.uploadtree_pk, uploadtree.parent, uploadtree.upload_fk, uploadtree.ufile_mode, uploadtree.lft, uploadtree.rgt, uploadtree.ufile_name, tag_file.tag_file_pk, tag_file.tag_fk, tag_file.tag_file_date, tag_file.tag_file_text FROM (uploadtree JOIN tag_file USING (pfile_fk));";
@@ -2375,7 +2389,7 @@
 
   $Schema["SEQUENCE"]["license_std_acknowledgement_la_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"license_std_acknowledgement_la_pk_seq\"";
   $Schema["SEQUENCE"]["license_std_acknowledgement_la_pk_seq"]["UPDATE"] = "SELECT setval('license_std_acknowledgement_la_pk_seq',(SELECT greatest(1,max(la_pk)) val FROM license_std_acknowledgement))";
-  
+
   $Schema["SEQUENCE"]["mimetype_mimetype_pk_seq"]["CREATE"] = "CREATE SEQUENCE \"mimetype_mimetype_pk_seq\"";
   $Schema["SEQUENCE"]["mimetype_mimetype_pk_seq"]["UPDATE"] = "SELECT setval('mimetype_mimetype_pk_seq',(SELECT greatest(1,max(mimetype_pk)) val FROM mimetype))";
 
@@ -2614,6 +2628,7 @@
   $Schema["CONSTRAINT"]["users_default_bucketpool_pk_fkey"] = "ALTER TABLE \"users\" ADD CONSTRAINT \"users_default_bucketpool_pk_fkey\" FOREIGN KEY (\"default_bucketpool_fk\") REFERENCES \"bucketpool\" (\"bucketpool_pk\") ON UPDATE NO ACTION ON DELETE NO ACTION;";
   $Schema["CONSTRAINT"]["users_group_id_fkey"] = "ALTER TABLE \"users\" ADD CONSTRAINT \"users_group_id_fkey\" FOREIGN KEY (\"group_fk\") REFERENCES \"groups\" (\"group_pk\") ON UPDATE NO ACTION ON DELETE NO ACTION;";
   $Schema["CONSTRAINT"]["users_new_upload_group_fk_fkey"] = "ALTER TABLE \"users\" ADD CONSTRAINT \"users_new_upload_group_fk_fkey\" FOREIGN KEY (\"new_upload_group_fk\") REFERENCES \"groups\" (\"group_pk\") ON UPDATE CASCADE ON DELETE RESTRICT;";
+  $Schema["CONSTRAINT"]["upload_events_upload_fk_fkey"] = "ALTER TABLE \"upload_events\" ADD CONSTRAINT \"upload_events_upload_fk_fkey\" FOREIGN KEY (\"upload_fk\") REFERENCES \"upload\" (\"upload_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["copyright_event_pkey"] = "ALTER TABLE \"copyright_event\" ADD CONSTRAINT \"copyright_event_pkey\" PRIMARY KEY (\"copyright_event_pk\");";
   $Schema["CONSTRAINT"]["copyright_event_upload_fk_fkey"] = "ALTER TABLE \"copyright_event\" ADD CONSTRAINT \"copyright_event_upload_fk_fkey\" FOREIGN KEY (\"upload_fk\") REFERENCES \"upload\" (\"upload_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["copyright_event_copyright_fk_fkey"] = "ALTER TABLE \"copyright_event\" ADD CONSTRAINT \"copyright_event_copyright_fk_fkey\" FOREIGN KEY (\"copyright_fk\") REFERENCES \"copyright\" (\"copyright_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
@@ -2746,6 +2761,8 @@
   $Schema["INDEX"]["uploadtree_a"]["uploadtree_a_upload_fk_lft_idx"] = "CREATE INDEX uploadtree_a_upload_fk_lft_idx ON uploadtree_a USING btree (upload_fk, lft);";
   $Schema["INDEX"]["uploadtree_a"]["uploadtree_a_upload_lft_ufilemode_pfile_idx"] = "CREATE INDEX uploadtree_a_upload_lft_ufilemode_pfile_idx ON uploadtree_a USING btree (upload_fk, lft, ufile_mode, pfile_fk);";
   $Schema["INDEX"]["upload_clearing_license"]["upload_clearing_license_upload_group_idx"] = "CREATE INDEX upload_clearing_license_upload_group_idx ON upload_clearing_license USING btree (upload_fk, group_fk);";
+
+  $Schema["INDEX"]["upload_events"]["upload_events_upload_fk_event_ts_event_type_idx"] = "CREATE INDEX upload_events_upload_fk_event_ts_event_type_idx ON upload_events USING btree (upload_fk, event_ts DESC, event_type);";
 
   $Schema["INDEX"]["copyright_event"]["copyright_event_upload_fk_index"] = "CREATE INDEX copyright_event_upload_fk_index ON copyright_event USING btree (upload_fk);";
   $Schema["INDEX"]["copyright_event"]["copyright_event_uploadtree_fk_index"] = "CREATE INDEX copyright_event_uploadtree_fk_index ON copyright_event USING btree (uploadtree_fk);";

--- a/src/www/ui/template/admin-folder-size-form.html.twig
+++ b/src/www/ui/template/admin-folder-size-form.html.twig
@@ -1,4 +1,4 @@
-{# SPDX-FileCopyrightText: © Fossology contributors
+{# SPDX-FileCopyrightText: © 2023 Siemens AG
 
    SPDX-License-Identifier: FSFAP
 #}
@@ -11,13 +11,15 @@
   <table border="0" align="center" cellpadding="5">
     <tr>
       <td>
+        <label for="selectfolderid">
         {{ "Size of folder "|trans }}
-        <select name="selectfolderid" onChange="window.location.href='{{ onchangeURI }}' + this.value" class="ui-render-select2">
+        </label>
+        <select name="selectfolderid" id="selectfolderid" onChange="window.location.href='{{ onchangeURI }}' + this.value" class="ui-render-select2">
         {{ folderListOption }} FolderListOption(-1, 0, 1, $folderId);
         </select>
       </td>
       <td align='center'>
-        is {{ wholeFolderSize }}
+        {{ "is"|trans }} {{ wholeFolderSize }}
       </td>
     </tr>
   </table>
@@ -31,13 +33,16 @@
       <th>
         {{ "Upload Size"|trans }}
       </th>
+      <th>
+        {{ "Clearing Duration"|trans }}
+      </th>
     </tr>
-        </thead>
-        <tbody>
+  </thead>
+  <tbody>
     {{ tableVars }}
   </tbody>
   </table>
 </form>
 <script type="text/javascript">
-$('#folderWiseuploadTable').DataTable();
+  $('#folderWiseuploadTable').DataTable();
 </script>

--- a/src/www/ui_tests/api/Controllers/UploadControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadControllerTest.php
@@ -855,6 +855,9 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     $this->dbManager->shouldReceive('getSingleRow')
       ->withArgs([M::any(), [$status, $comment, $this->groupId, $upload],
         M::any()]);
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs([M::any(), [$upload], M::any()])
+      ->andReturn(["exists" => ""]);
 
     $info = new Info(202, "Upload updated successfully.", InfoType::INFO);
     $expectedResponse = (new ResponseHelper())->withJson($info->getArray(),

--- a/src/www/ui_tests/api/Helper/DbHelperTest.php
+++ b/src/www/ui_tests/api/Helper/DbHelperTest.php
@@ -19,6 +19,7 @@ if (session_status() == PHP_SESSION_NONE) {
 require_once dirname(dirname(dirname(dirname(__DIR__)))) .
   '/lib/php/Plugin/FO_Plugin.php';
 
+use Fossology\Lib\Dao\UploadDao;
 use Mockery as M;
 use Fossology\Lib\Db\ModernDbManager;
 use Fossology\UI\Api\Helper\DbHelper;
@@ -57,6 +58,12 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
   private $folderDao;
 
   /**
+   * @var UploadDao $uploadDao
+   * UploadDao object to test
+   */
+  private $uploadDao;
+
+  /**
    * @brief Setup test objects
    * @see PHPUnit_Framework_TestCase::setUp()
    */
@@ -64,8 +71,10 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
   {
     $this->dbManager = M::mock(ModernDbManager::class);
     $this->folderDao = M::mock(FolderDao::class);
+    $this->uploadDao = M::mock(UploadDao::class);
 
-    $this->dbHelper = new DbHelper($this->dbManager, $this->folderDao);
+    $this->dbHelper = new DbHelper($this->dbManager, $this->folderDao,
+      $this->uploadDao);
     $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
   }
 

--- a/src/www/ui_tests/api/Models/UploadTest.php
+++ b/src/www/ui_tests/api/Models/UploadTest.php
@@ -12,8 +12,8 @@
 
 namespace Fossology\UI\Api\Test\Models;
 
-use Fossology\UI\Api\Models\Upload;
 use Fossology\UI\Api\Models\Hash;
+use Fossology\UI\Api\Models\Upload;
 
 /**
  * @class UploadTest
@@ -28,7 +28,6 @@ class UploadTest extends \PHPUnit\Framework\TestCase
   public function testDataFormat()
   {
     $hash = new Hash('sha1checksum', 'md5checksum', 'sha256checksum', 123123);
-    $upload = new Upload(2, 'root', 3, '', 'my.tar.gz', '01-01-2020', 3, $hash);
     $expectedUpload = [
       "folderid"    => 2,
       "foldername"  => 'root',
@@ -37,11 +36,15 @@ class UploadTest extends \PHPUnit\Framework\TestCase
       "uploadname"  => 'my.tar.gz',
       "uploaddate"  => '01-01-2020',
       "assignee"    => 3,
+      "assigneeDate" => '01-01-2020',
+      "closingDate" => '01-01-2020',
       "hash"        => $hash->getArray()
     ];
 
     $actualUpload = new Upload(2, 'root', 3, '', 'my.tar.gz', '01-01-2020', 3,
       $hash);
+    $actualUpload->setAssigneeDate("01-01-2020");
+    $actualUpload->setClosingDate("01-01-2020");
 
     $this->assertEquals($expectedUpload, $actualUpload->getArray());
   }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Implemented tracking of date-time on which a user was assigned to an upload. Additionally, tracking has been extended to capture the date-time when an upload was closed or rejected. This new feature will enhance monitoring and auditing capabilities.

The values are currently available only on REST endpoints `GET /uploads` and `GET /uploads/{id}`. The duration is displayed in Folder and upload dashboard.

### Changes

1. Add new table `upload_events` to hold events per upload, timestamp and event type.
2. New class `UploadEvents` to hold different event types.

## How to test

1. Assign an upload to a user, check if `upload_events` table is updated.
2. Assigning different user should not create new entry in `upload_events`.
3. Close or reject an upload, check if `upload_evens` table is updated.
4. Check if `GET /uploads` endpoint returns the `assigneeDate` and `closingDate`.
5. Check if "Folder and upload dashboard" shows clearing duration.