### PR TITLE
feat(report): Generation of SPDX v3.0 report

### DIFF
--- a/src/spdx2/CMakeLists.txt
+++ b/src/spdx2/CMakeLists.txt
@@ -20,6 +20,10 @@ install(DIRECTORY ui
     PATTERN "DepFiveAgentPlugin.php" EXCLUDE
     PATTERN "SpdxTwoTagValueAgentPlugin.php" EXCLUDE
     PATTERN "SpdxTwoCommaSeparatedValuesAgentPlugin.php" EXCLUDE
+    PATTERN "SpdxThreeJsonldAgentPlugin.php" EXCLUDE
+    PATTERN "SpdxThreeJsonAgentPlugin.php" EXCLUDE
+    PATTERN "SpdxThreeRDFAgentPlugin.php" EXCLUDE
+    PATTERN "SpdxThreeTagValueAgentPlugin.php" EXCLUDE
 )
 
 install(FILES ui/DepFiveAgentPlugin.php
@@ -34,7 +38,23 @@ install(FILES ui/SpdxTwoCommaSeparatedValuesAgentPlugin.php
     DESTINATION ${FO_MODDIR}/spdx2csv/ui
     COMPONENT spdx2)
 
-foreach(SPDX_INSTALL spdx2 spdx2tv dep5 spdx2csv)
+install(FILES ui/SpdxThreeJsonldAgentPlugin.php
+    DESTINATION ${FO_MODDIR}/spdx3jsonld/ui
+    COMPONENT spdx2)
+
+install(FILES ui/SpdxThreeJsonAgentPlugin.php
+    DESTINATION ${FO_MODDIR}/spdx3json/ui
+    COMPONENT spdx2)
+
+install(FILES ui/SpdxThreeRDFAgentPlugin.php
+    DESTINATION ${FO_MODDIR}/spdx3rdf/ui
+    COMPONENT spdx2)
+
+install(FILES ui/SpdxThreeTagValueAgentPlugin.php
+    DESTINATION ${FO_MODDIR}/spdx3tv/ui
+    COMPONENT spdx2)
+
+foreach(SPDX_INSTALL spdx2 spdx2tv dep5 spdx2csv spdx3jsonld spdx3json spdx3rdf spdx3tv)
     install(FILES ${SPDX_INSTALL}.conf "${CMAKE_CURRENT_BINARY_DIR}/VERSION"
         DESTINATION ${FO_MODDIR}/${SPDX_INSTALL}
         COMPONENT spdx2)

--- a/src/spdx2/agent/CMakeLists.txt
+++ b/src/spdx2/agent/CMakeLists.txt
@@ -22,7 +22,7 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gen/
     PATTERN *.twig
 )
 
