### PR TITLE
hotfix(docker_test): Use docker compose (v2) instead of docker-compose (v1)

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -21,7 +21,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: Build images
-      run: docker-compose build
+      run: docker compose build
 
     - name: Test cluster
       run: src/testing/docker/test-cluster.sh

--- a/src/testing/docker/test-cluster.sh
+++ b/src/testing/docker/test-cluster.sh
@@ -5,21 +5,21 @@
 
 set -o errexit -o nounset -o xtrace
 
-docker-compose build
-docker-compose up -d
+docker compose build
+docker compose up -d
 
 #### fossology needs up to 15 seconds to startup
 sleep 15
 
-readonly HOST="$(docker-compose port web 80)"
+readonly HOST="$(docker compose port web 80)"
 
 #### is fossology reachable? --> check title
 curl --silent --location "http://${HOST}/repo/" | grep -q "<title>Getting Started with FOSSology</title>"
 
 #### test copyright is running
-docker-compose exec -T web /usr/local/share/fossology/copyright/agent/copyright -h
+docker compose exec -T web /usr/local/share/fossology/copyright/agent/copyright -h
 
 #### test whether the scheduler is running
-docker-compose exec -T scheduler /usr/local/share/fossology/scheduler/agent/fo_cli -S
+docker compose exec -T scheduler /usr/local/share/fossology/scheduler/agent/fo_cli -S
 
-docker-compose down
+docker compose down

--- a/src/testing/docker/test-standalone.sh
+++ b/src/testing/docker/test-standalone.sh
@@ -6,7 +6,7 @@
 set -o errexit -o nounset -o xtrace
 
 #### build image
-docker-compose build web
+docker compose build web
 
 #### start container
 readonly CONTAINER_ID="$(docker run --rm -p 127.0.0.1::80 -d fossology)"


### PR DESCRIPTION

## Description

Use `docker compose` (v1) instead of `docker-compose` as it is deprecated by Ubuntu and Windows Runners.

### Changes
Please refer to this [discussion](https://github.com/orgs/community/discussions/116610) and this [issue](https://github.com/actions/runner-images/issues/9557)