### PR TITLE
fix(ReportUtils): Include files with 'No_license_found' as well

### DIFF
--- a/src/lib/php/Report/ReportUtils.php
+++ b/src/lib/php/Report/ReportUtils.php
@@ -134,8 +134,7 @@ class ReportUtils
     foreach ($rows as $row) {
       $reportedLicenseId = $this->licenseMap->getProjectedId($row['rf_fk']);
       $foundLicense = $this->licenseDao->getLicenseById($reportedLicenseId);
-      if ($foundLicense !== null && $foundLicense->getShortName() != 'Void' &&
-          $foundLicense->getShortName() != 'No_license_found') {
+      if ($foundLicense !== null && $foundLicense->getShortName() != 'Void') {
         $reportLicId =  "$reportedLicenseId-" . md5($foundLicense->getText());
         $listedLicense = !StringOperation::stringStartsWith(
           $foundLicense->getSpdxId(), LicenseRef::SPDXREF_PREFIX);
@@ -143,7 +142,11 @@ class ReportUtils
         if (!array_key_exists($row['uploadtree_pk'], $filesWithLicenses)) {
           $filesWithLicenses[$row['uploadtree_pk']] = new FileNode();
         }
-        $filesWithLicenses[$row['uploadtree_pk']]->addScanner($reportLicId);
+        if ($foundLicense->getShortName() != 'No_license_found') {
+          $filesWithLicenses[$row['uploadtree_pk']]->addScanner($reportLicId);
+        } else {
+          $filesWithLicenses[$row['uploadtree_pk']]->addScanner("");
+        }
         if (!array_key_exists($reportLicId, $licensesInDocument)) {
           $licensesInDocument[$reportLicId] = (new SpdxLicenseInfo())
             ->setLicenseObj($foundLicense)


### PR DESCRIPTION
## Description

Since the changes for de-duplication of licenses with the same SPDX ID in commit e01006b21646b4129b61bc72de7015e9714f0c71 , exported reports do not contain entries for files fith 'No_license_found'. These have to be included (and were included before the above mentioned commit).

### Changes

This commit adjusts the behaviour of addScannerResults() in a way, that files with 'No_license_found' will be reported.

## How to test

1. Take any FOSSology version starting with commit e01006b21646b4129b61bc72de7015e9714f0c71
2. Upload and clear a package (I've uploaded busybox-1.36.1.tar.bz2 and imported an existing RDF report from the OSSelot project)
3. Create a SPDX TV or RDF export

Without these changes the reports won't contain any entries for all files with 'No_license_found'  as scanner result (for busybox, Makefile.custom in the top level directory is such a file). With these changes applied, the reports will contain the relevant entries.
