### PR TITLE
feat(Dependecy Scan): Add Python Dependency Scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,6 @@ ubuntu-*
 **/build-clang
 cmake-build-release
 cmake-build-debug
+
+#pycache
+**/__pycache__/

--- a/utils/automation/FoScanner/CliOptions.py
+++ b/utils/automation/FoScanner/CliOptions.py
@@ -37,6 +37,8 @@ class CliOptions(object):
   :ivar allowlist_path: path to allowlist.json file
   :ivar allowlist: information from allowlist.json
   :ivar report_format: Report format to use
+  :ivar scan_only_deps: Scan only dependencies
+  :ivar sbom_path: Path to sbom file
   """
   nomos: bool = False
   ojo: bool = False
@@ -53,6 +55,8 @@ class CliOptions(object):
     'exclude': []
   }
   report_format: ReportFormat = ReportFormat.TEXT
+  scan_only_deps: bool = False
+  sbom_path : str = ''
 
   def update_args(self, args: Namespace):
     """
@@ -74,6 +78,8 @@ class CliOptions(object):
       self.repo = True
     if "differential" in args.operation:
       self.differential = True
+    if 'scan-only-deps' in args.operation:
+      self.scan_only_deps = True
     if args.tags is not None and self.differential and len(args.tags) == 2:
       self.tags = (args.tags[0],args.tags[1])
     if args.allowlist_path:
@@ -87,3 +93,5 @@ class CliOptions(object):
     self.report_format = ReportFormat[args.report]
     if self.keyword and args.keyword_conf:
       self.keyword_conf_file_path = args.keyword_conf
+    if (self.scan_only_deps or self.repo) and args.sbom_path:
+      self.sbom_path = args.sbom_path

--- a/utils/automation/FoScanner/FormatResults.py
+++ b/utils/automation/FoScanner/FormatResults.py
@@ -86,7 +86,7 @@ class FormatResult:
                 it is found.
       """
       found_words_with_line_number = {}
-      if self.cli_options.repo is True:
+      if self.cli_options.repo is True or self.cli_options.scan_only_deps is True:
         try:
           with open(file_path, 'rb') as file:
             binary_data = file.read()
@@ -121,7 +121,7 @@ class FormatResult:
       :param: root_dir : str Path of the temp dir root to format the files
       :return: None
       """
-      if self.cli_options.repo is True:
+      if self.cli_options.repo is True or self.cli_options.scan_only_deps is True:
         return None
       for root, dirs, files in os.walk(root_dir):
         for file_name in files:

--- a/utils/automation/ScanDeps/Downloader.py
+++ b/utils/automation/ScanDeps/Downloader.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+# SPDX-FileContributor: © Rajul Jha <rajuljha49@gmail.com>
+
+# SPDX-License-Identifier: GPL-2.0-only
+
+import os
+import re
+import requests
+import concurrent.futures
+import zipfile
+import tarfile
+
+
+class Downloader:
+    """
+    Class for parallely downloading dependencies from download urls.
+    """
+    
+    def __download_package(self, package_name: str, download_url: str,\
+                         save_dir: str) -> str:
+        response = requests.get(download_url)
+        package_folder = os.path.join(save_dir, package_name)
+        if not os.path.exists(package_folder):
+            os.makedirs(package_folder)
+
+        match = re.search(r'\.tar\.gz$|\.tar\.bz2$|\.tar\.xz$|\.zip$|\.whl$|\.tar$',\
+                           download_url)
+        file_extension = match.group(0) if match else os.path.splitext(download_url)[1]
+        file_path = os.path.join(package_folder, package_name + file_extension)
+
+        with open(file_path, 'wb') as f:
+            f.write(response.content)
+        
+        print(f"Downloaded {package_name} to {file_path}")
+
+        # Unpack the file based on its extension
+        if file_extension == ".zip":
+            with zipfile.ZipFile(file_path, 'r') as zip_ref:
+                zip_ref.extractall(package_folder)
+        elif file_extension in [".tar.gz", ".tgz", ".tar"]:
+            with tarfile.open(file_path, 'r:*') as tar_ref:
+                tar_ref.extractall(package_folder)
+        else:
+            print(f"Unsupported file format: {file_extension}")
+            return None
+        os.remove(file_path)
+        print(f"Exported {package_name} to {package_folder}")
+        
+        return file_path
+
+    def download_concurrently(self, download_list: list[tuple[str,str]], \
+                              save_dir: str):
+        """
+        Download files concurrently from a list of urls
+        """
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            futures = [
+                executor.submit(self.__download_package, name, url, save_dir)
+                for name, url in download_list
+            ]
+            
+            for future in concurrent.futures.as_completed(futures):
+                try:
+                    future.result()
+                except Exception as e:
+                    print(f"Error downloading package: {e}")
+        return f"Packages downloaded in the folder {save_dir}"

