### PR TITLE
feat(automation): Add line numbers for repo scans for copyright and keyword scanners

### DIFF
--- a/utils/automation/FoScanner/FormatResults.py
+++ b/utils/automation/FoScanner/FormatResults.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: © 2024 Rajul Jha <rajuljha49@gmail.com>
+
+# SPDX-License-Identifier: GPL-2.0-only
+
+import re
+import os
+
+from .CliOptions import CliOptions
+
+class FormatResult:
+    """
+    For formatting the results from scanners with line number information
+    """
+
+    def __init__(self,cli_options:CliOptions):
+        self.cli_options = cli_options
+    
+    def format_diff(self,diff_content):
+      """
+      Format the diff content in a particular format with corrected line numbers.
+
+      :param: diff_content: str String to format
+      :return: str formatted_string
+      """
+      formatted_diff = []
+      diff_lines = diff_content.splitlines()
+      left = right = 0
+      left_num_len = right_num_len = 0
+      for line in diff_lines:
+        match = re.match(r'^@@ -([0-9]+),([0-9]+) [+]([0-9]+),([0-9]+) @@', line)
+        if match:
+          left = int(match.group(1))
+          left_num_len = len(match.group(2))
+          right = int(match.group(3))
+          right_num_len = len(match.group(4))
+          formatted_diff.append(line)
+          continue
+          
+        if re.match(r'^(---|\+\+\+|[^-+ ])', line):
+          formatted_diff.append(line)
+          continue
+        line_content = line[1:]
+        if line.startswith('-'):
+          padding = ' ' * right_num_len
+          formatted_diff.append(f"-{left:<{left_num_len}} {padding}:{line_content}")
+          left += 1
+        elif line.startswith('+'):
+          padding = ' ' * left_num_len
+          formatted_diff.append(f"+{padding} {right:<{right_num_len}}:{line_content}")
+          right += 1
+        else:
+          formatted_diff.append(f" {left:<{left_num_len}} {right:<{right_num_len}}:{line_content}")
+          left += 1
+          right += 1
+
+      return "\n".join(formatted_diff)
+
+    def find_line_numbers(self, diff_string, word_start_byte, word_end_byte):
+      """
+      Find line numbers from formmatted diff data
+
+      :param: diff_string : str Formatted diff string 
+      :param: word_start_byte : int Start byte of scanner result
+      :param: word_end_byte : int End byte of scanner result
+      :return: List of line_numbers found for a given word
+      """
+      escaped_word = re.escape(diff_string[word_start_byte:word_end_byte])
+      pattern = re.compile(r'(\d+):.*?' + escaped_word)
+      matches = pattern.findall(diff_string)
+      return matches
+
+    def find_word_line_numbers(self, file_path, words:list) -> dict:
+      """
+      Find the line number of each word found for a given file path
+
+      :param: file_path : str Path of the file to scan
+      :param: words: list List of words(ScanResult Objects) to be scanned for
+      :return: found_words_with_line_number : dict Dictionary of scanned results
+                with key as scanned word and value as list of line_numbers where 
+                it is found.
+      """
+      found_words_with_line_number = {}
+      if self.cli_options.repo is True:
+        try:
+          with open(file_path, 'rb') as file:
+            binary_data = file.read()
+          string_data = binary_data.decode('utf-8', errors='ignore')
+          for i in range(0,len(words)):
+            line_numbers_list = []
+            line_number = string_data[0:words[i]['start']].count("\n") + 1
+            ln_list.append(str(line_number))
+            found_words_with_line_number[words[i]['content']] = line_numbers_list
+
+          return found_words_with_line_number
+    
+        except FileNotFoundError:
+          print(f"The file {file_path} does not exist.")
+          return None
+        except IOError as e:
+          print(f"An I/O error occurred: {e}")
+          return None
+        except Exception as e:
+          print(f"An error occurred: {e}")
+          return None
+          
+      with open(file_path, 'r') as file:
+          content = file.read()
+          for i in range(0,len(words)):
+              line_numbers = self.find_line_numbers(content, words[i]['start'], words[i]['end'])
+              found_words_with_line_number[words[i]['content']] = line_numbers
+      return found_words_with_line_number
+
+    def process_files(self, root_dir):
+      """
+      Format the files according to unified diff format
+      
+      :param: root_dir : str Path of the temp dir root to format the files
+      :return: None
+      """
+      if self.cli_options.repo is True:
+        return None
+      for root, dirs, files in os.walk(root_dir):
+        for file_name in files:
+          file_path = os.path.join(root, file_name)
+          with open(file_path, 'r') as file:
+            file_contents = file.read()
+            normal_string = file_contents.encode().decode('unicode_escape')
+            formatted_diff = self.format_diff(normal_string)
+          with open(file_path, 'w') as file:
+            file.write(formatted_diff)
+      return None

