### PR TITLE
fix(api): do not check page for empty response

### DIFF
--- a/src/www/ui/api/Controllers/CopyrightController.php
+++ b/src/www/ui/api/Controllers/CopyrightController.php
@@ -570,7 +570,7 @@ class CopyrightController extends RestController
       $finalVal[] = $row;
     }
     $totalPages = intval(ceil($iTotalRecords / $limit));
-    if ($page > $totalPages) {
+    if ($totalPages != 0 && $page > $totalPages) {
       throw (new HttpBadRequestException(
         "Can not exceed total pages: $totalPages"))
         ->setHeaders(["X-Total-Pages" => $totalPages]);

--- a/src/www/ui/api/Controllers/LicenseController.php
+++ b/src/www/ui/api/Controllers/LicenseController.php
@@ -180,7 +180,7 @@ class LicenseController extends RestController
         throw new HttpBadRequestException(
           "page should be positive integer > 0");
       }
-      if ($page > $totalPages) {
+      if ($totalPages != 0 && $page > $totalPages) {
         throw (new HttpBadRequestException(
           "Can not exceed total pages: $totalPages"))
           ->setHeaders(["X-Total-Pages" => $totalPages]);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Do not check page number 1 (which is the least value) if response list is empty.

### Changes

Do not check the page number if there are total 0 pages in response.

## How to test

1. Query copyrights/emails from a file where there are none.
    - The endpoint currently returns 400 saying page should not be > 0 which is wrong and confusing.
    - Expected response is empty list.