### PR TITLE
fix(ui): 'Ignore SCM files' option is always disabled on upload

### DIFF
--- a/src/www/ui/page/UploadSrvPage.php
+++ b/src/www/ui/page/UploadSrvPage.php
@@ -251,7 +251,7 @@ class UploadSrvPage extends UploadPageBase
 
     /* schedule agents */
     $unpackplugin = &$Plugins[plugin_find_id("agent_unpack")];
-    $unpackArgs = intval($request->get('scm') == 1) ? '-I' : '';
+    $unpackargs = intval($request->get('scm') == 1) ? '-I' : '';
     $ununpack_jq_pk = $unpackplugin->AgentAdd($jobpk, $uploadId, $ErrorMsg, array("wget_agent"), $unpackargs);
     if ($ununpack_jq_pk < 0) {
       return array(false, $text, _($ErrorMsg));


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

When upload files using "Upload" - "From Server" page the "Ignore SCM files" option is always evaluated as disabled. This happens due to the typo in "unpackargs" variable in "src/www/ui/page/UploadSrvPage.php"

### Changes

1) Variable "unpackArgs" renamed to "unpackargs"

## How to test

1) Deploy FOSSOlogy instance locally and setup it accordingly
2) Upload some repository using "Upload" - "From Server" page with disabled "Ignore SCM files" option
3) Navigate to "Browse" page and check your uploaded repository content - it should contain ".git" directory
4) Repeat step 2 with enabled "Ignore SCM files" option
5) Navigate to "Browse" page and check your uploaded repository content - it should not contain any ".git*" directories and files