### PR TITLE
Fix issue 1868: SPDX import does not conclude licenses based on hash values but on file name

### DIFF
--- a/src/reportImport/agent/ReportImportAgent.php
+++ b/src/reportImport/agent/ReportImportAgent.php
@@ -153,7 +153,7 @@ class ReportImportAgent extends Agent
   {
     $pfilesByFilename = self::getEntriesForFilename($fileName, $pfilePerFileName);
 
-    if (($pfilesByFilename !== null || sizeof($pfilesByFilename) === 0))
+    if (($pfilesByFilename !== null && sizeof($pfilesByFilename) > 0))
     {
       if ( $hashMap !== null && sizeof($hashMap) > 0 )
       {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
Fix #1868 

Fixed `if statement` which currently always equals to `true` and therefore never used the hash values for importing the report.  This caused the import to fail if the uploaded package name differs from the name used inside the `.rdf` file.

### Changes

Adjusted `if statement` to check correctly if `$pfilesByFilename` is not null and has entries. 

## How to test

Use a package (e.g. https://github.com/Open-Source-Compliance/package-analysis/tree/main/analysed-packages/dart-lang/characters/version-1.2.0), download the source and upload it to fossology. Before uploading it, change the name of the file so fossology has a different upload name than the package. Now import a report file `.rdf` and the files should be correctly concluded.

