### PR TITLE
feat(api): make cyclonedx report available via the API

### DIFF
--- a/src/www/ui/api/Controllers/ReportController.php
+++ b/src/www/ui/api/Controllers/ReportController.php
@@ -52,7 +52,8 @@ class ReportController extends RestController
     'readmeoss',
     'unifiedreport',
     'clixml',
-    'decisionexporter'
+    'decisionexporter',
+    'cyclonedx'
   );
 
   /**
@@ -121,6 +122,12 @@ class ReportController extends RestController
         /** @var FoDecisionExporter $decisionExporter */
         $decisionExporter = $this->restHelper->getPlugin('agent_fodecisionexporter');
         list($jobId, $jobQueueId) = $decisionExporter->scheduleAgent(
+          $this->restHelper->getGroupId(), $upload);
+        break;
+      case $this->reportsAllowed[7]:
+        /** @var CycloneDXGeneratorUi $cyclonedxGenerator */
+        $cyclonedxGenerator = $this->restHelper->getPlugin('ui_cyclonedx');
+        list ($jobId, $jobQueueId) = $cyclonedxGenerator->scheduleAgent(
           $this->restHelper->getGroupId(), $upload);
         break;
       default:

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -3979,6 +3979,7 @@ paths:
               - readmeoss
               - unifiedreport
               - clixml
+              - cyclonedx
         - name: groupName
           description: The group name to chose while generating a report
           in: header

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -3979,6 +3979,7 @@ paths:
               - readmeoss
               - unifiedreport
               - clixml
+              - cyclonedx
         - name: groupName
           description: The group name to chose while generating a report
           in: header


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This PR contains some minor changes to make the cycloneDX sbom report availble via the API. This enables the user to create this report on an automated basis.

### Changes

* Added the report type to the ReportController of the API
* Added the cyclonedx option to both versions of the openapi specification file. 

## How to test

Create and analyse an upload and let it create a cyclonedx file e.q. via the https://editor-next.swagger.io/ interface

