### PR TITLE
fix(scancode): Fixed failing scancode agent when using FOSSology in Docker

### DIFF
--- a/src/scancode/agent/runscanonfiles.py
+++ b/src/scancode/agent/runscanonfiles.py
@@ -6,8 +6,14 @@ Copyright (C) 2023  Sushant Kumar (sushantmishra02102002@gmail.com)
 SPDX-License-Identifier: GPL-2.0-only
 """
 
+import os
 import json
 import argparse
+
+# Set SCANCODE_CACHE environment variable
+script_directory = os.path.dirname(os.path.abspath(__file__))
+os.environ["SCANCODE_CACHE"] = os.path.join(script_directory, '.cache')
+
 from scancode import api
 
 def update_license(licenses):


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

When using FOSSology in Docker, the scancode agent fails to scan and throws a `Permission denied: '/root/.cache'` error.

This happens because scancode attempts to create a directory in `/root/.cache` while being initiated by the `fossy` user. To resolve this issue, scancode toolkit introduced various options as mentioned in [CHANGELOG.rst](https://github.com/nexB/scancode-toolkit/blob/66d71661f5ede54cb0f3b36d7663c92a67030299/CHANGELOG.rst#L2009-L2011) and [#2355](https://github.com/nexB/scancode-toolkit/issues/2355).  

### Changes

Introduced `SCANCODE_CACHE` environment variable in `runscanonfiles.py` file which holds the path to store cache (scancode agent directory in this case) which is accessible by `fossy` user.

## How to test
* Pull the changes and build the project using `docker compose up --build`.
* Upload any file (issue occured with tarball files, so preferably that) and schedule scancode agent under the section of scan selection.
* Scancode will run without fail. Images attached below (previous scan displays the error, latest scan shows the resolved result).

![Screenshot from 2024-03-07 03-45-15](https://github.com/fossology/fossology/assets/119073504/fdc3a1b6-402c-4c3c-933e-c41f6f4e9b6a)

fixes #2691 #2667 
CC @GMishx 