### PR TITLE
fix(spdx_ref): use LicenseRef to check ref license

### DIFF
--- a/src/lib/php/Data/LicenseRef.php
+++ b/src/lib/php/Data/LicenseRef.php
@@ -27,9 +27,14 @@ class LicenseRef
 
   /**
    * @var string
+   * SPDX license ref prefix
+   */
+  const SPDXREF_PREFIX = "LicenseRef-";
+  /**
+   * @var string
    * SPDX license ref prefix to use
    */
-  const SPDXREF_PREFIX = "LicenseRef-fossology-";
+  const SPDXREF_PREFIX_FOSSOLOGY = "LicenseRef-fossology-";
 
   /**
    * @param $licenseId
@@ -106,7 +111,7 @@ class LicenseRef
     } elseif (empty($spdxId)) {
       $spdxLicense = $shortname;
       if (! StringOperation::stringStartsWith($shortname, self::SPDXREF_PREFIX)) {
-        $spdxLicense = self::SPDXREF_PREFIX . $shortname;
+        $spdxLicense = self::SPDXREF_PREFIX_FOSSOLOGY . $shortname;
       }
     } else {
       $spdxLicense = $spdxId;

--- a/src/lib/php/Data/test/LicenseRefTest.php
+++ b/src/lib/php/Data/test/LicenseRefTest.php
@@ -48,6 +48,6 @@ class LicenseRefTest extends \PHPUnit\Framework\TestCase
   public function testDefaultSpdxId()
   {
     $licenseRef = new LicenseRef($this->id, $this->shortName, $this->fullName, "");
-    assertThat($licenseRef->getSpdxId(), is(LicenseRef::SPDXREF_PREFIX . $this->shortName));
+    assertThat($licenseRef->getSpdxId(), is(LicenseRef::SPDXREF_PREFIX_FOSSOLOGY . $this->shortName));
   }
 }

--- a/src/lib/php/Report/ReportUtils.php
+++ b/src/lib/php/Report/ReportUtils.php
@@ -272,8 +272,8 @@ class ReportUtils
             ->addConcludedLicense($reportLicId);
           if (!array_key_exists($reportLicId, $licensesInDocument)) {
             $licenseObj = $this->licenseDao->getLicenseById($reportedLicenseId);
-            $listedLicense = stripos($licenseObj->getSpdxId(),
-                LicenseRef::SPDXREF_PREFIX) !== 0;
+            $listedLicense = !StringOperation::stringStartsWith(
+              $licenseObj->getSpdxId(), LicenseRef::SPDXREF_PREFIX);
             $licensesInDocument[$reportLicId] = (new SpdxLicenseInfo())
               ->setLicenseObj($licenseObj)
               ->setCustomText(false)


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Create 2 consts:
1. `SPDXREF_PREFIX = "LicenseRef-"` to identify any LicenseRef
2. `SPDXREF_PREFIX_FOSSOLOGY = "LicenseRef-fossology-"` to add FOSSology's LicenseRef prefix.

## How to test

1. Create 1 license with shortname `LicenseA`.
2. Create 1 license with shortname `LicenseRef-LicenseB`.
3. Saving the licenses should create `LicenseRef-fossology-LicenseA` and `LicenseRef-LicenseB`.