### PR TITLE
fix(reportutils): use groupId to get concludedlicense

### DIFF
--- a/src/lib/php/Report/ReportUtils.php
+++ b/src/lib/php/Report/ReportUtils.php
@@ -244,7 +244,7 @@ class ReportUtils
         $filesWithLicenses[$clearingDecision->getUploadTreeId()]
           ->addAcknowledgement($clearingLicense->getAcknowledgement());
         $reportedLicenseId = $this->licenseMap->getProjectedId($clearingLicense->getLicenseId());
-        $concludedLicense = $this->licenseDao->getLicenseById($reportedLicenseId);
+        $concludedLicense = $this->licenseDao->getLicenseById($reportedLicenseId, $groupId);
         if ($clearingEvent->getReportinfo()) {
           $customLicenseText = $clearingEvent->getReportinfo();
           $reportedLicenseShortname = $concludedLicense->getShortName() . '-' .
@@ -271,7 +271,7 @@ class ReportUtils
           $filesWithLicenses[$clearingDecision->getUploadTreeId()]
             ->addConcludedLicense($reportLicId);
           if (!array_key_exists($reportLicId, $licensesInDocument)) {
-            $licenseObj = $this->licenseDao->getLicenseById($reportedLicenseId);
+            $licenseObj = $this->licenseDao->getLicenseById($reportedLicenseId, $groupId);
             $listedLicense = !StringOperation::stringStartsWith(
               $licenseObj->getSpdxId(), LicenseRef::SPDXREF_PREFIX);
             $licensesInDocument[$reportLicId] = (new SpdxLicenseInfo())


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

In `getFilesWithLicensesFromClearings` method of `ReportUtils.php` `getLicenseById` method of `licenseDao` is called without passing `groupId` as an argument. In case of candidate license it is not present in license_ref and when userId is not stored in the session groupId should be used but is currently not used. So `getLicenseById` returns `null`.

### Changes

`$groupId` is passed in the `getLicenseById` method of licenseDao when it is called in `getFilesWithLicensesFromClearings`.

## How to test

1.) Create a test file with SPDX-License-Identifier: LicenseRef-123 or any custom license identifier with LicenseRef- prefix.
2.) Scan the file with ojo and clear it.
3.) Export SPDX RDF report.

Fixes #2706 

CC @GMishx @shaheemazmalmmd 
