### PR TITLE
fix(deb): fix dependencies for bookworm

### DIFF
--- a/cmake/FoPackaging.cmake
+++ b/cmake/FoPackaging.cmake
@@ -119,11 +119,12 @@ This package contains the resources needed by all of the other
 fossology components. This includes admin tools for maintenance.")
 
 set(CPACK_DEBIAN_FOSSOLOGY-COMMON_PACKAGE_DEPENDS
-    "php7.2-pgsql | php7.3-pgsql | php7.4-pgsql | php8.1-pgsql, php-pear,
-    php7.2-cli | php7.3-cli | php7.4-cli | php8.1-cli, php-mbstring,
-    php7.2-json | php7.3-json | php7.4-json | php8.1-json, php-zip, php-xml,
-    php7.2-curl | php7.3-curl | php7.4-curl | php8.1-curl, php-uuid,
-    php7.2-gd | php7.3-gd | php7.4-gd | php8.1-gd")
+    "php7.2-pgsql | php7.3-pgsql | php7.4-pgsql | php8.1-pgsql | php8.2-pgsql,
+    php-pear, php7.2-cli | php7.3-cli | php7.4-cli | php8.1-cli | php8.2-cli,
+    php-mbstring, php7.2-json | php7.3-json | php7.4-json | php8.1-json | php8.2-json,
+    php-zip, php-xml,
+    php7.2-curl | php7.3-curl | php7.4-curl | php8.1-curl | php8.2-curl, php-uuid,
+    php7.2-gd | php7.3-gd | php7.4-gd | php8.1-gd | php8.2-gd")
 
 set(CPACK_DEBIAN_FOSSOLOGY-COMMON_PACKAGE_SECTION "utils")
 set(CPACK_DEBIAN_FOSSOLOGY-COMMON_PACKAGE_CONTROL_EXTRA
@@ -138,8 +139,8 @@ ${FO_PACKAGE_COMMON_DESCRIPTION}
 This package depends on the packages for the web interface.")
 
 set(CPACK_DEBIAN_WWW_PACKAGE_DEPENDS
-    "fossology-common, apache2, php7.2-gd|php7.3-gd|php7.4-gd|php8.1-gd,
-    libapache2-mod-php7.2|libapache2-mod-php7.3|libapache2-mod-php7.4|libapache2-mod-php8.1")
+    "fossology-common, apache2, php7.2-gd|php7.3-gd|php7.4-gd|php8.1-gd|php8.2-gd,
+    libapache2-mod-php7.2|libapache2-mod-php7.3|libapache2-mod-php7.4|libapache2-mod-php8.1|libapache2-mod-php8.2")
 
 set(CPACK_DEBIAN_WWW_PACKAGE_SECTION "utils")
 set(CPACK_DEBIAN_WWW_PACKAGE_RECOMMENDS "fossology-db")
@@ -294,6 +295,8 @@ set(CPACK_DEBIAN_IPRA_PACKAGE_DEPENDS
     "fossology-common, fossology-copyright, libpcre3")
 
 set(CPACK_DEBIAN_IPRA_PACKAGE_SECTION "utils")
+
+set(CPACK_DEBIAN_KEYWORD_PACKAGE_SECTION "utils")
 
 ## FOSSOLOGY-BUCKETS
 set(CPACK_DEBIAN_BUCKETS_PACKAGE_NAME "fossology-buckets")


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix PHP dependencies for Debian Bookworm.

### Changes

Add PHP8.2 dependencies for Debian Bookworm in CMake Packaging script.

## How to test

Create an install packages for Debian Bookworm (12).