### PR TITLE
feat(api): (1) Upgrade Upload APIs to Version 2 

### DIFF
--- a/src/www/ui/api/Controllers/FileInfoController.php
+++ b/src/www/ui/api/Controllers/FileInfoController.php
@@ -16,6 +16,7 @@ namespace Fossology\UI\Api\Controllers;
 use Fossology\UI\Api\Exceptions\HttpErrorException;
 use Fossology\UI\Api\Helper\ResponseHelper;
 use Fossology\UI\Api\Models\FileInfo;
+use Fossology\UI\Api\Models\ApiVersion;
 use Psr\Http\Message\ServerRequestInterface;
 
 
@@ -46,16 +47,15 @@ class FileInfoController extends RestController
   {
     $uploadPk = $args["id"];
     $uploadTreeId = $args["itemId"];
-
+    $apiVersion = ApiVersion::getVersion($request);
     $this->uploadAccessible($uploadPk);
     $this->isItemExists($uploadPk, $uploadTreeId);
-
     $response_view = $this->viewInfo->ShowView($uploadPk, $uploadTreeId);
     $response_meta = $this->viewInfo->ShowMetaView($uploadPk, $uploadTreeId);
     $response_package_info = $this->viewInfo->ShowPackageInfo($uploadPk, $uploadTreeId);
     $response_tag_info = $this->viewInfo->ShowTagInfo($uploadPk, $uploadTreeId);
     $response_reuse_info = $this->viewInfo->showReuseInfo($uploadPk);
     $finalValue = new FileInfo($response_view, $response_meta, $response_package_info, $response_tag_info, $response_reuse_info);
-    return $response->withJson($finalValue->getarray(), 200);
+    return $response->withJson($finalValue->getarray($apiVersion), 200);
   }
 }

--- a/src/www/ui/api/Helper/DbHelper.php
+++ b/src/www/ui/api/Helper/DbHelper.php
@@ -24,6 +24,7 @@ use Fossology\Lib\Exceptions\DuplicateTokenKeyException;
 use Fossology\Lib\Exceptions\DuplicateTokenNameException;
 use Fossology\Lib\Proxy\LicenseViewProxy;
 use Fossology\Lib\Proxy\UploadBrowseProxy;
+use Fossology\UI\Api\Models\ApiVersion;
 use Fossology\UI\Api\Models\Hash;
 use Fossology\UI\Api\Models\Job;
 use Fossology\UI\Api\Models\Upload;
@@ -94,7 +95,7 @@ class DbHelper
    *         value
    */
   public function getUploads($userId, $groupId, $limit, $page = 1,
-    $uploadId = null, $options = null, $recursive = true)
+    $uploadId = null, $options = null, $recursive = true, $apiVersion=ApiVersion::V1)
   {
     $uploadProxy = new UploadBrowseProxy($groupId, 0, $this->dbManager);
     $folderId = $options["folderId"];
@@ -197,7 +198,7 @@ FROM $partialQuery $where ORDER BY upload_pk ASC LIMIT $limit OFFSET $" .
         $upload->setAssigneeDate($this->uploadDao->getAssigneeDate($uploadId));
       }
       $upload->setClosingDate($this->uploadDao->getClosedDate($uploadId));
-      $uploads[] = $upload->getArray();
+      $uploads[] = $upload->getArray($apiVersion);
     }
     return [$totalResult, $uploads];
   }

--- a/src/www/ui/api/Helper/UploadHelper.php
+++ b/src/www/ui/api/Helper/UploadHelper.php
@@ -35,6 +35,7 @@ use Fossology\UI\Api\Models\Reuser;
 use Fossology\UI\Api\Models\Scancode;
 use Fossology\UI\Api\Models\ScanOptions;
 use Fossology\UI\Api\Models\UploadSummary;
+use Fossology\UI\Api\Models\ApiVersion;
 use Fossology\UI\Page\BrowseLicense;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use UIExportList;
@@ -739,7 +740,7 @@ class UploadHelper
    * @return array Array containing `filePath`, `agentFindings` and
    * `conclusions` for each upload tree item
    */
