### PR TITLE
feat(api): Add deprecation and sunset header

### DIFF
--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -116,10 +116,15 @@ AppFactory::setResponseFactory(new ResponseFactoryHelper());
 $app = AppFactory::create();
 $app->setBasePath($BASE_PATH);
 
-// Custom middleware to set the API version as a request attribute
+// Custom middleware to set the API version as a request attribute and add deprecation headers
 $apiVersionMiddleware = function (Request $request, RequestHandler $handler) use ($apiVersion) {
   $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, $apiVersion);
-  return $handler->handle($request);
+  $response = $handler->handle($request);
+  if ($apiVersion == ApiVersion::V1) {
+    $response = $response->withHeader('Deprecation', 'true')
+    ->withHeader('Sunset', '2024-12-31T23:59:59Z');
+  }
+  return $response;
 };
 
 /*


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Added deprecation and sunset headers in version 1 API responses.
NOTE: Merge after version 2 official release (sunset date needs to be changed accordingly).

### Changes

Modified the `apiVersionMiddleware` to handle the header addition logic for every version 1 request.

## How to test

Make a version 1 request to view these headers.
![image](https://github.com/user-attachments/assets/c9508622-4503-4444-8790-aeca038183f1)


CC @GMishx @shaheemazmalmmd @dushimsam @soham4abc 