### PR TITLE
fix(reportImport): Adding a fallback to ShortName for RDF imports.

### DIFF
--- a/src/reportImport/agent/ReportImportSink.php
+++ b/src/reportImport/agent/ReportImportSink.php
@@ -139,6 +139,10 @@ class ReportImportSink
     $licenseShortName = $dataItem->getLicenseId();
     if ($this->configuration->shouldMatchLicenseNameWithSPDX()) {
       $license = $this->licenseDao->getLicenseBySpdxId($licenseShortName, $groupId);
+      if ($license == null) {
+        echo "WARNING: Can not match by SPDX ID, trying Shortname=\"$licenseShortName\"\n";
+        $license = $this->licenseDao->getLicenseByShortName($licenseShortName, $groupId);
+      }
     } else {
       $license = $this->licenseDao->getLicenseByShortName($licenseShortName, $groupId);
     }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

When matching licenses by SPDX ID, an RDF import can fail completely if at least one license can not be matched by SPDX ID. Let's fall back to the ShortName in this case.

### Changes

The change adds a fallback to ShortName when a license can not be matched by SPDX ID.

## How to test

1. Take any FOSSology version starting from commit https://github.com/fossology/fossology/commit/d1e1b6e0dde4e37aa62e63b3246fd6b313e3d4d4
2. Choose a package for which you have an existing report
3. To test this change, the report has to contain at least one license statement that cannot be matched by SPDX ID (examples, that failed in my tests are: Public-domain, Dual license, ...)
4. I tested with busybox-1.36.1 and took an existing report from the OSSelot project (https://www.osselot.org/)
5. Upload the same package without any action
6. Do "Import Report" with the existing SPDX RDF report (and select "SPDX ID" under "Match license using")

With the change in this PR the import will work. Without the change the import agent will fail with "shortname already in use".

Fixes: #2703 
