### PR TITLE
feat(copyright): use icu::UnicodeString for IO

### DIFF
--- a/cmake/SetDefaults.cmake
+++ b/cmake/SetDefaults.cmake
@@ -118,9 +118,12 @@ if(DEFINED CMAKE_CXX_COMPILER)
     find_package(Boost REQUIRED COMPONENTS regex system filesystem program_options NO_MODULE)
 endif()
 find_package(Git REQUIRED)
+find_package(ICU COMPONENTS uc i18n REQUIRED)
+find_package(LibXslt REQUIRED)
+find_package(OpenMP REQUIRED)
 
 foreach(SCHE_LIBS
-        glib-2.0 gthread-2.0 gio-2.0 gobject-2.0 rpm libxml-2.0 libxslt icu-uc
+        glib-2.0 gthread-2.0 gio-2.0 gobject-2.0 rpm libxml-2.0
         json-c
 )
     string(REPLACE "-2.0" "" LIB_NAME ${SCHE_LIBS})

--- a/src/compatibility/agent/CMakeLists.txt
+++ b/src/compatibility/agent/CMakeLists.txt
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: © 2024 Siemens AG
 #]=======================================================================]
 
 set(FO_CWD ${CMAKE_CURRENT_SOURCE_DIR})
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FO_CXX_FLAGS} -fopenmp")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FO_CXX_FLAGS}")
 
 include_directories(
         ${glib_INCLUDE_DIRS}
@@ -44,8 +44,8 @@ foreach (FO_COMP_TARGET compatibility compatibility_exec compatibility_cov
         target_compile_options(${FO_COMP_TARGET} PRIVATE ${FO_COV_FLAGS})
     endif ()
     target_link_libraries(${FO_COMP_TARGET}
-            PRIVATE fossologyCPP ${icu-uc_LIBRARIES} ${Boost_LIBRARIES}
-            ${jsoncpp_LIBRARIES} yaml-cpp)
+            PRIVATE fossologyCPP ICU::uc ICU::i18n ${Boost_LIBRARIES}
+            ${jsoncpp_LIBRARIES} yaml-cpp OpenMP::OpenMP_CXX)
     if (${FO_COMP_TARGET} MATCHES "_exec$")
         string(REPLACE "_exec" "" FO_COMP_TARGET_R ${FO_COMP_TARGET})
         set_target_properties(${FO_COMP_TARGET}

--- a/src/compatibility/agent_tests/CMakeLists.txt
+++ b/src/compatibility/agent_tests/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT TARGET phpunit)
     prepare_phpunit()
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FO_CXX_FLAGS} -fopenmp -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FO_CXX_FLAGS} -Wextra")
 
 add_executable(test_compatibility "")
 target_sources(test_compatibility
@@ -39,10 +39,11 @@ target_link_libraries(test_compatibility
     PRIVATE
         compatibility
         ${cppunit_LIBRARIES}
-        ${icu-uc_LIBRARIES}
+        ICU::uc ICU::i18n
         ${Boost_LIBRARIES}
         ${jsoncpp_LIBRARIES}
         yaml-cpp
+        OpenMP::OpenMP_CXX
 )
 
 add_test(compatibility_unit_test test_compatibility)

--- a/src/copyright/agent/CMakeLists.txt
+++ b/src/copyright/agent/CMakeLists.txt
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
 set(FO_CWD ${CMAKE_CURRENT_SOURCE_DIR})
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FO_CXX_FLAGS} -fopenmp -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FO_CXX_FLAGS} -Wextra")
 
 include_directories(
     ${glib_INCLUDE_DIRS}
@@ -21,8 +21,8 @@ foreach(COMMON_OBJ copyright regscan scanners cleanEntries regexConfProvider
     add_library(${COMMON_OBJ}.cc.o OBJECT EXCLUDE_FROM_ALL
         ${FO_CWD}/${COMMON_OBJ}.cc)
     target_link_libraries(${COMMON_OBJ}.cc.o
-        PRIVATE fossologyCPP m ${icu-uc_LIBRARIES} stdc++
-        ${Boost_LIBRARIES} ${jsoncpp_LIBRARIES})
+        PRIVATE fossologyCPP m ICU::uc ICU::i18n stdc++
+        ${Boost_LIBRARIES} ${jsoncpp_LIBRARIES} OpenMP::OpenMP_CXX)
     list(APPEND COMMON_COPY_OBJECTS ${COMMON_OBJ}.cc.o)
 endforeach()
 
@@ -69,8 +69,9 @@ foreach(FO_COPY_TARGET copyright_lib copyright copyright_cov_lib copyright_cov
         set(COPY_LIBS "")
     endif()
     target_link_libraries(${FO_COPY_TARGET}
-        PRIVATE fossologyCPP m ${icu-uc_LIBRARIES} stdc++
-        ${Boost_LIBRARIES} ${jsoncpp_LIBRARIES} ${COPY_LIBS})
+        PRIVATE fossologyCPP m ICU::uc ICU::i18n stdc++
+        ${Boost_LIBRARIES} ${jsoncpp_LIBRARIES} ${COPY_LIBS}
+        OpenMP::OpenMP_CXX)
 endforeach()
 target_compile_options(copyright_cov PRIVATE ${FO_COV_FLAGS})
 set_target_properties(copyright_lib PROPERTIES OUTPUT_NAME copyright)

--- a/src/copyright/agent/cleanEntries.hpp
+++ b/src/copyright/agent/cleanEntries.hpp
@@ -15,7 +15,7 @@
 
 #include "libfossUtils.hpp"
 
-string cleanMatch(const string& sText, const match& m);
+icu::UnicodeString cleanMatch(const icu::UnicodeString& sText, const match& m);
 
 
 #endif /* CLEANENTRIES_HPP_ */

--- a/src/copyright/agent/copyright.cc
+++ b/src/copyright/agent/copyright.cc
@@ -60,6 +60,10 @@ int main(int argc, char** argv)
   CliOptions cliOptions;
   vector<string> fileNames;
   string directoryToScan;
+
+  // Set global locale to C to avoid problems
+  std::locale::global(std::locale("C"));
+
   if (!parseCliOptions(argc, argv, cliOptions, fileNames, directoryToScan))
   {
     return_sched(1);
@@ -86,7 +90,7 @@ int main(int argc, char** argv)
       for (unsigned int argn = 0; argn < fileNamesCount; ++argn)
       {
         const string fileName = fileNames[argn];
-        pair<string, list<match>> scanResult = processSingleFile(state, fileName);
+        pair<icu::UnicodeString, list<match>> scanResult = processSingleFile(state, fileName);
         if (json)
         {
           appendToJson(fileName, scanResult, printComma);
@@ -95,7 +99,7 @@ int main(int argc, char** argv)
         {
           printResultToStdout(fileName, scanResult);
         }
-        if (scanResult.first.empty())
+        if (scanResult.first.isEmpty())
         {
           fileError = true;
         }

--- a/src/copyright/agent/copyright.conf
+++ b/src/copyright/agent/copyright.conf
@@ -14,7 +14,7 @@ website=(?:http|https|ftp)\://[a-zA-Z0-9\-\.]+\.__TLD__(?<!example\.(com|net|org
 SPACES=[\t ]+
 SPACESALL=[[:space:]]*
 PUNCT_OR_SPACE=[[:punct:][:space:]]
-ALPHA=[:alpha:]
+ALPHA=[:alpha:]\xc0-\xd6\xd9-\xf6\xf8-\xff
 #\xc0-\xd6\xd9-\xf6\xf8-\xff
 NAME_OR_COMPANY=(?:[__ALPHA__]+|__email__|__website__)
 NAMESLIST=__NAME_OR_COMPANY__(?:[\-, &]+__NAME_OR_COMPANY__)*
@@ -27,7 +27,7 @@ author=__author____SPACESALL____NAMESLIST__\.?
 author=__author__|(?<=<author>)(.*?)(?=<\/author>)
 #
 COPYSYM=(?:\(c\)|&copy;|\xA9)
-REG_COPYRIGHT=(?:spdx-filecopyrighttext|copyright)(?:ed|s)?[[:space:]:]*|__COPYSYM__[ \t]+([[:alnum:] ][^\0]{0,2}){5,}
+REG_COPYRIGHT=(?:spdx-filecopyrighttext|copyright)(?:ed|s)?[[:space:]:]*|__COPYSYM__[ \t]+[[:alnum:] ][^\0\n\r]{4,}
 REG_EXCEPTION=\bcopyrights?(?:[ \t/\\\*\+#"\.-]+)(?:licen[cs]es?|notices?|holders?|and|statements?|owners?)[ \t\.,][^\0]*
 REG_EXCEPTION_COPY=\b(?:copyright|copyrights|copyrighted|__COPYSYM__)(?:[A-Z][a-zA-Z]+|(?:[\W_]*\(?(?:c|C)\)?[\W_]*)?(?:[\W_]+)(?:licen[cs]es?|notices?|files?|laws?|authors?|holders?|and|neither|including|grant|help|redistributions?|not|sources?|each|any|forums?|softwares?|individuals?|for|materials?|years?|patents?|statements?|owners?|disclaimer|design|designation|Act|permission|appearing|apply|appli|is|are|was|were|will|have|has|do|does|since|depuis|full|complete|entire|respective|To[A-Z]|Block[s]?|Handler|Helper|Header|Footer|Template|Provider))[^\0]*
 REG_NON_BLANK=.*(?:[[:alpha:]][[:alpha:]]|[[:digit:]][[:digit:]]).*

--- a/src/copyright/agent/copyright.conf
+++ b/src/copyright/agent/copyright.conf
@@ -14,7 +14,8 @@ website=(?:http|https|ftp)\://[a-zA-Z0-9\-\.]+\.__TLD__(?<!example\.(com|net|org
 SPACES=[\t ]+
 SPACESALL=[[:space:]]*
 PUNCT_OR_SPACE=[[:punct:][:space:]]
-ALPHA=[:alpha:]\xc0-\xd6\xd9-\xf6\xf8-\xff
+ALPHA=[:alpha:]
+#\xc0-\xd6\xd9-\xf6\xf8-\xff
 NAME_OR_COMPANY=(?:[__ALPHA__]+|__email__|__website__)
 NAMESLIST=__NAME_OR_COMPANY__(?:[\-, &]+__NAME_OR_COMPANY__)*
 # DATE=((19|20)[[:digit:]]{2,2}|[[:digit:]]{1,2})
@@ -25,8 +26,8 @@ author=(?:__author__)[:]?
 author=__author____SPACESALL____NAMESLIST__\.?
 author=__author__|(?<=<author>)(.*?)(?=<\/author>)
 #
-COPYSYM=(?:\(c\)|&copy;|(?<!\xC3)\xA9|\xC2\xA9|\xE2\x92\xB8|\xE2\x93\x92|\xE2\x92\x9E)
-REG_COPYRIGHT=(?:spdx-filecopyrighttext|copyright)(?:ed|s)?[[:space:]:]*|__COPYSYM__[ \t]+(?:[[:upper:]]?[[:lower:]]{5,}|(?:19|20)[[:digit:]]{2}|\([cC]\))[^\0]*
+COPYSYM=(?:\(c\)|&copy;|\xA9)
+REG_COPYRIGHT=(?:spdx-filecopyrighttext|copyright)(?:ed|s)?[[:space:]:]*|__COPYSYM__[ \t]+([[:alnum:] ][^\0]{0,2}){5,}
 REG_EXCEPTION=\bcopyrights?(?:[ \t/\\\*\+#"\.-]+)(?:licen[cs]es?|notices?|holders?|and|statements?|owners?)[ \t\.,][^\0]*
 REG_EXCEPTION_COPY=\b(?:copyright|copyrights|copyrighted|__COPYSYM__)(?:[A-Z][a-zA-Z]+|(?:[\W_]*\(?(?:c|C)\)?[\W_]*)?(?:[\W_]+)(?:licen[cs]es?|notices?|files?|laws?|authors?|holders?|and|neither|including|grant|help|redistributions?|not|sources?|each|any|forums?|softwares?|individuals?|for|materials?|years?|patents?|statements?|owners?|disclaimer|design|designation|Act|permission|appearing|apply|appli|is|are|was|were|will|have|has|do|does|since|depuis|full|complete|entire|respective|To[A-Z]|Block[s]?|Handler|Helper|Header|Footer|Template|Provider))[^\0]*
 REG_NON_BLANK=.*(?:[[:alpha:]][[:alpha:]]|[[:digit:]][[:digit:]]).*

--- a/src/copyright/agent/copyrightUtils.cc
+++ b/src/copyright/agent/copyrightUtils.cc
@@ -247,26 +247,28 @@ static void addDefaultScanners(CopyrightState& state)
  */
 scanner* makeRegexScanner(const std::string& regexDesc, const std::string& defaultType) {
   #define RGX_FMT_SEPARATOR "@@"
-  auto fmtRegex = rx::regex(
+  auto fmtRegex = rx::make_u32regex(
     "(?:([[:alpha:]]+)" RGX_FMT_SEPARATOR ")?(?:([[:digit:]]+)" RGX_FMT_SEPARATOR ")?(.*)",
     rx::regex_constants::icase
   );
 
   rx::match_results<std::string::const_iterator> match;
-  if (rx::regex_match(regexDesc.begin(), regexDesc.end(), match, fmtRegex))
+  if (rx::u32regex_match(regexDesc.begin(), regexDesc.end(), match, fmtRegex))
   {
-    std::string type(match.length(1) > 0 ? match.str(1) : defaultType.c_str());
+    std::string const type(match.length(1) > 0 ? match.str(1) : defaultType);
 
     int regId = match.length(2) > 0 ? std::stoi(std::string(match.str(2))) : 0;
 
     if (match.length(3) == 0)
-      return 0; // nullptr
+      return nullptr;
 
-    std::istringstream stream;
-    stream.str(type + "=" + match.str(3));
+    std::string streamContent = type + "=" + match.str(3);
+
+    std::wistringstream stream;
+    stream.str(std::wstring(streamContent.begin(), streamContent.end()));
     return new regexScanner(type, stream, regId);
   }
-  return 0; // nullptr
+  return nullptr;
 }
 
 /**
@@ -295,8 +297,9 @@ CopyrightState getState(CliOptions&& cliOptions)
  * \param uploadTreeTableName      Uploadtree table for this upload
  * \return True of successful insertion, false otherwise
  */
-bool saveToDatabase(const string& s, const list<match>& matches, unsigned long pFileId,
-    int agentId, const CopyrightDatabaseHandler& copyrightDatabaseHandler,
+bool saveToDatabase(const icu::UnicodeString& s, const list<match>& matches,
+    unsigned long pFileId, int agentId,
+    const CopyrightDatabaseHandler& copyrightDatabaseHandler,
     int uploadId, const string& uploadTreeTableName)
 {
   if (!copyrightDatabaseHandler.begin())
@@ -305,19 +308,19 @@ bool saveToDatabase(const string& s, const list<match>& matches, unsigned long p
   }
 
   size_t count = 0;
-  for (auto m = matches.begin(); m != matches.end(); ++m)
+  for (auto matche : matches)
   {
 
     DatabaseEntry entry;
     entry.agent_fk = agentId;
-    entry.content = cleanMatch(s, *m);
-    entry.copy_endbyte = m->end;
-    entry.copy_startbyte = m->start;
+    entry.content = cleanMatch(s, matche);
+    entry.copy_endbyte = matche.end;
+    entry.copy_startbyte = matche.start;
     entry.pfile_fk = pFileId;
-    entry.type = m->type;
-    entry.is_enabled = m->is_enabled;
+    entry.type = matche.type;
+    entry.is_enabled = matche.is_enabled;
 
-    if (entry.content.length() != 0)
+    if (!entry.content.isEmpty())
     {
       ++count;
       if (!copyrightDatabaseHandler.insertInDatabase(entry))
@@ -352,15 +355,15 @@ bool saveToDatabase(const string& s, const list<match>& matches, unsigned long p
  * \param uploadId            Upload being scanned
  * \param uploadTreeTableName Uploadtree table for this upload
  */
-void matchFileWithLicenses(const string& sContent, unsigned long pFileId,
+void matchFileWithLicenses(const icu::UnicodeString& sContent, unsigned long pFileId,
     CopyrightState const& state, int agentId, CopyrightDatabaseHandler& databaseHandler,
     int uploadId, const string& uploadTreeTableName)
 {
   list<match> l;
   const list<unptr::shared_ptr<scanner>>& scanners = state.getScanners();
-  for (auto sc = scanners.begin(); sc != scanners.end(); ++sc)
+  for (const auto & scanner : scanners)
   {
-    (*sc)->ScanString(sContent, l);
+    scanner->ScanString(sContent, l);
   }
   saveToDatabase(sContent, l, pFileId, agentId, databaseHandler, uploadId, uploadTreeTableName);
 }
@@ -392,14 +395,14 @@ void matchPFileWithLicenses(CopyrightState const& state, int agentId,
     bail(8);
   }
 
-  char* fileName = NULL;
+  char* fileName = nullptr;
   {
 #pragma omp critical (repo_mk_path)
     fileName = fo_RepMkPath("files", pFile);
   }
   if (fileName)
   {
-    string s;
+    icu::UnicodeString s;
     ReadFileToString(fileName, s);
 
     matchFileWithLicenses(s, pFileId, state, agentId, databaseHandler, uploadId, uploadTreeTableName);
@@ -461,24 +464,24 @@ bool processUploadId(const CopyrightState& state, int agentId, int uploadId, Cop
  * @param fileName Location of the file to be scanned
  * @return A pair of file scanned and list of matches found.
  */
-pair<string, list<match>> processSingleFile(const CopyrightState& state,
+pair<icu::UnicodeString, list<match>> processSingleFile(const CopyrightState& state,
   const string fileName)
 {
   const list<unptr::shared_ptr<scanner>>& scanners = state.getScanners();
   list<match> matchList;
 
   // Read file into one string
-  string s;
+  icu::UnicodeString s;
   if (!ReadFileToString(fileName, s))
   {
     // File error
-    s = "";
+    s = u"";
   }
   else
   {
-    for (auto sc = scanners.begin(); sc != scanners.end(); ++sc)
+    for (const auto & scanner : scanners)
     {
-      (*sc)->ScanString(s, matchList);
+      scanner->ScanString(s, matchList);
     }
   }
   return make_pair(s, matchList);
@@ -491,8 +494,8 @@ pair<string, list<match>> processSingleFile(const CopyrightState& state,
  * @param printComma Set true to print comma. Will be set true after first
  *                   data is printed
  */
-void appendToJson(const std::string fileName,
-    const std::pair<string, list<match>> resultPair, bool &printComma)
+void appendToJson(const std::string& fileName,
+    const std::pair<icu::UnicodeString, list<match>>& resultPair, bool &printComma)
 {
   Json::Value result;
 #if JSONCPP_VERSION_HEXA < ((1 << 24) | (4 << 16))
@@ -506,7 +509,7 @@ void appendToJson(const std::string fileName,
   jsonWriter["indentation"] = "";
 #endif
 
-  if (resultPair.first.empty())
+  if (resultPair.first.length() == 0)
   {
     result["file"] = fileName;
     result["results"] = "Unable to read file";
@@ -518,10 +521,12 @@ void appendToJson(const std::string fileName,
     for (auto m : resultList)
     {
       Json::Value j;
+      std::string utf8Content;
+      cleanMatch(resultPair.first, m).toUTF8String(utf8Content);
       j["start"] = m.start;
       j["end"] = m.end;
       j["type"] = m.type;
-      j["content"] = cleanMatch(resultPair.first, m);
+      j["content"] = utf8Content;
       results.append(j);
     }
     result["file"] = fileName;
@@ -557,10 +562,10 @@ void appendToJson(const std::string fileName,
  * @param fileName   File which was scanned
  * @param resultPair Result pair from scanSingleFile()
  */
-void printResultToStdout(const std::string fileName,
-    const std::pair<string, list<match>> resultPair)
+void printResultToStdout(const std::string& fileName,
+    const std::pair<icu::UnicodeString, list<match>>& resultPair)
 {
-  if (resultPair.first.empty())
+  if (resultPair.first.length() == 0)
   {
     cout << fileName << " :: Unable to read file" << endl;
     return;
@@ -569,10 +574,12 @@ void printResultToStdout(const std::string fileName,
   ss << fileName << " ::" << endl;
   // Output matches
   list<match> resultList = resultPair.second;
-  for (auto m = resultList.begin();  m != resultList.end(); ++m)
+  for (auto & m : resultList)
   {
-    ss << "\t[" << m->start << ':' << m->end << ':' << m->type << "] '"
-       << cleanMatch(resultPair.first, *m)
+    std::string utf8Content;
+    cleanMatch(resultPair.first, m).toUTF8String(utf8Content);
+    ss << "\t[" << m.start << ':' << m.end << ':' << m.type << "] '"
+       << utf8Content
        << "'" << endl;
   }
   // Thread-Safety: output all matches (collected in ss) at once to cout

--- a/src/copyright/agent/copyrightUtils.cc
+++ b/src/copyright/agent/copyrightUtils.cc
@@ -264,8 +264,7 @@ scanner* makeRegexScanner(const std::string& regexDesc, const std::string& defau
 
     std::string streamContent = type + "=" + match.str(3);
 
-    std::wistringstream stream;
-    stream.str(std::wstring(streamContent.begin(), streamContent.end()));
+    std::istringstream stream(streamContent);
     return new regexScanner(type, stream, regId);
   }
   return nullptr;

--- a/src/copyright/agent/copyrightUtils.hpp
+++ b/src/copyright/agent/copyrightUtils.hpp
@@ -51,14 +51,14 @@ void normalizeContent(std::string& content);
 
 bool processUploadId(const CopyrightState& state, int agentId, int uploadId, CopyrightDatabaseHandler& handler, bool ignoreFilesWithMimeType);
 
-std::pair<std::string, std::list<match>> processSingleFile(const CopyrightState& state,
+std::pair<icu::UnicodeString, std::list<match>> processSingleFile(const CopyrightState& state,
   const std::string fileName);
 
-void appendToJson(const std::string fileName,
-    const std::pair<string, list<match>> resultPair, bool &printComma);
+void appendToJson(const std::string& fileName,
+    const std::pair<icu::UnicodeString, list<match>>& resultPair, bool &printComma);
 
-void printResultToStdout(const std::string fileName,
-    const std::pair<string, list<match>> resultPair);
+void printResultToStdout(const std::string& fileName,
+    const std::pair<icu::UnicodeString, list<match>>& resultPair);
 
 #endif /* COPYRIGHTUTILS_HPP_ */
 

--- a/src/copyright/agent/copyscan.cc
+++ b/src/copyright/agent/copyscan.cc
@@ -6,6 +6,9 @@
 */
 
 #include "copyscan.hpp"
+#include <unicode/schriter.h>
+#include <unicode/brkiter.h>
+
 #include <cctype>
 #include <algorithm>
 #include "regexConfProvider.hpp"
@@ -17,6 +20,31 @@ extern "C" {
 const string copyrightType("statement");  /**< A constant for default copyrightType as "statement" */
 
 /**
+ * \brief Get the position of the line break
+ *
+ * Calculate the position of the line break in the input string using CRLF, CR,
+ * or LF.
+ * @param input Input string to search in
+ * @param begin Begin pointer of the string
+ * @param end End pointer of the string
+ * @param pos Position pointer to search from
+ * @return Position of the line break, else -1
+ */
+int32_t getLineBreakPosition(const icu::UnicodeString& input, const UChar* begin, const UChar* end, const UChar* pos)
+{
+  int32_t linePos = input.indexOf(icu::UnicodeString(u"\r\n"), pos - begin, end - pos);
+  if (linePos == -1)
+  {
+    linePos = input.indexOf(u'\r', pos - begin, end - pos);
+    if (linePos == -1)
+    {
+      linePos = input.indexOf(u'\n', pos - begin, end - pos);
+    }
+  }
+  return linePos;
+}
+
+/**
  * \brief Constructor for default hCopyrightScanner
  *
  * Initialize all regex values
@@ -26,44 +54,54 @@ hCopyrightScanner::hCopyrightScanner()
   RegexConfProvider rcp;
   rcp.maybeLoad("copyright");
 
-  regCopyright = rx::regex(rcp.getRegexValue("copyright","REG_COPYRIGHT"),
-                        rx::regex_constants::icase);
+  // getRegexValue returns icu::UnicodeString; convert to UTF-8 for rx::regex
+  auto toUtf8 = [&](const std::string& key) {
+    std::string out;
+    rcp.getRegexValue("copyright", key).toUTF8String(out);
+    return out;
+  };
 
-  regException = rx::regex(rcp.getRegexValue("copyright","REG_EXCEPTION"),
-               rx::regex_constants::icase);
-  regNonBlank = rx::regex(rcp.getRegexValue("copyright","REG_NON_BLANK"));
+  // Detection regexes: operate on UChar* buffer, produce UChar16 offsets
+  regCopyright = rx::make_u32regex(rcp.getRegexValue("copyright","REG_COPYRIGHT"),
+                                   rx::regex_constants::icase);
 
-  regSimpleCopyright = rx::regex(rcp.getRegexValue("copyright","REG_SIMPLE_COPYRIGHT"),
-                     rx::regex_constants::icase);
-  regSpdxCopyright = rx::regex(rcp.getRegexValue("copyright","REG_SPDX_COPYRIGHT"),
-                     rx::regex_constants::icase);
+  regException = rx::make_u32regex(rcp.getRegexValue("copyright","REG_EXCEPTION"),
+                                   rx::regex_constants::icase);
+
+  regNonBlank = rx::make_u32regex(rcp.getRegexValue("copyright","REG_NON_BLANK"));
+
+  regSimpleCopyright = rx::make_u32regex(rcp.getRegexValue("copyright","REG_SIMPLE_COPYRIGHT"),
+                                         rx::regex_constants::icase);
+
+  regSpdxCopyright = rx::make_u32regex(rcp.getRegexValue("copyright","REG_SPDX_COPYRIGHT"),
+                                       rx::regex_constants::icase);
 
   // Cleanup
-  regExceptionCopy = rx::regex(rcp.getRegexValue("copyright","REG_EXCEPTION_COPY"),
+  regExceptionCopy = rx::regex(toUtf8("REG_EXCEPTION_COPY"),
                      rx::regex_constants::icase);
-  regRemoveFileStmt = rx::regex(rcp.getRegexValue("copyright","REG_REMOVE_FILE_STATEMENT"),
+  regRemoveFileStmt = rx::regex(toUtf8("REG_REMOVE_FILE_STATEMENT"),
                       rx::regex_constants::icase);
-  regStripLicenseTrail = rx::regex(rcp.getRegexValue("copyright", "REG_STRIP_LICENSE_TRAIL"),
+  regStripLicenseTrail = rx::regex(toUtf8("REG_STRIP_LICENSE_TRAIL"),
                          rx::regex_constants::icase);
-  regStripTrademarkTrail = rx::regex(rcp.getRegexValue("copyright", "REG_STRIP_TRADEMARK_TRAIL"),
+  regStripTrademarkTrail = rx::regex(toUtf8("REG_STRIP_TRADEMARK_TRAIL"),
                            rx::regex_constants::icase);
-  regStripAllRightReserveTrail = rx::regex(rcp.getRegexValue("copyright", "REG_ALL_RIGHT_RESERVE_TRAIL"),
+  regStripAllRightReserveTrail = rx::regex(toUtf8("REG_ALL_RIGHT_RESERVE_TRAIL"),
                                  rx::regex_constants::icase);
-  regExceptionVerbFollow = rx::regex(rcp.getRegexValue("copyright", "REG_EXCEPTION_VERB_FOLLOW"),
+  regExceptionVerbFollow = rx::regex(toUtf8("REG_EXCEPTION_VERB_FOLLOW"),
                            rx::regex_constants::icase);
-  regExceptionAdjectivePrefix = rx::regex(rcp.getRegexValue("copyright", "REG_EXCEPTION_ADJECTIVE_PREFIX"),
+  regExceptionAdjectivePrefix = rx::regex(toUtf8("REG_EXCEPTION_ADJECTIVE_PREFIX"),
                                 rx::regex_constants::icase);
-  regExceptionTemplate = rx::regex(rcp.getRegexValue("copyright", "REG_EXCEPTION_TEMPLATE"),
+  regExceptionTemplate = rx::regex(toUtf8("REG_EXCEPTION_TEMPLATE"),
                          rx::regex_constants::icase);
-  regExceptionPassive = rx::regex(rcp.getRegexValue("copyright", "REG_EXCEPTION_PASSIVE"),
+  regExceptionPassive = rx::regex(toUtf8("REG_EXCEPTION_PASSIVE"),
                         rx::regex_constants::icase);
-  regStripCopySymNonYear = rx::regex(rcp.getRegexValue("copyright", "REG_STRIP_COPYSYM_NONYEAR"),
+  regStripCopySymNonYear = rx::regex(toUtf8("REG_STRIP_COPYSYM_NONYEAR"),
                            rx::regex_constants::icase);
-  regExceptionBinaryNoise = rx::regex(rcp.getRegexValue("copyright", "REG_EXCEPTION_BINARY_NOISE"),
+  regExceptionBinaryNoise = rx::regex(toUtf8("REG_EXCEPTION_BINARY_NOISE"),
                             rx::regex_constants::icase);
-  regExceptionMeta = rx::regex(rcp.getRegexValue("copyright", "REG_EXCEPTION_META"),
+  regExceptionMeta = rx::regex(toUtf8("REG_EXCEPTION_META"),
                      rx::regex_constants::icase);
-  regExceptionCharNameRun = rx::regex(rcp.getRegexValue("copyright", "REG_EXCEPTION_CHARNAME_RUN"),
+  regExceptionCharNameRun = rx::regex(toUtf8("REG_EXCEPTION_CHARNAME_RUN"),
                             rx::regex_constants::icase);
 }
 
@@ -73,24 +111,24 @@ hCopyrightScanner::hCopyrightScanner()
  * Given a string s, scans for copyright statements using regCopyrights.
  * Then checks for an regException match.
  * \param[in]  s   String to work on
- * \param[out] out List of matchs
+ * \param[out] results List of matchs
  */
-void hCopyrightScanner::ScanString(const string& s, list<match>& out) const
+void hCopyrightScanner::ScanString(const icu::UnicodeString& s, list<match>& results) const
 {
+  auto const begin = s.getBuffer();
+  auto pos = begin;
+  auto const end = begin + s.length();
 
-  string::const_iterator begin = s.begin();
-  string::const_iterator pos = begin;
-  string::const_iterator end = s.end();
   while (pos != end)
   {
     // Find potential copyright statement
-    rx::smatch results;
-    if (!rx::regex_search(pos, end, results, regCopyright))
+    rx::u16match matches;
+    if (!rx::u32regex_search(pos, end, matches, regCopyright))
       // No further copyright statement found
       break;
-    string::const_iterator foundPos = results[0].first;
+    auto const foundPos = matches[0].first;
 
-    if (!rx::regex_match(foundPos, end, regException))
+    if (!rx::u32regex_match(foundPos, end, regException))
     {
       /**
        * Not an exception, this means that at foundPos there is a copyright statement.
@@ -101,26 +139,36 @@ void hCopyrightScanner::ScanString(const string& s, list<match>& out) const
        * A blank line may consist of
        *   - spaces and punctuation
        *   - no word of two letters, no two consecutive digits
-      */
-      string::const_iterator j = find(foundPos, end, '\n');
+       */
+      auto const linePos = getLineBreakPosition(s, begin, end, foundPos);
+      auto j = end;
+      if (linePos != -1)
+      {
+        j = begin + linePos;
+      }
       while (j != end)
       {
-        string::const_iterator beginOfLine = j;
+        auto beginOfLine = j;
         ++beginOfLine;
-        string::const_iterator endOfLine = find(beginOfLine, end, '\n');
-        if (rx::regex_search(beginOfLine, endOfLine, regSpdxCopyright)){
+        auto const posEndOfLine = getLineBreakPosition(s, begin, end, beginOfLine);
+        auto const endOfLine = (posEndOfLine != -1) ? begin + posEndOfLine : end;
+        if (rx::u32regex_search(beginOfLine, endOfLine, regSpdxCopyright))
+        {
           // Found end
           break;
         }
-        if (rx::regex_search(beginOfLine, endOfLine, regSimpleCopyright)
-          || !rx::regex_match(beginOfLine, endOfLine, regNonBlank))
+        if (rx::u32regex_search(beginOfLine, endOfLine, regSimpleCopyright)
+          || !rx::u32regex_match(beginOfLine, endOfLine, regNonBlank))
         {
           // Found end
           break;
         }
         j = endOfLine;
       }
-      string raw = string(foundPos, j);
+      icu::UnicodeString sub;
+      s.extractBetween(foundPos - begin, j - begin, sub);
+      string raw;
+      sub.toUTF8String(raw);
       CleanupResult result = Cleanup(raw);
 
       if (result.disposition == CleanupResult::Disposition::DISCARD) {
@@ -131,7 +179,7 @@ void hCopyrightScanner::ScanString(const string& s, list<match>& out) const
 
       if (result.disposition == CleanupResult::Disposition::DEACTIVATE) {
         // deactivated copyright section
-        out.push_back(match(foundPos - begin, j - begin, copyrightType, false));
+        results.push_back(match(foundPos - begin, j - begin, copyrightType, false));
         pos = j;
         continue;
       }
@@ -140,13 +188,14 @@ void hCopyrightScanner::ScanString(const string& s, list<match>& out) const
       if (cleaned.size() > 300)
         cleaned = cleaned.substr(0, 300);
 
-      out.push_back(match(foundPos - begin, (foundPos - begin) + cleaned.size(), copyrightType));
+      icu::UnicodeString cleanedU = icu::UnicodeString::fromUTF8(cleaned);
+      results.push_back(match(foundPos - begin, (foundPos - begin) + cleanedU.length(), copyrightType));
       pos = j;
     }
     else
     {
       // An exception: this is not a copyright statement: continue at the end of this statement
-      pos = results[0].second;
+      pos = matches[0].second;
     }
   }
 }
@@ -271,6 +320,3 @@ void hCopyrightScanner::StripSuffixes(string& text) const{
     }
   }
 }
-
-
-

--- a/src/copyright/agent/copyscan.cc
+++ b/src/copyright/agent/copyscan.cc
@@ -119,16 +119,33 @@ void hCopyrightScanner::ScanString(const icu::UnicodeString& s, list<match>& res
   auto pos = begin;
   auto const end = begin + s.length();
 
+  // u32regex_search is implemented with recursive descent and will overflow
+  // the stack on very large inputs.  Search in bounded chunks to keep the
+  // recursive depth manageable.
+  static const int CHUNK_SIZE = 8192;
+  static const int CHUNK_OVERLAP = 256;
+
   while (pos != end)
   {
-    // Find potential copyright statement
+    // Find potential copyright statement within a bounded chunk
+    auto const searchEnd = (end - pos > CHUNK_SIZE) ? pos + CHUNK_SIZE : end;
     rx::u16match matches;
-    if (!rx::u32regex_search(pos, end, matches, regCopyright))
-      // No further copyright statement found
-      break;
+    if (!rx::u32regex_search(pos, searchEnd, matches, regCopyright))
+    {
+      // No match in this chunk; advance past it (keeping overlap for boundary matches)
+      if (searchEnd == end)
+        break;
+      pos = searchEnd - CHUNK_OVERLAP;
+      continue;
+    }
     auto const foundPos = matches[0].first;
 
-    if (!rx::u32regex_match(foundPos, end, regException))
+    // Limit the exception check to the first 256 UChar16 units from the
+    // match position.  Exception phrases ("copyright licenses", etc.) are
+    // short; running u32regex_match over the entire remaining file can
+    // exceed boost's regex complexity limit on large inputs.
+    auto const exEnd = (end - foundPos > 256) ? foundPos + 256 : end;
+    if (!rx::u32regex_match(foundPos, exEnd, regException))
     {
       /**
        * Not an exception, this means that at foundPos there is a copyright statement.
@@ -152,13 +169,21 @@ void hCopyrightScanner::ScanString(const icu::UnicodeString& s, list<match>& res
         ++beginOfLine;
         auto const posEndOfLine = getLineBreakPosition(s, begin, end, beginOfLine);
         auto const endOfLine = (posEndOfLine != -1) ? begin + posEndOfLine : end;
-        if (rx::u32regex_search(beginOfLine, endOfLine, regSpdxCopyright))
+
+        // Cap the range to avoid stack overflow in u32regex_match/search
+        // on very long "lines" (e.g., minified files with no newlines).
+        // A line longer than 4096 UChar16 units is certainly non-blank.
+        static const int MAX_LINE_CHECK = 4096;
+        auto const checkEnd = (endOfLine - beginOfLine > MAX_LINE_CHECK)
+                                ? beginOfLine + MAX_LINE_CHECK : endOfLine;
+
+        if (rx::u32regex_search(beginOfLine, checkEnd, regSpdxCopyright))
         {
           // Found end
           break;
         }
-        if (rx::u32regex_search(beginOfLine, endOfLine, regSimpleCopyright)
-          || !rx::u32regex_match(beginOfLine, endOfLine, regNonBlank))
+        if (rx::u32regex_search(beginOfLine, checkEnd, regSimpleCopyright)
+          || !rx::u32regex_match(beginOfLine, checkEnd, regNonBlank))
         {
           // Found end
           break;

--- a/src/copyright/agent/copyscan.hpp
+++ b/src/copyright/agent/copyscan.hpp
@@ -38,7 +38,7 @@ struct CleanupResult {
 class hCopyrightScanner : public scanner
 {
 public:
-  void ScanString(const string& s, list<match>& results) const;
+  void ScanString(const icu::UnicodeString& s, list<match>& results) const override;
   hCopyrightScanner();
   CleanupResult Cleanup(const string &raw) const;
   void TrimPunctuation(string &text) const;
@@ -58,8 +58,11 @@ private:
    * \var rx::regex regSpdxCopyright
    * Regex for SPDX-FileCopyrightText
    */
-  rx::regex regCopyright, regException, regExceptionCopy, regNonBlank, regSimpleCopyright,
-  regSpdxCopyright, regRemoveFileStmt, regStripLicenseTrail, regStripTrademarkTrail, regStripAllRightReserveTrail, regExceptionVerbFollow, regExceptionAdjectivePrefix, regExceptionTemplate, regExceptionPassive, regStripCopySymNonYear, regExceptionBinaryNoise, regExceptionMeta, regExceptionCharNameRun;
+  rx::u32regex regCopyright, regException, regNonBlank, regSimpleCopyright, regSpdxCopyright;
+  rx::regex regExceptionCopy, regRemoveFileStmt, regStripLicenseTrail, regStripTrademarkTrail,
+  regStripAllRightReserveTrail, regExceptionVerbFollow, regExceptionAdjectivePrefix,
+  regExceptionTemplate, regExceptionPassive, regStripCopySymNonYear, regExceptionBinaryNoise,
+  regExceptionMeta, regExceptionCharNameRun;
 } ;
 
 #endif

--- a/src/copyright/agent/database.cc
+++ b/src/copyright/agent/database.cc
@@ -354,6 +354,8 @@ std::vector<unsigned long> CopyrightDatabaseHandler::queryFileIdsForUpload(int a
 bool CopyrightDatabaseHandler::insertInDatabase(DatabaseEntry& entry) const
 {
   std::string tableName = IDENTITY;
+  std::string content;
+  entry.content.toUTF8String(content);
 
   if("author" == entry.type ||
      "email" == entry.type ||
@@ -371,7 +373,7 @@ bool CopyrightDatabaseHandler::insertInDatabase(DatabaseEntry& entry) const
         long, long, char*, char*, int, int
     ),
     entry.agent_fk, entry.pfile_fk,
-    entry.content.c_str(),
+    content.c_str(),
     entry.type.c_str(),
     entry.copy_startbyte, entry.copy_endbyte
   );
@@ -396,6 +398,9 @@ bool CopyrightDatabaseHandler::insertDeactivatedEvents(const DatabaseEntry& entr
     "WHERE cp.hash = md5($1) AND cp.agent_fk = $2 "
     "  AND cp.pfile_fk = $3 AND ut.upload_fk = $4";
 
+  std::string contentUtf8;
+  entry.content.toUTF8String(contentUtf8);
+
   return dbManager.execPrepared(
     fo_dbManager_PrepareStamement(
       dbManager.getStruct_dbManager(),
@@ -403,7 +408,7 @@ bool CopyrightDatabaseHandler::insertDeactivatedEvents(const DatabaseEntry& entr
       sql.c_str(),
       char*, long, long, int
     ),
-    entry.content.c_str(),
+    contentUtf8.c_str(),
     entry.agent_fk,
     entry.pfile_fk,
     uploadId

--- a/src/copyright/agent/database.hpp
+++ b/src/copyright/agent/database.hpp
@@ -28,7 +28,7 @@ public:
 
   long agent_fk;                    /**< Id of agent performed the scan */
   long pfile_fk;                    /**< Id of pfile on which the scan was performed */
-  std::string content;              /**< Statement found during the scan */
+  icu::UnicodeString content;       /**< Statement found during the scan */
   std::string hash;                 /**< MD5 hash of the statement */
   /**
    * \brief Type of statement found.

--- a/src/copyright/agent/directoryScan.cc
+++ b/src/copyright/agent/directoryScan.cc
@@ -48,7 +48,7 @@ void scanDirectory(const CopyrightState& state, const bool json,
     for (unsigned int i = 0; i < filePathsSize; i++)
     {
       string fileName = filePaths[i];
-      pair<string, list<match>> scanResult = processSingleFile(state, fileName);
+      pair<icu::UnicodeString, list<match>> scanResult = processSingleFile(state, fileName);
       if (json)
       {
         appendToJson(fileName, scanResult, printComma);

--- a/src/copyright/agent/regex.hpp
+++ b/src/copyright/agent/regex.hpp
@@ -12,6 +12,7 @@
 #ifdef USEBOOST
 
 #include <boost/regex.hpp>
+#include <boost/regex/icu.hpp>
 
 /**
  * \namespace rx
@@ -22,8 +23,7 @@
 namespace rx = boost;
 #else
   #include <regex>
-  namespace rx  = std;
+  namespace rx = std;
 #endif
-
 
 #endif /* REGEX_HPP_ */

--- a/src/copyright/agent/regexConfParser.cc
+++ b/src/copyright/agent/regexConfParser.cc
@@ -9,8 +9,11 @@
  * \brief Handles RegexMap related requests
  */
 #include "regexConfParser.hpp"
+
+#include <codecvt>
 #include <string>
 #include <iostream>
+#include <locale>
 
 using namespace std;
 
@@ -20,11 +23,11 @@ using namespace std;
  * \param isVerbosityDebug Print debug messages if true
  * \return RegexMap created using stream
  */
-RegexMap readConfStreamToMap(std::istringstream& stream,
+RegexMap readConfStreamToMap(std::wistringstream& stream,
                              const bool isVerbosityDebug)
 {
-  map<string, string> regexMap;
-  for (string line; getline(stream, line); )
+  map<string, icu::UnicodeString> regexMap;
+  for (wstring line; getline(stream, line); )
     addRegexToMap(regexMap, line, isVerbosityDebug);
 
   return regexMap;
@@ -33,11 +36,11 @@ RegexMap readConfStreamToMap(std::istringstream& stream,
 /**
  * \overload
  */
-RegexMap readConfStreamToMap(std::ifstream& stream,
+RegexMap readConfStreamToMap(std::wifstream& stream,
                              const bool isVerbosityDebug)
 {
-  map<string, string> regexMap;
-  for (string line; getline(stream, line); )
+  map<string, icu::UnicodeString> regexMap;
+  for (wstring line; getline(stream, line); )
     addRegexToMap(regexMap, line, isVerbosityDebug);
   stream.close();
   return regexMap;
@@ -51,31 +54,36 @@ RegexMap readConfStreamToMap(std::ifstream& stream,
  * \param[in]  isVerbosityDebug Print debug messages if true
  */
 void addRegexToMap(/*in and out*/ RegexMap& regexMap,
-                   const std::string& regexDesc,
+                   const std::wstring& regexDesc,
                    const bool isVerbosityDebug)
 {
   if (regexDesc[0] == '#')
     return;
 
-  istringstream is_line(regexDesc);
-  string key, value;
-  if (getline(is_line, key, '='))
+  wistringstream is_line(regexDesc);
+  wstring key, value;
+  if (getline(is_line, key, L'='))
   {
     if(getline(is_line, value))
     {
-      value=replaceTokens(regexMap, value);
-      regexMap[key]=value;
+      std::wstring_convert<codecvt_utf8<wchar_t>> converter;
+      string const convertedKey = converter.to_bytes(key);
+      regexMap[convertedKey] = replaceTokens(regexMap, value);
       if (isVerbosityDebug)
-        cout << "loaded or updated regex definition: " << key << " -> \"" << value << "\"" << endl;
+      {
+        string convertedValue;
+        regexMap[convertedKey].toUTF8String(convertedValue);
+        cout << "loaded or updated regex definition: " << convertedKey << " -> \"" << convertedValue << "\"" << endl;
+      }
     }
     else
     {
-      cout << "empty regex definition in conf: \"" << regexDesc << "\"" << endl;
+      wcout << L"empty regex definition in conf: \"" << regexDesc << L"\"" << endl;
     }
   }
   else
   {
-    cout << "bad regex definition in conf: \"" << regexDesc << "\"" << endl;
+    wcout << L"bad regex definition in conf: \"" << regexDesc << L"\"" << endl;
   }
 }
 
@@ -86,34 +94,37 @@ void addRegexToMap(/*in and out*/ RegexMap& regexMap,
  * \param[in] constInput Input which has to be removed
  * \return String with tokens removed
  */
-string replaceTokens(/*in*/ RegexMap& regexMap,
-                     const string& constInput)
+icu::UnicodeString replaceTokens(/*in*/ RegexMap& regexMap,
+                                 const wstring& constInput)
 {
-#define RGX_SEPARATOR_LEFT "__"
+#define RGX_SEPARATOR_LEFT u"__"
 #define RGX_SEPARATOR_RIGHT RGX_SEPARATOR_LEFT
 #define RGX_SEPARATOR_LEN 2
 
-  string input(constInput);
-  stringstream output;
+  icu::UnicodeString input = icu::UnicodeString::fromUTF32(
+    reinterpret_cast<const UChar32*>(constInput.c_str()),
+    constInput.length());
+  icu::UnicodeString output;
 
-  size_t pos = 0;
+  int32_t pos = 0;
   string token;
-  while ((pos = input.find(RGX_SEPARATOR_LEFT)) != string::npos) // find start of the next token
+  while ((pos = input.indexOf(RGX_SEPARATOR_LEFT)) != -1) // find start of the next token
   {
-    output << input.substr(0, pos);
-    input.erase(0, pos + RGX_SEPARATOR_LEN);
+    output.append(input.tempSubString(0, pos));
+    input.removeBetween(0, pos + RGX_SEPARATOR_LEN);
 
-    if ((pos = input.find(RGX_SEPARATOR_RIGHT)) != string::npos) // find end of token
+    if ((pos = input.indexOf(RGX_SEPARATOR_RIGHT)) != -1) // find end of token
     {
-      output << regexMap[input.substr(0, pos)];
-      input.erase(0, pos + RGX_SEPARATOR_LEN);
-
+      std::string utf8String;
+      input.tempSubString(0, pos).toUTF8String(utf8String);
+      output.append(regexMap[utf8String]);
+      input.removeBetween(0, pos + RGX_SEPARATOR_LEN);
     }
     else
     {
-      cout << "uneven number of delimiters: " << constInput << endl;
+      wcout << L"uneven number of delimiters: " << constInput << endl;
     }
   }
-  output << input;
-  return output.str();
+  output.append(input);
+  return output;
 }

--- a/src/copyright/agent/regexConfParser.cc
+++ b/src/copyright/agent/regexConfParser.cc
@@ -10,24 +10,22 @@
  */
 #include "regexConfParser.hpp"
 
-#include <codecvt>
 #include <string>
 #include <iostream>
-#include <locale>
 
 using namespace std;
 
 /**
- * \brief Read a string stream and crate a RegexMap
+ * \brief Read a string stream and create a RegexMap
  * \param stream           String stream to read from
  * \param isVerbosityDebug Print debug messages if true
  * \return RegexMap created using stream
  */
-RegexMap readConfStreamToMap(std::wistringstream& stream,
+RegexMap readConfStreamToMap(std::istringstream& stream,
                              const bool isVerbosityDebug)
 {
   map<string, icu::UnicodeString> regexMap;
-  for (wstring line; getline(stream, line); )
+  for (string line; getline(stream, line); )
     addRegexToMap(regexMap, line, isVerbosityDebug);
 
   return regexMap;
@@ -36,11 +34,11 @@ RegexMap readConfStreamToMap(std::wistringstream& stream,
 /**
  * \overload
  */
-RegexMap readConfStreamToMap(std::wifstream& stream,
+RegexMap readConfStreamToMap(std::ifstream& stream,
                              const bool isVerbosityDebug)
 {
   map<string, icu::UnicodeString> regexMap;
-  for (wstring line; getline(stream, line); )
+  for (string line; getline(stream, line); )
     addRegexToMap(regexMap, line, isVerbosityDebug);
   stream.close();
   return regexMap;
@@ -54,36 +52,34 @@ RegexMap readConfStreamToMap(std::wifstream& stream,
  * \param[in]  isVerbosityDebug Print debug messages if true
  */
 void addRegexToMap(/*in and out*/ RegexMap& regexMap,
-                   const std::wstring& regexDesc,
+                   const std::string& regexDesc,
                    const bool isVerbosityDebug)
 {
-  if (regexDesc[0] == '#')
+  if (regexDesc.empty() || regexDesc[0] == '#')
     return;
 
-  wistringstream is_line(regexDesc);
-  wstring key, value;
-  if (getline(is_line, key, L'='))
+  istringstream is_line(regexDesc);
+  string key, value;
+  if (getline(is_line, key, '='))
   {
     if(getline(is_line, value))
     {
-      std::wstring_convert<codecvt_utf8<wchar_t>> converter;
-      string const convertedKey = converter.to_bytes(key);
-      regexMap[convertedKey] = replaceTokens(regexMap, value);
+      regexMap[key] = replaceTokens(regexMap, value);
       if (isVerbosityDebug)
       {
         string convertedValue;
-        regexMap[convertedKey].toUTF8String(convertedValue);
-        cout << "loaded or updated regex definition: " << convertedKey << " -> \"" << convertedValue << "\"" << endl;
+        regexMap[key].toUTF8String(convertedValue);
+        cout << "loaded or updated regex definition: " << key << " -> \"" << convertedValue << "\"" << endl;
       }
     }
     else
     {
-      wcout << L"empty regex definition in conf: \"" << regexDesc << L"\"" << endl;
+      cout << "empty regex definition in conf: \"" << regexDesc << "\"" << endl;
     }
   }
   else
   {
-    wcout << L"bad regex definition in conf: \"" << regexDesc << L"\"" << endl;
+    cout << "bad regex definition in conf: \"" << regexDesc << "\"" << endl;
   }
 }
 
@@ -95,15 +91,13 @@ void addRegexToMap(/*in and out*/ RegexMap& regexMap,
  * \return String with tokens removed
  */
 icu::UnicodeString replaceTokens(/*in*/ RegexMap& regexMap,
-                                 const wstring& constInput)
+                                 const string& constInput)
 {
 #define RGX_SEPARATOR_LEFT u"__"
 #define RGX_SEPARATOR_RIGHT RGX_SEPARATOR_LEFT
 #define RGX_SEPARATOR_LEN 2
 
-  icu::UnicodeString input = icu::UnicodeString::fromUTF32(
-    reinterpret_cast<const UChar32*>(constInput.c_str()),
-    constInput.length());
+  icu::UnicodeString input = icu::UnicodeString::fromUTF8(constInput);
   icu::UnicodeString output;
 
   int32_t pos = 0;
@@ -122,7 +116,7 @@ icu::UnicodeString replaceTokens(/*in*/ RegexMap& regexMap,
     }
     else
     {
-      wcout << L"uneven number of delimiters: " << constInput << endl;
+      cout << "uneven number of delimiters: " << constInput << endl;
     }
   }
   output.append(input);

--- a/src/copyright/agent/regexConfParser.hpp
+++ b/src/copyright/agent/regexConfParser.hpp
@@ -11,6 +11,7 @@
 #include <map>
 #include <sstream>
 #include <fstream>
+#include <unicode/unistr.h>
 
 extern "C" {
 #include "libfossology.h"
@@ -20,19 +21,19 @@ extern "C" {
  * \typedef
  * Key value pair regex name in key and pattern in value
  */
-typedef std::map<std::string, std::string> RegexMap;
+typedef std::map<std::string, icu::UnicodeString> RegexMap;
 
-RegexMap readConfStreamToMap(std::istringstream& stream,
-                               const bool isVerbosityDebug = false);
+RegexMap readConfStreamToMap(std::wistringstream& stream,
+                             const bool isVerbosityDebug = false);
 
-RegexMap readConfStreamToMap(std::ifstream& stream,
-                               const bool isVerbosityDebug = false);
+RegexMap readConfStreamToMap(std::wifstream& stream,
+                             const bool isVerbosityDebug = false);
 
 void addRegexToMap(/*in and out*/ RegexMap& oldMap,
-                    const std::string& regexDesc,
+                    const std::wstring& regexDesc,
                     const bool isVerbosityDebug = false);
 
-std::string replaceTokens(/*in*/ RegexMap& dict,
-                          const std::string& constInput);
+icu::UnicodeString replaceTokens(/*in*/ RegexMap& dict,
+                                 const std::wstring& constInput);
 
 #endif /* REGEXCONFPARSER_HPP_ */

--- a/src/copyright/agent/regexConfParser.hpp
+++ b/src/copyright/agent/regexConfParser.hpp
@@ -23,17 +23,17 @@ extern "C" {
  */
 typedef std::map<std::string, icu::UnicodeString> RegexMap;
 
-RegexMap readConfStreamToMap(std::wistringstream& stream,
+RegexMap readConfStreamToMap(std::istringstream& stream,
                              const bool isVerbosityDebug = false);
 
-RegexMap readConfStreamToMap(std::wifstream& stream,
+RegexMap readConfStreamToMap(std::ifstream& stream,
                              const bool isVerbosityDebug = false);
 
 void addRegexToMap(/*in and out*/ RegexMap& oldMap,
-                    const std::wstring& regexDesc,
+                    const std::string& regexDesc,
                     const bool isVerbosityDebug = false);
 
 icu::UnicodeString replaceTokens(/*in*/ RegexMap& dict,
-                                 const std::wstring& constInput);
+                                 const std::string& constInput);
 
 #endif /* REGEXCONFPARSER_HPP_ */

--- a/src/copyright/agent/regexConfProvider.cc
+++ b/src/copyright/agent/regexConfProvider.cc
@@ -9,6 +9,8 @@
  */
 #include "regexConfProvider.hpp"
 
+#include <codecvt>
+
 using namespace std;
 
 /**
@@ -80,13 +82,15 @@ RegexConfProvider::RegexConfProvider(const bool isVerbosityDebug)
  * \return True on success, false otherwise
  */
 bool RegexConfProvider::getRegexConfStream(const string& identity,
-                                           /*out*/ ifstream& stream)
+                                           /*out*/ wifstream& stream)
 {
   string confFile = getRegexConfFile(identity);
 
   if (_isVerbosityDebug)
     cout << "try to open conf: " << confFile << endl;
   stream.open(confFile.c_str());
+
+  stream.imbue(std::locale(stream.getloc(), new codecvt_utf8_utf16<wchar_t>));
 
   return stream.is_open();
 }
@@ -105,7 +109,7 @@ void RegexConfProvider::maybeLoad(const std::string& identity)
     {
       if (rmm.find(identity) == rmm.end())
       {
-        ifstream stream;
+        wifstream stream;
         if (getRegexConfStream(identity, stream))
         {
           rmm[identity] = readConfStreamToMap(stream, _isVerbosityDebug);
@@ -129,7 +133,7 @@ void RegexConfProvider::maybeLoad(const std::string& identity)
  * \param stream   Stream to read from
  */
 void RegexConfProvider::maybeLoad(const string& identity,
-                                  istringstream& stream)
+                                  wistringstream& stream)
 {
   map<string,RegexMap>& rmm = RegexConfProvider::_regexMapMap;
   if (rmm.find(identity) == rmm.end())
@@ -150,17 +154,17 @@ void RegexConfProvider::maybeLoad(const string& identity,
 
 /**
  * \brief Get the regex as string from the RegexMap
- * \param identity Identity from which the map was loaded
- * \param key      Key of the regex value required
+ * \param name Identity from which the map was loaded
+ * \param key  Key of the regex value required
  * \return Regex value as a null terminated string
  */
-const char* RegexConfProvider::getRegexValue(const string& identity,
-                                             const string& key)
+const icu::UnicodeString RegexConfProvider::getRegexValue(const string& name,
+                                                const string& key)
 {
-  const string* rv;
+  icu::UnicodeString rv;
 #pragma omp critical(rmm)
   {
-    rv = &(RegexConfProvider::_regexMapMap[identity][key]);
+    rv = RegexConfProvider::_regexMapMap[name][key];
   }
-  return (*rv).c_str();
+  return rv;
 }

--- a/src/copyright/agent/regexConfProvider.cc
+++ b/src/copyright/agent/regexConfProvider.cc
@@ -9,8 +9,6 @@
  */
 #include "regexConfProvider.hpp"
 
-#include <codecvt>
-
 using namespace std;
 
 /**
@@ -82,15 +80,13 @@ RegexConfProvider::RegexConfProvider(const bool isVerbosityDebug)
  * \return True on success, false otherwise
  */
 bool RegexConfProvider::getRegexConfStream(const string& identity,
-                                           /*out*/ wifstream& stream)
+                                           /*out*/ ifstream& stream)
 {
   string confFile = getRegexConfFile(identity);
 
   if (_isVerbosityDebug)
     cout << "try to open conf: " << confFile << endl;
   stream.open(confFile.c_str());
-
-  stream.imbue(std::locale(stream.getloc(), new codecvt_utf8_utf16<wchar_t>));
 
   return stream.is_open();
 }
@@ -109,7 +105,7 @@ void RegexConfProvider::maybeLoad(const std::string& identity)
     {
       if (rmm.find(identity) == rmm.end())
       {
-        wifstream stream;
+        ifstream stream;
         if (getRegexConfStream(identity, stream))
         {
           rmm[identity] = readConfStreamToMap(stream, _isVerbosityDebug);
@@ -133,7 +129,7 @@ void RegexConfProvider::maybeLoad(const std::string& identity)
  * \param stream   Stream to read from
  */
 void RegexConfProvider::maybeLoad(const string& identity,
-                                  wistringstream& stream)
+                                  istringstream& stream)
 {
   map<string,RegexMap>& rmm = RegexConfProvider::_regexMapMap;
   if (rmm.find(identity) == rmm.end())

--- a/src/copyright/agent/regexConfProvider.hpp
+++ b/src/copyright/agent/regexConfProvider.hpp
@@ -30,10 +30,10 @@ public:
 
   void maybeLoad(const std::string& identity);
   void maybeLoad(const std::string& identity,
-                 std::istringstream& stream);
+                 std::wistringstream& stream);
 
-  const char* getRegexValue(const std::string& name,
-                            const std::string& key);
+  const icu::UnicodeString getRegexValue(const std::string& name,
+                                         const std::string& key);
 
 private:
   static std::map<std::string,RegexMap> _regexMapMap;
@@ -41,7 +41,7 @@ private:
   bool _isVerbosityDebug;      /**< True to print debug messages */
 
   bool getRegexConfStream(const std::string& identity,
-                          /*out*/ std::ifstream& stream);
+                          /*out*/ std::wifstream& stream);
 };
 
 #endif /* REGEXCONFPROVIDER_HPP_ */

--- a/src/copyright/agent/regexConfProvider.hpp
+++ b/src/copyright/agent/regexConfProvider.hpp
@@ -30,7 +30,7 @@ public:
 
   void maybeLoad(const std::string& identity);
   void maybeLoad(const std::string& identity,
-                 std::wistringstream& stream);
+                 std::istringstream& stream);
 
   const icu::UnicodeString getRegexValue(const std::string& name,
                                          const std::string& key);
@@ -41,7 +41,7 @@ private:
   bool _isVerbosityDebug;      /**< True to print debug messages */
 
   bool getRegexConfStream(const std::string& identity,
-                          /*out*/ std::wifstream& stream);
+                          /*out*/ std::ifstream& stream);
 };
 
 #endif /* REGEXCONFPROVIDER_HPP_ */

--- a/src/copyright/agent/regscan.cc
+++ b/src/copyright/agent/regscan.cc
@@ -20,8 +20,8 @@ regexScanner::regexScanner(const string& type,
 {
   RegexConfProvider rcp;
   rcp.maybeLoad(_identity);
-  _reg = rx::regex(rcp.getRegexValue(_identity, _type),
-                   rx::regex_constants::icase);
+  _reg = rx::make_u32regex(rcp.getRegexValue(_identity, _type),
+                           rx::regex_constants::icase);
 }
 
 /**
@@ -31,7 +31,7 @@ regexScanner::regexScanner(const string& type,
  *                                   std::istringstream& stream)
  */
 regexScanner::regexScanner(const string& type,
-                           std::istringstream& stream,
+                           std::wistringstream& stream,
                            int index)
   : _type(type),
     _identity(type),
@@ -39,8 +39,8 @@ regexScanner::regexScanner(const string& type,
 {
   RegexConfProvider rcp;
   rcp.maybeLoad(_identity,stream);
-  _reg = rx::regex(rcp.getRegexValue(_identity, _type),
-                   rx::regex_constants::icase);
+  _reg = rx::make_u32regex(rcp.getRegexValue(_identity, _type),
+                           rx::regex_constants::icase);
 }
 
 /**
@@ -48,18 +48,18 @@ regexScanner::regexScanner(const string& type,
  * \param[in]  s       String to scan
  * \param[out] results List of match results
  */
-void regexScanner::ScanString(const string& s, list<match>& results) const
+void regexScanner::ScanString(const icu::UnicodeString& s, list<match>& results) const
 {
   // Read file into one string
-  string::const_iterator end = s.end();
-  string::const_iterator pos = s.begin();
+  auto pos = s.getBuffer();
+  auto const end = pos + s.length();
   unsigned int intPos = 0;
 
   while (pos != end)
   {
     // Find next match
-    rx::smatch res;
-    if (rx::regex_search(pos, end, res, _reg))
+    rx::u16match res;
+    if (rx::u32regex_search(pos, end, res, _reg))
     {
       // Found match
       results.push_back(match(intPos + res.position(_index),
@@ -73,4 +73,3 @@ void regexScanner::ScanString(const string& s, list<match>& results) const
       break;
   }
 }
-

--- a/src/copyright/agent/regscan.cc
+++ b/src/copyright/agent/regscan.cc
@@ -20,8 +20,9 @@ regexScanner::regexScanner(const string& type,
 {
   RegexConfProvider rcp;
   rcp.maybeLoad(_identity);
-  _reg = rx::make_u32regex(rcp.getRegexValue(_identity, _type),
-                           rx::regex_constants::icase);
+  std::string pattern;
+  rcp.getRegexValue(_identity, _type).toUTF8String(pattern);
+  _reg = rx::regex(pattern, rx::regex_constants::icase);
 }
 
 /**
@@ -31,7 +32,7 @@ regexScanner::regexScanner(const string& type,
  *                                   std::istringstream& stream)
  */
 regexScanner::regexScanner(const string& type,
-                           std::wistringstream& stream,
+                           std::istringstream& stream,
                            int index)
   : _type(type),
     _identity(type),
@@ -39,37 +40,53 @@ regexScanner::regexScanner(const string& type,
 {
   RegexConfProvider rcp;
   rcp.maybeLoad(_identity,stream);
-  _reg = rx::make_u32regex(rcp.getRegexValue(_identity, _type),
-                           rx::regex_constants::icase);
+  std::string pattern;
+  rcp.getRegexValue(_identity, _type).toUTF8String(pattern);
+  _reg = rx::regex(pattern, rx::regex_constants::icase);
 }
 
 /**
  * \brief Scan a string using regex defined during initialization
- * \param[in]  s       String to scan
- * \param[out] results List of match results
+ *
+ * Converts the UnicodeString to UTF-8 and uses boost::regex for performance.
+ * The byte offsets from regex matches are then converted to UChar16 offsets
+ * so positions stored in the database are consistent with the ICU representation.
+ *
+ * \param[in]  s       UnicodeString to scan
+ * \param[out] results List of match results (positions in UChar16 offsets)
  */
 void regexScanner::ScanString(const icu::UnicodeString& s, list<match>& results) const
 {
-  // Read file into one string
-  auto pos = s.getBuffer();
-  auto const end = pos + s.length();
-  unsigned int intPos = 0;
+  std::string utf8;
+  s.toUTF8String(utf8);
+
+  const unsigned char* utf8Buf =
+    reinterpret_cast<const unsigned char*>(utf8.c_str());
+
+  auto pos = utf8.cbegin();
+  auto const end = utf8.cend();
 
   while (pos != end)
   {
-    // Find next match
-    rx::u16match res;
-    if (rx::u32regex_search(pos, end, res, _reg))
+    rx::smatch res;
+    if (rx::regex_search(pos, end, res, _reg))
     {
-      // Found match
-      results.push_back(match(intPos + res.position(_index),
-                              intPos + res.position(_index) + res.length(_index),
-                              _type));
+      // Compute byte offsets relative to start of utf8 string
+      size_t byteMatchStart = static_cast<size_t>(
+        res.position(_index) + std::distance(utf8.cbegin(), pos));
+      size_t byteMatchEnd = byteMatchStart +
+        static_cast<size_t>(res.length(_index));
+
+      // Convert byte offsets to UChar16 offsets
+      int ucharStart = static_cast<int>(
+        fo_utf8ByteLenToUChar16Len(utf8Buf, byteMatchStart));
+      int ucharEnd = static_cast<int>(
+        fo_utf8ByteLenToUChar16Len(utf8Buf, byteMatchEnd));
+
+      results.push_back(match(ucharStart, ucharEnd, _type));
       pos = res[0].second;
-      intPos += res.position() + res.length();
     }
     else
-      // No match found
       break;
   }
 }

--- a/src/copyright/agent/regscan.hpp
+++ b/src/copyright/agent/regscan.hpp
@@ -23,7 +23,7 @@ class regexScanner : public scanner
    * \var rx::regex _reg
    * Regex to be used during scan
    */
-  rx::regex _reg;
+  rx::u32regex _reg;
   /**
    * \var string _type
    * Type of regex to use
@@ -38,13 +38,13 @@ class regexScanner : public scanner
   int _index;
 
 public:
-  void ScanString(const string& str, list<match>& results) const;
+  void ScanString(const icu::UnicodeString& s, list<match>& results) const override;
 
   regexScanner(const string& type,
                const string& identity,
                int index = 0);
   regexScanner(const string& type,
-               std::istringstream& stream,
+               std::wistringstream& stream,
                int index = 0);
 } ;
 

--- a/src/copyright/agent/regscan.hpp
+++ b/src/copyright/agent/regscan.hpp
@@ -13,17 +13,25 @@
 #include "regexConfProvider.hpp"
 #include <sstream>
 
+extern "C" {
+#include "libfossology.h"
+}
+
 /**
  * \class regexScanner
  * \brief Provides a regex scanner using predefined regexs
+ *
+ * Uses boost::regex on UTF-8 strings for performance; the ecc/keyword/ipra
+ * patterns only match ASCII content.  Byte offsets are converted to UChar16
+ * offsets at the end so positions are consistent with the ICU-based storage.
  */
 class regexScanner : public scanner
 {
   /**
    * \var rx::regex _reg
-   * Regex to be used during scan
+   * Regex to be used during scan (operates on UTF-8 bytes)
    */
-  rx::u32regex _reg;
+  rx::regex _reg;
   /**
    * \var string _type
    * Type of regex to use
@@ -44,7 +52,7 @@ public:
                const string& identity,
                int index = 0);
   regexScanner(const string& type,
-               std::wistringstream& stream,
+               std::istringstream& stream,
                int index = 0);
 } ;
 

--- a/src/copyright/agent/scanners.cc
+++ b/src/copyright/agent/scanners.cc
@@ -7,8 +7,8 @@
 
 #include "scanners.hpp"
 
+#include <codecvt>
 #include <sstream>
-#include <cstring>
 
 /**
  * \brief Utility: read file to string from scanners.h
@@ -17,13 +17,15 @@
  * \return True on success, fail otherwise
  * \todo There should be a maximum string size
  */
-
-bool ReadFileToString(const string& fileName, string& out)
+bool ReadFileToString(const string& fileName, icu::UnicodeString& out)
 {
-  ifstream stream(fileName);
-  std::stringstream sstr;
+  wifstream stream(fileName);
+  stream.imbue(std::locale(stream.getloc(), new std::codecvt_utf8_utf16<wchar_t>));
+  std::wstringstream sstr;
   sstr << stream.rdbuf();
-  out = sstr.str();
+  out = icu::UnicodeString::fromUTF32(
+    reinterpret_cast<const UChar32*>(sstr.str().c_str()),
+    sstr.str().length());
   return !stream.fail();
 }
 

--- a/src/copyright/agent/scanners.cc
+++ b/src/copyright/agent/scanners.cc
@@ -7,25 +7,25 @@
 
 #include "scanners.hpp"
 
-#include <codecvt>
+#include <fstream>
 #include <sstream>
 
 /**
- * \brief Utility: read file to string from scanners.h
+ * \brief Utility: read file to UnicodeString from scanners.h
  * \param[in]  fileName Path of file to read
- * \param[out] out      String created from file
+ * \param[out] out      UnicodeString created from file
  * \return True on success, fail otherwise
  * \todo There should be a maximum string size
  */
 bool ReadFileToString(const string& fileName, icu::UnicodeString& out)
 {
-  wifstream stream(fileName);
-  stream.imbue(std::locale(stream.getloc(), new std::codecvt_utf8_utf16<wchar_t>));
-  std::wstringstream sstr;
+  std::ifstream stream(fileName, std::ios::binary);
+  if (!stream)
+    return false;
+  std::ostringstream sstr;
   sstr << stream.rdbuf();
-  out = icu::UnicodeString::fromUTF32(
-    reinterpret_cast<const UChar32*>(sstr.str().c_str()),
-    sstr.str().length());
+  std::string content = sstr.str();
+  out = icu::UnicodeString::fromUTF8(content);
   return !stream.fail();
 }
 

--- a/src/copyright/agent/scanners.hpp
+++ b/src/copyright/agent/scanners.hpp
@@ -12,14 +12,15 @@
 #define SCANNERS_HPP_
 
 #include <fstream>
-using std::ifstream;
-using std::istream;
-#include <string>
-using std::string;
 #include <list>
+#include <string>
+#include <unicode/unistr.h>
+using std::wifstream;
+using std::istream;
+using std::string;
 using std::list;
 
-bool ReadFileToString(const string& fileName, string& out);
+bool ReadFileToString(const string& fileName, icu::UnicodeString& out);
 
 /**
  * \struct match
@@ -65,7 +66,7 @@ public:
    * \param[in]  s       String to scan
    * \param[out] results Copyright matches are appended to this list
    */
-  virtual void ScanString(const string& s, list<match>& results) const = 0;
+  virtual void ScanString(const icu::UnicodeString& s, list<match>& results) const = 0;
 
   /**
    * \brief Helper function to scan file
@@ -76,7 +77,7 @@ public:
    */
   virtual void ScanFile(const string& fileName, list<match>& results) const
   {
-    string s;
+    icu::UnicodeString s;
     ReadFileToString(fileName, s);
     ScanString(s, results);
   }

--- a/src/copyright/agent/scanners.hpp
+++ b/src/copyright/agent/scanners.hpp
@@ -15,7 +15,6 @@
 #include <list>
 #include <string>
 #include <unicode/unistr.h>
-using std::wifstream;
 using std::istream;
 using std::string;
 using std::list;

--- a/src/copyright/agent_tests/CMakeLists.txt
+++ b/src/copyright/agent_tests/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT TARGET phpunit)
     prepare_phpunit()
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FO_CXX_FLAGS} -fopenmp -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FO_CXX_FLAGS} -Wextra")
 
 add_executable(test_copyright "")
 target_sources(test_copyright
@@ -20,14 +20,15 @@ target_sources(test_copyright
         ${FO_CWD}/Unit/test_regexConfProvider.cc)
 target_link_libraries(test_copyright
     PRIVATE
-        copyright_lib dl ${cppunit_LIBRARIES} ${jsoncpp_LIBRARIES})
-target_include_directories(test_copyright 
+        copyright_lib dl ${cppunit_LIBRARIES} ${jsoncpp_LIBRARIES}
+        OpenMP::OpenMP_CXX)
+target_include_directories(test_copyright
     PRIVATE ${FO_CWD}/../agent ${glib_INCLUDE_DIRS} ${jsoncpp_INCLUDE_DIRS}
     ${PostgreSQL_INCLUDE_DIRS} ${FO_CLIB_SRC} ${FO_CXXLIB_SRC})
 
 add_test(copyright_unit_test test_copyright)
 
-add_test(NAME copyright_functional_cli_test 
+add_test(NAME copyright_functional_cli_test
     COMMAND bash ${FO_CWD}/Functional/shunit2 ${FO_CWD}/Functional/cli_test.sh
     WORKING_DIRECTORY ${FO_CWD}/Functional)
 

--- a/src/copyright/agent_tests/Unit/test_regexConfProvider.cc
+++ b/src/copyright/agent_tests/Unit/test_regexConfProvider.cc
@@ -33,7 +33,7 @@ private:
    * \param testString String to check result against
    * \param testKey    Key to check result against
    */
-  void regexConfProviderTest (istringstream& testStream,
+  void regexConfProviderTest (wistringstream& testStream,
                     const string& testString,
                     const string& testKey)
   {
@@ -44,10 +44,13 @@ private:
     // load parse test-stream
     rcp.maybeLoad(testIdentity,testStream);
 
+    std::string currentString;
+    rcp.getRegexValue(testIdentity,testKey).toUTF8String(currentString);
+
     // test RegexConfProvider
     CPPUNIT_ASSERT_MESSAGE("The generated string should match the expected string",
                            0 == strcmp(testString.c_str(),
-                                       rcp.getRegexValue(testIdentity,testKey)));
+                                       currentString.c_str()));
   }
 
 protected:
@@ -61,7 +64,7 @@ protected:
     string testString = "Lorem Ipsum";
     string testKey = "TEST";
     string testLine = testKey + "=" + testString + "\n";
-    istringstream testStream(testLine);
+    wistringstream testStream(std::wstring(testLine.begin(), testLine.end()));
 
     regexConfProviderTest(testStream,testString,testKey);
   }
@@ -78,7 +81,7 @@ protected:
     string testLine =
       testKey + "=" + "Lorem \n" +
       testKey + "=__" + testKey + "__Ipsum\n";
-    istringstream testStream(testLine);
+    wistringstream testStream(std::wstring(testLine.begin(), testLine.end()));
 
     regexConfProviderTest(testStream,testString,testKey);
   }
@@ -97,7 +100,7 @@ protected:
       "INFIX2=su\n" +
       "INFIX1=rem__SPACE__I\n" +
       testKey + "=Lo__INFIX1__p__INFIX2__m\n";
-    istringstream testStream(testLine);
+    wistringstream testStream(std::wstring(testLine.begin(), testLine.end()));
 
     regexConfProviderTest(testStream,testString,testKey);
   }
@@ -115,7 +118,7 @@ protected:
     string testLine =
       string("LOREM=Lorem__LOREM__ \n") +
       testKey + "=__LOREM__Ipsum\n";
-    istringstream testStream(testLine);
+    wistringstream testStream(std::wstring(testLine.begin(), testLine.end()));
 
     string testIdentity("testIdentity");
 
@@ -126,7 +129,7 @@ protected:
 
     // evaluate and verify, that recursion does not appear
     CPPUNIT_ASSERT_MESSAGE("This should just terminate (the return value is not specified)",
-                           rcp.getRegexValue(testIdentity,testKey));
+                           !rcp.getRegexValue(testIdentity,testKey).isEmpty());
   }
 };
 

--- a/src/copyright/agent_tests/Unit/test_regexConfProvider.cc
+++ b/src/copyright/agent_tests/Unit/test_regexConfProvider.cc
@@ -33,7 +33,7 @@ private:
    * \param testString String to check result against
    * \param testKey    Key to check result against
    */
-  void regexConfProviderTest (wistringstream& testStream,
+  void regexConfProviderTest (istringstream& testStream,
                     const string& testString,
                     const string& testKey)
   {
@@ -64,7 +64,7 @@ protected:
     string testString = "Lorem Ipsum";
     string testKey = "TEST";
     string testLine = testKey + "=" + testString + "\n";
-    wistringstream testStream(std::wstring(testLine.begin(), testLine.end()));
+    istringstream testStream(testLine);
 
     regexConfProviderTest(testStream,testString,testKey);
   }
@@ -81,7 +81,7 @@ protected:
     string testLine =
       testKey + "=" + "Lorem \n" +
       testKey + "=__" + testKey + "__Ipsum\n";
-    wistringstream testStream(std::wstring(testLine.begin(), testLine.end()));
+    istringstream testStream(testLine);
 
     regexConfProviderTest(testStream,testString,testKey);
   }
@@ -100,7 +100,7 @@ protected:
       "INFIX2=su\n" +
       "INFIX1=rem__SPACE__I\n" +
       testKey + "=Lo__INFIX1__p__INFIX2__m\n";
-    wistringstream testStream(std::wstring(testLine.begin(), testLine.end()));
+    istringstream testStream(testLine);
 
     regexConfProviderTest(testStream,testString,testKey);
   }
@@ -118,7 +118,7 @@ protected:
     string testLine =
       string("LOREM=Lorem__LOREM__ \n") +
       testKey + "=__LOREM__Ipsum\n";
-    wistringstream testStream(std::wstring(testLine.begin(), testLine.end()));
+    istringstream testStream(testLine);
 
     string testIdentity("testIdentity");
 

--- a/src/copyright/agent_tests/Unit/test_scanners.cc
+++ b/src/copyright/agent_tests/Unit/test_scanners.cc
@@ -32,7 +32,7 @@ ostream& operator<<(ostream& out, const list<match>& l)
 /**
  * \brief test data
  */
-const char testContent[] = "© 2007 Hugh Jackman\n\n"
+const icu::UnicodeString testContent(u"© 2007 Hugh Jackman\n\n"
   "Copyright 2004 my company\n\n"
   "Copyrights by any strange people\n\n"
   "(C) copyright 2007-2011, 2013 my favourite company Google\n\n"
@@ -53,7 +53,7 @@ const char testContent[] = "© 2007 Hugh Jackman\n\n"
   "* Copyright (c) 1989, 1993\n" // Really just one newline here!
   "* The Regents of the University of California. All rights reserved.\n\n"
   "to be licensed as a whole"
-  "/* Most of the following tests are stolen from RCS 5.7's src/conf.sh.  */";
+  "/* Most of the following tests are stolen from RCS 5.7's src/conf.sh.  */");
 
 class scannerTestSuite : public CPPUNIT_NS :: TestFixture {
   CPPUNIT_TEST_SUITE (scannerTestSuite);
@@ -76,7 +76,8 @@ private:
    * \param type            Match type
    * \param expectedStrings Expected strings from scanner result
    */
-  void scannerTest (const scanner& sc, const char* content, const string& type, list<const char*> expectedStrings)
+  void scannerTest (const scanner& sc, const icu::UnicodeString& content,
+    const string& type, const list<icu::UnicodeString>& expectedStrings)
   {
     list<match> matches;
     list<match> expected;
@@ -84,12 +85,10 @@ private:
 
     for (auto s = expectedStrings.begin(); s != expectedStrings.end(); ++s)
     {
-      const char * p = strstr(content, *s);
-      if (p)
-      {
-        int pos = p - content;
-        expected.push_back(match(pos, pos+strlen(*s), type));
-      }
+      auto const begin = content.indexOf(*s);
+      auto const end = begin + s->countChar32();
+      if (begin > -1)
+        expected.emplace_back(begin, end, type);
       // else: expected string is not contained in original string
     }
     CPPUNIT_ASSERT_EQUAL(expected, matches);
@@ -207,12 +206,16 @@ protected:
    */
   void cleanEntries () {
     // Binary content
-    string actualFileContent;
+    icu::UnicodeString actualFileContent;
     ReadFileToString("../testdata/testdata142", actualFileContent);
 
-    vector<string> binaryStrings;
-    std::stringstream *ss = new std::stringstream(actualFileContent);
-    string temp;
+    string temp_string;
+    actualFileContent.toUTF8String(temp_string);
+    wstring actualFileContentW(temp_string.begin(), temp_string.end());
+
+    vector<wstring> binaryStrings;
+    auto *ss = new std::wstringstream(actualFileContentW);
+    wstring temp;
 
     while (std::getline(*ss, temp)) {
       binaryStrings.push_back(temp);
@@ -231,17 +234,23 @@ protected:
     }
 
     // Expected data
-    string expectedFileContent;
+    icu::UnicodeString expectedFileContent;
     ReadFileToString("../testdata/testdata142_exp", expectedFileContent);
 
+    expectedFileContent.toUTF8String(temp_string);
+    wstring expectedFileContentW(temp_string.begin(), temp_string.end());
+
     delete(ss);
-    ss = new std::stringstream(expectedFileContent);
-    vector<string> expectedStrings;
+    ss = new std::wstringstream(expectedFileContentW);
+    vector<icu::UnicodeString> expectedStrings;
     while (std::getline(*ss, temp)) {
-      expectedStrings.push_back(temp);
+      expectedStrings.push_back(icu::UnicodeString::fromUTF32(
+        reinterpret_cast<const UChar32*>(temp.c_str()),
+        temp.length())
+      );
     }
 
-    vector<string> actualStrings;
+    vector<icu::UnicodeString> actualStrings;
     for (size_t i = 0; i < matches.size(); i ++)
     {
       actualStrings.push_back(cleanMatch(actualFileContent, matches[i]));

--- a/src/copyright/agent_tests/Unit/test_scanners.cc
+++ b/src/copyright/agent_tests/Unit/test_scanners.cc
@@ -209,45 +209,50 @@ protected:
     icu::UnicodeString actualFileContent;
     ReadFileToString("../testdata/testdata142", actualFileContent);
 
-    string temp_string;
-    actualFileContent.toUTF8String(temp_string);
-    wstring actualFileContentW(temp_string.begin(), temp_string.end());
-
-    vector<wstring> binaryStrings;
-    auto *ss = new std::wstringstream(actualFileContentW);
-    wstring temp;
-
-    while (std::getline(*ss, temp)) {
-      binaryStrings.push_back(temp);
+    // Split by newline using UnicodeString operations to get proper UChar16 offsets
+    vector<int32_t> lineLengths;
+    int32_t lineStart = 0;
+    for (int32_t i = 0; i <= actualFileContent.length(); i++)
+    {
+      if (i == actualFileContent.length() || actualFileContent.charAt(i) == u'\n')
+      {
+        // Skip trailing empty segment (mimics getline semantics)
+        if (i == actualFileContent.length() && i == lineStart)
+          break;
+        lineLengths.push_back(i - lineStart);
+        lineStart = i + 1;
+      }
     }
 
-    // Simulate matches. Each line is a match
+    // Simulate matches. Each line is a match (in UChar16 offsets)
     vector<match> matches;
-    int pos = 0;
-    int size = binaryStrings.size();
-    for (int i = 0; i < size; i++)
+    int32_t pos = 0;
+    for (size_t i = 0; i < lineLengths.size(); i++)
     {
-      int length = binaryStrings[i].length();
+      int32_t length = lineLengths[i];
       matches.push_back(
         match(pos, pos + length, "statement"));
-      pos += length + 1;
+      pos += length + 1; // +1 for newline
     }
 
     // Expected data
     icu::UnicodeString expectedFileContent;
     ReadFileToString("../testdata/testdata142_exp", expectedFileContent);
 
-    expectedFileContent.toUTF8String(temp_string);
-    wstring expectedFileContentW(temp_string.begin(), temp_string.end());
-
-    delete(ss);
-    ss = new std::wstringstream(expectedFileContentW);
+    // Split expected content by newline
     vector<icu::UnicodeString> expectedStrings;
-    while (std::getline(*ss, temp)) {
-      expectedStrings.push_back(icu::UnicodeString::fromUTF32(
-        reinterpret_cast<const UChar32*>(temp.c_str()),
-        temp.length())
-      );
+    lineStart = 0;
+    for (int32_t i = 0; i <= expectedFileContent.length(); i++)
+    {
+      if (i == expectedFileContent.length() || expectedFileContent.charAt(i) == u'\n')
+      {
+        if (i == expectedFileContent.length() && i == lineStart)
+          break;
+        icu::UnicodeString line;
+        expectedFileContent.extractBetween(lineStart, i, line);
+        expectedStrings.push_back(line);
+        lineStart = i + 1;
+      }
     }
 
     vector<icu::UnicodeString> actualStrings;

--- a/src/lib/c/libfossagent.c
+++ b/src/lib/c/libfossagent.c
@@ -487,3 +487,124 @@ PGresult* getSelectedPFiles(PGconn* pgConn, int uploadPk, int agentPk, bool igno
   result = PQexec(pgConn, SQL);
   return result;
 }
+
+/**
+ * @brief Count UTF-16 code units (UChar16) in a UTF-8 byte buffer.
+ *
+ * Each ASCII byte maps to 1 UChar16. Each 2- or 3-byte UTF-8 sequence maps
+ * to 1 UChar16. A 4-byte sequence (supplementary character) maps to 2
+ * UChar16 units (a surrogate pair). This matches the counting used by
+ * icu::UnicodeString so that offsets stored in the database are consistent
+ * across all agents.
+ *
+ * When byteLen falls in the middle of a multi-byte sequence, only the
+ * complete bytes are counted; the partial trailing sequence is ignored.
+ *
+ * @param utf8    UTF-8 encoded byte buffer
+ * @param byteLen Number of bytes to examine
+ * @return Number of UTF-16 code units
+ */
+size_t fo_utf8ByteLenToUChar16Len(const unsigned char* utf8, size_t byteLen)
+{
+  size_t count = 0;
+  size_t i = 0;
+  while (i < byteLen)
+  {
+    unsigned char c = utf8[i];
+    if (c < 0x80)
+    {
+      i += 1;
+      count += 1;
+    }
+    else if ((c & 0xE0) == 0xC0)
+    {
+      if (i + 2 > byteLen) break;
+      if ((utf8[i + 1] & 0xC0) != 0x80)
+      {
+        /* Invalid continuation byte; treat lead as single unit */
+        i += 1;
+        count += 1;
+        continue;
+      }
+      i += 2;
+      count += 1;
+    }
+    else if ((c & 0xF0) == 0xE0)
+    {
+      if (i + 3 > byteLen) break;
+      if ((utf8[i + 1] & 0xC0) != 0x80 || (utf8[i + 2] & 0xC0) != 0x80)
+      {
+        /* Invalid continuation byte; treat lead as single unit */
+        i += 1;
+        count += 1;
+        continue;
+      }
+      i += 3;
+      count += 1;
+    }
+    else if ((c & 0xF8) == 0xF0)
+    {
+      if (i + 4 > byteLen) break;
+      if ((utf8[i + 1] & 0xC0) != 0x80 || (utf8[i + 2] & 0xC0) != 0x80 ||
+          (utf8[i + 3] & 0xC0) != 0x80)
+      {
+        /* Invalid continuation byte; treat lead as single unit */
+        i += 1;
+        count += 1;
+        continue;
+      }
+      i += 4;
+      count += 2;
+    }
+    else
+    {
+      i += 1; /* continuation byte or invalid: skip */
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/** Maximum file size (50 MB) we are willing to read for offset conversion.
+ *  Larger files are left with byte offsets to avoid excessive memory use. */
+#define FO_MAX_FILE_READ_SIZE (50UL * 1024 * 1024)
+
+/**
+ * \brief Read a file into a malloc'd buffer.
+ *
+ * Files larger than 50 MB are skipped (returns NULL) to avoid allocating
+ * excessive memory just for offset conversion.
+ *
+ * \param fileName  Path of the file to read
+ * \param outSize   Set to the number of bytes read on success
+ * \return Pointer to malloc'd buffer (caller must free), or NULL on failure
+ */
+unsigned char* fo_readFileBytes(const char* fileName, size_t* outSize)
+{
+  FILE* f = fopen(fileName, "rb");
+  if (!f)
+    return NULL;
+
+  fseek(f, 0, SEEK_END);
+  long fsize = ftell(f);
+  rewind(f);
+
+  if (fsize <= 0 || (unsigned long)fsize > FO_MAX_FILE_READ_SIZE)
+  {
+    fclose(f);
+    return NULL;
+  }
+
+  unsigned char* buf = (unsigned char*)malloc((size_t)fsize);
+  if (!buf)
+  {
+    fclose(f);
+    return NULL;
+  }
+
+  size_t bytesRead = fread(buf, 1, (size_t)fsize, f);
+  fclose(f);
+
+  *outSize = bytesRead;
+  return buf;
+}

--- a/src/lib/c/libfossagent.h
+++ b/src/lib/c/libfossagent.h
@@ -28,4 +28,7 @@ char* GetUploadtreeTableName(PGconn* pgConn, int upload_pk);
 PGresult* checkDuplicateReq(PGconn* pgConn, int uploadPk, int agentPk);
 PGresult* getSelectedPFiles(PGconn* pgConn, int uploadPk, int agentPk, bool ignoreFilesWithMimeType);
 
+size_t fo_utf8ByteLenToUChar16Len(const unsigned char* utf8, size_t byteLen);
+unsigned char* fo_readFileBytes(const char* fileName, size_t* outSize);
+
 #endif

--- a/src/lib/cpp/CMakeLists.txt
+++ b/src/lib/cpp/CMakeLists.txt
@@ -40,7 +40,8 @@ target_sources(fossologyCPP
 target_link_libraries(fossologyCPP
     PRIVATE
         fossology
-        ${icu-uc_LIBRARIES}
+        ICU::uc
+        ICU::i18n
 )
 
 target_include_directories(fossologyCPP

--- a/src/lib/cpp/CMakeLists.txt
+++ b/src/lib/cpp/CMakeLists.txt
@@ -38,10 +38,11 @@ target_sources(fossologyCPP
         ${FO_CWD}/libfossUtils.cc)
 
 target_link_libraries(fossologyCPP
-    PRIVATE
-        fossology
+    PUBLIC
         ICU::uc
         ICU::i18n
+    PRIVATE
+        fossology
 )
 
 target_include_directories(fossologyCPP

--- a/src/lib/cpp/libfossUtils.cc
+++ b/src/lib/cpp/libfossUtils.cc
@@ -4,6 +4,8 @@
  SPDX-License-Identifier: GPL-2.0-only
 */
 #include <sstream>
+#include <unicode/schriter.h>
+#include <unicode/brkiter.h>
 
 #include "libfossUtils.hpp"
 
@@ -45,8 +47,8 @@ bool fo::stringToBool(const char* str)
  */
 icu::UnicodeString fo::recodeToUnicode(const std::string &input)
 {
-  int len = input.length();
-  const unsigned char *in =
+  int const len = input.length();
+  const auto *in =
     reinterpret_cast<const unsigned char*>(input.c_str());
 
   icu::UnicodeString out;
@@ -63,6 +65,36 @@ icu::UnicodeString fo::recodeToUnicode(const std::string &input)
     {
       i = lastPos;
       U16_NEXT(in, i, len, uniChar);
+      if (U_IS_UNICODE_CHAR(uniChar) && uniChar > 0)
+      {
+        out.append(uniChar);
+      }
+    }
+  }
+  out.trim();
+  return out;
+}
+
+/**
+ * Remove all non-UTF8 characters from a string.
+ * @param input The string to be recoded
+ * @return Unicode string with invalid characters removed
+ */
+icu::UnicodeString fo::recodeToUnicode(const icu::UnicodeString &input)
+{
+  auto iter = icu::StringCharacterIterator(input);
+
+  icu::UnicodeString out;
+  while (iter.hasNext())
+  {
+    UChar32 uniChar = iter.next32PostInc();
+    if (uniChar > 0)
+    {
+      out.append(uniChar);
+    }
+    else
+    {
+      uniChar = iter.next32PostInc();
       if (U_IS_UNICODE_CHAR(uniChar) && uniChar > 0)
       {
         out.append(uniChar);

--- a/src/lib/cpp/libfossUtils.cc
+++ b/src/lib/cpp/libfossUtils.cc
@@ -88,18 +88,11 @@ icu::UnicodeString fo::recodeToUnicode(const icu::UnicodeString &input)
   while (iter.hasNext())
   {
     UChar32 uniChar = iter.next32PostInc();
-    if (uniChar > 0)
+    if (uniChar > 0 && U_IS_UNICODE_CHAR(uniChar))
     {
       out.append(uniChar);
     }
-    else
-    {
-      uniChar = iter.next32PostInc();
-      if (U_IS_UNICODE_CHAR(uniChar) && uniChar > 0)
-      {
-        out.append(uniChar);
-      }
-    }
+    // Skip null (U+0000) and invalid characters
   }
   out.trim();
   return out;

--- a/src/lib/cpp/libfossUtils.hpp
+++ b/src/lib/cpp/libfossUtils.hpp
@@ -18,6 +18,7 @@ namespace fo
   unsigned long stringToUnsignedLong(const char* string);
   bool stringToBool(const char* string);
   icu::UnicodeString recodeToUnicode(const std::string &input);
+  icu::UnicodeString recodeToUnicode(const icu::UnicodeString &input);
 }
 
 #endif

--- a/src/lib/php/Data/TextFragment.php
+++ b/src/lib/php/Data/TextFragment.php
@@ -8,6 +8,7 @@
 
 namespace Fossology\Lib\Data;
 
+
 class TextFragment
 {
 
@@ -28,7 +29,7 @@ class TextFragment
 
   public function getEndOffset()
   {
-    return $this->startOffset + strlen($this->text);
+    return $this->startOffset + mb_strlen($this->text, 'UTF-8');
   }
 
   public function getSlice($startOffset, $endOffset = null)
@@ -36,10 +37,10 @@ class TextFragment
     $adjustedStartOffset = max($startOffset - $this->startOffset, 0);
     if (isset($endOffset)) {
       $adjustedEndOffset = max($endOffset - $this->startOffset, 0);
-      return substr($this->text, $adjustedStartOffset,
-        max($adjustedEndOffset - $adjustedStartOffset, 0));
+      return mb_substr($this->text, $adjustedStartOffset,
+        max($adjustedEndOffset - $adjustedStartOffset, 0), 'UTF-8');
     } else {
-      return substr($this->text, $adjustedStartOffset);
+      return mb_substr($this->text, $adjustedStartOffset, null, 'UTF-8');
     }
   }
 }

--- a/src/lib/php/View/PagedResult.php
+++ b/src/lib/php/View/PagedResult.php
@@ -49,7 +49,7 @@ abstract class PagedResult
   public function appendContentText($text)
   {
     $this->empty = false;
-    $this->currentOffset += strlen($text);
+    $this->currentOffset += mb_strlen($text, 'UTF-8');
     $this->appendMetaText($this->renderContentText($text));
   }
 

--- a/src/monk/agent/CMakeLists.txt
+++ b/src/monk/agent/CMakeLists.txt
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
 set(FO_CWD ${CMAKE_CURRENT_SOURCE_DIR})
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FO_C_FLAGS} -std=c99 -Wextra -fopenmp")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FO_C_FLAGS} -std=c99 -Wextra")
 
 include_directories(
     ${glib_INCLUDE_DIRS}
@@ -18,7 +18,7 @@ add_executable(squareBuilder EXCLUDE_FROM_ALL buildSquareVisitor.c)
 target_link_libraries(squareBuilder PRIVATE fossology m magic)
 add_custom_command(
     OUTPUT _squareVisitor.c _squareVisitor.h
-    COMMAND ${CMAKE_COMMAND} -E copy_directory 
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
         ${FO_CWD}/generator $<TARGET_FILE_DIR:squareBuilder>
     COMMAND $<TARGET_FILE_DIR:squareBuilder>/genSquareVisitor
     WORKING_DIRECTORY $<TARGET_FILE_DIR:squareBuilder>
@@ -51,12 +51,12 @@ foreach(FO_MONK_TARGET monk monk_exec monk_cov monkbulk)
         ${FO_CWD}/serialize.c
         ${FO_CWD}/${MONK_XSRC}
         $<TARGET_FILE_DIR:squareBuilder>/_squareVisitor.c)
-    target_link_libraries(${FO_MONK_TARGET} PRIVATE fossology magic)
-    target_compile_definitions(${FO_MONK_TARGET} 
+    target_link_libraries(${FO_MONK_TARGET} PRIVATE fossology magic OpenMP::OpenMP_C)
+    target_compile_definitions(${FO_MONK_TARGET}
         PRIVATE _FILE_OFFSET_BITS=64
         VERSION_S="${FO_VERSION}"
         COMMIT_HASH_S="${FO_COMMIT_HASH}")
-    target_include_directories(${FO_MONK_TARGET} 
+    target_include_directories(${FO_MONK_TARGET}
         PRIVATE $<TARGET_FILE_DIR:squareBuilder>)
 endforeach()
 
@@ -64,10 +64,10 @@ set_target_properties(monk_exec PROPERTIES OUTPUT_NAME monk)
 
 install(TARGETS monk_exec
     RUNTIME
-    DESTINATION ${FO_MODDIR}/${PROJECT_NAME}/agent 
+    DESTINATION ${FO_MODDIR}/${PROJECT_NAME}/agent
     COMPONENT monk)
 
 install(TARGETS monkbulk
     RUNTIME
-    DESTINATION ${FO_MODDIR}/${PROJECT_NAME}bulk/agent 
+    DESTINATION ${FO_MODDIR}/${PROJECT_NAME}bulk/agent
     COMPONENT monkbulk)

--- a/src/monk/agent/monkbulk.c
+++ b/src/monk/agent/monkbulk.c
@@ -15,6 +15,7 @@
 #include "match.h"
 #include "common.h"
 #include "monk.h"
+#include "scheduler.h"
 
 int bulk_onAllMatches(MonkState* state, const File* file, const GArray* matches);
 
@@ -364,6 +365,10 @@ int bulk_onAllMatches(MonkState* state, const File* file, const GArray* matches)
     );
 
     if (licenseDecisionIds) {
+      /* Read file once for converting byte offsets to UChar16 offsets */
+      size_t fileSize = 0;
+      unsigned char* fileContent = readFileBytes(file->fileName, &fileSize);
+
       for (int i=0; i<PQntuples(licenseDecisionIds);i++) {
         long licenseDecisionEventId = atol(PQgetvalue(licenseDecisionIds,i,0));
 
@@ -375,6 +380,11 @@ int bulk_onAllMatches(MonkState* state, const File* file, const GArray* matches)
 
           DiffPoint* highlightTokens = match->ptr.full;
           DiffPoint highlight = getFullHighlightFor(file->tokens, highlightTokens->start, highlightTokens->length);
+
+          if (fileContent && fileSize > 0)
+          {
+            convertDiffPointToUChar16(&highlight, fileContent, fileSize);
+          }
 
           PGresult* highlightResult = fo_dbManager_ExecPrepared(
                   fo_dbManager_PrepareStamement(
@@ -392,11 +402,13 @@ int bulk_onAllMatches(MonkState* state, const File* file, const GArray* matches)
           if (highlightResult) {
             PQclear(highlightResult);
           } else {
+            free(fileContent);
             fo_dbManager_rollback(state->dbManager);
             return 0;
           }
         }
       }
+      free(fileContent);
       PQclear(licenseDecisionIds);
     } else {
       fo_dbManager_rollback(state->dbManager);

--- a/src/monk/agent/scheduler.c
+++ b/src/monk/agent/scheduler.c
@@ -7,8 +7,110 @@
 
 #include "scheduler.h"
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include "common.h"
 #include "database.h"
+
+/**
+ * @brief Thread-local file content cache for offset conversion.
+ *
+ * During match processing monk may invoke sched_onFullMatch /
+ * sched_onDiffMatch many times for the same file (once per license match).
+ * Re-reading the file from disk on every callback is extremely expensive
+ * for large files with many matches and can cause the scheduler watchdog
+ * to kill the agent.  This cache stores the last-read file content per
+ * thread so that it is reused across callbacks for the same file.
+ *
+ * The cache is invalidated (freed) when a new file is encountered.
+ * Call flushFileCache() after processing each file to free memory promptly.
+ */
+static __thread unsigned char* s_cachedContent = NULL;
+static __thread size_t s_cachedSize = 0;
+static __thread char* s_cachedName = NULL;
+
+/**
+ * @brief Get file content, using a thread-local cache.
+ *
+ * Returns a pointer to the cached file content (caller MUST NOT free it).
+ * Returns NULL if the file could not be read or is too large.
+ */
+static unsigned char* getCachedFileBytes(const char* fileName, size_t* outSize)
+{
+  if (s_cachedName && strcmp(s_cachedName, fileName) == 0)
+  {
+    *outSize = s_cachedSize;
+    return s_cachedContent;
+  }
+
+  /* Invalidate old cache */
+  free(s_cachedContent);
+  g_free(s_cachedName);
+  s_cachedContent = NULL;
+  s_cachedSize = 0;
+  s_cachedName = NULL;
+
+  s_cachedContent = fo_readFileBytes(fileName, &s_cachedSize);
+  if (s_cachedContent)
+  {
+    s_cachedName = g_strdup(fileName);
+    *outSize = s_cachedSize;
+  }
+  else
+  {
+    *outSize = 0;
+  }
+  return s_cachedContent;
+}
+
+/**
+ * @brief Flush the thread-local file cache.
+ *
+ * Should be called after all match callbacks for a given file have completed
+ * to free memory.  It is safe to call this multiple times.
+ */
+static void flushFileCache(void)
+{
+  free(s_cachedContent);
+  g_free(s_cachedName);
+  s_cachedContent = NULL;
+  s_cachedSize = 0;
+  s_cachedName = NULL;
+}
+
+/**
+ * @brief Read a file into a malloc'd buffer (legacy wrapper).
+ *
+ * Used by monkbulk.c which manages its own file reading lifetime.
+ */
+unsigned char* readFileBytes(const char* fileName, size_t* outSize)
+{
+  return fo_readFileBytes(fileName, outSize);
+}
+
+/**
+ * @brief Convert a DiffPoint's byte offsets to UChar16 offsets.
+ *
+ * @param pt          DiffPoint to convert (modified in place)
+ * @param fileContent UTF-8 file content
+ * @param fileSize    Total number of bytes in fileContent
+ */
+void convertDiffPointToUChar16(DiffPoint* pt,
+    const unsigned char* fileContent, size_t fileSize)
+{
+  size_t byteStart = pt->start;
+  size_t byteEnd   = byteStart + pt->length;
+
+  if (byteStart > fileSize) byteStart = fileSize;
+  if (byteEnd   > fileSize) byteEnd   = fileSize;
+
+  size_t charStart  = fo_utf8ByteLenToUChar16Len(fileContent, byteStart);
+  size_t charEnd    = fo_utf8ByteLenToUChar16Len(fileContent, byteEnd);
+
+  pt->start  = charStart;
+  pt->length = (charEnd >= charStart) ? (charEnd - charStart) : 0;
+}
 
 MatchCallbacks schedulerCallbacks =
   { .onNo = sched_onNoMatch,
@@ -64,6 +166,7 @@ int processUploadId(MonkState* state, int uploadId, const Licenses* licenses) {
           fo_scheduler_heart(0);
           threadError = 1;
         }
+        flushFileCache();
       }
       fo_dbManager_finish(threadLocalState->dbManager);
     } else {
@@ -117,10 +220,23 @@ int sched_onFullMatch(MonkState* state, const File* file, const License* license
 
   fo_dbManager_begin(dbManager);
 
+  /* Convert byte offsets to UChar16 offsets so that the stored positions
+   * are consistent with the ICU-based copyright agent output.
+   * NOTE: only .text (scanned file positions) is converted. The .search
+   * field holds positions in the reference license text, which is virtually
+   * always ASCII (byte == UChar16). */
+  DiffMatchInfo convertedInfo = *matchInfo;
+  size_t fileSize = 0;
+  unsigned char* fileContent = getCachedFileBytes(file->fileName, &fileSize);
+  if (fileContent && fileSize > 0)
+  {
+    convertDiffPointToUChar16(&convertedInfo.text, fileContent, fileSize);
+  }
+
   int success = 0;
   long licenseFileId = saveToDb(dbManager, agentId, license->refId, fileId, 100);
   if (licenseFileId > 0) {
-    success = saveDiffHighlightToDb(dbManager, matchInfo, licenseFileId);
+    success = saveDiffHighlightToDb(dbManager, &convertedInfo, licenseFileId);
   }
 
   if (success) {
@@ -149,11 +265,38 @@ int sched_onDiffMatch(MonkState* state, const File* file, const License* license
 
   fo_dbManager_begin(dbManager);
 
+  /* Read file once and convert all byte offsets in matchedInfo to UChar16 offsets
+   * so the stored positions match the ICU-based copyright agent output.
+   * NOTE: only .text (scanned file positions) is converted. The .search
+   * field holds positions in the reference license text, which is virtually
+   * always ASCII (byte == UChar16). */
+  size_t fileSize = 0;
+  unsigned char* fileContent = getCachedFileBytes(file->fileName, &fileSize);
+
+  GArray* convertedInfo = NULL;
+  const GArray* infoToSave = diffResult->matchedInfo;
+
+  if (fileContent && fileSize > 0)
+  {
+    size_t len = diffResult->matchedInfo->len;
+    convertedInfo = g_array_sized_new(FALSE, FALSE, sizeof(DiffMatchInfo), len);
+    for (size_t i = 0; i < len; i++)
+    {
+      DiffMatchInfo entry = g_array_index(diffResult->matchedInfo, DiffMatchInfo, i);
+      convertDiffPointToUChar16(&entry.text, fileContent, fileSize);
+      g_array_append_val(convertedInfo, entry);
+    }
+    infoToSave = convertedInfo;
+  }
+
   int success = 0;
   long licenseFileId = saveToDb(dbManager, agentId, license->refId, fileId, matchPercent);
   if (licenseFileId > 0) {
-    success = saveDiffHighlightsToDb(dbManager, diffResult->matchedInfo, licenseFileId);
+    success = saveDiffHighlightsToDb(dbManager, infoToSave, licenseFileId);
   }
+
+  if (convertedInfo)
+    g_array_free(convertedInfo, TRUE);
 
   if (success) {
     fo_dbManager_commit(dbManager);

--- a/src/monk/agent/scheduler.h
+++ b/src/monk/agent/scheduler.h
@@ -18,4 +18,8 @@ int sched_onDiffMatch(MonkState* state, const File* file, const License* license
 int sched_ignore(MonkState* state, const File* file);
 int sched_noop(MonkState* state);
 
+unsigned char* readFileBytes(const char* fileName, size_t* outSize);
+void convertDiffPointToUChar16(DiffPoint* pt,
+    const unsigned char* fileContent, size_t fileSize);
+
 #endif // MONK_AGENT_SCHEDULER_H

--- a/src/monk/agent_tests/CMakeLists.txt
+++ b/src/monk/agent_tests/CMakeLists.txt
@@ -17,11 +17,11 @@ if(NOT TARGET phpunit)
     prepare_phpunit()
 endif()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FO_C_FLAGS} -std=c99 -Wextra -fopenmp")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FO_C_FLAGS} -std=c99 -Wextra")
 
 add_executable(test_monk "")
-target_sources(test_monk 
-    PRIVATE 
+target_sources(test_monk
+    PRIVATE
     ${FO_CWD}/Unit/run_tests.c
     ${FO_CWD}/Unit/test_string_operations.c
     ${FO_CWD}/Unit/test_file_operations.c
@@ -33,9 +33,9 @@ target_sources(test_monk
     ${FO_CWD}/Unit/test_database.c
     ${FO_CWD}/Unit/test_encoding.c
     ${FO_CWD}/Unit/test_serialize.c)
-target_compile_definitions(test_monk 
+target_compile_definitions(test_monk
     PRIVATE _FILE_OFFSET_BITS=64 AGENT_DIR="${CMAKE_CURRENT_BINARY_DIR}/..")
-target_include_directories(test_monk 
+target_include_directories(test_monk
     PRIVATE ${FO_TESTDIR}/lib/c ${FO_TESTDIR}/db/c ${glib_INCLUDE_DIRS}
         ${PostgreSQL_INCLUDE_DIRS} ${FO_CLIB_SRC} ${FO_CWD}/../agent)
 target_link_libraries(test_monk
@@ -48,6 +48,6 @@ add_test(NAME monk_functional_scheduler_test
 
 add_test(NAME monk_functional_cli_test
     COMMAND ${PHPUNIT} --log-junit monk-Xunit2.xml --bootstrap ${PHPUNIT_BOOTSTRAP} ${CMAKE_CURRENT_LIST_DIR}/Functional/cliTest.php)
-    
+
 add_test(NAME monk_functional_bulk_test
     COMMAND ${PHPUNIT} --log-junit monk-Xunit3.xml --bootstrap ${PHPUNIT_BOOTSTRAP} ${CMAKE_CURRENT_LIST_DIR}/Functional/bulkTest.php)

--- a/src/monk/agent_tests/Functional/schedulerTest.php
+++ b/src/monk/agent_tests/Functional/schedulerTest.php
@@ -156,7 +156,7 @@ class MonkScheduledTest extends \PHPUnit\Framework\TestCase
 
     $highlights = $this->highlightDao->getHighlightDiffs($this->uploadDao->getItemTreeBounds(7));
 
-    $expectedHighlight = new Highlight(18, 35824, Highlight::MATCH, 0, 34505);
+    $expectedHighlight = new Highlight(18, 35823, Highlight::MATCH, 0, 34505);
     $expectedHighlight->setLicenseId($matchedLicense->getId());
 
     $this->assertEquals(array($expectedHighlight), $highlights);
@@ -164,9 +164,9 @@ class MonkScheduledTest extends \PHPUnit\Framework\TestCase
     $highlights = $this->highlightDao->getHighlightDiffs($this->uploadDao->getItemTreeBounds(11));
 
     $expectedHighlights = array();
-    $expectedHighlights[] = new Highlight(18, 338, Highlight::MATCH, 0, 265);
-    $expectedHighlights[] = new Highlight(339, 346, Highlight::CHANGED, 266, 272);
-    $expectedHighlights[] = new Highlight(347, 35148, Highlight::MATCH, 273, 34505);
+    $expectedHighlights[] = new Highlight(18, 337, Highlight::MATCH, 0, 265);
+    $expectedHighlights[] = new Highlight(338, 345, Highlight::CHANGED, 266, 272);
+    $expectedHighlights[] = new Highlight(346, 35147, Highlight::MATCH, 273, 34505);
     foreach($expectedHighlights as $expectedHighlight) {
       $expectedHighlight->setLicenseId($matchedLicense->getId());
     }

--- a/src/ninka/agent/CMakeLists.txt
+++ b/src/ninka/agent/CMakeLists.txt
@@ -5,7 +5,7 @@ SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 
 
 set(FO_CWD ${CMAKE_CURRENT_SOURCE_DIR})
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FO_CXX_FLAGS} -fopenmp")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FO_CXX_FLAGS}")
 
 include_directories(
     ${glib_INCLUDE_DIRS}
@@ -43,7 +43,7 @@ foreach(FO_NINKA_TARGET ninka ninka_exec ninka_cov ninka_cov_exec)
     endif()
     if(${FO_NINKA_TARGET} MATCHES "_exec$")
         target_link_libraries(${FO_NINKA_TARGET}
-            PRIVATE fossologyCPP stdc++ icuuc icudata gcov)
+            PRIVATE fossologyCPP stdc++ icuuc icudata gcov OpenMP::OpenMP_CXX)
         string(REPLACE "_exec" "" FO_NINKA_TARGET_R ${FO_NINKA_TARGET})
         set_target_properties(${FO_NINKA_TARGET}
             PROPERTIES OUTPUT_NAME ${FO_NINKA_TARGET_R})

--- a/src/ninka/agent/CMakeLists.txt
+++ b/src/ninka/agent/CMakeLists.txt
@@ -43,7 +43,7 @@ foreach(FO_NINKA_TARGET ninka ninka_exec ninka_cov ninka_cov_exec)
     endif()
     if(${FO_NINKA_TARGET} MATCHES "_exec$")
         target_link_libraries(${FO_NINKA_TARGET}
-            PRIVATE fossologyCPP stdc++ icuuc icudata gcov OpenMP::OpenMP_CXX)
+            PRIVATE fossologyCPP stdc++ ICU::uc ICU::i18n gcov OpenMP::OpenMP_CXX)
         string(REPLACE "_exec" "" FO_NINKA_TARGET_R ${FO_NINKA_TARGET})
         set_target_properties(${FO_NINKA_TARGET}
             PROPERTIES OUTPUT_NAME ${FO_NINKA_TARGET_R})

--- a/src/nomos/agent/nomos_utils.c
+++ b/src/nomos/agent/nomos_utils.c
@@ -8,6 +8,8 @@
 #define _GNU_SOURCE
 #endif /* not defined _GNU_SOURCE */
 
+#include <stdio.h>
+#include <stdlib.h>
 #include "nomos_utils.h"
 #include "nomos.h"
 
@@ -694,6 +696,18 @@ FUNCTION int updateLicenseHighlighting(cacheroot_t *pcroot){
   printf("%s %s %i \n", cur.filePath,cur.compLic , cur.theMatches->len);
 #endif
 
+  /* Read the scanned file once so we can convert byte offsets to UChar16
+   * offsets. This makes positions consistent with the ICU-based copyright
+   * agent which stores UChar16 (UTF-16 code unit) positions. */
+  size_t fileSize = 0;
+  unsigned char* fileContent = fo_readFileBytes(cur.filePath, &fileSize);
+
+  /* Helper macro: convert a byte offset to UChar16 offset */
+#define BYTE_TO_UCHAR16(byteOff) \
+  ((fileContent && (size_t)(byteOff) <= fileSize) \
+    ? (int)fo_utf8ByteLenToUChar16Len(fileContent, (size_t)(byteOff)) \
+    : (byteOff))
+
   // This speeds up the writing to the database and ensures that we have either full highlight information or none
   PGresult* begin1 = PQexec(gl.pgConn, "BEGIN");
   PQclear(begin1);
@@ -711,12 +725,14 @@ FUNCTION int updateLicenseHighlighting(cacheroot_t *pcroot){
   for (i = 0; i < cur.keywordPositions->len; ++i)
   {
     MatchPositionAndType* ourMatchv = getMatchfromHighlightInfo(cur.keywordPositions, i);
+    int charStart = BYTE_TO_UCHAR16(ourMatchv->start);
+    int charEnd   = BYTE_TO_UCHAR16(ourMatchv->end);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
     // If uninitialized, the loop will not start
     result = fo_dbManager_ExecPrepared(
                 preparedKeywords,
-                cur.pFileFk, ourMatchv->start, ourMatchv->end - ourMatchv->start);
+                cur.pFileFk, charStart, charEnd - charStart);
 #pragma GCC diagnostic pop
     if (result)
     {
@@ -751,23 +767,30 @@ FUNCTION int updateLicenseHighlighting(cacheroot_t *pcroot){
         //! the license File ID was never set and we should not insert it in the database
         continue;
       }
+      int charStart = BYTE_TO_UCHAR16(ourMatchv->start);
+      int charEnd   = BYTE_TO_UCHAR16(ourMatchv->end);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
       // If uninitialized, the loop will not start
       result = fo_dbManager_ExecPrepared(
                   preparedLicenses,
         ourLicence->licenseFileId,
-        ourMatchv->start, ourMatchv->end - ourMatchv->start
+        charStart, charEnd - charStart
       );
 #pragma GCC diagnostic pop
       if (result == NULL)
       {
+        if (fileContent) free(fileContent);
         return (FALSE);
       } else {
         PQclear(result);
       }
     }
   }
+
+#undef BYTE_TO_UCHAR16
+
+  if (fileContent) free(fileContent);
 
   PGresult* commit2 = PQexec(gl.pgConn, "COMMIT");
   PQclear(commit2);

--- a/src/nomos/agent_tests/CMakeLists.txt
+++ b/src/nomos/agent_tests/CMakeLists.txt
@@ -17,21 +17,21 @@ if(NOT TARGET phpunit)
     prepare_phpunit()
 endif()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FO_C_FLAGS} -std=c99 -Wextra -fopenmp")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FO_C_FLAGS} -std=c99 -Wextra")
 
 add_executable(test_nomos "")
-target_sources(test_nomos 
-    PRIVATE 
+target_sources(test_nomos
+    PRIVATE
     ${FO_CWD}/Unit/run_tests.c
     ${FO_CWD}/Unit/test_DoctoredBuffer.c
     ${FO_CWD}/Unit/test_nomos_gap.c)
-target_compile_definitions(test_nomos 
+target_compile_definitions(test_nomos
     PRIVATE _FILE_OFFSET_BITS=64
         TESTDATADIR="${FO_SOURCEDIR}/nomos/agent_tests/testdata")
-target_include_directories(test_nomos 
-    PRIVATE ${FO_TESTDIR}/lib/c ${FO_TESTDIR}/db/c ${glib_INCLUDE_DIRS} 
+target_include_directories(test_nomos
+    PRIVATE ${FO_TESTDIR}/lib/c ${FO_TESTDIR}/db/c ${glib_INCLUDE_DIRS}
         $<TARGET_FILE_DIR:encode> ${PostgreSQL_INCLUDE_DIRS} ${FO_CLIB_SRC} ${FO_CWD}/../agent)
-target_link_libraries(test_nomos PRIVATE ${cunit_LIBRARIES} focunit nomos)
+target_link_libraries(test_nomos PRIVATE ${cunit_LIBRARIES} focunit nomos OpenMP::OpenMP_C)
 
 add_test(nomos_unit_test test_nomos)
 

--- a/src/ojo/agent/CMakeLists.txt
+++ b/src/ojo/agent/CMakeLists.txt
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
 set(FO_CWD ${CMAKE_CURRENT_SOURCE_DIR})
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FO_CXX_FLAGS} -fopenmp")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FO_CXX_FLAGS}")
 
 include_directories(
     ${glib_INCLUDE_DIRS}
@@ -42,7 +42,8 @@ foreach(FO_OJO_TARGET ojo ojo_exec ojo_cov ojo_cov_exec)
         target_compile_options(${FO_OJO_TARGET} PRIVATE ${FO_COV_FLAGS})
     endif()
     target_link_libraries(${FO_OJO_TARGET}
-        PRIVATE fossologyCPP ${icu-uc_LIBRARIES} ${Boost_LIBRARIES} ${jsoncpp_LIBRARIES})
+        PRIVATE fossologyCPP ICU::uc ICU::i18n ${Boost_LIBRARIES} ${jsoncpp_LIBRARIES}
+            OpenMP::OpenMP_CXX)
     if(${FO_OJO_TARGET} MATCHES "_exec$")
         string(REPLACE "_exec" "" FO_OJO_TARGET_R ${FO_OJO_TARGET})
         set_target_properties(${FO_OJO_TARGET}

--- a/src/ojo/agent/OjoAgent.cc
+++ b/src/ojo/agent/OjoAgent.cc
@@ -15,12 +15,35 @@ using namespace std;
  */
 OjoAgent::OjoAgent() :
     regLicenseList(
-        boost::regex(SPDX_LICENSE_LIST, boost::regex_constants::icase)),
+        boost::make_u32regex(SPDX_LICENSE_LIST, boost::regex_constants::icase)),
     regLicenseName(
-        boost::regex(SPDX_LICENSE_NAMES, boost::regex_constants::icase)),
+        boost::make_u32regex(SPDX_LICENSE_NAMES, boost::regex_constants::icase)),
     regDualLicense(
-        boost::regex(SPDX_DUAL_LICENSE, boost::regex_constants::icase))
+        boost::make_u32regex(SPDX_DUAL_LICENSE, boost::regex_constants::icase))
 {
+}
+
+/**
+ * @brief Read a file into an icu::UnicodeString.
+ *
+ * Reads the file as raw bytes and interprets it as UTF-8, converting to a
+ * UnicodeString so that subsequent regex operations work on Unicode code
+ * points rather than raw bytes.
+ * @param filePath Path to the file
+ * @param out      Output UnicodeString
+ * @return True on success, false on failure
+ */
+bool OjoAgent::readFileToUnicodeString(const string &filePath,
+  icu::UnicodeString &out) const
+{
+  std::ifstream stream(filePath, std::ios::binary);
+  if (!stream)
+    return false;
+  std::ostringstream sstr;
+  sstr << stream.rdbuf();
+  std::string content = sstr.str();
+  out = icu::UnicodeString::fromUTF8(content);
+  return !stream.fail();
 }
 
 /**
@@ -39,23 +62,22 @@ OjoAgent::OjoAgent() :
 vector<ojomatch> OjoAgent::processFile(const string &filePath,
   OjosDatabaseHandler &databaseHandler, const int groupId, const int userId)
 {
-  ifstream stream(filePath);
-  std::stringstream sstr;
-  sstr << stream.rdbuf();
-  if (stream.fail())
+  icu::UnicodeString fileContent;
+  if (!readFileToUnicodeString(filePath, fileContent))
   {
     throw std::runtime_error(filePath);
   }
-  stream.close();
-  const string fileContent = sstr.str();
+
   vector<ojomatch> licenseList;
   vector<ojomatch> licenseNames;
 
   scanString(fileContent, regLicenseList, licenseList, 0, false);
   for (auto m : licenseList)
   {
-    scanString(m.content, regLicenseName, licenseNames, m.start, false);
-    scanString(m.content, regDualLicense, licenseNames, m.start, true);
+    icu::UnicodeString contentUnicode =
+      icu::UnicodeString::fromUTF8(m.content);
+    scanString(contentUnicode, regLicenseName, licenseNames, m.start, false);
+    scanString(contentUnicode, regDualLicense, licenseNames, m.start, true);
   }
 
   findLicenseId(licenseNames, databaseHandler, groupId, userId);
@@ -73,23 +95,22 @@ vector<ojomatch> OjoAgent::processFile(const string &filePath,
  */
 vector<ojomatch> OjoAgent::processFile(const string &filePath)
 {
-  ifstream stream(filePath);
-  std::stringstream sstr;
-  sstr << stream.rdbuf();
-  if (stream.fail())
+  icu::UnicodeString fileContent;
+  if (!readFileToUnicodeString(filePath, fileContent))
   {
     throw std::runtime_error(filePath);
   }
-  stream.close();
-  const string fileContent = sstr.str();
+
   vector<ojomatch> licenseList;
   vector<ojomatch> licenseNames;
 
   scanString(fileContent, regLicenseList, licenseList, 0, false);
   for (auto m : licenseList)
   {
-    scanString(m.content, regLicenseName, licenseNames, m.start, false);
-    scanString(m.content, regDualLicense, licenseNames, m.start, true);
+    icu::UnicodeString contentUnicode =
+      icu::UnicodeString::fromUTF8(m.content);
+    scanString(contentUnicode, regLicenseName, licenseNames, m.start, false);
+    scanString(contentUnicode, regDualLicense, licenseNames, m.start, true);
   }
 
   // Remove duplicate matches for CLI run
@@ -101,31 +122,43 @@ vector<ojomatch> OjoAgent::processFile(const string &filePath)
 }
 
 /**
- * Scan a string based using a regex and create matches.
- * @param text        String to be scanned
- * @param reg         Regex to be used
+ * Scan a UnicodeString using a u32regex and create matches.
+ *
+ * All positions returned are UTF-16 code unit (UChar16) offsets, which is
+ * the native unit of icu::UnicodeString. This ensures that multi-byte UTF-8
+ * characters are counted correctly and that the offsets stored in the database
+ * correspond to character positions, not raw byte positions.
+ *
+ * @param text        UnicodeString to be scanned
+ * @param reg         u32regex to be used
  * @param[out] result The match list.
- * @param offset      The offset to be added for each match
+ * @param offset      UChar16 offset to add for each match (used for nested scans)
  * @param isDualTest  True if testing for Dual-license, false otherwise
  */
-void OjoAgent::scanString(const string &text, boost::regex reg,
+void OjoAgent::scanString(const icu::UnicodeString &text, const boost::u32regex &reg,
     vector<ojomatch> &result, unsigned int offset, bool isDualTest)
 {
-  string::const_iterator end = text.end();
-  string::const_iterator pos = text.begin();
+  const UChar* begin = text.getBuffer();
+  const UChar* end   = begin + text.length();
+  const UChar* pos   = begin;
 
   while (pos != end)
   {
-    // Find next match
-    boost::smatch res;
-    if (boost::regex_search(pos, end, res, reg))
+    boost::u16match res;
+    if (boost::u32regex_search(pos, end, res, reg))
     {
-      string content = "Dual-license";
-      if (! isDualTest)
+      string content;
+      if (isDualTest)
       {
-        content = res[1].str();
+        content = "Dual-license";
       }
-      // Found match
+      else
+      {
+        // toUTF8String appends, so start with an empty string
+        icu::UnicodeString matched(res[1].first,
+          static_cast<int32_t>(res[1].second - res[1].first));
+        matched.toUTF8String(content);
+      }
       result.push_back(
           ojomatch(offset + res.position(1),
               offset + res.position(1) + res.length(1),

--- a/src/ojo/agent/OjoAgent.hpp
+++ b/src/ojo/agent/OjoAgent.hpp
@@ -10,9 +10,10 @@
 #ifndef SRC_OJO_AGENT_OJOAGENT_HPP_
 #define SRC_OJO_AGENT_OJOAGENT_HPP_
 
-#include <boost/regex.hpp>
+#include <boost/regex/icu.hpp>
 #include <fstream>
 #include <sstream>
+#include <unicode/unistr.h>
 
 #include "OjosDatabaseHandler.hpp"
 #include "ojomatch.hpp"
@@ -32,15 +33,17 @@ class OjoAgent
     std::vector<ojomatch> processFile(const std::string &filePath);
   private:
     /**
-     * @var boost::regex regLicenseList
+     * @var boost::u32regex regLicenseList
      * Regex to find the list of licenses
-     * @var boost::regex regLicenseName
+     * @var boost::u32regex regLicenseName
      * Regex to find the license names from the license lists
-     * @var boost::regex regDualLicense
+     * @var boost::u32regex regDualLicense
      * Regex to find dual license strings
      */
-    const boost::regex regLicenseList, regLicenseName, regDualLicense;
-    void scanString(const std::string &text, boost::regex reg,
+    const boost::u32regex regLicenseList, regLicenseName, regDualLicense;
+    bool readFileToUnicodeString(const std::string &filePath,
+      icu::UnicodeString &out) const;
+    void scanString(const icu::UnicodeString &text, const boost::u32regex &reg,
         std::vector<ojomatch> &result, unsigned int offset, bool isDualTest);
     void filterMatches(std::vector<ojomatch> &matches);
     void findLicenseId(std::vector<ojomatch> &matches,

--- a/src/ojo/agent/ojoregex.hpp
+++ b/src/ojo/agent/ojoregex.hpp
@@ -21,7 +21,7 @@
  * -# Matches at most 5 identifiers each with length greater than 3 (based on
  * https://github.com/spdx/license-list-data/tree/master/html)
  */
-#define SPDX_LICENSE_LIST "spdx-licen[cs]e(?:id|[- ]identifier): \\K((?:(?: (?:and|or|with) )?\\(?(?:[\\w\\d\\.\\+\\-]{3,})\\)?){1,5})"
+#define SPDX_LICENSE_LIST "spdx-licen[cs]e(?:id|[- ]identifier): ((?:(?: (?:and|or|with) )?\\(?(?:[\\w\\d\\.\\+\\-]{3,})\\)?){1,5})"
 /**
  * @def SPDX_LICENSE_NAMES
  * @brief Regex to filter license names from list of license list

--- a/src/ojo/agent_tests/CMakeLists.txt
+++ b/src/ojo/agent_tests/CMakeLists.txt
@@ -12,18 +12,18 @@ endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FO_CXX_FLAGS} -Wall")
 
 add_executable(test_ojo "")
-target_sources(test_ojo 
-    PRIVATE 
+target_sources(test_ojo
+    PRIVATE
     ${FO_CWD}/Unit/run_tests.cc
     ${FO_CWD}/Unit/test_regex.cc
     ${FO_CWD}/Unit/test_scanners.cc)
 target_compile_definitions(test_ojo PRIVATE _FILE_OFFSET_BITS=64)
-target_include_directories(test_ojo 
-    PRIVATE ${glib_INCLUDE_DIRS} ${PostgreSQL_INCLUDE_DIRS} ${FO_CXXLIB_SRC} 
+target_include_directories(test_ojo
+    PRIVATE ${glib_INCLUDE_DIRS} ${PostgreSQL_INCLUDE_DIRS} ${FO_CXXLIB_SRC}
         ${FO_CLIB_SRC} ${FO_CWD}/../agent)
 target_link_libraries(test_ojo
     PRIVATE ${cppunit_LIBRARIES} ojo ${Boost_LIBRARIES} fossologyCPP
-        ${icu-uc_LIBRARIES})
+        ICU::uc ICU::i18n)
 
 add_test(ojo_unit_test test_ojo)
 

--- a/src/ojo/agent_tests/Unit/test_regex.cc
+++ b/src/ojo/agent_tests/Unit/test_regex.cc
@@ -9,7 +9,7 @@
  */
 #include <cppunit/TestFixture.h>
 #include <cppunit/extensions/HelperMacros.h>
-#include <boost/regex.hpp>
+#include <boost/regex/icu.hpp>
 
 #include "ojoregex.hpp"
 
@@ -46,15 +46,15 @@ protected:
     std::string content = "SPDX-License-Identifier: " + gplLicense + " AND "
         + lgplLicense;
     // REUSE-IgnoreStart
-    boost::regex listRegex(SPDX_LICENSE_LIST, boost::regex_constants::icase);
-    boost::regex nameRegex(SPDX_LICENSE_NAMES, boost::regex_constants::icase);
+    boost::u32regex listRegex = boost::make_u32regex(SPDX_LICENSE_LIST, boost::regex_constants::icase);
+    boost::u32regex nameRegex = boost::make_u32regex(SPDX_LICENSE_NAMES, boost::regex_constants::icase);
 
     std::string::const_iterator begin = content.begin();
     std::string::const_iterator end = content.end();
-    boost::match_results<std::string::const_iterator> what;
+    boost::smatch what;
 
     string licenseList;
-    boost::regex_search(begin, end, what, listRegex);
+    boost::u32regex_search(begin, end, what, listRegex);
     licenseList = what[1].str();
 
     // Check if the correct license list is found
@@ -68,7 +68,7 @@ protected:
     while (begin != end)
     {
       boost::smatch res;
-      if (boost::regex_search(begin, end, res, nameRegex))
+      if (boost::u32regex_search(begin, end, res, nameRegex))
       {
         licensesFound.push_back(res[1].str());
         begin = res[0].second;
@@ -110,15 +110,15 @@ protected:
     std::string content = "SPDX-License-Identifier: " + gplLicense + " AND "
         + badLicense;
     // REUSE-IgnoreStart
-    boost::regex listRegex(SPDX_LICENSE_LIST, boost::regex_constants::icase);
-    boost::regex nameRegex(SPDX_LICENSE_NAMES, boost::regex_constants::icase);
+    boost::u32regex listRegex = boost::make_u32regex(SPDX_LICENSE_LIST, boost::regex_constants::icase);
+    boost::u32regex nameRegex = boost::make_u32regex(SPDX_LICENSE_NAMES, boost::regex_constants::icase);
 
     std::string::const_iterator begin = content.begin();
     std::string::const_iterator end = content.end();
-    boost::match_results<std::string::const_iterator> what;
+    boost::smatch what;
 
     string licenseList;
-    boost::regex_search(begin, end, what, listRegex);
+    boost::u32regex_search(begin, end, what, listRegex);
     licenseList = what[1].str();
 
     // Check if only correct license is found
@@ -132,7 +132,7 @@ protected:
     while (begin != end)
     {
       boost::smatch res;
-      if (boost::regex_search(begin, end, res, nameRegex))
+      if (boost::u32regex_search(begin, end, res, nameRegex))
       {
         licensesFound.push_back(res[1].str());
         begin = res[0].second;
@@ -177,15 +177,15 @@ protected:
     std::string content = "SPDX-License-Identifier: (" + gplLicense + " AND "
         + lgplLicense + ") OR " + mplLicense + " AND " + mitLicense + ".";
     // REUSE-IgnoreStart
-    boost::regex listRegex(SPDX_LICENSE_LIST, boost::regex_constants::icase);
-    boost::regex nameRegex(SPDX_LICENSE_NAMES, boost::regex_constants::icase);
+    boost::u32regex listRegex = boost::make_u32regex(SPDX_LICENSE_LIST, boost::regex_constants::icase);
+    boost::u32regex nameRegex = boost::make_u32regex(SPDX_LICENSE_NAMES, boost::regex_constants::icase);
 
     std::string::const_iterator begin = content.begin();
     std::string::const_iterator end = content.end();
-    boost::match_results<std::string::const_iterator> what;
+    boost::smatch what;
 
     string licenseList;
-    boost::regex_search(begin, end, what, listRegex);
+    boost::u32regex_search(begin, end, what, listRegex);
     licenseList = what[1].str();
 
     // Check if the correct license list is found
@@ -200,7 +200,7 @@ protected:
     while (begin != end)
     {
       boost::smatch res;
-      if (boost::regex_search(begin, end, res, nameRegex))
+      if (boost::u32regex_search(begin, end, res, nameRegex))
       {
         licensesFound.push_back(res[1].str());
         begin = res[0].second;

--- a/src/pkgagent/agent_tests/CMakeLists.txt
+++ b/src/pkgagent/agent_tests/CMakeLists.txt
@@ -19,11 +19,11 @@ endif()
 
 file(COPY ${FO_CWD}/testdata DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FO_C_FLAGS} -Wextra -fopenmp")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FO_C_FLAGS} -Wextra")
 
 add_executable(test_pkgagent "")
-target_sources(test_pkgagent 
-    PRIVATE 
+target_sources(test_pkgagent
+    PRIVATE
     ${FO_CWD}/Unit/testRun.c
     ${FO_CWD}/Unit/testGetFieldValue.c
     ${FO_CWD}/Unit/testGetMetadata.c
@@ -38,13 +38,13 @@ if(FO_RPM_CRYPTO_H_HEADER)
   target_compile_definitions(test_pkgagent PRIVATE HAVE_RPM_CRYPTO_H=1)
 endif()
 
-target_include_directories(test_pkgagent 
+target_include_directories(test_pkgagent
     PRIVATE ${FO_TESTDIR}/lib/c ${FO_TESTDIR}/db/c ${glib_INCLUDE_DIRS}
         ${PostgreSQL_INCLUDE_DIRS} ${FO_CLIB_SRC} ${FO_CWD}/../agent
         ${rpm_INCLUDE_DIRS})
-target_link_libraries(test_pkgagent 
+target_link_libraries(test_pkgagent
     PRIVATE fossology cunit focunit ${rpm_LIBRARIES} fodbreposysconf pthread
-        ${rpm_LIBRARIES})
+        ${rpm_LIBRARIES} OpenMP::OpenMP_C)
 
 add_test(pkgagent_unit_test test_pkgagent)
 

--- a/src/scancode/agent/CMakeLists.txt
+++ b/src/scancode/agent/CMakeLists.txt
@@ -41,7 +41,7 @@ foreach(FO_SCANCODE_TARGET scancode scancode_exec scancode_cov scancode_cov_exec
         target_compile_options(${FO_SCANCODE_TARGET} PRIVATE ${FO_COV_FLAGS})
     endif()
     target_link_libraries(${FO_SCANCODE_TARGET}
-        PRIVATE fossologyCPP ICU::uc ICU::i18n ${Boost_LIBRARIES} ${jsoncpp_LIBRARIES})
+        PRIVATE fossologyCPP ICU::uc ICU::i18n ${Boost_LIBRARIES} ${jsoncpp_LIBRARIES} OpenMP::OpenMP_CXX)
     if(${FO_SCANCODE_TARGET} MATCHES "_exec$")
         string(REPLACE "_exec" "" FO_SCANCODE_TARGET_R ${FO_SCANCODE_TARGET})
         set_target_properties(${FO_SCANCODE_TARGET}

--- a/src/scancode/agent/CMakeLists.txt
+++ b/src/scancode/agent/CMakeLists.txt
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: © 2022 Gaurav Mishra <mishra.gaurav@siemens.com>
 #]=======================================================================]
 
 set(FO_CWD ${CMAKE_CURRENT_SOURCE_DIR})
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FO_CXX_FLAGS} -fopenmp")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FO_CXX_FLAGS}")
 
 include_directories(
     ${glib_INCLUDE_DIRS}
@@ -41,7 +41,7 @@ foreach(FO_SCANCODE_TARGET scancode scancode_exec scancode_cov scancode_cov_exec
         target_compile_options(${FO_SCANCODE_TARGET} PRIVATE ${FO_COV_FLAGS})
     endif()
     target_link_libraries(${FO_SCANCODE_TARGET}
-        PRIVATE fossologyCPP ${icu-uc_LIBRARIES} ${Boost_LIBRARIES} ${jsoncpp_LIBRARIES})
+        PRIVATE fossologyCPP ICU::uc ICU::i18n ${Boost_LIBRARIES} ${jsoncpp_LIBRARIES})
     if(${FO_SCANCODE_TARGET} MATCHES "_exec$")
         string(REPLACE "_exec" "" FO_SCANCODE_TARGET_R ${FO_SCANCODE_TARGET})
         set_target_properties(${FO_SCANCODE_TARGET}

--- a/src/scancode/agent/scancode_wrapper.cc
+++ b/src/scancode/agent/scancode_wrapper.cc
@@ -6,18 +6,23 @@
 
 #include "scancode_wrapper.hpp"
 
+extern "C" {
+#include "libfossology.h"
+}
+
 #define MINSCORE 50
 
 /**
- * @brief converts start line to start byte of the matched text
+ * @brief converts start line to start UChar16 offset of the matched text
  *
- * count number of characters before start line and add it to the
- * characters before the matched text in the start line.
+ * Locates the match in the file by line number and text search (byte-level),
+ * then converts the resulting byte offset to a UTF-16 code unit (UChar16)
+ * offset so that it is consistent with the ICU-based in-house agent output.
  *
- * @param filename name of the file uploaded
- * @param start_line  start line of the matched text by scancode
- * @param match_text  text in the codefile matched by scancode
- * @return  start byte of the matched text on success, -1 on failure
+ * @param filename   name of the file uploaded
+ * @param start_line start line of the matched text by scancode
+ * @param match_text text in the codefile matched by scancode
+ * @return UChar16 offset of the matched text on success, 0 on failure
  */
 unsigned getFilePointer(const string &filename, size_t start_line,
                         const string &match_text) {
@@ -31,8 +36,16 @@ unsigned getFilePointer(const string &filename, size_t start_line,
     getline(checkfile, str);
     unsigned int pos = str.find(match_text);
     if (pos != string::npos) {
-      return file_p + pos;
-    }else{
+      size_t byteOffset = file_p + pos;
+
+      /* Convert the byte offset to a UChar16 offset by reading the file
+       * prefix in binary mode and counting UTF-16 code units. */
+      ifstream binFile(filename, ios::binary);
+      vector<unsigned char> buf(byteOffset);
+      binFile.read(reinterpret_cast<char*>(buf.data()), byteOffset);
+      size_t bytesRead = static_cast<size_t>(binFile.gcount());
+      return static_cast<unsigned>(fo_utf8ByteLenToUChar16Len(buf.data(), bytesRead));
+    } else {
       LOG_NOTICE("Failed to find startbyte for %s\n", filename.c_str());
     }
   }
@@ -141,7 +154,9 @@ map<string, vector<Match>> extractDataFromScancodeResult(const string& scancodeR
           unsigned long start_line=oneresult["start_line"].asUInt();
           string temp_text= match_text.substr(0,match_text.find("\n"));
           unsigned start_pointer = getFilePointer(filename, start_line, temp_text);
-          unsigned length = match_text.length();
+          unsigned length = static_cast<unsigned>(fo_utf8ByteLenToUChar16Len(
+              reinterpret_cast<const unsigned char*>(match_text.c_str()),
+              match_text.length()));
           result["scancode_license"].push_back(Match(licensename,percentage,full_name,text_url,start_pointer,length));
       }
     }
@@ -152,7 +167,9 @@ map<string, vector<Match>> extractDataFromScancodeResult(const string& scancodeR
         unsigned long start_line=oneresult["start"].asUInt();
         string temp_text= copyrightname.substr(0,copyrightname.find("[\n\t]"));
         unsigned start_pointer = getFilePointer(filename, start_line, temp_text);
-        unsigned length = copyrightname.length();
+        unsigned length = static_cast<unsigned>(fo_utf8ByteLenToUChar16Len(
+            reinterpret_cast<const unsigned char*>(copyrightname.c_str()),
+            copyrightname.length()));
         string type="scancode_statement";
         result["scancode_statement"].push_back(Match(copyrightname,type,start_pointer,length));
     }
@@ -163,7 +180,9 @@ map<string, vector<Match>> extractDataFromScancodeResult(const string& scancodeR
         unsigned long start_line=oneresult["start"].asUInt();
         string temp_text= holdername.substr(0,holdername.find("\n"));
         unsigned start_pointer = getFilePointer(filename, start_line, temp_text);
-        unsigned length = holdername.length();
+        unsigned length = static_cast<unsigned>(fo_utf8ByteLenToUChar16Len(
+            reinterpret_cast<const unsigned char*>(holdername.c_str()),
+            holdername.length()));
         string type="scancode_author";
         result["scancode_author"].push_back(Match(holdername,type,start_pointer,length));
     }
@@ -174,7 +193,9 @@ map<string, vector<Match>> extractDataFromScancodeResult(const string& scancodeR
         unsigned long start_line=oneresult["start"].asUInt();
         string temp_text= emailname.substr(0,emailname.find("\n"));
         unsigned start_pointer = getFilePointer(filename, start_line, temp_text);
-        unsigned length = emailname.length();
+        unsigned length = static_cast<unsigned>(fo_utf8ByteLenToUChar16Len(
+            reinterpret_cast<const unsigned char*>(emailname.c_str()),
+            emailname.length()));
         string type="scancode_email";
         result["scancode_email"].push_back(Match(emailname,type,start_pointer,length));
     }
@@ -185,7 +206,9 @@ map<string, vector<Match>> extractDataFromScancodeResult(const string& scancodeR
         unsigned long start_line=oneresult["start"].asUInt();
         string temp_text= urlname.substr(0,urlname.find("\n"));
         unsigned start_pointer = getFilePointer(filename, start_line, temp_text);
-        unsigned length = urlname.length();
+        unsigned length = static_cast<unsigned>(fo_utf8ByteLenToUChar16Len(
+            reinterpret_cast<const unsigned char*>(urlname.c_str()),
+            urlname.length()));
         string type="scancode_url";
         result["scancode_url"].push_back(Match(urlname,type,start_pointer,length));
     }

--- a/src/www/ui/ui-view.php
+++ b/src/www/ui/ui-view.php
@@ -174,8 +174,19 @@ class ui_view extends FO_Plugin
     $output .= ($Flowed ? '<div class="text">' : '<div class="mono"><pre style="overflow:unset;">');
 
     fseek($inputFile, $startOffset, SEEK_SET);
-    $textFragment = new TextFragment($startOffset,
-      fread($inputFile, $outputLength));
+    $content = fread($inputFile, $outputLength);
+
+    // Convert byte startOffset to character offset for consistency
+    // with highlight positions stored in the database.
+    if ($startOffset > 0) {
+      rewind($inputFile);
+      $prefix = fread($inputFile, $startOffset);
+      $charStartOffset = mb_strlen($prefix, 'UTF-8');
+    } else {
+      $charStartOffset = 0;
+    }
+
+    $textFragment = new TextFragment($charStartOffset, $content);
 
     $renderedText = $this->textRenderer->renderText($textFragment,
       $splitPositions, $insertBacklink);
@@ -210,8 +221,18 @@ class ui_view extends FO_Plugin
 
     $output = "";
     fseek($inputFile, $startOffset, SEEK_SET);
-    $textFragment = new TextFragment($startOffset,
-      fread($inputFile, $outputLength));
+    $content = fread($inputFile, $outputLength);
+
+    // Convert byte startOffset to character offset
+    if ($startOffset > 0) {
+      rewind($inputFile);
+      $prefix = fread($inputFile, $startOffset);
+      $charStartOffset = mb_strlen($prefix, 'UTF-8');
+    } else {
+      $charStartOffset = 0;
+    }
+
+    $textFragment = new TextFragment($charStartOffset, $content);
 
     $output .= "<div class='mono'>";
 
@@ -338,6 +359,13 @@ class ui_view extends FO_Plugin
 
     $blockSize = $Format == 'hex' ? $this->blockSizeHex : $this->blockSizeText;
 
+    // Read full file content to compute character-level page boundaries.
+    // Highlight positions from the database are in character space,
+    // so pagination must also work in character space.
+    rewind($inputFile);
+    $fullContent = stream_get_contents($inputFile);
+    rewind($inputFile);
+
     if (! isset($Page) && ! empty($licenseId)) {
       $startPos = - 1;
       foreach ($highlightEntries as $highlightEntry) {
@@ -360,12 +388,16 @@ class ui_view extends FO_Plugin
       $output .= "<center>$PageMenu</center><br>\n";
     }
 
-    $startAt = $PageSize;
-    $endAt = $PageSize + $blockSize;
+    // Compute character-level page boundaries for highlight filtering.
+    // $PageSize is a byte offset; convert to character offset for the range check.
+    $charStartAt = ($PageSize > 0) ? mb_strlen(substr($fullContent, 0, $PageSize), 'UTF-8') : 0;
+    $charBlockContent = substr($fullContent, $PageSize, $blockSize);
+    $charEndAt = $charStartAt + mb_strlen($charBlockContent, 'UTF-8');
+
     $relevantHighlightEntries = array();
     foreach ($highlightEntries as $highlightEntry) {
-      if ($highlightEntry->getStart() < $endAt &&
-        $highlightEntry->getEnd() >= $startAt) {
+      if ($highlightEntry->getStart() < $charEndAt &&
+        $highlightEntry->getEnd() >= $charStartAt) {
         $relevantHighlightEntries[] = $highlightEntry;
       }
     }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Use `icu::UnicodeString` to support unicode strings. This allows Copyright agent to handle files with unicode content correctly.

As a side-effect, the copyright highlights in PHP UI are currently broken as PHP also needs to be updated to handle unicode files using `mb_` functions. However, doing so breaks highlights of other license agents which also needs to be updated to support unicode.

Thus, this change is broken into 2 stages:
1. First support copyright and other sister agents with unicode supports.
2. Support unicode in license agents and update PHP.

### Changes

1. Use `icu::UnicodeString` to hold any file content instead of `std::string`.
2. Use boost with ICU.
3. Move ICU, LibXslt and OpenMP libraries to CMake way.

## How to test

Run copyright agent on files with unicode content and check the match start and end positions.