-foreach(SPDX_INSTALL spdx2 spdx2tv dep5 spdx2csv)
+foreach(SPDX_INSTALL spdx2 spdx2tv dep5 spdx2csv spdx3jsonld spdx3json spdx3rdf spdx3tv)
     install(PROGRAMS agent.sh
         DESTINATION ${FO_MODDIR}/${SPDX_INSTALL}/agent
         RENAME ${SPDX_INSTALL}.sh

--- a/src/spdx2/agent/template/spdx3json-document.twig
+++ b/src/spdx2/agent/template/spdx3json-document.twig
@@ -1,0 +1,112 @@
+{# SPDX-FileCopyrightText: © 2015 Siemens AG
+
+   SPDX-License-Identifier: FSFAP
+#}
+[
+  {
+    "@id": "https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1",
+    "type": "CreationInfo",
+    "specVersion": "3.0.0",
+    "created": "{{ 'now'|date('Y-m-d\\TH:i:s\\Z', 'UTC') }}",
+    "createdBy": [
+    "https://spdx.org/rdf/3.0.0/terms/Core/Person#SPDXRef-Actor-{{ userName | replace({' (': '-', ')': ''}) }}"
+    ],
+    "createdUsing": [
+    "https://spdx.org/rdf/3.0.0/terms/Core/Tool#SPDXRef-Actor-{{ toolVersion }}"
+    ],
+    "comment":"<text>This document was created using license information and a generator from Fossology.</text>"
+  },
+  {
+    "type":"SpdxDocument",
+    "spdxId":"https://spdx.org/rdf/3.0.0/terms/Core/SpdxDocument#SpdxRef-DOCUMENT",
+    "creationInfo":"https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1",
+    "name": "{{ documentName }}",
+    "profileConformance": ["core", "software", "simpleLicensing", "expandedLicensing"],
+    "element": [
+        "https://spdx.org/rdf/3.0.0/terms/Core/Tool#SPDXRef-Actor-{{ toolVersion }}",
+        "https://spdx.org/rdf/3.0.0/terms/Core/Person#SPDXRef-Actor-{{ userName | replace({' (': '-', ')': ''}) }}",
+        {% for packageId in packageIds%}
+        "https://spdx.org/rdf/3.0.0/terms/Software/Package#SPDXRef-upload{{ packageId }}",
+        {% endfor %}
+        {% for fileId in fileIds%}
+        "https://spdx.org/rdf/3.0.0/terms/Software/File#SPDXRef-item{{ fileId }}"{% if not loop.last %},{{ "\n" }}{% endif %}
+        {% endfor %}
+    ],
+    "rootElement": [
+        {% for packageId in packageIds%}
+        "https://spdx.org/rdf/3.0.0/terms/Software/Package#SPDXRef-upload{{ packageId }}"{% if not loop.last %},{{ "\n" }}{% endif %}
+        {% endfor %}
+    ],
+    "dataLicense": {
+        "type": "simplelicensing_AnyLicenseInfo",
+        "creationInfo": "https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1",
+        "description":"{{ licenseList[dataLicense].licenseObj.spdxId|replace({' ': '-'}) }}"
+      }
+  },
+  {% if toolVersion is not empty %} 
+  {
+    "type":"Tool",
+    "spdxId":"https://spdx.org/rdf/3.0.0/terms/Core/Tool#SPDXRef-Actor-{{ toolVersion }}",
+    "creationInfo":"https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1",
+    "name": "{{ toolVersion }}"
+  },
+  {% endif %}
+  {% if userName is not empty %}
+  {
+    "type": "Person",
+    "spdxId": "https://spdx.org/rdf/3.0.0/terms/Core/Person#SPDXRef-Actor-{{ userName | replace({' (': '-', ')': ''}) }}",
+    "creationInfo":"https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1",
+    "name": "{{ userName | split(' ')[0] }}",
+    "externalIdentifier": [
+      {
+        "type": "ExternalIdentifier",
+        "externalIdentifierType": "email",
+        "identifier": "{{ userName | split(' (')[1] | split(')')[0]}}"
+      }   
+    ]
+  },
+  {% endif %}
+  {% if organization is not empty %}
+  {
+    "type":"Organization",
+    "spdxId":"https://spdx.org/rdf/3.0.0/terms/Core/Organization#SPDXRef-Actor-{{ organization }}",
+    "creationInfo":"https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1",
+    "name": "{{ userName | split(' ')[0] }}"
+  },
+  {% endif %}
+  {% for licenseData in licenseList %}{% if licenseData.licenseObj.spdxId starts with 'LicenseRef-' or licenseData.licenseObj.shortName starts with 'LicenseRef-' ~%}
+    {%- set licId=licenseData.licenseObj.spdxId %}
+    {% if licenseData.licenseObj.shortName starts with 'LicenseRef-' %}
+        {% set licId=licenseData.licenseObj.shortName %}
+    {%- endif ~%}
+    {
+      "type":"expandedlicensing_CustomLicense",
+      "spdxId":"{{ uri }}#{{ licId|replace({' ': '-'}) }}",
+      "creationInfo":"https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1",
+      "name":"{{ licenseData.licenseObj.fullName }}",
+      "simplelicensing_licenseText":"<text> {{ licenseData.licenseObj.text|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})|replace({'\f':'','"':"'", '\n':''}) }} </text>"{% if licenseData.licenseObj.url is not empty %},{% endif %}
+      {% if licenseData.licenseObj.url is not empty %}
+      {%~ if '&' in licenseData.licenseObj.url %}
+      "expandedlicensing_seeAlso":["{{ licenseData.licenseObj.url|url_encode }}"]
+      {%~ else %}
+      "expandedlicensing_seeAlso":["{{ licenseData.licenseObj.url }}"]
+      {%~ endif %}
+      {% endif %}
+    },
+  {% endif %}{% endfor %}
+  {{packageNodes}}
+  {% for packageId in packageIds%}
+  {
+    "type": "Relationship",
+    "spdxId": "{{ uri }}:SPDXRef-Relationship-{{ fileIds | length }}",
+    "from":"https://spdx.org/rdf/3.0.0/terms/Software/Package#SPDXRef-upload{{ packageId }}",
+    "to": [
+        {% for fileId in fileIds%}
+        "https://spdx.org/rdf/3.0.0/terms/Software/File#SPDXRef-item{{ fileId }}"{% if not loop.last %},{{ "\n" }}{% endif %}
+        {% endfor %}
+    ],
+    "relationshipType": "describes",
+    "creationInfo":"https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"
+  }
+  {% endfor %}
+]

--- a/src/spdx2/agent/template/spdx3json-file.twig
+++ b/src/spdx2/agent/template/spdx3json-file.twig
@@ -1,0 +1,126 @@
+{# SPDX-FileCopyrightText: © 2015 Siemens AG
+
+   SPDX-License-Identifier: FSFAP
+#}
+{% set dualLicense = false %}
+{% set textPrintedList = [] %}
+{% if fileData.concludedLicenses|length > 2 %}
+  {% for res in fileData.concludedLicenses %}
+    {% if 'Dual-license' == licenseList[res].licenseObj.shortName %}
+      {% set dualLicense = true %}
+    {% endif %}
+  {% endfor %}
+{%- endif -%}
+{
+  "type": "software_File",
+  "spdxId": "https://spdx.org/rdf/3.0.0/terms/Software/File#SPDXRef-item{{ fileId }}",
+  "creationInfo":"https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1",
+  "name": "{{ fileName }}",
+  {% if licenseCommentState %}
+  {% if fileData.comments is empty %}
+  "comment": "NOASSERTION",
+  {%~ else %}
+  "comment": "<text> {{ fileData.comments|join('\n')
+  |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
+  |replace({'\f':''}) }} </text>",
+  {% endif %}
+  {% endif %}
+  {% if fileData.copyrights|default is empty %}
+  "software_copyrightText": "NOASSERTION",
+  {% else %}
+  "software_copyrightText": "<text> {{ fileData.copyrights|join('\n')
+    |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
+    |replace({'\f':'','"':"'", '\n':''}) }} </text>",
+  {% endif %}
+  {% if fileData.acknowledgements|default is not empty %}
+  "software_attributionText": "<text> {{ fileData.acknowledgements|join('\n')
+  |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
+  |replace({'\f':'','"':"'", '\n':''}) }} </text>"
+  {% endif %}
+  "verifiedUsing": [
+    {
+      "type": "Hash",
+      "algorithm": "sha1",
+      "hashValue": "{{ sha1 | lower }}"
+    },
+    {
+      "type": "Hash",
+      "algorithm": "sha256",
+      "hashValue": "{{ sha256 | lower }}"
+    },
+    {
+      "type": "Hash",
+      "algorithm": "md5",
+      "hashValue": "{{ md5 | lower }}"
+    }
+  ]
+},
+{%~ if fileData.isCleared() %}
+  {# File clearing decisions #}
+  {%~ if fileData.concludedLicenses|default is empty %}
+    {
+      "type": "expandedlicensing_IndividualLicensingInfo",
+      "spdxId": "https://spdx.org/rdf/3.0.0/terms/Software/File/SPDXRef-item{{ fileId }}#NoneLicense",
+      "creationInfo": "creationInfo:creationInfo1"
+    },
+  {%~ elseif fileData.concludedLicenses|length > 1 %}
+    {
+      {% if dualLicense %}
+        "type": "expandedlicensing_DisjunctiveLicenseSet",
+      {% else %}
+        "type": "expandedlicensing_ConjunctiveLicenseSet",
+      {% endif %} {# End dual license check #}
+      "spdxId": "https://spdx.org/rdf/3.0.0/terms/Software/File#SPDXRef-item{{ fileId }}",
+      "creationInfo": "creationInfo:creationInfo1",
+      "expandedlicensing_member": [
+        {%~ for res in fileData.concludedLicenses %}
+          {%~ if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' or licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+            {%- set licId = licenseList[res].licenseObj.spdxId %}
+            {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+              {% set licId = licenseList[res].licenseObj.shortName %}
+            {%- endif %}
+            {
+              "type": "simplelicensing_AnyLicenseInfo",
+              "creationInfo": "creationInfo:creationInfo1",
+              "spdxId": "{{ uri }}#{{ licId|replace({' ': '-'})|url_encode }}"
+            }{% if not loop.last %},{{ "\n" }}{% endif %}
+          {% else %}
+            {
+              "type": "simplelicensing_AnyLicenseInfo",
+              "creationInfo": "creationInfo:creationInfo1",
+              "spdxId": "{{ uri }}#{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}",
+              "name": "{{ licenseList[res].licenseObj.fullName|e }}"
+            }{% if not loop.last %},{{ "\n" }}{% endif %}
+          {% endif %}
+        {% endfor %}
+      ]
+    },
+  {%~ elseif fileData.concludedLicenses|length == 1 %}
+    {%- set res = fileData.concludedLicenses[0] %}
+    {%- if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' or licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+      {%- set licId = licenseList[res].licenseObj.spdxId %}
+      {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+        {% set licId = licenseList[res].licenseObj.shortName %}
+      {%- endif %}
+      {
+        "type": "simplelicensing_AnyLicenseInfo",
+        "creationInfo": "creationInfo:creationInfo1",
+        "spdxId": "https://spdx.org/rdf/3.0.0/terms/Software/File/SPDXRef-item{{ fileId }}#{{ licId|replace({' ': '-'})|url_encode }}"
+      },
+    {% else %}
+      {
+        "type": "simplelicensing_AnyLicenseInfo",
+        "creationInfo": "creationInfo:creationInfo1",
+        "spdxId": "https://spdx.org/rdf/3.0.0/terms/Software/File/SPDXRef-item{{ fileId }}#{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}",
+        "name": "{{ licenseList[res].licenseObj.fullName|e }}"
+      },
+    {% endif %} 
+  {%~ endif %}{# End printing single conclusion #}
+  {%~ else %}
+    {# No concluded licenses #}
+    {
+      "type": "expandedlicensing_IndividualLicensingInfo",
+      "spdxId": "https://spdx.org/rdf/3.0.0/terms/Software/File/SPDXRef-item{{ fileId }}#NoAssertionLicense",
+      "creationInfo": "creationInfo:creationInfo1"
+    },
+{% endif %}

--- a/src/spdx2/agent/template/spdx3json-package.twig
+++ b/src/spdx2/agent/template/spdx3json-package.twig
@@ -1,0 +1,128 @@
+{# SPDX-FileCopyrightText: © 2015 Siemens AG
+
+   SPDX-License-Identifier: FSFAP
+#}
+{%- set dualLicense = false -%}
+{% if mainLicenses|length > 2 %}
+  {% for res in mainLicenses %}
+    {% if 'Dual-license' == licenseList[res].licenseObj.shortName %}
+      {% set dualLicense = true %}
+    {% endif %}
+  {% endfor %}
+{%- endif -%}
+{
+  "type": "software_Package",
+  "spdxId": "https://spdx.org/rdf/3.0.0/terms/Software/Package#SPDXRef-upload{{ packageId }}",
+  "creationInfo":"https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1",
+  "name": "{{ packageName }}",
+  {% if licenseComments %}
+  "comment": "<text> {{ licenseComments|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})| replace({'\f':'','"':"'", '\n':''})}} </text>",
+  {% endif %}
+  "software_downloadLocation": "NOASSERTION",
+  {% if packageVersion is not empty %}
+  "software_packageVersion": "{{ packageVersion }}",
+  {% endif %}
+  {% if releaseDate is not empty %}
+  "releaseTime":"{{ releaseDate }}",
+  {% endif %}
+  {%- if componentId is not empty ~%}
+  "externalRef": [
+        {
+          "type": "ExternalRef",
+          "comment":"Package-Manager"
+          "externalRefType": "{{ componentType }}",
+          "locator":["{{ componentId|trim }}"]
+        }
+      ],
+  {%- endif ~%}
+  "software_copyrightText": "NOASSERTION",
+  {% if obligations|default is not empty %}
+  "software_attributionText": ["<text> {{ obligations|join('\n')
+                                             |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
+                                             |replace({'\f':''}) }} </text>"],
+  {% endif %}
+  "verifiedUsing": [
+    {
+      "type": "Hash",
+      "algorithm": "sha1",
+      "hashValue": "{{ sha1 | lower }}"
+    },
+    {
+      "type": "Hash",
+      "algorithm": "sha256",
+      "hashValue": "{{ sha256 | lower }}"
+    },
+    {
+      "type": "Hash",
+      "algorithm": "md5",
+      "hashValue": "{{ md5 | lower }}"
+    }
+  ]
+},
+{
+  "type": "PackageVerificationCode",
+  "algorithm": "sha1",
+  "hashValue": "{{verificationCode}}"
+},
+{% if mainLicenses|length > 1 %}
+{
+  {% if dualLicense %}
+    "type": "expandedlicensing_DisjunctiveLicenseSet",
+  {% else %}
+    "type": "expandedlicensing_ConjunctiveLicenseSet",
+  {% endif %}
+  "spdxId": "https://spdx.org/rdf/3.0.0/terms/Software/Package#SPDXRef-upload{{ packageId }}",
+  "creationInfo":"https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"
+  "expandedlicensing_member": [
+    {% for res in mainLicenses %}
+      {% if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' %}
+        {% set licId = licenseList[res].licenseObj.spdxId %}
+        {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+          {% set licId = licenseList[res].licenseObj.shortName %}
+        {% endif %}
+        {
+          "type": "simplelicensing_AnyLicenseInfo",
+          "creationInfo":"https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"
+          "spdxId": "{{ uri }}#{{ licId|replace({' ': '-'})|url_encode }}"
+        }{% if not loop.last %},{{ "\n" }}{% endif %}
+      {% else %}
+        {
+          "type": "simplelicensing_AnyLicenseInfo",
+          "creationInfo": "creationInfo:creationInfo1",
+          "spdxId": "{{ uri }}#{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}"
+        }{% if not loop.last %},{{ "\n" }}{% endif %}
+      {% endif %}
+    {% endfor %}
+  ]
+},
+{% elseif mainLicenses|length == 1 %}
+  {% set res = mainLicenses[0] %}
+  {% if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' %}
+    {% set licId = licenseList[res].licenseObj.spdxId %}
+    {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+      {% set licId = licenseList[res].licenseObj.shortName %}
+    {% endif %}
+    {
+      "type": "simplelicensing_AnyLicenseInfo",
+      "creationInfo": "creationInfo:creationInfo1",
+      "spdxId": "https://spdx.org/rdf/3.0.0/terms/Software/Package/SPDXRef-upload{{ packageId }}#{{ licId|replace({' ': '-'})|url_encode }}"
+    },
+  {% else %}
+    {
+      "type": "simplelicensing_AnyLicenseInfo",
+      "creationInfo": "creationInfo:creationInfo1",
+      "spdxId": "https://spdx.org/rdf/3.0.0/terms/Software/Package/SPDXRef-upload{{ packageId }}#{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}"
+    },
+  {% endif %}
+{% endif %}
+{
+    "type": "Relationship",
+    "spdxId": "{{ uri }}:SPDXRef-Relationship-0",
+    "from": "https://spdx.org/rdf/3.0.0/terms/Core/SpdxDocument#SpdxRef-DOCUMENT",
+    "to": [
+        "https://spdx.org/rdf/3.0.0/terms/Software/Package#SPDXRef-upload{{ packageId }}"
+    ],
+    "relationshipType": "describes",
+    "creationInfo":"https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"
+},
+{{ fileNodes }}

--- a/src/spdx2/agent/template/spdx3jsonld-document.twig
+++ b/src/spdx2/agent/template/spdx3jsonld-document.twig
@@ -1,0 +1,120 @@
+{# SPDX-FileCopyrightText: © 2015 Siemens AG
+
+   SPDX-License-Identifier: FSFAP
+#}
+{
+"@context": "https://spdx.org/rdf/3.0.0/spdx-context.jsonld",
+"@graph":[
+  {
+      "type":"NamespaceMap",
+      "namespace":"{{ uri }}",
+      "prefix":"URI"
+  },
+  {
+    "@id": "creationInfo:creationInfo1",
+    "type": "CreationInfo",
+    "specVersion": "3.0.0",
+    "created": "{{ 'now'|date('Y-m-d\\TH:i:s\\Z', 'UTC') }}",
+    "createdBy": [
+    "Person:SPDXRef-Actor-{{ userName | replace({' (': '-', ')': ''}) }}"
+    ],
+    "createdUsing": [
+    "Tool:SPDXRef-Actor-{{ toolVersion }}"
+    ],
+    "comment":"<text>This document was created using license information and a generator from Fossology.</text>"
+  },
+  {
+    "type":"SpdxDocument",
+    "spdxId":"SpdxDocument:SpdxRef-DOCUMENT",
+    "creationInfo":"creationInfo:creationInfo1",
+    "name": "{{ documentName }}",
+    "profileConformance": ["core", "software", "simpleLicensing", "expandedLicensing"],
+    "element": [
+        "Tool:SPDXRef-Actor-{{ toolVersion }}",
+        "Person:SPDXRef-Actor-{{ userName | replace({' (': '-', ')': ''}) }}",
+        {% for packageId in packageIds%}
+        "Package:SPDXRef-upload{{ packageId }}",
+        {% endfor %}
+        {% for fileId in fileIds%}
+        "File:SPDXRef-item{{ fileId }}"{% if not loop.last %},{{ "\n" }}{% endif %}
+        {% endfor %}
+    ],
+    "rootElement": [
+        {% for packageId in packageIds%}
+        "Package:SPDXRef-upload{{ packageId }}"{% if not loop.last %},{{ "\n" }}{% endif %}
+        {% endfor %}
+    ],
+    "dataLicense": {
+        "type": "simplelicensing_AnyLicenseInfo",
+        "creationInfo": "creationInfo:creationInfo1",
+        "description":"{{ licenseList[dataLicense].licenseObj.spdxId|replace({' ': '-'}) }}"
+      }
+  },
+  {% if toolVersion is not empty %} 
+  {
+    "type":"Tool",
+    "spdxId":"Tool:SPDXRef-Actor-{{ toolVersion }}",
+    "creationInfo":"creationInfo:creationInfo1",
+    "name": "{{ toolVersion }}"
+  },
+  {% endif %}
+  {% if userName is not empty %}
+  {
+    "type": "Person",
+    "spdxId": "Person:SPDXRef-Actor-{{ userName | replace({' (': '-', ')': ''}) }}",
+    "creationInfo":"creationInfo:creationInfo1",
+    "name": "{{ userName | split(' ')[0] }}",
+    "externalIdentifier": [
+      {
+        "type": "ExternalIdentifier",
+        "externalIdentifierType": "email",
+        "identifier": "{{ userName | split(' (')[1] | split(')')[0]}}"
+      }   
+    ]
+  },
+  {% endif %}
+  {% if organization is not empty %}
+  {
+    "type":"Organization",
+    "spdxId":"Organization:SPDXRef-Actor-{{ organization }}",
+    "creationInfo":"creationInfo:creationInfo1",
+    "name": "{{ userName | split(' ')[0] }}"
+  },
+  {% endif %}
+  {% for licenseData in licenseList %}{% if licenseData.licenseObj.spdxId starts with 'LicenseRef-' or licenseData.licenseObj.shortName starts with 'LicenseRef-' ~%}
+    {%- set licId=licenseData.licenseObj.spdxId %}
+    {% if licenseData.licenseObj.shortName starts with 'LicenseRef-' %}
+        {% set licId=licenseData.licenseObj.shortName %}
+    {%- endif ~%}
+    {
+      "type":"expandedlicensing_CustomLicense",
+      "spdxId":"URI:{{ licId|replace({' ': '-'}) }}",
+      "creationInfo":"creationInfo:creationInfo1",
+      "name":"{{ licenseData.licenseObj.fullName }}",
+      "simplelicensing_licenseText":"<text> {{ licenseData.licenseObj.text|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})|replace({'\f':'','"':"'", '\n':''}) }} </text>"{% if licenseData.licenseObj.url is not empty %},{% endif %}
+      {% if licenseData.licenseObj.url is not empty %}
+      {%~ if '&' in licenseData.licenseObj.url %}
+      "expandedlicensing_seeAlso":["{{ licenseData.licenseObj.url|url_encode }}"]
+      {%~ else %}
+      "expandedlicensing_seeAlso":["{{ licenseData.licenseObj.url }}"]
+      {%~ endif %}
+      {% endif %}
+    },
+  {% endif %}{% endfor %}
+  {{packageNodes}}
+  {% for packageId in packageIds%}
+  {
+    "type": "Relationship",
+    "spdxId": "URI:SPDXRef-Relationship-{{ fileIds | length }}",
+    "from":"Package:SPDXRef-upload{{ packageId }}",
+    "to": [
+        {% for fileId in fileIds%}
+        "File:SPDXRef-item{{ fileId }}"{% if not loop.last %},{{ "\n" }}{% endif %}
+        {% endfor %}
+    ],
+    "relationshipType": "describes",
+    "creationInfo":"creationInfo:creationInfo1"
+  }
+  {% endfor %}
+  ]
+}

--- a/src/spdx2/agent/template/spdx3jsonld-file.twig
+++ b/src/spdx2/agent/template/spdx3jsonld-file.twig
@@ -1,0 +1,126 @@
+{# SPDX-FileCopyrightText: © 2015 Siemens AG
+
+   SPDX-License-Identifier: FSFAP
+#}
+{% set dualLicense = false %}
+{% set textPrintedList = [] %}
+{% if fileData.concludedLicenses|length > 2 %}
+  {% for res in fileData.concludedLicenses %}
+    {% if 'Dual-license' == licenseList[res].licenseObj.shortName %}
+      {% set dualLicense = true %}
+    {% endif %}
+  {% endfor %}
+{%- endif -%}
+{
+  "type": "software_File",
+  "spdxId": "File:SPDXRef-item{{ fileId }}",
+  "creationInfo":"creationInfo:creationInfo1",
+  "name": "{{ fileName }}",
+  {% if licenseCommentState %}
+  {% if fileData.comments is empty %}
+  "comment": "NOASSERTION",
+  {%~ else %}
+  "comment": "<text> {{ fileData.comments|join('\n')
+  |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
+  |replace({'\f':''}) }} </text>",
+  {% endif %}
+  {% endif %}
+  {% if fileData.copyrights|default is empty %}
+  "software_copyrightText": "NOASSERTION",
+  {% else %}
+  "software_copyrightText": "<text> {{ fileData.copyrights|join('\n')
+    |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
+    |replace({'\f':'','"':"'", '\n':''}) }} </text>",
+  {% endif %}
+  {% if fileData.acknowledgements|default is not empty %}
+  "software_attributionText": "<text> {{ fileData.acknowledgements|join('\n')
+  |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
+  |replace({'\f':'','"':"'", '\n':''}) }} </text>"
+  {% endif %}
+  "verifiedUsing": [
+    {
+      "type": "Hash",
+      "algorithm": "sha1",
+      "hashValue": "{{ sha1 | lower }}"
+    },
+    {
+      "type": "Hash",
+      "algorithm": "sha256",
+      "hashValue": "{{ sha256 | lower }}"
+    },
+    {
+      "type": "Hash",
+      "algorithm": "md5",
+      "hashValue": "{{ md5 | lower }}"
+    }
+  ]
+},
+{%~ if fileData.isCleared() %}
+  {# File clearing decisions #}
+  {%~ if fileData.concludedLicenses|default is empty %}
+    {
+      "type": "expandedlicensing_IndividualLicensingInfo",
+      "spdxId": "File:SPDXRef-item{{ fileId }}#NoneLicense",
+      "creationInfo": "creationInfo:creationInfo1"
+    },
+  {%~ elseif fileData.concludedLicenses|length > 1 %}
+    {
+      {% if dualLicense %}
+        "type": "expandedlicensing_DisjunctiveLicenseSet",
+      {% else %}
+        "type": "expandedlicensing_ConjunctiveLicenseSet",
+      {% endif %} {# End dual license check #}
+      "spdxId": "File:SPDXRef-item{{ fileId }}",
+      "creationInfo": "creationInfo:creationInfo1",
+      "expandedlicensing_member": [
+        {%~ for res in fileData.concludedLicenses %}
+          {%~ if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' or licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+            {%- set licId = licenseList[res].licenseObj.spdxId %}
+            {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+              {% set licId = licenseList[res].licenseObj.shortName %}
+            {%- endif %}
+            {
+              "type": "simplelicensing_AnyLicenseInfo",
+              "creationInfo": "creationInfo:creationInfo1",
+              "spdxId": "URI:#{{ licId|replace({' ': '-'})|url_encode }}"
+            }{% if not loop.last %},{{ "\n" }}{% endif %}
+          {% else %}
+            {
+              "type": "simplelicensing_AnyLicenseInfo",
+              "creationInfo": "creationInfo:creationInfo1",
+              "spdxId": "URI:#{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}",
+              "name": "{{ licenseList[res].licenseObj.fullName|e }}"
+            }{% if not loop.last %},{{ "\n" }}{% endif %}
+          {% endif %}
+        {% endfor %}
+      ]
+    },
+  {%~ elseif fileData.concludedLicenses|length == 1 %}
+    {%- set res = fileData.concludedLicenses[0] %}
+    {%- if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' or licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+      {%- set licId = licenseList[res].licenseObj.spdxId %}
+      {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+        {% set licId = licenseList[res].licenseObj.shortName %}
+      {%- endif %}
+      {
+        "type": "simplelicensing_AnyLicenseInfo",
+        "creationInfo": "creationInfo:creationInfo1",
+        "spdxId": "File:SPDXRef-item{{ fileId }}#{{ licId|replace({' ': '-'})|url_encode }}"
+      },
+    {% else %}
+      {
+        "type": "simplelicensing_AnyLicenseInfo",
+        "creationInfo": "creationInfo:creationInfo1",
+        "spdxId": "File:SPDXRef-item{{ fileId }}#{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}",
+        "name": "{{ licenseList[res].licenseObj.fullName|e }}"
+      },
+    {% endif %} 
+  {%~ endif %}{# End printing single conclusion #}
+  {%~ else %}
+    {# No concluded licenses #}
+    {
+      "type": "expandedlicensing_IndividualLicensingInfo",
+      "spdxId": "File:SPDXRef-item{{ fileId }}#NoAssertionLicense",
+      "creationInfo": "creationInfo:creationInfo1"
+    },
+{% endif %}

--- a/src/spdx2/agent/template/spdx3jsonld-package.twig
+++ b/src/spdx2/agent/template/spdx3jsonld-package.twig
@@ -1,0 +1,128 @@
+{# SPDX-FileCopyrightText: © 2015 Siemens AG
+
+   SPDX-License-Identifier: FSFAP
+#}
+{%- set dualLicense = false -%}
+{% if mainLicenses|length > 2 %}
+  {% for res in mainLicenses %}
+    {% if 'Dual-license' == licenseList[res].licenseObj.shortName %}
+      {% set dualLicense = true %}
+    {% endif %}
+  {% endfor %}
+{%- endif -%}
+{
+  "type": "software_Package",
+  "spdxId": "Package:SPDXRef-upload{{ packageId }}",
+  "creationInfo":"creationInfo:creationInfo1",
+  "name": "{{ packageName }}",
+  {%- if licenseComments is not empty ~%}
+  "comment": "<text> {{ licenseComments|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})| replace({'\f':'','"':"'", '\n':''})}} </text>",
+  {% endif %}
+  "software_downloadLocation": "NOASSERTION",
+  {% if packageVersion is not empty %}
+  "software_packageVersion": "{{ packageVersion|e }}",
+  {% endif %}
+  {% if releaseDate is not empty %}
+  "releaseTime":"{{ releaseDate }}",
+  {% endif %}
+  {%- if componentId is not empty ~%}
+  "externalRef": [
+        {
+          "type": "ExternalRef",
+          "comment":"Package-Manager"
+          "externalRefType": "{{ componentType }}",
+          "locator":["{{ componentId|trim }}"]
+        }
+      ],
+  {%- endif ~%}
+  "software_copyrightText": "NOASSERTION",
+  {% if obligations|default is not empty %}
+  "software_attributionText": ["<text> {{ obligations|join('\n')
+                                             |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
+                                             |replace({'\f':''}) }} </text>"],
+  {% endif %}
+  "verifiedUsing": [
+    {
+      "type": "Hash",
+      "algorithm": "sha1",
+      "hashValue": "{{ sha1 | lower }}"
+    },
+    {
+      "type": "Hash",
+      "algorithm": "sha256",
+      "hashValue": "{{ sha256 | lower }}"
+    },
+    {
+      "type": "Hash",
+      "algorithm": "md5",
+      "hashValue": "{{ md5 | lower }}"
+    }
+  ]
+},
+{
+  "type": "PackageVerificationCode",
+  "algorithm": "sha1",
+  "hashValue": "{{verificationCode}}"
+},
+{% if mainLicenses|length > 1 %}
+{
+  {% if dualLicense %}
+    "type": "expandedlicensing_DisjunctiveLicenseSet",
+  {% else %}
+    "type": "expandedlicensing_ConjunctiveLicenseSet",
+  {% endif %}
+  "spdxId": "Package:SPDXRef-upload{{ packageId }}",
+  "creationInfo": "creationInfo:creationInfo1",
+  "expandedlicensing_member": [
+    {% for res in mainLicenses %}
+      {% if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' %}
+        {% set licId = licenseList[res].licenseObj.spdxId %}
+        {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+          {% set licId = licenseList[res].licenseObj.shortName %}
+        {% endif %}
+        {
+          "type": "simplelicensing_AnyLicenseInfo",
+          "creationInfo": "creationInfo:creationInfo1",
+          "spdxId": "URI:#{{ licId|replace({' ': '-'})|url_encode }}"
+        }{% if not loop.last %},{{ "\n" }}{% endif %}
+      {% else %}
+        {
+          "type": "simplelicensing_AnyLicenseInfo",
+          "creationInfo": "creationInfo:creationInfo1",
+          "spdxId": "URI:#{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}"
+        }{% if not loop.last %},{{ "\n" }}{% endif %}
+      {% endif %}
+    {% endfor %}
+  ]
+},
+{% elseif mainLicenses|length == 1 %}
+  {% set res = mainLicenses[0] %}
+  {% if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' %}
+    {% set licId = licenseList[res].licenseObj.spdxId %}
+    {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+      {% set licId = licenseList[res].licenseObj.shortName %}
+    {% endif %}
+    {
+      "type": "simplelicensing_AnyLicenseInfo",
+      "creationInfo": "creationInfo:creationInfo1",
+      "spdxId": "URI:#{{ licId|replace({' ': '-'})|url_encode }}"
+    },
+  {% else %}
+    {
+      "type": "simplelicensing_AnyLicenseInfo",
+      "creationInfo": "creationInfo:creationInfo1",
+      "spdxId": "URI:#{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}"
+    },
+  {% endif %}
+{% endif %}
+{
+    "type": "Relationship",
+    "spdxId": "URI:SPDXRef-Relationship-0",
+    "from": "SpdxDocument:SpdxRef-DOCUMENT",
+    "to": [
+        "Package:SPDXRef-upload{{ packageId }}"
+    ],
+    "relationshipType": "describes",
+    "creationInfo":"creationInfo:creationInfo1"
+},
+{{ fileNodes }}

--- a/src/spdx2/agent/template/spdx3rdf-document.xml.twig
+++ b/src/spdx2/agent/template/spdx3rdf-document.xml.twig
@@ -1,0 +1,105 @@
+{# SPDX-FileCopyrightText: © 2015,2023 Siemens AG
+
+   SPDX-License-Identifier: FSFAP
+#}
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:spdx="https://spdx.org/rdf/3.0.0/spdx-context.jsonld#">
+
+  <spdx:CreationInfo rdf:about="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1">
+    <spdx:specVersion>3.0.0</spdx:specVersion>
+    <spdx:created>{{ 'now'|date('Y-m-d\\TH:i:s\\Z', 'UTC') }}</spdx:created>
+    <spdx:createdBy rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/Person#SPDXRef-Actor-{{ userName | replace({' (': '-', ')': ''}) }}"/>
+    <spdx:createdUsing rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/Tool#SPDXRef-Actor-{{ toolVersion }}"/>
+    <rdfs:comment><text>This document was created using license information and a generator from Fossology.</text></rdfs:comment>
+  </spdx:CreationInfo>
+  <spdx:SpdxDocument rdf:about="https://spdx.org/rdf/3.0.0/terms/Core/SpdxDocument#SpdxRef-DOCUMENT">
+    <spdx:spdxId>SpdxRef-DOCUMENT</spdx:spdxId>
+    <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+    <spdx:name>{{ documentName }}</spdx:name>
+    <spdx:profileConformance>core</spdx:profileConformance>
+    <spdx:profileConformance>software</spdx:profileConformance>
+    <spdx:profileConformance>simpleLicensing</spdx:profileConformance>
+    <spdx:profileConformance>expandedLicensing</spdx:profileConformance>
+    <spdx:element rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/Tool#SPDXRef-Actor-{{ toolVersion }}"/>
+    <spdx:element rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/Person#SPDXRef-Actor-{{ userName | replace({' (': '-', ')': ''}) }}"/>
+    {% for packageId in packageIds %}
+    <spdx:element rdf:resource="https://spdx.org/rdf/3.0.0/terms/Software/Package#SPDXRef-upload{{ packageId }}"/>
+    {% endfor %}
+    {% for fileId in fileIds %}
+    <spdx:element rdf:resource="https://spdx.org/rdf/3.0.0/terms/Software/File#SPDXRef-item{{ fileId }}"/>
+    {% endfor %}
+    {% for packageId in packageIds %}
+    <spdx:rootElement rdf:resource="https://spdx.org/rdf/3.0.0/terms/Software/Package#SPDXRef-upload{{ packageId }}"/>
+    {% endfor %}
+    <spdx:dataLicense >
+      <spdx:simplelicensing_AnyLicenseInfo >
+        <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+        <spdx:description>{{ licenseList[dataLicense].licenseObj.spdxId|replace({' ': '-'}) }}</spdx:description>
+      </spdx:simplelicensing_AnyLicenseInfo>
+    </spdx:dataLicense>
+  </spdx:SpdxDocument>
+
+  {% if toolVersion is not empty %}
+  <spdx:Tool rdf:about="https://spdx.org/rdf/3.0.0/terms/Core/Tool#SPDXRef-Actor-{{ toolVersion }}">
+    <spdx:spdxId>SPDXRef-Actor-{{ toolVersion }}</spdx:spdxId>
+    <spdx:creationInfo rdf:resource="#creationInfo:creationInfo1"/>
+    <spdx:name>{{ toolVersion }}</spdx:name>
+  </spdx:Tool>
+  {% endif %}
+
+  {% if userName is not empty %}
+  <spdx:Person rdf:about="https://spdx.org/rdf/3.0.0/terms/Core/Person#SPDXRef-Actor-{{ userName | replace({' (': '-', ')': ''}) }}">
+    <spdx:spdxId>SPDXRef-Actor-{{ userName | replace({' (': '-', ')': ''}) }}</spdx:spdxId>
+    <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+    <spdx:name>{{ userName | split(' ')[0] }}</spdx:name>
+    <spdx:externalIdentifier>
+      <spdx:ExternalIdentifier>
+        <spdx:externalIdentifierType>email</spdx:externalIdentifierType>
+        <spdx:identifier>{{ userName | split(' (')[1] | split(')')[0] }}</spdx:identifier>
+      </spdx:ExternalIdentifier>
+    </spdx:externalIdentifier>
+  </spdx:Person>
+  {% endif %}
+
+  {% if organization is not empty %}
+  <spdx:Organization rdf:about="https://spdx.org/rdf/3.0.0/terms/Core/Organization#SPDXRef-Actor-{{ organization }}">
+    <spdx:spdxId>SPDXRef-Actor-{{ organization }}</spdx:spdxId>
+    <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+    <spdx:name>{{ userName | split(' ')[0] }}</spdx:name>
+  </spdx:Tool>
+  {% endif %}
+  {% for licenseData in licenseList %}{% if licenseData.licenseObj.spdxId starts with 'LicenseRef-' or licenseData.licenseObj.shortName starts with 'LicenseRef-' ~%}
+    {%- set licId=licenseData.licenseObj.spdxId %}
+    {% if licenseData.licenseObj.shortName starts with 'LicenseRef-' %}
+        {% set licId=licenseData.licenseObj.shortName %}
+    {%- endif ~%}
+    <spdx:expandedlicensing_CustomLicense rdf:about="https://spdx.org/rdf/3.0.0/terms/ExpandedLicensing/CustomLicense#{{ licId|replace({' ': '-'}) }}">
+      <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+      <spdx:name>{{ licenseData.licenseObj.fullName }}</spdx:name>
+      <spdx:simplelicensing_licenseText><text> {{ licenseData.licenseObj.text|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})|replace({'\f':'','"':"'", '\n':''}) }} </text></spdx:simplelicensing_licenseText>
+      {% if licenseData.licenseObj.url is not empty %}
+      {%~ if '&' in licenseData.licenseObj.url %}
+      <spdx:expandedlicensing_seeAlso>{{ licenseData.licenseObj.url|url_encode }}</spdx:expandedlicensing_seeAlso>
+      {%~ else %}
+      <spdx:expandedlicensing_seeAlso>{{ licenseData.licenseObj.url }}</spdx:expandedlicensing_seeAlso>
+      {%~ endif %}
+      {% endif %}
+      </spdx:expandedlicensing_CustomLicense>
+  {% endif %}{% endfor %}
+  {{ packageNodes }}
+  {% for packageId in packageIds%}
+  <spdx:Relationship>
+    <spdx:spdxId>SPDXRef-Relationship-{{ fileIds | length }}</spdx:spdxId>
+    <spdx:relationshipType>describes</spdx:relationshipType>
+    <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+    <spdx:from>https://spdx.org/rdf/3.0.0/terms/Software/Package#SPDXRef-upload{{ packageId }}</spdx:from>
+    {% for fileId in fileIds%}
+    <spdx:to>https://spdx.org/rdf/3.0.0/terms/Software/File#SPDXRef-upload{{ fileId }}</spdx:to>
+    {% endfor %}
+  </spdx:Relationship>
+  {% endfor %}
+
+</rdf:RDF>

--- a/src/spdx2/agent/template/spdx3rdf-file.xml.twig
+++ b/src/spdx2/agent/template/spdx3rdf-file.xml.twig
@@ -1,0 +1,115 @@
+{# SPDX-FileCopyrightText: © 2015,2023 Siemens AG
+
+   SPDX-License-Identifier: FSFAP
+#}
+{% set dualLicense = false %}
+{% set textPrintedList = [] %}
+{% if fileData.concludedLicenses|length > 2 %}
+  {% for res in fileData.concludedLicenses %}
+    {% if 'Dual-license' == licenseList[res].licenseObj.shortName %}
+      {% set dualLicense = true %}
+    {% endif %}
+  {% endfor %}
+{%- endif -%}
+  <spdx:File rdf:about="https://spdx.org/rdf/3.0.0/terms/Software/File#SPDXRef-item{{ fileId }}">
+    <spdx:spdxId>SPDXRef-item{{ fileId }}</spdx:spdxId>
+    <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+    <spdx:name>{{ fileName }}</spdx:name>
+    {% if licenseCommentState %}
+    {% if fileData.comments is empty %}
+    <spdx:comment>NOASSERTION</spdx:comment>
+    {%~ else %}
+    <spdx:comment><text>{{ fileData.comments|join('\n')|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;','\f':''}) }}</text></spdx:comment>
+    {% endif %}
+    {% endif %}
+    {%~ if fileData.copyrights|default is empty %}
+    <spdx:software_copyrightText rdf:resource="http://spdx.org/rdf/terms#noassertion" />
+    {%~ else %}
+    <spdx:software_copyrightText><![CDATA[
+    {%~ for cp in fileData.copyrights %}
+      {{ cp|replace({'\f':''})
+           |replace({']]>':']]]]><![CDATA[>'}) }}
+    {%~ endfor %}
+    ]]></spdx:software_copyrightText>
+    {%~ endif %}
+    {% if fileData.acknowledgements|default is not empty %}
+    <spdx:software_attributionText>&lt;text&gt;{{ fileData.acknowledgements|join('\n')|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;','\f':'','"':"'", '\n':''}) }}&lt;/text&gt;</spdx:software_attributionText>
+    {% endif %}
+    <spdx:verifiedUsing>
+      <spdx:Hash>
+        <spdx:algorithm>sha1</spdx:algorithm>
+        <spdx:hashValue>{{ sha1 | lower }}</spdx:hashValue>
+        <spdx:algorithm>sha256</spdx:algorithm>
+        <spdx:hashValue>{{ sha256 | lower }}</spdx:hashValue>
+        <spdx:algorithm>md5</spdx:algorithm>
+        <spdx:hashValue>{{ md5 | lower }}</spdx:hashValue>
+      </spdx:Hash>
+    </spdx:verifiedUsing>
+  </spdx:File>
+{%~ if fileData.isCleared() %}
+  {# File clearing decisions #}
+  {%~ if fileData.concludedLicenses|default is empty %}
+    <spdx:expandedlicensing_IndividualLicensingInfo rdf:about="https://spdx.org/rdf/3.0.0/terms/ExpandedLicensing/IndividualLicensingInfo">
+      <spdx:spdxId rdf:resource="https://spdx.org/rdf/3.0.0/terms/Software/File/SPDXRef-item{{ fileId }}#NoneLicense"/>
+      <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+    </spdx:expandedlicensing_IndividualLicensingInfo>
+  {%~ elseif fileData.concludedLicenses|length > 1 %}
+      {% if dualLicense %}
+        <spdx:expandedlicensing_DisjunctiveLicenseSet rdf:about="https://spdx.org/rdf/3.0.0/terms/ExpandedLicensing/DisjunctiveLicenseSet">
+      {% else %}
+        <spdx:expandedlicensing_ConjunctiveLicenseSet rdf:about="https://spdx.org/rdf/3.0.0/terms/ExpandedLicensing/ConjunctiveLicenseSet">
+      {% endif %} {# End dual license check #}
+      <spdx:spdxId rdf:resource="https://spdx.org/rdf/3.0.0/terms/Software/File#SPDXRef-item{{ fileId }}"/>
+      <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+      <spdx:expandedlicensing_member rdf:about="https://spdx.org/rdf/3.0.0/terms/ExpandedLicensing/member">
+        {%~ for res in fileData.concludedLicenses %}
+          {%~ if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' or licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+            {%- set licId = licenseList[res].licenseObj.spdxId %}
+            {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+              {% set licId = licenseList[res].licenseObj.shortName %}
+            {%- endif %}
+            <spdx:simplelicensing_AnyLicenseInfo rdf:about="https://spdx.org/rdf/3.0.0/terms/SimpleLicensing/AnyLicenseInfo">
+              <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+              <spdx:spdxId rdf:resource="{{ uri }}#{{ licId|replace({' ': '-'})|url_encode }}"/>
+            </spdx:simplelicensing_AnyLicenseInfo>
+          {% else %}
+            <spdx:simplelicensing_AnyLicenseInfo rdf:about="https://spdx.org/rdf/3.0.0/terms/SimpleLicensing/AnyLicenseInfo">
+              <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+              <spdx:spdxId rdf:resource="{{ uri }}#{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}"/>
+              "name": "{{ licenseList[res].licenseObj.fullName|e }}"
+            </spdx:simplelicensing_AnyLicenseInfo>
+          {% endif %}
+        {% endfor %}
+      </spdx:expandedlicensing_member>
+    {% if dualLicense %}
+        </spdx:expandedlicensing_DisjunctiveLicenseSet>
+      {% else %}
+        </spdx:expandedlicensing_ConjunctiveLicenseSet>
+      {% endif %} {# End dual license check #}
+  {%~ elseif fileData.concludedLicenses|length == 1 %}
+    {%- set res = fileData.concludedLicenses[0] %}
+    {%- if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' or licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+      {%- set licId = licenseList[res].licenseObj.spdxId %}
+      {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+        {% set licId = licenseList[res].licenseObj.shortName %}
+      {%- endif %}
+      <spdx:simplelicensing_AnyLicenseInfo rdf:about="https://spdx.org/rdf/3.0.0/terms/SimpleLicensing/AnyLicenseInfo">
+        <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+        <spdx:spdxId rdf:resource="https://spdx.org/rdf/3.0.0/terms/Software/File/SPDXRef-item{{ fileId }}#{{ licId|replace({' ': '-'})|url_encode }}"/>
+      </spdx:simplelicensing_AnyLicenseInfo>
+    {% else %}
+      <spdx:simplelicensing_AnyLicenseInfo rdf:about="https://spdx.org/rdf/3.0.0/terms/SimpleLicensing/AnyLicenseInfo">
+        <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+        <spdx:spdxId rdf:resource="https://spdx.org/rdf/3.0.0/terms/Software/File/SPDXRef-item{{ fileId }}#{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}"/>
+        <spdx:name>{{ licenseList[res].licenseObj.fullName|e }}</spdx:name>
+      </spdx:simplelicensing_AnyLicenseInfo>
+    {% endif %} 
+  {%~ endif %}{# End printing single conclusion #}
+  {%~ else %}
+    {# No concluded licenses #}
+    <spdx:expandedlicensing_IndividualLicensingInfo rdf:about="https://spdx.org/rdf/3.0.0/terms/ExpandedLicensing/IndividualLicensingInfo">
+      <spdx:spdxId rdf:resource="https://spdx.org/rdf/3.0.0/terms/Software/File/SPDXRef-item{{ fileId }}#NoAssertionLicense"/>
+      <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+    </spdx:expandedlicensing_IndividualLicensingInfo>
+{% endif %}
+

--- a/src/spdx2/agent/template/spdx3rdf-package.xml.twig
+++ b/src/spdx2/agent/template/spdx3rdf-package.xml.twig
@@ -1,0 +1,115 @@
+{# SPDX-FileCopyrightText: © 2015 Siemens AG
+
+   SPDX-License-Identifier: FSFAP
+#}
+{%- set dualLicense = false -%}
+{% if mainLicenses|length > 2 %}
+  {% for res in mainLicenses %}
+    {% if 'Dual-license' == licenseList[res].licenseObj.shortName %}
+      {% set dualLicense = true %}
+    {% endif %}
+  {% endfor %}
+{%- endif -%}
+<spdx:Package rdf:about="https://spdx.org/rdf/3.0.0/terms/Software/Package#SPDXRef-upload{{ packageId }}">
+   <spdx:spdxId>SPDXRef-upload{{ packageId }}</spdx:spdxId>
+   <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+   <spdx:name>{{ packageName }}</spdx:name>
+   {% if licenseComments %}
+   <rdfs:comment>&lt;text&gt;{{ licenseComments|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;','\f':'','"':"'", '\n':''}) }}&lt;/text&gt;</rdfs:comment>
+   {% endif %}
+   <spdx:software_downloadLocation>NOASSERTION</spdx:software_downloadLocation>
+   {% if packageVersion is not empty %}
+   <spdx:software_packageVersion>{{ packageVersion }}</spdx:software_packageVersion>
+   {% endif %}
+   {% if releaseDate is not empty %}
+   <spdx:releaseTime>{{ releaseDate }}</spdx:releaseTime>
+   {% endif %}
+   {%- if componentId is not empty ~%}
+   <spdx:externalRef rdf:about="https://spdx.org/rdf/3.0.0/terms/Core/externalRef">
+      <spdx:ExternalRef rdf:about="https://spdx.org/rdf/3.0.0/terms/Core/ExternalRef">
+        <spdx:comment>Package-Manager</spdx:comment>
+        <spdx:externalRefType>{{ componentType }}</spdx:externalRefType>
+        <spdx:locator>{{ componentId|trim }}</spdx:locator>
+      </spdx:ExternalRef>
+    </spdx:externalRef>
+   {%- endif ~%}
+   <spdx:software_copyrightText>NOASSERTION</spdx:software_copyrightText>
+   {% if obligations|default is not empty %}
+   <spdx:software_attributionText><text>{{ obligations|join('\n')|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;','\f':''}) }}</text>></spdx:software_attributionText>
+   {% endif %}
+   <spdx:verifiedUsing>
+      <spdx:Hash>
+         <spdx:algorithm>sha1</spdx:algorithm>
+         <spdx:hashValue>{{ sha1 | lower }}</spdx:hashValue>
+         <spdx:algorithm>sha256</spdx:algorithm>
+         <spdx:hashValue>{{ sha256 | lower }}</spdx:hashValue>
+         <spdx:algorithm>md5</spdx:algorithm>
+         <spdx:hashValue>{{ md5 | lower }}</spdx:hashValue>
+      </spdx:Hash>
+   </spdx:verifiedUsing>
+</spdx:Package>
+
+<spdx:PackageVerificationCode>
+   <spdx:algorithm>sha1</spdx:algorithm>
+   <spdx:hashValue>{{ verificationCode }}</spdx:hashValue>
+</spdx:PackageVerificationCode>
+
+{% if mainLicenses|length > 1 %}
+{% if dualLicense %}
+        <spdx:expandedlicensing_DisjunctiveLicenseSet rdf:about="https://spdx.org/rdf/3.0.0/terms/ExpandedLicensing/DisjunctiveLicenseSet">
+      {% else %}
+        <spdx:expandedlicensing_ConjunctiveLicenseSet rdf:about="https://spdx.org/rdf/3.0.0/terms/ExpandedLicensing/ConjunctiveLicenseSet">
+      {% endif %} {# End dual license check #}
+   <spdx:spdxId rdf:resource="https://spdx.org/rdf/3.0.0/terms/Software/Package#SPDXRef-upload{{ packageId }}"/>
+   <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+   <spdx:expandedlicensing_member rdf:about="https://spdx.org/rdf/3.0.0/terms/ExpandedLicensing/member">
+    {% for res in mainLicenses %}
+      {% if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' %}
+        {% set licId = licenseList[res].licenseObj.spdxId %}
+        {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+          {% set licId = licenseList[res].licenseObj.shortName %}
+        {% endif %}
+        <spdx:simplelicensing_AnyLicenseInfo rdf:about="https://spdx.org/rdf/3.0.0/terms/SimpleLicensing/AnyLicenseInfo">
+          <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+          <spdx:spdxId rdf:resource="{{ uri }}#{{ licId|replace({' ': '-'})|url_encode }}"/>
+        </spdx:simplelicensing_AnyLicenseInfo>
+      {% else %}
+        <spdx:simplelicensing_AnyLicenseInfo rdf:about="https://spdx.org/rdf/3.0.0/terms/SimpleLicensing/AnyLicenseInfo">
+          <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+          <spdx:spdxId rdf:resource="{{ uri }}#{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}"/>
+        </spdx:simplelicensing_AnyLicenseInfo>
+      {% endif %}
+    {% endfor %}
+  </spdx:expandedlicensing_member>
+{% if dualLicense %}
+        </spdx:expandedlicensing_DisjunctiveLicenseSet>
+      {% else %}
+        </spdx:expandedlicensing_ConjunctiveLicenseSet>
+      {% endif %} {# End dual license check #}
+{% elseif mainLicenses|length == 1 %}
+  {% set res = mainLicenses[0] %}
+  {% if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' %}
+    {% set licId = licenseList[res].licenseObj.spdxId %}
+    {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+      {% set licId = licenseList[res].licenseObj.shortName %}
+    {% endif %}
+    <spdx:simplelicensing_AnyLicenseInfo rdf:about="https://spdx.org/rdf/3.0.0/terms/SimpleLicensing/AnyLicenseInfo">
+      <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+      <spdx:spdxId rdf:resource="https://spdx.org/rdf/3.0.0/terms/Software/Package/SPDXRef-upload{{ packageId }}#{{ licId|replace({' ': '-'})|url_encode }}"/>
+    </spdx:simplelicensing_AnyLicenseInfo>
+  {% else %}
+   <spdx:simplelicensing_AnyLicenseInfo rdf:about="https://spdx.org/rdf/3.0.0/terms/SimpleLicensing/AnyLicenseInfo">
+     <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+      <spdx:spdxId rdf:resource="https://spdx.org/rdf/3.0.0/terms/Software/Package/SPDXRef-upload{{ packageId }}#{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}"/>
+    </spdx:simplelicensing_AnyLicenseInfo>
+  {% endif %}
+{% endif %}
+<spdx:Relationship>
+   <spdx:spdxId>URI:SPDXRef-Relationship-0</spdx:spdxId>
+   <spdx:relationshipType>describes</spdx:relationshipType>
+   <spdx:creationInfo rdf:resource="https://spdx.org/rdf/3.0.0/terms/Core/creationInfo#creationInfo1"/>
+   <spdx:from>https://spdx.org/rdf/3.0.0/terms/Core/SpdxDocument#SPDXRef-DOCUMENT</spdx:from>
+   <spdx:to>https://spdx.org/rdf/3.0.0/terms/Software/Package#SPDXRef-upload{{ packageId }}</spdx:to>
+</spdx:Relationship>
+
+{{ fileNodes }}

--- a/src/spdx2/agent/template/spdx3tv-document.twig
+++ b/src/spdx2/agent/template/spdx3tv-document.twig
@@ -1,0 +1,128 @@
+{# SPDX-FileCopyrightText: © 2015 Siemens AG
+
+   SPDX-License-Identifier: FSFAP
+#}
+type: NamespaceMap
+namespace: {{ uri }}
+prefix: URI
+
+##-------------------------
+## Creation Information
+##-------------------------
+
+type: CreationInfo
+spdxId: creationInfo:creationInfo1
+specVersion: 3.0.0
+created: {{ 'now'|date('Y-m-d\\TH:i:s\\Z', 'UTC') }}
+createdBy: Person:SPDXRef-Actor-{{ userName | replace({' (': '-', ')': ''}) }}
+createdUsing: Tool:SPDXRef-Actor-{{ toolVersion }}
+comment: <text>This document was created using license information and a generator from Fossology.</text>
+
+##-------------------------
+## Document Information
+##-------------------------
+
+type: SpdxDocument
+spdxId: SpdxDocument:SPDXRef-DOCUMENT
+creationInfo: creationInfo:creationInfo1
+name: {{ documentName }}
+profileConformance: core, software, simpleLicensing, expandedLicensing
+element: Tool:SPDXRef-Actor-{{ toolVersion }}, Person:SPDXRef-Actor-{{ userName | replace({' (': '-', ')': ''}) }}
+{% for packageId in packageIds %}
+element: Package:SPDXRef-upload{{ packageId }}
+{% endfor %}
+{% for fileId in fileIds %}
+element: File:SPDXRef-item{{ fileId }}{% if not loop.last %},{{ "\n" }}{% endif %}
+{% endfor %}
+rootElement: 
+{% for packageId in packageIds %}
+rootElement: Package:SPDXRef-upload{{ packageId }}{% if not loop.last %},{{ "\n" }}{% endif %}
+{% endfor %}
+dataLicense.type: simplelicensing_AnyLicenseInfo
+dataLicense.creationInfo: creationInfo:creationInfo1
+dataLicense.description: {{ licenseList[dataLicense].licenseObj.spdxId|replace({' ': '-'}) }}
+
+
+{%- if toolVersion is not empty %}
+
+##-------------------------
+## Tool Information
+##-------------------------
+
+type: Tool
+spdxId: Tool:SPDXRef-Actor-{{ toolVersion }}
+creationInfo: creationInfo:creationInfo1
+name: {{ toolVersion }}
+{%- endif %}
+
+{%- if userName is not empty %}
+
+##-------------------------
+## Person Information
+##-------------------------
+
+type: Person
+spdxId: Person:SPDXRef-Actor-{{ userName | replace({' (': '-', ')': ''}) }}
+creationInfo: creationInfo:creationInfo1
+name: {{ userName | split(' ')[0] }}
+externalIdentifier.type: ExternalIdentifier
+externalIdentifier.externalIdentifierType: email
+externalIdentifier.identifier: {{ userName | split(' (')[1] | split(')')[0] }}
+{%- endif %}
+
+{%- if organization is not empty %}
+
+##--------------------------
+## Organization Information
+##--------------------------
+
+type: Organization
+spdxId: Organization:SPDXRef-Actor-{{ organization }}
+creationInfo: creationInfo:creationInfo1
+name: {{ userName | split(' ')[0] }}
+{%- endif %}
+
+##-------------------------
+## License Information
+##-------------------------
+
+{% for licenseData in licenseList %}
+{%- if licenseData.licenseObj.spdxId starts with 'LicenseRef-' or licenseData.licenseObj.shortName starts with 'LicenseRef-' %}
+{%- set licId = licenseData.licenseObj.spdxId %}
+{%- if licenseData.licenseObj.shortName starts with 'LicenseRef-' %}
+{%- set licId = licenseData.licenseObj.shortName %}
+{%- endif %}
+type: expandedlicensing_CustomLicense
+spdxId: URI:{{ licId|replace({' ': '-'}) }}
+creationInfo: creationInfo:creationInfo1
+name: {{ licenseData.licenseObj.fullName }}
+simplelicensing_licenseText: <text> {{ licenseData.licenseObj.text|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})|replace({'\f':'','"':"'", '\n':''}) }} </text>
+{%- if licenseData.licenseObj.url is not empty %}
+{%- if '&' in licenseData.licenseObj.url %}
+
+expandedlicensing_seeAlso: {{ licenseData.licenseObj.url|url_encode }}
+{%- else %}
+
+expandedlicensing_seeAlso: {{ licenseData.licenseObj.url }}
+{%- endif %}
+{%- endif %}
+{%- endif %}
+{% endfor %}
+
+{{ packageNodes }}
+
+##---------------------------------------
+## File-Package Relationship Information
+##---------------------------------------
+
+{% for packageId in packageIds %}
+type: Relationship
+spdxId: URI:SPDXRef-Relationship-{{ fileIds | length }}
+from: Package:SPDXRef-upload{{ packageId }}
+{% for fileId in fileIds %}
+to: File:SPDXRef-item{{ fileId }}{% if not loop.last %},{{ "\n" }}{% endif %}
+{% endfor %}
+
+relationshipType: describes
+creationInfo: creationInfo:creationInfo1
+{% endfor %}

--- a/src/spdx2/agent/template/spdx3tv-file.twig
+++ b/src/spdx2/agent/template/spdx3tv-file.twig
@@ -1,0 +1,106 @@
+{# SPDX-FileCopyrightText: © 2015 Siemens AG
+
+   SPDX-License-Identifier: FSFAP
+#}
+
+##File
+
+type: software_File
+spdxId: File:SPDXRef-item{{ fileId }}
+creationInfo: creationInfo:creationInfo1
+name: {{ fileName }}
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: {{ sha1 | lower }}
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: {{ sha256 | lower }}
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: {{ md5 | lower }}
+
+{%- if fileData.isCleared() %}
+{%- if fileData.concludedLicenses|default is empty %}
+
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: File:SPDXRef-item{{ fileId }}#NoneLicense
+creationInfo: creationInfo:creationInfo1
+{%- elseif fileData.concludedLicenses|length > 1 %}
+{%- if dualLicense %}
+
+type: expandedlicensing_DisjunctiveLicenseSet
+{%- else %}
+
+type: expandedlicensing_ConjunctiveLicenseSet
+{%- endif %}
+spdxId: File:SPDXRef-item{{ fileId }}
+creationInfo: creationInfo:creationInfo1
+expandedlicensing_member.type: simplelicensing_AnyLicenseInfo
+expandedlicensing_member.creationInfo: creationInfo:creationInfo1
+{%- for res in fileData.concludedLicenses %}
+{%- if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' or licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+{%- set licId = licenseList[res].licenseObj.spdxId %}
+{%- if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+{%- set licId = licenseList[res].licenseObj.shortName %}
+{%- endif %}
+expandedlicensing_member.spdxId: URI:#{{ licId|replace({' ': '-'})|url_encode }}
+{%- else %}
+expandedlicensing_member.spdxId: URI:#{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}
+expandedlicensing_member.name: {{ licenseList[res].licenseObj.fullName|e }}
+{%- endif %}
+{%- endfor %}
+{%- else %}
+{%- if fileData.concludedLicenses|length == 1 %}
+{%- set res = fileData.concludedLicenses[0] %}
+{%- if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' or licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+{%- set licId = licenseList[res].licenseObj.spdxId %}
+{%- if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+{%- set licId = licenseList[res].licenseObj.shortName %}
+{%- endif %}
+type: simplelicensing_AnyLicenseInfo
+creationInfo: creationInfo:creationInfo1
+spdxId: File:SPDXRef-item{{ fileId }}#{{ licId|replace({' ': '-'})|url_encode }}
+{%- else %}
+type: simplelicensing_AnyLicenseInfo
+creationInfo: creationInfo:creationInfo1
+spdxId: File:SPDXRef-item{{ fileId }}#{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}
+name: {{ licenseList[res].licenseObj.fullName|e }}
+{%- endif %}
+{%- endif %}
+{%- endif %}
+{%- else %}
+
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: File:SPDXRef-item{{ fileId }}#NoAssertionLicense
+creationInfo: creationInfo:creationInfo1
+{%- endif %}
+
+
+
+{%- if licenseCommentState %}
+{%- if fileData.comments is empty %}
+
+comment: NOASSERTION
+{%- else %}
+
+comment: <text>{{ fileData.comments|join('\n')|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})|replace({'\f':''}) }}</text>
+{%- endif %}
+{%- endif %}
+
+{%- if fileData.copyrights|default is empty %}
+
+software_copyrightText: NOASSERTION
+{%- else %}
+
+software_copyrightText: <text> {{ fileData.copyrights|join('\n')|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})|replace({'\f':'','"':"'", '\n':''}) }} </text>
+{%- endif %}
+
+{%- if fileData.acknowledgements|default is not empty %}
+
+software_attributionText: <text> {{ fileData.acknowledgements|join('\n')|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})|replace({'\f':'','"':"'", '\n':''}) }} </text>
+{%- endif %}
+
+

--- a/src/spdx2/agent/template/spdx3tv-package.twig
+++ b/src/spdx2/agent/template/spdx3tv-package.twig
@@ -1,0 +1,114 @@
+{# SPDX-FileCopyrightText: © 2015 Siemens AG
+
+   SPDX-License-Identifier: FSFAP
+#}
+
+##--------------------------
+## Package Information
+##--------------------------
+
+type: software_Package
+spdxId: Package:SPDXRef-upload{{ packageId }}
+creationInfo: creationInfo:creationInfo1
+name: {{ packageName }}
+
+{%- if licenseComments is not empty %}
+
+comment: <text> {{ licenseComments|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})|replace({'\f':'','"':"'", '\n':''}) }} </text>
+{%- endif %}
+
+software_downloadLocation: NOASSERTION
+
+{%- if packageVersion is not empty %}
+
+software_packageVersion: {{ packageVersion|e }}
+{%- endif %}
+
+{%- if releaseDate is not empty %}
+
+releaseTime: {{ releaseDate }}
+{%- endif %}
+
+{%- if componentId is not empty %}
+
+externalRef.type: ExternalRef
+externalRef.comment: Package-Manager
+externalRef.externalRefType: {{ componentType }}
+externalRef.locator: {{ componentId|trim }}
+{%- endif %}
+
+software_copyrightText: NOASSERTION
+
+{%- if obligations|default is not empty %}
+
+  software_attributionText: <text> {{ obligations|join('\n')|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})|replace({'\f':''}) }} </text>
+{%- endif %}
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: {{ sha1 | lower }}
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: {{ sha256 | lower }}
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: {{ md5 | lower }}
+
+type: PackageVerificationCode
+algorithm: sha1
+hashValue: {{ verificationCode }}
+
+{%- if mainLicenses|length > 1 %}
+{%- if dualLicense %}
+
+type: expandedlicensing_DisjunctiveLicenseSet
+{%- else %}
+
+type: expandedlicensing_ConjunctiveLicenseSet
+{%- endif %}
+spdxId: Package:SPDXRef-upload{{ packageId }}
+creationInfo: creationInfo:creationInfo1
+expandedlicensing_member.type: simplelicensing_AnyLicenseInfo
+expandedlicensing_member.creationInfo: creationInfo:creationInfo1
+{%- for res in mainLicenses %}
+{%- if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' %}
+{%- set licId = licenseList[res].licenseObj.spdxId %}
+{%- if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+{%- set licId = licenseList[res].licenseObj.shortName %}
+{%- endif %}
+expandedlicensing_member.spdxId: URI:#{{ licId|replace({' ': '-'})|url_encode }}
+{%- else %}
+expandedlicensing_member.spdxId: URI:#{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}
+{%- endif %}
+{%- endfor %}
+{%- elseif mainLicenses|length == 1 %}
+{%- set res = mainLicenses[0] %}
+{%- if licenseList[res].licenseObj.spdxId starts with 'LicenseRef-' %}
+{%- set licId = licenseList[res].licenseObj.spdxId %}
+{%- if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
+{%- set licId = licenseList[res].licenseObj.shortName %}
+{%- endif %}
+type: simplelicensing_AnyLicenseInfo
+creationInfo: creationInfo:creationInfo1
+spdxId: URI:#{{ licId|replace({' ': '-'})|url_encode }}
+{%- else %}
+type: simplelicensing_AnyLicenseInfo
+creationInfo: creationInfo:creationInfo1
+spdxId: URI:#{{ licenseList[res].licenseObj.spdxId|replace({' ': '-'})|url_encode }}
+{%- endif %}
+{%- endif %}
+
+##-------------------------------------------
+## Document-Package Relationship Information
+##-------------------------------------------
+
+type: Relationship
+spdxId: URI:SPDXRef-Relationship-0
+from: SpdxDocument:SPDXRef-DOCUMENT
+to: Package:SPDXRef-upload{{ packageId }}
+relationshipType: describes
+creationInfo: creationInfo:creationInfo1
+
+{{ fileNodes }}

--- a/src/spdx2/spdx3json.conf
+++ b/src/spdx2/spdx3json.conf
@@ -1,0 +1,23 @@
+; SPDX-FileCopyrightText: © 2015 Siemens AG
+
+; SPDX-License-Identifier: FSFAP
+
+; scheduler configure file for this agent
+[default]
+
+; name: The name of the agent from the agent table
+name = spdx3json
+
+; command: The command that the scheduler will use when creating an instance of this agent. 
+; This will be parsed like a normal Unix command line.
+command = ../../spdx2/agent/spdx2 --outputFormat=spdx3json
+
+; max: The maximum number of this agent that is allowed to exist at any one time. 
+; This is set to -1 if there is no limit on the number of instances of the agent.
+max = -1
+
+; special: Scheduler directive for special agent attributes.
+; A comma separated list of values.
+; Directives:
+;     EXCLUSIVE: the agent cannot run concurrently with any other agent. 
+special[] = 

--- a/src/spdx2/spdx3jsonld.conf
+++ b/src/spdx2/spdx3jsonld.conf
@@ -1,0 +1,23 @@
+; SPDX-FileCopyrightText: © 2015 Siemens AG
+
+; SPDX-License-Identifier: FSFAP
+
+; scheduler configure file for this agent
+[default]
+
+; name: The name of the agent from the agent table
+name = spdx3jsonld
+
+; command: The command that the scheduler will use when creating an instance of this agent. 
+; This will be parsed like a normal Unix command line.
+command = ../../spdx2/agent/spdx2 --outputFormat=spdx3jsonld
+
+; max: The maximum number of this agent that is allowed to exist at any one time. 
+; This is set to -1 if there is no limit on the number of instances of the agent.
+max = -1
+
+; special: Scheduler directive for special agent attributes.
+; A comma separated list of values.
+; Directives:
+;     EXCLUSIVE: the agent cannot run concurrently with any other agent. 
+special[] = 

--- a/src/spdx2/spdx3rdf.conf
+++ b/src/spdx2/spdx3rdf.conf
@@ -1,0 +1,23 @@
+; SPDX-FileCopyrightText: © 2021 Orange
+
+; SPDX-License-Identifier: FSFAP
+
+; scheduler configure file for this agent
+[default]
+
+; name: The name of the agent from the agent table
+name = spdx3rdf
+
+; command: The command that the scheduler will use when creating an instance of this agent. 
+; This will be parsed like a normal Unix command line.
+command = ../../spdx2/agent/spdx2 --outputFormat=spdx3rdf
+
+; max: The maximum number of this agent that is allowed to exist at any one time. 
+; This is set to -1 if there is no limit on the number of instances of the agent.
+max = -1
+
+; special: Scheduler directive for special agent attributes.
+; A comma separated list of values.
+; Directives:
+;     EXCLUSIVE: the agent cannot run concurrently with any other agent. 
+special[] = 

--- a/src/spdx2/spdx3tv.conf
+++ b/src/spdx2/spdx3tv.conf
@@ -1,0 +1,23 @@
+; SPDX-FileCopyrightText: © 2021 Orange
+
+; SPDX-License-Identifier: FSFAP
+
+; scheduler configure file for this agent
+[default]
+
+; name: The name of the agent from the agent table
+name = spdx3tv
+
+; command: The command that the scheduler will use when creating an instance of this agent. 
+; This will be parsed like a normal Unix command line.
+command = ../../spdx2/agent/spdx2 --outputFormat=spdx3tv
+
+; max: The maximum number of this agent that is allowed to exist at any one time. 
+; This is set to -1 if there is no limit on the number of instances of the agent.
+max = -1
+
+; special: Scheduler directive for special agent attributes.
+; A comma separated list of values.
+; Directives:
+;     EXCLUSIVE: the agent cannot run concurrently with any other agent. 
+special[] = 

--- a/src/spdx2/ui/SpdxThreeGeneratorUi.php
+++ b/src/spdx2/ui/SpdxThreeGeneratorUi.php
@@ -1,0 +1,218 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2015-2018 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\Spdx\UI;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Data\Upload\Upload;
+use Fossology\Lib\Plugin\DefaultPlugin;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @class SpdxThreeGeneratorUi
+ * @brief Call SPDX3 agent to generate report from UI
+ */
+class SpdxThreeGeneratorUi extends DefaultPlugin
+{
+  const NAME = 'ui_spdx3';                ///< Mod name of the plugin
+  const DEFAULT_OUTPUT_FORMAT = "spdx3jsonld";  ///< Default report format
+  /** @var string $outputFormat
+   * Report format in use
+   */
+  protected $outputFormat = self::DEFAULT_OUTPUT_FORMAT;
+
+  function __construct()
+  {
+    $possibleOutputFormat = trim(GetParm("outputFormat",PARM_STRING));
+    if (strcmp($possibleOutputFormat,"") !== 0 &&
+        strcmp($possibleOutputFormat,self::DEFAULT_OUTPUT_FORMAT) !== 0 &&
+        ctype_alnum($possibleOutputFormat)) {
+      $this->outputFormat = $possibleOutputFormat;
+    }
+    parent::__construct(self::NAME, array(
+        self::TITLE => _("SPDX3 generation"),
+        self::PERMISSION => Auth::PERM_WRITE,
+        self::REQUIRES_LOGIN => true
+    ));
+  }
+
+  /**
+   * @copydoc Fossology::Lib::Plugin::DefaultPlugin::preInstall()
+   * @see Fossology::Lib::Plugin::DefaultPlugin::preInstall()
+   */
+  function preInstall()
+  {
+    $text = _("Generate SPDX3.0 report in JSON-LD format");
+    menu_insert("Browse-Pfile::Export&nbsp;SPDX3.0&nbsp;JSON-LD&nbsp;report", 0, self::NAME . '&outputFormat=spdx3jsonld', $text);
+    menu_insert("UploadMulti::Generate&nbsp;SPDX3.0", 0, self::NAME, $text);
+
+    $text = _("Generate SPDX3.0 report in JSON format");
+    menu_insert("Browse-Pfile::Export&nbsp;SPDX3.0&nbsp;JSON&nbsp;report", 0, self::NAME . '&outputFormat=spdx3json', $text);
+
+    $text = _("Generate SPDX3.0 report in RDF format");
+    menu_insert("Browse-Pfile::Export&nbsp;SPDX3.0&nbsp;RDF&nbsp;report", 0, self::NAME . '&outputFormat=spdx3rdf', $text);
+
+    $text = _("Generate SPDX3.0 report in tag/value format");
+    menu_insert("Browse-Pfile::Export&nbsp;SPDX3.0&nbsp;tag/value&nbsp;report", 0, self::NAME . '&outputFormat=spdx3tv', $text);
+  }
+
+  /**
+   * @copydoc Fossology::Lib::Plugin::DefaultPlugin::handle()
+   * @see Fossology::Lib::Plugin::DefaultPlugin::handle()
+   */
+  protected function handle(Request $request)
+  {
+
+    $groupId = Auth::getGroupId();
+    $uploadIds = $request->get('uploads') ?: array();
+    $uploadIds[] = intval($request->get('upload'));
+    $addUploads = array();
+    foreach ($uploadIds as $uploadId) {
+      if (empty($uploadId)) {
+        continue;
+      }
+      try {
+        $addUploads[$uploadId] = $this->getUpload($uploadId, $groupId);
+      } catch(Exception $e) {
+        return $this->flushContent($e->getMessage());
+      }
+    }
+    $folderId = $request->get('folder');
+    if (!empty($folderId)) {
+      /* @var $folderDao FolderDao */
+      $folderDao = $this->getObject('dao.folder');
+      $folderUploads = $folderDao->getFolderUploads($folderId, $groupId);
+      foreach ($folderUploads as $uploadProgress) {
+        $addUploads[$uploadProgress->getId()] = $uploadProgress;
+      }
+    }
+    if (empty($addUploads)) {
+      return $this->flushContent(_('No upload selected'));
+    }
+    $upload = array_pop($addUploads);
+    try {
+      list($jobId,$jobQueueId) = $this->getJobAndJobqueue($groupId, $upload, $addUploads);
+    } catch (\Exception $ex) {
+      return $this->flushContent($ex->getMessage());
+    }
+
+    $vars = array('jqPk' => $jobQueueId,
+                  'downloadLink' => Traceback_uri(). "?mod=download&report=".$jobId,
+                  'reportType' => $this->outputFormat);
+    $text = sprintf(_("Generating ". $this->outputFormat . " report for '%s'"), $upload->getFilename());
+    $vars['content'] = "<h2>".$text."</h2>";
+    $content = $this->renderer->load("report.html.twig")->render($vars);
+    $message = '<h3 id="jobResult"></h3>';
+    $request->duplicate(array('injectedMessage'=>$message,'injectedFoot'=>$content,'mod'=>'showjobs'))->overrideGlobals();
+    $showJobsPlugin = \plugin_find('showjobs');
+    $showJobsPlugin->OutputOpen();
+    return $showJobsPlugin->getResponse();
+  }
+
+  /**
+   * @brief Add multiple uploads to the report
+   * @param array $uploads List of upload IDs
+   * @return string
+   */
+  protected function uploadsAdd($uploads)
+  {
+    if (count($uploads) == 0) {
+      return '';
+    }
+    return '--uploadsAdd='. implode(',', array_keys($uploads));
+  }
+
+  /**
+   * @brief Get the Job ID and Job queue ID
+   * @param int $groupId
+   * @param Upload $upload
+   * @param array $addUploads
+   * @throws Exception
+   * @return array JobID, JobQuqueID
+   */
+  protected function getJobAndJobqueue($groupId, $upload, $addUploads)
+  {
+    $uploadId = $upload->getId();
+    $SpdxThreeAgent = plugin_find('agent_'.$this->outputFormat);
+    $userId = Auth::getUserId();
+    $jqCmdArgs = $this->uploadsAdd($addUploads);
+
+    $dbManager = $this->getObject('db.manager');
+    $sql = 'SELECT jq_pk,job_pk FROM jobqueue, job '
+         . 'WHERE jq_job_fk=job_pk AND jq_type=$1 AND job_group_fk=$4 AND job_user_fk=$3 AND jq_args=$2 AND jq_endtime IS NULL';
+    $params = array($SpdxThreeAgent->AgentName,$uploadId,$userId,$groupId);
+    $log = __METHOD__;
+    if ($jqCmdArgs) {
+      $sql .= ' AND jq_cmd_args=$5';
+      $params[] = $jqCmdArgs;
+      $log .= '.args';
+    } else {
+      $sql .= ' AND jq_cmd_args IS NULL';
+    }
+    $scheduled = $dbManager->getSingleRow($sql,$params,$log);
+    if (!empty($scheduled)) {
+      return array($scheduled['job_pk'],$scheduled['jq_pk']);
+    }
+    if (empty($jqCmdArgs)) {
+      $jobName = $upload->getFilename();
+    } else {
+      $jobName = "Multi File SPDX3";
+    }
+    $jobId = JobAddJob($userId, $groupId, $jobName, $uploadId);
+    $error = "";
+    $jobQueueId = $SpdxThreeAgent->AgentAdd($jobId, $uploadId, $error, array(), $jqCmdArgs);
+    if ($jobQueueId < 0) {
+      throw new \Exception(_("Cannot schedule").": ".$error);
+    }
+    return array($jobId,$jobQueueId, $error);
+  }
+
+  /**
+   * @brief Get Upload object for a given upload id
+   * @param int $uploadId
+   * @param int $groupId
+   * @throws Exception
+   * @return Fossology::Lib::Data::Upload::Upload
+   */
+  protected function getUpload($uploadId, $groupId)
+  {
+    if ($uploadId <= 0) {
+      throw new \Exception(_("parameter error: $uploadId"));
+    }
+    /* @var $uploadDao UploadDao */
+    $uploadDao = $this->getObject('dao.upload');
+    if (!$uploadDao->isAccessible($uploadId, $groupId)) {
+      throw new \Exception(_("permission denied"));
+    }
+    /** @var Upload */
+    $upload = $uploadDao->getUpload($uploadId);
+    if ($upload === null) {
+      throw new \Exception(_('cannot find uploadId'));
+    }
+    return $upload;
+  }
+
+  /**
+   * Schedules spdx agent to generate report based of outputFormat
+   *
+   * @param int $groupId
+   * @param Upload $upload
+   * @param string $outputFormat
+   * @param array $addUploads
+   * @return array|number[] Job id and job queue id
+   * @throws Exception
+   */
+  public function scheduleAgent($groupId, $upload,
+    $outputFormat = self::DEFAULT_OUTPUT_FORMAT, $addUploads = array())
+  {
+    $this->outputFormat = $outputFormat;
+    return $this->getJobAndJobqueue($groupId, $upload, $addUploads);
+  }
+}
+
+register_plugin(new SpdxThreeGeneratorUi());

--- a/src/spdx2/ui/SpdxThreeJsonAgentPlugin.php
+++ b/src/spdx2/ui/SpdxThreeJsonAgentPlugin.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\SpdxThree\UI;
+
+use Fossology\Lib\Plugin\AgentPlugin;
+
+/**
+ * @class SpdxThreeJsonAgentPlugin
+ * @brief Add multiple uploads to SPDX3 report in Json format
+ */
+class SpdxThreeJsonAgentPlugin extends AgentPlugin
+{
+  public function __construct()
+  {
+    $this->Name = "agent_spdx3json";
+    $this->Title =  _("SPDX3 generation in JSON format");
+    $this->AgentName = "spdx3json";
+
+    parent::__construct();
+  }
+
+  /**
+   * @copydoc Fossology::Lib::Plugin::AgentPlugin::preInstall()
+   * @see Fossology::Lib::Plugin::AgentPlugin::preInstall()
+   */
+  function preInstall()
+  {
+    // no AgentCheckBox
+  }
+
+  /**
+   * @brief Add uploads to report
+   * @param array $uploads Array of upload ids
+   * @return string
+   */
+  public function uploadsAdd($uploads)
+  {
+    if (count($uploads) == 0) {
+      return '';
+    }
+    return '--uploadsAdd='. implode(',', array_keys($uploads));
+  }
+}
+
+register_plugin(new SpdxThreeJsonAgentPlugin());

--- a/src/spdx2/ui/SpdxThreeJsonldAgentPlugin.php
+++ b/src/spdx2/ui/SpdxThreeJsonldAgentPlugin.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * @dir
+ * @brief UI for SPDX3 agent
+ */
+namespace Fossology\Spdx\UI;
+
+use Fossology\Lib\Plugin\AgentPlugin;
+
+/**
+ * @class SpdxThreeAgentPlugin
+ * @brief Add multiple uploads to SPDX3 report in Json-ld format
+ */
+class SpdxThreeJsonldAgentPlugin extends AgentPlugin
+{
+  public function __construct()
+  {
+    $this->Name = "agent_spdx3jsonld";
+    $this->Title =  _("SPDX3 generation in JSON-LD format");
+    $this->AgentName = "spdx3jsonld";
+
+    parent::__construct();
+  }
+
+  /**
+   * @copydoc Fossology::Lib::Plugin::AgentPlugin::preInstall()
+   * @see Fossology::Lib::Plugin::AgentPlugin::preInstall()
+   */
+  function preInstall()
+  {
+    // no AgentCheckBox
+  }
+
+  /**
+   * @brief Add uploads to report
+   * @param array $uploads Array of upload ids
+   * @return string
+   */
+  public function uploadsAdd($uploads)
+  {
+    if (count($uploads) == 0) {
+      return '';
+    }
+    return '--uploadsAdd='. implode(',', array_keys($uploads));
+  }
+}
+
+register_plugin(new SpdxThreeJsonldAgentPlugin());

--- a/src/spdx2/ui/SpdxThreeRDFAgentPlugin.php
+++ b/src/spdx2/ui/SpdxThreeRDFAgentPlugin.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2021 Orange
+ Author: Piotr Pszczola <piotr.pszczola@orange.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\Spdx\UI;
+
+use Fossology\Lib\Plugin\AgentPlugin;
+
+/**
+ * @class SpdxThreeRDFAgentPlugin
+ * @brief Add multiple uploads to SPDX3 report in RDF format
+ */
+class SpdxThreeRDFAgentPlugin extends AgentPlugin
+{
+  public function __construct()
+  {
+    $this->Name = "agent_spdx3rdf";
+    $this->Title =  _("Export SPDX3.0 RDF report");
+    $this->AgentName = "spdx3rdf";
+
+    parent::__construct();
+  }
+
+  /**
+   * @copydoc Fossology::Lib::Plugin::AgentPlugin::preInstall()
+   * @see Fossology::Lib::Plugin::AgentPlugin::preInstall()
+   */
+  function preInstall()
+  {
+    // no AgentCheckBox
+  }
+
+  /**
+   * @brief Add uploads to report
+   * @param array $uploads Array of upload ids
+   * @return string
+   */
+  public function uploadsAdd($uploads)
+  {
+    if (count($uploads) == 0) {
+      return '';
+    }
+    return '--uploadsAdd='. implode(',', array_keys($uploads));
+  }
+}
+
+register_plugin(new SpdxThreeRDFAgentPlugin());

--- a/src/spdx2/ui/SpdxThreeTagValueAgentPlugin.php
+++ b/src/spdx2/ui/SpdxThreeTagValueAgentPlugin.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2015 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\Spdx\UI;
+
+use Fossology\Lib\Plugin\AgentPlugin;
+
+/**
+ * @class SpdxThreeTagValueAgentPlugin
+ * @brief Add multiple uploads to SPDX3 report in Tag:Value format
+ */
+class SpdxThreeTagValueAgentPlugin extends AgentPlugin
+{
+  public function __construct()
+  {
+    $this->Name = "agent_spdx3tv";
+    $this->Title =  _("SPDX3 generation in Tag:Value format");
+    $this->AgentName = "spdx3tv";
+
+    parent::__construct();
+  }
+
+  /**
+   * @copydoc Fossology::Lib::Plugin::AgentPlugin::preInstall()
+   * @see Fossology::Lib::Plugin::AgentPlugin::preInstall()
+   */
+  function preInstall()
+  {
+    // no AgentCheckBox
+  }
+
+  /**
+   * @brief Add uploads to report
+   * @param array $uploads Array of upload ids
+   * @return string
+   */
+  public function uploadsAdd($uploads)
+  {
+    if (count($uploads) == 0) {
+      return '';
+    }
+    return '--uploadsAdd='. implode(',', array_keys($uploads));
+  }
+}
+
+register_plugin(new SpdxThreeTagValueAgentPlugin());

--- a/src/www/ui/async/AjaxShowJobs.php
+++ b/src/www/ui/async/AjaxShowJobs.php
@@ -287,6 +287,18 @@ class AjaxShowJobs extends \FO_Plugin
           case 'spdx2csv':
             $jobArr['jobQueue'][$key]['download'] = "SPDX2 CSV report";
             break;
+          case 'spdx3jsonld':
+            $jobArr['jobQueue'][$key]['download'] = "SPDX3 JSON-LD report";
+            break;
+          case 'spdx3json':
+            $jobArr['jobQueue'][$key]['download'] = "SPDX3 JSON report";
+            break;
+          case 'spdx3rdf':
+            $jobArr['jobQueue'][$key]['download'] = "SPDX# RDF report";
+            break;
+          case 'spdx3tv':
+            $jobArr['jobQueue'][$key]['download'] = "SPDX3 tag/value report";
+            break;
           case 'dep5':
             $jobArr['jobQueue'][$key]['download'] = "DEP5 copyright file";
             break;


### PR DESCRIPTION
# Description

Implementation of generation of SPDX v3.0 report in JSON-ld, JSON, RDF and Tag:Value format for Core, Software and Licensing profiles and validation of these generated reports.

# Changes

Integrated the previous SPDXv2 directory, with the latest SPDXv3 codebase in a new directory, named spdx2, in ./src folder. This folder contains all the codebase made in the generation of SPDX v2.0 and v3.0 report. The SPDXv3.0 can generate reports in JSON-ld, JSON, RDF and Tag:Value format.

# How to test

1. Do a fresh installation of the FOSSology software from source.
2. Upload the file and select the desired scanner.
3. Generate the SPDX v3.0 report in JSON-ld, JSON, RDF and Tag: Value format from the drop-down action menu.

# Validation

## JSON-LD Reports

There are two mechanisms for validating SPDX 3 JSON-LD documents: validating the JSON Schema, and validating against the SHACL model. These two different mechanisms serve to validate the document in different ways, so it is recommended to perform both types of validation to ensure that your documents are correct.

### JSON Schema Validation

To validate JSON-LD documents using JSON Schema, follow the steps below:

#### Using AJV CLI

1. Install the AJV CLI tool globally:
    ```sh
    npm install --global ajv-cli
    ```

2. Download the SPDX JSON Schema:
    ```sh
    wget -O spdx-json-schema.json https://spdx.org/schema/3.0.0/spdx-json-schema.json
    ```

3. Validate your document:
    ```sh
    ajv validate --spec=draft2020 -s spdx-json-schema.json -d <DOCUMENT>
    ```

#### Using `check-jsonschema`

1. Install the `check-jsonschema` tool:
    ```sh
    python3 -m pip install --user check-jsonschema
    ```

2. Validate your document:
    ```sh
    check-jsonschema -v --schemafile https://spdx.org/schema/3.0.0/spdx-json-schema.json <DOCUMENT>
    ```

**Note:**
1. Please ensure to rename the generated JSON-LD (.jsonld) file into a JSON (.json) file.
2. The `check-jsonschema` tool might take time to validate the reports.

### SHACL Model Validation

To validate JSON-LD documents against the SHACL model, use the `pyshacl` tool:

```sh
pyshacl     --shacl https://spdx.org/rdf/3.0.0/spdx-model.ttl     --ont-graph https://spdx.org/rdf/3.0.0/spdx-model.ttl     <DOCUMENT>
```

## JSON Reports

Follow the JSON Serialization instructions given on the [SPDX GitHub repository](https://github.com/spdx/spdx-3-model/blob/main/serialization/json.md).

## RDF Reports

Use SHACL model validation to validate RDF reports:

```sh
pyshacl     --shacl https://spdx.org/rdf/3.0.0/spdx-model.ttl     --ont-graph https://spdx.org/rdf/3.0.0/spdx-model.ttl     
```
CC @GMishx, @shaheemazmalmmd 