-  public function getUploadLicenseList($uploadId, $agents, $printContainers, $boolLicense, $boolCopyright, $page = 0, $limit = 50)
+  public function getUploadLicenseList($uploadId, $agents, $printContainers, $boolLicense, $boolCopyright, $page = 0, $limit = 50, $apiVersion=ApiVersion::V1)
   {
     global $container;
     $restHelper = $container->get('helper.restHelper');
@@ -807,7 +808,7 @@ class UploadHelper
           $clearingDao, $groupId);
         $responseRow = new FileLicenses($license['filePath'], $findings,
           $clearingDecision);
-        $responseList[] = $responseRow->getArray();
+        $responseList[] = $responseRow->getArray($apiVersion);
       }
     } elseif (!$boolLicense && $boolCopyright) {
       foreach ($copyrightList as $copyFilepath) {
@@ -820,7 +821,7 @@ class UploadHelper
         $findings = new Findings();
         $findings->setCopyright($copyrightContent);
         $responseRow = new FileLicenses($copyFilepath['filePath'], $findings);
-        $responseList[] = $responseRow->getArray();
+        $responseList[] = $responseRow->getArray($apiVersion);
       }
     }
     $offset = $page * $limit;

--- a/src/www/ui/api/Middlewares/RestAuthMiddleware.php
+++ b/src/www/ui/api/Middlewares/RestAuthMiddleware.php
@@ -18,6 +18,7 @@ use Fossology\UI\Api\Exceptions\HttpBadRequestException;
 use Fossology\UI\Api\Exceptions\HttpForbiddenException;
 use Fossology\UI\Api\Helper\AuthHelper;
 use Fossology\UI\Api\Helper\CorsHelper;
+use Fossology\UI\Api\Models\ApiVersion;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
@@ -80,7 +81,12 @@ class RestAuthMiddleware
          */
         throw new HttpForbiddenException("Do not have required scope.");
       }
-      $groupName = $request->getHeaderLine('groupName');
+      if (ApiVersion::getVersion($request) == ApiVersion::V2) {
+        $queryParameters = $request->getQueryParams();
+        $groupName = $queryParameters['groupName'] ?? "";
+      } else {
+        $groupName = $request->getHeaderLine('groupName');
+      }
       if (!empty($groupName)) { // if request contains groupName
         $authHelper->userHasGroupAccess($userId, $groupName);
         $authHelper->updateUserSession($userId, $tokenScope, $groupName);

--- a/src/www/ui/api/Models/FileInfo.php
+++ b/src/www/ui/api/Models/FileInfo.php
@@ -73,23 +73,33 @@ class FileInfo
    * Get the info as JSON representation
    * @return string
    */
-  public function getJSON()
+  public function getJSON($version=ApiVersion::V1)
   {
-    return json_encode($this->getArray());
+    return json_encode($this->getArray($version));
   }
 
   /**
    * Get info as associative array
    * @return array
    */
-  public function getArray()
+  public function getArray($version=ApiVersion::V1)
   {
-    return array(
+    if ($version==ApiVersion::V2) {
+      return array(
+        'viewInfo' => $this->view_info,
+        'metaInfo' => $this->meta_info,
+        'packageInfo' => $this->package_info,
+        'tagInfo' => $this->tag_info,
+        'reuseInfo' => $this->reuse_info
+      );
+    } else {
+      return array(
       'view_info' => $this->view_info,
       'meta_info' => $this->meta_info,
       'package_info' => $this->package_info,
       'tag_info' => $this->tag_info,
       'reuse_info' => $this->reuse_info
-    );
+      );
+    }
   }
 }

--- a/src/www/ui/api/Models/FileLicenses.php
+++ b/src/www/ui/api/Models/FileLicenses.php
@@ -107,12 +107,20 @@ class FileLicenses
    *
    * @return array
    */
