### PR TITLE
fix(reportImport): Parse for ListedLicense when importing an RDF report

### DIFF
--- a/src/reportImport/agent/SpdxTwoImportSource.php
+++ b/src/reportImport/agent/SpdxTwoImportSource.php
@@ -302,7 +302,8 @@ class SpdxTwoImportSource implements ImportSource
         return array($item);
       }
     }
-    elseif ($this->isPropertyOfType($license, 'License'))
+    elseif ($this->isPropertyOfType($license, 'License') ||
+            $this->isPropertyOfType($license, 'ListedLicense'))
     {
       $licenseId = $this->stripLicenseRefPrefix($this->getValue($license,'licenseId'));
       $item = new ReportImportDataItem($licenseId);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Since 4.2.1.45 the ListedLicense tag is being used for exported reports, but is not being parsed when importing a report. This prevents created RDF reports from being re-imported. This patch takes ListedLicense into account when importing an RDF report and treats it the same way as "License".

### Changes

Take "ListedLicense" into account when importing an RDF report and treat it the same way as "License".

## How to test

1. Take any FOSSology version >= 4.2.1.45
2. Upload and scan a package
3. Put your license decisions
4. Generate an SPDX RDF report
5. Upload the same package without any action
6. Do "Import Report" for the new upload and use the previously exported RDF report

With the change in this PR the import will work. Without the change the import agent will return success but nothing is being imported.

Fixes: #2701
