### PR TITLE
fix(ojo): ignore extra symbols at end

### DIFF
--- a/src/ojo/agent/ojoregex.hpp
+++ b/src/ojo/agent/ojoregex.hpp
@@ -27,10 +27,11 @@
  * @brief Regex to filter license names from list of license list
  *
  * -# License names will consist of words, digits, dots and hyphens.
- * -# Length of license names greater than 3 (based on
+ * -# Length of license names greater than 2 (based on
  * https://github.com/spdx/license-list-data/tree/master/html)
+ * -# License name should end with a word, digit or +
  */
-#define SPDX_LICENSE_NAMES "(?: and | or | with )?\\(?([\\w\\d\\.\\+\\-]{3,})\\)?"
+#define SPDX_LICENSE_NAMES "(?: and | or | with )?\\(?([\\w\\d\\.\\+\\-]{1,}[\\w\\d\\+])\\)?"
 /**
  * @def SPDX_DUAL_LICENSE
  * @brief Regex to check if Dual-license

--- a/src/ojo/agent_tests/Unit/test_regex.cc
+++ b/src/ojo/agent_tests/Unit/test_regex.cc
@@ -23,6 +23,7 @@ class regexTest : public CPPUNIT_NS :: TestFixture {
   CPPUNIT_TEST_SUITE (regexTest);
   CPPUNIT_TEST (regTest);
   CPPUNIT_TEST (badNameTest);
+  CPPUNIT_TEST (regTestSpecialEnd);
 
   CPPUNIT_TEST_SUITE_END ();
 
@@ -154,6 +155,79 @@ protected:
     CPPUNIT_ASSERT(
       std::find(licensesFound.begin(), licensesFound.end(), badLicense)
         == licensesFound.end());
+  };
+
+  /**
+   * \brief Test regex on a special test string
+   *
+   * \test
+   * -# Create a test SPDX identifier string with special characters at end
+   * -# Load the regex patterns
+   * -# Run the regex on the string
+   * -# Check the actual number of matches against expected result
+   * -# Check the actual findings matches the expected licenses
+   */
+  void regTestSpecialEnd (void) {
+
+    const std::string gplLicense = "GPL-2.0-only";
+    const std::string lgplLicense = "LGPL-2.1-or-later";
+    const std::string mitLicense = "MIT";
+    const std::string mplLicense = "MPL-1.1+";
+    // REUSE-IgnoreStart
+    std::string content = "SPDX-License-Identifier: (" + gplLicense + " AND "
+        + lgplLicense + ") OR " + mplLicense + " AND " + mitLicense + ".";
+    // REUSE-IgnoreStart
+    boost::regex listRegex(SPDX_LICENSE_LIST, boost::regex_constants::icase);
+    boost::regex nameRegex(SPDX_LICENSE_NAMES, boost::regex_constants::icase);
+
+    std::string::const_iterator begin = content.begin();
+    std::string::const_iterator end = content.end();
+    boost::match_results<std::string::const_iterator> what;
+
+    string licenseList;
+    boost::regex_search(begin, end, what, listRegex);
+    licenseList = what[1].str();
+
+    // Check if the correct license list is found
+    CPPUNIT_ASSERT_EQUAL("(" + gplLicense + " AND " + lgplLicense + ") OR " +
+      mplLicense + " AND " + mitLicense + ".", licenseList);
+
+    // Find the actual licenses in the list
+    begin = licenseList.begin();
+    end = licenseList.end();
+    list<string> licensesFound;
+
+    while (begin != end)
+    {
+      boost::smatch res;
+      if (boost::regex_search(begin, end, res, nameRegex))
+      {
+        licensesFound.push_back(res[1].str());
+        begin = res[0].second;
+      }
+      else
+      {
+        break;
+      }
+    }
+
+    size_t expectedNos = 4;
+    size_t actualNos = licensesFound.size();
+    // Check if 4 licenses are found
+    CPPUNIT_ASSERT_EQUAL(expectedNos, actualNos);
+    // Check if the result contains the expected string
+    CPPUNIT_ASSERT(
+      std::find(licensesFound.begin(), licensesFound.end(), gplLicense)
+        != licensesFound.end());
+    CPPUNIT_ASSERT(
+      std::find(licensesFound.begin(), licensesFound.end(), lgplLicense)
+        != licensesFound.end());
+    CPPUNIT_ASSERT(
+      std::find(licensesFound.begin(), licensesFound.end(), mitLicense)
+        != licensesFound.end());
+    CPPUNIT_ASSERT(
+      std::find(licensesFound.begin(), licensesFound.end(), mplLicense)
+        != licensesFound.end());
   };
 
 };


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

License names should end with either words, digits or a + symbol.

This prevents creation of licenses such as "MIT."

### Changes

1. Reduce the min length of licenses from 3 to 2 (there are "GD" and "SL" licenses now).
2. Make sure the license text ends with a word, digit or a "+".
3. Add test case to check scenarios with "MPL-1.1+" and "MIT."

## How to test

1. Create test files with following kind of license text:
    - "SPDX-License-Identifier: GPL-3.0-or-later."
    - "SPDX-License-Identifier: GPL-3.0+."
    - "SPDX-License-Identifier: GPL-3.0-or-later WITH GCC-exception-3.1."
2. Archive the file and scan with OJO.
3. OJO should find only "GPL-3.0-or-later", "GPL-3.0+" and "GCC-exception-3.1".