### PR TITLE
feat(api): Added OneShot analysis endpoints for license & copyright

### DIFF
--- a/src/copyright/ui/oneshot.php
+++ b/src/copyright/ui/oneshot.php
@@ -42,7 +42,7 @@ class agent_copyright_once extends FO_Plugin
    * \brief Analyze one uploaded file.
    * \return string
    */
-  function AnalyzeOne()
+  function AnalyzeOne($getHighlightInfo = false, $tempFileName = null)
   {
     global $Plugins;
     global $SYSCONFDIR;
@@ -52,7 +52,7 @@ class agent_copyright_once extends FO_Plugin
 
     /** @var ui_view $view */
     $view = & $Plugins[plugin_find_id("view") ];
-    $tempFileName = $_FILES['licfile']['tmp_name'];
+    $tempFileName = $getHighlightInfo ? $tempFileName : $_FILES['licfile']['tmp_name'];
     $ui_dir = getcwd();
     $copyright_dir =  "$SYSCONFDIR/mods-enabled/copyright/agent/";
     if (!chdir($copyright_dir)) {
@@ -109,6 +109,9 @@ class agent_copyright_once extends FO_Plugin
     }
     pclose($inputFile);
 
+    if ($getHighlightInfo) {
+      return array($copyright_array, $highlights);
+    }
     if ($this->NoHTML) { // For REST API:
       return $copyright_array;
     }

--- a/src/lib/php/Data/Highlight.php
+++ b/src/lib/php/Data/Highlight.php
@@ -202,12 +202,12 @@ class Highlight
   public function getArray()
   {
     return array(
-      "start" => $this->start,
-      "end" => $this->end,
-      "type" => $this->type,
+      "start" => intval($this->start),
+      "end" => intval($this->end),
+      "type" => $this->type == null ? Highlight::UNDEFINED : $this->type,
       "licenseId" => $this->licenseId,
-      "refStart" => $this->refStart,
-      "refEnd" => $this->refEnd,
+      "refStart" => $this->refStart == -1 ? 0 : $this->refStart,
+      "refEnd" => $this->refEnd == -1 ? 0 : $this->refEnd,
       "infoText" => $this->infoText,
       "htmlElement" => $this->htmlElement
     );

--- a/src/nomos/ui/agent-nomos-once.php
+++ b/src/nomos/ui/agent-nomos-once.php
@@ -44,9 +44,9 @@ class agent_nomos_once extends FO_Plugin
   /**
    * @brief Analyze one uploaded file.
    * @param string $FilePath the filepath to the file to analyze.
-   * @return string $V, html to display the results.
+   * @return mixed If $getHighlightInfo is true, returns an array with display html, keyword highlights, and license highlights. If false, returns only display html
    */
-  function AnalyzeFile($FilePath)
+  public function AnalyzeFile($FilePath, $getHighlightInfo = false)
   {
     global $SYSCONFDIR;
 
@@ -61,6 +61,9 @@ class agent_nomos_once extends FO_Plugin
       '/License #(?P<name>[^#]*)# at (?P<position>\d+), length (?P<length>\d+),/',
       $licenses[1], $this->HighlightInfoLicenses);
 
+    if ($getHighlightInfo) {
+      return array($licenses[0], $this->HighlightInfoKeywords, $this->HighlightInfoLicenses);
+    }
     return ($licenses[0]);
   }
 

--- a/src/www/ui/api/Controllers/OneShotController.php
+++ b/src/www/ui/api/Controllers/OneShotController.php
@@ -1,0 +1,144 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Divij Sharma <divijs75@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Controller for OneShot Analysis
+ */
+
+namespace Fossology\UI\Api\Controllers;
+
+use Fossology\Lib\Data\Highlight;
+use Fossology\Lib\Dao\LicenseDao;
+use Fossology\Lib\View\HighlightProcessor;
+use Fossology\UI\Api\Models\OneShot;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Exceptions\HttpBadRequestException;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * @class OneShotController
+ * @brief Controller for OneShot Analysis
+ */
+class OneShotController extends RestController
+{
+  const FILE_INPUT_NAME = 'fileInput';
+
+  /** @var HighlightProcessor */
+  private $highlightProcessor;
+
+  /** @var LicenseDao */
+  private $licenseDao;
+
+  public function __construct($container)
+  {
+    parent::__construct($container);
+    $this->highlightProcessor = $this->container->get('view.highlight_processor');
+    $this->licenseDao = $this->container->get('dao.license');
+  }
+
+  /**
+   * Run OneShot Analysis using Nomos
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpBadRequestException
+   */
+  public function runOneShotNomos($request, $response, $args)
+  {
+    $symReq = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
+    $uploadedFile = $symReq->files->get($this::FILE_INPUT_NAME, null);
+    if (is_null($uploadedFile)) {
+      throw new HttpBadRequestException("No file uploaded");
+    }
+    if ($uploadedFile->getError() !== UPLOAD_ERR_OK) {
+      throw new HttpBadRequestException("Error uploading file");
+    }
+    list($licenses, $highlightInfoKeywords, $highlightInfoLicenses) = $this->restHelper->getPlugin('agent_nomos_once')->
+      AnalyzeFile($uploadedFile->getPathname(), true);
+
+    $highlights = array();
+
+    for ($index = 0; $index < count($highlightInfoKeywords['position']); $index ++) {
+      $position = $highlightInfoKeywords['position'][$index];
+      $length = $highlightInfoKeywords['length'][$index];
+
+      $highlights[] = new Highlight($position, $position + $length,
+        Highlight::KEYWORD);
+    }
+    for ($index = 0; $index < count($highlightInfoLicenses['position']); $index ++) {
+      $position = $highlightInfoLicenses['position'][$index];
+      $length = $highlightInfoLicenses['length'][$index];
+      $name = $highlightInfoLicenses['name'][$index];
+
+      $highlights[] = new Highlight($position, $position + $length,
+        Highlight::SIGNATURE, $name);
+    }
+    $this->highlightProcessor->sortHighlights($highlights);
+    $returnVal = new OneShot($licenses, $highlights);
+    return $response->withJson($returnVal->getArray(), 200);
+  }
+
+  /**
+   * Run OneShot Analysis using Monk
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpBadRequestException
+   */
+  public function runOneShotMonk($request, $response, $args)
+  {
+    $symReq = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
+    $uploadedFile = $symReq->files->get($this::FILE_INPUT_NAME, null);
+    if (is_null($uploadedFile)) {
+      throw new HttpBadRequestException("No file uploaded");
+    }
+    if ($uploadedFile->getError() !== UPLOAD_ERR_OK) {
+      throw new HttpBadRequestException("Error uploading file");
+    }
+
+    list($licenseIds, $highlights) = $this->restHelper->getPlugin('oneshot-monk')->
+      scanMonk($uploadedFile->getPathname());
+    $this->highlightProcessor->addReferenceTexts($highlights);
+    $licenseArray = array_map(function($licenseIds) {
+      return ($this->licenseDao->getLicenseById($licenseIds))
+        ->getShortName();
+    }, $licenseIds);
+    $returnVal = new OneShot($licenseArray, $highlights);
+    return $response->withJson($returnVal->getArray(), 200);
+  }
+
+  /**
+   * Run OneShot Analysis for Copyright, Email, URL
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpBadRequestException
+   */
+  public function runOneShotCEU($request, $response, $args)
+  {
+    $symReq = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
+    $uploadedFile = $symReq->files->get($this::FILE_INPUT_NAME, null);
+    if (is_null($uploadedFile)) {
+      throw new HttpBadRequestException("No file uploaded");
+    }
+    if ($uploadedFile->getError() !== UPLOAD_ERR_OK) {
+      throw new HttpBadRequestException("Error uploading file");
+    }
+    list($copyrights, $highlights) = $this->restHelper->getPlugin('agent_copyright_once')->
+      AnalyzeOne(true, $uploadedFile->getPathname());
+    $this->highlightProcessor->sortHighlights($highlights);
+    $returnVal = new OneShot($copyrights, $highlights);
+    return $response->withJson($returnVal->getArray('copyrights'), 200);
+  }
+}

--- a/src/www/ui/api/Models/OneShot.php
+++ b/src/www/ui/api/Models/OneShot.php
@@ -1,0 +1,108 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Divij Sharma <divijs75@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief OneShot model
+ */
+
+namespace Fossology\UI\Api\Models;
+
+use Fossology\Lib\Data\Highlight;
+
+class OneShot
+{
+  /**
+   * @var mixed $data
+   */
+  private $data;
+
+  /**
+   * @var Highlight[] $highlights
+   */
+  private $highlights;
+
+  /**
+   * OneShot constructor.
+   *
+   * @param mixed $data License string or License array
+   * @param Highlight[] $highlights
+   */
+  public function __construct($data, $highlights)
+  {
+    $this->data  = $data;
+    $this->highlights = $highlights;
+  }
+
+  ////// Setters //////
+
+  /**
+   * @param mixed $data
+   */
+  public function setData($data)
+  {
+    $this->data = $data;
+  }
+
+  /**
+   * @param Highlight[] $highlights
+   */
+  public function setHighlights($highlights)
+  {
+    $this->highlights = $highlights;
+  }
+
+  ////// Getters //////
+
+  /**
+   * @return mixed $Data
+   */
+  public function getData()
+  {
+    return $this->data;
+  }
+
+  /**
+   * @return Highlight[]
+   */
+  public function getHighlights()
+  {
+    return $this->highlights;
+  }
+
+  /**
+   * @return string json
+   */
+  public function getJSON()
+  {
+    return json_encode($this->getArray());
+  }
+
+  /**
+   * @return array
+   */
+  public function getHighlightsArray()
+  {
+    $highlightsArray = array_map(function($highlight) {
+      return $highlight->getArray();
+    }, $this->highlights);
+    return $highlightsArray;
+  }
+
+  /**
+   * Get the OneShot object as associative array
+   *
+   * @return array
+   */
+  public function getArray($dataType = 'licenses')
+  {
+    return [
+      $dataType => $this->data,
+      'highlights' => $this->getHighlightsArray()
+    ];
+  }
+}

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -2221,6 +2221,93 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /uploads/oneshot/nomos:
+    post:
+      operationId: runOneShotNomos
+      tags:
+        - Upload
+      summary: Run one-shot nomos analysis
+      description: >
+        Run one-shot nomos analysis on the upload without storing the results.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                fileInput:
+                  type: string
+                  format: binary
+              required:
+                - fileInput
+      responses:
+        '200':
+          description: Scanner result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OneShotInfo'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /uploads/oneshot/monk:
+    post:
+      operationId: runOneShotMonk
+      tags:
+        - Upload
+      summary: Run one-shot monk analysis
+      description: >
+        Run one-shot monk analysis on the upload without storing the results.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                fileInput:
+                  type: string
+                  format: binary
+              required:
+                - fileInput
+      responses:
+        '200':
+          description: Scanner result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OneShotInfo'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /uploads/oneshot/ceu:
+    post:
+      operationId: runOneShotCEU
+      tags:
+        - Upload
+      summary: Run one-shot Copyright/Email/URL analysis
+      description: >
+        Run one-shot Copyright/Email/URL analysis on the upload without storing the results.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                fileInput:
+                  type: string
+                  format: binary
+              required:
+                - fileInput
+      responses:
+        '200':
+          description: Scanner result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OneShotInfo'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /search:
     get:
       operationId: searchFile
@@ -6006,6 +6093,16 @@ components:
           example: "MIT: 'MIT License\n\nCopyright (c) <year> <copyright holders>'"
         htmlElement:
           type: string
+    OneShotInfo:
+      type: object
+      properties:
+        data:
+          description: Data found during scan, e.g. Licenses, Copyrights
+          type: array
+        highlights:
+          type: array
+          items:
+            $ref: '#/components/schemas/HighlightInfo'
     ClearingProgressInfo:
       type: object
       properties:

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -2169,6 +2169,93 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /uploads/oneshot/nomos:
+    post:
+      operationId: runOneShotNomos
+      tags:
+        - Upload
+      summary: Run one-shot nomos analysis
+      description: >
+        Run one-shot nomos analysis on the upload without storing the results.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                fileInput:
+                  type: string
+                  format: binary
+              required:
+                - fileInput
+      responses:
+        '200':
+          description: Scanner result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OneShotInfo'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /uploads/oneshot/monk:
+    post:
+      operationId: runOneShotMonk
+      tags:
+        - Upload
+      summary: Run one-shot monk analysis
+      description: >
+        Run one-shot monk analysis on the upload without storing the results.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                fileInput:
+                  type: string
+                  format: binary
+              required:
+                - fileInput
+      responses:
+        '200':
+          description: Scanner result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OneShotInfo'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /uploads/oneshot/ceu:
+    post:
+      operationId: runOneShotCEU
+      tags:
+        - Upload
+      summary: Run one-shot Copyright/Email/URL analysis
+      description: >
+        Run one-shot Copyright/Email/URL analysis on the upload without storing the results.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                fileInput:
+                  type: string
+                  format: binary
+              required:
+                - fileInput
+      responses:
+        '200':
+          description: Scanner result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OneShotInfo'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /search:
     get:
       operationId: searchFile
@@ -5986,6 +6073,16 @@ components:
           example: "MIT: 'MIT License\n\nCopyright (c) <year> <copyright holders>'"
         htmlElement:
           type: string
+    OneShotInfo:
+      type: object
+      properties:
+        data:
+          description: Data found during scan, e.g. Licenses, Copyrights
+          type: array
+        highlights:
+          type: array
+          items:
+            $ref: '#/components/schemas/HighlightInfo'
     ClearingProgressInfo:
       type: object
       properties:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -35,6 +35,7 @@ use Fossology\UI\Api\Controllers\JobController;
 use Fossology\UI\Api\Controllers\LicenseController;
 use Fossology\UI\Api\Controllers\MaintenanceController;
 use Fossology\UI\Api\Controllers\ObligationController;
+use Fossology\UI\Api\Controllers\OneShotController;
 use Fossology\UI\Api\Controllers\OverviewController;
 use Fossology\UI\Api\Controllers\ReportController;
 use Fossology\UI\Api\Controllers\SearchController;
@@ -179,6 +180,9 @@ $app->group('/uploads',
     $app->patch('/{id:\\d+}', UploadController::class . ':updateUpload');
     $app->put('/{id:\\d+}', UploadController::class . ':moveUpload');
     $app->post('', UploadController::class . ':postUpload');
+    $app->post('/oneshot/nomos', OneShotController::class . ':runOneShotNomos');
+    $app->post('/oneshot/monk', OneShotController::class . ':runOneShotMonk');
+    $app->post('/oneshot/ceu', OneShotController::class . ':runOneShotCEU');
     $app->put('/{id:\\d+}/permissions', UploadController::class . ':setUploadPermissions');
     $app->get('/{id:\\d+}/perm-groups', UploadController::class . ':getGroupsWithPermissions');
     $app->get('/{id:\\d+}/groups/permission', UploadController::class . ':getGroupsWithPermissions');


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
 
This PR introduces three new endpoints to enable one-shot analysis functionality using Nomos, Monk, and copyright scanners:

1. `/uploads/oneshot/nomos` 

![image](https://github.com/fossology/fossology/assets/119073504/362d52e3-7224-4f32-887a-55f1de8954d4)

2. `/uploads/oneshot/monk`

![image](https://github.com/fossology/fossology/assets/119073504/9c151d00-410b-4e55-b326-3b13f55e8b79)

3. `/uploads/oneshot/ceu`

![image](https://github.com/fossology/fossology/assets/119073504/8cc905b0-52db-4339-8c52-60da46f7c917)

### Changes

- Added new `OneShotController` to handle all one shot analysis requests.
- Added new `OneShot` model to provide responses.
- Changed respective `oneshot.php` files to accommodate requests.
- Modified `openapiv2.yaml` and `openapi.yaml` files for documentation changes.
 
### How to test

Create a `txt` file containing license, copyright, email, and URL details. Transmit them through the endpoints to check the outcomes. You can also validate them through a comprehensive upload.

tracked by #2503
closes #2503 

CC @GMishx @shaheemazmalmmd @dushimsam @soham4abc 