### PR TITLE
test(api): upgraded controller test cases to support v2 standards

### DIFF
--- a/src/www/ui_tests/api/Controllers/FolderControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/FolderControllerTest.php
@@ -59,6 +59,7 @@ namespace Fossology\UI\Api\Test\Controllers
   use Fossology\UI\Api\Helper\DbHelper;
   use Fossology\UI\Api\Helper\ResponseHelper;
   use Fossology\UI\Api\Helper\RestHelper;
+  use Fossology\UI\Api\Models\ApiVersion;
   use Fossology\UI\Api\Models\Info;
   use Fossology\UI\Api\Models\InfoType;
   use Mockery as M;
@@ -325,10 +326,28 @@ namespace Fossology\UI\Api\Test\Controllers
 
     /**
      * @test
-     * -# Check for FolderController::createFolder()
+     * -# Check for FolderController::createFolder() with version 1 attributes
      * -# Check for 201 response with folder id
      */
-    public function testCreateFolder()
+    public function testCreateFolderV1()
+    {
+      $this->testCreateFolder(ApiVersion::V1);
+    }
+    /**
+     * @test
+     * -# Check for FolderController::createFolder() with version 2 attributes
+     * -# Check for 201 response with folder id
+     */
+    public function testCreateFolderV2()
+    {
+      $this->testCreateFolder();
+    }
+
+    /**
+     * @param $version to test
+     * @return void
+     */
+    private  function testCreateFolder($version = ApiVersion::V2)
     {
       $parentFolder = 2;
       $folderName = "root-child1";
@@ -342,12 +361,17 @@ namespace Fossology\UI\Api\Test\Controllers
       $this->folderDao->shouldReceive('getFolderId')
         ->withArgs(array($folderName, $parentFolder))->andReturn($folderId);
       $requestHeaders = new Headers();
-      $requestHeaders->setHeader('parentFolder', $parentFolder);
-      $requestHeaders->setHeader('folderName', $folderName);
-      $requestHeaders->setHeader('folderDescription', $folderDescription);
       $body = $this->streamFactory->createStream();
       $request = new Request("POST", new Uri("HTTP", "localhost"),
         $requestHeaders, [], [], $body);
+      if ($version == ApiVersion::V2) {
+        $request = $request->withQueryParams(['parentFolder'=>$parentFolder, 'folderName'=>$folderName, 'folderDescription'=>$folderDescription]);
+      } else {
+        $request = $request->withHeader('parentFolder', $parentFolder)
+          ->withHeader('folderName', $folderName)
+          ->withHeader('folderDescription', $folderDescription);
+      }
+      $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, $version);
       $response = new ResponseHelper();
       $actualResponse = $this->folderController->createFolder($request,
         $response, []);
@@ -357,13 +381,30 @@ namespace Fossology\UI\Api\Test\Controllers
       $this->assertEquals($expectedResponse->getArray(),
         $this->getResponseJson($actualResponse));
     }
-
     /**
      * @test
-     * -# Check for inaccessible parent on FolderController::createFolder()
+     * -# Check for inaccessible parent on FolderController::createFolder() with version 1 attributes
      * -# Check for 403 response
      */
-    public function testCreateFolderParentNotAccessible()
+    public function testCreateFolderParentNotAccessibleV1()
+    {
+      $this->testCreateFolderParentNotAccessible(ApiVersion::V1);
+    }
+    /**
+     * @test
+     * -# Check for inaccessible parent on FolderController::createFolder() with version 1 attributes
+     * -# Check for 403 response
+     */
+    public function testCreateFolderParentNotAccessibleV2()
+    {
+      $this->testCreateFolderParentNotAccessible();
+    }
+
+    /**
+     * @param $version to test
+     * @return void
+     */
+    private function testCreateFolderParentNotAccessible($version = ApiVersion::V2)
     {
       $parentFolder = 2;
       $folderName = "root-child1";
@@ -371,26 +412,47 @@ namespace Fossology\UI\Api\Test\Controllers
       $this->folderDao->shouldReceive('isFolderAccessible')
         ->withArgs(array($parentFolder, $this->userId))->andReturn(false);
       $requestHeaders = new Headers();
-      $requestHeaders->setHeader('parentFolder', $parentFolder);
-      $requestHeaders->setHeader('folderName', $folderName);
-      $requestHeaders->setHeader('folderDescription', $folderDescription);
       $body = $this->streamFactory->createStream();
       $request = new Request("POST", new Uri("HTTP", "localhost"),
         $requestHeaders, [], [], $body);
+      if ($version == ApiVersion::V2) {
+        $request = $request->withQueryParams(['parentFolder'=>$parentFolder, 'folderName'=>$folderName, 'folderDescription'=>$folderDescription]);
+      } else {
+        $request = $request->withHeader('parentFolder', $parentFolder)
+          ->withHeader('folderName', $folderName)
+          ->withHeader('folderDescription', $folderDescription);
+      }
+      $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, $version);
       $response = new ResponseHelper();
-
       $this->expectException(HttpForbiddenException::class);
-
       $this->folderController->createFolder($request, $response, []);
     }
 
     /**
-     * @test
+     * @test FolderController::createFolder() with version 1 attributes
      * -# Check for duplicate folder response from
      *    FolderController::createFolder()
      * -# Check for 200 response
      */
-    public function testCreateFolderDuplicateNames()
+    public function testCreateFolderDuplicateNamesV1()
+    {
+      $this->testCreateFolderDuplicateNames(ApiVersion::V1);
+    }
+    /**
+     * @test FolderController::createFolder() with version 2 attributes
+     * -# Check for duplicate folder response from
+     *    FolderController::createFolder()
+     * -# Check for 200 response
+     */
+    public function testCreateFolderDuplicateNamesV2()
+    {
+      $this->testCreateFolderDuplicateNames();
+    }
+    /**
+     * @param $version to test
+     * @return void
+     */
+    private function testCreateFolderDuplicateNames($version = ApiVersion::V2)
     {
       $parentFolder = 2;
       $folderName = "root-child1";
@@ -407,6 +469,14 @@ namespace Fossology\UI\Api\Test\Controllers
       $body = $this->streamFactory->createStream();
       $request = new Request("POST", new Uri("HTTP", "localhost"),
         $requestHeaders, [], [], $body);
+      if ($version == ApiVersion::V2) {
+        $request = $request->withQueryParams(['parentFolder'=>$parentFolder,'folderName'=>$folderName, 'folderDescription'=>$folderDescription]);
+      } else {
+        $request = $request->withHeader('parentFolder', $parentFolder)
+          ->withHeader('folderName', $folderName)
+          ->withHeader('folderDescription', $folderDescription);
+      }
+      $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, $version);
       $response = new ResponseHelper();
       $actualResponse = $this->folderController->createFolder($request,
         $response, []);
@@ -479,10 +549,28 @@ namespace Fossology\UI\Api\Test\Controllers
 
     /**
      * @test
-     * -# Test for FolderController::editFolder()
+     * -# Test for FolderController::editFolder() with version 1 attributes
      * -# Check for 200 response
      */
-    public function testEditFolder()
+    public function testEditFolderV1()
+    {
+      $this->testEditFolder(APiVersion::V1);
+    }
+    /**
+     * @test
+     * -# Test for FolderController::editFolder() with version 2 attributes
+     * -# Check for 200 response
+     */
+    public function testEditFolderV2()
+    {
+      $this->testEditFolder();
+    }
+
+    /**
+     * @param $version to test
+     * @return void
+     */
+    private function testEditFolder($version = ApiVersion::V2)
     {
       $folderId = 3;
       $folderName = "new name";
@@ -494,11 +582,16 @@ namespace Fossology\UI\Api\Test\Controllers
       $this->folderPropertiesPlugin->shouldReceive('Edit')
         ->withArgs(array($folderId, $folderName, $folderDescription));
       $requestHeaders = new Headers();
-      $requestHeaders->setHeader('name', $folderName);
-      $requestHeaders->setHeader('description', $folderDescription);
       $body = $this->streamFactory->createStream();
       $request = new Request("PATCH", new Uri("HTTP", "localhost"),
         $requestHeaders, [], [], $body);
+      if ($version == ApiVersion::V2) {
+        $request = $request->withQueryParams(['name'=> $folderName, 'description'=>$folderDescription]);
+      } else {
+        $request = $request->withHeader('name', $folderName)
+          ->withHeader('description', $folderDescription);
+      }
+      $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, $version);
       $response = new ResponseHelper();
       $actualResponse = $this->folderController->editFolder($request,
         $response, ["id" => $folderId]);
