### PR TITLE
feat(api): New endpoints to get/delete/restore/update user copyright findings

### DIFF
--- a/src/copyright/ui/ajax-copyright-hist.php
+++ b/src/copyright/ui/ajax-copyright-hist.php
@@ -340,6 +340,9 @@ count(*) AS copyright_count " .
       case "scancode_statement":
         $tableName = "scancode_copyright";
         break;
+      case "user_statement":
+        $tableName = "copyright_decision";
+        break;
       case "scancode_email":
       case "scancode_author":
       case "scancode_url":

--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -665,6 +665,7 @@ WHERE $withHash ( ut.lft BETWEEN $1 AND $2 ) $agentFilter AND ut.upload_fk = $3"
     }
 
     $params = array($left, $right, $upload_pk);
+    $orderString = 'ORDER BY copyright_count desc, textfinding desc';
 
     $activatedClause = "cd.is_enabled = 'false'";
     if ($activated) {
@@ -683,7 +684,7 @@ WHERE $withHash ( ut.lft BETWEEN $1 AND $2 ) $agentFilter AND ut.upload_fk = $3"
     $countAllQuery = "SELECT count(*) FROM (SELECT
     (CASE WHEN (cd.textfinding IS NULL OR cd.textfinding = '') THEN '' ELSE cd.textfinding END) AS mcontent
     $unorderedQuery GROUP BY cd.textfinding) as K;";
-    $iTotalRecordsRow = $this->dbManager->getSingleRow($countAllQuery, $params, __METHOD__,$tableName . "count.all" . ($activated ? '' : '_deactivated'));
+    $iTotalRecordsRow = $this->dbManager->getSingleRow($countAllQuery, $params, __METHOD__ . $tableName . "count.all" . ($activated ? '' : '_deactivated'));
     $iTotalRecords = $iTotalRecordsRow['count'];
 
     $range = "";
@@ -692,8 +693,8 @@ WHERE $withHash ( ut.lft BETWEEN $1 AND $2 ) $agentFilter AND ut.upload_fk = $3"
     $params[] = $limit;
     $range .= ' LIMIT $' . count($params);
 
-    $sql = "SELECT cd.textfinding AS content, cd.hash AS hash, COUNT(DISTINCT cd.copyright_decision_pk) AS copyright_count " .
-    "$unorderedQuery $grouping $range";
+    $sql = "SELECT cd.textfinding AS content, cd.hash AS hash, COUNT(*) AS copyright_count " .
+    "$unorderedQuery $grouping $orderString $range";
     $statement = __METHOD__ . $tableName . $uploadTreeTableName . ($activated ? '' : '_deactivated');
     $rows = $this->dbManager->getRows($sql, $params, $statement);
 

--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -584,6 +584,9 @@ WHERE $withHash ( ut.lft BETWEEN $1 AND $2 ) $agentFilter AND ut.upload_fk = $3"
       case "statement":
         $tableName = "copyright";
         break;
+      case "userfindingcopyright":
+        $tableName = "copyright_decision";
+        break;
       case "scancode_statement":
         $tableName = "scancode_copyright";
         break;
@@ -640,5 +643,60 @@ WHERE $withHash ( ut.lft BETWEEN $1 AND $2 ) $agentFilter AND ut.upload_fk = $3"
     $unorderedQuery$grouping) as K";
     $iTotalRecordsRow = $this->dbManager->getSingleRow($countAllQuery, $params, __METHOD__, $tableName . "count.all" . ($activated ? '' : '_deactivated'));
     return $iTotalRecordsRow['count'];