-  public function getArray()
+  public function getArray($apiVersion = ApiVersion::V1)
   {
-    return [
+    if ($apiVersion == ApiVersion::V2) {
+      return [
+      'filePath'         => $this->getFilePath(),
+      'findings'         => $this->getFindings()->getArray(),
+      'clearingStatus'   => $this->getClearingStatus()
+      ];
+    } else {
+      return [
       'filePath'         => $this->getFilePath(),
       'findings'         => $this->getFindings()->getArray(),
       'clearing_status'  => $this->getClearingStatus()
-    ];
+      ];
+    }
   }
 }

--- a/src/www/ui/api/Models/GroupPermission.php
+++ b/src/www/ui/api/Models/GroupPermission.php
@@ -1,0 +1,123 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Divij Sharma <divijs75@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * @file
+ * @brief SuccessfulAgent model
+ */
+namespace Fossology\UI\Api\Models;
+
+
+class GroupPermission
+{
+  /**
+   * @var string $perm
+   * Permissions
+   */
+  private $perm;
+  /**
+   * @var string $groupPk
+   * Group id
+   */
+  private $groupPk;
+  /**
+   * @var string $groupName
+   * Group name
+   */
+  private $groupName;
+
+  /**
+   * @param string $perm
+   * @param string $groupPk
+   * @param string $groupName
+   */
+  public function __construct($perm, $groupPk, $groupName)
+  {
+    $this->perm = $perm;
+    $this->groupPk = $groupPk;
+    $this->groupName = $groupName;
+  }
+
+  /**
+   * @return string
+   */
+  public function getPerm()
+  {
+    return $this->perm;
+  }
+
+  /**
+   * @return string
+   */
+  public function getGroupPk()
+  {
+    return $this->groupPk;
+  }
+
+  /**
+   * @return string
+   */
+  public function getGroupName()
+  {
+    return $this->groupName;
+  }
+
+
+
+  /**
+   * JSON representation of current scannedLicense
+   * @param integer $version
+   * @return string
+   */
+  public function getJSON($version=ApiVersion::V1)
+  {
+    return json_encode($this->getArray($version));
+  }
+
+  /**
+   * Get ScannedLicense element as associative array
+   * @param integer $version
+   * @return array
+   */
+  public function getArray($version=ApiVersion::V1)
+  {
+    if ($version == ApiVersion::V2) {
+        return [
+          'perm' => $this->getPerm(),
+          'groupPk' => $this->getGroupPk(),
+          'groupName' => $this->getGroupName()
+        ];
+    }
+    return [
+      'perm' => $this->getPerm(),
+      'group_pk' => $this->getGroupPk(),
+      'group_name' => $this->getGroupName()
+    ];
+  }
+
+  /**
+   * @param string $perm
+   */
+  public function setperm($perm)
+  {
+    $this->perm = $perm;
+  }
+
+  /**
+   * @param string $groupPk
+   */
+  public function setGroupPk($groupPk)
+  {
+    $this->groupPk = $groupPk;
+  }
+
+  /**
+   * @param string $groupName
+   */
+  public function setGroupName($groupName)
+  {
+    $this->groupName = $groupName;
+  }
+}

--- a/src/www/ui/api/Models/Permissions.php
+++ b/src/www/ui/api/Models/Permissions.php
@@ -1,0 +1,95 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Divij Sharma <divijs75@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * @file
+ * @brief SuccessfulAgent model
+ */
+namespace Fossology\UI\Api\Models;
+
+
+class Permissions
+{
+  /**
+   * @var string $publicPerm
+   * public permissions
+   */
+  private $publicPerm;
+  /**
+   * @var array $permGroups
+   * permissions for groups
+   */
+  private $permGroups;
+  /**
+   * @param string $PublicPerm
+   * @param array $permGroups
+   */
+  public function __construct($publicPerm, $permGroups)
+  {
+    $this->publicPerm = $publicPerm;
+    $this->permGroups = $permGroups;
+  }
+
+  /**
+   * @return string
+   */
+  public function getpublicPerm()
+  {
+    return $this->publicPerm;
+  }
+
+  /**
+   * @return array
+   */
+  public function getpermGroups()
+  {
+    return $this->permGroups;
+  }
+
+  /**
+   * JSON representation of current scannedLicense
+   * @param integer $version
+   * @return string
+   */
+  public function getJSON($version=ApiVersion::V1)
+  {
+    return json_encode($this->getArray($version));
+  }
+
+  /**
+   * Get ScannedLicense element as associative array
+   * @param integer $version
+   * @return array
+   */
+  public function getArray($version=ApiVersion::V1)
+  {
+    if ($version == ApiVersion::V2) {
+        return [
+          'publicPerm' => $this->getpublicPerm(),
+          'permGroups' => $this->getpermGroups(),
+        ];
+    }
+    return [
+      'publicPerm' => $this->getpublicPerm(),
+      'permGroups' => $this->getpermGroups(),
+    ];
+  }
+
+  /**
+   * @param string $publicPerm
+   */
+  public function setpublicPerm($publicPerm)
+  {
+    $this->publicPerm= $publicPerm;
+  }
+
+  /**
+   * @param array $permGroups
+   */
+  public function setpermGroups($permGroups)
+  {
+    $this->permGroups = $permGroups;
+  }
+}

