### PR TITLE
refactor(reportImport): use EasyRdf to read report

### DIFF
--- a/src/lib/php/Util/StringOperation.php
+++ b/src/lib/php/Util/StringOperation.php
@@ -51,4 +51,16 @@ class StringOperation
   {
     return strncmp($haystack, $needle, strlen($needle)) === 0;
   }
+
+  /**
+   * Polyfill for PHP8's str_ends_with
+   * https://www.php.net/manual/en/function.str-ends-with.php
+   * @param string $haystack String to search in
+   * @param string $needle   String to search for
+   * @return bool True if haystack ends with needle.
+   */
+  public static function stringEndsWith($haystack, $needle)
+  {
+    return substr_compare($haystack, $needle, -strlen($needle)) === 0;
+  }
 }

--- a/src/reportImport/agent/ImportSource.php
+++ b/src/reportImport/agent/ImportSource.php
@@ -21,14 +21,14 @@ interface ImportSource
   public function parse();
 
   /**
-   * @param $fileid
+   * @param $fileId
    * @return array
    */
-  public function getHashesMap($fileid);
+  public function getHashesMap($fileId);
 
   /**
    * @param $fileid
-   * @return array
+   * @return array|ReportImportData
    */
   public function getDataForFile($fileid);
 }

--- a/src/reportImport/agent/ReportImportDataItem.php
+++ b/src/reportImport/agent/ReportImportDataItem.php
@@ -26,7 +26,7 @@ class ReportImportDataItem
 
   public function setCustomText($customText)
   {
-    $this->customText = $customText;
+    $this->customText = trim($customText);
     return $this;
   }
 
@@ -34,9 +34,10 @@ class ReportImportDataItem
    * @param $name
    * @param $text
    * @param bool $spdxCompatible
+   * @param string $url
    * @return $this
    */
