### PR TITLE
fix(token): fix token generation for user

### DIFF
--- a/src/www/ui/api/Controllers/UserController.php
+++ b/src/www/ui/api/Controllers/UserController.php
@@ -221,6 +221,8 @@ class UserController extends RestController
       throw new HttpTooManyRequestException("Please try again later.", $e);
     } catch (DuplicateTokenNameException $e) {
       throw new HttpConflictException($e->getMessage(), $e);
+    } catch (\UnexpectedValueException $e) {
+      throw new HttpBadRequestException($e->getMessage(), $e);
     }
 
     $returnVal = new Info(201, "Token created successfully", InfoType::INFO);

--- a/src/www/ui/api/Middlewares/RestAuthMiddleware.php
+++ b/src/www/ui/api/Middlewares/RestAuthMiddleware.php
@@ -57,6 +57,7 @@ class RestAuthMiddleware
     } elseif ($isPassThroughPath) {
       $response = $handler->handle($request);
     } elseif (stristr($requestUri->getPath(), "/tokens") !== false &&
+        stristr($requestUri->getPath(), "/users/tokens") === false &&
         stristr($request->getMethod(), "post") !== false) {
       $response = $handler->handle($request);
     } else {

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -51,6 +51,7 @@ use Fossology\UI\Api\Models\ApiVersion;
 use Fossology\UI\Api\Models\Info;
 use Fossology\UI\Api\Models\InfoType;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
 use Psr\Log\LoggerInterface;
 use Slim\Exception\HttpMethodNotAllowedException;
 use Slim\Exception\HttpNotFoundException;
@@ -115,7 +116,7 @@ $app = AppFactory::create();
 $app->setBasePath($BASE_PATH);
 
 // Custom middleware to set the API version as a request attribute
-$apiVersionMiddleware = function (Request $request, $handler) use ($apiVersion) {
+$apiVersionMiddleware = function (Request $request, RequestHandler $handler) use ($apiVersion) {
   $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, $apiVersion);
   return $handler->handle($request);
 };


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix token generation from user-edit page.

### Changes

1. Fix token generation for user page.
2. Fix error handling in user-edit.php
3. Fix the path `/users/token` to be authenticated.
4. Handle `user_edit` plugin exception in UserController.php

## How to test

Try to generate new tokens from UI (User edit page) and from rest API (`/users/tokens`).