--- a/src/www/ui/api/Models/Upload.php
+++ b/src/www/ui/api/Models/Upload.php
@@ -9,7 +9,6 @@
  * @brief Upload model
  */
 namespace Fossology\UI\Api\Models;
-
 /**
  * @class Upload
  * @brief Model class to hold Upload info
@@ -96,29 +95,44 @@ class Upload
    * Get current upload in JSON representation
    * @return string
    */
-  public function getJSON()
+  public function getJSON($version=ApiVersion::V1)
   {
-    return json_encode($this->getArray());
+    return json_encode($this->getArray($version));
   }
 
   /**
    * Get the upload element as an associative array
    * @return array
    */
-  public function getArray()
+  public function getArray($version=ApiVersion::V1)
   {
-    return [
-      "folderid"    => $this->folderId,
-      "foldername"  => $this->folderName,
-      "id"          => $this->uploadId,
-      "description" => $this->description,
-      "uploadname"  => $this->uploadName,
-      "uploaddate"  => $this->uploadDate,
-      "assignee"    => $this->assignee,
-      "assigneeDate" => $this->assigneeDate,
-      "closingDate" => $this->closingDate,
-      "hash"        => $this->hash->getArray()
-    ];
+    if ($version==ApiVersion::V2) {
+      return [
+        "folderId"    => $this->folderId,
+        "folderName"  => $this->folderName,
+        "id"          => $this->uploadId,
+        "description" => $this->description,
+        "uploadName"  => $this->uploadName,
+        "uploadDate"  => $this->uploadDate,
+        "assignee"    => $this->assignee,
+        "assigneeDate" => $this->assigneeDate,
+        "closingDate" => $this->closingDate,
+        "hash"        => $this->hash->getArray()
+      ];
+    } else {
+      return [
+        "folderid"    => $this->folderId,
+        "foldername"  => $this->folderName,
+        "id"          => $this->uploadId,
+        "description" => $this->description,
+        "uploadname"  => $this->uploadName,
+        "uploaddate"  => $this->uploadDate,
+        "assignee"    => $this->assignee,
+        "assigneeDate" => $this->assigneeDate,
+        "closingDate" => $this->closingDate,
+        "hash"        => $this->hash->getArray()
+      ];
+    }
   }
 
   /**

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -492,7 +492,7 @@ paths:
           type: integer
       - name: groupName
         description: The group name to chose while accessing the package
-        in: header
+        in: query
         required: false
         schema:
           type: string
@@ -596,12 +596,12 @@ paths:
       parameters:
         - name: folderId
           description: Folder Id, where upload should be copied to
-          in: header
+          in: query
           required: true
           schema:
             type: integer
         - name: action
-          in: header
+          in: query
           required: true
           description: Action to be performed
           schema:
@@ -624,7 +624,7 @@ paths:
     parameters:
       - name: groupName
         description: The group name to chose while accessing the package
-        in: header
+        in: query
         required: false
         schema:
           type: string
@@ -681,14 +681,14 @@ paths:
             pattern: \d{4}\-\d{2}\-\d{2}
         - name: page
           description: Page number to fetch
-          in: header
+          in: query
           required: false
           schema:
             type: integer
             default: 1
         - name: limit
           description: Limits of responses per request
-          in: header
+          in: query
           required: false
           schema:
             type: integer
@@ -976,7 +976,7 @@ paths:
       - name: page
         description: Page number (starts from 1)
         required: false
-        in: header
+        in: query
         schema:
           type: integer
           default: 1
@@ -984,7 +984,7 @@ paths:
       - name: limit
         description: Limits of responses per request
         required: false
-        in: header
+        in: query
         schema:
           type: integer
           default: 50
@@ -992,7 +992,7 @@ paths:
           maximum: 1000
       - name: groupName
         description: The group name to chose while accessing the package
-        in: header
+        in: query
         required: false
         schema:
           type: string
@@ -1183,7 +1183,7 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
-  /uploads/{id}/perm-groups:
+  /uploads/{id}/groups/permission:
     parameters:
       - name: id
         required: true
@@ -5064,10 +5064,10 @@ components:
     Upload:
       type: object
       properties:
-        folderid:
+        folderId:
           type: integer
           description: The folder id, where the upload is located
-        foldername:
+        folderName:
           type: string
           description: The name of the folder where the upload is located
         id:
@@ -5076,10 +5076,10 @@ components:
         description:
           type: string
           description: Description of the upload.
-        uploadname:
+        uploadName:
           type: string
           description: Display name of the upload.
-        uploaddate:
+        uploadDate:
           type: string
           description: Date, when the file was uploaded.
         assignee:
@@ -5164,19 +5164,19 @@ components:
     Fileinfo:
       type: object
       properties:
-        view_info:
+        viewInfo:
           type: object
           description: viewinfo of the file
-        meta_info:
+        metaInfo:
           type: object
           description: Display display meta info of the file
-        package_info:
+        packageInfo:
           type: object
           description: Shows package info of the file
-        tag_info:
+        tagInfo:
           type: object
           description: Provides tag related information
-        reuse_info:
+        reuseInfo:
           type: object
           description: Reuse info of the file.
     SetCustomiseInfo:
@@ -5491,7 +5491,7 @@ components:
             example: "path/to/LICENSE"
           findings:
             $ref: '#/components/schemas/Findings'
-          clearing_status:
+          clearingStatus:
             type: string
             example: "Do not use"
     UploadCopyrights:
@@ -5526,9 +5526,9 @@ components:
             properties:
               perm:
                 type: string
-              group_pk:
+              groupPk:
                 type: string
-              group_name:
+              groupName:
                 type: string
     JobQueue:
       description: Structure of jobs queue

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -178,6 +178,7 @@ $app->group('/uploads',
     $app->post('', UploadController::class . ':postUpload');
     $app->put('/{id:\\d+}/permissions', UploadController::class . ':setUploadPermissions');
     $app->get('/{id:\\d+}/perm-groups', UploadController::class . ':getGroupsWithPermissions');
+    $app->get('/{id:\\d+}/groups/permission', UploadController::class . ':getGroupsWithPermissions');
     $app->get('/{id:\\d+}/summary', UploadController::class . ':getUploadSummary');
     $app->get('/{id:\\d+}/agents', UploadController::class . ':getAllAgents');
     $app->get('/{id:\\d+}/agents/revision', UploadController::class . ':getAgentsRevision');

--- a/src/www/ui_tests/api/Models/UploadTest.php
+++ b/src/www/ui_tests/api/Models/UploadTest.php
@@ -14,6 +14,8 @@ namespace Fossology\UI\Api\Test\Models;
 
 use Fossology\UI\Api\Models\Hash;
 use Fossology\UI\Api\Models\Upload;
+use Fossology\UI\Api\Models\ApiVersion;
+
 
 /**
  * @class UploadTest
@@ -23,29 +25,61 @@ class UploadTest extends \PHPUnit\Framework\TestCase
 {
   /**
    * @test
-   * -# Test the data format returned by Upload::getArray() model
+   * -# Test the data format returned by Upload::getArray($version) model when $version is V1
    */