--- a/utils/automation/ScanDeps/Parsers.py
+++ b/utils/automation/ScanDeps/Parsers.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+
+# SPDX-FileContributor: © Rajul Jha <rajuljha49@gmail.com>
+
+# SPDX-License-Identifier: GPL-2.0-only
+
+import requests
+import json
+from typing import Dict, Union
+
+
+class Parser:
+    """
+    Parser to classify each component based on it's type.
+    Ex: If purl is pkg:pypi/django@1.11.1,
+    it is a pypi package and should belong to python_components.
+    """
+    def __init__(self, sbom_file: str):
+        """
+        Initialize components list and load the sbom_data.
+        Args:
+            sbom_file: str | Path to sbom file
+        """
+        with open(sbom_file, 'r') as file:
+            self.sbom_data = json.load(file)
+        self.python_components = []
+        self.npm_components = []
+        self.php_components = []
+        self.unsupported_components = []
+    
+    def classify_components(self):
+        """
+        Classify components based on it's type
+        """
+        for component in self.sbom_data.get('components',[]):
+            purl = component.get('purl')
+            if not purl:
+                continue
+            type = self._extract_type(purl)
+
+            if type == 'pypi':
+                self.python_components.append(component)
+            # elif type == 'npm':
+            #     self.npm_components.append(component)
+            # elif type == 'composer':
+            #     self.php_components.append(component)
+            else:
+                self.unsupported_components.append(component)
+
+    def _extract_type(self, purl: str) -> Union[str,None]:
+        """
+        Extracts the package type from the purl. 
+        Example purl: pkg:pypi/django@1.11.1
+        The type here is 'pypi'.
+        Args:
+            purl: str | Purl of the package to scan
+        Return:
+            purl_type: str | Type of component or None
+        """
+        # purl format: pkg:type/namespace/name@version?qualifiers#subpath
+        try:
+            if purl.startswith("pkg:"):
+                purl_type = purl.split(':')[1].split('/')[0]
+                return purl_type
+            return None
+        except Exception as e:
+            return None, str(e)
+
+
+class PythonParser:
+    """
+    Python Parser to parse the python sboms to generate download urls from
+    cyclonedx format sbom files.
+    """
+
+    def __process_components(self, components : list[Dict]) -> list[str,str]:
+        """
+        Returns list of package name and version from SBOM component.
+        Args:
+            components: list[Dict]
+        Return:
+            list[str, str]: Name and versions of packages from sbom file
+        """
+        return [(comp['name'], comp['version']) for comp in components]
+
+    def __generate_api_endpoint(self, package_name: str, version: str) -> str:
+        """
+        Generate JSON REST API Endpoint to fetch download url.
+        Args:
+            package_name: str Name of package
+            version: str Version of paclage
+        Return:
+            JSON REST API endpoint tp fetch metadata of package
+        """
+        return f"https://pypi.org/pypi/{package_name}/{version}/json"
+
+    def parse_components(self, components: list[Dict]) -> Union[list[tuple[str,str]],None]:
+        """
+        Parse SBOM file for package name and download url of package.
+        Args:
+            sbom_file: str Path to sbom_file
+        Return:
+            list of tuples with package_name and download_url of that package
+        """
+        download_urls = []
+        packages = self.__process_components(components)
+        
+        for package_name, version in packages:
+            api_endpoint = self.__generate_api_endpoint(package_name, version)
+            print(f"API endpoint for {package_name} : {api_endpoint}")            
+            response = requests.get(api_endpoint)
+            
+            if response.status_code == 200:
+                data = response.json()
+                sdist_url = None
+                wheel_url = None
+
+                for url_info in data.get('urls', []):
+                    if url_info.get('packagetype') == 'sdist':
+                        sdist_url = url_info.get('url')
+                    elif url_info.get('packagetype') == 'bdist_wheel':
+                        wheel_url = url_info.get('url')
+
+                # Prefer sdist, fallback to wheel if sdist is not available
+                download_url = sdist_url if sdist_url else wheel_url
+                if download_url:
+                    download_urls.append((package_name, download_url))
+                else:
+                    print(f"No suitable download URL found for {package_name} {version}")
+            else:
+                print(f"Failed to retrieve data for {package_name} {version}")
+
+        return download_urls if download_urls else None

--- a/utils/automation/ScanDeps/__init__.py
+++ b/utils/automation/ScanDeps/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# SPDX-FileContributor: © Rajul Jha <rajuljha49@gmail.com>
+
+# SPDX-License-Identifier: GPL-2.0-only


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add feature to download and scan dependencies in CI. Add new CLI arguments `scan-only-deps` and `--sbom-path`.
Python Packages on PyPI are supported for now. Packages can be scanned independently in a seperate mode using `scan-only-deps`.

### Changes
- Add new CLI argument `scan-only-deps` and `--sbom-path`
- Add Parsers and Downloaders for Parsing SBOM file and Downloading Dependencies locally.
- packages are downloaded locally depending on registry type (PyPI, NPM etc).
- They can be scanned independently or in repo mode along with the whole directory.
- `Repo` mode overrides the `scan-only-deps` mode.

## How to test
- Build new image.
- Scan using
  -  `fossologyscanner nomos ojo scan-only-deps --sbom-path <path_to_sbom_file>` for scanning only dependencies.
  - `fossologyscanner nomos ojo repo --sbom-path <path_to_sbom_file>` for scanning repo along with dependencies.

CC @GMishx @shaheemazmalmmd @avinal @Kaushl2208 