### PR TITLE
fix(api): read optional agentId, UploadController

### DIFF
--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -310,7 +310,7 @@ class UploadController extends RestController
   {
     $id = intval($args['id']);
     $query = $request->getQueryParams();
-    $selectedAgentId = $query['agentId'];
+    $selectedAgentId = $query['agentId'] ?? null;
     $agentDao = $this->container->get('dao.agent');
     $this->uploadAccessible($id);
     if ($selectedAgentId !== null && !$this->dbHelper->doesIdExist("agent", "agent_pk", $selectedAgentId)) {
@@ -1011,7 +1011,7 @@ class UploadController extends RestController
     $uploadId = intval($args['id']);
     $uploadDao = $this->restHelper->getUploadDao();
     $query = $request->getQueryParams();
-    $selectedAgentId = $query['agentId'];
+    $selectedAgentId = $query['agentId'] ?? null;
 
     $this->uploadAccessible($uploadId);
 
@@ -1165,7 +1165,7 @@ class UploadController extends RestController
   {
     $uploadId = intval($args['id']);
     $query = $request->getQueryParams();
-    $selectedAgentId = $query['agentId'];
+    $selectedAgentId = $query['agentId'] ?? null;
     $licenseDao = $this->container->get('dao.license');
 
     $this->uploadAccessible($uploadId);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix reading of optional query parameters in `UploadController.php`

### Changes

Read optional parameters with `??` format.

## How to test

Request `/uploads/{id}/summary`, `/uploads/{id}/licenses/histogram` and `/uploads/{id}/licenses/scanned` with and without the `agentId` parameter.

```
[php:warn] [pid 224455] PHP Warning:  Undefined array key "agentId" in /usr/share/fossology/www/ui/api/Controllers/UploadController.php on line 313
```