### PR TITLE
feat(api): JSON format export/import of licenses and obligations via APIs

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -462,6 +462,76 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /obligations/import-json:
+    post:
+      operationId: importObligationsFromJSON
+      tags:
+        - License
+      summary: Import an obligation json file
+      description: >
+        Import an obligation json file
+      requestBody:
+        description: Include the JSON file
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                fileInput:
+                  type: string
+                  format: binary
+                  description: JSON to be imported
+              required:
+                - fileInput
+      responses:
+        '400':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '200':
+          description: Successfully imported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /obligations/export-json:
+    get:
+      operationId: exportObligationsToJSON
+      parameters:
+        - name: id
+          description: Obligation id to export, 0 for all
+          in: query
+          required: false
+          schema:
+            type: integer
+      tags:
+        - License
+      summary: Export a json obligation list
+      description: >
+        Export a json license obligation list
+      responses:
+        '200':
+          description: Successfully exported
+          content:
+            text/json:
+              schema:
+                type: string
+                format: binary
+        '403':
+          description: Route is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /obligations:
     get:
       operationId: getAllObligationsData
@@ -4721,6 +4791,74 @@ paths:
       summary: Export a csv license
       description: >
         Export a csv license
+      responses:
+        '200':
+          description: Successfully exported
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+        '403':
+          description: Route is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /license/import-json:
+    post:
+      operationId: handleImportLicense
+      tags:
+        - License
+      summary: Import a json license
+      description: >
+        Import a json license to the database
+      requestBody:
+        description: Include the JSON file
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                fileInput:
+                  type: string
+                  format: binary
+                  description: JSON to be imported
+              required:
+                - fileInput
+      responses:
+        '400':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '200':
+          description: Successfully imported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /license/export-json:
+    get:
+      operationId: exportAdminLicenseToJSON
+      parameters:
+        - name: id
+          description: License id to export, 0 for all
+          in: query
+          required: false
+          schema:
+            type: integer
+      tags:
+        - License
+      summary: Export a json license
+      description: >
+        Export a json license
       responses:
         '200':
           description: Successfully exported

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -462,6 +462,75 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /obligations/import-json:
+    post:
+      operationId: importObligationsFromJSON
+      tags:
+        - License
+      summary: Import an obligation json file
+      description: >
+        Import an obligation json file
+      requestBody:
+        description: Include the JSON file
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                fileInput:
+                  type: string
+                  format: binary
+                  description: JSON to be imported
+              required:
+                - fileInput
+      responses:
+        '400':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '200':
+          description: Successfully imported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /obligations/export-json:
+    get:
+      operationId: exportObligationsToJSON
+      parameters:
+        - name: id
+          description: Obligation id to export, 0 for all
+          in: query
+          required: false
+          schema:
+            type: integer
+      tags:
+        - License
+      summary: Export a json obligation list
+      description: >
+        Export a json license obligation list
+      responses:
+        '200':
+          description: Successfully exported
+          content:
+            text/json:
+              schema:
+                type: string
+                format: binary
+        '403':
+          description: Route is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /obligations:
     get:
       operationId: getAllObligationsData
@@ -4618,6 +4687,74 @@ paths:
       summary: Export a csv license
       description: >
         Export a csv license
+      responses:
+        '200':
+          description: Successfully exported
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+        '403':
+          description: Route is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /license/import-json:
+    post:
+      operationId: handleImportLicense
+      tags:
+        - License
+      summary: Import a json license
+      description: >
+        Import a json license to the database
+      requestBody:
+        description: Include the JSON file
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                fileInput:
+                  type: string
+                  format: binary
+                  description: JSON to be imported
+              required:
+                - fileInput
+      responses:
+        '400':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '200':
+          description: Successfully imported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /license/export-json:
+    get:
+      operationId: exportAdminLicenseToJSON
+      parameters:
+        - name: id
+          description: License id to export, 0 for all
+          in: query
+          required: false
+          schema:
+            type: integer
+      tags:
+        - License
+      summary: Export a json license
+      description: >
+        Export a json license
       responses:
         '200':
           description: Successfully exported

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -293,6 +293,8 @@ $app->group('/obligations',
     $app->delete('/{id:\\d+}', ObligationController::class . ':deleteObligation');
     $app->get('/export-csv', ObligationController::class . ':exportObligationsToCSV');
     $app->post('/import-csv', ObligationController::class . ':importObligationsFromCSV');
+    $app->get('/export-json', ObligationController::class . ':exportObligationsToJSON');
+    $app->post('/import-json', ObligationController::class . ':importObligationsFromJSON');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 
@@ -398,6 +400,8 @@ $app->group('/license',
     $app->get('', LicenseController::class . ':getAllLicenses');
     $app->post('/import-csv', LicenseController::class . ':handleImportLicense');
     $app->get('/export-csv', LicenseController::class . ':exportAdminLicenseToCSV');
+    $app->post('/import-json', LicenseController::class . ':handleImportLicense');
+    $app->get('/export-json', LicenseController::class . ':exportAdminLicenseToJSON');
     $app->post('', LicenseController::class . ':createLicense');
     $app->put('/verify/{shortname:.+}', LicenseController::class . ':verifyLicense');
     $app->put('/merge/{shortname:.+}', LicenseController::class . ':mergeLicense');


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

JSON format for export and import of licenses and obligations was introduced in #2734. This PR aims to expose the same over REST APIs.

### Changes

- Added controller functions and routes.
- Modified the corresponding V1 and V2 documentation. 

## How to test

1. Send a `GET` request to `/license/export-json` to test the license export functionality in JSON format.
![image](https://github.com/user-attachments/assets/6ef3da2a-6c78-413e-adaa-d14ec113b607)
2. Send a `GET` request to `/obligations/export-json` to test the obligation export functionality in JSON format.
![image](https://github.com/user-attachments/assets/8a7d550b-cef5-49f9-b3c7-d907175d956d)
3. Send a `POST` request to `/license/import-json` along with JSON file to import licenses.
4. Send a `POST` request to `/obligations/import-json` along with JSON file to import obligations.

CC @GMishx @shaheemazmalmmd @dushimsam @soham4abc 