### PR TITLE
feat(api): modify /jobs and related endpoints

### DIFF
--- a/src/lib/php/Dao/JobDao.php
+++ b/src/lib/php/Dao/JobDao.php
@@ -48,6 +48,25 @@ class JobDao
     return $result;
   }
 
+  public function getChlidJobStatus($jobId)
+  {
+    $result = array();
+    $stmt = __METHOD__;
+    $this->dbManager->prepare($stmt,
+      "SELECT jobqueue.jq_pk as jq_pk,
+              jobqueue.jq_end_bits as end_bits
+      FROM jobqueue
+      WHERE jq_job_fk = $1");
+
+    $res = $this->dbManager->execute($stmt, array($jobId));
+    while ($row = $this->dbManager->fetchArray($res)) {
+      $result[$row['jq_pk']] = $row['end_bits'];
+    }
+    $this->dbManager->freeResult($res);
+
+    return $result;
+  }
+
   public function hasActionPermissionsOnJob($jobId, $userId, $groupId)
   {
     $result = array();

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -3189,50 +3189,6 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
-  /jobs/history:
-    parameters:
-      - name: upload
-        required: true
-        in: query
-        description: Return jobs for the given upload id
-        schema:
-          type: integer
-    get:
-      operationId: getJobsHistoryPerUpload
-      tags:
-        - Job
-      summary: Get the history of all the jobs queued based on an upload
-      description: Returns the history of all the jobs queued based on an upload
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ShowJob'
-        '400':
-          description: "Bad Request. 'upload' is a required query param"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Info'
-        '403':
-          description: Upload is not accessible
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Info'
-        '404':
-          description: Upload does not exist
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Info'
-        default:
-          $ref: '#/components/responses/defaultResponse'
-
   /jobs/dashboard/statistics:
     get:
       operationId: getJobStatistics
@@ -5391,6 +5347,11 @@ components:
             - Queued
             - Processing
           description: Denotes the current status of the job in the queue
+        jobQueue:
+          type: array
+          description: List of child jobs
+          items:
+            $ref: '#/components/schemas/JobQueue'
     Info:
       type: object
       properties:

--- a/src/www/ui/async/AjaxShowJobs.php
+++ b/src/www/ui/async/AjaxShowJobs.php
@@ -205,11 +205,12 @@ class AjaxShowJobs extends \FO_Plugin
   } /* getGeekyScanDetailsForJob() */
 
   /**
-   * @brief Returns an upload job status in array
+   * @brief Returns an upload job status in array for API or browser
    * @param array $jobData
-   * @return Returns an upload job status in array
+   * @param bool $forApi
+   * @return Returns an upload job status in array for API or browser
    **/
-  public function getShowJobsForEachJob($jobData)
+  public function getShowJobsForEachJob($jobData, $forApi = false)
   {
     if (count($jobData) == 0) {
       return array('showJobsData' => "There are no jobs to display");
@@ -222,13 +223,15 @@ class AjaxShowJobs extends \FO_Plugin
         'jobQueue' => $jobs['jobqueue']
       );
       foreach ($jobArr['jobQueue'] as $key => $singleJobQueue) {
-        if (! empty($jobArr['jobQueue'][$key]['jq_starttime'])) {
-          $jobArr['jobQueue'][$key]['jq_starttime'] = Convert2BrowserTime(
-            $jobArr['jobQueue'][$key]['jq_starttime']);
-        }
-        if (! empty($jobArr['jobQueue'][$key]['jq_endtime'])) {
-          $jobArr['jobQueue'][$key]['jq_endtime'] = Convert2BrowserTime(
-            $jobArr['jobQueue'][$key]['jq_endtime']) ;
+        if (! $forApi) {
+          if (! empty($jobArr['jobQueue'][$key]['jq_starttime'])) {
+            $jobArr['jobQueue'][$key]['jq_starttime'] = Convert2BrowserTime(
+              $jobArr['jobQueue'][$key]['jq_starttime']);
+          }
+          if (! empty($jobArr['jobQueue'][$key]['jq_endtime'])) {
+            $jobArr['jobQueue'][$key]['jq_endtime'] = Convert2BrowserTime(
+              $jobArr['jobQueue'][$key]['jq_endtime']) ;
+          }
         }
         if (! empty($singleJobQueue["jq_endtime"])) {
           $numSecs = strtotime($singleJobQueue['jq_endtime']) -
@@ -426,7 +429,7 @@ class AjaxShowJobs extends \FO_Plugin
 
     $pagination = ($totalPages > 1 ? MenuPage($page, $totalPages, $uri) : "");
 
-    $showJobData = $this->getShowJobsForEachJob($jobsInfo);
+    $showJobData = $this->getShowJobsForEachJob($jobsInfo, false);
     return new JsonResponse(
       array(
         'showJobsData' => $showJobData,

--- a/src/www/ui_tests/api/Controllers/JobControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/JobControllerTest.php
@@ -17,7 +17,9 @@ use Fossology\Lib\Dao\ShowJobsDao;
 use Fossology\UI\Api\Controllers\JobController;
 use Fossology\UI\Api\Exceptions\HttpNotFoundException;
 use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Models\ApiVersion;
 use Fossology\UI\Api\Models\Job;
+use Fossology\UI\Api\Models\JobQueue;
 use Fossology\UI\Api\Models\User;
 use Mockery as M;
 use Slim\Psr7\Factory\StreamFactory;
@@ -156,12 +158,15 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
   public function testGetJobs()
   {
     $job = new Job(11, "job_name", "01-01-2020", 4, 2, 2, 0, "Completed");
-    $this->jobDao->shouldReceive('getAllJobStatus')->withArgs(array(4, 2, 2))
-      ->andReturn(['11' => 0]);
+    $jobQueue = new JobQueue(44, 'readmeoss', '2020-01-01 20:41:49', '2020-01-01 20:41:50',
+      'Completed', 0, null, [], 0, true, false, true,
+      ['text' => 'ReadMeOss', 'link' => 'http://localhost/repo/api/v1/report/16']);
+    $this->jobDao->shouldReceive('getChlidJobStatus')->withArgs(array(11))
+      ->andReturn(['44' => 0]);
     $this->showJobsDao->shouldReceive('getEstimatedTime')
       ->withArgs(array(11, '', 0, 4))->andReturn("0");
     $this->showJobsDao->shouldReceive('getDataForASingleJob')
-      ->withArgs(array(11))->andReturn(["jq_endtext"=>'Completed']);
+      ->withArgs(array(44))->andReturn(["jq_endtext"=>'Completed']);
 
     $requestHeaders = new Headers();
     $body = $this->streamFactory->createStream();
@@ -174,7 +179,7 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
     $this->dbHelper->shouldReceive('getUserJobs')->withArgs(array(null, 2, 0, 1))
       ->andReturn([[$job], 1]);
     $actualResponse = $this->jobController->getJobs($request, $response, []);
-    $expectedResponse = $job->getArray();
+    $expectedResponse = $job->getArray(ApiVersion::V1);
     $this->assertEquals(200, $actualResponse->getStatusCode());
     $this->assertEquals($expectedResponse,
       $this->getResponseJson($actualResponse)[0]);
@@ -190,14 +195,17 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
   public function testGetJobsLimitPage()
   {
     $jobTwo = new Job(12, "job_two", "01-01-2020", 5, 2, 2, 0, "Completed");
-    $this->jobDao->shouldReceive('getAllJobStatus')->withArgs(array(4, 2, 2))
-      ->andReturn(['11' => 0]);
-    $this->jobDao->shouldReceive('getAllJobStatus')->withArgs(array(5, 2, 2))
-      ->andReturn(['12' => 0]);
+    $jobTwoQueue = new JobQueue(45, 'readmeoss', '2020-01-01 20:41:49', '2020-01-01 20:41:50',
+    'Completed', 0, null, [], 0, true, false, true,
+    ['text' => 'ReadMeOss', 'link' => 'http://localhost/repo/api/v1/report/16']);
+    $this->jobDao->shouldReceive('getChlidJobStatus')->withArgs(array(11))
+      ->andReturn(['44' => 0]);
+    $this->jobDao->shouldReceive('getChlidJobStatus')->withArgs(array(12))
+      ->andReturn(['45' => 0]);
     $this->showJobsDao->shouldReceive('getEstimatedTime')
       ->withArgs(array(M::anyOf(11, 12), '', 0, M::anyOf(4, 5)))->andReturn("0");
     $this->showJobsDao->shouldReceive('getDataForASingleJob')
-      ->withArgs([M::anyOf(11, 12)])->andReturn(["jq_endtext"=>'Completed']);
+      ->withArgs([M::anyOf(44, 45)])->andReturn(["jq_endtext"=>'Completed']);
 
     $requestHeaders = new Headers();
     $requestHeaders->setHeader('limit', '1');
@@ -212,7 +220,7 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
     $this->dbHelper->shouldReceive('getUserJobs')->withArgs(array(null, 2, 1, 2))
     ->andReturn([[$jobTwo], 2]);
     $actualResponse = $this->jobController->getJobs($request, $response, []);
-    $expectedResponse = $jobTwo->getArray();
+    $expectedResponse = $jobTwo->getArray(ApiVersion::V1);
     $this->assertEquals(200, $actualResponse->getStatusCode());
     $this->assertEquals($expectedResponse,
       $this->getResponseJson($actualResponse)[0]);
@@ -252,16 +260,19 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
   public function testGetJobFromId()
   {
     $job = new Job(12, "job_two", "01-01-2020", 5, 2, 2, 0, "Completed");
+    $jobTwoQueue = new JobQueue(45, 'readmeoss', '2020-01-01 20:41:49', '2020-01-01 20:41:50',
+    'Completed', 0, null, [], 0, true, false, true,
+    ['text' => 'ReadMeOss', 'link' => 'http://localhost/repo/api/v1/report/16']);
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(["job", "job_pk", 12])->andReturn(true);
     $this->dbHelper->shouldReceive('getJobs')->withArgs(array(12, 0, 1))
       ->andReturn([[$job], 1]);
-    $this->jobDao->shouldReceive('getAllJobStatus')->withArgs(array(5, 2, 2))
-      ->andReturn(['12' => 0]);
+    $this->jobDao->shouldReceive('getChlidJobStatus')->withArgs(array(12))
+      ->andReturn(['45' => 0]);
     $this->showJobsDao->shouldReceive('getEstimatedTime')
       ->withArgs(array(12, '', 0, 5))->andReturn("0");
     $this->showJobsDao->shouldReceive('getDataForASingleJob')
-      ->withArgs([12])->andReturn(["jq_endtext"=>'Completed']);
+      ->withArgs([45])->andReturn(["jq_endtext"=>'Completed']);
 
     $requestHeaders = new Headers();
     $body = $this->streamFactory->createStream();
@@ -273,7 +284,7 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
     $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
     $actualResponse = $this->jobController->getJobs($request, $response, [
       "id" => 12]);
-    $expectedResponse = $job->getArray();
+    $expectedResponse = $job->getArray(ApiVersion::V1);
     $this->assertEquals(200, $actualResponse->getStatusCode());
     $this->assertEquals($expectedResponse,
       $this->getResponseJson($actualResponse));
@@ -289,18 +300,21 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
   public function testGetJobsFromUpload()
   {
     $job = new Job(12, "job_two", "01-01-2020", 5, 2, 2, 0, "Completed");
+    $jobTwoQueue = new JobQueue(45, 'readmeoss', '2020-01-01 20:41:49', '2020-01-01 20:41:50',
+    'Completed', 0, null, [], 0, true, false, true,
+    ['text' => 'ReadMeOss', 'link' => 'http://localhost/repo/api/v1/report/16']);
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(["upload", "upload_pk", 5])->andReturn(true);
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(['job', 'job_pk', 12])->andReturn(true);
     $this->dbHelper->shouldReceive('getJobs')->withArgs(array(null, 0, 1, 5))
       ->andReturn([[$job], 1]);
-    $this->jobDao->shouldReceive('getAllJobStatus')->withArgs(array(5, 2, 2))
-      ->andReturn(['12' => 0]);
+    $this->jobDao->shouldReceive('getChlidJobStatus')->withArgs(array(12))
+      ->andReturn(['45' => 0]);
     $this->showJobsDao->shouldReceive('getEstimatedTime')
       ->withArgs(array(12, '', 0, 5))->andReturn("0");
     $this->showJobsDao->shouldReceive('getDataForASingleJob')
-      ->withArgs([12])->andReturn(["jq_endtext"=>'Completed']);
+      ->withArgs([45])->andReturn(["jq_endtext"=>'Completed']);
 
     $requestHeaders = new Headers();
     $body = $this->streamFactory->createStream();
@@ -312,7 +326,7 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
     $user = $this->getUsers([$userId]);
     $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
     $actualResponse = $this->jobController->getJobs($request, $response, []);
-    $expectedResponse = $job->getArray();
+    $expectedResponse = $job->getArray(ApiVersion::V1);
     $this->assertEquals(200, $actualResponse->getStatusCode());
     $this->assertEquals($expectedResponse,
       $this->getResponseJson($actualResponse)[0]);

--- a/src/www/ui_tests/api/Models/JobTest.php
+++ b/src/www/ui_tests/api/Models/JobTest.php
@@ -12,7 +12,11 @@
 
 namespace Fossology\UI\Api\Test\Models;
 
+use Fossology\Lib\Dao\UserDao;
+use Fossology\UI\Api\Models\ApiVersion;
 use Fossology\UI\Api\Models\Job;
+use Fossology\UI\Api\Models\JobQueue;
+use Mockery as M;
 
 /**
  * @class JobTest
@@ -20,25 +24,67 @@ use Fossology\UI\Api\Models\Job;
  */
 class JobTest extends \PHPUnit\Framework\TestCase
 {
+
   /**
    * @test
-   * -# Test data model returned by Job::getArray() is correct
+   * -# Test data model returned by Job::getArray($version) when API version is V1
    */
-  public function testDataFormat()
+  public function testDataFormatV1()
   {
-    $expectedStatus = [
-      'id'        => 22,
-      'name'      => 'ojo',
-      'queueDate' => '01-01-2020',
-      'uploadId'  => 4,
-      'userId'    => 2,
-      'groupId'   => 2,
-      'eta'       => 3,
-      'status'    => 'Processing'
-    ];
+    $this->testDataFormat(ApiVersion::V1);
+  }
 
-    $actualJob = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+  /**
+   * @test
+   * -# Test data model returned by Job::getArray($version) when API version is V2
+   */
+  public function testDataFormatV2()
+  {
+    $this->testDataFormat(ApiVersion::V2);
+  }
 
-    $this->assertEquals($expectedStatus, $actualJob->getArray());
+  /**
+   * -# Test the data format returned by Job::getArray($version) model 
+   */
+  private function testDataFormat($version)
+  {
+    $jobQueue = new JobQueue(44, 'readmeoss', '2024-07-03 20:41:49', '2024-07-03 20:41:50',
+      'Completed', 0, null, [], 0, true, false, true,
+      ['text' => 'ReadMeOss', 'link' => 'http://localhost/repo/api/v1/report/16']);
+    if ($version == ApiVersion::V2){
+      $expectedStatus = [
+        'id'        => 22,
+        'name'      => 'ojo',
+        'queueDate' => '01-01-2020',
+        'uploadId'  => 4,
+        'userName'  => "fossy",
+        'groupName' => "fossy",
+        'eta'       => 3,
+        'status'    => 'Processing',
+        'jobQueue'  => $jobQueue->getArray()
+      ];
+      global $container;
+      $userDao = M::mock(UserDao::class);
+      $container = M::mock('ContainerBuilder');
+      $container->shouldReceive('get')->withArgs(array(
+        "dao.user"))->andReturn($userDao);
+      $userDao->shouldReceive("getUserName")->with(2)->andReturn("fossy");
+      $userDao->shouldReceive("getGroupNameById")->with(2)->andReturn("fossy");
+    } else {
+      $expectedStatus = [
+        'id'        => 22,
+        'name'      => 'ojo',
+        'queueDate' => '01-01-2020',
+        'uploadId'  => 4,
+        'userId'    => 2,
+        'groupId'   => 2,
+        'eta'       => 3,
+        'status'    => 'Processing'
+      ];
+    }
+
+    $actualJob = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing', $jobQueue->getArray());
+
+    $this->assertEquals($expectedStatus, $actualJob->getArray($version));
   }
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This PR aims to modify and enhance `/jobs` and related endpoints to contain more useful information.

### Changes

1. For every distinct job, the `/jobs` endpoint now includes all the associated child jobs along with their detailed information.

![image](https://github.com/fossology/fossology/assets/119073504/269cb785-f120-4f5d-8744-e57a1b1abc49)

2. The job status of each parent job is confined to its child job scope exclusively. If any other child job fails for the same upload, it won't affect the status of current job.

![image](https://github.com/fossology/fossology/assets/119073504/da496486-05e2-45df-a21f-ea043eebb08b)
![image](https://github.com/fossology/fossology/assets/119073504/fb8c2452-9976-48f5-9857-057d16a82635)

3. Modified `openapiv2.yml` and `openapi.yml` files to reflect documentation changes.
## How to test

Make a 'GET' request to any of `/jobs`, `/jobs/id`, `/jobs/all` or `/jobs?upload=<id>` to view the modifications.

Tracked by #2514
fixes #1301 
fixes #1800 
fixes #1972 
closes #2514 

CC @GMishx @shaheemazmalmmd @dushimsam @soham4abc 
