### PR TITLE
fix(conf): unify license names to match in reports

### DIFF
--- a/src/www/ui/ui-report-conf.php
+++ b/src/www/ui/ui-report-conf.php
@@ -11,6 +11,7 @@ use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Dao\UserDao;
 use Fossology\Lib\Dao\ClearingDao;
 use Fossology\Lib\Dao\LicenseDao;
+use Fossology\Lib\Data\LicenseRef;
 use Fossology\Lib\Data\DecisionTypes;
 use Fossology\Lib\BusinessRules\LicenseMap;
 use Fossology\Lib\Data\Package\ComponentType;
@@ -277,16 +278,18 @@ class ui_report_conf extends FO_Plugin
     $groupedObligations = array();
     foreach ($allObligations as $obligations) {
       $groupBy = $obligations['ob_topic'];
+      $licenseName = LicenseRef::convertToSpdxId($obligations['rf_shortname'],
+        $obligations['rf_spdx_id']);
       if (array_key_exists($groupBy, $groupedObligations)) {
         $currentLicenses = &$groupedObligations[$groupBy]['license'];
-        if (!in_array($obligations['rf_shortname'], $currentLicenses)) {
-          $currentLicenses[] = $obligations['rf_shortname'];
+        if (!in_array($licenseName, $currentLicenses)) {
+          $currentLicenses[] = $licenseName;
         }
       } else {
         $groupedObligations[$groupBy] = array(
          "topic" => $obligations['ob_topic'],
          "text" => $obligations['ob_text'],
-         "license" => array($obligations['rf_shortname'])
+         "license" => array($licenseName)
         );
       }
     }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Deactivated licenses are still appearing in report. as the license names that are stored in report info and license names that we are comparing are different.

### Changes

List the changes done to fix a bug or introducing a new feature.

## How to test

* Create a license name "gpl-2.0-with-classpath-exception" and add some obligations.
* Go to conf section and deactivate few obligations.
* Deactivated obligations should not appear in report.
