### PR TITLE
fix(Report): Check the return value of getLicenseById()

### DIFF
--- a/src/lib/php/Report/LicenseClearedGetter.php
+++ b/src/lib/php/Report/LicenseClearedGetter.php
@@ -199,7 +199,12 @@ class LicenseClearedGetter extends ClearedGetterCommon
     if (!array_key_exists($licenseId, $this->licenseCache)) {
       $this->licenseCache[$licenseId] = $this->licenseDao->getLicenseById($licenseId, $groupId);
     }
-    return $this->licenseCache[$licenseId]->getText();
+
+    if ($this->licenseCache[$licenseId] !== null) {
+       return $this->licenseCache[$licenseId]->getText();
+    } else {
+       return null;
+    }
   }
 
   /**
@@ -211,7 +216,12 @@ class LicenseClearedGetter extends ClearedGetterCommon
     if (!array_key_exists($licenseId, $this->licenseCache)) {
       $this->licenseCache[$licenseId] = $this->licenseDao->getLicenseById($licenseId, $groupId);
     }
-    return $this->licenseCache[$licenseId]->getRisk();
+
+    if ($this->licenseCache[$licenseId] !== null) {
+      return $this->licenseCache[$licenseId]->getRisk();
+    } else {
+      return null;
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

getCachedLicenseRisk() and getCachedLicenseText() do call getRisk() / getText() on $this->licenseCache[$licenseId] without checking the value before.

```
if (!array_key_exists($licenseId, $this->licenseCache)) {
  $this->licenseCache[$licenseId] = $this->licenseDao->getLicenseById($licenseId, $groupId);
  }
return $this->licenseCache[$licenseId]->getText();
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

In an error condition, this will make a report generation fail with a null pointer dereference.

### Changes
I propose to check $this->licenseCache[$licenseId] for null before calling getRisk() or getText(). In case $this->licenseCache[$licenseId] is null, we return null to the callers of getCachedLicenseRisk() and getCachedLicenseText(), so they can deal with it.

## How to test

Only the behaviour in an unexpected error condition is changed. No functional changes are expected. No visible changes for the users.
