### PR TITLE
feat(automation) : Add line numbers to keyword and copyright scanners

### DIFF
--- a/utils/automation/FoScanner/FormatResults.py
+++ b/utils/automation/FoScanner/FormatResults.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2024 Rajul Jha <rajuljha49@gmail.com>
+# SPDX-FileContributor: © Rajul Jha <rajuljha49@gmail.com>
 
 # SPDX-License-Identifier: GPL-2.0-only
 
 import re
 import os
-import binascii
 
 from .CliOptions import CliOptions
 
 class FormatResult:
     """
     For formatting the results from scanners with line number information
+
+    :ivar cli_options: CliOptions object
     """
 
     def __init__(self,cli_options:CliOptions):
@@ -105,10 +106,13 @@ class FormatResult:
       for root, dirs, files in os.walk(root_dir):
         for file_name in files:
           file_path = os.path.join(root, file_name)
-          with open(file_path, 'r') as file:
+          with open(file_path, 'r', encoding='UTF-8') as file:
             file_contents = file.read()
-            normal_string = file_contents.encode().decode('unicode_escape')
+            try:
+              normal_string = file_contents.encode().decode('unicode_escape')
+            except UnicodeDecodeError:
+              normal_string = file_contents
             formatted_diff = self.format_diff(normal_string)
-          with open(file_path, 'w') as file:
+          with open(file_path, 'w', encoding='utf-8') as file:
             file.write(formatted_diff)
       return None

--- a/utils/automation/FoScanner/FormatResults.py
+++ b/utils/automation/FoScanner/FormatResults.py
@@ -15,6 +15,7 @@ class FormatResult:
 
     :ivar cli_options: CliOptions object
     """
+    cli_options : CliOptions = None
 
     def __init__(self,cli_options:CliOptions):
         self.cli_options = cli_options
@@ -29,31 +30,31 @@ class FormatResult:
       formatted_diff = []
       diff_lines = diff_content.splitlines()
       left = right = 0
-      ll = rl = 0
+      left_num_len = right_num_len = 0
       for line in diff_lines:
         match = re.match(r'^@@ -([0-9]+),([0-9]+) [+]([0-9]+),([0-9]+) @@', line)
         if match:
           left = int(match.group(1))
-          ll = len(match.group(2))
+          left_num_len = len(match.group(2))
           right = int(match.group(3))
-          rl = len(match.group(4))
+          right_num_len = len(match.group(4))
           formatted_diff.append(line)
           continue
-          
+
         if re.match(r'^(---|\+\+\+|[^-+ ])', line):
           formatted_diff.append(line)
           continue
         line_content = line[1:]
         if line.startswith('-'):
-          padding = ' ' * rl
-          formatted_diff.append(f"-{left:<{ll}} {padding}:{line_content}")
+          padding = ' ' * right_num_len
+          formatted_diff.append(f"-{left:<{left_num_len}} {padding}:{line_content}")
           left += 1
         elif line.startswith('+'):
-          padding = ' ' * ll
-          formatted_diff.append(f"+{padding} {right:<{rl}}:{line_content}")
+          padding = ' ' * left_num_len
+          formatted_diff.append(f"+{padding} {right:<{right_num_len}}:{line_content}")
           right += 1
         else:
-          formatted_diff.append(f" {left:<{ll}} {right:<{rl}}:{line_content}")
+          formatted_diff.append(f" {left:<{left_num_len}} {right:<{right_num_len}}:{line_content}")
           left += 1
           right += 1
 
@@ -69,29 +70,48 @@ class FormatResult:
       :return: List of line_numbers found for a given word
       """
       escaped_word = re.escape(diff_string[word_start_byte:word_end_byte])
-      # pattern = re.compile(r'(\d+):.*\b' + escaped_word + r'\b')
       pattern = re.compile(r'(\d+):.*?' + escaped_word)
       matches = pattern.findall(diff_string)
       return matches
 
-    def find_word_line_numbers(self, file_path, words:list) -> dict:
+    def find_word_line_numbers(self, file_path, words:list, key:str) -> dict:
       """
       Find the line number of each word found for a given file path
 
       :param: file_path : str Path of the file to scan
       :param: words: list List of words(ScanResult Objects) to be scanned for
+      :param: Key to scan: 'contents' for copyright and keyword and 'license' for nomos and ojo
       :return: found_words_with_line_number : dict Dictionary of scanned results
                 with key as scanned word and value as list of line_numbers where 
                 it is found.
       """
-      if self.cli_options.repo is True:
-          return {}
       found_words_with_line_number = {}
-      with open(file_path, 'r') as file:
+      if self.cli_options.repo is True:
+        try:
+          with open(file_path, 'rb') as file:
+            binary_data = file.read()
+          string_data = binary_data.decode('utf-8', errors='ignore')
+          for i in range(0,len(words)):
+            line_numbers_list = []
+            line_number = string_data[0:words[i]['start']].count("\n") + 1
+            line_numbers_list.append(str(line_number))
+            found_words_with_line_number[words[i][f'{key}']] = line_numbers_list
+          return found_words_with_line_number
+        except FileNotFoundError:
+          print(f"The file {file_path} does not exist.")
+          return None
+        except IOError as e:
+          print(f"An I/O error occurred: {e}")
+          return None
+        except Exception as e:
+          print(f"An error occurred: {e}")
+          return None
+      else:    
+        with open(file_path, 'r') as file:
           content = file.read()
           for i in range(0,len(words)):
-              line_numbers = self.find_line_numbers(content, words[i]['start'], words[i]['end'])
-              found_words_with_line_number[words[i]['content']] = line_numbers
+            line_numbers = self.find_line_numbers(content, words[i]['start'], words[i]['end'])
+            found_words_with_line_number[words[i][f'{key}']] = line_numbers
       return found_words_with_line_number
 
     def process_files(self, root_dir):

