### PR TITLE
fix(delagent): use uploadtree as default table name

### DIFF
--- a/src/delagent/agent/delagent.c
+++ b/src/delagent/agent/delagent.c
@@ -153,7 +153,6 @@ int main (int argc, char *argv[])
   int  c;
   int  listProj=0, listFolder=0;
   long delUpload=0, delFolder=0, delFolderParent=0;
-  int  scheduler=0; /* should it run from the scheduler? */
   int  gotArg=0;
   char *agentDesc = "Deletes upload.  Other list/delete options available from the command line.";
   char *commitHash;
@@ -202,7 +201,7 @@ int main (int argc, char *argv[])
         gotArg=1;
         break;
       case 's':
-        scheduler=1;
+        Scheduler=1;
         gotArg=1;
         break;
       case 'T':
@@ -238,7 +237,7 @@ int main (int argc, char *argv[])
     exitNow(-1);
   }
 
-  if (scheduler != 1)
+  if (Scheduler != 1)
   {
     if (0 != authentication(userName, password, &userId, &userPerm))
     {

--- a/src/delagent/agent/delagent.h
+++ b/src/delagent/agent/delagent.h
@@ -32,6 +32,11 @@ extern int Verbose;
  * Set if working in test mode else 0
  */
 extern int Test;
+/**
+ * \var int Scheduler
+ * Set if working in scheduler mode else 0
+ */
+extern int Scheduler;
 
 /* for DB */
 extern PGconn* pgConn;


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix minor errors in delagent.

### Changes

1. Use default table name as `uploadtree`.
2. Make most of SQL calls logged.
3. Send heartbeat if running from scheduler.

## How to test

1. Run delagent from CLI using `-U` flag to delete an upload.
2. Try to delete the same upload again.
3. Run delagent from UI.