### PR TITLE
fix(api): default values of page and limit

### DIFF
--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -215,8 +215,9 @@ class UploadController extends RestController
         throw new HttpBadRequestException(
           "page should be positive integer > 0");
       }
+    } else {
+      $page = 1;
     }
-    $page = 1;
 
     $limit = $request->getHeaderLine(self::LIMIT_PARAM);
     if (! empty($limit)) {
@@ -225,8 +226,9 @@ class UploadController extends RestController
         throw new HttpBadRequestException(
           "limit should be positive integer > 1");
       }
+    } else {
+      $limit = self::UPLOAD_FETCH_LIMIT;
     }
-    $limit = self::UPLOAD_FETCH_LIMIT;
 
     if (isset($args['id'])) {
       $id = intval($args['id']);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Default values for 'page' and 'limit' are now correctly assigned within else blocks.

### Changes

Fix `UploadController`.

## How to test

Check #2625

Closes #2625

Thanks to @deveaud-m for pointing to the error.