### PR TITLE
fix(doc): Update UploadTree Description

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -66,7 +66,7 @@ x-reuse:
         type: integer
     - name: itemId
       required: true
-      description: UploadTree ID
+      description: UploadTree ID (available via /uploads/{id}/topitem & /uploads/{id}/item/{itemId}/tree/view)
       in: path
       schema:
         type: integer


### PR DESCRIPTION
## Description

The information on how to to getting UploadTree ID via api using topitem API is not straight forward. So updated the openapi spec to make it easier for others
![image](https://github.com/fossology/fossology/assets/4498415/c8f4c775-2792-4c28-8215-e93c4cee1087)



## How to test

load the spec in swagger and check if above screenshot change is visible


Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)
