### PR TITLE
fix(report): use groupId to get candidate licenses which are main license

### DIFF
--- a/src/cyclonedx/agent/cyclonedx.php
+++ b/src/cyclonedx/agent/cyclonedx.php
@@ -193,7 +193,7 @@ class CycloneDXAgent extends Agent
     $mainLicenses = array();
     foreach ($mainLicenseIds as $licId) {
       $reportedLicenseId = $this->licenseMap->getProjectedId($licId);
-      $mainLicObj = $this->licenseDao->getLicenseById($reportedLicenseId);
+      $mainLicObj = $this->licenseDao->getLicenseById($reportedLicenseId, $this->groupId);
       $licId = $mainLicObj->getId() . "-" . md5($mainLicObj->getText());
       if (!array_key_exists($licId, $this->licensesInDocument)) {
         $this->licensesInDocument = (new SpdxLicenseInfo())

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -354,7 +354,7 @@ class SpdxTwoAgent extends Agent
     $mainLicenses = array();
     foreach ($mainLicenseIds as $licId) {
       $reportedLicenseId = $this->licenseMap->getProjectedId($licId);
-      $mainLicense = $this->licenseDao->getLicenseById($reportedLicenseId);
+      $mainLicense = $this->licenseDao->getLicenseById($reportedLicenseId, $this->groupId);
       $reportLicId = $mainLicense->getId() . "-" . md5($mainLicense->getText());
       $mainLicenses[] = $reportLicId;
       if (!array_key_exists($reportLicId, $this->licensesInDocument)) {


### PR DESCRIPTION

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Main licenses are obtained using `getLicenseById` method of `licenseDao`. But `groupId` is not passed as an argument so if a candidate license is a main license an error will occur when generating reports for that upload.

### Changes

- `groupId` is passed in the `getLicenseById` method of licenseDao.

## How to test

1.) Create a test file with SPDX-License-Identifier: LicenseRef-123 or any custom license identifier with LicenseRef- prefix.
2.) Scan the file with ojo, make it main license and clear it.
3.) Export SPDX tag value report.

Fixes #2752 
CC @GMishx @shaheemazmalmmd 