--- a/utils/automation/FoScanner/FormatResults.py
+++ b/utils/automation/FoScanner/FormatResults.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2024 Rajul Jha <rajuljha49@gmail.com>
+
+# SPDX-License-Identifier: GPL-2.0-only
+
+import re
+import os
+import binascii
+
+from .CliOptions import CliOptions
+
+class FormatResult:
+    """
+    For formatting the results from scanners with line number information
+    """
+
+    def __init__(self,cli_options:CliOptions):
+        self.cli_options = cli_options
+    
+    def format_diff(self,diff_content):
+      """
+      Format the diff content in a particular format with corrected line numbers.
+
+      :param: diff_content: str String to format
+      :return: str formatted_string
+      """
+      formatted_diff = []
+      diff_lines = diff_content.splitlines()
+      left = right = 0
+      ll = rl = 0
+      for line in diff_lines:
+        match = re.match(r'^@@ -([0-9]+),([0-9]+) [+]([0-9]+),([0-9]+) @@', line)
+        if match:
+          left = int(match.group(1))
+          ll = len(match.group(2))
+          right = int(match.group(3))
+          rl = len(match.group(4))
+          formatted_diff.append(line)
+          continue
+          
+        if re.match(r'^(---|\+\+\+|[^-+ ])', line):
+          formatted_diff.append(line)
+          continue
+        line_content = line[1:]
+        if line.startswith('-'):
+          padding = ' ' * rl
+          formatted_diff.append(f"-{left:<{ll}} {padding}:{line_content}")
+          left += 1
+        elif line.startswith('+'):
+          padding = ' ' * ll
+          formatted_diff.append(f"+{padding} {right:<{rl}}:{line_content}")
+          right += 1
+        else:
+          formatted_diff.append(f" {left:<{ll}} {right:<{rl}}:{line_content}")
+          left += 1
+          right += 1
+
+      return "\n".join(formatted_diff)
+
+    def find_line_numbers(self, diff_string, word_start_byte, word_end_byte):
+      """
+      Find line numbers from formmatted diff data
+
+      :param: diff_string : str Formatted diff string 
+      :param: word_start_byte : int Start byte of scanner result
+      :param: word_end_byte : int End byte of scanner result
+      :return: List of line_numbers found for a given word
+      """
+      escaped_word = re.escape(diff_string[word_start_byte:word_end_byte])
+      # pattern = re.compile(r'(\d+):.*\b' + escaped_word + r'\b')
+      pattern = re.compile(r'(\d+):.*?' + escaped_word)
+      matches = pattern.findall(diff_string)
+      return matches
+
+    def find_word_line_numbers(self, file_path, words:list) -> dict:
+      """
+      Find the line number of each word found for a given file path
+
+      :param: file_path : str Path of the file to scan
+      :param: words: list List of words(ScanResult Objects) to be scanned for
+      :return: found_words_with_line_number : dict Dictionary of scanned results
+                with key as scanned word and value as list of line_numbers where 
+                it is found.
+      """
+      if self.cli_options.repo is True:
+          return {}
+      found_words_with_line_number = {}
+      with open(file_path, 'r') as file:
+          content = file.read()
+          for i in range(0,len(words)):
+              line_numbers = self.find_line_numbers(content, words[i]['start'], words[i]['end'])
+              found_words_with_line_number[words[i]['content']] = line_numbers
+      return found_words_with_line_number
+
+    def process_files(self, root_dir):
+      """
+      Format the files according to unified diff format
+      
+      :param: root_dir : str Path of the temp dir root to format the files
+      :return: None
+      """
+      if self.cli_options.repo is True:
+        return None
+      for root, dirs, files in os.walk(root_dir):
+        for file_name in files:
+          file_path = os.path.join(root, file_name)
+          with open(file_path, 'r') as file:
+            file_contents = file.read()
+            normal_string = file_contents.encode().decode('unicode_escape')
+            formatted_diff = self.format_diff(normal_string)
+          with open(file_path, 'w') as file:
+            file.write(formatted_diff)
+      return None

--- a/utils/automation/FoScanner/RepoSetup.py
+++ b/utils/automation/FoScanner/RepoSetup.py
@@ -144,4 +144,5 @@ class RepoSetup:
             os.makedirs(name=curr_dir, exist_ok=True)
           curr_file = open(file=curr_file, mode='w+', encoding='UTF-8')
           print(change[change_key],file=curr_file)
+
     return self.temp_dir.name

--- a/utils/automation/FoScanner/RepoSetup.py
+++ b/utils/automation/FoScanner/RepoSetup.py
@@ -144,5 +144,4 @@ class RepoSetup:
             os.makedirs(name=curr_dir, exist_ok=True)
           curr_file = open(file=curr_file, mode='w+', encoding='UTF-8')
           print(change[change_key],file=curr_file)
-
     return self.temp_dir.name

--- a/utils/automation/FoScanner/Scanners.py
+++ b/utils/automation/FoScanner/Scanners.py
@@ -176,7 +176,6 @@ class Scanners:
         continue
       if result['results'] is not None and result['results'] != "Unable to " \
                                                                 "read file":
-        # contents = set() # Giving error with set
         contents = list()
 
         for finding in result['results']:

--- a/utils/automation/FoScanner/Scanners.py
+++ b/utils/automation/FoScanner/Scanners.py
@@ -32,6 +32,24 @@ class ScanResult:
     self.result = result
 
 
+class ScanResultList(ScanResult):
+  """
+  Store scan results from agents with result as a list of dictionaries.
+
+  :ivar file: File location
+  :ivar path: Actual location of file
+  :ivar result: License list for file as a list of dictionaries
+  """
+  file: str = None
+  path: str = None
+  result: List[dict] = None
+
+  def __init__(self, file: str, path: str, result: List[dict]):
+    self.file = file
+    self.path = path
+    self.result = result
+
+
 class Scanners:
   """
   Handle all the data from different scanners.
@@ -87,7 +105,7 @@ class Scanners:
 
     :return: raw json from nomos
     """