@@ -512,10 +605,23 @@ namespace Fossology\UI\Api\Test\Controllers
 
     /**
      * @test
-     * -# Check FolderController::editFolder() on non-existing folder
+     * -# Check FolderController::editFolder() on non-existing folder with version 1 attributes
      * -# Check for 404 response
      */
-    public function testEditFolderNotExists()
+    public function testEditFolderNotExistsV1()
+    {
+      $this->testEditFolderNotExists(ApiVersion::V1);
+    }
+    /**
+     * @test
+     * -# Check FolderController::editFolder() on non-existing folder with version 2 attributes
+     * -# Check for 404 response
+     */
+    public function testEditFolderNotExistsV2()
+    {
+      $this->testEditFolderNotExists();
+    }
+    private function testEditFolderNotExists($version = ApiVersion::V2)
     {
       $folderId = 8;
       $folderName = "new name";
@@ -527,19 +633,42 @@ namespace Fossology\UI\Api\Test\Controllers
       $body = $this->streamFactory->createStream();
       $request = new Request("PATCH", new Uri("HTTP", "localhost"),
         $requestHeaders, [], [], $body);
+      if ($version == ApiVersion::V2) {
+        $request = $request->withQueryParams(['name'=> $folderName, 'description'=>$folderDescription]);
+      } else {
+        $request = $request->withHeader('name', $folderName)
+          ->withHeader('description', $folderDescription);
+      }
+      $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, $version);
       $response = new ResponseHelper();
       $this->expectException(HttpNotFoundException::class);
 
       $this->folderController->editFolder($request, $response,
         ["id" => $folderId]);
     }
-
     /**
      * @test
-     * -# Test for inaccessible folder on FolderController::editFolder()
+     * -# Test for inaccessible folder on FolderController::editFolder() with version 1 attributes
      * -# Check for 403 response
      */
-    public function testEditFolderNotAccessible()
+    public function testEditFolderNotAccessibleV1()
+    {
+      $this->testEditFolderNotAccessible(APIVersion::V2);
+    }
+    /**
+     * @test
+     * -# Test for inaccessible folder on FolderController::editFolder() with version 2 attributes
+     * -# Check for 403 response
+     */
+    public function testEditFolderNotAccessibleV2()
+    {
+      $this->testEditFolderNotAccessible();
+    }
+    /**
+     * @param $version to test
+     * @return void
+     */
+    private function testEditFolderNotAccessible($version = ApiVersion::V2)
     {
       $folderId = 3;
       $folderName = "new name";
@@ -554,6 +683,13 @@ namespace Fossology\UI\Api\Test\Controllers
       $body = $this->streamFactory->createStream();
       $request = new Request("PATCH", new Uri("HTTP", "localhost"),
         $requestHeaders, [], [], $body);
+      if ($version == ApiVersion::V2) {
+        $request = $request->withQueryParams(['name'=> $folderName, 'description'=>$folderDescription]);
+      } else {
+        $request = $request->withHeader('name', $folderName)
+          ->withHeader('description', $folderDescription);
+      }
+      $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, $version);
       $response = new ResponseHelper();
       $this->expectException(HttpForbiddenException::class);
 
@@ -563,10 +699,27 @@ namespace Fossology\UI\Api\Test\Controllers
 
     /**
      * @test
-     * -# Test for copy action on FolderController::copyFolder()
+     * -# Test for copy action on FolderController::copyFolder() with version 1 attributes
      * -# Check for 202 response
      */