--- a/utils/automation/FoScanner/RepoSetup.py
+++ b/utils/automation/FoScanner/RepoSetup.py
@@ -111,8 +111,6 @@ class RepoSetup:
     else:
       changes = change_response
 
-    remove_diff_regex = re.compile(r"^([ +-])(.*)$", re.MULTILINE)
-
     for change in changes:
       if path_key in change and change_key in change:
         path_to_be_excluded = self.__is_excluded_path(change[path_key])
@@ -122,7 +120,6 @@ class RepoSetup:
           if curr_dir != self.temp_dir.name:
             os.makedirs(name=curr_dir, exist_ok=True)
           curr_file = open(file=curr_file, mode='w+', encoding='UTF-8')
-          print(re.sub(remove_diff_regex, r"\2", change[change_key]),
-                file=curr_file)
+          print(change[change_key],file=curr_file)
 
     return self.temp_dir.name

--- a/utils/automation/FoScanner/Scanners.py
+++ b/utils/automation/FoScanner/Scanners.py
@@ -157,6 +157,62 @@ class Scanners:
       return copyright_list
     return False
 
+  def get_copyright_whole(self, all_results: bool = False) \
+      -> Union[List[ScanResult], bool]:
+    """
+    Get the formatted results from copyright scanner
+
+    :param all_results: Get all results even excluded files?
+    :type all_results: bool
+    :return: list of findings
+    :rtype: list[ScanResult]
+    """
+    copyright_results = self.__get_copyright_results()
+    copyright_list = list()
+    for result in copyright_results:
+      path = self.__normalize_path(result['file'])
+      if self.cli_options.repo is True and all_results is False and \
+          self.is_excluded_path(path) is True:
+        continue
+      if result['results'] is not None and result['results'] != "Unable to " \
+                                                                "read file":
+        # contents = set() # Giving error with set
+        contents = list()
+
+        for finding in result['results']:
+          if finding is not None and finding['type'] == "statement":
+            contents.append(finding)
+        if len(contents) > 0:
+          copyright_list.append(ScanResult(path, result['file'], contents))
+    if len(copyright_list) > 0:
+      return copyright_list
+    return False
+
+  def get_keyword_whole(self) -> Union[List[ScanResult], bool]:
+    """
+    Get the formatted results from keyword scanner
+
+    :return: list of findings
+    """
+    keyword_results = self.__get_keyword_results()
+    keyword_list = list()
+    for result in keyword_results:
+      path = self.__normalize_path(result['file'])
+      if self.cli_options.repo is True and self.is_excluded_path(path) is \
+          True:
+        continue
+      if result['results'] is not None and result['results'] != "Unable to " \
+                                                                "read file":
+        contents = list()
+        for finding in result['results']:
+          if finding is not None:
+            contents.append(finding)
+        if len(contents) > 0:
+          keyword_list.append(ScanResult(path, result['file'], contents))
+    if len(keyword_list) > 0:
+      return keyword_list
+    return False
+  
   def get_keyword_list(self) -> Union[List[ScanResult], bool]:
     """
     Get the formatted results from keyword scanner

--- a/utils/automation/fossologyscanner.py
+++ b/utils/automation/fossologyscanner.py
@@ -18,6 +18,7 @@ from FoScanner.CliOptions import (CliOptions, ReportFormat)
 from FoScanner.RepoSetup import RepoSetup
 from FoScanner.Scanners import (Scanners, ScanResult)
 from FoScanner.SpdxReport import SpdxReport
+from FoScanner.FormatResults import FormatResult
 
 
 def get_api_config() -> ApiConfig:
@@ -82,13 +83,14 @@ def get_allow_list() -> dict:
   return data
 
 
-def print_results(name: str, failed_results: List[ScanResult],
+def print_results(name: str, failed_results: List[ScanResult],scan_results_with_line_number:List[dict],
                   result_file: IO):
   """
   Print the formatted scanner results
 
   :param name: Name of the scanner
   :param failed_results: formatted scanner results to be printed
