### PR TITLE
fix(scancode): Use spdx_license_key instead of key

### DIFF
--- a/src/scancode/agent/runscanonfiles.py
+++ b/src/scancode/agent/runscanonfiles.py
@@ -25,7 +25,7 @@ def update_license(licenses):
     list: A list of dictionaries containing relevant license information.
   """
   updated_licenses = []
-  keys_to_extract_from_licenses = ['key', 'score', 'name', 'text_url', 'start_line', 'matched_text']
+  keys_to_extract_from_licenses = ['spdx_license_key', 'score', 'name', 'text_url', 'start_line', 'matched_text']
 
   for key, value in licenses.items():
     if key == 'licenses':

--- a/src/scancode/agent/scancode_wrapper.cc
+++ b/src/scancode/agent/scancode_wrapper.cc
@@ -91,7 +91,7 @@ void scanFileWithScancode(const State &state, string fileLocation, string output
  * @brief extract data from scancode scanned result
  *
  * In licenses array:
- * key-> license spdx key
+ * spdx_license_key-> license spdx key
  * score-> score of a rule to matched with the output licenes
  * name-> license full name
  * text_url-> license text reference url
@@ -133,7 +133,7 @@ map<string, vector<Match>> extractDataFromScancodeResult(const string& scancodeR
     {
       for (auto oneresult : licensearrays)
       {
-          string licensename = oneresult["key"].asString();
+          string licensename = oneresult["spdx_license_key"].asString();
           int percentage = (int)oneresult["score"].asFloat();
           string full_name=oneresult["name"].asString();
           string text_url=oneresult["text_url"].asString();


### PR DESCRIPTION


<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

For scancode findings currently only the ScanCode LicenseDB key is being extracted and reported. I think, this should be changed to use the SPDX ID. The comment before `scanFileWithScancode` (`src/scancode/agent/scancode_wrapper.cc`) already mentions the SPDX ID:
```
  * In licenses array:
  * key-> license spdx key
[...]
```
but the ScanCode LicenseDB key is being used (key instead of spdx_license_key):
```
keys_to_extract_from_licenses = ['key', 'score', 'name', 'text_url', 'start_line',, 'matched_text']
```
### Changes

This change extracts and uses `spdx_license_key` from the scancode results instead of `key`.

## How to test

Upload a package and activate: "ScancodeToolkit, scan for License". The scancode results should be shown with their SPDX ID (e.g. GPL-2.0-or-later instead of gpl-2.0-plus).
