### PR TITLE
feat(differential scans): Add differential scans to CI Scanner

### DIFF
--- a/utils/automation/.github-workflow.yml
+++ b/utils/automation/.github-workflow.yml
@@ -30,11 +30,26 @@ jobs:
             -e GITHUB_ACTIONS \
             fossology/fossology:scanner "/bin/fossologyscanner" nomos ojo
 
+      - name: Run fossology scanner in differential mode
+        if: ${{ vars.FROM_TAG != '' }} && ${{ vars.TO_TAG != '' }}
+        run : |
+          docker run --rm --name "fossologyscanner" -w "/opt/repo" -v ${PWD}:/opt/repo \
+            -e GITHUB_TOKEN=${{ github.token }} \
+            -e GITHUB_PULL_REQUEST=${{ github.event.number }} \
+            -e GITHUB_REPOSITORY=${{ github.repository }} \
+            -e GITHUB_API=${{ github.api_url }} \
+            -e GITHUB_REPO_URL=${{ github.repositoryUrl }} \
+            -e GITHUB_REPO_OWNER=${{ github.repository_owner }} \
+            -e GITHUB_ACTIONS \
+            fossology/fossology:scanner "/bin/fossologyscanner" nomos ojo \
+            differential --tags ${{ vars.FROM_TAG }} ${{ vars.TO_TAG }}
+
   check-copyright:
     name: Check copyright
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout this repository
+
+      - name: Checkout
         uses: actions/checkout@v3
 
       - name: Set up QEMU
@@ -67,3 +82,17 @@ jobs:
             -e GITHUB_REPO_OWNER=${{ github.repository_owner }} \
             -e GITHUB_ACTIONS \
             fossology/fossology:scanner "/bin/fossologyscanner" copyright keyword
+
+      - name: Run fossology scanner in differential mode
+        if: ${{ vars.FROM_TAG != '' }} && ${{ vars.TO_TAG != '' }}
+        run : |
+          docker run --rm --name "fossologyscanner" -w "/opt/repo" -v ${PWD}:/opt/repo \
+            -e GITHUB_TOKEN=${{ github.token }} \
+            -e GITHUB_PULL_REQUEST=${{ github.event.number }} \
+            -e GITHUB_REPOSITORY=${{ github.repository }} \
+            -e GITHUB_API=${{ github.api_url }} \
+            -e GITHUB_REPO_URL=${{ github.repositoryUrl }} \
+            -e GITHUB_REPO_OWNER=${{ github.repository_owner }} \
+            -e GITHUB_ACTIONS \
+            fossology/fossology:scanner "/bin/fossologyscanner" copyright keyword \
+            differential --tags ${{ vars.FROM_TAG }} ${{ vars.TO_TAG }}

--- a/utils/automation/.gitlab-ci.sample.yml
+++ b/utils/automation/.gitlab-ci.sample.yml
@@ -54,3 +54,17 @@ repo_sbom:
     - results
     expire_in: 1 week
     when: always
+
+differential_scan:
+  stage: license
+  image: fossology/fossology:scanner
+  script:
+    - /bin/fossologyscanner copyright keyword nomos ojo differential --tags $FROM_TAG $TO_TAG --report SPDX_JSON
+  only:
+    - tags
+    - merge_requests
+  artifacts:
+    paths:
+    - results
+    expire_in: 1 week
+    when: always

--- a/utils/automation/FoScanner/CliOptions.py
+++ b/utils/automation/FoScanner/CliOptions.py
@@ -6,6 +6,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 import os
+import sys
 from argparse import Namespace
 from enum import Enum
 
@@ -30,6 +31,8 @@ class CliOptions(object):
   :ivar copyright: run copyright scanner
   :ivar keyword: run keyword scanner
   :ivar repo: scan whole repo or just diff
+  :ivar differential: scan between two versions of a repo
+  :ivar tags: tuple of length 2: (from_tag , to_tag) to scan
   :ivar diff_dir: directory to scan
   :ivar keyword_conf_file_path: path to custom keyword.conf file passed by user
   :ivar allowlist: information from allowlist.json
@@ -40,6 +43,8 @@ class CliOptions(object):
   copyright: bool = False
   keyword: bool = False
   repo: bool = False
+  differential: bool = False
+  tags: tuple = ('','')
   diff_dir: str = os.getcwd()
   keyword_conf_file_path : str = ''
   allowlist: dict[str, list[str]] = {
@@ -62,8 +67,14 @@ class CliOptions(object):
       self.keyword = True
     if "ojo" in args.operation:
       self.ojo = True
+    if 'repo' in args.operation and 'differential' in args.operation:
+      raise ValueError("You can only specify either 'repo' or 'differential' scans at a time.")
     if "repo" in args.operation:
       self.repo = True
+    if "differential" in args.operation:
+      self.differential = True
+    if args.tags is not None and self.differential and len(args.tags) == 2:
+      self.tags = (args.tags[0],args.tags[1])
     if self.nomos is False and self.ojo is False and self.copyright is False \
         and self.keyword is False:
       self.nomos = True

--- a/utils/automation/fossologyscanner.py
+++ b/utils/automation/fossologyscanner.py
@@ -274,7 +274,11 @@ if __name__ == "__main__":
   )
   parser.add_argument(
     "operation", type=str, help="Operations to run.", nargs='*',
-    choices=["nomos", "copyright", "keyword", "ojo", "repo"]
+    choices=["nomos", "copyright", "keyword", "ojo", "repo", "differential"]
+  )
+  parser.add_argument(
+    "--tags", type=str, nargs=2, help="Tags for differential scan. Required if 'differential'" \
+     "is specified."
   )
   parser.add_argument(
     "--report", type=str, help="Type of report to generate. Default 'TEXT'.",


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add Differential scan using the differential scan argument. Scans the files between two different releases. User provides target release tag value. Script fetches the diff and scans them.

### Changes

* Modifies script to take tags from user and scan between them.
* Add new cli operation `differential` and cli argument flag `--tags`.
* Modify github workflow and gitlab workflow examples.

## How to test

* Build new image or test using [this](https://hub.docker.com/layers/rjknightmare/fo-ci-test/diff/images/sha256-8c2825368fdaa866827c4e0cce65cd0e6fda612c98de96bd81142036a3ae8791?context=repo) one: `rjknightmare/fo-ci-test:diff`
* Use workfow files from examples.
* Add env variable called FROM_TAG and TO_TAG with appropriate values in CI settings.