-    public function testCopyFolder()
+    public function testCopyFolderV1()
+    {
+      $this->testCopyFolder(APiVersion::V1);
+    }
+    /**
+     * @test
+     * -# Test for copy action on FolderController::copyFolder() with version 2 attributes
+     * -# Check for 202 response
+     */
+    public function testCopyFolderV2()
+    {
+      $this->testCopyFolder();
+    }
+    /**
+     * @param $version to test
+     * @return void
+     */
+    private function testCopyFolder($version = ApiVersion::V2)
     {
       $folderId = 3;
       $parentId = 2;
@@ -579,16 +732,25 @@ namespace Fossology\UI\Api\Test\Controllers
       $this->folderDao->shouldReceive('isFolderAccessible')
         ->withArgs(array(M::anyOf($folderId, "$parentId"),
           $this->userId))->andReturn(true);
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs([$parentId,
+          $this->userId])->andReturn(true);
       $this->folderDao->shouldReceive('getFolderContentsId')
         ->withArgs(array($folderId, 1))->andReturn($folderContentPk);
       $this->folderContentPlugin->shouldReceive('copyContent')
         ->withArgs(array([$folderContentPk], $parentId, true))->andReturn("");
+
       $requestHeaders = new Headers();
-      $requestHeaders->setHeader('parent', $parentId);
-      $requestHeaders->setHeader('action', "copy");
       $body = $this->streamFactory->createStream();
       $request = new Request("PUT", new Uri("HTTP", "localhost"),
         $requestHeaders, [], [], $body);
+      if ($version == ApiVersion::V2) {
+        $request = $request->withQueryParams(['parent'=> $parentId, 'action'=>"copy"]);
+      } else {
+        $request = $request->withHeader('parent', $parentId)
+          ->withHeader('action', "copy");
+      }
+      $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, $version);
       $response = new ResponseHelper();
 
       $actualResponse = $this->folderController->copyFolder($request,
@@ -604,10 +766,28 @@ namespace Fossology\UI\Api\Test\Controllers
 
     /**
      * @test
-     * -# Test for move action on FolderController::copyFolder()
+     * -# Test for move action on FolderController::copyFolder() with version 1 attributes
      * -# Check for 202 response
      */
-    public function testMoveFolder()
+    public function testMoveFolderV1()
+    {
+      $this->testMoveFolder(ApiVersion::V1);
+    }
+    /**
+     * @test
+     * -# Test for move action on FolderController::copyFolder() with version 2 attributes
+     * -# Check for 202 response
+     */
+    public function testMoveFolderV2()
+    {
+      $this->testMoveFolder();
+    }
+
+    /**
+     * @param $version to test
+     * @return void
+     */
+    private function testMoveFolder($version = ApiVersion::V2)
     {
       $folderId = 3;
       $parentId = 2;
@@ -620,18 +800,24 @@ namespace Fossology\UI\Api\Test\Controllers
       $this->folderDao->shouldReceive('isFolderAccessible')
         ->withArgs(array(M::anyOf($folderId, "$parentId"),
           $this->userId))->andReturn(true);
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs([$parentId, $this->userId])->andReturn(true);
       $this->folderDao->shouldReceive('getFolderContentsId')
         ->withArgs(array($folderId, 1))->andReturn($folderContentPk);
       $this->folderContentPlugin->shouldReceive('copyContent')
         ->withArgs(array([$folderContentPk], $parentId, false))->andReturn("");
       $requestHeaders = new Headers();
-      $requestHeaders->setHeader('parent', $parentId);
-      $requestHeaders->setHeader('action', "move");
       $body = $this->streamFactory->createStream();
       $request = new Request("PUT", new Uri("HTTP", "localhost"),
         $requestHeaders, [], [], $body);
       $response = new ResponseHelper();
-
+      if ($version == ApiVersion::V2) {
+        $request = $request->withQueryParams(['parent'=>$parentId, 'action'=>'move']);
+      } else {
+        $request = $request->withHeader('parent', $parentId)
+          ->withHeader('action', "move");
+      }
+      $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,$version);
       $actualResponse = $this->folderController->copyFolder($request,
         $response, ["id" => $folderId]);
       $expectedResponse = new Info(202,
@@ -645,10 +831,23 @@ namespace Fossology\UI\Api\Test\Controllers
 
     /**
      * @test
-     * -# Test for invalid folder copy on FolderController::copyFolder()
+     * -# Test for invalid folder copy on FolderController::copyFolder() with version 1 attributes
      * -# Check for 404 response
      */
-    public function testCopyFolderNotFound()
+    public function testCopyFolderNotFoundV1()
+    {
+      $this->testCopyFolderNotFound(APiVersion::V2);
+    }
+    /**
+     * @test
+     * -# Test for invalid folder copy on FolderController::copyFolder() with version 2 attributes
+     * -# Check for 404 response
+     */
+    public function testCopyFolderNotFoundV2()
+    {
+      $this->testCopyFolderNotFound();
+    }
+    private function testCopyFolderNotFound($version = ApiVersion::V2)
     {
       $folderId = 3;
       $parentId = 2;
@@ -656,11 +855,16 @@ namespace Fossology\UI\Api\Test\Controllers
       $this->folderDao->shouldReceive('getFolder')->withArgs(array($folderId))
         ->andReturnNull();
       $requestHeaders = new Headers();
-      $requestHeaders->setHeader('parent', $parentId);
-      $requestHeaders->setHeader('action', "copy");
       $body = $this->streamFactory->createStream();
       $request = new Request("PUT", new Uri("HTTP", "localhost"),
         $requestHeaders, [], [], $body);
+      if ($version == ApiVersion::V2) {
+        $request = $request->withQueryParams(['parent'=>$parentId, 'action'=>'copy']);
+      } else {
+        $request = $request->withHeader('parent', $parentId)
+          ->withHeader('action', "copy");
+      }
+      $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,$version);
       $response = new ResponseHelper();
       $this->expectException(HttpNotFoundException::class);
 
@@ -670,10 +874,23 @@ namespace Fossology\UI\Api\Test\Controllers
 
     /**
      * @test
-     * -# Test for invalid parent copy on FolderController::copyFolder()
+     * -# Test for invalid parent copy on FolderController::copyFolder() with version 1 attributes
      * -# Check for 404 response
      */
-    public function testCopyParentFolderNotFound()
+    public function testCopyParentFolderNotFoundV1()
+    {
+      $this->testCopyParentFolderNotFound(APiVersion::V1);
+    }
+    /**
+     * @test
+     * -# Test for invalid parent copy on FolderController::copyFolder() with version 2 attributes
+     * -# Check for 404 response
+     */
+    public function testCopyParentFolderNotFoundV2()
+    {
+      $this->testCopyParentFolderNotFound();
+    }
+    private function testCopyParentFolderNotFound($version = ApiVersion::V2)
     {
       $folderId = 3;
       $parentId = 2;
@@ -688,6 +905,13 @@ namespace Fossology\UI\Api\Test\Controllers
       $body = $this->streamFactory->createStream();
       $request = new Request("PUT", new Uri("HTTP", "localhost"),
         $requestHeaders, [], [], $body);
+      if ($version == ApiVersion::V2) {
+        $request = $request->withQueryParams(['parent'=>$parentId, 'action'=>'copy']);
+      } else {
+        $request = $request->withHeader('parent', $parentId)
+          ->withHeader('action', "copy");
+      }
+      $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,$version);
       $response = new ResponseHelper();
       $this->expectException(HttpNotFoundException::class);
 
@@ -697,10 +921,28 @@ namespace Fossology\UI\Api\Test\Controllers
 
     /**
      * @test
-     * -# Test for inaccessible folder on FolderController::copyFolder()
+     * -# Test for inaccessible folder on FolderController::copyFolder() with version 1 attributes
      * -# Check for 403 response
      */
-    public function testCopyFolderNotAccessible()
+    public function testCopyFolderNotAccessibleV1()
+    {
+      $this->testCopyFolderNotAccessible(ApiVersion::V1);
+    }
+    /**
+     * @test
+     * -# Test for inaccessible folder on FolderController::copyFolder() with version 2 attributes
+     * -# Check for 403 response
+     */
+    public function testCopyFolderNotAccessibleV2()
+    {
+      $this->testCopyFolderNotAccessible();
+    }
+
+    /**
+     * @param $version to test
+     * @return void
+     */
+    private function testCopyFolderNotAccessible($version = ApiVersion::V2)
     {
       $folderId = 3;
       $parentId = 2;
@@ -710,11 +952,16 @@ namespace Fossology\UI\Api\Test\Controllers
       $this->folderDao->shouldReceive('isFolderAccessible')
         ->withArgs(array($folderId, $this->userId))->andReturn(false);
       $requestHeaders = new Headers();
-      $requestHeaders->setHeader('parent', $parentId);
-      $requestHeaders->setHeader('action', "copy");
       $body = $this->streamFactory->createStream();
       $request = new Request("PUT", new Uri("HTTP", "localhost"),
         $requestHeaders, [], [], $body);
+      if ($version == ApiVersion::V2) {
+        $request = $request->withQueryParams(['parent'=>$parentId, 'action'=>'copy']);
+      } else {
+        $request = $request->withHeader('parent', $parentId)
+          ->withHeader('action', "copy");
+      }
+      $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,$version);
       $response = new ResponseHelper();
       $this->expectException(HttpForbiddenException::class);
 
@@ -724,10 +971,23 @@ namespace Fossology\UI\Api\Test\Controllers
 
     /**
      * @test
-     * -# Test for inaccessible parent folder on FolderController::copyFolder()
+     * -# Test for inaccessible parent folder on FolderController::copyFolder() with version 1 attributes
      * -# Check for 403 response
      */
-    public function testCopyParentFolderNotAccessible()
+    public function testCopyParentFolderNotAccessibleV1()
+    {
+      $this->testCopyParentFolderNotAccessible(ApiVersion::V1);
+    }
+    /**
+     * @test
+     * -# Test for inaccessible parent folder on FolderController::copyFolder() with version 2 attributes
+     * -# Check for 403 response
+     */
+    public function testCopyParentFolderNotAccessibleV2()
+    {
+      $this->testCopyParentFolderNotAccessible();
+    }
+    private function testCopyParentFolderNotAccessible($version = ApiVersion::V2)
     {
       $folderId = 3;
       $parentId = 2;
@@ -739,11 +999,16 @@ namespace Fossology\UI\Api\Test\Controllers
       $this->folderDao->shouldReceive('isFolderAccessible')
         ->withArgs(array("$parentId", $this->userId))->andReturn(false);
       $requestHeaders = new Headers();
-      $requestHeaders->setHeader('parent', $parentId);
-      $requestHeaders->setHeader('action', "copy");
       $body = $this->streamFactory->createStream();
       $request = new Request("PUT", new Uri("HTTP", "localhost"),
         $requestHeaders, [], [], $body);
+      if ($version == ApiVersion::V2) {
+        $request = $request->withQueryParams(['parent'=>$parentId, 'action'=>'copy']);
+      } else {
+        $request = $request->withHeader('parent', $parentId)
+          ->withHeader('action', "copy");
+      }
+      $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,$version);
       $response = new ResponseHelper();
       $this->expectException(HttpForbiddenException::class);
 
@@ -753,10 +1018,29 @@ namespace Fossology\UI\Api\Test\Controllers
 
     /**
      * @test
-     * -# Test for invalid action on FolderController::copyFolder()
+     * -# Test for invalid action on FolderController::copyFolder() with version 1 attributes
      * -# Check for 400 response
      */
-    public function testCopyFolderInvalidAction()
+    public function testCopyFolderInvalidActionV1()
+    {
+      $this->testCopyFolderInvalidAction(ApiVersion::V1);
+    }
+    /**
+     * @test
+     * -# Test for invalid action on FolderController::copyFolder() with version 2 attributes
+     * -# Check for 400 response
+     */
+    public function testCopyFolderInvalidActionV2()
+    {
+      $this->testCopyFolderInvalidAction();
+    }
+
+
+    /**
+     * @param $version to test
+     * @return void
+     */
+    private function testCopyFolderInvalidAction($version = ApiVersion::V2)
     {
       $folderId = 3;
       $parentId = 2;
@@ -766,12 +1050,19 @@ namespace Fossology\UI\Api\Test\Controllers
       $this->folderDao->shouldReceive('isFolderAccessible')
         ->withArgs(array(M::anyOf($folderId, "$parentId"),
           $this->userId))->andReturn(true);
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs([$parentId,$this->userId])->andReturn(true);
       $requestHeaders = new Headers();
-      $requestHeaders->setHeader('parent', $parentId);
-      $requestHeaders->setHeader('action', "somethingrandom");
       $body = $this->streamFactory->createStream();
       $request = new Request("PUT", new Uri("HTTP", "localhost"),
         $requestHeaders, [], [], $body);
+      if ($version == ApiVersion::V2) {
+        $request = $request->withQueryParams(['parent'=>$parentId, 'action'=>'somethingrandom']);
+      } else {
+        $request = $request->withHeader('parent', $parentId)
+          ->withHeader('action', "somethingrandom");
+      }
+      $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,$version);
       $response = new ResponseHelper();
       $this->expectException(HttpBadRequestException::class);
 

--- a/src/www/ui_tests/api/Controllers/GroupControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/GroupControllerTest.php
@@ -169,22 +169,43 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     }
     return $usersWithGroup;
   }
-
-
-
   /**
    * @test
-   * -# Test GroupController::deleteGroup() for valid delete request
+   * -# Test GroupController::deleteGroup() for valid delete request in version 1
    * -# Check if response status is 202
    */
