### PR TITLE
hotfix(scanner): fix scanner image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 #
 # Description: Docker container image recipe
 
-FROM debian:bookworm-slim as builder
+FROM debian:bookworm-slim AS builder
 LABEL org.opencontainers.image.authors="Fossology <fossology@fossology.org>"
 LABEL org.opencontainers.image.source="https://github.com/fossology/fossology"
 LABEL org.opencontainers.image.vendor="FOSSology"

--- a/utils/automation/Dockerfile.ci
+++ b/utils/automation/Dockerfile.ci
@@ -8,7 +8,7 @@
 # Description: Gitlab CI runner image recipie
 # Using Debian 12
 
-FROM debian:bookworm-slim as builder
+FROM debian:bookworm-slim AS builder
 
 WORKDIR /fossology
 
@@ -44,13 +44,13 @@ RUN chown $(whoami):$(whoami) -R .
 RUN cmake -DCMAKE_BUILD_TYPE=MinSizeRel \
     -DAGENTS="nomos;copyright;ojo" \
     -S. -B./build -G Ninja \
- && ninja -C ./build nomossa copyright keyword ojo
+ && ninja -C ./build nomossa copyright keyword ojo_exec
 
 RUN dpkg-shlibdeps -Orun-deps -ebuild/src/nomos/agent/nomossa \
                               -ebuild/src/copyright/agent/copyright \
                               -ebuild/src/copyright/agent/keyword \
                               -ebuild/src/ojo/agent/ojo \
- && sed -E -i -e 's/(shlibs:Depends=)|(\(>=?[ 0-9\:\.\~\-]*\))|(,)//g' run-deps
+ && sed -E -i -e 's/(shlibs:Depends=)|(\(>=?[ 0-9a-z:.~+-]*\))|(,)//ig' run-deps
 
 FROM debian:bookworm-slim
 
@@ -77,7 +77,7 @@ RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' >> /etc/apt
  && DEBIAN_FRONTEND=noninteractive apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install --yes \
  --no-install-recommends $(cat /opt/run-deps) python3 python3-pip \
- && python3 -m pip install -r /bin/requirements.txt \
+ && python3 -m pip install --break-system-packages -r /bin/requirements.txt \
  && DEBIAN_FRONTEND=noninteractive apt-get autoremove --yes \
  && rm -rf /var/lib/apt/lists/* /opt/run-deps /bin/requirements.txt
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Hotfix for scanner image fix.

### Changes

1. Use build target `ojo_exec` to build ojo binary instead of `ojo` which is a project.
2. Update dependency regex to include words and `+` symbols.