-  public function setLicenseCandidate($name, $text, $spdxCompatible)
+  public function setLicenseCandidate($name, $text, $spdxCompatible, $url = "")
   {
     $spdxCompatible = $spdxCompatible == true;
     $this->licenseCandidate = new License(
@@ -44,8 +45,8 @@ class ReportImportDataItem
       $this->licenseId,
       $name,
       "",
-      $text,
-      "", // TODO: $this->getValue($license,'seeAlso'),
+      trim($text),
+      $url,
       "", // TODO
       $spdxCompatible);
     return $this;

--- a/src/reportImport/agent/ReportImportSink.php
+++ b/src/reportImport/agent/ReportImportSink.php
@@ -1,6 +1,6 @@
 <?php
 /*
- SPDX-FileCopyrightText: © 2015-2017 Siemens AG
+ SPDX-FileCopyrightText: © 2015-2017,2024 Siemens AG
 
  SPDX-License-Identifier: GPL-2.0-only
 */
@@ -8,10 +8,8 @@ namespace Fossology\ReportImport;
 
 use Fossology\Lib\Dao\ClearingDao;
 use Fossology\Lib\Dao\CopyrightDao;
-use Fossology\Lib\Data\License;
-use Fossology\Lib\Dao\UserDao;
 use Fossology\Lib\Dao\LicenseDao;
-use Fossology\ReportImport\ReportImportHelper;
+use Fossology\Lib\Dao\UserDao;
 use Fossology\Lib\Data\Clearing\ClearingEventTypes;
 use Fossology\Lib\Data\DecisionScopes;
 use Fossology\Lib\Data\DecisionTypes;
@@ -139,8 +137,8 @@ class ReportImportSink
     $licenseShortName = $dataItem->getLicenseId();
     if ($this->configuration->shouldMatchLicenseNameWithSPDX()) {
       $license = $this->licenseDao->getLicenseBySpdxId($licenseShortName, $groupId);
-      if ($license == null) {
-        echo "WARNING: Can not match by SPDX ID, trying Shortname=\"$licenseShortName\"\n";
+      if ($license === null) {
+        echo "WARNING: Could not find license with spdx id '$licenseShortName' ... trying ShortName\n";
         $license = $this->licenseDao->getLicenseByShortName($licenseShortName, $groupId);
       }
     } else {

--- a/src/reportImport/agent/SpdxTwoImportSource.php
+++ b/src/reportImport/agent/SpdxTwoImportSource.php
@@ -1,13 +1,20 @@
 <?php
 /*
- SPDX-FileCopyrightText: © 2015-2017 Siemens AG
+ SPDX-FileCopyrightText: © 2015-2017,2023-2024 Siemens AG
 
  SPDX-License-Identifier: GPL-2.0-only
 */
+
 namespace Fossology\ReportImport;
 
-use Fossology\Lib\Data\License;
 use EasyRdf\Graph;
+use EasyRdf\Literal;
+use EasyRdf\RdfNamespace;
+use EasyRdf\Resource;
+use Fossology\Lib\Data\License;
+use Fossology\Lib\Data\LicenseRef;
+use Fossology\Lib\Util\StringOperation;
+
 require_once 'ReportImportData.php';
 require_once 'ReportImportDataItem.php';
 require_once 'ImportSource.php';
@@ -16,18 +23,16 @@ class SpdxTwoImportSource implements ImportSource
 {
   const TERMS = 'http://spdx.org/rdf/terms#';
   const SPDX_URL = 'http://spdx.org/licenses/';
-  const SYNTAX_NS = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+  const SPDX_FILE = 'spdx:File';
 
-  /** @var  string */
+  /** @var string */
   private $filename;
-  /** @var  string */
+  /** @var string */
   private $uri;
   /** @var Graph $graph */
   private $graph;
-  /** @var array */
-  private $index;
-  /** @var string */
-  private $licenseRefPrefix = "LicenseRef-";
+  /** @var Resource */
+  private $spdxDoc;
 
   function __construct($filename, $uri = null)
   {
@@ -40,22 +45,35 @@ class SpdxTwoImportSource implements ImportSource
    */
   public function parse()
   {
+    RdfNamespace::set('spdx', self::TERMS);
     $this->graph = $this->loadGraph($this->filename, $this->uri);
-    $this->index = $this->loadIndex($this->graph);
-    return true;
+    $this->spdxDoc = $this->getSpdxDoc();
+    return $this->graph !== null && $this->spdxDoc !== null;
   }
 
   private function loadGraph($filename, $uri = null)
   {
     /** @var Graph $graph */
     $graph = new Graph();
-    $graph->parseFile($filename, 'rdfxml', $uri);
+    if (StringOperation::stringEndsWith($filename, ".rdf") || StringOperation::stringEndsWith($filename, ".rdf.xml")) {
+      $graph->parseFile($filename, 'rdfxml', $uri);
+    } elseif (StringOperation::stringEndsWith($filename, ".ttl")) {
+      $graph->parseFile($filename, 'turtle', $uri);
+    } else {
+      $graph->parseFile($filename, 'guess', $uri);
+    }
     return $graph;
   }
 
-  private function loadIndex($graph)
+  private function getSpdxDoc()
   {
-    return $graph->toRdfPhp();
+    $docs = $this->graph->allOfType("spdx:SpdxDocument");
+    if (count($docs) == 1) {
+      return $docs[0];
+    } else {
+      error_log("ERROR: Expected exactly one SPDX document, found " . count($docs));
+      return null;
+    }
   }
 
   /**
@@ -63,146 +81,265 @@ class SpdxTwoImportSource implements ImportSource
    */
   public function getAllFiles()
   {
+    $relationship = $this->spdxDoc->getResource("spdx:relationship");
+    $element = $relationship->getResource("spdx:relatedSpdxElement");
+    /* @var $files Resource[] */
+    $files = $element->allResources("spdx:hasFile");
+    if (count($files) < 1) {
+      $files = $this->getNestedFiles($element);
+    }
     $fileIds = array();
-    foreach ($this->index as $subject => $property){
-      if ($this->isPropertyAFile($property))
-      {
-        $fileIds[$subject] = $this->getFileName($property);
-      }
+    foreach ($files as $file) {
+      $fileIds[$file->getUri()] = trim($file->getLiteral("spdx:fileName")->getValue());
     }
     return $fileIds;
   }
 
   /**
-   * @param $property
-   * @param $type
-   * @return bool
+   * @param Resource $element Package element
+   * @return Resource[] Nested files
    */
-  private function isPropertyOfType(&$property, $type)
+  private function getNestedFiles($element): array
   {
-    $key = self::SYNTAX_NS . 'type';
-    $target = self::TERMS . $type;
-
-    return is_array ($property) &&
-      array_key_exists($key, $property) &&
-      sizeof($property[$key]) === 1 &&
-      $property[$key][0]['type'] === "uri" &&
-      $property[$key][0]['value'] === $target;
+    $nestedFiles = [];
+    /** @var Resource[] $nestedRelations */
+    $nestedRelations = $element->allResources("spdx:relationship");
+    foreach ($nestedRelations as $nestedRelation) {
+      $relationType = $nestedRelation->getResource("spdx:relationshipType");
+      if (StringOperation::stringEndsWith($relationType->getUri(), "contains")) {
+        $fileResource = $nestedRelation->getResource("spdx:relatedSpdxElement");
+        if ($fileResource !== null) {
+          $nestedFiles[] = $fileResource;
+        }
+      }
+    }
+    return $nestedFiles;
   }
 
   /**
-   * @param $property
-   * @return bool
-   */
-  private function isPropertyAFile(&$property)
-  {
-    return $this->isPropertyOfType($property, 'File');
-  }
-
-  /**
-   * @param $fileid
+   * @param string $fileId File URI
    * @return array
    */
-  public function getHashesMap($fileid)
+  public function getHashesMap($fileId)
   {
-    if ($this->isPropertyAFile($property))
-    {
-      return array();
+    $fileNode = $this->graph->resource($fileId, self::SPDX_FILE);
+    if ($fileNode->getLiteral("spdx:fileName") == null) {
+      return [];
     }
 
-    $hashItems = $this->getValues($fileid, 'checksum');
+    $hashes = [];
 
-    $hashes = array();
-    $keyAlgo = self::TERMS . 'algorithm';
     $algoKeyPrefix = self::TERMS . 'checksumAlgorithm_';
-    $keyAlgoVal = self::TERMS . 'checksumValue';
-    foreach ($hashItems as $hashItem)
-    {
-      $algorithm = $hashItem[$keyAlgo][0]['value'];
-      if(substr($algorithm, 0, strlen($algoKeyPrefix)) === $algoKeyPrefix)
-      {
-        $algorithm = substr($algorithm, strlen($algoKeyPrefix));
-      }
-      $hashes[$algorithm] = $hashItem[$keyAlgoVal][0]['value'];
-    }
 
+    /* @var $checksums Resource[] */
+    $checksums = $fileNode->allResources("spdx:checksum");
+    foreach ($checksums as $checksum) {
+      $algorithm = $checksum->getResource("spdx:algorithm");
+      $value = $checksum->getLiteral("spdx:checksumValue");
+      if ($algorithm != null && $value != null) {
+        if (StringOperation::stringStartsWith($algorithm->getUri(), $algoKeyPrefix)) {
+          $algo = substr($algorithm->getUri(), strlen($algoKeyPrefix));
+        } else {
+          $algo = $algorithm->getUri();
+        }
+        $hashes[$algo] = trim($value->getValue());
+      }
+    }
     return $hashes;
   }
 
   /**
-   * @param $propertyOrId
-   * @param $key
-   * @param null $default
-   * @return mixed|null
+   * @param string $fileid File URI
+   * @return ReportImportData
    */
-  private function getValue($propertyOrId, $key, $default=null)
+  public function getDataForFile($fileid): ReportImportData
   {
-    $values = $this->getValues($propertyOrId, $key);
-    if(sizeof($values) === 1)
-    {
-      return $values[0];
-    }
-    return $default;
+    return new ReportImportData($this->getLicenseInfoInFileForFile($fileid),
+      $this->getConcludedLicenseInfoForFile($fileid),
+      $this->getCopyrightTextsForFile($fileid));
   }
 
   /**
-   * @param $propertyOrId
-   * @param $key
+   * @param $propertyId
    * @return array
    */
-  private function getValues($propertyOrId, $key)
+  public function getLicenseInfoInFileForFile($propertyId)
   {
-    if (is_string($propertyOrId))
-    {
-      $property = $this->index[$propertyOrId];
-    }
-    else
-    {
-      $property = $propertyOrId;
-    }
-
-    $key = self::TERMS . $key;
-    if (is_array($property) && isset($property[$key]))
-    {
-      $values = array();
-      foreach($property[$key] as $entry)
-      {
-        if($entry['type'] === 'literal')
-        {
-          $values[] = $entry['value'];
-        }
-        elseif($entry['type'] === 'uri')
-        {
-          if(array_key_exists($entry['value'],$this->index))
-          {
-            $values[$entry['value']] = $this->index[$entry['value']];
-          }
-          else
-          {
-            $values[] = $entry['value'];
-          }
-        }
-        elseif($entry['type'] === 'bnode')
-        {
-          $values[$entry['value']] = $this->index[$entry['value']];
-        }
-        else
-        {
-          error_log("ERROR: can not handle entry=[".$entry."] of type=[" . $entry['type'] . "]");
-        }
-      }
-      return $values;
-    }
-    return array();
+    return $this->getLicenseInfoForFile($propertyId, 'licenseInfoInFile');
   }
 
   /**
-   * @param $propertyOrId
-   * @return mixed|null
+   * @param string $fileId File URI
+   * @param string $kind licenseConcluded or licenseInfoInFile
+   * @return array
    */
-  private function getFileName($propertyOrId)
+  private function getLicenseInfoForFile($fileId, $kind)
   {
-    return $this->getValue($propertyOrId, 'fileName');
+    $fileNode = $this->graph->resource($fileId, self::SPDX_FILE);
+    /* @var $licenses Resource[] */
+    $licenses = $fileNode->allResources("spdx:$kind");
+
+    $output = [];
+    foreach ($licenses as $license) {
+      if (!$this->isNotNoassertion($license->getUri())) {
+        continue;
+      }
+      $innerOutput = $this->parseLicense($license);
+      foreach ($innerOutput as $innerItem) {
+        $output[] = $innerItem;
+      }
+    }
+    return $output;
+  }
+
+  private function isNotNoassertion($str)
+  {
+    return !(strtolower($str) === self::TERMS . "noassertion" ||
+      strtolower($str) === "http://spdx.org/licenses/noassertion");
+  }
+
+  /**
+   * Parse license info. Element can be:
+   * -# License ID (string)
+   * -# License resource (ExtractedLicensingInfo, License, ListedLicense)
+   * -# License set (DisjunctiveLicenseSet, ConjunctiveLicenseSet)
+   * -# OrLaterOperator
+   * -# Old-style license ID (Resource)
+   * @param Resource|string $license
+   * @return array|ReportImportDataItem[]
+   */
+  private function parseLicense($license)
+  {
+    if (is_string($license)) {
+      return $this->parseLicenseId($license);
+    } elseif ($license->isA('spdx:ExtractedLicensingInfo') ||
+      $license->isA('spdx:License') ||
+      $license->isA('spdx:ListedLicense')) {
+      return $this->handleLicenseInfo($license);
+    } elseif ($license->isA('spdx:DisjunctiveLicenseSet') ||
+      $license->isA('spdx:ConjunctiveLicenseSet')) {
+      return $this->handleLicenseSet($license);
+    } elseif ($license->isA('spdx:OrLaterOperator')) {
+      return $this->handleOrLaterOperator($license);
+    }
+    if ($license instanceof Resource || $license instanceof Graph) {
+      return $this->parseLicenseId($license->getUri());
+    } else {
+      error_log("ERROR: can not handle license=[" . $license . "] of class=[" .
+        get_class($license) . "]");
+      return [];
+    }
+  }
+
+  private function parseLicenseId($licenseId)
+  {
+    if (!is_string($licenseId)) {
+      error_log("ERROR: Id not a string: " . $licenseId);
+      return [];
+    }
+    if (!$this->isNotNoassertion($licenseId)) {
+      return [];
+    }
+
+    if (StringOperation::stringStartsWith($licenseId, self::SPDX_URL)) {
+      $spdxId = urldecode(substr($licenseId, strlen(self::SPDX_URL)));
+      $item = new ReportImportDataItem($spdxId);
+      return [$item];
+    } else {
+      error_log("ERROR: can not handle license with ID=" . $licenseId);
+      return [];
+    }
+  }
+
+  /**
+   * From License resource, create ReportImportDataItem.
+   * If the resource is an ExtractedLicensingInfo, the license is generally a
+   * candidate license.
+   * @param Resource $license License resource
+   * @return ReportImportDataItem[]
+   */
+  private function handleLicenseInfo($license)
+  {
+    $licenseIdLiteral = $license->getLiteral("spdx:licenseId");
+    $licenseNameLiteral = $license->getLiteral("spdx:name");
+    if ($license->isA('spdx:ExtractedLicensingInfo')) {
+      $licenseTextLiteral = $license->getLiteral("spdx:extractedText");
+    } else {
+      $licenseTextLiteral = $license->getLiteral("spdx:licenseText");
+    }
+    if ($licenseIdLiteral != null && $licenseNameLiteral != null &&
+      $licenseTextLiteral != null) {
+      $seeAlsoLiteral = $license->getLiteral("rdfs:seeAlso");
+      $rawLicenseId = $licenseIdLiteral->getValue();
+      $licenseId = $this->stripLicenseRefPrefix($rawLicenseId);
+
+      if ($license->isA('spdx:ExtractedLicensingInfo') &&
+        (strlen($licenseId) > 33 &&
+          substr($licenseId, -33, 1) === "-" &&
+          ctype_alnum(substr($licenseId, -32))
+        )) {
+        $licenseId = substr($licenseId, 0, -33);
+        $item = new ReportImportDataItem($licenseId);
+        $item->setCustomText($licenseTextLiteral->getValue());
+      } else {
+        $item = new ReportImportDataItem($licenseId);
+        $item->setLicenseCandidate($licenseNameLiteral->getValue(),
+          $licenseTextLiteral->getValue(),
+          strpos($rawLicenseId, LicenseRef::SPDXREF_PREFIX),
+          ($seeAlsoLiteral != null) ? $seeAlsoLiteral->getValue() : ""
+        );
+      }
+      return [$item];
+    }
+    return [];
+  }
+
+  private function stripLicenseRefPrefix($licenseId)
+  {
+    if (StringOperation::stringStartsWith($licenseId, LicenseRef::SPDXREF_PREFIX)) {
+      if (StringOperation::stringStartsWith($licenseId, LicenseRef::SPDXREF_PREFIX_FOSSOLOGY)) {
+        return urldecode(substr($licenseId, strlen(LicenseRef::SPDXREF_PREFIX_FOSSOLOGY)));
+      }
+      return urldecode(substr($licenseId, strlen(LicenseRef::SPDXREF_PREFIX)));
+    } else {
+      return urldecode($licenseId);
+    }
+  }
+
+  private function handleLicenseSet($license)
+  {
+    $output = [];
+    $subLicenses = $license->allResources("spdx:member");
+    if (sizeof($subLicenses) > 1 && $license->isA('spdx:DisjunctiveLicenseSet')) {
+      $output[] = new ReportImportDataItem("Dual-license");
+    }
+    foreach ($subLicenses as $subLicense) {
+      $innerOutput = $this->parseLicense($subLicense);
+      $output = array_merge($output, $innerOutput);
+    }
+    return $output;
+  }
+
+  private function handleOrLaterOperator($license)
+  {
+    $output = [];
+    $subLicenses = $license->allResources("spdx:member");
+    foreach ($subLicenses as $subLicense) {
+      /** @var ReportImportDataItem[] $innerOutput */
+      $innerOutput = $this->parseLicense($subLicense);
+      foreach ($innerOutput as $innerItem) {
+        /** @var License $innerLicenseCandidate */
+        $item = new ReportImportDataItem($innerItem->getLicenseId() . "-or-later");
+
+        $innerLicenseCandidate = $innerItem->getLicenseCandidate();
+        $item->setLicenseCandidate($innerLicenseCandidate->getFullName() . " or later",
+          $innerLicenseCandidate->getText(), false,
+          $innerLicenseCandidate->getUrl()
+        );
+        $output[] = $item;
+      }
+    }
+    return $output;
   }
 
   /**
@@ -215,187 +352,20 @@ class SpdxTwoImportSource implements ImportSource
   }
 
   /**
-   * @param $propertyId
-   * @return array
+   * @param string $fileId File URI
+   * @return array Copyrights from the file or empty array
    */
-  public function getLicenseInfoInFileForFile($propertyId)
+  private function getCopyrightTextsForFile($fileId): array
   {
-    return $this->getLicenseInfoForFile($propertyId, 'licenseInfoInFile');
-  }
-
-  private function stripLicenseRefPrefix($licenseId)
-  {
-    if(substr($licenseId, 0, strlen($this->licenseRefPrefix)) === $this->licenseRefPrefix)
-    {
-      return urldecode(substr($licenseId, strlen($this->licenseRefPrefix)));
+    $fileNode = $this->graph->resource($fileId, self::SPDX_FILE);
+    /* @var $licenses Literal[] */
+    $copyrights = $fileNode->allLiterals("spdx:copyrightText");
+    if (count($copyrights) == 1 && $copyrights[0] instanceof Literal) {
+      # There should be only 1 copyright element containing 1 copyright per line
+      $copyrights = explode("\n", trim($copyrights[0]->getValue()));
+      return array_map('trim', $copyrights);
     }
-    else
-    {
-      return urldecode($licenseId);
-    }
-  }
-
-  private function isNotNoassertion($str)
-  {
-    return ! ( strtolower($str) === self::TERMS."noassertion" ||
-               strtolower($str) === "http://spdx.org/licenses/noassertion" );
-  }
-
-  private function parseLicenseId($licenseId)
-  {
-    if (!is_string($licenseId))
-    {
-      error_log("ERROR: Id not a string: ".$licenseId);
-      return array();
-    }
-    if (strtolower($licenseId) === self::TERMS."noassertion" ||
-        strtolower($licenseId) === "http://spdx.org/licenses/noassertion")
-    {
-      return array();
-    }
-
-    $license = $this->index[$licenseId];
-
-    if ($license)
-    {
-      return $this->parseLicense($license);
-    }
-    elseif(substr($licenseId, 0, strlen(self::SPDX_URL)) === self::SPDX_URL)
-    {
-      $spdxId = urldecode(substr($licenseId, strlen(self::SPDX_URL)));
-      $item = new ReportImportDataItem($spdxId);
-      return array($item);
-    }
-    else
-    {
-      error_log("ERROR: can not handle license with ID=".$licenseId);
-      return array();
-    }
-  }
-
-  private function parseLicense($license)
-  {
-    if (is_string($license))
-    {
-      return $this->parseLicenseId($license);
-    }
-    elseif ($this->isPropertyOfType($license, 'ExtractedLicensingInfo'))
-    {
-      $licenseId = $this->stripLicenseRefPrefix($this->getValue($license,'licenseId'));
-
-      if(strlen($licenseId) > 33 &&
-         substr($licenseId, -33, 1) === "-" &&
-         ctype_alnum(substr($licenseId, -32)))
-      {
-        $licenseId = substr($licenseId, 0, -33);
-        $item = new ReportImportDataItem($licenseId);
-        $item->setCustomText($this->getValue($license,'extractedText'));
-        return array($item);
-
-      }
-      else
-      {
-        $item = new ReportImportDataItem($licenseId);
-        $item->setLicenseCandidate($this->getValue($license,'name', $licenseId),
-                                   $this->getValue($license,'extractedText'),
-                                   strpos($this->getValue($license,'licenseId'), $this->licenseRefPrefix));
-        return array($item);
-      }
-    }
-    elseif ($this->isPropertyOfType($license, 'License') ||
-            $this->isPropertyOfType($license, 'ListedLicense'))
-    {
-      $licenseId = $this->stripLicenseRefPrefix($this->getValue($license,'licenseId'));
-      $item = new ReportImportDataItem($licenseId);
-      $item->setLicenseCandidate($this->getValue($license,'name', $licenseId),
-                                 $this->getValue($license,'licenseText'),
-                                 strpos($this->getValue($license,'licenseId'), $this->licenseRefPrefix));
-      return array($item);
-    }
-    elseif ($this->isPropertyOfType($license, 'DisjunctiveLicenseSet') ||
-            $this->isPropertyOfType($license, 'ConjunctiveLicenseSet')
-    )
-    {
-      $output = array();
-      $subLicenses = $this->getValues($license, 'member');
-      if (sizeof($subLicenses) > 1 &&
-          $this->isPropertyOfType($license, 'DisjunctiveLicenseSet'))
-      {
-        $output[] = new ReportImportDataItem("Dual-license");
-      }
-      foreach($subLicenses as $subLicense)
-      {
-        $innerOutput = $this->parseLicense($subLicense);
-        foreach($innerOutput as $innerItem)
-        {
-          $output[] = $innerItem;
-        }
-      }
-      return $output;
-    }
-    elseif ($this->isPropertyOfType($license, 'OrLaterOperator'))
-    {
-      $output = array();
-      $subLicenses = $this->getValues($license, 'member');
-      foreach($subLicenses as $subLicense) {
-        /** @var ReportImportDataItem[] $innerOutput */
-        $innerOutput = $this->parseLicense($subLicense);
-        foreach($innerOutput as $innerItem)
-        {
-          /** @var License $innerLicenseCandidate */
-          $item = new ReportImportDataItem($innerItem->getLicenseId() . "+");
-
-          $innerLicenseCandidate = $innerItem->getLicenseCandidate();
-          $item->setLicenseCandidate($innerLicenseCandidate->getFullName() . " or later",
-            $innerLicenseCandidate->getText(),
-            false);
-          $output[] = $item;
-        }
-      }
-      return $output;
-    }
-    else
-    {
-      error_log("ERROR: can not handle license=[".$license."] of type=[".gettype($license)."]");
-      return array();
-    }
-  }
-
-  /**
-   * @param $propertyId
-   * @param $kind
-   * @return array
-   */
-  private function getLicenseInfoForFile($propertyId, $kind)
-  {
-    $property = $this->index[$propertyId];
-    $licenses = $this->getValues($property, $kind);
-
-    $output = array();
-    foreach ($licenses as $license)
-    {
-      $innerOutput = $this->parseLicense($license);
-      foreach($innerOutput as $innerItem)
-      {
-        $output[] = $innerItem;
-      }
-    }
-    return $output;
-  }
-
-  private function getCopyrightTextsForFile($propertyId)
-  {
-    return array_filter(
-      array_map(
-        'trim',
-        $this->getValues($propertyId, "copyrightText")) ,
-      array($this, "isNotNoassertion"));
-  }
-
-  public function getDataForFile($propertyId)
-  {
-    return new ReportImportData($this->getLicenseInfoInFileForFile($propertyId),
-                                 $this->getConcludedLicenseInfoForFile($propertyId),
-                                 $this->getCopyrightTextsForFile($propertyId));
+    # There is only 1 copyright literal or noAssertion resource
+    return [];
   }
 }

--- a/src/reportImport/agent/XmlImportSource.php
+++ b/src/reportImport/agent/XmlImportSource.php
@@ -9,6 +9,7 @@ namespace Fossology\ReportImport;
 
 
 use Symfony\Component\DependencyInjection\SimpleXMLElement;
+
 require_once 'ImportSource.php';
 
 class XmlImportSource implements ImportSource
@@ -130,10 +131,10 @@ class XmlImportSource implements ImportSource
   }
 
   /**
-   * @param $fileid
+   * @param $fileId
    * @return array
    */
-  public function getHashesMap($fileid)
+  public function getHashesMap($fileId)
   {
     return array();
   }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

1. Use EasyRdf to navigate through RDF graph instead of reading it as an associative PHP array. This allows for more flexibility between SPDX versions.
2. Support reading Turtle files as EasyRdf already supports it.

### Changes

1. Move code in `SpdxTwoImportSource.php` from associative array to EasyRdf object.

## How to test

1. Test if reports generated from FOSSology can be imported.
2. Test if reports generated from other tools can also be imported.