-    nomossa_process = Popen([self.nomos_path, "-J", "-l", "-d",
+    nomossa_process = Popen([self.nomos_path, "-S", "-J", "-l", "-d",
                              self.cli_options.diff_dir, "-n",
                              str(multiprocessing.cpu_count() - 1)], stdout=PIPE)
     result = nomossa_process.communicate()[0]
@@ -126,15 +144,16 @@ class Scanners:
     result = keyword_process.communicate()[0]
     return json.loads(result.decode('UTF-8').strip())
 
-  def get_copyright_list(self, all_results: bool = False) \
-      -> Union[List[ScanResult], bool]:
+  def get_copyright_list(self, all_results: bool = False, whole: bool = False) \
+    -> Union[List[ScanResult],List[ScanResultList],bool]:
     """
     Get the formatted results from copyright scanner
 
     :param all_results: Get all results even excluded files?
     :type all_results: bool
+    :param: whole: return whole content from scanner
     :return: list of findings
-    :rtype: list[ScanResult]
+    :rtype: List[ScanResult] | List[ScanResultList]
     """
     copyright_results = self.__get_copyright_results()
     copyright_list = list()
@@ -146,77 +165,31 @@ class Scanners:
       if result['results'] is not None and result['results'] != "Unable to " \
                                                                 "read file":
         contents = set()
+        json_copyright_info = list()
         for finding in result['results']:
-          if finding is not None and finding['type'] == "statement":
-            content = finding['content'].strip()
-            if content != "":
-              contents.add(content)
-        if len(contents) > 0:
+          if whole:
+            if finding is not None and finding['type'] == "statement" and finding['content'] != "":
+              json_copyright_info.append(finding)              
+          else:
+            if finding is not None and finding['type'] == "statement":
+              content = finding['content'].strip()
+              if content != "":
+                contents.add(content)
+        if whole and len(json_copyright_info) > 0:
+          copyright_list.append(ScanResultList(path, result['file'], json_copyright_info))
+        elif not whole and len(contents) > 0:
           copyright_list.append(ScanResult(path, result['file'], contents))
     if len(copyright_list) > 0:
       return copyright_list
-    return False
-
-  def get_copyright_whole(self, all_results: bool = False) \
-      -> Union[List[ScanResult], bool]:
-    """
-    Get the formatted results from copyright scanner
-
-    :param all_results: Get all results even excluded files?
-    :type all_results: bool
-    :return: list of findings
-    :rtype: list[ScanResult]
-    """
-    copyright_results = self.__get_copyright_results()
-    copyright_list = list()
-    for result in copyright_results:
-      path = self.__normalize_path(result['file'])
-      if self.cli_options.repo is True and all_results is False and \
-          self.is_excluded_path(path) is True:
-        continue
-      if result['results'] is not None and result['results'] != "Unable to " \
-                                                                "read file":
-        contents = list()
-
-        for finding in result['results']:
-          if finding is not None and finding['type'] == "statement":
-            contents.append(finding)
-        if len(contents) > 0:
-          copyright_list.append(ScanResult(path, result['file'], contents))
-    if len(copyright_list) > 0:
-      return copyright_list
-    return False
-
-  def get_keyword_whole(self) -> Union[List[ScanResult], bool]:
-    """
-    Get the formatted results from keyword scanner
-
-    :return: list of findings
-    """
-    keyword_results = self.__get_keyword_results()
-    keyword_list = list()
-    for result in keyword_results:
-      path = self.__normalize_path(result['file'])
-      if self.cli_options.repo is True and self.is_excluded_path(path) is \
-          True:
-        continue
-      if result['results'] is not None and result['results'] != "Unable to " \
-                                                                "read file":
-        contents = list()
-        for finding in result['results']:
-          if finding is not None:
-            contents.append(finding)
-        if len(contents) > 0:
-          keyword_list.append(ScanResult(path, result['file'], contents))
-    if len(keyword_list) > 0:
-      return keyword_list
     return False
   
-  def get_keyword_list(self) -> Union[List[ScanResult], bool]:
+  def get_keyword_list(self, whole:bool = False) -> Union[List[ScanResult],List[ScanResultList],bool]:
     """
     Get the formatted results from keyword scanner
 
-    :return: list of findings
+    :param: whole: return whole content from scanner
+    :return: List of findings
+    :rtype: List[ScanResult] | List[ScanResultList] | bool
     """
     keyword_results = self.__get_keyword_results()
     keyword_list = list()
@@ -228,40 +201,59 @@ class Scanners:
       if result['results'] is not None and result['results'] != "Unable to " \
                                                                 "read file":
         contents = set()
+        json_keyword_info = list()
         for finding in result['results']:
-          if finding is not None:
-            content = finding['content'].strip()
-            if content != "":
-              contents.add(content)
-        if len(contents) > 0:
+          if whole:
+            if finding is not None and finding['content'] != "":
+              json_keyword_info.append(finding)
+          else:
+            if finding is not None:
+              content = finding['content'].strip()
+              if content != "":
+                contents.add(content)
+        if whole and len(json_keyword_info) > 0:
+          keyword_list.append(ScanResultList(path, result['file'], json_keyword_info))
+        elif not whole and len(contents) > 0:
           keyword_list.append(ScanResult(path, result['file'], contents))
     if len(keyword_list) > 0:
       return keyword_list
     return False
 
-  def __get_license_nomos(self) -> List[ScanResult]:
+  def __get_license_nomos(self, whole: bool = False) -> Union[List[ScanResult],List[ScanResultList]]:
     """
     Get the formatted results from nomos scanner
 
+    :param: whole: return whole content from scanner
     :return: list of findings
+    :rtype: List[ScanResult] | List[ScanResultList]
     """
+    
     nomos_result = self.__get_nomos_result()
     scan_result = list()
-    for result in nomos_result['results']:
+    for result in nomos_result['results']: # result is an item of list and is a dict
       path = self.__normalize_path(result['file'])
       licenses = set()
+      json_license_info = list()
       for scan_license in result['licenses']:
-        if scan_license != 'No_license_found':
-          licenses.add(scan_license.strip())
-      if len(licenses) > 0:
+        if whole:
+          if scan_license['license'] != "No_license_found":
+            json_license_info.append(scan_license)
+        else:
+          if scan_license['license'] != 'No_license_found':
+            licenses.add(scan_license['license'])
+      if whole and len(json_license_info) > 0:
+        scan_result.append(ScanResultList(path,result['file'], json_license_info))
+      elif not whole and len(licenses) > 0:
         scan_result.append(ScanResult(path, result['file'], licenses))
     return scan_result
 
-  def __get_license_ojo(self) -> List[ScanResult]:
+  def __get_license_ojo(self, whole:bool = False) -> Union[List[ScanResult],List[ScanResultList]]:
     """
     Get the formatted results from ojo scanner
 
+    :param: whole: return whole content from scanner
     :return: list of findings
+    :rtype: List[ScanResult] | List[ScanResultList]
     """
     ojo_result = self.__get_ojo_result()
     scan_result = list()
@@ -270,11 +262,18 @@ class Scanners:
       if result['results'] is not None and result['results'] != 'Unable to ' \
                                                                 'read file':
         licenses = set()
+        json_license_info = list()
         for finding in result['results']:
-          if finding['license'] is not None:
-            licenses.add(finding['license'].strip())
+          if whole:
+            if finding['license'] is not None:
+              json_license_info.append(finding)
+          else:
+            if finding['license'] is not None:
+              licenses.add(finding['license'].strip())
         if len(licenses) > 0:
           scan_result.append(ScanResult(path, result['file'], licenses))
+        elif len(json_license_info) > 0:
+          scan_result.append(ScanResultList(path, result['file'], json_license_info))
     return scan_result
 
   def __merge_nomos_ojo(self, nomos_licenses: List[ScanResult],
@@ -296,24 +295,41 @@ class Scanners:
         nomos_licenses.append(ojo_entry)
     return nomos_licenses
 
-  def get_non_allow_listed_results(self, scan_results: List[ScanResult]) \
-      -> List[ScanResult]:
+  def get_non_allow_listed_results(self, scan_results: List[ScanResult]= None, \
+                                  scan_results_whole: List[ScanResultList]= None, \
+                                  whole:bool = False) \
+                                  -> Union[List[ScanResult],List[ScanResultList]]:
     """
     Get results where license check failed.
 
     :param scan_results: Scan result from ojo/nomos
+    :param scan_results_whole: Whole scan result from ojo/nomos
+    :param: whole: return whole content from scanner
+    
     :return: List of results with only not allowed licenses
+    :rtype: List[ScanResult] | List[ScanResultList]
     """
     final_results = []
-    for row in scan_results:
-      if self.cli_options.repo is True and self.is_excluded_path(row.file) \
+    if whole and scan_results_whole is not None:
+      for row in scan_results_whole:
+        if self.cli_options.repo is True and self.is_excluded_path(row.file) \
           is True:
-        continue
-      license_set = row.result
-      failed_licenses = set([lic for lic in license_set if lic not in
-                             self.cli_options.allowlist['licenses']])
-      if len(failed_licenses) > 0:
-        final_results.append(ScanResult(row.file, row.path, failed_licenses))
+          continue
+        license_info_list = row.result
+        failed_licenses_list = list([lic for lic in license_info_list if lic['license'] not in
+                              self.cli_options.allowlist['licenses']])
+        if len(failed_licenses_list) > 0:
+          final_results.append(ScanResultList(row.file, row.path, failed_licenses_list))
+    elif not whole and scan_results is not None:
+      for row in scan_results:
+        if self.cli_options.repo is True and self.is_excluded_path(row.file) \
+            is True:
+          continue
+        license_set = row.result
+        failed_licenses = set([lic for lic in license_set if lic not in
+                              self.cli_options.allowlist['licenses']])
+        if len(failed_licenses) > 0:
+          final_results.append(ScanResult(row.file, row.path, failed_licenses))
     return final_results
 
   def get_non_allow_listed_copyrights(self,
@@ -331,49 +347,82 @@ class Scanners:
                                           False
     ]
 
-  def results_are_allow_listed(self) -> Union[List[ScanResult], bool]:
+  def results_are_allow_listed(self, whole:bool = False) \
+    -> Union[List[ScanResult],List[ScanResultList],bool]:
     """
     Get the formatted list of license scanner findings
 
     The list contains the merged result of nomos/ojo scanner based on
     cli_options passed
 
+    :param: whole: return whole content from scanner
     :return: merged list of scanner findings
+    :rtype: List[ScanResult] | List[ScanResultList] | bool
     """
     failed_licenses = None
     nomos_licenses = []
 
     if self.cli_options.nomos:
-      nomos_licenses = self.__get_license_nomos()
-      if self.cli_options.ojo is False:
-        failed_licenses = self.get_non_allow_listed_results(nomos_licenses)
-    if self.cli_options.ojo:
-      ojo_licenses = self.__get_license_ojo()
-      if self.cli_options.nomos is False:
-        failed_licenses = self.get_non_allow_listed_results(ojo_licenses)
+      if whole is True:
+        nomos_licenses = self.__get_license_nomos(whole=True)
       else:
-        failed_licenses = self.get_non_allow_listed_results(
-          self.__merge_nomos_ojo(nomos_licenses, ojo_licenses))
+        nomos_licenses = self.__get_license_nomos()
+      if self.cli_options.ojo is False:
+        if whole is True:
+          failed_licenses = self.get_non_allow_listed_results(
+          scan_results_whole=nomos_licenses, whole=True)
+        else:
+          failed_licenses = self.get_non_allow_listed_results(scan_results=nomos_licenses)
+    if self.cli_options.ojo:
+      if whole is True:
+        ojo_licenses = self.__get_license_ojo(whole=True)
+      else:
+        ojo_licenses = self.__get_license_ojo()
+      if self.cli_options.nomos is False:
+        if whole is True:
+          failed_licenses = self.get_non_allow_listed_results(
+          scan_results_whole=ojo_licenses, whole=True)
+        else:
+          failed_licenses = self.get_non_allow_listed_results(scan_results=ojo_licenses)
+      else:
+        if whole is True:
+          failed_licenses = self.get_non_allow_listed_results(
+            scan_results_whole=nomos_licenses + ojo_licenses, whole=True)
+        else:
+          failed_licenses = self.get_non_allow_listed_results(
+            scan_results=self.__merge_nomos_ojo(nomos_licenses, ojo_licenses))
     if len(failed_licenses) > 0:
       return failed_licenses
     return True
 
-  def get_scanner_results(self) -> List[ScanResult]:
+  def get_scanner_results(self, whole:bool = False) \
+    -> Union[List[ScanResult],List[ScanResultList]]:
     """
     Get scan results from nomos and ojo scanners (whichever is selected).
 
+    :param: whole: return whole content from scanner
     :return: List of scan results
+    :rtype: List[ScanResult] | List[ScanResultList]
     """
     nomos_licenses = []
     ojo_licenses = []
 
     if self.cli_options.nomos:
-      nomos_licenses = self.__get_license_nomos()
+      if whole:
+        nomos_licenses = self.__get_license_nomos(whole=True)
+      else:
+        nomos_licenses = self.__get_license_nomos()
     if self.cli_options.ojo:
-      ojo_licenses = self.__get_license_ojo()
+      if whole:
+        ojo_licenses = self.__get_license_ojo(whole=True)
+      else:
+        ojo_licenses = self.__get_license_ojo()
 
     if self.cli_options.nomos and self.cli_options.ojo:
-      return self.__merge_nomos_ojo(nomos_licenses, ojo_licenses)
+      if whole:
+        return nomos_licenses + ojo_licenses
+      else:
+        return self.__merge_nomos_ojo(nomos_licenses, ojo_licenses)
     elif self.cli_options.nomos:
       return nomos_licenses
     else:

--- a/utils/automation/FoScanner/Scanners.py
+++ b/utils/automation/FoScanner/Scanners.py
@@ -157,6 +157,62 @@ class Scanners:
       return copyright_list
     return False
 
+  def get_copyright_whole(self, all_results: bool = False) \
+      -> Union[List[ScanResult], bool]:
+    """
+    Get the formatted results from copyright scanner
+
+    :param all_results: Get all results even excluded files?
+    :type all_results: bool
+    :return: list of findings
+    :rtype: list[ScanResult]
+    """
+    copyright_results = self.__get_copyright_results()
+    copyright_list = list()
+    for result in copyright_results:
+      path = self.__normalize_path(result['file'])
+      if self.cli_options.repo is True and all_results is False and \
+          self.is_excluded_path(path) is True:
+        continue
+      if result['results'] is not None and result['results'] != "Unable to " \
+                                                                "read file":
+        # contents = set() # Giving error with set
+        contents = list()
+
+        for finding in result['results']:
+          if finding is not None and finding['type'] == "statement":
+            contents.append(finding)
+        if len(contents) > 0:
+          copyright_list.append(ScanResult(path, result['file'], contents))
+    if len(copyright_list) > 0:
+      return copyright_list
+    return False
+
+  def get_keyword_whole(self) -> Union[List[ScanResult], bool]:
+    """
+    Get the formatted results from keyword scanner
+
+    :return: list of findings
+    """
+    keyword_results = self.__get_keyword_results()
+    keyword_list = list()
+    for result in keyword_results:
+      path = self.__normalize_path(result['file'])
+      if self.cli_options.repo is True and self.is_excluded_path(path) is \
+          True:
+        continue
+      if result['results'] is not None and result['results'] != "Unable to " \
+                                                                "read file":
+        contents = list()
+        for finding in result['results']:
+          if finding is not None:
+            contents.append(finding)
+        if len(contents) > 0:
+          keyword_list.append(ScanResult(path, result['file'], contents))
+    if len(keyword_list) > 0:
+      return keyword_list
+    return False
+  
   def get_keyword_list(self) -> Union[List[ScanResult], bool]:
     """
     Get the formatted results from keyword scanner

--- a/utils/automation/fossologyscanner.py
+++ b/utils/automation/fossologyscanner.py
@@ -19,6 +19,7 @@ from FoScanner.CliOptions import (CliOptions, ReportFormat)
 from FoScanner.RepoSetup import RepoSetup
 from FoScanner.Scanners import (Scanners, ScanResult)
 from FoScanner.SpdxReport import SpdxReport
+from FoScanner.FormatResults import FormatResult
 from FoScanner.Utils import (validate_keyword_conf_file, copy_keyword_file_to_destination)
 
 
@@ -91,13 +92,14 @@ def get_allow_list(path: str = '') -> dict:
   return data
 
 
-def print_results(name: str, failed_results: List[ScanResult],
+def print_results(name: str, failed_results: List[ScanResult],scan_results_with_line_number:List[dict],
                   result_file: IO):
   """
   Print the formatted scanner results
 
   :param name: Name of the scanner
   :param failed_results: formatted scanner results to be printed
+  :param: scan_results_with_line_number : List[dict] List of words mapped to their line numbers
   :param result_file: File to write results to
   """
   for files in failed_results:
@@ -109,6 +111,15 @@ def print_results(name: str, failed_results: List[ScanResult],
     print(f"{name}{plural}:")
     result_file.write(f"{name}{plural}:\n")
     for result in files.result:
+      for item in scan_results_with_line_number:
+        for scanned_word, lines in item.items():
+          if len(lines) > 1 :
+            plural = "s"
+          else:
+            plural = ""
+          if result == scanned_word:
+            lines_str = ", ".join(lines)
+            result = f"{scanned_word} at line{plural} {lines_str}\n"
       print("\t" + result)
       result_file.write("\t" + result + "\n")
 
@@ -117,7 +128,7 @@ def print_log_message(filename: str,
                       failed_list: Union[bool, List[ScanResult]],
                       check_value: bool, failure_text: str,
                       acceptance_text: str, scan_type: str,
-                      return_val: int) -> int:
+                      return_val: int, scan_results_with_line_number:List[dict] ) -> int:
   """
   Common helper function to print scan results.
 
@@ -128,6 +139,7 @@ def print_log_message(filename: str,
   :param acceptance_text: Message to print in case of no failures.
   :param scan_type: Type of scan to print.
   :param return_val: Return value for program
+  :param: scan_results_with_line_number : List[dict] List of words mapped to their line numbers
   :return: New return value
   """
   report_file = open(filename, 'w')
@@ -135,7 +147,7 @@ def print_log_message(filename: str,
       (isinstance(failed_list, list) and len(failed_list) != 0):
     print(f"\u2718 {failure_text}:")
     report_file.write(f"{failure_text}:\n")
-    print_results(scan_type, failed_list, report_file)
+    print_results(scan_type, failed_list, scan_results_with_line_number,report_file)
     if scan_type == "License":
       return_val = return_val | 2
     elif scan_type == "Copyright":
@@ -149,9 +161,59 @@ def print_log_message(filename: str,
   report_file.close()
   return return_val
 
+def format_keyword_results_with_line_numbers(scanner:Scanners,format_results:FormatResult):
+  """
+  Format the keyword results with line numbers
+
+  :param: scanner : Scanner Scanner object
+  :param: format_results : FormatResult FormatResult object
+  :return: list of dicts with key as word and value as list of line numbers of the words
+  """
+  keyword_results = scanner.get_keyword_whole()
+  formatted_list_of_keyword_line_numbers = list()
+  for keyword_result in keyword_results:
+    list_of_scan_results = list(keyword_result.result)
+    words_to_search = [list_of_scan_results[i] for i in range(0,len(list_of_scan_results))]
+    words_with_line_numbers = format_results.find_word_line_numbers(keyword_result.path,words_to_search)
+    formatted_list_of_keyword_line_numbers.append(words_with_line_numbers)
+  return formatted_list_of_keyword_line_numbers
+
+def format_copyright_results_with_line_numbers(scanner:Scanners,format_results:FormatResult):
+  """
+  Format the copyright results with line numbers
+
+  :param: scanner : Scanner Scanner object
+  :param: format_results : FormatResult FormatResult object
+  :return: list of dicts with key as word and value as list of line numbers of the words
+  """
+  copyright_results = scanner.get_copyright_whole()
+  formatted_list_of_copyright_line_numbers = list()
+  for copyright_result in copyright_results:
+    list_of_scan_results = list(copyright_result.result)
+    words_to_search = [list_of_scan_results[i] for i in range(0,len(list_of_scan_results))]
+    words_with_line_numbers = format_results.find_word_line_numbers(copyright_result.path,words_to_search)
+    formatted_list_of_copyright_line_numbers.append(words_with_line_numbers)
+  return formatted_list_of_copyright_line_numbers
+
+def format_license_results_with_line_numbers(scanner:Scanners,format_results:FormatResult):
+  """
+  Format the licenses results with line numbers
+
+  :param: scanner : Scanner Scanner object
+  :param: format_results : FormatResult FormatResult object
+  :return: list of dicts with key as word and value as list of line numbers of the words
+  """
+  license_results = scanner.results_are_allow_listed()
+  formatted_list_of_license_line_numbers = list()
+  for license_result in license_results:
+    list_of_scan_results = list(license_result.result)
+    words_to_search = [list_of_scan_results[i] for i in range(0,len(list_of_scan_results))]
+    words_with_line_numbers = format_results.find_word_line_numbers_without_bytes(license_result.path,words_to_search)
+    formatted_list_of_license_line_numbers.append(words_with_line_numbers)
+  return formatted_list_of_license_line_numbers
 
 def text_report(cli_options: CliOptions, result_dir: str, return_val: int,
-                scanner: Scanners) -> int:
+                scanner: Scanners, format_results = FormatResult) -> int:
   """
   Run scanners and print results in text format.
 
@@ -159,28 +221,32 @@ def text_report(cli_options: CliOptions, result_dir: str, return_val: int,
   :param result_dir: Result directory location
   :param return_val: Return value of program
   :param scanner: Scanner object
+  :param: format_results : FormatResult FormatResult object
   :return: Program's return value
   """
   if cli_options.nomos or cli_options.ojo:
     failed_licenses = scanner.results_are_allow_listed()
+    scan_results_with_line_number = []
     print_log_message(f"{result_dir}/licenses.txt", failed_licenses, True,
                       "Following licenses found which are not allow listed",
-                      "No license violation found", "License", return_val)
+                      "No license violation found", "License", return_val, scan_results_with_line_number)
   if cli_options.copyright:
     copyright_results = scanner.get_copyright_list()
+    scan_results_with_line_number = format_copyright_results_with_line_numbers(scanner=scanner, format_results=format_results)
     print_log_message(f"{result_dir}/copyrights.txt", copyright_results, False,
                       "Following copyrights found",
-                      "No copyright violation found", "Copyright", return_val)
+                      "No copyright violation found", "Copyright", return_val, scan_results_with_line_number)
   if cli_options.keyword:
     keyword_results = scanner.get_keyword_list()
+    scan_results_with_line_number = format_keyword_results_with_line_numbers(scanner=scanner, format_results=format_results)
     print_log_message(f"{result_dir}/keywords.txt", keyword_results, False,
                       "Following keywords found",
-                      "No keyword violation found", "Keyword", return_val)
+                      "No keyword violation found", "Keyword", return_val, scan_results_with_line_number)
   return return_val
 
 
 def bom_report(cli_options: CliOptions, result_dir: str, return_val: int,
-               scanner: Scanners, api_config: ApiConfig) -> int:
+               scanner: Scanners, api_config: ApiConfig, format_results: FormatResult) -> int:
   """
   Run scanners and print results as an SBOM.
 
@@ -189,17 +255,19 @@ def bom_report(cli_options: CliOptions, result_dir: str, return_val: int,
   :param return_val: Return value
   :param scanner: Scanner object
   :param api_config: API config options
+  :param: format_results : FormatResult FormatResult object
   :return: Program's return value
   """
   report_obj = SpdxReport(cli_options, api_config)
   if cli_options.nomos or cli_options.ojo:
     scan_results = scanner.get_scanner_results()
     report_obj.add_license_results(scan_results)
+    scan_results_with_line_number = []
     failed_licenses = scanner.get_non_allow_listed_results(scan_results)
     return_val = print_log_message(f"{result_dir}/licenses.txt",
         failed_licenses, True, "Following licenses found which are not allow "
                                "listed", "No license violation found",
-        "License", return_val)
+        "License", return_val, scan_results_with_line_number)
   if cli_options.copyright:
     copyright_results = scanner.get_copyright_list(all_results=True)
     if copyright_results is False:
@@ -207,14 +275,16 @@ def bom_report(cli_options: CliOptions, result_dir: str, return_val: int,
     report_obj.add_copyright_results(copyright_results)
     failed_copyrights = scanner.get_non_allow_listed_copyrights(
       copyright_results)
+    scan_results_with_line_number = format_copyright_results_with_line_numbers(scanner=scanner, format_results=format_results)
     return_val = print_log_message(f"{result_dir}/copyrights.txt",
         failed_copyrights, False, "Following copyrights found",
-        "No copyright violation found", "Copyright", return_val)
+        "No copyright violation found", "Copyright", return_val,scan_results_with_line_number)
   if cli_options.keyword:
     keyword_results = scanner.get_keyword_list()
+    scan_results_with_line_number = format_keyword_results_with_line_numbers(scanner=scanner, format_results=format_results)
     return_val = print_log_message(f"{result_dir}/keywords.txt",
         keyword_results, False, "Following keywords found",
-        "No keyword violation found", "Keyword", return_val)
+        "No keyword violation found", "Keyword", return_val, scan_results_with_line_number)
   report_obj.finalize_document()
   report_name = f"{result_dir}/sbom_"
   if cli_options.report_format == ReportFormat.SPDX_JSON:
@@ -268,15 +338,19 @@ def main(parsed_args):
   scanner = Scanners(cli_options)
   return_val = 0
 
+  # Populate tmp dir in unified diff format
+  format_results = FormatResult(cli_options)
+  format_results.process_files(scanner.cli_options.diff_dir)
+     
   # Create result dir
   result_dir = "results"
   os.makedirs(name=result_dir, exist_ok=True)
 
   if cli_options.report_format == ReportFormat.TEXT:
-    return_val = text_report(cli_options, result_dir, return_val, scanner)
+    return_val = text_report(cli_options, result_dir, return_val, scanner,format_results)
   else:
     return_val = bom_report(cli_options, result_dir, return_val, scanner,
-                            api_config)
+                            api_config,format_results)                      
   return return_val
 
 

--- a/utils/automation/fossologyscanner.py
+++ b/utils/automation/fossologyscanner.py
@@ -162,7 +162,8 @@ def print_log_message(filename: str,
   report_file.close()
   return return_val
 
-def format_keyword_results_with_line_numbers(scanner:Scanners,format_results:FormatResult):
+def format_keyword_results_with_line_numbers(scanner:Scanners,format_results:FormatResult) \
+  -> List[dict]:
   """
   Format the keyword results with line numbers
 
@@ -170,16 +171,19 @@ def format_keyword_results_with_line_numbers(scanner:Scanners,format_results:For
   :param: format_results : FormatResult FormatResult object
   :return: list of dicts with key as word and value as list of line numbers of the words
   """
-  keyword_results = scanner.get_keyword_whole()
+  keyword_results = scanner.get_keyword_list(whole=True)
+  if keyword_results is False:
+    return []
   formatted_list_of_keyword_line_numbers = list()
   for keyword_result in keyword_results:
     list_of_scan_results = list(keyword_result.result)
     words_with_line_numbers = format_results.find_word_line_numbers(keyword_result.path,
-    list_of_scan_results)
+    list_of_scan_results, key='content')
     formatted_list_of_keyword_line_numbers.append(words_with_line_numbers)
   return formatted_list_of_keyword_line_numbers
 
-def format_copyright_results_with_line_numbers(scanner:Scanners,format_results:FormatResult):
+def format_copyright_results_with_line_numbers(scanner:Scanners,format_results:FormatResult) \
+  -> List[dict]:
   """
   Format the copyright results with line numbers
 
@@ -187,15 +191,19 @@ def format_copyright_results_with_line_numbers(scanner:Scanners,format_results:F
   :param: format_results : FormatResult FormatResult object
   :return: list of dicts with key as word and value as list of line numbers of the words
   """
-  copyright_results = scanner.get_copyright_whole()
+  copyright_results = scanner.get_copyright_list(whole=True)
+  if copyright_results is False:
+    copyright_results = []
   formatted_list_of_copyright_line_numbers = list()
   for copyright_result in copyright_results:
     list_of_scan_results = list(copyright_result.result)
-    words_with_line_numbers = format_results.find_word_line_numbers(copyright_result.path,list_of_scan_results)
+    words_with_line_numbers = format_results.find_word_line_numbers(
+      copyright_result.path,list_of_scan_results, key='content')
     formatted_list_of_copyright_line_numbers.append(words_with_line_numbers)
   return formatted_list_of_copyright_line_numbers
 
-def format_license_results_with_line_numbers(scanner:Scanners,format_results:FormatResult):
+def format_license_results_with_line_numbers(scanner:Scanners,format_results:FormatResult) \
+  -> List[dict]:
   """
   Format the licenses results with line numbers
 
@@ -203,12 +211,14 @@ def format_license_results_with_line_numbers(scanner:Scanners,format_results:For
   :param: format_results : FormatResult FormatResult object
   :return: list of dicts with key as word and value as list of line numbers of the words
   """
-  license_results = scanner.results_are_allow_listed()
+  license_results = scanner.results_are_allow_listed(whole=True)
+  if license_results is True or license_results is None:
+    license_results = []
   formatted_list_of_license_line_numbers = list()
   for license_result in license_results:
     list_of_scan_results = list(license_result.result)
-    words_with_line_numbers = format_results.find_word_line_numbers_without_bytes(
-      license_result.path,list_of_scan_results)
+    words_with_line_numbers = format_results.find_word_line_numbers(
+      license_result.path,list_of_scan_results, key='license')
     formatted_list_of_license_line_numbers.append(words_with_line_numbers)
   return formatted_list_of_license_line_numbers
 
@@ -226,20 +236,24 @@ def text_report(cli_options: CliOptions, result_dir: str, return_val: int,
   """
   if cli_options.nomos or cli_options.ojo:
     failed_licenses = scanner.results_are_allow_listed()
-    scan_results_with_line_number = []
+    scan_results_with_line_number = format_license_results_with_line_numbers(
+    scanner=scanner,format_results=format_results)
     print_log_message(f"{result_dir}/licenses.txt", failed_licenses, True,
                       "Following licenses found which are not allow listed",
                       "No license violation found", "License", return_val, 
                       scan_results_with_line_number)
   if cli_options.copyright:
     copyright_results = scanner.get_copyright_list()
-    scan_results_with_line_number = format_copyright_results_with_line_numbers(scanner=scanner, format_results=format_results)
+    scan_results_with_line_number = format_copyright_results_with_line_numbers(
+    scanner=scanner, format_results=format_results)
     print_log_message(f"{result_dir}/copyrights.txt", copyright_results, False,
                       "Following copyrights found",
-                      "No copyright violation found", "Copyright", return_val, scan_results_with_line_number)
+                      "No copyright violation found", "Copyright", return_val,
+                      scan_results_with_line_number)
   if cli_options.keyword:
     keyword_results = scanner.get_keyword_list()
-    scan_results_with_line_number = format_keyword_results_with_line_numbers(scanner=scanner, format_results=format_results)
+    scan_results_with_line_number = format_keyword_results_with_line_numbers(
+    scanner=scanner, format_results=format_results)
     print_log_message(f"{result_dir}/keywords.txt", keyword_results, False,
                       "Following keywords found",
                       "No keyword violation found", "Keyword", return_val, 
@@ -264,7 +278,8 @@ def bom_report(cli_options: CliOptions, result_dir: str, return_val: int,
   if cli_options.nomos or cli_options.ojo:
     scan_results = scanner.get_scanner_results()
     report_obj.add_license_results(scan_results)
-    scan_results_with_line_number = []
+    scan_results_with_line_number = format_license_results_with_line_numbers(
+    scanner=scanner, format_results=format_results)
     failed_licenses = scanner.get_non_allow_listed_results(scan_results)
     return_val = print_log_message(f"{result_dir}/licenses.txt",
         failed_licenses, True, "Following licenses found which are not allow "
@@ -277,13 +292,15 @@ def bom_report(cli_options: CliOptions, result_dir: str, return_val: int,
     report_obj.add_copyright_results(copyright_results)
     failed_copyrights = scanner.get_non_allow_listed_copyrights(
       copyright_results)
-    scan_results_with_line_number = format_copyright_results_with_line_numbers(scanner=scanner, format_results=format_results)
+    scan_results_with_line_number = format_copyright_results_with_line_numbers(
+    scanner=scanner, format_results=format_results)
     return_val = print_log_message(f"{result_dir}/copyrights.txt",
         failed_copyrights, False, "Following copyrights found",
         "No copyright violation found", "Copyright", return_val,scan_results_with_line_number)
   if cli_options.keyword:
     keyword_results = scanner.get_keyword_list()
-    scan_results_with_line_number = format_keyword_results_with_line_numbers(scanner=scanner, format_results=format_results)
+    scan_results_with_line_number = format_keyword_results_with_line_numbers(
+    scanner=scanner, format_results=format_results)
     return_val = print_log_message(f"{result_dir}/keywords.txt",
         keyword_results, False, "Following keywords found",
         "No keyword violation found", "Keyword", return_val, scan_results_with_line_number)
@@ -373,7 +390,9 @@ if __name__ == "__main__":
     "--report", type=str, help="Type of report to generate. Default 'TEXT'.",
     choices=[member.name for member in ReportFormat], default=ReportFormat.TEXT.name
   )
-  parser.add_argument('--keyword-conf', type=str, help='Path to the keyword configuration file. Use only when keyword argument is true')
+  parser.add_argument('--keyword-conf', type=str, help='Path to the keyword configuration file.' \
+  'Use only when keyword argument is true'
+  )
 
   parser.add_argument(
     "--allowlist-path", type=str, help="Pass allowlist.json to allowlist dependencies."

--- a/utils/automation/fossologyscanner.py
+++ b/utils/automation/fossologyscanner.py
@@ -92,7 +92,8 @@ def get_allow_list(path: str = '') -> dict:
   return data
 
 
-def print_results(name: str, failed_results: List[ScanResult],scan_results_with_line_number:List[dict],
+def print_results(name: str, failed_results: List[ScanResult], 
+                  scan_results_with_line_number:List[dict],
                   result_file: IO):
   """
   Print the formatted scanner results
@@ -173,8 +174,8 @@ def format_keyword_results_with_line_numbers(scanner:Scanners,format_results:For
   formatted_list_of_keyword_line_numbers = list()
   for keyword_result in keyword_results:
     list_of_scan_results = list(keyword_result.result)
-    words_to_search = [list_of_scan_results[i] for i in range(0,len(list_of_scan_results))]
-    words_with_line_numbers = format_results.find_word_line_numbers(keyword_result.path,words_to_search)
+    words_with_line_numbers = format_results.find_word_line_numbers(keyword_result.path,
+    list_of_scan_results)
     formatted_list_of_keyword_line_numbers.append(words_with_line_numbers)
   return formatted_list_of_keyword_line_numbers
 
@@ -190,8 +191,7 @@ def format_copyright_results_with_line_numbers(scanner:Scanners,format_results:F
   formatted_list_of_copyright_line_numbers = list()
   for copyright_result in copyright_results:
     list_of_scan_results = list(copyright_result.result)
-    words_to_search = [list_of_scan_results[i] for i in range(0,len(list_of_scan_results))]
-    words_with_line_numbers = format_results.find_word_line_numbers(copyright_result.path,words_to_search)
+    words_with_line_numbers = format_results.find_word_line_numbers(copyright_result.path,list_of_scan_results)
     formatted_list_of_copyright_line_numbers.append(words_with_line_numbers)
   return formatted_list_of_copyright_line_numbers
 
@@ -207,13 +207,13 @@ def format_license_results_with_line_numbers(scanner:Scanners,format_results:For
   formatted_list_of_license_line_numbers = list()
   for license_result in license_results:
     list_of_scan_results = list(license_result.result)
-    words_to_search = [list_of_scan_results[i] for i in range(0,len(list_of_scan_results))]
-    words_with_line_numbers = format_results.find_word_line_numbers_without_bytes(license_result.path,words_to_search)
+    words_with_line_numbers = format_results.find_word_line_numbers_without_bytes(
+      license_result.path,list_of_scan_results)
     formatted_list_of_license_line_numbers.append(words_with_line_numbers)
   return formatted_list_of_license_line_numbers
 
 def text_report(cli_options: CliOptions, result_dir: str, return_val: int,
-                scanner: Scanners, format_results = FormatResult) -> int:
+                scanner: Scanners, format_results : FormatResult) -> int:
   """
   Run scanners and print results in text format.
 
@@ -229,7 +229,8 @@ def text_report(cli_options: CliOptions, result_dir: str, return_val: int,
     scan_results_with_line_number = []
     print_log_message(f"{result_dir}/licenses.txt", failed_licenses, True,
                       "Following licenses found which are not allow listed",
-                      "No license violation found", "License", return_val, scan_results_with_line_number)
+                      "No license violation found", "License", return_val, 
+                      scan_results_with_line_number)
   if cli_options.copyright:
     copyright_results = scanner.get_copyright_list()
     scan_results_with_line_number = format_copyright_results_with_line_numbers(scanner=scanner, format_results=format_results)
@@ -241,7 +242,8 @@ def text_report(cli_options: CliOptions, result_dir: str, return_val: int,
     scan_results_with_line_number = format_keyword_results_with_line_numbers(scanner=scanner, format_results=format_results)
     print_log_message(f"{result_dir}/keywords.txt", keyword_results, False,
                       "Following keywords found",
-                      "No keyword violation found", "Keyword", return_val, scan_results_with_line_number)
+                      "No keyword violation found", "Keyword", return_val, 
+                      scan_results_with_line_number)
   return return_val
 
 
@@ -341,16 +343,17 @@ def main(parsed_args):
   # Populate tmp dir in unified diff format
   format_results = FormatResult(cli_options)
   format_results.process_files(scanner.cli_options.diff_dir)
-     
+
   # Create result dir
   result_dir = "results"
   os.makedirs(name=result_dir, exist_ok=True)
 
   if cli_options.report_format == ReportFormat.TEXT:
-    return_val = text_report(cli_options, result_dir, return_val, scanner,format_results)
+    return_val = text_report(cli_options, result_dir, return_val, scanner,
+                            format_results)
   else:
     return_val = bom_report(cli_options, result_dir, return_val, scanner,
-                            api_config,format_results)                      
+                            api_config, format_results)
   return return_val
 
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add line numbers for the copyright and keyword scanners for diff scans

### Changes

- Introduced a new class FormatResult to handle adding line numbers to the output of the scanners
- Modified existing print results functionality to include the line number results.
- Add new functions in main script `fossologyscanner.py` to format the results of scanners
- Add a new class `ScanResultList`, which inherits from `ScanResult` to hold full content from the scan results
- Refactored the scanner module functions to include 'whole` flags for spitting complete info.

## How to test

- Build the docker image from the `Dockerfile.ci` located at `utils/automation` directory.
- Set up a Github Actions workflow in any of your repositories with this [example](https://github.com/fossology/fossology/blob/master/utils/automation/.github-workflow.yml)
- Set up a Github Fine Grained Token ([link](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token))
- Set up a environment variable file and include the following Environment variables: 
```
GITHUB_ACTIONS=true
GITHUB_TOKEN=<your_github_token>
GITHUB_REPOSITORY=<your_gihtub_repo>
GITHUB_REPO_OWNER=<your_github_username>
GITHUB_REPO_URL=<youor_repo_url>
GITHUB_PULL_REQUEST=<your_pull_request_id>
```
- Run the docker container built with passing this environment variable file as a parameter
- Go to `/bin` directory and run the `fossologyscanner.py` script.

### Depends on 
This PR depends on #2785