-  public function testDeleteGroup()
+  public function testDeleteGroupV1()
   {
-    $groupName = 'fossy';
+    $this->testDeleteGroup(ApiVersion::V1);
+  }
+  /**
+   * @test
+   * -# Test GroupController::deleteGroup() for valid delete request in version 2
+   * -# Check if response status is 202
+   */
+  public function testDeleteGroupV2()
+  {
+    $this->testDeleteGroup();
+  }
+  /**
+   * @param $version
+   * @return void
+   */
+  private function testDeleteGroup($version = ApiVersion::V2)
+  {
     $groupId = 4;
     $userId = 1;
+    $userPk = 1;
+    $newUser = 2;
     $request = M::mock(Request::class);
-    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V1);
-    $this->restHelper->getUserDao()->shouldReceive('getGroupIdByName')->withArgs([$groupName])->andReturn($groupId);
+    $userArray = ['user_pk' => $newUser];
+
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    if ($version == ApiVersion::V2) {
+      $this->restHelper->getUserDao()->shouldReceive('getGroupIdByName')->withArgs([$groupId])->andReturn($groupId);
+      $this->restHelper->getUserDao()->shouldReceive('getUserByName')->withArgs([$userPk])->andReturn($userArray);
+    }
+    $request->shouldReceive('getAttribute')->andReturn($version);
     $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
@@ -203,13 +224,29 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $this->assertEquals($this->getResponseJson($expectedResponse),
       $this->getResponseJson($actualResponse));
   }
-
   /**
    * @test
-   * -# Test GroupController::getDeletableGroups()
+   * -# Test GroupController::getDeletableGroups() for version 1
    * -# Check if the response is a list of groups.
    */
-  public function testGetDeletableGroups()
+  public function testGetDeletableGroupsV1()
+  {
+    $this->testGetDeletableGroups(ApiVersion::V1);
+  }
+  /**
+   * @test
+   * -# Test GroupController::getDeletableGroups() for version 2
+   * -# Check if the response is a list of groups.
+   */
+  public function testGetDeletableGroupsV2()
+  {
+    $this->testGetDeletableGroups();
+  }
+  /**
+   * @param $version
+   * @return void
+   */
+  private function testGetDeletableGroups($version = ApiVersion::V2)
   {
     $userId = 2;
     $groupList = array();
@@ -222,22 +259,48 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $this->assertEquals($expectedResponse->getStatusCode(), $actualResponse->getStatusCode());
     $this->assertEquals($this->getResponseJson($expectedResponse), $this->getResponseJson($actualResponse));
   }
-    /**
+  /**
    * @test
-   * -# Test GroupController::getGroupMembers() for all groups
+   * -# Test GroupController::getGroupMembers() for all groups in version 2
    * -# Check if the response is list of group members
    */
-  public function testGetGroupMembers()
+  public function testGetGroupMembersV2()
+  {
+    $this->testGetGroupMembers();
+  }
+  /**
+   * @test
+   * -# Test GroupController::getGroupMembers() for all groups in version 1
+   * -# Check if the response is list of group members
+   */
+  public function testGetGroupMembersV1()
+  {
+    $this->testGetGroupMembers(APiVersion::V1);
+  }
+  /**
+   * @param $version
+   * @return void
+   */
+  private function testGetGroupMembers($version = ApiVersion::V2)
   {
     $userIds = [2];
     $groupName = 'fossy';
     $groupId = 1;
+    $newuser = 3;
+    $userPk = 2;
     $memberList = $this->getGroupMembers($userIds);
     $request = M::mock(Request::class);
-    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V1);
+    $groupIds = [1,2,3,4,5,6];
+    $userArray = ['user_pk' => $newuser];
+
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    if ($version == ApiVersion::V2) {
+      $this->restHelper->getUserDao()->shouldReceive('getGroupIdByName')->withArgs([$groupIds[0]])->andReturn($groupIds[0]);
+      $this->restHelper->getUserDao()->shouldReceive('getUserByName')->withArgs([$userPk])->andReturn($userArray);
+    }
+    $request->shouldReceive('getAttribute')->andReturn($version);
     $this->restHelper->getUserDao()->shouldReceive('getGroupIdByName')->withArgs([$groupName])->andReturn($groupId);
     $this->restHelper->shouldReceive('getUserId')->andReturn($userIds[0]);
-    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
     $this->userDao->shouldReceive('getAdminGroupMap')->withArgs([$userIds[0],$_SESSION[Auth::USER_LEVEL]])->andReturn([1]);
 
     $this->dbManager->shouldReceive('prepare')->withArgs([M::any(),M::any()]);
@@ -256,29 +319,49 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $actualResponse = $this->groupController->getGroupMembers($request, new ResponseHelper(), ['pathParam' => $groupId]);
     $this->assertEquals($expectedResponse->getStatusCode(),$actualResponse->getStatusCode());
   }
-
-
- /**
+  /**
    * @test
-   * -# Test GroupController::addMember()
+   * -# Test GroupController::addMember() for version 1
    * -# The user already a member
    * -# Test if the response body matches
    * -# Test if the response status is 200
    *
    */
-  public function testAddMemberUserNotMember()
+  public function testAddMemberUserNotMemberV1()
   {
-    $groupName = "fossy";
-    $userName = "user";
+    $this->testAddMemberUserNotMember(ApiVersion::V1);
+  }
+  /**
+   * @test
+   * -# Test GroupController::addMember() for version 2
+   * -# The user already a member
+   * -# Test if the response body matches
+   * -# Test if the response status is 200
+   *
+   */
+  public function testAddMemberUserNotMemberV2()
+  {
+    $this->testAddMemberUserNotMember();
+  }
+  /**
+   * @param $version to test
+   * @return void
+   */
+  public function testAddMemberUserNotMember($version = ApiVersion::V2)
+  {
     $groupId = 1;
     $newuser = 1;
-    $userArray = ['user_pk' => $newuser];
     $newPerm = 2;
     $emptyArr=[];
+    $groupIds = [1,2,3,4,5,6];
+    $userArray = ['user_pk' => $newuser];
     $userId = 1;
+
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
-    $this->restHelper->getUserDao()->shouldReceive('getGroupIdByName')->withArgs([$groupName])->andReturn($groupId);
-    $this->restHelper->getUserDao()->shouldReceive('getUserByName')->withArgs([$userName])->andReturn($userArray);
+    if ($version == ApiVersion::V2) {
+      $this->restHelper->getUserDao()->shouldReceive('getGroupIdByName')->withArgs([$groupIds[0]])->andReturn($groupId);
+      $this->restHelper->getUserDao()->shouldReceive('getUserByName')->withArgs([$userId])->andReturn($userArray);
+    }
     $this->dbHelper->shouldReceive('doesIdExist')->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
     $this->dbHelper->shouldReceive('doesIdExist')->withArgs(["users","user_pk",$newuser])->andReturn(true);
     $this->dbManager->shouldReceive('getSingleRow')->withArgs([M::any(),M::any(),M::any()])->andReturn($emptyArr);
@@ -289,7 +372,6 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $this->dbManager->shouldReceive('execute')->withArgs([M::any(),array($groupId, $newuser,$newPerm)])->andReturn(1);
     $this->dbManager->shouldReceive('freeResult')->withArgs([1]);
 
-
     $body = $this->streamFactory->createStream(json_encode([
       "perm" => $newPerm
     ]));
@@ -297,33 +379,51 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $requestHeaders->setHeader('Content-Type', 'application/json');
     $request = new Request("POST", new Uri("HTTP", "localhost"),
       $requestHeaders, [], [], $body);
-
+    $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,$version);
     $expectedResponse =  new Info(200, "User will be added to group.", InfoType::INFO);
 
     $actualResponse = $this->groupController->addMember($request, new ResponseHelper(), ['pathParam' => $groupId,'userPathParam' => $newuser]);
     $this->assertEquals($expectedResponse->getCode(),$actualResponse->getStatusCode());
     $this->assertEquals($expectedResponse->getArray(),$this->getResponseJson($actualResponse));
   }
-
   /**
    * @test
-   * -# Test GroupController::addMember()
+   * -# Test GroupController::addMember() for version 2
    * -# The user is not an admin
    * -# Test if the response status is 403
    */
