### PR TITLE
fix(AjaxExplorer): Check the return value of getLicenseByShortName()

### DIFF
--- a/src/www/ui/async/AjaxExplorer.php
+++ b/src/www/ui/async/AjaxExplorer.php
@@ -359,11 +359,14 @@ class AjaxExplorer extends DefaultPlugin
 
       if ($request->get('fromRest')) {
         foreach ($licenseEntries as $shortName) {
-          $licenseEntriesRest[] = array(
-            "id" => $this->licenseDao->getLicenseByShortName($shortName, $groupId)->getId(),
-            "name" => $shortName,
-            "agents" => []
-          );
+          $lookedupLicense = $this->licenseDao->getLicenseByShortName($shortName, $groupId);
+          if ($lookedupLicense !== null) {
+            $licenseEntriesRest[] = array(
+              "id" => $lookedupLicense->getId(),
+              "name" => $shortName,
+              "agents" => []
+            );
+          }
         }
       }
     } else {
@@ -386,11 +389,16 @@ class AjaxExplorer extends DefaultPlugin
               "matchPercentage" => intval($match['match_percentage']),
             );
           }
-          $licenseEntriesRest[] = array(
-            "id" => $this->licenseDao->getLicenseByShortName($shortName, $groupId)->getId(),
-            "name" => $shortName,
-            "agents" => $agentEntriesRest,
-          );
+
+          $lookedupLicense = $this->licenseDao->getLicenseByShortName($shortName, $groupId);
+          if ($lookedupLicense !== null) {
+            $licenseEntriesRest[] = array(
+              "id" => $lookedupLicense->getId(),
+              "name" => $shortName,
+              "agents" => $agentEntriesRest,
+            );
+          }
+
           $licenseEntries[] = $shortName . " [" . implode("][", $agentEntries) . "]";
         }
       }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

createFileDataRow() calls getId() on the return value of getLicenseByShortName() without checking it:

```
$licenseEntriesRest[] = array(
  "id" => $this->licenseDao->getLicenseByShortName($shortName, $groupId)->getId(),
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  "name" => $shortName,
  "agents" => $agentEntriesRest,
  );
```

In an error condition that would make the UI silently fail / crash.

### Changes

Make the code more robust and check the return value of getLicenseByShortName() before using it. Only call getId() if a valid license is returned by getLicenseByShortName().

## How to test

Only the behaviour in an unexpected error condition is changed. No functional changes are expected. No visible changes for the users.
