### PR TITLE
ci: define permissions for conflict check workflow

### DIFF
--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -8,6 +8,9 @@ on:
   pull_request_target:
     types: [synchronize]
 
+permissions:
+  pull-requests: write # to label PRs
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
    
Explicitely stating required permissions is considered best practice. This case was detected by Poutine, see 
https://github.com/boostsecurityio/poutine/blob/main/docs/content/en/rules/default_permissions_on_risky_events.md.

### Changes

See above

## How to test

Run CI

---

:hammer_and_pick: with :heart: by [Siemens](https://opensource.siemens.com/)