### PR TITLE
fix(api): Modified v2 YML file to accommodate v2 post upload request with multipart/form-data content type

### DIFF
--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -725,59 +725,23 @@ paths:
           application/json:
             schema:
               type: object
+              allOf:
+                - $ref: '#/components/schemas/UploadOptions'
               properties:
                 location:
                   oneOf:
                     - $ref: '#/components/schemas/VcsUpload'
                     - $ref: '#/components/schemas/UrlUpload'
                     - $ref: '#/components/schemas/ServerUpload'
-                scanOptions:
-                  $ref: '#/components/schemas/ScanOptions'
-                folderId:
-                  type: integer
-                  description: Folder Id, where upload should be created
-                uploadDescription:
-                  type: string
-                  description: Visible description of the file
-                public:
-                  type: string
-                  enum:
-                    - private
-                    - protected
-                    - public
-                  default: protected
-                  description: The access level to the upload
-                applyGlobal:
-                  type: boolean
-                  default: false
-                  description: >
-                    Apply global decisions for current upload
-                ignoreScm:
-                  type: boolean
-                  default: false
-                  description: >
-                    Ignore SCM files (Git, SVN, TFS) and files with particular Mimetype
-                uploadType:
-                  type: string
-                  enum:
-                    - file
-                    - vcs
-                    - url
-                    - server
-                  default: vcs
-                  description: Type of upload done. Choose `file` if uploading a file.
-              required:
-                - folderId
-                - uploadType
           multipart/form-data:
             schema:
               type: object
+              allOf:
+                - $ref: '#/components/schemas/UploadOptions'
               properties:
                 fileInput:
                   type: string
                   format: binary
-                scanOptions:
-                  $ref: '#/components/schemas/ScanOptions'
               required:
                 - fileInput
       responses:
@@ -5046,6 +5010,47 @@ components:
           $ref: '#/components/schemas/Reuser'
         scancode:
           $ref: '#/components/schemas/Scancode'
+    UploadOptions:
+      type: object
+      properties:
+        folderId:
+          type: integer
+          description: Folder Id, where upload should be created
+        uploadDescription:
+          type: string
+          description: Visible description of the file
+        public:
+          type: string
+          enum:
+            - private
+            - protected
+            - public
+          default: protected
+          description: The access level to the upload
+        applyGlobal:
+          type: boolean
+          default: false
+          description: >
+            Apply global decisions for current upload
+        ignoreScm:
+          type: boolean
+          default: false
+          description: >
+            Ignore SCM files (Git, SVN, TFS) and files with particular Mimetype
+        uploadType:
+          type: string
+          enum:
+            - file
+            - vcs
+            - url
+            - server
+          default: vcs
+          description: Type of upload done. Choose `file` if uploading a file.
+        scanOptions:
+          $ref: '#/components/schemas/ScanOptions'
+      required:
+        - folderId
+        - uploadType
     Upload:
       type: object
       properties:


### PR DESCRIPTION
## Description

As mentioned in issue #2704, the `openapiv2.yaml` file fails to include all required information when making a v2 post upload request using the `multipart/form-data` content-type. This PR aims to fix this.

### Changes

In #2634, the documentation was updated for requests with content-type `application/json` to shift parameters from headers to the request body. However, the scenario of `multipart/form-data` content-type request was overlooked. Therefore, this case has been addressed to pass all necessary information for the endpoint.

![image](https://github.com/fossology/fossology/assets/119073504/8eb26d0d-c9ee-4747-bfa9-6701bf5b9321)


## How to test

Load `openapiv2.yaml` file in Swagger-Editor and fire up a `POST` request to `/uploads` endpoint with content-type: `multipart/form-data`. The endpoint will behave as expected. 
<img src="https://github.com/fossology/fossology/assets/119073504/38a6a080-8f71-45c8-b812-ea0251e82d3c" width="50%" height="50%">

CC @GMishx @Akashsah2003 