### PR TITLE
fix(ui): use group id to get shortname

### DIFF
--- a/src/www/ui/async/AjaxExplorer.php
+++ b/src/www/ui/async/AjaxExplorer.php
@@ -360,7 +360,7 @@ class AjaxExplorer extends DefaultPlugin
       if ($request->get('fromRest')) {
         foreach ($licenseEntries as $shortName) {
           $licenseEntriesRest[] = array(
-            "id" => $this->licenseDao->getLicenseByShortName($shortName)->getId(),
+            "id" => $this->licenseDao->getLicenseByShortName($shortName, $groupId)->getId(),
             "name" => $shortName,
             "agents" => []
           );
@@ -387,7 +387,7 @@ class AjaxExplorer extends DefaultPlugin
             );
           }
           $licenseEntriesRest[] = array(
-            "id" => $this->licenseDao->getLicenseByShortName($shortName)->getId(),
+            "id" => $this->licenseDao->getLicenseByShortName($shortName, $groupId)->getId(),
             "name" => $shortName,
             "agents" => $agentEntriesRest,
           );


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Use GroupID while fetching licenses in AjaxExplorer as OJO can create candidate licenses since #1887

### Changes

Pass `$groupId` to `LicenseDao::getLicenseByShortName()`.

## How to test

1. Scan an upload with a license OJO has never seen and does not exists in the DB.
2. This causes OJO to create a new candidate license.
3. Clean the upload and navigate it in the UI.
4. Generate reports.