+  }
+
+  /**
+   * @brief get user copyright findings for a uploadtree
+   * @param int     $upload_pk           Upload id to get results from
+   * @param int     $item                Upload tree id of the item
+   * @param string  $uploadTreeTableName Upload tree table to use
+   * @param string  $type                Type of the statement (statement, url, email, author or ecc)
+   * @param boolean $activated           True to get activated copyrights, else false
+   * @return array[][] Array of table records, total records
+   */
+  public function getUserCopyrights($upload_pk, $item, $uploadTreeTableName, $type, $activated = true, $offset = null , $limit = null)
+  {
+    $tableName = $this->getTableName($type);
+    list($left, $right) = $this->uploadDao->getLeftAndRight($item, $uploadTreeTableName);
+
+    $sql_upload = "";
+    if ('uploadtree_a' == $uploadTreeTableName) {
+      $sql_upload = " AND UT.upload_fk=$3 ";
+    }
+
+    $params = array($left, $right, $upload_pk);
+
+    $activatedClause = "cd.is_enabled = 'false'";
+    if ($activated) {
+      $activatedClause = "cd.is_enabled IS NULL OR cd.is_enabled = 'true'";
+    }
+
+    $unorderedQuery = "FROM $tableName AS cd " .
+        "INNER JOIN $uploadTreeTableName AS UT ON cd.pfile_fk = UT.pfile_fk " .
+        "WHERE cd.textfinding!='' " .
+        "AND ( UT.lft  BETWEEN  $1 AND  $2 ) " .
+        "AND cd.user_fk IS NOT NULL " .
+        "AND ($activatedClause)" .
+        $sql_upload;
+    $grouping = " GROUP BY cd.textfinding, cd.hash ";
+
+    $countAllQuery = "SELECT count(*) FROM (SELECT
+    (CASE WHEN (cd.textfinding IS NULL OR cd.textfinding = '') THEN '' ELSE cd.textfinding END) AS mcontent
+    $unorderedQuery GROUP BY cd.textfinding) as K;";
+    $iTotalRecordsRow = $this->dbManager->getSingleRow($countAllQuery, $params, __METHOD__,$tableName . "count.all" . ($activated ? '' : '_deactivated'));
+    $iTotalRecords = $iTotalRecordsRow['count'];
+
+    $range = "";
+    $params[] = $offset;
+    $range .= ' OFFSET $' . count($params);
+    $params[] = $limit;
+    $range .= ' LIMIT $' . count($params);
+
+    $sql = "SELECT cd.textfinding AS content, cd.hash AS hash, COUNT(DISTINCT cd.copyright_decision_pk) AS copyright_count " .
+    "$unorderedQuery $grouping $range";
+    $statement = __METHOD__ . $tableName . $uploadTreeTableName . ($activated ? '' : '_deactivated');
+    $rows = $this->dbManager->getRows($sql, $params, $statement);
+
+    return array($rows, $iTotalRecords);
   }
 }

--- a/src/www/ui/api/Controllers/CopyrightController.php
+++ b/src/www/ui/api/Controllers/CopyrightController.php
@@ -62,6 +62,7 @@ class CopyrightController extends RestController
   const TYPE_ECC = 16;
   const TYPE_KEYWORD = 32;
   const TYPE_IPRA = 64;