-  public function testDataFormat()
+  public function testDataFormatV1()
+  {
+    $this->testDataFormat(ApiVersion::V1);
+  }
+  /**
+   * @test
+   * -# Test the data format returned by Upload::getArray($version) model when $version is V2
+   */
+  public function testDataFormatV2()
+  {
+    $this->testDataFormat(ApiVersion::V2);
+  }
+  /**
+   * @param $version version to test
+   * @return void
+   * -# Test the data format returned by Upload::getArray($version) model 
+   */
+  private function testDataFormat($version)
   {
     $hash = new Hash('sha1checksum', 'md5checksum', 'sha256checksum', 123123);
-    $expectedUpload = [
-      "folderid"    => 2,
-      "foldername"  => 'root',
-      "id"          => 3,
-      "description" => '',
-      "uploadname"  => 'my.tar.gz',
-      "uploaddate"  => '01-01-2020',
-      "assignee"    => 3,
-      "assigneeDate" => '01-01-2020',
-      "closingDate" => '01-01-2020',
-      "hash"        => $hash->getArray()
-    ];
+    if($version==ApiVersion::V1){
+      $expectedUpload = [
+        "folderid"    => 2,
+        "foldername"  => 'root',
+        "id"          => 3,
+        "description" => '',
+        "uploadname"  => 'my.tar.gz',
+        "uploaddate"  => '01-01-2020',
+        "assignee"    => 3,
+        "assigneeDate" => '01-01-2020',
+        "closingDate" => '01-01-2020',
+        "hash"        => $hash->getArray()
+      ];
+    } else{
+      $expectedUpload = [
+        "folderId"    => 2,
+        "folderName"  => 'root',
+        "id"          => 3,
+        "description" => '',
+        "uploadName"  => 'my.tar.gz',
+        "uploadDate"  => '01-01-2020',
+        "assignee"    => 3,
+        "assigneeDate" => '01-01-2020',
+        "closingDate" => '01-01-2020',
+        "hash"        => $hash->getArray()
+      ];
+    }
 
     $actualUpload = new Upload(2, 'root', 3, '', 'my.tar.gz', '01-01-2020', 3,
       $hash);
     $actualUpload->setAssigneeDate("01-01-2020");
     $actualUpload->setClosingDate("01-01-2020");
 
-    $this->assertEquals($expectedUpload, $actualUpload->getArray());
+    $this->assertEquals($expectedUpload, $actualUpload->getArray($version));
   }
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This PR addresses tasks 1, 3, 4, 5, 6, 9, 10, and 11 outlined in issue #2623 