-  public function testAddMemberUserNotAdmin()
+  public function testAddMemberUserNotAdminV2()
   {
-    $groupName = "fossy";
-    $userName = "user";
+    $this->testAddMemberUserNotAdmin();
+  }
+  /**
+   * @test
+   * -# Test GroupController::addMember() for version 1
+   * -# The user is not an admin
+   * -# Test if the response status is 403
+   */
+  public function testAddMemberUserNotAdminV1()
+  {
+    $this->testAddMemberUserNotAdmin(ApiVersion::V1);
+  }
+  /**
+   * @param $version to test
+   * @return void
+   */
+  private function testAddMemberUserNotAdmin($version = ApiVersion::V2)
+  {
     $groupId = 1;
     $newuser = 1;
-    $userArray = ['user_pk' => $newuser];
     $newPerm = 2;
+    $groupIds = [1,2,3,4,5,6];
+    $userArray = ['user_pk' => $newuser];
     $userId = 1;
 
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
-    $this->restHelper->getUserDao()->shouldReceive('getGroupIdByName')->withArgs([$groupName])->andReturn($groupId);
-    $this->restHelper->getUserDao()->shouldReceive('getUserByName')->withArgs([$userName])->andReturn($userArray);
+    if ($version == ApiVersion::V2) {
+      $this->restHelper->getUserDao()->shouldReceive('getGroupIdByName')->withArgs([$groupIds[0]])->andReturn($groupId);
+      $this->restHelper->getUserDao()->shouldReceive('getUserByName')->withArgs([$userId])->andReturn($userArray);
+    }
     $this->dbHelper->shouldReceive('doesIdExist')->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
     $this->dbHelper->shouldReceive('doesIdExist')->withArgs(["users","user_pk",$newuser])->andReturn(true);
     $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
@@ -336,33 +436,48 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $requestHeaders->setHeader('Content-Type', 'application/json');
     $request = new Request("POST", new Uri("HTTP", "localhost"),
       $requestHeaders, [], [], $body);
-
+    $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,$version);
     $this->expectException(HttpForbiddenException::class);
 
     $this->groupController->addMember($request, new ResponseHelper(),
-    ['pathParam' => $groupId,'userPathParam' => $newuser]);
+      ['pathParam' => $groupId,'userPathParam' => $newuser]);
   }
 
   /**
    * @test
-   * -# Test GroupController::addMember()
+   * -# Test GroupController::addMember() for version 1
    * -# The user is not an admin but group admin
    * -# Test if the response status is 200
    */
-  public function testAddMemberUserGroupAdmin()
+  public function testAddMemberUserGroupAdminV1()
   {
-    $groupName = "fossy";
-    $userName = "user";
+    $this->testAddMemberUserGroupAdmin(ApiVersion::V1);
+  }
+  /**
+   * @test
+   * -# Test GroupController::addMember() for version 2
+   * -# The user is not an admin but group admin
+   * -# Test if the response status is 200
+   */
+  public function testAddMemberUserGroupAdminV2()
+  {
+    $this->testAddMemberUserGroupAdmin();
+  }
+  private  function testAddMemberUserGroupAdmin($version = ApiVersion::V2)
+  {
     $groupId = 1;
     $newuser = 1;
-    $userArray = ['user_pk' => $newuser];
     $newPerm = 2;
     $emptyArr=[];
+    $groupIds = [1,2,3,4,5,6];
+    $userArray = ['user_pk' => $newuser];
     $userId = 1;
 
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
-    $this->restHelper->getUserDao()->shouldReceive('getGroupIdByName')->withArgs([$groupName])->andReturn($groupId);
-    $this->restHelper->getUserDao()->shouldReceive('getUserByName')->withArgs([$userName])->andReturn($userArray);
+    if ($version == ApiVersion::V2) {
+      $this->restHelper->getUserDao()->shouldReceive('getGroupIdByName')->withArgs([$groupIds[0]])->andReturn($groupId);
+      $this->restHelper->getUserDao()->shouldReceive('getUserByName')->withArgs([$userId])->andReturn($userArray);
+    }
     $this->dbHelper->shouldReceive('doesIdExist')->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
     $this->dbHelper->shouldReceive('doesIdExist')->withArgs(["users","user_pk",$newuser])->andReturn(true);
     $this->dbManager->shouldReceive('getSingleRow')->withArgs([M::any(),M::any(),M::any()])->andReturn($emptyArr);
@@ -380,7 +495,7 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $requestHeaders->setHeader('Content-Type', 'application/json');
     $request = new Request("POST", new Uri("HTTP", "localhost"),
       $requestHeaders, [], [], $body);
-
+    $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,$version);
     $expectedResponse =  new Info(200, "User will be added to group.", InfoType::INFO);
 
     $actualResponse = $this->groupController->addMember($request, new ResponseHelper(), ['pathParam' => $groupId,'userPathParam' => $newuser]);
@@ -388,28 +503,49 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $this->assertEquals($expectedResponse->getArray(),$this->getResponseJson($actualResponse));
   }
 
-
   /**
    * @test
-   * -# Test GroupController::addMember()
+   * -# Test GroupController::addMember() for version 2
    * -# The user already a member
    * -# Test if the response body matches
    * -# Test if the response status is 400
    *
    */
-  public function testAddMemberUserAlreadyMember()
+  public function testAddMemberUserAlreadyMemberV2()
   {
-    $groupName = "fossy";
-    $userName = "user";
+    $this->testAddMemberUserAlreadyMember();
+  }
+  /**
+   * @test
+   * -# Test GroupController::addMember() for version 1
+   * -# The user already a member
+   * -# Test if the response body matches
+   * -# Test if the response status is 400
+   *
+   */
+  public function testAddMemberUserAlreadyMemberV1()
+  {
+    $this->testAddMemberUserAlreadyMember(ApiVersion::V1);
+  }
+
+  /**
+   * @param $version to test
+   * @return void
+   */
+  private function testAddMemberUserAlreadyMember($version = ApiVersion::V2)
+  {
     $groupId = 1;
     $newuser = 1;
-    $userArray = ['user_pk' => $newuser];
     $newPerm = 2;
+    $groupIds = [1,2,3,4,5,6];
+    $userArray = ['user_pk' => $newuser];
     $userId = 1;
 
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
-    $this->restHelper->getUserDao()->shouldReceive('getGroupIdByName')->withArgs([$groupName])->andReturn($groupId);
-    $this->restHelper->getUserDao()->shouldReceive('getUserByName')->withArgs([$userName])->andReturn($userArray);
+    if ($version == ApiVersion::V2) {
+      $this->restHelper->getUserDao()->shouldReceive('getGroupIdByName')->withArgs([$groupIds[0]])->andReturn($groupId);
+      $this->restHelper->getUserDao()->shouldReceive('getUserByName')->withArgs([$userId])->andReturn($userArray);
+    }
     $this->dbHelper->shouldReceive('doesIdExist')->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
     $this->dbHelper->shouldReceive('doesIdExist')->withArgs(["users","user_pk",$newuser])->andReturn(true);
     $this->dbManager->shouldReceive('getSingleRow')->withArgs([M::any(),M::any(),M::any()])->andReturn(true);
@@ -423,36 +559,56 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $requestHeaders->setHeader('Content-Type', 'application/json');
     $request = new Request("POST", new Uri("HTTP", "localhost"),
       $requestHeaders, [], [], $body);
-
+    $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,$version);
     $this->expectException(HttpBadRequestException::class);
 
     $this->groupController->addMember($request, new ResponseHelper(),
-    ['pathParam' => $groupId,'userPathParam' => $newuser]);
+      ['pathParam' => $groupId,'userPathParam' => $newuser]);
   }
-      /**
+
+  /**
    * @test
-   * -# Test GroupController::getGroupMembers() for all groups
+   * -# Test GroupController::changeUserPermission() in version 2
    * -# Check if the response is list of group members
    */
