### PR TITLE
Fix(php) : Fix null pointer issue in createClearingDecisions()

### DIFF
--- a/src/decisionimporter/agent/DecisionImporterDataCreator.php
+++ b/src/decisionimporter/agent/DecisionImporterDataCreator.php
@@ -202,6 +202,9 @@ class DecisionImporterDataCreator
       }
       foreach ($ceList as $oldCeId) {
         $newCeId = $clearingEventList[$oldCeId]["new_event"];
+        if ($newCeId === null) {
+          continue;
+        }
         $this->dbManager->insertTableRow("clearing_decision_event", [
           "clearing_decision_fk" => $newCdId,
           "clearing_event_fk" => $newCeId


### PR DESCRIPTION
### Description


This pull request addresses a potential null pointer  issue #2656  in the `createClearingDecisions()` method within `DecisionImporterDataCreator.php`
Closes #2656. 

### Changes

- Added null pointer that check for the variable `$newCeId` before processing within the foreach loop.
- Inserted `if ($newCeId === null) { continue; }` to ensure the loop skips operations if `$newCeId` is null.

### How to test

- Tested the updated code by simulating scenarios where `$newCeId` could be null.
- Verified that the loop correctly skips operations and doesn't cause any errors.

/cc @GMishx 