+  :param: scan_results_with_line_number : List[dict] List of words mapped to their line numbers
   :param result_file: File to write results to
   """
   for files in failed_results:
@@ -100,6 +102,15 @@ def print_results(name: str, failed_results: List[ScanResult],
     print(f"{name}{plural}:")
     result_file.write(f"{name}{plural}:\n")
     for result in files.result:
+      for item in scan_results_with_line_number:
+        for scanned_word, lines in item.items():
+          if len(lines) > 1 :
+            plural = "s"
+          else:
+            plural = ""
+          if result == scanned_word:
+            lines_str = ", ".join(lines)
+            result = f"{scanned_word} at line{plural} {lines_str}\n"
       print("\t" + result)
       result_file.write("\t" + result + "\n")
 
@@ -108,7 +119,7 @@ def print_log_message(filename: str,
                       failed_list: Union[bool, List[ScanResult]],
                       check_value: bool, failure_text: str,
                       acceptance_text: str, scan_type: str,
-                      return_val: int) -> int:
+                      return_val: int, scan_results_with_line_number:List[dict] ) -> int:
   """
   Common helper function to print scan results.
 
@@ -119,6 +130,7 @@ def print_log_message(filename: str,
   :param acceptance_text: Message to print in case of no failures.
   :param scan_type: Type of scan to print.
   :param return_val: Return value for program
+  :param: scan_results_with_line_number : List[dict] List of words mapped to their line numbers
   :return: New return value
   """
   report_file = open(filename, 'w')
@@ -126,7 +138,7 @@ def print_log_message(filename: str,
       (isinstance(failed_list, list) and len(failed_list) != 0):
     print(f"\u2718 {failure_text}:")
     report_file.write(f"{failure_text}:\n")
-    print_results(scan_type, failed_list, report_file)
+    print_results(scan_type, failed_list, scan_results_with_line_number,report_file)
     if scan_type == "License":
       return_val = return_val | 2
     elif scan_type == "Copyright":
@@ -140,9 +152,65 @@ def print_log_message(filename: str,
   report_file.close()
   return return_val
 
+def format_keyword_results_with_line_numbers(scanner:Scanners,format_results:FormatResult):
+  """
+  Format the keyword results with line numbers
+
+  :param: scanner : Scanner Scanner object
+  :param: format_results : FormatResult FormatResult object
+  :return: list of dicts with key as word and value as list of line numbers of the words
+  """
+  keyword_results = scanner.get_keyword_whole()
+  if keyword_results is False:
+    return []
+  formatted_list_of_keyword_line_numbers = list()
+  for keyword_result in keyword_results:
+    list_of_scan_results = list(keyword_result.result)
+    words_to_search = [list_of_scan_results[i] for i in range(0,len(list_of_scan_results))]
+    words_with_line_numbers = format_results.find_word_line_numbers(keyword_result.path,words_to_search)
+    formatted_list_of_keyword_line_numbers.append(words_with_line_numbers)
+  return formatted_list_of_keyword_line_numbers
+
+def format_copyright_results_with_line_numbers(scanner:Scanners,format_results:FormatResult):
+  """
+  Format the copyright results with line numbers
+
+  :param: scanner : Scanner Scanner object
+  :param: format_results : FormatResult FormatResult object
+  :return: list of dicts with key as word and value as list of line numbers of the words
+  """
+  copyright_results = scanner.get_copyright_whole()
+  if copyright_results is False:
+    return []
+  formatted_list_of_copyright_line_numbers = list()
+  for copyright_result in copyright_results:
+    list_of_scan_results = list(copyright_result.result)
+    words_to_search = [list_of_scan_results[i] for i in range(0,len(list_of_scan_results))]
+    words_with_line_numbers = format_results.find_word_line_numbers(copyright_result.path,words_to_search)
+    formatted_list_of_copyright_line_numbers.append(words_with_line_numbers)
+  return formatted_list_of_copyright_line_numbers
+
+def format_license_results_with_line_numbers(scanner:Scanners,format_results:FormatResult):
+  """
+  Format the licenses results with line numbers
+
+  :param: scanner : Scanner Scanner object
+  :param: format_results : FormatResult FormatResult object
+  :return: list of dicts with key as word and value as list of line numbers of the words
+  """
+  license_results = scanner.results_are_allow_listed()
+  if license_results is False:
+    return []
+  formatted_list_of_license_line_numbers = list()
+  for license_result in license_results:
+    list_of_scan_results = list(license_result.result)
+    words_to_search = [list_of_scan_results[i] for i in range(0,len(list_of_scan_results))]
+    words_with_line_numbers = format_results.find_word_line_numbers_without_bytes(license_result.path,words_to_search)
+    formatted_list_of_license_line_numbers.append(words_with_line_numbers)
+  return formatted_list_of_license_line_numbers
 
 def text_report(cli_options: CliOptions, result_dir: str, return_val: int,
-                scanner: Scanners) -> int:
+                scanner: Scanners, format_results = FormatResult) -> int:
   """
   Run scanners and print results in text format.
 
@@ -150,28 +218,32 @@ def text_report(cli_options: CliOptions, result_dir: str, return_val: int,
   :param result_dir: Result directory location
   :param return_val: Return value of program
   :param scanner: Scanner object
+  :param: format_results : FormatResult FormatResult object
   :return: Program's return value
   """
   if cli_options.nomos or cli_options.ojo:
     failed_licenses = scanner.results_are_allow_listed()
+    scan_results_with_line_number = []
     print_log_message(f"{result_dir}/licenses.txt", failed_licenses, True,
                       "Following licenses found which are not allow listed",
-                      "No license violation found", "License", return_val)
+                      "No license violation found", "License", return_val, scan_results_with_line_number)
   if cli_options.copyright:
     copyright_results = scanner.get_copyright_list()
+    scan_results_with_line_number = format_copyright_results_with_line_numbers(scanner=scanner, format_results=format_results)
     print_log_message(f"{result_dir}/copyrights.txt", copyright_results, False,
                       "Following copyrights found",
-                      "No copyright violation found", "Copyright", return_val)
+                      "No copyright violation found", "Copyright", return_val, scan_results_with_line_number)
   if cli_options.keyword:
     keyword_results = scanner.get_keyword_list()
+    scan_results_with_line_number = format_keyword_results_with_line_numbers(scanner=scanner, format_results=format_results)
     print_log_message(f"{result_dir}/keywords.txt", keyword_results, False,
                       "Following keywords found",
-                      "No keyword violation found", "Keyword", return_val)
+                      "No keyword violation found", "Keyword", return_val, scan_results_with_line_number)
   return return_val
 
 
 def bom_report(cli_options: CliOptions, result_dir: str, return_val: int,
-               scanner: Scanners, api_config: ApiConfig) -> int:
+               scanner: Scanners, api_config: ApiConfig, format_results: FormatResult) -> int:
   """
   Run scanners and print results as an SBOM.
 
@@ -180,17 +252,19 @@ def bom_report(cli_options: CliOptions, result_dir: str, return_val: int,
   :param return_val: Return value
   :param scanner: Scanner object
   :param api_config: API config options
+  :param: format_results : FormatResult FormatResult object
   :return: Program's return value
   """
   report_obj = SpdxReport(cli_options, api_config)
   if cli_options.nomos or cli_options.ojo:
     scan_results = scanner.get_scanner_results()
     report_obj.add_license_results(scan_results)
+    scan_results_with_line_number = []
     failed_licenses = scanner.get_non_allow_listed_results(scan_results)
     return_val = print_log_message(f"{result_dir}/licenses.txt",
         failed_licenses, True, "Following licenses found which are not allow "
                                "listed", "No license violation found",
-        "License", return_val)
+        "License", return_val, scan_results_with_line_number)
   if cli_options.copyright:
     copyright_results = scanner.get_copyright_list(all_results=True)
     if copyright_results is False:
@@ -198,14 +272,16 @@ def bom_report(cli_options: CliOptions, result_dir: str, return_val: int,
     report_obj.add_copyright_results(copyright_results)
     failed_copyrights = scanner.get_non_allow_listed_copyrights(
       copyright_results)
+    scan_results_with_line_number = format_copyright_results_with_line_numbers(scanner=scanner, format_results=format_results)
     return_val = print_log_message(f"{result_dir}/copyrights.txt",
         failed_copyrights, False, "Following copyrights found",
-        "No copyright violation found", "Copyright", return_val)
+        "No copyright violation found", "Copyright", return_val,scan_results_with_line_number)
   if cli_options.keyword:
     keyword_results = scanner.get_keyword_list()
+    scan_results_with_line_number = format_keyword_results_with_line_numbers(scanner=scanner, format_results=format_results)
     return_val = print_log_message(f"{result_dir}/keywords.txt",
         keyword_results, False, "Following keywords found",
-        "No keyword violation found", "Keyword", return_val)
+        "No keyword violation found", "Keyword", return_val, scan_results_with_line_number)
   report_obj.finalize_document()
   report_name = f"{result_dir}/sbom_"
   if cli_options.report_format == ReportFormat.SPDX_JSON:
@@ -245,15 +321,19 @@ def main(parsed_args):
   scanner = Scanners(cli_options)
   return_val = 0
 
+  # Populate tmp dir in unified diff format
+  format_results = FormatResult(cli_options)
+  format_results.process_files(scanner.cli_options.diff_dir)
+     
   # Create result dir
   result_dir = "results"
   os.makedirs(name=result_dir, exist_ok=True)
 
   if cli_options.report_format == ReportFormat.TEXT:
-    return_val = text_report(cli_options, result_dir, return_val, scanner)
+    return_val = text_report(cli_options, result_dir, return_val, scanner,format_results)
   else:
     return_val = bom_report(cli_options, result_dir, return_val, scanner,
-                            api_config)
+                            api_config,format_results)                      
   return return_val
 
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
- Add line numbers for repo scans for copyright and keyword scanners

### Changes

- Add function to calculate line number for repo scans in `FormatResults.py`

## How to test


- Build the docker image from the `Dockerfile.ci` located at `utils/automation` directory.
- Set up a Github Actions workflow in any of your repositories with this [example](https://github.com/fossology/fossology/blob/master/utils/automation/.github-workflow.yml)
- Set up a Github Fine Grained Token ([link](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token))
- Set up a environment variable file and include the following Environment variables: 
```
GITHUB_ACTIONS=true
GITHUB_TOKEN=<your_github_token>
GITHUB_REPOSITORY=<your_gihtub_repo>
GITHUB_REPO_OWNER=<your_github_username>
GITHUB_REPO_URL=<youor_repo_url>
GITHUB_PULL_REQUEST=<your_pull_request_id>
```
- Run the docker container built with passing this environment variable file as a parameter
- Go to `/bin` directory and run the `fossologyscanner.py` script.

This PR is a superset of #2754 .
Please merge after #2754 

CC @GMishx @shaheemazmalmmd @avinal 