-  public function testChangeUserPermission()
+  public function testChangeUserPermissionV2()
   {
-    $groupIds = [1,2,3,4,5,6];
-    $groupName = "fossy";
-    $userName = "user";
-    $userId = 1;
+    $this->testChangeUserPermission();
+  }
+  /**
+   * @test
+   * -# Test GroupController::changeUserPermission() in version 1
+   * -# Check if the response is list of group members
+   */
+  public function testChangeUserPermissionV1()
+  {
+    $this->testChangeUserPermission(ApiVersion::V1);
+  }
+  /**
+   * @param $version to test
+   * @return void
+   */
+  private function testChangeUserPermission($version = ApiVersion::V2)
+  {
     $group_user_member_pk = 1;
     $newPerm = 2;
     $userPk = 1;
-    $userArray = ['user_pk' => $userId];
+    $groupId = 1;
+    $groupIds = [1,2,3,4,5,6];
+    $userArray = ['user_pk' => $userPk];
+    $userId = 1;
 
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
-    $this->restHelper->getUserDao()->shouldReceive('getGroupIdByName')->withArgs([$groupName])->andReturn($groupIds[0]);
-    $this->restHelper->getUserDao()->shouldReceive('getUserByName')->withArgs([$userName])->andReturn($userArray);
+    if ($version == ApiVersion::V2) {
+      $this->restHelper->getUserDao()->shouldReceive('getGroupIdByName')->withArgs([$groupIds[0]])->andReturn($groupId);
+      $this->restHelper->getUserDao()->shouldReceive('getUserByName')->withArgs([$userId])->andReturn($userArray);
+    }
     $this->dbHelper->shouldReceive('doesIdExist')->withArgs(["groups", "group_pk", $groupIds[0]])->andReturn(true);
-    $this->dbHelper->shouldReceive('doesIdExist')->withArgs(["users","user_pk",$userId])->andReturn(true);
+    $this->dbHelper->shouldReceive('doesIdExist')->withArgs(["users","user_pk",$userPk])->andReturn(true);
     $this->dbManager->shouldReceive('getSingleRow')->withArgs([M::any(),M::any(),M::any()])->andReturn(['group_pk'=>$groupIds[0],'group_user_member_pk'=>$group_user_member_pk,'permission'=>$newPerm]);
-    $this->restHelper->shouldReceive('getUserId')->andReturn($userPk);
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
     $this->userDao->shouldReceive('isAdvisorOrAdmin')->withArgs([$userPk, $groupIds[0]])->andReturn(true);
+    $this->userDao->shouldReceive('getUserByName')->withArgs([M::any(),M::any()]);
 
     $this->adminPlugin->shouldReceive('updateGUMPermission')->withArgs([$group_user_member_pk,$newPerm, $this->dbManager ]);
 
@@ -463,8 +619,7 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $requestHeaders->setHeader('Content-Type', 'application/json');
     $request = new Request("POST", new Uri("HTTP", "localhost"),
       $requestHeaders, [], [], $body);
-
-    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,$version);
     $expectedResponse = new Info(202, "Permission updated successfully.", InfoType::INFO);
 
     $actualResponse = $this->groupController->changeUserPermission($request, new ResponseHelper(), ['pathParam' => $groupIds[0],'userPathParam' => $userId]);

--- a/src/www/ui_tests/api/Controllers/InfoControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/InfoControllerTest.php
@@ -16,6 +16,7 @@ use Fossology\UI\Api\Controllers\InfoController;
 use Fossology\UI\Api\Helper\DbHelper;
 use Fossology\UI\Api\Helper\ResponseHelper;
 use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Models\ApiVersion;
 use Mockery as M;
 use Slim\Psr7\Factory\StreamFactory;
 use Slim\Psr7\Headers;
@@ -95,7 +96,19 @@ class InfoControllerTest extends \PHPUnit\Framework\TestCase
     return json_decode($response->getBody()->getContents(), true);
   }
 
