### PR TITLE
fix(import): Do not require an agent if the report has no related data

### DIFF
--- a/src/decisionimporter/agent/DecisionImporterDataCreator.php
+++ b/src/decisionimporter/agent/DecisionImporterDataCreator.php
@@ -276,12 +276,6 @@ class DecisionImporterDataCreator
                                       DecisionImporterAgent &$agentObj,
                                       string $agentName, int $jobId): void
   {
-    if (!$this->agentDao->arsTableExists($agentName)) {
-      throw new UnexpectedValueException("No agent '$agentName' exists on server.");
-    }
-    $latestAgentId = $this->agentDao->getCurrentAgentId($agentName);
-    $this->createCxJobs($agentName, $jobId, $latestAgentId);
-
     $type = $agentName;
     if ($agentName == "copyright") {
       $type = "statement";
@@ -294,6 +288,18 @@ class DecisionImporterDataCreator
     $decisionList = $reportData->$decisionListMethod();
     $eventList = $reportData->$eventListMethod();
 
+    if (!$cxList and !$decisionList and !$eventList) {
+      // No relevant data in the report - nothing to do
+      return;
+    }
+
+    if (!$this->agentDao->arsTableExists($agentName)) {
+      // FIXME This requires the user to manually run the respective agent to get past this point
+      throw new UnexpectedValueException("No agent '$agentName' exists on server.");               
+    }                                                                                              
+    $latestAgentId = $this->agentDao->getCurrentAgentId($agentName);
+    $this->createCxJobs($agentName, $jobId, $latestAgentId);
+                                                                                                   
     $cxExistSql = "SELECT " . $agentName . "_pk FROM $agentName WHERE pfile_fk = $1 AND agent_fk = $2 AND hash = $3;";
     $cxExistStatement = __METHOD__ . ".$agentName" . "Exist";
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This fixes an error that happened when importing a FOSSology dump from other machine. On the receiving side data was uploaded from a Git repository without running any agents. The dump contained no copyright/ECC/IPRA data. Yet it kept failing with the "No agent 'copyright' exists on server." and similar errors until I manually ran the three agents on the upload.

### Changes

Bail out in the nothing-to-do case.

## How to test

1. Have two FOSSsology instances - sending and receiving
2. On the sending side have an upload with decisions but no Copyright/ECC/IPRA data. Export a FOSSology dump of it.
3. On the receiving side upload the same data using the From Version Control System option. Select NO optional analysis and no options below that
4. On the receiving side import the previously created dump

Original result:

Import fails with the error "No agent 'copyright' exists on server.". After running the "copyright agent" it goes further and complains about ECC, then about IPRA.

Fixed result:

It does not fail. (Though it would still fail if the sending side had any of those data - hence the FIXME note as a suggestion for further improvement.)