### Changes

**Common for all: Moved `groupName` variable from headers to query parameters by making a change in  RestAuthMiddleware**

**Task 1: /updoads/{id}, GET:**
 - moved `groupName` variable  from headers to query params
 - changed the response keys to camelCase
 - modified the unit test to accommodate changes  

**Task 3: /updoads/{id}, DELETE:**

-  moved `groupName` variable  from headers to query params

**Task 4: /updoads/{id}, PATCH:**

-  moved `groupName` variable  from headers to query params

**Task 5: /updoads/{id}, PUT:**
-  moved `groupName`, `folderId`, `action` variable  from headers to query params
-  modified the unit test to accommodate changes  

**Task 6: /updoads, GET:** 
- moved `groupName`, `page`, `limit` variable  from headers to query params

**Task 9: /uploads/{id}/item/{itemId}/info, GET:**
- changed the response keys to camelCase 

**Task 10: /uploads/{id}/licenses, GET:**
-  moved `groupName`, `page`, `limit` variable  from headers to query params 
-  changed the response keys to camelCase 

**Task 11: /uploads/{id}/perm-groups, GET:**
-  updated the API Url to `/uploads/{id}/groups/permission`
-  changed the response keys to camelCase 

## How to test

- Changes pass all the unit tests
- Can be tested manually by making requests to the mentioned endpoints using swagger or postman

/cc @dushimsam @GMishx @shaheemazmalmmd 