-  public function testGetInfo()
+  public function testGetInfoV1()
+  {
+    $this->testGetInfo(ApiVersion::V1);
+  }
+  public function testGetInfoV2()
+  {
+    $this->testGetInfo();
+  }
+  /**
+   * @param $version
+   * @return void
+   */
+  private function testGetInfo($version = ApiVersion::V2)
   {
     $yaml = new Parser();
     $yamlDocArray = $yaml->parseFile(self::YAML_LOC);
@@ -127,7 +140,7 @@ class InfoControllerTest extends \PHPUnit\Framework\TestCase
     $expectedResponse = (new ResponseHelper())->withJson(array(
       "name" => $apiTitle,
       "description" => $apiDescription,
-      "version" => $apiVersion,
+      "version" => $version == APiVersion::V1 ? $apiVersion : "2.0.0",
       "security" => $security,
       "contact" => $apiContact,
       "license" => [
@@ -138,6 +151,7 @@ class InfoControllerTest extends \PHPUnit\Framework\TestCase
     ), 200);
     $request = new Request("POST", new Uri("HTTP", "localhost"), new Headers(),
       [], [], (new StreamFactory())->createStream());
+    $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,$version);
     $actualResponse = $this->infoController->getInfo($request,
       new ResponseHelper());
     $this->assertEquals($expectedResponse->getStatusCode(),

--- a/src/www/ui_tests/api/Controllers/MaintenanceControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/MaintenanceControllerTest.php
@@ -38,8 +38,6 @@ require_once dirname(__DIR__, 4) . '/lib/php/Plugin/FO_Plugin.php';
  */
 class MaintenanceControllerTest extends \PHPUnit\Framework\TestCase
 {
-
-
   /**
    * @var string YAML_LOC
    * Location of openapi.yaml file
@@ -171,7 +169,7 @@ class MaintenanceControllerTest extends \PHPUnit\Framework\TestCase
       "goldDate"=>"2022-07-16"
     ];
 
-     $OPTIONS =[
+    $OPTIONS =[
       "A"=>"Run all maintenance operations.",
       "F"=>"Validate folder contents.",
       "g"=>"Remove orphaned gold files.",

--- a/src/www/ui_tests/api/Controllers/UploadControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadControllerTest.php
@@ -289,7 +289,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
   {
     $this->testGetSingleUpload(ApiVersion::V1);
   }
-   /**
+  /**
    * @test
    * -# Test for UploadController::getUploads() to fetch single upload when version is V2
    * -# Check if response is 200
@@ -325,7 +325,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
       ->withArgs([$uploadId])->andReturn($this->getUploadBounds($uploadId));
     $this->dbHelper->shouldReceive('getUploads')
       ->withArgs([$this->userId, $this->groupId, 100, 1, $uploadId, $options,
-      true, $version])->andReturn([1, [$upload->getArray()]]);
+        true, $version])->andReturn([1, [$upload->getArray()]]);
     $expectedResponse = (new ResponseHelper())->withJson($upload->getArray(), 200);
     $actualResponse = $this->uploadController->getUploads($request,
       new ResponseHelper(), ['id' => $uploadId]);
@@ -407,7 +407,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
       ->withArgs([$folderId, $this->userId])->andReturn(true)->once();
     $this->dbHelper->shouldReceive('getUploads')
       ->withArgs([$this->userId, $this->groupId, 100, 1, null, $folderOptions,
-      true, $version])->andReturn([1, []])->once();
+        true, $version])->andReturn([1, []])->once();
     $this->uploadController->getUploads($request, new ResponseHelper(), []);
 
     // Test for name filter
@@ -425,7 +425,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     }
     $this->dbHelper->shouldReceive('getUploads')
       ->withArgs([$this->userId, $this->groupId, 100, 1, null, $nameOptions,
-      true, $version])->andReturn([1, []])->once();
+        true, $version])->andReturn([1, []])->once();
     $this->uploadController->getUploads($request, new ResponseHelper(), []);
 
     // Test for status filter
@@ -444,7 +444,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     }
     $this->dbHelper->shouldReceive('getUploads')
       ->withArgs([$this->userId, $this->groupId, 100, 1, null, $statusOptions,
-      true, $version])->andReturn([1, []])->once();
+        true, $version])->andReturn([1, []])->once();
     $this->uploadController->getUploads($request, new ResponseHelper(), []);
 
     // Test for assignee filter
@@ -462,7 +462,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     }
     $this->dbHelper->shouldReceive('getUploads')
       ->withArgs([$this->userId, $this->groupId, 100, 1, null, $assigneeOptions,
-      true, $version])->andReturn([1, []])->once();
+        true, $version])->andReturn([1, []])->once();
     $this->uploadController->getUploads($request, new ResponseHelper(), []);
 
     // Test for since filter
@@ -480,7 +480,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     }
     $this->dbHelper->shouldReceive('getUploads')
       ->withArgs([$this->userId, $this->groupId, 100, 1, null, $sinceOptions,
-      true, $version])->andReturn([1, []])->once();
+        true, $version])->andReturn([1, []])->once();
     $this->uploadController->getUploads($request, new ResponseHelper(), []);
 
     // Test for status and since filter
@@ -502,7 +502,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     }
     $this->dbHelper->shouldReceive('getUploads')
       ->withArgs([$this->userId, $this->groupId, 100, 1, null, $combOptions,
-      true, $version])->andReturn([1, []])->once();
+        true, $version])->andReturn([1, []])->once();
     $this->uploadController->getUploads($request, new ResponseHelper(), []);
   }
 
@@ -514,7 +514,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
   public function testGetUploadsV1(){
     $this->testGetUploads(ApiVersion::V1);
   }
-   /**
+  /**
    * @test
    * -# Test UploadController::getUploads() for all uploads when version is V2
    * -# Check if the response is array with status 200
@@ -599,7 +599,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
   {
     $this->testCopyUpload(ApiVersion::V2);
   }
-    /**
+  /**
    * @param $version version to test
    * @return void
    * -# Test the data format returned by Upload::getArray($version) model
@@ -623,13 +623,13 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
       $requestHeaders->setHeader('folderId', $folderId);
       $requestHeaders->setHeader('action', 'copy');
       $request = new Request("PUT", new Uri("HTTP", "localhost"),
-      $requestHeaders, [], [], $body);
+        $requestHeaders, [], [], $body);
       $actualResponse = $this->uploadController->moveUpload($request,
         new ResponseHelper(), ['id' => $uploadId]);
     }
     else{
       $request = new Request("PUT", new Uri("HTTP", "localhost"),
-      $requestHeaders, [], [], $body);
+        $requestHeaders, [], [], $body);
       if ($version == ApiVersion::V2) {
         $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,
           ApiVersion::V2);
@@ -645,10 +645,27 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
 
   /**
    * @test
-   * -# Test for UploadController::moveUpload() with invalid folder id
+   * -# Test for UploadController::moveUpload() with invalid folder id with version 1
    * -# Check if response status is 400
    */
-  public function testMoveUploadInvalidFolder()
+  public function testMoveUploadInvalidFolderV1()
+  {
+    $this->testMoveUploadInvalidFolder(ApiVersion::V1);
+  }
+  /**
+   * @test
+   * -# Test for UploadController::moveUpload() with invalid folder id with version 2
+   * -# Check if response status is 400
+   */
+  public function testMoveUploadInvalidFolderV2()
+  {
+    $this->testMoveUploadInvalidFolder();
+  }
+  /**
+   * @param $version
+   * @return void
+   */
+  private function testMoveUploadInvalidFolder($version = ApiVersion::V2)
   {
     $uploadId = 3;
 
@@ -658,6 +675,13 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     $body = $this->streamFactory->createStream();
     $request = new Request("PATCH", new Uri("HTTP", "localhost"),
       $requestHeaders, [], [], $body);
+    if ($version==ApiVersion::V2) {
+      $request = $request->withQueryParams(['folderId' => 'alpha', 'action' => 'move']);
+    } else {
+      $request = $request->withHeader("folderId", "alpha")
+        ->withHeader("action", "move");
+    }
+    $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,$version);
     $this->expectException(HttpBadRequestException::class);
 
     $this->uploadController->moveUpload($request, new ResponseHelper(),
@@ -740,7 +764,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     $info = new Info(201, intval(20), InfoType::INFO);
 
     $uploadHelper->shouldReceive('handleScheduleAnalysis')->withArgs([$uploadId,$folderId,$reqBody["scanOptions"],false])
-    ->andReturn($info);
+      ->andReturn($info);
 
     $this->folderDao->shouldReceive('getAllFolderIds')->andReturn([2,3,4]);
     $this->folderDao->shouldReceive('isFolderAccessible')
@@ -768,7 +792,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     $this->testPostUploadFolderNotAccessible(ApiVersion::V1);
   }
 
-    /**
+  /**
    * @runInSeparateProcess
    * @preserveGlobalState disabled
    * @test
@@ -927,7 +951,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
   /**
    * @param int $version Version to test
    * @return void
-    */
+   */
   private function testPostUploadInternalError(int $version)
   {
     $folderId = 3;
@@ -974,7 +998,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
 
     $this->folderDao->shouldReceive('getAllFolderIds')->andReturn([2,3,4]);
     $this->folderDao->shouldReceive('isFolderAccessible')
-    ->withArgs([$folderId])->andReturn(true);
+      ->withArgs([$folderId])->andReturn(true);
     $this->expectException(HttpInternalServerErrorException::class);
 
     $this->uploadController->postUpload($request, new ResponseHelper(), []);
@@ -1018,8 +1042,8 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     $requestHeaders = new Headers();
     $body = $this->streamFactory->createStream();
     $request = new Request("POST", new Uri("HTTP", "localhost", 80,
-        "/uploads/$uploadId/licenses", UploadController::AGENT_PARAM .
-        "=nomos,monk&containers=false"),
+      "/uploads/$uploadId/licenses", UploadController::AGENT_PARAM .
+      "=nomos,monk&containers=false"),
       $requestHeaders, [], [], $body);
     if ($version == ApiVersion::V2) {
       $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,
@@ -1060,11 +1084,31 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
    * @runInSeparateProcess
    * @preserveGlobalState disabled
    * @test
-   * -# Test for UploadController::getUploadLicenses() when agents pending
+   * -# Test for UploadController::getUploadLicenses() when agents pending with version 1 params
    * -# Check if response status is 503
    * -# Check if response headers `Retry-After` and `Look-at` set
    */
-  public function testGetUploadLicensesPendingScan()
+  public function testGetUploadLicensesPendingScanV1()
+  {
+    $this->testGetUploadLicensesPendingScan(ApiVersion::V1);
+  }
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test for UploadController::getUploadLicenses() when agents pending with version 2 params
+   * -# Check if response status is 503
+   * -# Check if response headers `Retry-After` and `Look-at` set
+   */
+  public function testGetUploadLicensesPendingScanV2()
+  {
+    $this->testGetUploadLicensesPendingScan();
+  }
+  /**
+   * @param $version to test
+   * @return void
+   */
+  private function testGetUploadLicensesPendingScan($version = ApiVersion::V2)
   {
     $uploadId = 3;
     $agentsRun = [
@@ -1075,9 +1119,16 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     $requestHeaders = new Headers();
     $body = $this->streamFactory->createStream();
     $request = new Request("POST", new Uri("HTTP", "localhost", 80,
-        "/uploads/$uploadId/licenses", UploadController::AGENT_PARAM .
-        "=nomos,monk&containers=false"),
+      "/uploads/$uploadId/licenses", UploadController::AGENT_PARAM .
+      "=nomos,monk&containers=false"),
       $requestHeaders, [], [], $body);
+    if ($version == ApiVersion::V2) {
+      $request = $request->withQueryParams(['page' => 1, 'limit' => 2, "agent" =>"nomos,monk" ]);
+    } else {
+      $request = $request->withHeader("limit",2)
+        ->withHeader("page",1);
+    }
+    $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,$version);
 
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
@@ -1262,7 +1313,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
       "shortName" => $shortName,
     ];
     $license = new License($licenseId, $shortName, "MIT License", "risk", "texts", [],
-     'type', 1);
+      'type', 1);
     $licenseIds[$licenseId] = $licenseId;
     $this->uploadDao->shouldReceive('isAccessible')
       ->withArgs([$uploadId, $this->groupId])->andReturn(true);
@@ -1372,12 +1423,12 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
   {
     $uploadId = 2;
     $reuseReportSummary = [
-        'declearedLicense' => "",
-        'clearedLicense' => "MIT, BSD-3-Clause",
-        'usedLicense' => "",
-        'unusedLicense' => "",
-        'missingLicense' => "MIT, BSD-3-Clause",
-      ];
+      'declearedLicense' => "",
+      'clearedLicense' => "MIT, BSD-3-Clause",
+      'usedLicense' => "",
+      'unusedLicense' => "",
+      'missingLicense' => "MIT, BSD-3-Clause",
+    ];
     $this->uploadDao->shouldReceive('isAccessible')
       ->withArgs([$uploadId, $this->groupId])->andReturn(true);
     $this->dbHelper->shouldReceive('doesIdExist')

--- a/src/www/ui_tests/api/Controllers/UserControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UserControllerTest.php
@@ -124,24 +124,46 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
 
   /**
    * @test
-   * -# Test UserController::getUsers() for specific user id
+   * -# Test UserController::getUsers() for specific user id for version 1
    * -# Check if response contains only one user info
    */
-  public function testGetSpecificUser()
+  public function testGetSpecificUserV1()
+  {
+    $this->testGetSpecificUser(ApiVersion::V1);
+  }
+  /**
+   * @test
+   * -# Test UserController::getUsers() for specific user id for version 2
+   * -# Check if response contains only one user info
+   */
+  public function testGetSpecificUserV2()
+  {
+    $this->testGetSpecificUser();
+  }
+  /**
+   * @param $version to test
+   * @return void
+   */
+  private function testGetSpecificUser($version = ApiVersion::V2)
   {
     $userId = 2;
     $userName = 'fossy';
     $userArray = ['user_pk' => $userId];
     $user = $this->getUsers([$userId]);
+    if ($version == ApiVersion::V2) {
+      $userArray = ['user_pk' => $userId];
+      $this->restHelper->getUserDao()->shouldReceive('getUserByName')
+        ->withArgs([$userId])->andReturn($userArray);
+    }
     $request = M::mock(Request::class);
     $this->restHelper->getUserDao()->shouldReceive('getUserByName')
       ->withArgs([$userName])->andReturn($userArray);
-    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V1);
+    $request->shouldReceive('getAttribute')->andReturn($version);
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(["users", "user_pk", $userId])->andReturn(true);
     $this->dbHelper->shouldReceive('getUsers')->withArgs([$userId])
       ->andReturn($user);
-    $expectedResponse = (new ResponseHelper())->withJson($user[0]->getArray(), 200);
+    $expectedResponse = (new ResponseHelper())->withJson($user[0]->getArray($version), 200);
     $actualResponse = $this->userController->getUsers($request, new ResponseHelper(),
       ['pathParam' => $userId]);
     $this->assertEquals($expectedResponse->getStatusCode(),
@@ -152,14 +174,36 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
 
   /**
    * @test
-   * -# Test UserController::getUsers() for invalid user id
+   * -# Test UserController::getUsers() for invalid user id for version 1
    * -# Check if response status is 404
    */
-  public function testGetSpecificUserNotFound()
+  public function testGetSpecificUserNotFoundV1()
+  {
+    $this->testGetSpecificUserNotFound(ApiVersion::V1);
+  }
+  /**
+   * @test
+   * -# Test UserController::getUsers() for invalid user id for version 2
+   * -# Check if response status is 404
+   */
+  public function testGetSpecificUserNotFoundV2()
+  {
+    $this->testGetSpecificUserNotFound();
+  }
+  /**
+   * @param $version to test
+   * @return void
+   */
+  private function testGetSpecificUserNotFound($version = ApiVersion::V2)
   {
     $userId = 6;
     $request = M::mock(Request::class);
-    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V1);
+    if ($version == ApiVersion::V2) {
+      $userArray = ['user_pk' => $userId];
+      $this->restHelper->getUserDao()->shouldReceive('getUserByName')
+        ->withArgs([$userId])->andReturn($userArray);
+    }
+    $request->shouldReceive('getAttribute')->andReturn($version);
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(["users", "user_pk", $userId])->andReturn(false);
     $this->expectException(HttpNotFoundException::class);
@@ -170,20 +214,43 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
 
   /**
    * @test
-   * -# Test UserController::getUsers() for all users
+   * -# Test UserController::getUsers() for all users for version 1
    * -# Check if the response is list of user info
    */
-  public function testGetAllUsers()
+  public function testGetAllUsersV1()
   {
+    $this->testGetAllUsers(ApiVersion::V1);
+  }
+  /**
+   * @test
+   * -# Test UserController::getUsers() for all users for version 2
+   * -# Check if the response is list of user info
+   */
+  public function testGetAllUsersV2()
+  {
+    $this->testGetAllUsers();
+  }
+  /**
+   * @param $version to test
+   * @return void
+   */
+  private function testGetAllUsers($version = ApiVersion::V2)
+  {
+    $userId = 2;
     $users = $this->getUsers([2, 3, 4]);
+    if ($version == ApiVersion::V2) {
+      $userArray = ['user_pk' => $userId];
+      $this->restHelper->getUserDao()->shouldReceive('getUserByName')
+        ->withArgs([$userId])->andReturn($userArray);
+    }
     $request = M::mock(Request::class);
-    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V1);
+    $request->shouldReceive('getAttribute')->andReturn($version);
     $this->dbHelper->shouldReceive('getUsers')->withArgs([null])
       ->andReturn($users);
 
     $allUsers = array();
     foreach ($users as $user) {
-      $allUsers[] = $user->getArray();
+      $allUsers[] = $user->getArray($version);
     }
 
     $expectedResponse = (new ResponseHelper())->withJson($allUsers, 200);
@@ -196,18 +263,34 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
 
   /**
    * @test
-   * -# Test UserController::deleteUser() for valid delete request
+   * -# Test UserController::deleteUser() for valid delete request for version 1
    * -# Check if response status is 202
    */
-  public function testDeleteUser()
+  public function testDeleteUserV1()
+  {
+    $this->testDeleteUser(ApiVersion::V1);
+  }
+  /**
+   * @test
+   * -# Test UserController::deleteUser() for valid delete request for version 2
+   * -# Check if response status is 202
+   */
+  public function testDeleteUserV2()
+  {
+    $this->testDeleteUser();
+  }
+  /**
+   * @param $version to test
+   * @return void
+   */
+  private function testDeleteUser($version = ApiVersion::V2)
   {
     $userId = 4;
-    $userName = 'fossy';
     $userArray = ['user_pk' => $userId];
     $request = M::mock(Request::class);
-    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V1);
+    $request->shouldReceive('getAttribute')->andReturn($version);
     $this->restHelper->getUserDao()->shouldReceive('getUserByName')
-      ->withArgs([$userName])->andReturn($userArray);
+      ->withArgs([$userId])->andReturn($userArray);
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(["users", "user_pk", $userId])->andReturn(true);
     $this->dbHelper->shouldReceive('deleteUser')->withArgs([$userId]);
@@ -215,7 +298,7 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
     $expectedResponse = (new ResponseHelper())->withJson($info->getArray(),
       $info->getCode());
     $actualResponse = $this->userController->deleteUser($request, new ResponseHelper(),
-    ['pathParam' => $userId]);
+      ['pathParam' => $userId]);
     $this->assertEquals($expectedResponse->getStatusCode(),
       $actualResponse->getStatusCode());
     $this->assertEquals($this->getResponseJson($expectedResponse),
@@ -224,18 +307,34 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
 
   /**
    * @test
-   * -# Test UserController::deleteUser() for invalid user id
+   * -# Test UserController::deleteUser() for invalid user id for version 1
    * -# Check if response status is 404
    */
-  public function testDeleteUserDoesNotExists()
+  public function testDeleteUserDoesNotExistsV1()
+  {
+    $this->testDeleteUserDoesNotExists(ApiVersion::V1);
+  }
+  /**
+   * @test
+   * -# Test UserController::deleteUser() for invalid user id for version 2
+   * -# Check if response status is 404
+   */
+  public function testDeleteUserDoesNotExistsV2()
+  {
+    $this->testDeleteUserDoesNotExists();
+  }
+  /**
+   * @param $version
+   * @return void
+   */
+  private function testDeleteUserDoesNotExists($version = ApiVersion::V2)
   {
     $userId = 8;
-    $userName = 'fossy';
     $userArray = ['user_pk' => $userId];
     $request = M::mock(Request::class);
-    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V1);
+    $request->shouldReceive('getAttribute')->andReturn($version);
     $this->restHelper->getUserDao()->shouldReceive('getUserByName')
-      ->withArgs([$userName])->andReturn($userArray);
+      ->withArgs([$userId])->andReturn($userArray);
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(["users", "user_pk", $userId])->andReturn(false);
     $this->expectException(HttpNotFoundException::class);
@@ -246,29 +345,46 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
 
   /**
    * @test
-   * -# Test UserController::getCurrentUser()
+   * -# Test UserController::getCurrentUser() for version 1
    * -# Check if response contains current user's info
    */
-  public function testGetCurrentUser()
+  public function testGetCurrentUserV1()
+  {
+    $this->testGetCurrentUser(ApiVersion::V1);
+  }
+  /**
+   * @test
+   * -# Test UserController::getCurrentUser() for version 2
+   * -# Check if response contains current user's info
+   */
+  public function testGetCurrentUserV2()
+  {
+    $this->testGetCurrentUser();
+  }
+  /**
+   * @param $version to test
+   * @return void
+   */
+  private function testGetCurrentUser($version = ApiVersion::V2)
   {
     $userId = 2;
     $user = $this->getUsers([$userId]);
     $request = M::mock(Request::class);
-    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V1);
+    $request->shouldReceive('getAttribute')->andReturn($version);
     $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
     $this->dbHelper->shouldReceive('getUsers')->withArgs([$userId])
       ->andReturn($user);
     $this->userDao->shouldReceive('getUserAndDefaultGroupByUserName')->withArgs([$user[0]->getArray()["name"]])
       ->andReturn(["group_name" => "fossy"]);
 
-    $expectedUser = $user[0]->getArray();
-    $expectedUser["default_group"] = "fossy";
-
+    $expectedUser = $user[0]->getArray($version);
+    if ($version == ApiVersion::V1) {
+      $expectedUser["default_group"] = "fossy";
+    }
     $expectedResponse = (new ResponseHelper())->withJson($expectedUser, 200);
 
     $actualResponse = $this->userController->getCurrentUser($request,
       new ResponseHelper(), []);
-
     $this->assertEquals($expectedResponse->getStatusCode(),
       $actualResponse->getStatusCode());
     $this->assertEquals($this->getResponseJson($expectedResponse),


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This pull request adds versioning in some test cases enabling them to run on both version 1 and 2 as requested in issue [#2788](https://github.com/fossology/fossology/issues/2788)

## How to test

- Go and run all test cases; they pass with no issues.

CC @shaheemazmalmmd @soham4abc @dushimsam @GMishx 