### PR TITLE
feat(buildsystem): Introduce FORCE_CONF_OVERWRITE option to control configuration file overwrites

### DIFF
--- a/install/CMakeLists.txt
+++ b/install/CMakeLists.txt
@@ -3,6 +3,8 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
+option(FORCE_CONF_OVERWRITE "Force overwrite of configuration files" OFF)
+
 set(FO_CWD ${CMAKE_CURRENT_SOURCE_DIR})
 
 file(GLOB_RECURSE FO_INSTALL_CONFS ${FO_CWD}/*.in)
@@ -35,28 +37,44 @@ add_custom_target(BUILD_version ALL
         BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/VERSION")
 
 
-install(FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/VERSION"
+function(install_config_files FILES DEST_DIR COMPONENT_NAME)
+    foreach(FILE_NAME ${FILES})
+        get_filename_component(FILE_BASE ${FILE_NAME} NAME)
+        if (NOT EXISTS "${DEST_DIR}/${FILE_BASE}" OR FORCE_CONF_OVERWRITE)
+            message(STATUS "Installing ${FILE_BASE}")
+            install(FILES ${FILE_NAME}
+                    COMPONENT ${COMPONENT_NAME}
+                    DESTINATION ${DEST_DIR})
+        else()
+            message(STATUS "${FILE_BASE} already exists. Not overwriting, use the FORCE_CONF_OVERWRITE option to overwrite.")
+        endif()
+    endforeach()
+endfunction()
+
+set(FO_CONFIG_FILES
     ${CMAKE_CURRENT_BINARY_DIR}/gen/Db.conf
     ${CMAKE_CURRENT_BINARY_DIR}/gen/fossology.conf
+)
+install_config_files("${FO_CONFIG_FILES}" "${FO_SYSCONFDIR}" "common")
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/VERSION"
+    DESTINATION ${FO_SYSCONFDIR}
     COMPONENT common
-    DESTINATION ${FO_SYSCONFDIR})
+)
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/VERSION"
     DESTINATION ${FO_MODDIR}
     COMPONENT common
 )
 
-
-install(DIRECTORY
-    ${CMAKE_CURRENT_SOURCE_DIR}/defconf/
-    ${CMAKE_CURRENT_SOURCE_DIR}/fossdash/
-    COMPONENT common
-    DESTINATION ${FO_SYSCONFDIR}
-    FILES_MATCHING
-    PATTERN *.txt
-    PATTERN *.yml
+file(GLOB FO_DIR_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/defconf/*.txt
+    ${CMAKE_CURRENT_SOURCE_DIR}/defconf/*.yml
+    ${CMAKE_CURRENT_SOURCE_DIR}/fossdash/*.txt
+    ${CMAKE_CURRENT_SOURCE_DIR}/fossdash/*.yml
 )
+
+install_config_files("${FO_DIR_FILES}" "${FO_SYSCONFDIR}" "common")
 
 install(DIRECTORY ${FO_CWD}/db/
     ${CMAKE_CURRENT_BINARY_DIR}/gen/
@@ -83,12 +101,12 @@ install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/gen/dbcreate
     COMPONENT db
 )
 
-install(FILES
+set(FO_APACHE_FILES
     ${FO_CWD}/fo-apache.conf
     ${FO_CWD}/src-install-apache-example.conf
-    COMPONENT common
-    DESTINATION ${FO_SYSCONFDIR}/conf
 )
+
+install_config_files("${FO_APACHE_FILES}" "${FO_SYSCONFDIR}/conf" "common")
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gen/db.cron
     DESTINATION ${FO_INITDIR}/cron.d


### PR DESCRIPTION
## Description
In the previous repository state, configuration files were being overwritten during the installation process, potentially leading to unintended changes. To address this, a new option, `FORCE_CONF_OVERWRITE`, has been introduced. When set to `OFF` (default), the installation process will skip overwriting existing configuration files. Conversely, setting `FORCE_CONF_OVERWRITE` to `ON` will enable overwriting, allowing users to control whether configuration files should be replaced during installation.

### Changes
* Introduced a new option `FORCE_CONF_OVERWRITE` (default `OFF`) to manage weather user files should be overwritten or not during installation. 
* Implemented a general function to handle installs in CMake. It takes `FILES` (list of files to install with their path), `DEST_DIR` (installation path) and `COMPONENT_NAME` (value of `COMPONENT`) as parameters and based on the value of `FORCE_CONF_OVERWRITE` option, it handles if files should be overwritten or not.
* Currently excluded `Db.conf`, `fossology.conf`, `samplefooter.txt`, `sampleheader.txt`, `fossdash_metrices.yml`, `fo-apache.conf`, and `src-install-apache-example.conf`.

## How to test
Change anything in the above mentioned files (example, change the default password `fossy`) and then build the project using `cmake -S. -B./build -G Ninja` followed by installation as specified in [wiki](https://github.com/fossology/fossology/wiki/Install-from-Source). You will notice the files are not overwritten.

![Screenshot from 2024-02-21 00-49-18](https://github.com/fossology/fossology/assets/119073504/9397e637-4cba-4c5c-b0ae-0288662fa5e6)

To test the option, use `cmake -S. -B./build -DFORCE_CONF_OVERWRITE=ON -G Ninja` and you will see the files are overwritten.

![Screenshot from 2024-02-21 01-03-48](https://github.com/fossology/fossology/assets/119073504/844933cf-dfc1-4fe4-a0db-71baac52b474)

PS. If the above steps do not work, please use `rm -rf build` command before installation to delete build directory (reason- CMake caches stuff).

fixes #2683 
CC @GMishx @avinal 