+  const TYPE_COPYRIGHT_USERFINDINGS = 128;
 
   public function __construct($container)
   {
@@ -81,6 +82,19 @@ class CopyrightController extends RestController
   public function getFileCopyrights($request, $response, $args)
   {
     return $this->getFileCX($request, $response, $args, self::TYPE_COPYRIGHT);
+  }
+
+  /**
+   * Get all user copyright findings for a particular upload-tree
+   *
+   * @param  ServerRequestInterface $request
+   * @param  ResponseHelper         $response
+   * @param  array                  $args
+   * @return ResponseHelper
+   */
+  public function getFileUserCopyrights($request, $response, $args)
+  {
+    return $this->getFileCX($request, $response, $args, self::TYPE_COPYRIGHT_USERFINDINGS);
   }
 
   /**
@@ -489,6 +503,10 @@ class CopyrightController extends RestController
         $dataType = 'statement';
         $agentArs = 'copyright_ars';
         break;
+      case self::TYPE_COPYRIGHT_USERFINDINGS:
+        $dataType = 'userfindingcopyright';
+        $agentArs = 'copyright_ars';
+        break;
       case self::TYPE_EMAIL:
         $dataType = 'email';
         $agentArs = 'copyright_ars';
@@ -571,9 +589,15 @@ class CopyrightController extends RestController
       }
     }
     $offset = $limit * ($page - 1);
-    list($rows, $iTotalDisplayRecords, $iTotalRecords) = $this->copyrightHist
-      ->getCopyrights($uploadPk, $uploadTreeId, $uploadTreeTableName,
-        $agentId, $dataType, 'active', $statusVal, $offset, $limit);
+    if (self::TYPE_COPYRIGHT_USERFINDINGS == $cxType) {
+      list($rows, $iTotalRecords) = $this->copyrightDao
+        ->getUserCopyrights($uploadPk, $uploadTreeId, $uploadTreeTableName,
+          $dataType, $statusVal, $offset, $limit);
+    } else {
+      list($rows, $iTotalDisplayRecords, $iTotalRecords) = $this->copyrightHist
+        ->getCopyrights($uploadPk, $uploadTreeId, $uploadTreeTableName,
+          $agentId, $dataType, 'active', $statusVal, $offset, $limit);
+    }
     foreach ($rows as $row) {
       $row['count'] = intval($row['copyright_count']);
       unset($row['copyright_count']);

--- a/src/www/ui/api/Controllers/CopyrightController.php
+++ b/src/www/ui/api/Controllers/CopyrightController.php
@@ -189,6 +189,19 @@ class CopyrightController extends RestController
   }
 
   /**
+   * Delete user copyright for a particular file
+   *
+   * @param  ServerRequestInterface $request
+   * @param  ResponseHelper         $response
+   * @param  array                  $args
+   * @return ResponseHelper
+   */
+  public function deleteFileUserCopyright($request, $response, $args)
+  {
+    return $this->deleteFileCX($args, $response, self::TYPE_COPYRIGHT_USERFINDINGS);
+  }
+
+  /**
    * Delete email for a particular file
    *
    * @param  ServerRequestInterface $request
@@ -277,6 +290,19 @@ class CopyrightController extends RestController
   public function updateFileCopyright($request, $response, $args)
   {
     return $this->updateFileCx($request, $response, $args, self::TYPE_COPYRIGHT);
+  }
+
+  /**
+   * Update user copyright for a particular file
+   *
+   * @param  ServerRequestInterface $request
+   * @param  ResponseHelper         $response
+   * @param  array                  $args
+   * @return ResponseHelper
+   */
+  public function updateFileUserCopyright($request, $response, $args)
+  {
+    return $this->updateFileCx($request, $response, $args, self::TYPE_COPYRIGHT_USERFINDINGS);
   }
 
   /**
@@ -371,6 +397,19 @@ class CopyrightController extends RestController
   }
 
   /**
+   * Restore user copyright for a particular file
+   *
+   * @param  ServerRequestInterface $request
+   * @param  ResponseHelper         $response
+   * @param  array                  $args
+   * @return ResponseHelper
+   */
+  public function restoreFileUserCopyright($request, $response, $args)
+  {
+    return $this->restoreFileCx($args, $response, self::TYPE_COPYRIGHT_USERFINDINGS);
+  }
+
+  /**
    * Restore email for a particular file
    *
    * @param  ServerRequestInterface $request
@@ -449,7 +488,7 @@ class CopyrightController extends RestController
   }
 
   /**
-   * Get total number of copyrights for a particular upload-tree
+   * Get total number of scanner copyrights
    *
    * @param ServerRequestInterface $request
    * @param ResponseHelper $response
@@ -459,6 +498,35 @@ class CopyrightController extends RestController
    */
   public function getTotalFileCopyrights($request, $response, $args)
   {
+    return $this->getTotalCX($request, $response, $args, self::TYPE_COPYRIGHT);
+  }
+
+  /**
+   * Get total number of user copyright findings
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpErrorException
+   */
+  public function getTotalFileUserCopyrights($request, $response, $args)
+  {
+    return $this->getTotalCX($request, $response, $args, self::TYPE_COPYRIGHT_USERFINDINGS);
+  }
+
+  /**
+   * Get total number of copyrights for a particular upload-tree
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpErrorException
+   */
+  private function getTotalCX($request, $response, $args, $cxType)
+  {
+    $version = ApiVersion::getVersion($request);
     $uploadPk = $args["id"];
     $uploadTreeId = $args["itemId"];
     $query = $request->getQueryParams();
@@ -480,10 +548,16 @@ class CopyrightController extends RestController
       throw new HttpBadRequestException("Bad Request. Invalid query " .
         "parameter, expected values 'active' or 'inactive");
     }
-    $agentId = $this->copyrightHist->getAgentId($uploadPk, 'copyright_ars');
     $uploadTreeTableName = $this->restHelper->getUploadDao()->getUploadtreeTableName($uploadPk);
-    $returnVal = $this->copyrightDao->getTotalCopyrights($uploadPk, $uploadTreeId, $uploadTreeTableName, $agentId, 'statement', $statusVal);
-    return $response->withJson(array("total_copyrights" => intval($returnVal)), 200);
+
+    if ($cxType == self::TYPE_COPYRIGHT) {
+      $agentId = $this->copyrightHist->getAgentId($uploadPk, 'copyright_ars');
+      $returnVal = $this->copyrightDao->getTotalCopyrights($uploadPk, $uploadTreeId, $uploadTreeTableName, $agentId, 'statement', $statusVal);
+    } else if ($cxType == self::TYPE_COPYRIGHT_USERFINDINGS) {
+      $copyrightData = $this->copyrightDao->getUserCopyrights($uploadPk, $uploadTreeId, $uploadTreeTableName, 'userfindingcopyright', $statusVal);
+      $returnVal = $copyrightData[1];
+    }
+    return $response->withJson(array($version == ApiVersion::V2 ? "totalCopyrights" : "total_copyrights" => $returnVal), 200);
   }
 
   /**
@@ -636,8 +710,18 @@ class CopyrightController extends RestController
     $this->isItemExists($uploadPk, $uploadTreeId);
 
     $uploadTreeTableName = $uploadDao->getUploadTreeTableName($uploadTreeId);
-    $item = $uploadDao->getItemTreeBounds($uploadTreeId, $uploadTreeTableName);
-    $this->copyrightDao->updateTable($item, $copyrightHash, '', $userId, $cpTable, 'delete');
+    if (self::TYPE_COPYRIGHT_USERFINDINGS == $cxType) {
+      $tableName = $cpTable."_decision";
+      $decisions = $this->copyrightDao->getDecisionsFromHash($tableName, $copyrightHash,
+        $uploadPk, $uploadTreeTableName);
+      foreach ($decisions as $decision) {
+        $this->copyrightDao->removeDecision($tableName, $decision['pfile_fk'],
+          $decision[$tableName . '_pk']);
+      }
+    } else {
+      $item = $uploadDao->getItemTreeBounds($uploadTreeId, $uploadTreeTableName);
+      $this->copyrightDao->updateTable($item, $copyrightHash, '', $userId, $cpTable, 'delete');
+    }
     $returnVal = new Info(200, "Successfully removed $delName.", InfoType::INFO);
     return $response->withJson($returnVal->getArray(), $returnVal->getCode());
   }
@@ -664,8 +748,18 @@ class CopyrightController extends RestController
     $this->isItemExists($uploadPk, $uploadTreeId);
 
     $uploadTreeTableName = $this->restHelper->getUploadDao()->getuploadTreeTableName($uploadTreeId);
-    $item = $this->restHelper->getUploadDao()->getItemTreeBounds($uploadTreeId, $uploadTreeTableName);
-    $this->copyrightDao->updateTable($item, $copyrightHash, '', $userId, $cpTable, 'rollback');
+    if (self::TYPE_COPYRIGHT_USERFINDINGS == $cxType) {
+      $tableName = $cpTable."_decision";
+      $decisions = $this->copyrightDao->getDecisionsFromHash($tableName, $copyrightHash,
+        $uploadPk, $uploadTreeTableName);
+      foreach ($decisions as $decision) {
+        $this->copyrightDao->undoDecision($tableName, $decision['pfile_fk'],
+          $decision[$tableName . '_pk']);
+      }
+    } else {
+      $item = $this->restHelper->getUploadDao()->getItemTreeBounds($uploadTreeId, $uploadTreeTableName);
+      $this->copyrightDao->updateTable($item, $copyrightHash, '', $userId, $cpTable, 'rollback');
+    }
     $returnVal = new Info(200, "Successfully restored $resName.", InfoType::INFO);
     return $response->withJson($returnVal->getArray(), 200);
   }
@@ -695,8 +789,19 @@ class CopyrightController extends RestController
     $this->isItemExists($uploadPk, $uploadTreeId);
 
     $uploadTreeTableName = $this->restHelper->getUploadDao()->getuploadTreeTableName($uploadTreeId);
-    $item = $this->restHelper->getUploadDao()->getItemTreeBounds($uploadTreeId, $uploadTreeTableName);
-    $this->copyrightDao->updateTable($item, $copyrightHash, $content, $userId, $cpTable);
+    if (self::TYPE_COPYRIGHT_USERFINDINGS == $cxType) {
+      $tableName = $cpTable."_decision";
+      $decisions = $this->copyrightDao->getDecisionsFromHash($tableName, $copyrightHash,
+        $uploadPk, $uploadTreeTableName);
+      foreach ($decisions as $decision) {
+        $this->copyrightDao->saveDecision($tableName, $decision['pfile_fk'], $decision['user_fk'],
+          $decision['clearing_decision_type_fk'], $decision['description'],
+          $content, $decision['comment'], $decision[$tableName . '_pk']);
+      }
+    } else {
+      $item = $this->restHelper->getUploadDao()->getItemTreeBounds($uploadTreeId, $uploadTreeTableName);
+      $this->copyrightDao->updateTable($item, $copyrightHash, $content, $userId, $cpTable);
+    }
     $returnVal = new Info(200, "Successfully Updated $resName.", InfoType::INFO);
     return $response->withJson($returnVal->getArray(), 200);
   }
@@ -713,6 +818,10 @@ class CopyrightController extends RestController
       case self::TYPE_COPYRIGHT:
         $dataType = 'statement';
         $dispName = 'copyright';
+        break;
+      case self::TYPE_COPYRIGHT_USERFINDINGS:
+        $dataType = 'statement';
+        $dispName = 'user-copyright';
         break;
       case self::TYPE_EMAIL:
         $dispName = $dataType = 'email';

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -2663,6 +2663,31 @@ paths:
       description: Returns the list of user copyright findings associated with the file
       responses: *cxGetResponses
 
+  /uploads/{id}/item/{itemId}/user-copyrights/{hash}:
+    parameters: *cxUpdateParams
+    delete:
+      operationId: deleteFileUserCopyright
+      tags:
+        - Copyrights
+      summary: Deletes user copyright for a file
+      description: Deletes user copyright statement for a particular file
+      responses: *cxUpdateResponses
+    patch:
+      operationId: restoreFileUserCopyright
+      tags:
+        - Copyrights
+      summary: Restores user copyright for a file
+      description: Restores user copyright statement for a particular file
+      responses: *cxUpdateResponses
+    put:
+      operationId: updateFileUserCopyright
+      tags:
+        - Copyrights
+      summary: Updates user copyright for a file
+      description: Updates user copyright statement for a particular file
+      requestBody: *cxUpdateBody
+      responses: *cxUpdateResponses
+
   /uploads/{id}/item/{itemId}/emails:
     parameters: *cxGetParams
     get:
@@ -3572,6 +3597,72 @@ paths:
                         total_copyrights:
                           type: integer
                           description: Total Number of copyrights for the uploadtree
+                          example:
+                            125
+        '400':
+          description: "Bad Request. 'upload' is a required query param"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Upload is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Upload does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /uploads/{id}/item/{ItemId}/totalusercopyrights:
+    parameters:
+      - name: id
+        required: true
+        description: Upload Id
+        in: path
+        schema:
+          type: integer
+      - name: ItemId
+        required: true
+        description: Upload Tree ID
+        in: path
+        schema:
+          type: integer
+      - name: status
+        required: true
+        in: query
+        description: status of the copyright
+        schema:
+          type: string
+          enum:
+            - active
+            - inactive
+    get:
+      operationId: getTotalFileUserCopyrights
+      tags:
+        - Copyrights
+      summary: Get the total user copyright findings of the mentioned upload tree ID
+      description: Returns the total number of user copyright findings associated with the file
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  allOf:
+                    - type: object
+                      properties:
+                        total_copyrights:
+                          type: integer
+                          description: Total Number of user copyright findings for the uploadtree
                           example:
                             125
         '400':

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -2653,6 +2653,16 @@ paths:
       requestBody: *cxUpdateBody
       responses: *cxUpdateResponses
 
+  /uploads/{id}/item/{itemId}/user-copyrights:
+    parameters: *cxGetParams
+    get:
+      operationId: getFileUserCopyrights
+      tags:
+        - Copyrights
+      summary: Get the user copyright findings of the mentioned upload tree ID
+      description: Returns the list of user copyright findings associated with the file
+      responses: *cxGetResponses
+
   /uploads/{id}/item/{itemId}/emails:
     parameters: *cxGetParams
     get:

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -2603,6 +2603,31 @@ paths:
       summary: Get the user copyright findings of the mentioned upload tree ID
       description: Returns the list of user copyright findings associated with the file
       responses: *cxGetResponses
+  
+  /uploads/{id}/item/{itemId}/user-copyrights/{hash}:
+    parameters: *cxUpdateParams
+    delete:
+      operationId: deleteFileUserCopyright
+      tags:
+        - Copyrights
+      summary: Deletes user copyright for a file
+      description: Deletes user copyright statement for a particular file
+      responses: *cxUpdateResponses
+    patch:
+      operationId: restoreFileUserCopyright
+      tags:
+        - Copyrights
+      summary: Restores user copyright for a file
+      description: Restores user copyright statement for a particular file
+      responses: *cxUpdateResponses
+    put:
+      operationId: updateFileUserCopyright
+      tags:
+        - Copyrights
+      summary: Updates user copyright for a file
+      description: Updates user copyright statement for a particular file
+      requestBody: *cxUpdateBody
+      responses: *cxUpdateResponses
 
   /uploads/{id}/item/{itemId}/emails:
     parameters: *cxGetParams
@@ -3510,9 +3535,75 @@ paths:
                   allOf:
                     - type: object
                       properties:
-                        total_copyrights:
+                        totalCopyrights:
                           type: integer
                           description: Total Number of copyrights for the uploadtree
+                          example:
+                            125
+        '400':
+          description: "Bad Request. 'upload' is a required query param"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Upload is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Upload does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /uploads/{id}/item/{ItemId}/totalusercopyrights:
+    parameters:
+      - name: id
+        required: true
+        description: Upload Id
+        in: path
+        schema:
+          type: integer
+      - name: ItemId
+        required: true
+        description: Upload Tree ID
+        in: path
+        schema:
+          type: integer
+      - name: status
+        required: true
+        in: query
+        description: status of the copyright
+        schema:
+          type: string
+          enum:
+            - active
+            - inactive
+    get:
+      operationId: getTotalFileUserCopyrights
+      tags:
+        - Copyrights
+      summary: Get the total user copyright findings of the mentioned upload tree ID
+      description: Returns the total number of user copyright findings associated with the file
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  allOf:
+                    - type: object
+                      properties:
+                        totalCopyrights:
+                          type: integer
+                          description: Total Number of user copyright findings for the uploadtree
                           example:
                             125
         '400':

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -2594,6 +2594,16 @@ paths:
       requestBody: *cxUpdateBody
       responses: *cxUpdateResponses
 
+  /uploads/{id}/item/{itemId}/user-copyrights:
+    parameters: *cxGetParams
+    get:
+      operationId: getFileUserCopyrights
+      tags:
+        - Copyrights
+      summary: Get the user copyright findings of the mentioned upload tree ID
+      description: Returns the list of user copyright findings associated with the file
+      responses: *cxGetResponses
+
   /uploads/{id}/item/{itemId}/emails:
     parameters: *cxGetParams
     get:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -204,7 +204,6 @@ $app->group('/uploads',
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/bulk-history', UploadTreeController::class . ':getBulkHistory');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/clearing-history', UploadTreeController::class . ':getClearingHistory');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/highlight', UploadTreeController::class . ':getHighlightEntries');
-    $app->get('/{id:\\d+}/item/{itemId:\\d+}/totalcopyrights', CopyrightController::class . ':getTotalFileCopyrights');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/tree/view', UploadTreeController::class . ':getTreeView');
     $app->get('/{id:\\d+}/item/{itemId:\\d+}/info', FileInfoController::class . ':getItemInfo');
     $app->post('/{id:\\d+}/item/{itemId:\\d+}/bulk-scan', UploadTreeController::class . ':scheduleBulkScan');
@@ -217,7 +216,12 @@ $app->group('/uploads',
       $app->delete('/copyrights/{hash:.*}', CopyrightController::class . ':deleteFileCopyright');
       $app->patch('/copyrights/{hash:.*}', CopyrightController::class . ':restoreFileCopyright');
       $app->put('/copyrights/{hash:.*}', CopyrightController::class . ':updateFileCopyright');
+      $app->get('/totalcopyrights', CopyrightController::class . ':getTotalFileCopyrights');
       $app->get('/user-copyrights', CopyrightController::class . ':getFileUserCopyrights');
+      $app->delete('/user-copyrights/{hash:.*}', CopyrightController::class . ':deleteFileUserCopyright');
+      $app->patch('/user-copyrights/{hash:.*}', CopyrightController::class . ':restoreFileUserCopyright');
+      $app->put('/user-copyrights/{hash:.*}', CopyrightController::class . ':updateFileUserCopyright');
+      $app->get('/totalusercopyrights', CopyrightController::class . ':getTotalFileUserCopyrights');
       $app->get('/emails', CopyrightController::class . ':getFileEmail');
       $app->delete('/emails/{hash:.*}', CopyrightController::class . ':deleteFileEmail');
       $app->patch('/emails/{hash:.*}', CopyrightController::class . ':restoreFileEmail');

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -217,6 +217,7 @@ $app->group('/uploads',
       $app->delete('/copyrights/{hash:.*}', CopyrightController::class . ':deleteFileCopyright');
       $app->patch('/copyrights/{hash:.*}', CopyrightController::class . ':restoreFileCopyright');
       $app->put('/copyrights/{hash:.*}', CopyrightController::class . ':updateFileCopyright');
+      $app->get('/user-copyrights', CopyrightController::class . ':getFileUserCopyrights');
       $app->get('/emails', CopyrightController::class . ':getFileEmail');
       $app->delete('/emails/{hash:.*}', CopyrightController::class . ':deleteFileEmail');
       $app->patch('/emails/{hash:.*}', CopyrightController::class . ':restoreFileEmail');


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This PR adds new endpoints to get/delete/restore/update/count user copyright findings via API.

### Changes

1. Added the following new endpoints
  - GET `uploads/{id}/item/{itemId}/user-copyrights` : To retrieve user copyright findings.
  - DELETE `uploads/{id}/item/{itemId}/user-copyrights/{hash}` : To deactivate user copyright.
  - PATCH `uploads/{id}/item/{itemId}/user-copyrights/{hash}` : To restore deactivated user copyright.
  - PUT `uploads/{id}/item/{itemId}/user-copyrights/{hash}` : To update user copyright.
  - GET `uploads/{id}/item/{itemId}/totalusercopyrights` : To get the count of user copyright findings.
2. Enhanced controllers, DAOs, and plugins with new methods and adjustments.
3. Updated the `openapi.yaml` & `openapiv2.yaml` files to have the new API's documentation.

## Test & Screenshots

Make a `GET` request to the endpoint: `uploads/{id}/item/{itemId}/user-copyrights`.

![image](https://github.com/fossology/fossology/assets/119073504/d89aa9cf-b38d-4b92-84f1-6ed8ccf5670c)

Make a `DELETE` request to the endpoint: `uploads/{id}/item/{itemId}/user-copyrights/{hash}`.

![Screenshot from 2024-06-20 03-26-22](https://github.com/fossology/fossology/assets/119073504/a9b72fd3-1001-4086-9c79-1a34ccf44e2d)

Make a `PATCH` request to the endpoint: `uploads/{id}/item/{itemId}/user-copyrights/{hash}`.

![Screenshot from 2024-06-20 03-26-32](https://github.com/fossology/fossology/assets/119073504/42e2b7e1-f878-45dc-9b32-08ddeaed2e0b)

Make a `PUT` request to the endpoint: `uploads/{id}/item/{itemId}/user-copyrights/{hash}`.

![Screenshot from 2024-06-20 03-27-25](https://github.com/fossology/fossology/assets/119073504/7b1a1717-8d15-4198-96dc-4a0bc8d185c5)

Make a `GET` request to the endpoint: `uploads/{id}/item/{itemId}/totalusercopyrights`.

![image](https://github.com/fossology/fossology/assets/119073504/9d1d99b6-1f4c-4cd6-a50c-ea436f33b7a3)

Tracked by #2491 

CC @GMishx @shaheemazmalmmd @dushimsam @soham4abc 