### PR TITLE
fix(action): Ensure proper handeling of enum values in argparse

### DIFF
--- a/utils/automation/fossologyscanner.py
+++ b/utils/automation/fossologyscanner.py
@@ -267,7 +267,7 @@ if __name__ == "__main__":
   )
   parser.add_argument(
     "--report", type=str, help="Type of report to generate. Default 'TEXT'.",
-    choices=[member.name for member in ReportFormat], default=ReportFormat.TEXT
+    choices=[member.name for member in ReportFormat], default=ReportFormat.TEXT.name
   )
   args = parser.parse_args()
   sys.exit(main(args))


### PR DESCRIPTION
## Description

The default parameter sets the default value for the `--report` argument. In the original code, it uses `ReportFormat.TEXT`, which is an enum member. However, when the user provides a value, it might be a string, not an enum member. The fix involves using `ReportFormat.TEXT.name` as the default value. This explicitly sets the default value as the string "TEXT" rather than the enum member `ReportFormat.TEXT`

Resolves #2641 

### Changes

Modified the `default` parameter for the `--report` argument to use strings directly.

## How to test
* Run the script with various combinations of `--report` values.
* Verify that the default behavior is now correctly set to `TEXT`.

CC- @GMishx 