### PR TITLE
fix(postinstall): check status of a2ensite

### DIFF
--- a/cmake/SetDefaults.cmake
+++ b/cmake/SetDefaults.cmake
@@ -99,7 +99,9 @@ set(FO_WRAPPER "${CMAKE_BINARY_DIR}/src/cli/gen/fo_wrapper.php" CACHE PATH "fo w
 
 set(FO_APACHE_CTL "/usr/sbin/apachectl" CACHE PATH "apache ctl")
 
-set(FO_APACHE2_EN_SITE "/usr/sbin/a2ensite" CACHE PATH "apachec ensite")
+set(FO_APACHE2_EN_SITE "/usr/sbin/a2ensite" CACHE PATH "apache ensite")
+
+set(FO_APACHE2_DIS_SITE "/usr/sbin/a2dissite" CACHE PATH "apache dissite")
 
 set(FO_APACHE2SITE_DIR "/etc/apache2/sites-available" CACHE PATH "apache site dir")
 

--- a/debian/web/postinst
+++ b/debian/web/postinst
@@ -24,6 +24,9 @@ case "$1" in
     if [ -f "/etc/apache2/sites-enabled/fossology.conf" ]; then
         rm -rf  /etc/apache2/sites-enabled/fossology.conf
     fi
+    if [ -f "/etc/apache2/sites-available/fossology.conf" ]; then
+        rm -rf  /etc/apache2/sites-available/fossology.conf
+    fi
     PHP_PATH=$(php --ini | awk '/\/etc\/php.*\/cli$/{print $5}')
     phpIni="${PHP_PATH}/../apache2/php.ini"
     cp ${phpIni} ${phpIni}.bak
@@ -31,7 +34,8 @@ case "$1" in
     sed -i 's/^\(memory_limit\s*=\s*\).*$/\1702M/' ${phpIni}
     sed -i 's/^\(post_max_size\s*=\s*\).*$/\1701M/' ${phpIni}
     sed -i 's/^\(upload_max_filesize\s*=\s*\).*$/\1700M/' ${phpIni}
-    ln -s /etc/fossology/conf/fo-apache.conf /etc/apache2/sites-enabled/fossology.conf
+    ln -s /etc/fossology/conf/fo-apache.conf /etc/apache2/sites-available/fossology.conf
+    ln -s /etc/apache2/sites-available/fossology.conf /etc/apache2/sites-enabled/fossology.conf
     # need to run fo-postinstall web and agent stuff
     /usr/lib/fossology/fo-postinstall --web-only
     invoke-rc.d apache2 restart

--- a/install/fo-postinstall.in
+++ b/install/fo-postinstall.in
@@ -336,6 +336,11 @@ if [[ $WEBONLY ]]; then
         echo "NOTE: enabling fossology site for apache2";
         ln -s @FO_DESTDIR@@FO_SYSCONFDIR@/conf/src-install-apache-example.conf @FO_APACHE2SITE_DIR@/fossology.conf;
         @FO_APACHE2_EN_SITE@ fossology.conf;
+        # Exit code 1, soft link points to wrong file. Fix it.
+        if [[ $? -eq 1 ]]; then
+          @FO_APACHE2_DIS_SITE@ fossology.conf;
+          @FO_APACHE2_EN_SITE@ fossology.conf;
+        fi;
         RESTART_MESSAGE=true
       fi;
     elif [[ -d @FO_HTTPD_SITE_DIR@ ]]; then


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix apache error while trying to upgrade from Debian packages.

### Changes

1. If a2ensite fails on postinstall, disable (delete) the old file first
2. Do not create files in site-enabled, rather in sites-available in `web/postinst`

## How to test

1. Install Debian packages of older version (before CMake, before 4.3.0).
2. Create new packages of this branch.
3. Install the latest packages. There should be no error from apache.