### PR TITLE
fix(reports): remove additional licenses in obligation section

### DIFF
--- a/src/lib/php/Report/ObligationsGetter.php
+++ b/src/lib/php/Report/ObligationsGetter.php
@@ -96,6 +96,11 @@ class ObligationsGetter
     $bulkHistory = $this->clearingDao->getBulkHistory($parentTreeBounds, $groupId, false);
     $licenseId = [];
     if (!empty($bulkHistory)) {
+      foreach ($bulkHistory as $key => $value) {
+        if (empty($value['id'])) {
+          unset($bulkHistory[$key]);
+        }
+      }
       $licenseLists = array_column($bulkHistory, 'addedLicenses');
       $allLicenses = array();
       foreach ($licenseLists as $licenseList) {

--- a/src/www/ui/template/ui-clearing-view_bulk.html.twig
+++ b/src/www/ui/template/ui-clearing-view_bulk.html.twig
@@ -137,7 +137,7 @@
                 </div>
                 <div class="col-sm-auto pr-0">
                   <div class="form-check form-check-inline">
-                    <input type="checkbox" class="form-check-input" id="scanOnlyFindings" name="scanOnlyFindings"/>
+                    <input type="checkbox" class="form-check-input" id="scanOnlyFindings" name="scanOnlyFindings" checked="checked"/>
                     <label for="scanOnlyFindings" class="form-check-label">
                       {{ 'Scan files with findings'|trans }}
                       <img src="images/info_16.png" data-toggle="tooltip" data-placement="left" title="{{ 'The bulk scan will be executed on the files where there is atleast one license finding'|trans }}" alt="" class="info-bullet"/></img>


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Remove added licenses which are not identified from obligations.
Make default checked for scan only findings to improve the performance. 

## How to test

* Upload a package add dummy bulk findings
* ex: choose a license which doesnt exist in that package and add with dummy text.
* same license should not appear in reports
