### PR TITLE
fix(spdx): replaced & with &amp;

### DIFF
--- a/src/spdx2/agent/template/listedlicense.xml.twig
+++ b/src/spdx2/agent/template/listedlicense.xml.twig
@@ -11,7 +11,11 @@
     |replace({']]>':']]]]><![CDATA[>'}) }}
   ]]></spdx:licenseText>
 {%~ if licenseObj.url is not empty %}
+  {%~ if '&' in licenseObj.url %}
+  <rdfs:seeAlso>{{ licenseObj.url|url_encode }}</rdfs:seeAlso>
+  {%~ else %}
   <rdfs:seeAlso>{{ licenseObj.url }}</rdfs:seeAlso>
+  {%~ endif %}
 {%~ endif %}
 </spdx:ListedLicense>
 {% endmacro %}

--- a/src/spdx2/agent/template/spdx2-document.xml.twig
+++ b/src/spdx2/agent/template/spdx2-document.xml.twig
@@ -39,7 +39,11 @@
         |replace({']]>':']]]]><![CDATA[>'}) }}
       ]]></spdx:extractedText>
 {% if licenseData.licenseObj.url is not empty %}
+  {%~ if '&' in licenseData.licenseObj.url %}
+      <rdfs:seeAlso>{{ licenseData.licenseObj.url|url_encode }}</rdfs:seeAlso>
+  {%~ else %}
       <rdfs:seeAlso>{{ licenseData.licenseObj.url }}</rdfs:seeAlso>
+  {%~ endif %}
 {% endif %}
     </spdx:ExtractedLicensingInfo>
   </spdx:hasExtractedLicensingInfo>


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Replaced `&` with `&amp;` in the `<rdfs:seeAlso>` tag.

## How to test

1.) Create a test file with SPDX-License-Identifier: BitTorrent-1.0.
2.) Scan the file with ojo.
3.) Export SPDX RDF report.

 Fixes #2688 

CC @GMishx @shaheemazmalmmd 
