### PR TITLE
feat(menu): add new button to indicate system load in banner

### DIFF
--- a/src/lib/php/UI/Component/Menu.php
+++ b/src/lib/php/UI/Component/Menu.php
@@ -232,8 +232,10 @@ class Menu
     $vars['title'] = empty($title) ? _("Welcome to FOSSology") : $title;
     if ($hide_banner) {
       $vars['bannerMsg'] = "";
+      $vars['systemLoad'] = "";
     } else {
       $vars['bannerMsg'] = @$sysConfig['BannerMsg'];
+      $vars['systemLoad'] = get_system_load_average().'<br/>';
     }
     $vars['logoLink'] =  $sysConfig['LogoLink']?: 'http://fossology.org';
     $vars['logoImg'] =  $sysConfig['LogoImage']?: 'images/fossology-logo.gif';

--- a/src/lib/php/UI/template/components/menu.html.twig
+++ b/src/lib/php/UI/template/components/menu.html.twig
@@ -5,6 +5,7 @@
 {% if bannerMsg %}
   <div class="alert alert-danger" id="topBanner">
     <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+  {{ systemLoad }}
   {{ bannerMsg }}
   </div>
 {% endif %}

--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -795,3 +795,31 @@ function set_python_path()
   putenv("PYTHONPATH=/home/" . $SysConf['DIRECTORIES']['PROJECTUSER'] .
       "/pythondeps");
 }
+/**
+ * \brief Get system load average.
+ *
+ * Get no of cores using nproc command.
+ * Get load using sys_getloadavg
+ *
+ * \return button with different colors
+ */
+function get_system_load_average()
+{
+  // Get No.of cores
+  $cores = trim(shell_exec("nproc"));
+
+  // Get CPU load
+  $load = sys_getloadavg()[1];
+
+  $percentageOfLoad = ($load / $cores);
+
+  if ($percentageOfLoad < 0.30) {
+    $class = 'btn-success';
+  } else if ($percentageOfLoad < 0.60) {
+    $class = 'btn-warning';
+  } else {
+    $class = 'btn-danger';
+  }
+
+  return '<button type="button" aria-disabled="true" disabled class="btn '.$class.'">System Load</button>';
+}

--- a/src/www/ui/async/AjaxAllJobStatus.php
+++ b/src/www/ui/async/AjaxAllJobStatus.php
@@ -92,11 +92,12 @@ class AjaxAllJobStatus extends DefaultPlugin
     $output = "";
     $error_msg = "";
     $schedStatus = "Running";
+    $systemLoad = get_system_load_average();
     if (! fo_communicate_with_scheduler("status", $output, $error_msg)
       && strstr($error_msg, "Connection refused") !== false) {
       $schedStatus = "Stopped";
     }
-    return new JsonResponse(["data" => $returnData, "scheduler" => $schedStatus]);
+    return new JsonResponse(["data" => $returnData, "scheduler" => $schedStatus, "systemLoad" => $systemLoad]);
   }
 }
 

--- a/src/www/ui/template/all_job_status.html.twig
+++ b/src/www/ui/template/all_job_status.html.twig
@@ -7,6 +7,7 @@
 {% block content %}
   <table border="0">
     <tr>
+      <td style="padding:3px 10px" id="system_status"></td>
       <th style="padding:3px 10px">{{ 'Scheduler'|trans }}</th>
       <td style="padding:3px 10px" id="scheduler_status"></td>
     </tr>
@@ -57,6 +58,7 @@
               returnval.push(newrow);
             }
             $("#scheduler_status").html(json.scheduler);
+            $("#system_status").html(json.systemLoad);
             return returnval;
           }
         },


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add a button to indicate system load in banner.
also add same in all jobs page.

## How to test

* Install FOSSology.
* add a banner message.
* You should also be able to see 'CPU/System Load'
