### PR TITLE
fix(fo_mapping_license.php): Fix update_license()

### DIFF
--- a/install/db/fo_mapping_license.php
+++ b/install/db/fo_mapping_license.php
@@ -526,17 +526,26 @@ function update_license($old_rf_pk, $new_rf_pk)
 {
   global $PG_CONN;
 
+  $updateTables = array(
+    "clearing_event",
+    "license_file",
+    "license_set_bulk",
+    "upload_clearing_license"
+  );
+
   /** transaction begin */
   $sql = "BEGIN;";
   $result_begin = pg_query($PG_CONN, $sql);
   DBCheckResult($result_begin, $sql, __FILE__, __LINE__);
   pg_free_result($result_begin);
 
-  /* Update license_file table, substituting the old_rf_id  with the new_rf_id */
-  $sql = "update license_file set rf_fk = $new_rf_pk where rf_fk = $old_rf_pk;";
-  $result_license_file = pg_query($PG_CONN, $sql);
-  DBCheckResult($result_license_file, $sql, __FILE__, __LINE__);
-  pg_free_result($result_license_file);
+  /* Update all relevant tables, substituting the old_rf_id with the new_rf_id */
+  foreach ($updateTables as $table) {
+    $sql = "update $table set rf_fk = $new_rf_pk where rf_fk = $old_rf_pk;";
+    $result_license_file = pg_query($PG_CONN, $sql);
+    DBCheckResult($result_license_file, $sql, __FILE__, __LINE__);
+    pg_free_result($result_license_file);
+  }
 
   /* Check if license_file_audit table exists */
   $sql = "select count(tablename) from pg_tables where tablename like 'license_file_audit';";


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

When upgrading from version < 4.3 to 4.3 or later, obsolete identifiers will be renamed (e.g. GPL-2.0 -> GPL-2.0 only). If a license candidate exists with a shortname identical to the one to which we want to rename (e.g. we have a candidate with the name GPL-2.0-only), edited results and the main license can be lost for existing uploads. This Pull request addresses this issue.

### Changes

The problem happens, because update_license() is not taking all relevant tables into account (only the license_file table is touched). This can be fixed by updating clearing_event, license_set_bulk and upload_clearing_license as well.

## How to test


1. Install any FOSSology version < 4.3 (I tested with 4.1)
2. Create a license candidate with the name GPL-2.0-only
3. Upload a package with GPL-2.0 licensed files (I tested with busybox 1.36.1) and scan with nomos, monk and ojo for licenses
4. Clear a few files with a GPL-2.0 finding and set "Identified" for "Clearing decision type"
5. Select GPL-2.0 as main license
6. Upgrade your installation to >= 4.3. The fo-postinstall step will rename old identifiers (e.g. GPL-2.0 -> GPL-2.0-only)
7. Review the previously cleared package

Without this fix the main license and the "Edited results" for all files, which had GPL-2.0 as a clearing decision, will be gone. With this fix applied, the update works as expected.

Fixes: #2732 