### PR TITLE
fix(RestAuthMiddleware): exclude from auth. only the right endpoints

### DIFF
--- a/src/www/ui/api/Middlewares/RestAuthMiddleware.php
+++ b/src/www/ui/api/Middlewares/RestAuthMiddleware.php
@@ -43,11 +43,14 @@ class RestAuthMiddleware
   {
     $requestUri = $request->getUri();
     $requestPath = strtolower($requestUri->getPath());
-    $authFreePaths = ["/version", "/info", "/openapi", "/health"];
+    $authFreePaths = ["/info", "/openapi", "/health"];
 
     $isPassThroughPath = false;
+    // path is /repo/api/v2/<endpoint>, we need to get only the endpoint part
+    $parts = explode("/", $requestPath, 5);
+    $endpoint = "/".end($parts);
     foreach ($authFreePaths as $authFreePath) {
-      if (strpos($requestPath, $authFreePath) !== false) {
+      if ( $endpoint === $authFreePath ) {
         $isPassThroughPath = true;
         break;
       }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

In RestAuthMiddleware class, there is some code that excludes some endpoints from authentication ("/version", "/info", "/openapi", "/health") but the problem is that that code simply searches for the corresponing strings (i.e. "/version", "/info", "/openapi", "/health") inside the request path regardless of their position inside the path, so also paths like /uploads/{id}/item/{itemId}/info are excluded from authentication. This implies that when one makes an authenticated request with /uploads/{id}/item/{itemId}/info, authentication gets ignored, user is set to "Default User" and group id is set to 2. Therefore all plugins that do require authentication (including view_info, which is needed to respond to the above-mentioned API call) are not loaded, and this causes a 500 error - "Unable to find plugin view_info". 

To debug the above error, you may force the loading of view_info (by adding a call to $NewPlugin->PostInitialize() at the end of www/ui/ui-view-info.php), and you get a 403 error -  "Upload is not accessible" - when you try to perform the same request. Then, you may add some debug code to www/ui/api/Controllers/RestController.php to log $_SESSION['User'] and group ID values before the "Upload is not accessible" exception is thrown: you will see that user is set to "Default User" and group id to 2, even if the request is authenticated. So the problem lies in an authenticated request that gets transformed into an unauthenticated request by RestAuthMiddleware.

The problem can be solved by modifying RestAuthMiddleware code, so that only endpoints that do not actually require authentication are excluded from authentication. 

### Changes

RestAuthMiddleware should check if any of the authFreePaths exactly matches the endpoint of the request, and not simply search for the authFreePath string in the request, which may lead to the errors described above.

Moreover, the "/version" endpoint does not exist in the API, so it does not need to be included in the list of endpoints not requiring authentication.

## How to test

Perform an /uploads/{id}/item/{itemId}/info API call, and check that it returns a correct result (200).

Fix #2693 
