### PR TITLE
feat(api): Upgrade User & Group APIs to Version 2

### DIFF
--- a/src/www/ui/api/Helper/UserHelper.php
+++ b/src/www/ui/api/Helper/UserHelper.php
@@ -17,6 +17,7 @@ use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\UserDao;
 use Fossology\UI\Api\Models\Info;
 use Fossology\UI\Api\Models\InfoType;
+use Fossology\UI\Api\Models\ApiVersion;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -40,7 +41,7 @@ class UserHelper
     $this->user_pk = $user_pk;
   }
 
-  public function modifyUserDetails($reqBody)
+  public function modifyUserDetails($reqBody, $version = ApiVersion::V1)
   {
     global $container;
     $restHelper = $container->get('helper.restHelper');
@@ -50,7 +51,7 @@ class UserHelper
     $SessionUserRec = $userEditObj->GetUserRec($sessionOwnerUser_pk);
     $SessionIsAdmin = $userEditObj->IsSessionAdmin($SessionUserRec);
 
-    $symReq = $this->createSymRequest($reqBody);
+    $symReq = $this->createSymRequest($reqBody, $version);
     if (!$SessionIsAdmin) {
       $returnVal = new Info(403, "The session owner is not an admin!", InfoType::INFO);
     } else {
@@ -70,7 +71,7 @@ class UserHelper
    * @param array $userDetails parsed from request body
    * @return Request $symfonyRequest
    */
-  public function createSymRequest($userDetails)
+  public function createSymRequest($userDetails, $version = ApiVersion::V1)
   {
     global $container;
     $restHelper = $container->get('helper.restHelper');
@@ -90,8 +91,8 @@ class UserHelper
     $symfonyRequest->request->set('public', $userDetails['defaultVisibility'] ?? $user['upload_visibility']);
     $symfonyRequest->request->set('default_folder_fk', $userDetails['defaultFolderId'] ?? $user['default_folder_fk']);
     $symfonyRequest->request->set('user_desc', $userDetails['description'] ?? $user['user_desc']);
-    $symfonyRequest->request->set('_pass1', $userDetails['user_pass'] ?? null);
-    $symfonyRequest->request->set('_pass2', $userDetails['user_pass'] ?? null);
+    $symfonyRequest->request->set('_pass1', $userDetails[$version == ApiVersion::V2 ? 'userPass' : 'user_pass'] ?? null);
+    $symfonyRequest->request->set('_pass2', $userDetails[$version == ApiVersion::V2 ? 'userPass' : 'user_pass'] ?? null);
     $symfonyRequest->request->set('_blank_pass', $userDetails['_blank_pass'] ?? "");
     $symfonyRequest->request->set('user_status', $userDetails['user_status'] ?? $user['user_status']);
     $symfonyRequest->request->set('user_email', $userDetails['email'] ?? $user['user_email']);
@@ -125,8 +126,8 @@ class UserHelper
       if (isset($userDetails['agents']['ojo'])) {
         $newAgents['Check_agent_ojo'] = $userDetails['agents']['ojo'] ? 1 : 0;
       }
-      if (isset($userDetails['agents']['copyright_email_author'])) {
-        $newAgents['Check_agent_copyright'] = $userDetails['agents']['copyright_email_author'] ? 1 : 0;
+      if (isset($userDetails['agents'][$version == ApiVersion::V2 ? 'copyrightEmailAuthor' : 'copyright_email_author'])) {
+        $newAgents['Check_agent_copyright'] = $userDetails['agents'][$version == ApiVersion::V2 ? 'copyrightEmailAuthor' : 'copyright_email_author'] ? 1 : 0;
       }
       if (isset($userDetails['agents']['ecc'])) {
         $newAgents['Check_agent_ecc'] = $userDetails['agents']['ecc'] ? 1 : 0;

--- a/src/www/ui/api/Models/Analysis.php
+++ b/src/www/ui/api/Models/Analysis.php
@@ -103,14 +103,14 @@ class Analysis
    * @param array $analysisArray Associative boolean array
    * @return Analysis Current object
    */
-  public function setUsingArray($analysisArray)
+  public function setUsingArray($analysisArray, $version = ApiVersion::V1)
   {
     if (array_key_exists("bucket", $analysisArray)) {
       $this->bucket = filter_var($analysisArray["bucket"],
         FILTER_VALIDATE_BOOLEAN);
     }
-    if (array_key_exists("copyright_email_author", $analysisArray)) {
-      $this->copyright = filter_var($analysisArray["copyright_email_author"],
+    if (array_key_exists(($version == ApiVersion::V1? "copyright_email_author" : "copyrightEmailAuthor"), $analysisArray)) {
+      $this->copyright = filter_var($analysisArray[$version == ApiVersion::V1? "copyright_email_author" : "copyrightEmailAuthor"],
         FILTER_VALIDATE_BOOLEAN);
     }
     if (array_key_exists("ecc", $analysisArray)) {
@@ -349,19 +349,34 @@ class Analysis
    * Get the object as an associative array
    * @return array
    */
-  public function getArray()
+  public function getArray($version = ApiVersion::V1)
   {
-    return [
-      "bucket"    => $this->bucket,
-      "copyright_email_author" => $this->copyright,
-      "ecc"       => $this->ecc,
-      "keyword"   => $this->keyword,
-      "mimetype"  => $this->mimetype,
-      "monk"      => $this->monk,
-      "nomos"     => $this->nomos,
-      "ojo"       => $this->ojo,
-      "reso"       => $this->reso,
-      "package"   => $this->pkgagent
-    ];
+    if ($version == ApiVersion::V2) {
+      return [
+        "bucket"    => $this->bucket,
+        "copyrightEmailAuthor" => $this->copyright,
+        "ecc"       => $this->ecc,
+        "keyword"   => $this->keyword,
+        "mimetype"  => $this->mimetype,
+        "monk"      => $this->monk,
+        "nomos"     => $this->nomos,
+        "ojo"       => $this->ojo,
+        "reso"       => $this->reso,
+        "package"   => $this->pkgagent
+      ];
+    } else {
+      return [
+        "bucket"    => $this->bucket,
+        "copyright_email_author" => $this->copyright,
+        "ecc"       => $this->ecc,
+        "keyword"   => $this->keyword,
+        "mimetype"  => $this->mimetype,
+        "monk"      => $this->monk,
+        "nomos"     => $this->nomos,
+        "ojo"       => $this->ojo,
+        "reso"       => $this->reso,
+        "package"   => $this->pkgagent
+      ];
+    }
   }
 }

--- a/src/www/ui/api/Models/User.php
+++ b/src/www/ui/api/Models/User.php
@@ -218,8 +218,10 @@ class User
    * Get user element as an associative array
    * @return array
    */
-  public function getArray()
+  public function getArray($version = ApiVersion::V1)
   {
+    global $container;
+    $restHelper = $container->get('helper.restHelper');
     $returnUser = array();
     $returnUser["id"] = $this->id;
     $returnUser["name"] = $this->name;
@@ -232,13 +234,13 @@ class User
       $returnUser["rootFolderId"] = $this->rootFolderId;
     }
     if ($this->defaultGroup !== null) {
-      $returnUser["defaultGroup"] = $this->defaultGroup;
+      $returnUser["defaultGroup"] = $version == ApiVersion::V2 ? $restHelper->getUserDao()->getGroupNameById($this->defaultGroup) : $this->defaultGroup;
     }
     if ($this->emailNotification !== null) {
       $returnUser["emailNotification"] = $this->emailNotification;
     }
     if ($this->agents !== null) {
-      $returnUser["agents"] = $this->analysis->getArray();
+      $returnUser["agents"] = $this->analysis->getArray($version);
     }
     if ($this->defaultBucketPool !== null) {
       $returnUser["defaultBucketpool"] = $this->defaultBucketPool;

--- a/src/www/ui/api/Models/UserGroupMember.php
+++ b/src/www/ui/api/Models/UserGroupMember.php
@@ -87,11 +87,18 @@ class UserGroupMember
    *
    * @return array
    */
-  public function getArray()
+  public function getArray($version=ApiVersion::V1)
   {
-    return [
-      'user' => $this->user->getArray(),
-      'group_perm' => intval($this->group_perm)
-    ];
+    if ($version==ApiVersion::V2) {
+      return [
+        'user' => $this->user->getArray($version),
+        'groupPerm' => intval($this->group_perm)
+      ];
+    } else {
+      return [
+        'user' => $this->user->getArray($version),
+        'group_perm' => intval($this->group_perm)
+      ];
+    }
   }
 }

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -2290,7 +2290,7 @@ paths:
                 - $ref: '#/components/schemas/User'
                 - type: object
                   properties:
-                    user_pass:
+                    userPass:
                       type: string
                     defaultVisibility:
                       type: string
@@ -2306,7 +2306,7 @@ paths:
                 - $ref: '#/components/schemas/User'
                 - type: object
                   properties:
-                    user_pass:
+                    userPass:
                       type: string
                     defaultVisibility:
                       type: string
@@ -2354,24 +2354,24 @@ paths:
                   $ref: '#/components/schemas/User'
         default:
           $ref: '#/components/responses/defaultResponse'
-  /users/{id}:
+  /users/{name}:
     parameters:
-      - name: id
+      - name: name
         required: true
         in: path
         schema:
-          type: integer
+          type: string
     get:
-      operationId: getUserById
+      operationId: getUserByName
       tags:
         - User
         - Admin
-      summary: Get user by id
+      summary: Get user by name
       description: >
-        Get one single user by id
+        Get one single user by name
       responses:
         '200':
-          description: User with the given id
+          description: User with the given name
           content:
             application/json:
               schema:
@@ -2379,13 +2379,13 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
     put:
-      operationId: modifyUserById
+      operationId: modifyUserByName
       tags:
         - User
         - Admin
-      summary: Edit user details by id
+      summary: Edit user details by name
       description: >
-        Edit user details by id
+        Edit user details by name
       requestBody:
         required: true
         content:
@@ -2395,7 +2395,7 @@ paths:
                 - $ref: '#/components/schemas/User'
                 - type: object
                   properties:
-                    user_pass:
+                    userPass:
                       type: string
                     defaultFolderId:
                       type: integer
@@ -2411,7 +2411,7 @@ paths:
                 - $ref: '#/components/schemas/User'
                 - type: object
                   properties:
-                    user_pass:
+                    userPass:
                       type: string
                     defaultFolderId:
                       type: integer
@@ -2450,13 +2450,13 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
     delete:
-      operationId: deleteUserById
+      operationId: deleteUserByName
       tags:
         - User
         - Admin
-      summary: Delete user by id
+      summary: Delete user by name
       description: >
-        Delete a single user by id
+        Delete a single user by name
       responses:
         '202':
           description: User will be deleted
@@ -2480,13 +2480,6 @@ paths:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/User'
-                  - type: object
-                    properties:
-                      default_group:
-                        type: string
-                        description: Default group of the user
-                        example:
-                          "fossy"
         default:
           $ref: '#/components/responses/defaultResponse'
   /users/tokens:
@@ -2554,7 +2547,7 @@ paths:
                   - $ref: '#/components/schemas/Info'
                   - type: object
                     properties:
-                      active_tokens:
+                      activeTokens:
                         $ref: '#/components/schemas/Token'
         '400':
           description: Invalid request
@@ -3673,7 +3666,7 @@ paths:
         Create a new user group
       parameters:
         - name: name
-          in: header
+          in: query
           required: true
           description: Name of the new group
           schema:
@@ -3699,21 +3692,21 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-  /groups/{id}:
+  /groups/{name}:
     parameters:
-      - name: id
+      - name: name
         required: true
-        description: Id of the group
+        description: Name of the group
         in: path
         schema:
-          type: integer
+          type: string
     delete:
-      operationId: deleteGroupById
+      operationId: deleteGroupByName
       tags:
         - Groups
-      summary: Delete group by id
+      summary: Delete group by name
       description: >
-        Deletes a single group by id.
+        Deletes a single group by name.
       responses:
         '202':
           description: User group will be deleted
@@ -3723,27 +3716,27 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
-  /groups/{id}/user/{userId}:
+  /groups/{name}/user/{userName}:
     parameters:
-      - name: id
+      - name: name
         required: true
-        description: Id of the group
+        description: Name of the group
         in: path
         schema:
-          type: integer
-      - name: userId
+          type: string
+      - name: userName
         required: true
-        description: user id of the member
+        description: user name of the member
         in: path
         schema:
-          type: integer
+          type: string
     delete:
-      operationId: deleteGroupMemberByGroupIdAndUserId
+      operationId: deleteGroupMemberByGroupNameAndUserName
       tags:
         - Groups
-      summary: Delete group member by groupId and userId
+      summary: Delete group member by groupName and userName
       description: >
-        Deletes a single group member by groupId and userId
+        Deletes a single group member by groupName and userName
       responses:
         '200':
           description: User will be removed from group.
@@ -3808,7 +3801,7 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
     put:
-      operationId: updatePermissionByGroupIdAndUserId
+      operationId: updatePermissionByGroupNameAndUserName
       tags:
         - User
         - Groups
@@ -3872,14 +3865,14 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
-  /groups/{id}/members:
+  /groups/{name}/members:
     parameters:
-      - name: id
+      - name: name
         in: path
         required: true
-        description: ID of the group
+        description: Name of the group
         schema:
-          type: integer
+          type: string
     get:
       operationId: getGroupUsersWithRoles
       tags:
@@ -5232,7 +5225,7 @@ components:
         id:
           type: string
           description: Token Id
-        token_name:
+        name:
           type: string
           description: Name of the Token
         created:
@@ -5240,7 +5233,7 @@ components:
           format: date
           description: Denotes when the token was created
           example: 2022-07-11
-        token_expire:
+        expire:
           type: string
           format: date
           description: Denotes when the token was created
@@ -5310,8 +5303,8 @@ components:
           type: boolean
           description: enable email notification when upload scan completes
         defaultGroup:
-          type: integer
-          description: Default group id of the user
+          type: string
+          description: Default group name of the user
         agents:
           $ref: '#/components/schemas/Analysis'
         defaultBucketpool:
@@ -5326,7 +5319,7 @@ components:
         bucket:
           type: boolean
           description: Should bucket analysis be run on this upload
-        copyright_email_author:
+        copyrightEmailAuthor:
           type: boolean
           description: Should Copyright/Email/URL/Author Analysis be run on this upload.
         ecc:
@@ -6190,7 +6183,7 @@ components:
       properties:
         user:
           $ref: '#/components/schemas/User'
-        group_perm:
+        groupPerm:
           type: integer
           description: Permission of the user in the group.
           example: 1

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -162,6 +162,9 @@ if ($dbConnected) {
   return 0;
 }
 
+// Regex for matching a valid path parameter
+$pattern = "[\\w\\d\\-\\.@_]+}";
+
 //////////////////////////OPTIONS/////////////////////
 $app->options('/{routes:.+}', AuthController::class . ':optionsVerification');
 
@@ -245,12 +248,12 @@ $app->group('/uploads',
 
 ////////////////////////////ADMIN-USERS/////////////////////
 $app->group('/users',
-  function (\Slim\Routing\RouteCollectorProxy $app) {
-    $app->get('[/{id:\\d+}]', UserController::class . ':getUsers');
-    $app->put('[/{id:\\d+}]', UserController::class . ':updateUser');
-    $app->post('', UserController::class . ':addUser');
-    $app->delete('/{id:\\d+}', UserController::class . ':deleteUser');
+  function (\Slim\Routing\RouteCollectorProxy $app) use ($pattern) {
     $app->get('/self', UserController::class . ':getCurrentUser');
+    $app->get("[/{pathParam:$pattern]", UserController::class . ':getUsers');
+    $app->put("/{pathParam:$pattern", UserController::class . ':updateUser');
+    $app->post('', UserController::class . ':addUser');
+    $app->delete("/{pathParam:$pattern", UserController::class . ':deleteUser');
     $app->post('/tokens', UserController::class . ':createRestApiToken');
     $app->get('/tokens/{type:\\w+}', UserController::class . ':getTokens');
     $app->any('/{params:.*}', BadRequestController::class);
@@ -270,15 +273,15 @@ $app->group('/obligations',
 
 ////////////////////////////GROUPS/////////////////////
 $app->group('/groups',
-  function (\Slim\Routing\RouteCollectorProxy $app) {
+  function (\Slim\Routing\RouteCollectorProxy $app) use ($pattern) {
     $app->get('', GroupController::class . ':getGroups');
     $app->post('', GroupController::class . ':createGroup');
-    $app->post('/{id:\\d+}/user/{userId:\\d+}', GroupController::class . ':addMember');
-    $app->delete('/{id:\\d+}', GroupController::class . ':deleteGroup');
-    $app->delete('/{id:\\d+}/user/{userId:\\d+}', GroupController::class . ':deleteGroupMember');
+    $app->post("/{pathParam:$pattern/user/{userPathParam:$pattern", GroupController::class . ':addMember');
+    $app->delete("/{pathParam:$pattern", GroupController::class . ':deleteGroup');
+    $app->delete("/{pathParam:$pattern/user/{userPathParam:$pattern", GroupController::class . ':deleteGroupMember');
     $app->get('/deletable', GroupController::class . ':getDeletableGroups');
-    $app->get('/{id:\\d+}/members', GroupController::class . ':getGroupMembers');
-    $app->put('/{id:\\d+}/user/{userId:\\d+}', GroupController::class . ':changeUserPermission');
+    $app->get("/{pathParam:$pattern/members", GroupController::class . ':getGroupMembers');
+    $app->put("/{pathParam:$pattern/user/{userPathParam:$pattern", GroupController::class . ':changeUserPermission');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui_tests/api/Helper/DbHelperTest.php
+++ b/src/www/ui_tests/api/Helper/DbHelperTest.php
@@ -23,6 +23,7 @@ use Fossology\Lib\Dao\UploadDao;
 use Mockery as M;
 use Fossology\Lib\Db\ModernDbManager;
 use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\RestHelper;
 use Fossology\Lib\Auth\Auth;
 use Fossology\UI\Api\Models\User;
 use Fossology\Lib\Dao\FolderDao;
@@ -69,6 +70,9 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
    */
   protected function setUp() : void
   {
+    global $container;
+    $restHelper = M::mock(RestHelper::class);
+    $container = M::mock('ContainerBuilder');
     $this->dbManager = M::mock(ModernDbManager::class);
     $this->folderDao = M::mock(FolderDao::class);
     $this->uploadDao = M::mock(UploadDao::class);
@@ -76,6 +80,8 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     $this->dbHelper = new DbHelper($this->dbManager, $this->folderDao,
       $this->uploadDao);
     $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($restHelper);
   }
 
   /**

--- a/src/www/ui_tests/api/Models/AnalysisTest.php
+++ b/src/www/ui_tests/api/Models/AnalysisTest.php
@@ -19,6 +19,7 @@
 namespace Fossology\UI\Api\Test\Models;
 
 use Fossology\UI\Api\Models\Analysis;
+use Fossology\UI\Api\Models\ApiVersion;
 
 /**
  * @class AnalysisTest
@@ -28,26 +29,59 @@ class AnalysisTest extends \PHPUnit\Framework\TestCase
 {
   /**
    * @test
-   * -# Test for Analysis::setUsingArray()
+   * -# Test for Analysis::setUsingArray() when $version is V1
    * -# Check if the Analysis object is updated with actual array values
    */
-  public function testSetUsingArray()
+  public function testSetUsingArrayV1()
   {
-    $analysisArray = [
-      "bucket" => true,
-      "copyright_email_author" => "true",
-      "ecc" => 1,
-      "keyword" => (1==1),
-      "mime" => false,
-      "monk" => "false",
-      "nomos" => 0,
-      "ojo" => (1==2)
-    ];
+    $this->testSetUsingArray(ApiVersion::V1);
+  }
+
+  /**
+   * @test
+   * -# Test for Analysis::setUsingArray() when $version is V2
+   * -# Check if the Analysis object is updated with actual array values
+   */
+  public function testSetUsingArrayV2()
+  {
+    $this->testSetUsingArray(ApiVersion::V2);
+  }
+
+  /**
+   * @param $version version to test
+   * @return void
+   * -# Test for Analysis::setUsingArray() to check if the Analysis object is updated with actual array values
+   */
+  private function testSetUsingArray($version)
+  {
+    if($version==ApiVersion::V1){
+      $analysisArray = [
+        "bucket" => true,
+        "copyright_email_author" => "true",
+        "ecc" => 1,
+        "keyword" => (1==1),
+        "mime" => false,
+        "monk" => "false",
+        "nomos" => 0,
+        "ojo" => (1==2)
+      ];
+    } else{
+      $analysisArray = [
+        "bucket" => true,
+        "copyrightEmailAuthor" => "true",
+        "ecc" => 1,
+        "keyword" => (1==1),
+        "mime" => false,
+        "monk" => "false",
+        "nomos" => 0,
+        "ojo" => (1==2)
+      ];
+    }
 
     $expectedObject = new Analysis(true, true, true, true);
 
     $actualObject = new Analysis();
-    $actualObject->setUsingArray($analysisArray);
+    $actualObject->setUsingArray($analysisArray, $version);
 
     $this->assertEquals($expectedObject, $actualObject);
   }
@@ -84,25 +118,62 @@ class AnalysisTest extends \PHPUnit\Framework\TestCase
 
   /**
    * @test
-   * -# Test for Analysis::getArray()
+   * -# Test the data format returned by Analysis::getArray($version) model when $version is V1
    * -# Create expected array
    * -# Create test object and set the values
    * -# Get the array from object and match with expected array
    */
-  public function testDataFormat()
+  public function testDataFormatV1()
   {
-    $expectedArray = [
-      "bucket"    => true,
-      "copyright_email_author" => true,
-      "ecc"       => false,
-      "keyword"   => false,
-      "mimetype"  => true,
-      "monk"      => false,
-      "nomos"     => true,
-      "ojo"       => true,
-      "package"   => false,
-      "reso"      => true
-    ];
+    $this->testDataFormat(ApiVersion::V1);
+  }
+
+  /**
+   * @test
+   * -# Test the data format returned by Analysis::getArray($version) model when $version is V2
+   * -# Create expected array
+   * -# Create test object and set the values
+   * -# Get the array from object and match with expected array
+   */
+  public function testDataFormatV2()
+  {
+    $this->testDataFormat(ApiVersion::V2);
+  }
+
+  /**
+   * @param $version version to test
+   * @return void
+   * -# Test the data format returned by Upload::getArray($version) model 
+   */
+  private function testDataFormat($version)
+  {
+    if($version==ApiVersion::V1){
+      $expectedArray = [
+        "bucket"    => true,
+        "copyright_email_author" => true,
+        "ecc"       => false,
+        "keyword"   => false,
+        "mimetype"  => true,
+        "monk"      => false,
+        "nomos"     => true,
+        "ojo"       => true,
+        "package"   => false,
+        "reso"      => true
+      ];
+    } else{
+      $expectedArray = [
+        "bucket"    => true,
+        "copyrightEmailAuthor" => true,
+        "ecc"       => false,
+        "keyword"   => false,
+        "mimetype"  => true,
+        "monk"      => false,
+        "nomos"     => true,
+        "ojo"       => true,
+        "package"   => false,
+        "reso"      => true
+      ];
+    }
     $actualObject = new Analysis();
     $actualObject->setBucket(true);
     $actualObject->setCopyright(true);
@@ -111,6 +182,6 @@ class AnalysisTest extends \PHPUnit\Framework\TestCase
     $actualObject->setOjo(true);
     $actualObject->setReso(true);
 
-    $this->assertEquals($expectedArray, $actualObject->getArray());
+    $this->assertEquals($expectedArray, $actualObject->getArray($version));
   }
 }

--- a/src/www/ui_tests/api/Models/UserTest.php
+++ b/src/www/ui_tests/api/Models/UserTest.php
@@ -12,7 +12,12 @@
 
 namespace Fossology\UI\Api\Test\Models;
 
+use Fossology\Lib\Dao\UserDao;
 use Fossology\UI\Api\Models\User;
+use Fossology\UI\Api\Models\ApiVersion;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Helper\DbHelper;
+use Mockery as M;
 
 require_once dirname(dirname(dirname(dirname(__DIR__)))) .
   '/lib/php/Plugin/FO_Plugin.php';
@@ -24,33 +29,140 @@ require_once dirname(dirname(dirname(dirname(__DIR__)))) .
 class UserTest extends \PHPUnit\Framework\TestCase
 {
   /**
-   * @test
-   * -# Test the data format returned by User::getArray() model
+   * @var integer $assertCountBefore
+   * Assertions before running tests
    */
-  public function testDataFormat()
+  private $assertCountBefore;
+  /**
+   * @var DbHelper $dbHelper
+   * DbHelper mock
+   */
+  private $dbHelper;
+  /**
+   * @var UserDao $userDao
+   * UserDao mock
+   */
+  private $userDao;
+
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp() : void
   {
-    $expectedCurrentUser = [
-      "id"           => 2,
-      "name"         => 'fossy',
-      "description"  => 'super user',
-      "email"        => 'fossy@localhost',
-      "accessLevel"  => 'admin',
-      "rootFolderId" => 2,
-      "defaultGroup" => 0,
-      "emailNotification" => true,
-      "agents"       => [
-        "bucket"    => true,
-        "copyright_email_author" => true,
-        "ecc"       => false,
-        "keyword"   => false,
-        "mimetype"  => false,
-        "monk"      => false,
-        "nomos"     => true,
-        "ojo"       => true,
-        "package"   => false,
-        "reso"      => false
-      ]
-    ];
+    global $container;
+    $container = M::mock('ContainerBuilder');
+    $this->restHelper = M::mock(RestHelper::class);
+    $this->userDao = M::mock(UserDao::class);
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+    $this->restHelper->shouldReceive('getUserDao')
+      ->andReturn($this->userDao);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+  }
+
+  /**
+   * @brief Remove test objects
+   * @see PHPUnit_Framework_TestCase::tearDown()
+   */
+  protected function tearDown() : void
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  /**
+   * Helper function to get JSON array from response
+   *
+   * @param Response $response
+   * @return array Decoded response
+   */
+  /**
+   * @test
+   * -# Test the data format returned by User::getArray($version) model when $version is V1
+   * -# Create expected array
+   * -# Create test object and set the values
+   * -# Get the array from object and match with expected array
+   */
+  public function testDataFormatV1()
+  {
+    $this->testDataFormat(ApiVersion::V1);
+  }
+
+  /**
+   * @test
+   * -# Test the data format returned by User::getArray($version) model when $version is V2
+   * -# Create expected array
+   * -# Create test object and set the values
+   * -# Get the array from object and match with expected array
+   */
+  public function testDataFormatV2()
+  {
+    $this->testDataFormat(ApiVersion::V2);
+  }
+
+  /**
+   * @param $version version to test
+   * @return void
+   * -# Test the data format returned by User::getArray($version) model 
+   */
+  private function testDataFormat($version)
+  {
+    if($version==ApiVersion::V1){
+      $expectedCurrentUser = [
+        "id"           => 2,
+        "name"         => 'fossy',
+        "description"  => 'super user',
+        "email"        => 'fossy@localhost',
+        "accessLevel"  => 'admin',
+        "rootFolderId" => 2,
+        "defaultGroup" => 0,
+        "emailNotification" => true,
+        "agents"       => [
+          "bucket"    => true,
+          "copyright_email_author" => true,
+          "ecc"       => false,
+          "keyword"   => false,
+          "mimetype"  => false,
+          "monk"      => false,
+          "nomos"     => true,
+          "ojo"       => true,
+          "package"   => false,
+          "reso"      => false
+        ]
+      ];
+    } else{
+      $expectedCurrentUser = [
+        "id"           => 2,
+        "name"         => 'fossy',
+        "description"  => 'super user',
+        "email"        => 'fossy@localhost',
+        "accessLevel"  => 'admin',
+        "rootFolderId" => 2,
+        "defaultGroup" => "fossy",
+        "emailNotification" => true,
+        "agents"       => [
+          "bucket"    => true,
+          "copyrightEmailAuthor" => true,
+          "ecc"       => false,
+          "keyword"   => false,
+          "mimetype"  => false,
+          "monk"      => false,
+          "nomos"     => true,
+          "ojo"       => true,
+          "package"   => false,
+          "reso"      => false
+        ]
+      ];
+    }
     $expectedNonAdminUser = [
       "id"           => 8,
       "name"         => 'userii',
@@ -58,12 +170,20 @@ class UserTest extends \PHPUnit\Framework\TestCase
       "defaultGroup" => 0,
     ];
 
-    $actualCurrentUser = new User(2, 'fossy', 'super user', 'fossy@localhost',
+    $actualCurrentUserV1 = new User(2, 'fossy', 'super user', 'fossy@localhost',
       PLUGIN_DB_ADMIN, 2, true, "bucket,copyright,nomos,ojo", 0);
+
+    $this->userDao->shouldReceive('getGroupNameById')->withArgs([0])->andReturn("fossy");
+
+    $actualCurrentUserV2 = new User(2, 'fossy', 'super user', 'fossy@localhost',
+      PLUGIN_DB_ADMIN, 2, true, "bucket,copyright,nomos,ojo", "fossy");
     $actualNonAdminUser = new User(8, 'userii', 'very useri', null, null, null,
       null, null, 0);
-
-    $this->assertEquals($expectedCurrentUser, $actualCurrentUser->getArray());
+    if ($version == ApiVersion::V2) {
+      $this->assertEquals($expectedCurrentUser, $actualCurrentUserV2->getArray($version));
+    } else {
+      $this->assertEquals($expectedCurrentUser, $actualCurrentUserV1->getArray($version));
+    }
     $this->assertEquals($expectedNonAdminUser, $actualNonAdminUser->getArray());
   }
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This PR aims to upgrade the `/users` and `/group` endpoints to v2 in accordance with the new upgrade guidelines.

### Changes

* Completed all tasks mentioned in #2709.
* Updated `openapiv2.yaml` to have all documentation changes.
* Modified models & unit tests to make them version aware.


### How to Test

* Open the `openapiv2.yaml` file in Swagger Editor and test all the updated endpoints for v2 specific responses. All function as intended.
* Execute unit tests, all pass without any issues.



CC @GMishx @shaheemazmalmmd @dushimsam 
