### PR TITLE
deps(docker)!: update docker base to Debian 12

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,9 @@ utils/automation/Dockerfile.ci
 
 Vagrantfile
 
+# Include README as required by CMake Debian packages.
+!README.md
+
 # omit rebuilding after changing the docker tests.
 src/testing/docker
 
@@ -156,7 +159,6 @@ variable.list
 /src/readmeoss/agent/version.php
 /src/reuser/agent/reuser
 /src/reuser/agent/version.php
-/src/reuser/agent/reuser
 /src/copyright/agent/ecc
 /src/copyright/VERSION-ecc
 /src/copyright/VERSION-keyword

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 #
 # Description: Docker container image recipe
 
-FROM debian:bullseye-slim as builder
+FROM debian:bookworm-slim as builder
 LABEL org.opencontainers.image.authors="Fossology <fossology@fossology.org>"
 LABEL org.opencontainers.image.source="https://github.com/fossology/fossology"
 LABEL org.opencontainers.image.vendor="FOSSology"
@@ -21,7 +21,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       git \
       lsb-release \
-      php7.4-cli \
+      php8.2-cli \
       sudo \
       cmake \
       ninja-build \
@@ -56,7 +56,7 @@ RUN cmake -DCMAKE_BUILD_TYPE=MinSizeRel -S. -B./build -G Ninja \
  && cmake --build ./build --parallel \
  && cmake --install build
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 LABEL org.opencontainers.image.authors="Fossology <fossology@fossology.org>"
 LABEL org.opencontainers.image.url="https://fossology.org"
@@ -82,13 +82,11 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
       lsb-release \
       sudo \
       cron \
-      python \
       python3 \
       python3-yaml \
       python3-psycopg2 \
       python3-requests \
       python3-pip \
- && python3 -m pip install pip==21.2.2 \
  && DEBIAN_FRONTEND=noninteractive /fossology/utils/fo-installdeps --offline --runtime -y \
  && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       timeout: 5s
       retries: 5
   db:
-    image: postgres:9.6
+    image: postgres:16
     restart: unless-stopped
     environment:
       - POSTGRES_DB=fossology

--- a/utils/automation/Dockerfile.ci
+++ b/utils/automation/Dockerfile.ci
@@ -6,9 +6,9 @@
 # SPDX-License-Identifier: FSFAP
 #
 # Description: Gitlab CI runner image recipie
-# Using Debian 11
+# Using Debian 12
 
-FROM debian:bullseye-slim as builder
+FROM debian:bookworm-slim as builder
 
 WORKDIR /fossology
 
@@ -52,7 +52,7 @@ RUN dpkg-shlibdeps -Orun-deps -ebuild/src/nomos/agent/nomossa \
                               -ebuild/src/ojo/agent/ojo \
  && sed -E -i -e 's/(shlibs:Depends=)|(\(>=?[ 0-9\:\.\~\-]*\))|(,)//g' run-deps
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 LABEL org.opencontainers.image.authors="Fossology <fossology@fossology.org>"
 LABEL org.opencontainers.image.url="https://fossology.org"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Update base image for Docker from Debian Bullseye (11) to Bookworm (12).

Debian 11 will reach its end of initial support on August 14th, 2024.

**BREAKING CHANGE:** Upgrade PostgreSQL image from 9.6 to 16 in Docker Compose. This requires manual export and import of data for upgrade on existing clusters.

See helpful blogs like https://thomasbandt.com/postgres-docker-major-version-upgrade

### Changes

1. Upgrade base image to Debian Bookworm.
2. Upgrade PostgreSQL image in compose to 16

## How to test

Build and run FOSSology with Docker and Docker Compose.