### PR TITLE
fix(spdx2): accept null values for arrays

### DIFF
--- a/src/lib/php/Data/Report/FileNode.php
+++ b/src/lib/php/Data/Report/FileNode.php
@@ -44,12 +44,14 @@ class FileNode
   /**
    * Add comment to file.
    *
-   * @param string $comment
+   * @param string|null $comment
    * @return FileNode
    */
-  public function addComment(string $comment): FileNode
+  public function addComment(?string $comment): FileNode
   {
-    $this->comments[] = $comment;
+    if (!empty($comment)) {
+      $this->comments[] = $comment;
+    }
     return $this;
   }
 
@@ -68,12 +70,14 @@ class FileNode
   /**
    * Add acknowledgement to file.
    *
-   * @param string $acknowledgement
+   * @param string|null $acknowledgement
    * @return FileNode
    */
-  public function addAcknowledgement(string $acknowledgement): FileNode
+  public function addAcknowledgement(?string $acknowledgement): FileNode
   {
-    $this->acknowledgements[] = $acknowledgement;
+    if (!empty($acknowledgement)) {
+      $this->acknowledgements[] = $acknowledgement;
+    }
     return $this;
   }
 
@@ -92,12 +96,14 @@ class FileNode
   /**
    * Add concluded license to file.
    *
-   * @param string $concludedLicense
+   * @param string|null $concludedLicense
    * @return FileNode
    */
-  public function addConcludedLicense(string $concludedLicense): FileNode
+  public function addConcludedLicense(?string $concludedLicense): FileNode
   {
-    $this->concludedLicenses[] = $concludedLicense;
+    if (!empty($concludedLicense)) {
+      $this->concludedLicenses[] = $concludedLicense;
+    }
     return $this;
   }
 
@@ -116,24 +122,28 @@ class FileNode
   /**
    * Add scanner finding to file.
    *
-   * @param string $scanner
+   * @param string|null $scanner
    * @return FileNode
    */
-  public function addScanner(string $scanner): FileNode
+  public function addScanner(?string $scanner): FileNode
   {
-    $this->scanners[] = $scanner;
+    if (!empty($scanner)) {
+      $this->scanners[] = $scanner;
+    }
     return $this;
   }
 
   /**
    * Add copyright to file.
    *
-   * @param string $copyright
+   * @param string|null $copyright
    * @return FileNode
    */
-  public function addCopyright(string $copyright): FileNode
+  public function addCopyright(?string $copyright): FileNode
   {
-    $this->copyrights[] = $copyright;
+    if (!empty($copyright)) {
+      $this->copyrights[] = $copyright;
+    }
     return $this;
   }
 

--- a/src/lib/php/Data/Report/SpdxLicenseInfo.php
+++ b/src/lib/php/Data/Report/SpdxLicenseInfo.php
@@ -27,6 +27,11 @@ class SpdxLicenseInfo
    * Is a custom text license?
    */
   private $customText = false;
+  /**
+   * @var bool $textPrinted
+   * Is the license text already printed?
+   */
+  private $textPrinted = false;
 
   /**
    * @return bool
@@ -45,11 +50,6 @@ class SpdxLicenseInfo
     $this->textPrinted = $textPrinted;
     return $this;
   }
-  /**
-   * @var bool $textPrinted
-   * Is the license text already printed?
-   */
-  private $textPrinted = false;
 
   /**
    * @return License

--- a/src/spdx2/agent/template/spdx2-file.xml.twig
+++ b/src/spdx2/agent/template/spdx2-file.xml.twig
@@ -4,6 +4,7 @@
 #}
 {%- from "listedlicense.xml.twig" import listedLicenseFull -%}
 {% set dualLicense = false %}
+{% set textPrintedList = [] %}
 {% if fileData.concludedLicenses|length > 2 %}
   {% for res in fileData.concludedLicenses %}
     {% if 'Dual-license' == licenseList[res].licenseObj.shortName %}
@@ -50,7 +51,8 @@
         {%- endif ~%}
         <spdx:member rdf:resource="#{{ licId|replace({' ': '-'})|url_encode }}" />
       {%~ else %}
-        {%~ if not licenseList[res].isTextPrinted() %}{# License to be printed #}
+        {%~ if res not in textPrintedList and not licenseList[res].isTextPrinted() ~%}{# License to be printed #}
+          {%~ set textPrintedList = textPrintedList|merge([res]) %}
         <spdx:member>
           {{ listedLicenseFull(licenseList[res].licenseObj) }}
         </spdx:member>
@@ -74,7 +76,8 @@
       {%- endif ~%}
     <spdx:licenseConcluded rdf:resource="#{{ licId|replace({' ': '-'})|url_encode }}" />
     {%~ else %}
-      {%~ if not licenseList[res].isTextPrinted() %}{# License to be printed #}
+      {%~ if res not in textPrintedList and not licenseList[res].isTextPrinted() ~%}{# License to be printed #}
+        {%~ set textPrintedList = textPrintedList|merge([res]) %}
     <spdx:licenseConcluded>
       {{ listedLicenseFull(licenseList[res].licenseObj) }}
     </spdx:licenseConcluded>
@@ -104,7 +107,8 @@
       {%- endif ~%}
     <spdx:licenseInfoInFile rdf:resource="#{{ licId|replace({' ': '-'})|url_encode }}" />
     {%~ else %}
-      {%~ if not licenseList[res].isTextPrinted() %}{# License to be printed #}
+      {%~ if res not in textPrintedList and not licenseList[res].isTextPrinted() ~%}{# License to be printed #}
+        {%~ set textPrintedList = textPrintedList|merge([res]) %}
     <spdx:licenseInfoInFile>
       {{ listedLicenseFull(licenseList[res].licenseObj) }}
     </spdx:licenseInfoInFile>


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

1. Allow `null` values for arrays in `FileNode` class. Type hinting was throwing error for null values.
2. Prevent duplicate license text printing in RDF.

### Changes

1. Allow `null` values in `FileNode` class.
2. Create new array to track printing of license text in same file.

## How to test

1. Generate SPDX RDF report of package with no comments, acknowledgements and copyrights.
2. Generate SPDX RDF report of package where at least 1 file has a license finding of SPDX listed license and use same license as conclusion.
    - For the file node in report, the license text for this SPDX listed license should only be printed once.