### PR TITLE
fix(spdx2): Mark duplicates correctly with LicenseRef prefix

### DIFF
--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -870,7 +870,7 @@ class SpdxTwoAgent extends Agent
           $localList[$i + 1]->getLicenseObj()->getSpdxId()) {
         $newShortName = $localList[$i + 1]->getLicenseObj()->getShortName();
         if (! StringOperation::stringStartsWith(
-            $localList[$i + 1]->getLicenseObj()->getSpdxId(),
+            $localList[$i + 1]->getLicenseObj()->getShortName(),
             LicenseRef::SPDXREF_PREFIX)) {
           $newShortName = LicenseRef::SPDXREF_PREFIX .
             $localList[$i + 1]->getLicenseObj()->getShortName();


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The intention of deduplicateLicenseList() is de-duplicating licenses with the same SPDX ID. Duplicates are marked by adding a LicenseRef prefix and adding the MD5 hash of the license text to the shortname. Currently the sanity check for adding the prefix doesn't seem to be correct and LicenseRef might not be added. As a result duplicate licenses can end up in a generated report.

### Changes

The current sanity check before adding the LicenseRef prefix doesn't seem to be correct:
```
if (! StringOperation::stringStartsWith(
            $localList[$i + 1]->getLicenseObj()->getSpdxId(),
                                                 ^^^^^^^^^^^^
            LicenseRef::SPDXREF_PREFIX)) {
          $newShortName = LicenseRef::SPDXREF_PREFIX .
            $localList[$i + 1]->getLicenseObj()->getShortName();
```
The sanity check has to call getShortName() instead of getSpdxId():
```

if (! StringOperation::stringStartsWith(
            $localList[$i + 1]->getLicenseObj()->getShortname(),
                                                 ^^^^^^^^^^^^^^
            LicenseRef::SPDXREF_PREFIX)) {
          $newShortName = LicenseRef::SPDXREF_PREFIX .
            $localList[$i + 1]->getLicenseObj()->getShortName();
```

Open question: Do you want to use SPDXREF_PREFIX or SPDXREF_PREFIX_FOSSOLOGY here?

## How to test

1. Take the latest version from master
2. Manually create a potential duplicate for the report
   1. Create a license with the name "GPL-2.0-or-later WITH Libtool-exception"
   2. Create a license with the name "GPL-2.0-or-later-WITH-Libtool-exception"
3. Upload and scan a package
4. Conclude a couple of files with "GPL-2.0-or-later WITH Libtool-exception"
5. Conclude a couple of files with "GPL-2.0-or-later-WITH-Libtool-exception"
6. Create an SPDX tag value report

Without this commit the License Information section of the generated report will contain two licenses with LicenseID: LicenseRef-GPL-2.0-or-later-WITH-Libtool-exception
With the change in this commit the duplicate is marked correctly.
