### PR TITLE
fix(ui): implemented search in software heritage page and search and filter in file browser page

### DIFF
--- a/src/softwareHeritage/ui/AjaxSHDetailsBrowser.php
+++ b/src/softwareHeritage/ui/AjaxSHDetailsBrowser.php
@@ -94,7 +94,7 @@ class AjaxSHDetailsBrowser extends DefaultPlugin
 
     $UniqueTagArray = array();
     $this->licenseProjector = new LicenseMap($this->getObject('db.manager'),$groupId,LicenseMap::CONCLUSION,true);
-    $vars = $this->createFileListing($tag_pk, $itemTreeBounds, $UniqueTagArray, $selectedAgentId, $groupId, $scanJobProxy);
+    $vars = $this->createFileListing($tag_pk, $itemTreeBounds, $UniqueTagArray, $selectedAgentId, $groupId, $scanJobProxy, $request);
 
     return new JsonResponse(array(
       'sEcho' => intval($request->get('sEcho')),
@@ -113,7 +113,7 @@ class AjaxSHDetailsBrowser extends DefaultPlugin
    * @param ScanJobProxy $scanJobProxy
    * @return array
    */
-  private function createFileListing($tagId, ItemTreeBounds $itemTreeBounds, &$UniqueTagArray, $selectedAgentId, $groupId, $scanJobProxy)
+  private function createFileListing($tagId, ItemTreeBounds $itemTreeBounds, &$UniqueTagArray, $selectedAgentId, $groupId, $scanJobProxy, $request)
   {
     if (!empty($selectedAgentId)) {
       $agentName = $this->agentDao->getAgentName($selectedAgentId);
@@ -130,6 +130,23 @@ class AjaxSHDetailsBrowser extends DefaultPlugin
       $options = array(UploadTreeProxy::OPT_RANGE => $itemTreeBounds);
     } else {
       $options = array(UploadTreeProxy::OPT_REALPARENT => $itemTreeBounds->getItemId());
+    }
+
+    $searchMap = array();
+    foreach (explode(' ',$request->get('sSearch')) as $pair) {
+      $a = explode(':',$pair);
+      if (count($a) == 1) {
+        $searchMap['head'] = $pair;
+      } else {
+        $searchMap[$a[0]] = $a[1];
+      }
+    }
+
+    if (array_key_exists('ext', $searchMap) && strlen($searchMap['ext'])>=1) {
+      $options[UploadTreeProxy::OPT_EXT] = $searchMap['ext'];
+    }
+    if (array_key_exists('head', $searchMap) && strlen($searchMap['head'])>=1) {
+      $options[UploadTreeProxy::OPT_HEAD] = $searchMap['head'];
     }
 
     $descendantView = new UploadTreeProxy($uploadId, $options, $itemTreeBounds->getUploadTreeTableName(), 'uberItems');

--- a/src/www/ui/async/AjaxFileBrowser.php
+++ b/src/www/ui/async/AjaxFileBrowser.php
@@ -85,7 +85,7 @@ class AjaxFileBrowser extends DefaultPlugin
 
     $UniqueTagArray = array();
     $this->licenseProjector = new LicenseMap($this->getObject('db.manager'),$groupId,LicenseMap::CONCLUSION,true);
-    $vars = $this->createFileListing($tag_pk, $itemTreeBounds, $UniqueTagArray, $selectedAgentId, $groupId, $scanJobProxy);
+    $vars = $this->createFileListing($tag_pk, $itemTreeBounds, $UniqueTagArray, $selectedAgentId, $groupId, $scanJobProxy, $request);
 
     return new JsonResponse(array(
             'sEcho' => intval($request->get('sEcho')),
@@ -105,7 +105,7 @@ class AjaxFileBrowser extends DefaultPlugin
    * @param ScanJobProxy $scanJobProxy
    * @return array
    */
-  private function createFileListing($tagId, ItemTreeBounds $itemTreeBounds, &$UniqueTagArray, $selectedAgentId, $groupId, $scanJobProxy)
+  private function createFileListing($tagId, ItemTreeBounds $itemTreeBounds, &$UniqueTagArray, $selectedAgentId, $groupId, $scanJobProxy, $request)
   {
     if (!empty($selectedAgentId)) {
       $agentName = $this->agentDao->getAgentName($selectedAgentId);
@@ -122,6 +122,27 @@ class AjaxFileBrowser extends DefaultPlugin
       $options = array(UploadTreeProxy::OPT_RANGE => $itemTreeBounds);
     } else {
       $options = array(UploadTreeProxy::OPT_REALPARENT => $itemTreeBounds->getItemId());
+    }
+
+    $searchMap = array();
+    foreach (explode(' ',$request->get('sSearch')) as $pair) {
+      $a = explode(':',$pair);
+      if (count($a) == 1) {
+        $searchMap['head'] = $pair;
+      } else {
+        $searchMap[$a[0]] = $a[1];
+      }
+    }
+
+    if (array_key_exists('ext', $searchMap) && strlen($searchMap['ext'])>=1) {
+      $options[UploadTreeProxy::OPT_EXT] = $searchMap['ext'];
+    }
+    if (array_key_exists('head', $searchMap) && strlen($searchMap['head'])>=1) {
+      $options[UploadTreeProxy::OPT_HEAD] = $searchMap['head'];
+    }
+    if (($rfId=$request->get('scanFilter'))>0) {
+      $options[UploadTreeProxy::OPT_AGENT_SET] = $selectedScanners;
+      $options[UploadTreeProxy::OPT_SCAN_REF] = $rfId;
     }
 
     $descendantView = new UploadTreeProxy($uploadId, $options, $itemTreeBounds->getUploadTreeTableName(), 'uberItems');


### PR DESCRIPTION

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Implemented the search functionality in the `Software Heritage` page and search and filter functionality in the `File Browser` page.

### Changes

- Added server side logic to implement the functionalities in `AjaxFileBrowser.php` and `AjaxSHDetailsBrowser.php`.

## How to test

- Type the file/directoru name in the search box to search for it or type `ext:` followed by extension to search for files with the provided extension in software heritage and file browser page.
- Select the license in `filter for scan results` to filter out all files/directories with the selected license.

## Screeenshots

![Screenshot from 2024-05-10 22-11-06](https://github.com/fossology/fossology/assets/73382164/2e00e743-63d0-4ddd-9444-5463642333fd)
![Screenshot from 2024-05-10 22-11-22](https://github.com/fossology/fossology/assets/73382164/dacdd54b-03e6-4135-bb77-b8d0667f6549)


Fixes #2737 

CC @GMishx @shaheemazmalmmd 