### PR TITLE
test(modes): Add more test cases for models including Permissions,LicenseCandidate, Group, Agent, and FileInfo

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -33,7 +33,7 @@
         "symfony/translation" : "v5.4.12",
         "symfony/yaml" : "v5.4.12",
         "symfony/mime" : "v5.4.13",
-        "twig/twig" : "v3.4.3",
+        "twig/twig" : "v3.11.1",
         "guzzlehttp/guzzle": "v7.5.0",
         "phpoffice/phpspreadsheet": "1.19.0",
         "twbs/bootstrap": "v4.1.0",

--- a/src/composer.json.in
+++ b/src/composer.json.in
@@ -33,7 +33,7 @@
         "symfony/translation" : "v5.4.12",
         "symfony/yaml" : "v5.4.12",
         "symfony/mime" : "v5.4.13",
-        "twig/twig" : "v3.4.3",
+        "twig/twig" : "v3.11.1",
         "guzzlehttp/guzzle": "v7.5.0",
         "phpoffice/phpspreadsheet": "1.19.0",
         "twbs/bootstrap": "v4.1.0",

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "88841b471e58e9ff60f7f350c6919f4f",
+    "content-hash": "3f9206227edd4976d806c0d54d0902f6",
     "packages": [
         {
             "name": "composer/spdx-licenses",
@@ -2514,16 +2514,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.2",
+            "version": "v2.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
+                "reference": "80d075412b557d41002320b96a096ca65aa2c98d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/80d075412b557d41002320b96a096ca65aa2c98d",
+                "reference": "80d075412b557d41002320b96a096ca65aa2c98d",
                 "shasum": ""
             },
             "require": {
@@ -2561,7 +2561,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.2"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.3"
             },
             "funding": [
                 {
@@ -2577,7 +2577,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2023-01-24T14:02:46+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -2804,20 +2804,20 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.28.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb"
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
-                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "provide": {
                 "ext-ctype": "*"
@@ -2827,9 +2827,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -2866,7 +2863,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -2882,7 +2879,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
@@ -3057,20 +3054,20 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.28.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "42292d99c55abe617799667f454222c54c60e229"
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
-                "reference": "42292d99c55abe617799667f454222c54c60e229",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "provide": {
                 "ext-mbstring": "*"
@@ -3080,9 +3077,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -3120,7 +3114,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -3136,7 +3130,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-28T09:04:16+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
@@ -3295,26 +3289,23 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.28.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5"
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
-                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -3358,7 +3349,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -3374,30 +3365,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.28.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "7581cd600fa9fd681b797d00b02f068e2f13263b"
+                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/7581cd600fa9fd681b797d00b02f068e2f13263b",
-                "reference": "7581cd600fa9fd681b797d00b02f068e2f13263b",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
+                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -3437,7 +3425,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -3453,7 +3441,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/process",
@@ -3980,34 +3968,38 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.4.3",
+            "version": "v3.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "c38fd6b0b7f370c198db91ffd02e23b517426b58"
+                "reference": "ff063afc691e1cfda6714f1915ed766cb108d188"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/c38fd6b0b7f370c198db91ffd02e23b517426b58",
-                "reference": "c38fd6b0b7f370c198db91ffd02e23b517426b58",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/ff063afc691e1cfda6714f1915ed766cb108d188",
+                "reference": "ff063afc691e1cfda6714f1915ed766cb108d188",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-mbstring": "^1.3"
+                "symfony/polyfill-mbstring": "^1.3",
+                "symfony/polyfill-php80": "^1.22",
+                "symfony/polyfill-php81": "^1.29"
             },
             "require-dev": {
-                "psr/container": "^1.0",
-                "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0"
+                "psr/container": "^1.0|^2.0",
+                "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
+                "files": [
+                    "src/Resources/core.php",
+                    "src/Resources/debug.php",
+                    "src/Resources/escaper.php",
+                    "src/Resources/string_loader.php"
+                ],
                 "psr-4": {
                     "Twig\\": "src/"
                 }
@@ -4040,7 +4032,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.4.3"
+                "source": "https://github.com/twigphp/Twig/tree/v3.11.1"
             },
             "funding": [
                 {
@@ -4052,7 +4044,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-28T08:42:51+00:00"
+            "time": "2024-09-10T10:40:14+00:00"
         }
     ],
     "packages-dev": [
@@ -6153,5 +6145,5 @@
     "platform-overrides": {
         "php": "7.3.31"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/www/ui_tests/api/Models/AgentTest.php
+++ b/src/www/ui_tests/api/Models/AgentTest.php
@@ -1,0 +1,229 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Valens NIYONSENGA <valensniyonsenga2003@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for Agent model
+ */
+
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\Agent;
+use Fossology\UI\Api\Models\ApiVersion;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @class AgentTest
+ * @brief Tests for Agent model
+ */
+class AgentTest extends TestCase
+{
+  /**
+   * Provides test data and an instance of the Decider class.
+   *
+   * @param string $version The API version to use for formatting.
+   * @return array An associative array containing:
+   *  - `expectedArray`: The expected array structure.
+   *  - `obj`: The instance of Decider being tested.
+   */
+  private function getAgentInfo()
+  {
+    $expectedArray = [
+      'successfulAgents' => ["Monk","nomos"],
+      'uploadId' => 3,
+      'agentName' => "ninka",
+      'currentAgentId' => 4,
+      'currentAgentRev' => 454,
+      'isAgentRunning' => null
+      ];
+    $obj = new Agent($expectedArray['successfulAgents'], $expectedArray['uploadId'], $expectedArray['agentName'], $expectedArray['currentAgentId'], $expectedArray['currentAgentRev'],null);
+    return [
+      'expectedArray' => $expectedArray,
+      'obj' => $obj
+    ];
+  }
+  /**
+   * Tests Agent::getSuccessfulAgents() method.
+   *
+   * This method validates that the `getSuccessfulAgents` method returns the correct array of successful agents.
+   */
+  public function testGetSuccessfulAgents()
+  {
+    $info = $this->getAgentInfo();
+    $agent = $info['obj'];
+    $this->assertEquals(["Monk","nomos"], $agent->getSuccessfulAgents());
+  }
+
+  /**
+   * Tests Agent::getUploadId() method.
+   *
+   * This method validates that the `getUploadId` method returns the correct upload ID value.
+   */
+  public function testGetUploadId()
+  {
+    $info = $this->getAgentInfo();
+    $agent = $info['obj'];
+    $this->assertEquals(3, $agent->getUploadId());
+  }
+
+  /**
+   * Tests Agent::getAgentName() method.
+   *
+   * This method validates that the `getAgentName` method returns the correct agent name.
+   */
+  public function testGetAgentName()
+  {
+    $info = $this->getAgentInfo();
+    $agent = $info['obj'];
+    $this->assertEquals("ninka", $agent->getAgentName());
+  }
+
+  /**
+   * Tests Agent::getCurrentAgentId() method.
+   *
+   * This method validates that the `getCurrentAgentId` method returns the correct current agent ID value.
+   */
+  public function testGetCurrentAgentId()
+  {
+    $info = $this->getAgentInfo();
+    $agent = $info['obj'];
+    $this->assertEquals(4, $agent->getCurrentAgentId());
+  }
+
+  /**
+   * Tests Agent::getCurrentAgentRev() method.
+   *
+   * This method validates that the `getCurrentAgentRev` method returns the correct current agent revision.
+   */
+  public function testGetCurrentAgentRev()
+  {
+    $info = $this->getAgentInfo();
+    $agent = $info['obj'];
+    $this->assertEquals(454, $agent->getCurrentAgentRev());
+  }
+
+  /**
+   * Tests Agent::setSuccessfulAgents() method.
+   *
+   * This method validates that the `setSuccessfulAgents` method updates the list of successful agents.
+   */
+  public function testSetSuccessfulAgents()
+  {
+    $info = $this->getAgentInfo();
+    $agent = $info['obj'];
+    $agent->setSuccessfulAgents(["nomos"]);
+    $this->assertEquals(["nomos"], $agent->getSuccessfulAgents());
+  }
+
+  /**
+   * Tests Agent::setUploadId() method.
+   *
+   * This method validates that the `setUploadId` method updates the upload ID value.
+   */
+  public function testSetUploadId()
+  {
+    $info = $this->getAgentInfo();
+    $agent = $info['obj'];
+    $agent->setUploadId(5);
+    $this->assertEquals(5, $agent->getUploadId());
+  }
+
+  /**
+   * Tests Agent::setAgentName() method.
+   *
+   * This method validates that the `setAgentName` method updates the agent's name.
+   */
+  public function testSetAgentName()
+  {
+    $info = $this->getAgentInfo();
+    $agent = $info['obj'];
+    $agent->setAgentName("monk");
+    $this->assertEquals("monk", $agent->getAgentName());
+  }
+
+  /**
+   * Tests Agent::setCurrentAgentId() method.
+   *
+   * This method validates that the `setCurrentAgentId` method updates the current agent ID.
+   */
+  public function testSetCurrentAgentId()
+  {
+    $info = $this->getAgentInfo();
+    $agent = $info['obj'];
+    $agent->setCurrentAgentId(6);
+    $this->assertEquals(6, $agent->getCurrentAgentId());
+  }
+
+  /**
+   * Tests Agent::setCurrentAgentRev() method.
+   *
+   * This method validates that the `setCurrentAgentRev` method updates the current agent revision.
+   */
+  public function testSetCurrentAgentRev()
+  {
+    $info = $this->getAgentInfo();
+    $agent = $info['obj'];
+    $agent->setCurrentAgentRev(40);
+    $this->assertEquals(40, $agent->getCurrentAgentRev());
+  }
+
+  /**
+   * Tests Agent::setIsAgentRunning() method.
+   *
+   * This method validates that the `setIsAgentRunning` method updates the agent running status.
+   */
+  public function testSetIsAgentRunning()
+  {
+    $info = $this->getAgentInfo();
+    $agent = $info['obj'];
+    $agent->setIsAgentRunning(true);
+    $this->assertTrue($agent->getIsAgentRunning());
+  }
+
+  /**
+   * Tests Agent::getArray() method for API version V1.
+   *
+   * This method checks if `getArray()` returns the correct associative array for version V1.
+   */
+  public function testGetArrayV1()
+  {
+    $info = $this->getAgentInfo();
+    $agent = $info['obj'];
+
+    $expectedArray = [
+      'successfulAgents' =>  $agent->getSuccessfulAgents(),
+      'uploadId' =>  $agent->getUploadId(),
+      'agentName' =>  $agent->getAgentName(),
+      'currentAgentId' =>  $agent->getCurrentAgentId(),
+      'currentAgentRev' =>  $agent->getCurrentAgentRev(),
+      'isAgentRunning' => null,
+    ];
+
+    $this->assertEquals($expectedArray, $agent->getArray(ApiVersion::V1));
+  }
+
+  /**
+   * Tests Agent::getJSON() method for API version V1.
+   *
+   * This method checks if `getJSON()` returns the correct JSON string for version V1.
+   */
+  public function testGetJSONV1()
+  {
+    $info = $this->getAgentInfo();
+    $agent = $info['obj'];
+
+    $expectedJSON = json_encode([
+      'successfulAgents' => $agent->getSuccessfulAgents(),
+      'uploadId' => $agent->getUploadId(),
+      'agentName' => $agent->getAgentName(),
+      'currentAgentId' => $agent->getCurrentAgentId(),
+      'currentAgentRev' => $agent->getCurrentAgentRev(),
+      'isAgentRunning' => null,
+    ]);
+
+    $this->assertEquals($expectedJSON, $agent->getJSON(ApiVersion::V1));
+  }
+}

--- a/src/www/ui_tests/api/Models/AnalysisTest.php
+++ b/src/www/ui_tests/api/Models/AnalysisTest.php
@@ -143,7 +143,7 @@ class AnalysisTest extends \PHPUnit\Framework\TestCase
   /**
    * @param $version version to test
    * @return void
-   * -# Test the data format returned by Upload::getArray($version) model
+   * -# Test the data format returned by Upload::getArray($version) model 
    */
   private function testDataFormat($version)
   {

--- a/src/www/ui_tests/api/Models/AnalysisTest.php
+++ b/src/www/ui_tests/api/Models/AnalysisTest.php
@@ -143,7 +143,7 @@ class AnalysisTest extends \PHPUnit\Framework\TestCase
   /**
    * @param $version version to test
    * @return void
-   * -# Test the data format returned by Upload::getArray($version) model 
+   * -# Test the data format returned by Upload::getArray($version) model
    */
   private function testDataFormat($version)
   {
@@ -183,5 +183,122 @@ class AnalysisTest extends \PHPUnit\Framework\TestCase
     $actualObject->setReso(true);
 
     $this->assertEquals($expectedArray, $actualObject->getArray($version));
+  }
+
+  ////// New Getter and Setter Tests //////
+
+  /**
+   * @test
+   * -# Test getter for bucket
+   */
+  public function testGetBucket()
+  {
+    $analysis = new Analysis(true);
+    $this->assertTrue($analysis->getBucket());
+  }
+
+  /**
+   * @test
+   * -# Test setter for bucket
+   */
+  public function testSetBucket()
+  {
+    $analysis = new Analysis();
+    $analysis->setBucket(true);
+    $this->assertTrue($analysis->getBucket());
+  }
+
+  /**
+   * @test
+   * -# Test getter for copyright
+   */
+  public function testGetCopyright()
+  {
+    $analysis = new Analysis(false, true);
+    $this->assertTrue($analysis->getCopyright());
+  }
+
+  /**
+   * @test
+   * -# Test setter for copyright
+   */
+  public function testSetCopyright()
+  {
+    $analysis = new Analysis();
+    $analysis->setCopyright(true);
+    $this->assertTrue($analysis->getCopyright());
+  }
+
+  /**
+   * @test
+   * -# Test getter for ecc
+   */
+  public function testGetEcc()
+  {
+    $analysis = new Analysis(false, false, true);
+    $this->assertTrue($analysis->getEcc());
+  }
+
+  /**
+   * @test
+   * -# Test setter for ecc
+   */
+  public function testSetEcc()
+  {
+    $analysis = new Analysis();
+    $analysis->setEcc(true);
+    $this->assertTrue($analysis->getEcc());
+  }
+
+  /**
+   * @test
+   * -# Test getter for keyword
+   */
+  public function testGetKeyword()
+  {
+    $analysis = new Analysis(false, false, false, true);
+    $this->assertTrue($analysis->getKeyword());
+  }
+
+  /**
+   * @test
+   * -# Test setter for keyword
+   */
+  public function testSetKeyword()
+  {
+    $analysis = new Analysis();
+    $analysis->setKeyword(true);
+    $this->assertTrue($analysis->getKeyword());
+  }
+
+  /**
+   * @test
+   * -# Test getter for mimetype
+   */
+  public function testGetMime()
+  {
+    $analysis = new Analysis(false, false, false, false, true);
+    $this->assertTrue($analysis->getMime());
+  }
+
+  /**
+   * @test
+   * -# Test setter for mimetype
+   */
+  public function testSetMime()
+  {
+    $analysis = new Analysis();
+    $analysis->setMime(true);
+    $this->assertTrue($analysis->getMime());
+  }
+
+  /**
+   * @test
+   * -# Test getter for monk
+   */
+  public function testGetMonk()
+  {
+    $analysis = new Analysis(false, false, false, false, false, true);
+    $this->assertTrue($analysis->getMonk());
   }
 }

--- a/src/www/ui_tests/api/Models/ApiVersionTest.php
+++ b/src/www/ui_tests/api/Models/ApiVersionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ SPDX-FileCopyrightText: © 2024 Valens Niyonsenga <valensniyonsenga2003@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for ApiVersion model
+ */
+namespace Fossology\UI\Api\Test\Models;
+
+
+use Fossology\UI\Api\Models\ApiVersion;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+class ApiVersionTest extends TestCase
+{
+  /**
+   * Test that getVersion returns the correct version when ATTRIBUTE_NAME is set.
+   */
+  public function testGetVersionReturnsSetVersion()
+  {
+    $requestMock = $this->createMock(ServerRequestInterface::class);
+    $requestMock->method('getAttribute')
+      ->with(ApiVersion::ATTRIBUTE_NAME, ApiVersion::V1)
+      ->willReturn(ApiVersion::V2);
+
+    $this->assertEquals(ApiVersion::V2, ApiVersion::getVersion($requestMock));
+  }
+
+  /**
+   * Test that getVersion returns the default version (V1) when ATTRIBUTE_NAME is not set.
+   */
+  public function testGetVersionReturnsDefaultVersion()
+  {
+    $requestMock = $this->createMock(ServerRequestInterface::class);
+    $requestMock->method('getAttribute')
+      ->with(ApiVersion::ATTRIBUTE_NAME, ApiVersion::V1)
+      ->willReturn(ApiVersion::V1);
+
+    $this->assertEquals(ApiVersion::V1, ApiVersion::getVersion($requestMock));
+  }
+}

--- a/src/www/ui_tests/api/Models/BulkHistory.php
+++ b/src/www/ui_tests/api/Models/BulkHistory.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ SPDX-FileCopyrightText: © 2023 Samuel Dushimimana <dushsam100@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/*
+ SPDX-FileCopyrightText: © 2024 Valens Niyonsenga <valensniyonsenga2003@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for BulkHistory model
+ */
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\BulkHistory;
+use PHPUnit\Framework\TestCase;
+
+class BulkHistoryTest extends TestCase
+{
+  /**
+   * Provides test data and an instance of the BulkHistory class.
+   *
+   * @return array An associative array containing:
+   *  - `expectedArray`: The expected array structure.
+   *  - `obj`: The instance of BulkHistory being tested.
+   */
+  private function getBulkHistoryInfo()
+  {
+    $expectedArray = [
+      "bulkId" => 4,
+      "clearingEventId" => 3,
+      "text" => "BulkHistory text",
+      "matched" => false,
+      "tried" => false,
+      "addedLicenses" => [],
+      "removedLicenses" => []
+    ];
+    $obj = new BulkHistory(4, 3, "BulkHistory text", false, false, [], []);
+    return [
+      'expectedArray' => $expectedArray,
+      'obj' => $obj
+    ];
+  }
+
+  /**
+   * Tests BulkHistory::getArray() method.
+   *
+   * This method validates that the `getArray` method returns the correct data structure.
+   */
+  public function testDataFormat()
+  {
+    $expectedArray = $this->getBulkHistoryInfo()['expectedArray'];
+    $bulkHistory = $this->getBulkHistoryInfo()['obj'];
+    $this->assertEquals($expectedArray, $bulkHistory->getArray());
+  }
+
+  /**
+   * Tests BulkHistory::setBulkId() and getBulkId() methods.
+   *
+   * This method verifies that the `setBulkId` method correctly updates the bulkId property,
+   * and that the `getBulkId` method returns the updated value.
+   */
+  public function testSetAndGetBulkId()
+  {
+    $info = $this->getBulkHistoryInfo();
+    $bulkHistory = $info['obj'];
+    $bulkId = 5;
+    $bulkHistory->setBulkId($bulkId);
+    $this->assertEquals($bulkId, $bulkHistory->getBulkId());
+  }
+
+  /**
+   * Tests BulkHistory::setClearingEventId() and getClearingEventId() methods.
+   *
+   * This method verifies that the `setClearingEventId` method correctly updates the clearingEventId property,
+   * and that the `getClearingEventId` method returns the updated value.
+   */
+  public function testSetAndGetClearingEventId()
+  {
+    $info = $this->getBulkHistoryInfo();
+    $bulkHistory = $info['obj'];
+    $clearingEventId = 6;
+    $bulkHistory->setClearingEventId($clearingEventId);
+    $this->assertEquals($clearingEventId, $bulkHistory->getClearingEventId());
+  }
+
+  /**
+   * Tests BulkHistory::setText() and getText() methods.
+   *
+   * This method verifies that the `setText` method correctly updates the text property,
+   * and that the `getText` method returns the updated value.
+   */
+  public function testSetAndGetText()
+  {
+    $info = $this->getBulkHistoryInfo();
+    $bulkHistory = $info['obj'];
+    $text = "Updated text";
+    $bulkHistory->setText($text);
+    $this->assertEquals($text, $bulkHistory->getText());
+  }
+
+  /**
+   * Tests BulkHistory::setMatched() and getMatched() methods.
+   *
+   * This method verifies that the `setMatched` method correctly updates the matched property,
+   * and that the `getMatched` method returns the updated value.
+   */
+  public function testSetAndGetMatched()
+  {
+    $info = $this->getBulkHistoryInfo();
+    $bulkHistory = $info['obj'];
+    $matched = true;
+    $bulkHistory->setMatched($matched);
+    $this->assertEquals($matched, $bulkHistory->getMatched());
+  }
+
+  /**
+   * Tests BulkHistory::setTried() and getTried() methods.
+   *
+   * This method verifies that the `setTried` method correctly updates the tried property,
+   * and that the `getTried` method returns the updated value.
+   */
+  public function testSetAndGetTried()
+  {
+    $info = $this->getBulkHistoryInfo();
+    $bulkHistory = $info['obj'];
+    $tried = true;
+    $bulkHistory->setTried($tried);
+    $this->assertEquals($tried, $bulkHistory->getTried());
+  }
+
+  /**
+   * Tests BulkHistory::setAddedLicenses() and getAddedLicenses() methods.
+   *
+   * This method verifies that the `setAddedLicenses` method correctly updates the addedLicenses property,
+   * and that the `getAddedLicenses` method returns the updated value.
+   */
+  public function testSetAndGetAddedLicenses()
+  {
+    $info = $this->getBulkHistoryInfo();
+    $bulkHistory = $info['obj'];
+    $addedLicenses = ['LicenseA', 'LicenseB'];
+    $bulkHistory->setAddedLicenses($addedLicenses);
+    $this->assertEquals($addedLicenses, $bulkHistory->getAddedLicenses());
+  }
+
+  /**
+   * Tests BulkHistory::setRemovedLicenses() and getRemovedLicenses() methods.
+   *
+   * This method verifies that the `setRemovedLicenses` method correctly updates the removedLicenses property,
+   * and that the `getRemovedLicenses` method returns the updated value.
+   */
+  public function testSetAndGetRemovedLicenses()
+  {
+    $info = $this->getBulkHistoryInfo();
+    $bulkHistory = $info['obj'];
+    $removedLicenses = ['LicenseX', 'LicenseY'];
+    $bulkHistory->setRemovedLicenses($removedLicenses);
+    $this->assertEquals($removedLicenses, $bulkHistory->getRemovedLicenses());
+  }
+}

--- a/src/www/ui_tests/api/Models/DeciderTest.php
+++ b/src/www/ui_tests/api/Models/DeciderTest.php
@@ -14,69 +14,55 @@ namespace Fossology\UI\Api\Test\Models;
 
 use Fossology\UI\Api\Models\Decider;
 use Fossology\UI\Api\Models\ApiVersion;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @class DeciderTest
  * @brief Tests for Decider model
  */
-class DeciderTest extends \PHPUnit\Framework\TestCase
+class DeciderTest extends TestCase
 {
   /**
-   * @test
-   * -# Test for Decider::setUsingArray() when $version is V1
-   * -# Create a test array and pass to setUsingArray() on test object
-   * -# Check if the object is updated
+   * Provides test data and an instance of the Decider class.
+   *
+   * @param string $version The API version to use for formatting.
+   * @return array An associative array containing:
+   *  - `expectedArray`: The expected array structure.
+   *  - `obj`: The instance of Decider being tested.
    */
-  public function testSetUsingArrayV1()
+  private function getDeciderInfo($version = ApiVersion::V1)
   {
-    $this->testSetUsingArray(ApiVersion::V1);
-  }
+    $nomosMonk = true;
+    $bulkReused = false;
+    $newScanner = false;
+    $ojoDecider = true;
 
-  /**
-   * @test
-   * -# Test for Decider::setUsingArray() when $version is V2
-   * -# Create a test array and pass to setUsingArray() on test object
-   * -# Check if the object is updated
-   */
-  public function testSetUsingArrayV2()
-  {
-    $this->testSetUsingArray(ApiVersion::V2);
-  }
-
-  /**
-   * @param $version version to test
-   * @return void
-   * -# Test for Decider::setUsingArray() to check if the object is updated
-   */
-  private function testSetUsingArray($version)
-  {
     if ($version == ApiVersion::V1) {
-      $deciderArray = [
-        "nomos_monk" => true,
-        "bulk_reused" => false,
-        "ojo_decider" => (1==1)
+      $expectedArray = [
+        "nomos_monk"  => $nomosMonk,
+        "bulk_reused" => $bulkReused,
+        "new_scanner" => $newScanner,
+        "ojo_decider" => $ojoDecider
       ];
     } else {
-      $deciderArray = [
-        "nomosMonk" => true,
-        "bulkReused" => false,
-        "ojoDecider" => (1==1)
+      $expectedArray = [
+        "nomosMonk"  => $nomosMonk,
+        "bulkReused" => $bulkReused,
+        "newScanner" => $newScanner,
+        "ojoDecider" => $ojoDecider
       ];
     }
 
-    $expectedObject = new Decider(true, false, false, true);
-
-    $actualObject = new Decider();
-    $actualObject->setUsingArray($deciderArray, $version);
-
-    $this->assertEquals($expectedObject, $actualObject);
+    $obj = new Decider($nomosMonk, $bulkReused, $newScanner, $ojoDecider);
+    return [
+      'expectedArray' => $expectedArray,
+      'obj' => $obj
+    ];
   }
 
   /**
    * @test
-   * -# Test the data format returned by Decider::getArray($version) model when $version is V1
-   * -# Create expected array and update test object to match it
-   * -# Get the array from object and match with expected array
+   * -# Test data format returned by Decider::getArray($version) when API version is V1
    */
   public function testDataFormatV1()
   {
@@ -85,9 +71,7 @@ class DeciderTest extends \PHPUnit\Framework\TestCase
 
   /**
    * @test
-   * -# Test the data format returned by Decider::getArray($version) model when $version is V2
-   * -# Create expected array and update test object to match it
-   * -# Get the array from object and match with expected array
+   * -# Test data format returned by Decider::getArray($version) when API version is V2
    */
   public function testDataFormatV2()
   {
@@ -95,32 +79,85 @@ class DeciderTest extends \PHPUnit\Framework\TestCase
   }
 
   /**
-   * @param $version version to test
-   * @return void
-   * -# Test the data format returned by Decider::getArray($version) model
+   * -# Test the data format returned by Decider::getArray($version) model.
+   *
+   * @param string $version The API version to test.
    */
   private function testDataFormat($version)
   {
-    if ($version == ApiVersion::V1) {
-      $expectedArray = [
-        "nomos_monk"  => true,
-        "bulk_reused" => false,
-        "new_scanner" => false,
-        "ojo_decider" => true
-      ];
-    } else {
-      $expectedArray = [
-        "nomosMonk"  => true,
-        "bulkReused" => false,
-        "newScanner" => false,
-        "ojoDecider" => true
-      ];
-    }
+    $info = $this->getDeciderInfo($version);
+    $expectedArray = $info['expectedArray'];
+    $decider = $info['obj'];
+    $this->assertEquals($expectedArray, $decider->getArray($version));
+  }
 
+  /**
+   * @test
+   * -# Test for Decider::setUsingArray() when $version is V1.
+   */
+  public function testSetUsingArrayV1()
+  {
+    $this->testSetUsingArray(ApiVersion::V1);
+  }
+
+  /**
+   * @test
+   * -# Test for Decider::setUsingArray() when $version is V2.
+   */
+  public function testSetUsingArrayV2()
+  {
+    $this->testSetUsingArray(ApiVersion::V2);
+  }
+
+  /**
+   * Test Decider::setUsingArray() to check if the object is updated.
+   *
+   * @param string $version The API version to test.
+   */
+  private function testSetUsingArray($version)
+  {
+    $info = $this->getDeciderInfo($version);
+    $expectedObject = $info['obj'];
+
+    $deciderArray = $info['expectedArray'];
     $actualObject = new Decider();
-    $actualObject->setNomosMonk(true);
-    $actualObject->setOjoDecider(true);
+    $actualObject->setUsingArray($deciderArray, $version);
 
-    $this->assertEquals($expectedArray, $actualObject->getArray($version));
+    $this->assertEquals($expectedObject, $actualObject);
+  }
+
+  /**
+   * @test
+   * -# Test getters for Decider properties.
+   */
+  public function testGetters()
+  {
+    $decider = new Decider(true, false, false, true);
+
+    $this->assertTrue($decider->getNomosMonk());
+    $this->assertFalse($decider->getBulkReused());
+    $this->assertFalse($decider->getNewScanner());
+    $this->assertTrue($decider->getOjoDecider());
+  }
+
+  /**
+   * @test
+   * -# Test setters for Decider properties.
+   */
+  public function testSetters()
+  {
+    $decider = new Decider();
+
+    $decider->setNomosMonk(true);
+    $this->assertTrue($decider->getNomosMonk());
+
+    $decider->setBulkReused(false);
+    $this->assertFalse($decider->getBulkReused());
+
+    $decider->setNewScanner(true);
+    $this->assertTrue($decider->getNewScanner());
+
+    $decider->setOjoDecider(false);
+    $this->assertFalse($decider->getOjoDecider());
   }
 }

--- a/src/www/ui_tests/api/Models/FileInfoTest.php
+++ b/src/www/ui_tests/api/Models/FileInfoTest.php
@@ -1,0 +1,135 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Valens NIYONSENGA <valensniyonsenga2003@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for FileInfo model
+ */
+
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\FileInfo;
+use Fossology\UI\Api\Models\ApiVersion;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @class FileInfoTest
+ * @brief Tests for FileInfo model
+ */
+class FileInfoTest extends TestCase
+{
+  /**
+   * @test
+   * -# Test for FileInfo::getArray() when API version is V1
+   * -# Create expected array and update test object to match it
+   * -# Get the array from object and match with expected array
+   */
+  public function testDataFormatV1()
+  {
+    $this->testDataFormat(ApiVersion::V1);
+  }
+
+  /**
+   * @test
+   * -# Test for FileInfo::getArray() when API version is V2
+   * -# Create expected array and update test object to match it
+   * -# Get the array from object and match with expected array
+   */
+  public function testDataFormatV2()
+  {
+    $this->testDataFormat(ApiVersion::V2);
+  }
+
+  /**
+   * -# Test the data format returned by FileInfo::getArray($version) model
+   * @param $version API version to test (V1 or V2)
+   */
+  private function testDataFormat($version)
+  {
+    $viewInfo = (object) ['key' => 'view_value'];
+    $metaInfo = (object) ['key' => 'meta_value'];
+    $packageInfo = (object) ['key' => 'package_value'];
+    $tagInfo = (object) ['key' => 'tag_value'];
+    $reuseInfo = (object) ['key' => 'reuse_value'];
+
+    if ($version == ApiVersion::V1) {
+      $expectedArray = [
+        'view_info' => $viewInfo,
+        'meta_info' => $metaInfo,
+        'package_info' => $packageInfo,
+        'tag_info' => $tagInfo,
+        'reuse_info' => $reuseInfo
+      ];
+    } else {
+      $expectedArray = [
+        'viewInfo' => $viewInfo,
+        'metaInfo' => $metaInfo,
+        'packageInfo' => $packageInfo,
+        'tagInfo' => $tagInfo,
+        'reuseInfo' => $reuseInfo
+      ];
+    }
+
+    $fileInfo = new FileInfo($viewInfo, $metaInfo, $packageInfo, $tagInfo, $reuseInfo);
+
+    $this->assertEquals($expectedArray, $fileInfo->getArray($version));
+  }
+
+  /**
+   * @test
+   * -# Test for FileInfo::getJSON() when API version is V1
+   * -# Check if the JSON representation matches the expected output
+   */
+  public function testGetJSONV1()
+  {
+    $this->testGetJSON(ApiVersion::V1);
+  }
+
+  /**
+   * @test
+   * -# Test for FileInfo::getJSON() when API version is V2
+   * -# Check if the JSON representation matches the expected output
+   */
+  public function testGetJSONV2()
+  {
+    $this->testGetJSON(ApiVersion::V2);
+  }
+
+  /**
+   * -# Test the JSON output from FileInfo::getJSON() method
+   * @param $version API version to test (V1 or V2)
+   */
+  private function testGetJSON($version)
+  {
+    $viewInfo = (object) ['key' => 'view_value'];
+    $metaInfo = (object) ['key' => 'meta_value'];
+    $packageInfo = (object) ['key' => 'package_value'];
+    $tagInfo = (object) ['key' => 'tag_value'];
+    $reuseInfo = (object) ['key' => 'reuse_value'];
+
+    if ($version == ApiVersion::V2) {
+      $expectedJSON = json_encode([
+        'viewInfo' => $viewInfo,
+        'metaInfo' => $metaInfo,
+        'packageInfo' => $packageInfo,
+        'tagInfo' => $tagInfo,
+        'reuseInfo' => $reuseInfo
+      ]);
+    } else {
+      $expectedJSON = json_encode([
+        'view_info' => $viewInfo,
+        'meta_info' => $metaInfo,
+        'package_info' => $packageInfo,
+        'tag_info' => $tagInfo,
+        'reuse_info' => $reuseInfo
+      ]);
+    }
+
+    $fileInfo = new FileInfo($viewInfo, $metaInfo, $packageInfo, $tagInfo, $reuseInfo);
+
+    $this->assertEquals($expectedJSON, $fileInfo->getJSON($version));
+  }
+}

--- a/src/www/ui_tests/api/Models/FolderTest.php
+++ b/src/www/ui_tests/api/Models/FolderTest.php
@@ -45,4 +45,56 @@ class FolderTest extends \PHPUnit\Framework\TestCase
     $this->assertEquals($expectedParent, $parentFolder->getArray());
     $this->assertEquals($expectedChild, $childFolder->getArray());
   }
+
+  /**
+   * Tests Folder::getId() and Folder::setId() methods.
+   *
+   * This method verifies that the setId method correctly updates the folder ID,
+   * and that the getId method returns the correct value.
+   */
+  public function testSetAndGetId()
+  {
+    $folder = new Folder(1, 'name', 'description', null);
+    $folder->setId(10);
+    $this->assertEquals(10, $folder->getId());
+  }
+
+  /**
+   * Tests Folder::getName() and Folder::setName() methods.
+   *
+   * This method verifies that the setName method correctly updates the folder name,
+   * and that the getName method returns the correct value.
+   */
+  public function testSetAndGetName()
+  {
+    $folder = new Folder(1, 'name', 'description', null);
+    $folder->setName('newName');
+    $this->assertEquals('newName', $folder->getName());
+  }
+
+  /**
+   * Tests Folder::getDescription() and Folder::setDescription() methods.
+   *
+   * This method verifies that the setDescription method correctly updates the folder description,
+   * and that the getDescription method returns the correct value.
+   */
+  public function testSetAndGetDescription()
+  {
+    $folder = new Folder(1, 'name', 'description', null);
+    $folder->setDescription('newDescription');
+    $this->assertEquals('newDescription', $folder->getDescription());
+  }
+
+  /**
+   * Tests Folder::getParent() and Folder::setParent() methods.
+   *
+   * This method verifies that the setParent method correctly updates the parent ID,
+   * and that the getParent method returns the correct value.
+   */
+  public function testSetAndGetParent()
+  {
+    $folder = new Folder(1, 'name', 'description', null);
+    $folder->setParent(5);
+    $this->assertEquals(5, $folder->getParent());
+  }
 }

--- a/src/www/ui_tests/api/Models/GroupPermissionsTest.php
+++ b/src/www/ui_tests/api/Models/GroupPermissionsTest.php
@@ -1,0 +1,146 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Valens Niyonsenga <valensniyonsenga2003@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for GroupPermission model
+ */
+namespace Fossology\UI\Api\Test\Models;
+
+
+use Fossology\UI\Api\Models\ApiVersion;
+use Fossology\UI\Api\Models\GroupPermission;
+use Monolog\Test\TestCase;
+
+class GroupPermissionsTest extends TestCase
+{
+  /**
+   * Provides test data and an instance of the GroupPermission class.
+   *
+   * @return array An associative array containing:
+   *  - `expectedArray`: The expected array structure.
+   *  - `obj`: The instance of Group being tested.
+   */
+  private function getGroupPermissionInfo($version = ApiVersion::V2)
+  {
+    $expectedArray = null;
+    if ($version == ApiVersion::V1)
+    {
+      $expectedArray = [
+        "perm" => "Group perm",
+        "group_pk"  => 4,
+        "group_name" => "fossy",
+      ];
+    } else {
+      $expectedArray = [
+        "perm" => "Group perm",
+        "groupPk"  => 4,
+        "groupName" => "fossy",
+      ];
+    }
+    $obj = new GroupPermission("Group perm",4,"fossy");
+    return [
+      'expectedArray' => $expectedArray,
+      'obj' => $obj
+    ];
+  }
+  /**
+   * @test
+   * -# Test data model returned by GroupPermission::getArray($version) when API version is V1
+   */
+  public function testDataFormatV1()
+  {
+    $this->testDataFormat(ApiVersion::V1);
+  }
+
+  /**
+   * @test
+   * -# Test data model returned by GroupPermission::getArray($version) when API version is V2
+   */
+  public function testDataFormatV2()
+  {
+    $this->testDataFormat(ApiVersion::V2);
+  }
+
+  /**
+   * -# Test the data format returned by GroupPermission::getArray($version) model
+   */
+  private function testDataFormat($version)
+  {
+    $info = $this->getGroupPermissionInfo($version);
+    $expectedArray = $info['expectedArray'];
+    $groupPermission = $info['obj'];
+    $this->assertEquals($expectedArray, $groupPermission->getArray($version));
+  }
+  /**
+   * Tests GroupPermission::getPerm() method.
+   *
+   * This method validates that the `getPerm` method returns the correct permission value.
+   */
+  public function testGetPerm()
+  {
+    $groupPermission = new GroupPermission("Group perm", "4", "fossy");
+    $this->assertEquals("Group perm", $groupPermission->getPerm());
+  }
+
+  /**
+   * Tests GroupPermission::setPerm() method.
+   *
+   * This method validates that the `setPerm` method correctly updates the permission value.
+   */
+  public function testSetPerm()
+  {
+    $groupPermission = new GroupPermission("Group perm", "4", "fossy");
+    $groupPermission->setPerm("New perm");
+    $this->assertEquals("New perm", $groupPermission->getPerm());
+  }
+
+  /**
+   * Tests GroupPermission::getGroupPk() method.
+   *
+   * This method validates that the `getGroupPk` method returns the correct group ID value.
+   */
+  public function testGetGroupPk()
+  {
+    $groupPermission = new GroupPermission("Group perm", "4", "fossy");
+    $this->assertEquals("4", $groupPermission->getGroupPk());
+  }
+
+  /**
+   * Tests GroupPermission::setGroupPk() method.
+   *
+   * This method validates that the `setGroupPk` method correctly updates the group ID value.
+   */
+  public function testSetGroupPk()
+  {
+    $groupPermission = new GroupPermission("Group perm", "4", "fossy");
+    $groupPermission->setGroupPk("10");
+    $this->assertEquals("10", $groupPermission->getGroupPk());
+  }
+
+  /**
+   * Tests GroupPermission::getGroupName() method.
+   *
+   * This method validates that the `getGroupName` method returns the correct group name value.
+   */
+  public function testGetGroupName()
+  {
+    $groupPermission = new GroupPermission("Group perm", "4", "fossy");
+    $this->assertEquals("fossy", $groupPermission->getGroupName());
+  }
+
+  /**
+   * Tests GroupPermission::setGroupName() method.
+   *
+   * This method validates that the `setGroupName` method correctly updates the group name value.
+   */
+  public function testSetGroupName()
+  {
+    $groupPermission = new GroupPermission("Group perm", "4", "fossy");
+    $groupPermission->setGroupName("newName");
+    $this->assertEquals("newName", $groupPermission->getGroupName());
+  }
+}

--- a/src/www/ui_tests/api/Models/GroupTest.php
+++ b/src/www/ui_tests/api/Models/GroupTest.php
@@ -1,0 +1,96 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Valens Niyonsenga <valensniyonsenga2003@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for GroupTest model
+ */
+namespace Fossology\UI\Api\Test\Models;
+
+
+use Fossology\UI\Api\Models\Group;
+use PHPUnit\Framework\TestCase;
+
+class GroupTest extends TestCase
+{
+  /**
+   * Provides test data and an instance of the Group class.
+   *
+   * @return array An associative array containing:
+   *  - `expectedArray`: The expected array structure.
+   *  - `obj`: The instance of Group being tested.
+   */
+  private function getGroupInfo()
+  {
+    $expectedArray = [
+      "id"  => 4,
+      "name" => "fossy",
+    ];
+    $obj = new Group(4,"fossy");
+    return [
+      'expectedArray' => $expectedArray,
+      'obj' => $obj
+    ];
+  }
+
+  /**
+   * Tests Group::getArray() method.
+   *
+   * This method validates that the `getArray` method returns the correct data structure.
+   */
+  public function testDataFormat()
+  {
+    $expectedArray = $this->getGroupInfo()['expectedArray'];
+    $group = $this->getGroupInfo()['obj'];
+    $this->assertEquals($expectedArray, $group->getArray());
+  }
+
+  /**
+   * Tests Group::getId() method.
+   *
+   * This method validates that the `getId` method returns the correct ID value.
+   */
+  public function testGetId()
+  {
+    $group = new Group(4, "fossy");
+    $this->assertEquals(4, $group->getId());
+  }
+
+  /**
+   * Tests Group::setId() method.
+   *
+   * This method validates that the `setId` method correctly updates the ID value.
+   */
+  public function testSetId()
+  {
+    $group = new Group(4, "fossy");
+    $group->setId(10);
+    $this->assertEquals(10, $group->getId());
+  }
+
+  /**
+   * Tests Group::getName() method.
+   *
+   * This method validates that the `getName` method returns the correct name value.
+   */
+  public function testGetName()
+  {
+    $group = new Group(4, "fossy");
+    $this->assertEquals("fossy", $group->getName());
+  }
+
+  /**
+   * Tests Group::setName() method.
+   *
+   * This method validates that the `setName` method correctly updates the name value.
+   */
+  public function testSetName()
+  {
+    $group = new Group(4, "fossy");
+    $group->setName("newName");
+    $this->assertEquals("newName", $group->getName());
+  }
+}

--- a/src/www/ui_tests/api/Models/GroupTest.php
+++ b/src/www/ui_tests/api/Models/GroupTest.php
@@ -6,13 +6,12 @@
 
 /**
  * @file
- * @brief Tests for GroupTest model
+ * @brief Tests for Group model
  */
 namespace Fossology\UI\Api\Test\Models;
 
-
 use Fossology\UI\Api\Models\Group;
-use PHPUnit\Framework\TestCase;
+use Monolog\Test\TestCase;
 
 class GroupTest extends TestCase
 {
@@ -26,10 +25,10 @@ class GroupTest extends TestCase
   private function getGroupInfo()
   {
     $expectedArray = [
-      "id"  => 4,
-      "name" => "fossy",
+      'id' => 1,
+      'name' => 'TestGroup'
     ];
-    $obj = new Group(4,"fossy");
+    $obj = new Group(1, 'TestGroup');
     return [
       'expectedArray' => $expectedArray,
       'obj' => $obj
@@ -37,60 +36,75 @@ class GroupTest extends TestCase
   }
 
   /**
-   * Tests Group::getArray() method.
-   *
-   * This method validates that the `getArray` method returns the correct data structure.
+   * @test
+   * -# Test data model returned by Group::getArray()
    */
   public function testDataFormat()
   {
-    $expectedArray = $this->getGroupInfo()['expectedArray'];
-    $group = $this->getGroupInfo()['obj'];
+    $info = $this->getGroupInfo();
+    $expectedArray = $info['expectedArray'];
+    $group = $info['obj'];
     $this->assertEquals($expectedArray, $group->getArray());
   }
 
   /**
    * Tests Group::getId() method.
    *
-   * This method validates that the `getId` method returns the correct ID value.
+   * This method validates that the `getId` method returns the correct group ID.
    */
   public function testGetId()
   {
-    $group = new Group(4, "fossy");
-    $this->assertEquals(4, $group->getId());
+    $group = $this->getGroupInfo()['obj'];
+    $this->assertEquals(1, $group->getId());
   }
 
   /**
    * Tests Group::setId() method.
    *
-   * This method validates that the `setId` method correctly updates the ID value.
+   * This method validates that the `setId` method correctly updates the group ID.
    */
   public function testSetId()
   {
-    $group = new Group(4, "fossy");
-    $group->setId(10);
-    $this->assertEquals(10, $group->getId());
+    $group = $this->getGroupInfo()['obj'];
+    $group->setId(2);
+    $this->assertEquals(2, $group->getId());
   }
 
   /**
    * Tests Group::getName() method.
    *
-   * This method validates that the `getName` method returns the correct name value.
+   * This method validates that the `getName` method returns the correct group name.
    */
   public function testGetName()
   {
-    $group = new Group(4, "fossy");
-    $this->assertEquals("fossy", $group->getName());
+    $group = $this->getGroupInfo()['obj'];
+    $this->assertEquals('TestGroup', $group->getName());
   }
 
   /**
    * Tests Group::setName() method.
    *
-   * This method validates that the `setName` method correctly updates the name value.
+   * This method validates that the `setName` method correctly updates the group name.
    */
   public function testSetName()
   {
-    $group = new Group(4, "fossy");
-    $group->setName("newName");
-    $this->assertEquals("newName", $group->getName());
+    $group = $this->getGroupInfo()['obj'];
+    $group->setName('NewGroupName');
+    $this->assertEquals('NewGroupName', $group->getName());
+  }
+
+  /**
+   * Tests Group::getJSON() method.
+   *
+   * This method validates that the `getJSON` method returns the correct JSON representation of the group.
+   */
+  public function testGetJSON()
+  {
+    $group = $this->getGroupInfo()['obj'];
+    $expectedJson = json_encode([
+      'id' => 1,
+      'name' => 'TestGroup'
+    ]);
+    $this->assertEquals($expectedJson, $group->getJSON());
   }
 }

--- a/src/www/ui_tests/api/Models/JobTest.php
+++ b/src/www/ui_tests/api/Models/JobTest.php
@@ -1,10 +1,12 @@
 <?php
+
 /*
  SPDX-FileCopyrightText: © 2020 Siemens AG
  Author: Gaurav Mishra <mishra.gaurav@siemens.com>
 
  SPDX-License-Identifier: GPL-2.0-only
 */
+
 /**
  * @file
  * @brief Tests for Job model
@@ -17,14 +19,14 @@ use Fossology\UI\Api\Models\ApiVersion;
 use Fossology\UI\Api\Models\Job;
 use Fossology\UI\Api\Models\JobQueue;
 use Mockery as M;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @class JobTest
  * @brief Test for Job model
  */
-class JobTest extends \PHPUnit\Framework\TestCase
+class JobTest extends TestCase
 {
-
   /**
    * @test
    * -# Test data model returned by Job::getArray($version) when API version is V1
@@ -44,13 +46,15 @@ class JobTest extends \PHPUnit\Framework\TestCase
   }
 
   /**
-   * -# Test the data format returned by Job::getArray($version) model 
+   * -# Test the data format returned by Job::getArray($version) model
    */
   private function testDataFormat($version)
   {
     $jobQueue = new JobQueue(44, 'readmeoss', '2024-07-03 20:41:49', '2024-07-03 20:41:50',
       'Completed', 0, null, [], 0, true, false, true,
-      ['text' => 'ReadMeOss', 'link' => 'http://localhost/repo/api/v1/report/16']);
+      ['text' => 'ReadMeOss', 'link' => 'http://localhost/repo/api/v1/report/16']
+    );
+
     if ($version == ApiVersion::V2){
       $expectedStatus = [
         'id'        => 22,
@@ -63,13 +67,13 @@ class JobTest extends \PHPUnit\Framework\TestCase
         'status'    => 'Processing',
         'jobQueue'  => $jobQueue->getArray()
       ];
+
       global $container;
       $userDao = M::mock(UserDao::class);
       $container = M::mock('ContainerBuilder');
-      $container->shouldReceive('get')->withArgs(array(
-        "dao.user"))->andReturn($userDao);
-      $userDao->shouldReceive("getUserName")->with(2)->andReturn("fossy");
-      $userDao->shouldReceive("getGroupNameById")->with(2)->andReturn("fossy");
+      $container->shouldReceive('get')->with('dao.user')->andReturn($userDao);
+      $userDao->shouldReceive('getUserName')->with(2)->andReturn('fossy');
+      $userDao->shouldReceive('getGroupNameById')->with(2)->andReturn('fossy');
     } else {
       $expectedStatus = [
         'id'        => 22,
@@ -86,5 +90,113 @@ class JobTest extends \PHPUnit\Framework\TestCase
     $actualJob = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing', $jobQueue->getArray());
 
     $this->assertEquals($expectedStatus, $actualJob->getArray($version));
+  }
+
+  // Getter tests
+  public function testGetId()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $this->assertEquals(22, $job->getId());
+  }
+
+  public function testGetName()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $this->assertEquals('ojo', $job->getName());
+  }
+
+  public function testGetQueueDate()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $this->assertEquals('01-01-2020', $job->getQueueDate());
+  }
+
+  public function testGetUploadId()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $this->assertEquals(4, $job->getUploadId());
+  }
+
+  public function testGetUserId()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $this->assertEquals(2, $job->getUserId());
+  }
+
+  public function testGetGroupId()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $this->assertEquals(2, $job->getGroupId());
+  }
+
+  public function testGetEta()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $this->assertEquals(3, $job->getEta());
+  }
+
+  public function testGetStatus()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $this->assertEquals('Processing', $job->getStatus());
+  }
+
+  public function testGetJobQueue()
+  {
+    $jobQueue = new JobQueue(44, 'readmeoss', '2024-07-03 20:41:49', '2024-07-03 20:41:50',
+      'Completed', 0, null, [], 0, true, false, true,
+      ['text' => 'ReadMeOss', 'link' => 'http://localhost/repo/api/v1/report/16']
+    );
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing', $jobQueue->getArray());
+    $this->assertEquals($jobQueue->getArray(), $job->getJobQueue());
+  }
+
+  // Setter tests
+  public function testSetName()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $job->setName('newName');
+    $this->assertEquals('newName', $job->getName());
+  }
+
+  public function testSetQueueDate()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $job->setQueueDate('02-02-2020');
+    $this->assertEquals('02-02-2020', $job->getQueueDate());
+  }
+
+  public function testSetUploadId()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $job->setUploadId(5);
+    $this->assertEquals(5, $job->getUploadId());
+  }
+
+  public function testSetUserId()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $job->setUserId(3);
+    $this->assertEquals(3, $job->getUserId());
+  }
+
+  public function testSetGroupId()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $job->setGroupId(4);
+    $this->assertEquals(4, $job->getGroupId());
+  }
+  public function testSetEta()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $job->setEta(10);
+    $this->assertEquals(10, $job->getEta());
+  }
+
+  public function testSetStatus()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $job->setStatus('Completed');
+    $this->assertEquals('Completed', $job->getStatus());
   }
 }

--- a/src/www/ui_tests/api/Models/LicenseCandidateTest.php
+++ b/src/www/ui_tests/api/Models/LicenseCandidateTest.php
@@ -1,0 +1,201 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Valens Niyonsenga <valensniyonsenga2003@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for LicenseCandidate model
+ */
+
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\ApiVersion;
+use Fossology\UI\Api\Models\LicenseCandidate;
+use Monolog\Test\TestCase;
+
+class LicenseCandidateTest extends TestCase
+{
+  /**
+   * Provides test data and an instance of the LicenseCandidate class.
+   *
+   * @return array An associative array containing:
+   *  - `expectedArray`: The expected array structure.
+   *  - `obj`: The instance of LicenseCandidate being tested.
+   */
+  private function getLicenseCandidateInfo($version = ApiVersion::V1)
+  {
+    $id = 1;
+    $shortname = "AGPL-1.0-or-later";
+    $spdxid = "MIT";
+    $fullname = "AGPL-1.0-or-later License";
+    $text = "Permission is hereby granted...";
+    $group_name = "TestGroup";
+    $group_id = 12;
+
+    if ($version == ApiVersion::V1) {
+      $expectedArray = [
+        "id"         => $id,
+        "shortname"  => $shortname,
+        "spdxid"     => $spdxid,
+        "fullname"   => $fullname,
+        "text"       => $text,
+        "group_name" => $group_name,
+        "group_id"   => $group_id,
+      ];
+    } else {
+      $expectedArray = [
+        "id"         => $id,
+        "shortname"  => $shortname,
+        "spdxid"     => $spdxid,
+        "fullname"   => $fullname,
+        "text"       => $text,
+        "groupName" => $group_name,
+        "groupId"   => $group_id,
+      ];
+    }
+
+    $obj = new LicenseCandidate($id, $shortname, $spdxid, $fullname, $text, $group_name, $group_id);
+    return [
+      'expectedArray' => $expectedArray,
+      'obj' => $obj
+    ];
+  }
+
+  /**
+   * @test
+   * -# Test data model returned by LicenseCandidate::getArray($version) when API version is V1
+   */
+  public function testDataFormatV1()
+  {
+    $this->testDataFormat(ApiVersion::V1);
+  }
+
+  /**
+   * @test
+   * -# Test data model returned by LicenseCandidate::getArray($version) when API version is V2
+   */
+  public function testDataFormatV2()
+  {
+    $this->testDataFormat(ApiVersion::V2);
+  }
+
+  /**
+   * -# Test the data format returned by LicenseCandidate::getArray($version) model
+   */
+  private function testDataFormat($version)
+  {
+    $info = $this->getLicenseCandidateInfo($version);
+    $expectedArray = $info['expectedArray'];
+    $licenseCandidate = $info['obj'];
+    $this->assertEquals($expectedArray, $licenseCandidate->getArray($version));
+  }
+
+  /**
+   * Tests LicenseCandidate::getId() method.
+   *
+   * This method validates that the `getId` method returns the correct license ID value.
+   */
+  public function testGetId()
+  {
+    $licenseCandidate = $this->getLicenseCandidateInfo(ApiVersion::V1)['obj'];
+    $this->assertEquals(1, $licenseCandidate->getId());
+  }
+
+  /**
+   * Tests LicenseCandidate::getShortname() method.
+   *
+   * This method validates that the `getShortname` method returns the correct shortname value.
+   */
+  public function testGetShortname()
+  {
+    $licenseCandidate = $this->getLicenseCandidateInfo(ApiVersion::V1)['obj'];
+    $this->assertEquals("AGPL-1.0-or-later", $licenseCandidate->getShortname());
+  }
+
+  /**
+   * Tests LicenseCandidate::getSpdxid() method.
+   */
+  public function testGetSpdxid()
+  {
+    $licenseCandidate = $this->getLicenseCandidateInfo(ApiVersion::V1)['obj'];
+    $this->assertEquals("MIT", $licenseCandidate->getSpdxid());
+  }
+
+  /**
+   * Tests LicenseCandidate::setSpdxid() method.
+   */
+  public function testSetSpdxid()
+  {
+    $licenseCandidate = $this->getLicenseCandidateInfo(ApiVersion::V1)['obj'];
+    $licenseCandidate->setSpdxid("Apache-2.0");
+    $this->assertEquals("Apache-2.0", $licenseCandidate->getSpdxid());
+  }
+
+  /**
+   * Tests LicenseCandidate::getFullname() method.
+   */
+  public function testGetFullname()
+  {
+    $licenseCandidate = $this->getLicenseCandidateInfo(ApiVersion::V1)['obj'];
+    $this->assertEquals("AGPL-1.0-or-later License", $licenseCandidate->getFullname());
+  }
+
+  /**
+   * Tests LicenseCandidate::setFullname() method.
+   */
+  public function testSetFullname()
+  {
+    $licenseCandidate = $this->getLicenseCandidateInfo(ApiVersion::V1)['obj'];
+    $licenseCandidate->setFullname("Apache License 2.0");
+    $this->assertEquals("Apache License 2.0", $licenseCandidate->getFullname());
+  }
+
+  /**
+   * Tests LicenseCandidate::getText() method.
+   */
+  public function testGetText()
+  {
+    $licenseCandidate = $this->getLicenseCandidateInfo(ApiVersion::V1)['obj'];
+    $this->assertEquals("Permission is hereby granted...", $licenseCandidate->getText());
+  }
+
+  /**
+   * Tests LicenseCandidate::setText() method.
+   */
+  public function testSetText()
+  {
+    $licenseCandidate = $this->getLicenseCandidateInfo(ApiVersion::V1)['obj'];
+    $licenseCandidate->setText("Apache License text...");
+    $this->assertEquals("Apache License text...", $licenseCandidate->getText());
+  }
+
+  /**
+   * Tests LicenseCandidate::getGroupName() method.
+   */
+  public function testGetGroupName()
+  {
+    $licenseCandidate = $this->getLicenseCandidateInfo(ApiVersion::V1)['obj'];
+    $this->assertEquals("TestGroup", $licenseCandidate->getGroupName());
+  }
+
+  /**
+   * Tests LicenseCandidate::getGroupId() method.
+   */
+  public function testGetGroupId()
+  {
+    $licenseCandidate = $this->getLicenseCandidateInfo(ApiVersion::V1)['obj'];
+    $this->assertEquals(12, $licenseCandidate->getGroupId());
+  }
+
+  /**
+   * Tests LicenseCandidate::setGroupId() method.
+   */
+  public function testSetGroupId()
+  {
+    $licenseCandidate = $this->getLicenseCandidateInfo(ApiVersion::V1)['obj'];
+    $licenseCandidate->setGroupId(456);
+    $this->assertEquals(456, $licenseCandidate->getGroupId());
+  }
+}

--- a/src/www/ui_tests/api/Models/PermissionsTest.php
+++ b/src/www/ui_tests/api/Models/PermissionsTest.php
@@ -1,0 +1,135 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Valens Niyonsenga <valensniyonsenga2003@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for Permissions model
+ */
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\ApiVersion;
+use Fossology\UI\Api\Models\Permissions;
+use Monolog\Test\TestCase;
+
+class PermissionsTest extends TestCase
+{
+  /**
+   * Provides test data and an instance of the Permissions class.
+   *
+   * @return array An associative array containing:
+   *  - `expectedArray`: The expected array structure.
+   *  - `obj`: The instance of Permissions being tested.
+   */
+  private function getPermissionsInfo($version = ApiVersion::V2)
+  {
+    $expectedArray = null;
+    $permGroups = [
+      ['groupPk' => 1, 'perm' => 'read'],
+      ['groupPk' => 2, 'perm' => 'write']
+    ];
+
+    if ($version == ApiVersion::V1)
+    {
+      $expectedArray = [
+        "publicPerm" => "public",
+        "permGroups" => $permGroups,
+      ];
+    } else {
+      $expectedArray = [
+        "publicPerm" => "public",
+        "permGroups" => $permGroups,
+      ];
+    }
+    $obj = new Permissions("public", $permGroups);
+    return [
+      'expectedArray' => $expectedArray,
+      'obj' => $obj
+    ];
+  }
+
+  /**
+   * @test
+   * -# Test data model returned by Permissions::getArray($version) when API version is V1
+   */
+  public function testDataFormatV1()
+  {
+    $this->testDataFormat(ApiVersion::V1);
+  }
+
+  /**
+   * @test
+   * -# Test data model returned by Permissions::getArray($version) when API version is V2
+   */
+  public function testDataFormatV2()
+  {
+    $this->testDataFormat(ApiVersion::V2);
+  }
+
+  /**
+   * -# Test the data format returned by Permissions::getArray($version) model
+   */
+  private function testDataFormat($version)
+  {
+    $info = $this->getPermissionsInfo($version);
+    $expectedArray = $info['expectedArray'];
+    $permissions = $info['obj'];
+    $this->assertEquals($expectedArray, $permissions->getArray($version));
+  }
+
+  /**
+   * Tests Permissions::getpublicPerm() method.
+   *
+   * This method validates that the `getpublicPerm` method returns the correct public permission value.
+   */
+  public function testGetPublicPerm()
+  {
+    $permissions = $this->getPermissionsInfo(ApiVersion::V2)['obj'];
+    $this->assertEquals("public", $permissions->getpublicPerm());
+  }
+
+  /**
+   * Tests Permissions::setpublicPerm() method.
+   *
+   * This method validates that the `setpublicPerm` method correctly updates the public permission value.
+   */
+  public function testSetPublicPerm()
+  {
+    $permissions = $this->getPermissionsInfo(ApiVersion::V2)['obj'];
+    $permissions->setpublicPerm("private");
+    $this->assertEquals("private", $permissions->getpublicPerm());
+  }
+
+  /**
+   * Tests Permissions::getpermGroups() method.
+   *
+   * This method validates that the `getpermGroups` method returns the correct permissions groups array.
+   */
+  public function testGetPermGroups()
+  {
+    $permGroups = [
+      ['groupPk' => 1, 'perm' => 'read'],
+      ['groupPk' => 2, 'perm' => 'write']
+    ];
+    $permissions = $this->getPermissionsInfo(ApiVersion::V2)['obj'];
+    $this->assertEquals($permGroups, $permissions->getpermGroups());
+  }
+
+  /**
+   * Tests Permissions::setpermGroups() method.
+   *
+   * This method validates that the `setpermGroups` method correctly updates the permissions groups array.
+   */
+  public function testSetPermGroups()
+  {
+    $permGroups = [
+      ['groupPk' => 1, 'perm' => 'read'],
+      ['groupPk' => 2, 'perm' => 'write']
+    ];
+    $permissions = $this->getPermissionsInfo(ApiVersion::V2)['obj'];
+    $permissions->setpermGroups($permGroups);
+    $this->assertEquals($permGroups, $permissions->getpermGroups());
+  }
+}

--- a/src/www/ui_tests/api/Models/ScanCodeTest.php
+++ b/src/www/ui_tests/api/Models/ScanCodeTest.php
@@ -1,0 +1,107 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Valens Niyonsenga <valensniyonsenga2003@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for ScanCode model
+ */
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\Scancode;
+use Monolog\Test\TestCase;
+
+class ScanCodeTest extends TestCase
+{
+  /**
+   * Provides test data and an instance of the ScanCode class.
+   *
+   * @return array An associative array containing:
+   *  - `expectedArray`: The expected array structure.
+   *  - `obj`: The instance of ScanCode being tested.
+   */
+  private function getScanCodeInfo()
+  {
+    $expectedArray = [
+      "license"  => false,
+      "copyright" => false,
+      "email" => false,
+      "url" => false
+    ];
+    $obj = new Scancode();
+    return [
+      'expectedArray' => $expectedArray,
+      'obj' => $obj
+    ];
+  }
+
+  /**
+   * Tests ScanCode::getArray() method.
+   *
+   * This method validates that the `getArray` method returns the correct data structure.
+   */
+  public function testDataFormat()
+  {
+    $expectedArray = $this->getScanCodeInfo()['expectedArray'];
+    $scanCode = $this->getScanCodeInfo()['obj'];
+    $this->assertEquals($expectedArray, $scanCode->getArray());
+  }
+
+  /**
+   * Tests ScanCode::setLicense() and getLicense() methods.
+   *
+   * This method verifies that the `setLicense` method correctly updates the license property,
+   * and that the `getLicense` method returns the updated value.
+   */
+  public function testSetAndGetLicense()
+  {
+    $info = $this->getScanCodeInfo();
+    $obj = $info['obj'];
+    $obj->setScanLicense(true);
+    $this->assertTrue($obj->getScanLicense());
+  }
+
+  /**
+   * Tests ScanCode::setCopyright() and getCopyright() methods.
+   *
+   * This method verifies that the `setCopyright` method correctly updates the copyright property,
+   * and that the `getCopyright` method returns the updated value.
+   */
+  public function testSetAndGetCopyright()
+  {
+    $info = $this->getScanCodeInfo();
+    $obj = $info['obj'];
+    $obj->setScanCopyright(true);
+    $this->assertTrue($obj->getScanCopyright());
+  }
+
+  /**
+   * Tests ScanCode::setEmail() and getEmail() methods.
+   *
+   * This method verifies that the `setEmail` method correctly updates the email property,
+   * and that the `getEmail` method returns the updated value.
+   */
+  public function testSetAndGetEmail()
+  {
+    $info = $this->getScanCodeInfo();
+    $obj = $info['obj'];
+    $obj->setScanEmail(true);
+    $this->assertTrue($obj->getScanEmail());
+  }
+
+  /**
+   * Tests ScanCode::setUrl() and getUrl() methods.
+   *
+   * This method verifies that the `setUrl` method correctly updates the url property,
+   * and that the `getUrl` method returns the updated value.
+   */
+  public function testSetAndGetUrl()
+  {
+    $info = $this->getScanCodeInfo();
+    $obj = $info['obj'];
+    $obj->setScanUrl(true);
+    $this->assertTrue($obj->getScanUrl());
+  }
+}

--- a/src/www/ui_tests/api/Models/UploadTest.php
+++ b/src/www/ui_tests/api/Models/UploadTest.php
@@ -23,6 +23,7 @@ use Fossology\UI\Api\Models\ApiVersion;
  */
 class UploadTest extends \PHPUnit\Framework\TestCase
 {
+
   /**
    * @test
    * -# Test the data format returned by Upload::getArray($version) model when $version is V1
@@ -42,7 +43,7 @@ class UploadTest extends \PHPUnit\Framework\TestCase
   /**
    * @param $version version to test
    * @return void
-   * -# Test the data format returned by Upload::getArray($version) model 
+   * -# Test the data format returned by Upload::getArray($version) model
    */
   private function testDataFormat($version)
   {

--- a/src/www/ui_tests/api/Models/UserGroupMemberTest.php
+++ b/src/www/ui_tests/api/Models/UserGroupMemberTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Models;
+
+use Fossology\Lib\Dao\UserDao;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Models\ApiVersion;
+use Fossology\UI\Api\Models\User;
+use Fossology\UI\Api\Models\UserGroupMember;
+use Monolog\Test\TestCase;
+use Mockery as M;
+class UserGroupMemberTest extends TestCase
+{
+
+  private $dbHelper;
+  private $restHelper;
+  private $userDao;
+  protected function setup(): void
+  {
+    global $container;
+    $container = M::mock('ContainerBuilder');
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->restHelper = M::mock(RestHelper::class);
+    $this->userDao = M::mock(UserDao::class);
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+    $this->restHelper->shouldReceive('getUserDao')->andReturn($this->userDao);
+  }
+  /**
+   * Provides test data and an instance of the UserGroupMember class.
+   *
+   * @return array An associative array containing:
+   *  - `expectedArray`: The expected array structure.
+   *  - `obj`: The instance of UserGroupMember being tested.
+   */
+  private function getUserGroupMemberInfo($version = ApiVersion::V2)
+  {
+
+    $user = new User(1, "fossy", "Admin user", "fossy@gmail.com", "admin", 4, "fossy@gmail.com", "monk", 3, null);
+    if ($version == ApiVersion::V1) {
+      $expectedArray = [
+        'user' => $user->getArray($version),
+        'group_perm' => 0
+      ];
+    } else {
+      $expectedArray = [
+        'user' => $user->getArray($version),
+        'groupPerm' => 0
+      ];
+    }
+
+    $obj = new UserGroupMember($user, $expectedArray['group_perm']);
+    return [
+      'expectedArray' => $expectedArray,
+      'obj' => $obj
+    ];
+  }
+
+  // Getter Tests
+  public function testGetUser()
+  {
+    $user = new User(1, "fossy", "Admin user", "fossy@gmail.com", "admin", 4, "fossy@gmail.com", "monk", 3, null);
+    $userGroupMember = new UserGroupMember($user, 3);
+    $this->assertEquals($user, $userGroupMember->getUser());
+  }
+
+  public function testGetGroupPerm()
+  {
+    $user = new User(1, "fossy", "Admin user", "fossy@gmail.com", "admin", 4, "fossy@gmail.com", "monk", 3, null);
+    $userGroupMember = new UserGroupMember($user, 3);
+    $this->assertEquals(3, $userGroupMember->getGroupPerm());
+  }
+
+  // Setter Tests
+  public function testSetUser()
+  {
+    $user1 = new User(1, "fossy", "Admin user", "fossy@gmail.com", "admin", 4, "fossy@gmail.com", 'monk', 3, null);
+    $user2 = new User(2, "newuser", "New user", "newuser@gmail.com", "user", 5, "newuser@gmail.com", 'monk', 4, null);
+    $userGroupMember = new UserGroupMember($user1, 3);
+
+    $userGroupMember->setUser($user2);
+    $this->assertEquals($user2, $userGroupMember->getUser());
+  }
+
+  public function testSetGroupPerm()
+  {
+    $user = new User(1, "fossy", "Admin user", "fossy@gmail.com", "admin", 4, "fossy@gmail.com", "monk", 3, null);
+    $userGroupMember = new UserGroupMember($user, 3);
+
+    $userGroupMember->setGroupPerm(5);
+    $this->assertEquals(5, $userGroupMember->getGroupPerm());
+  }
+
+  // Test for JSON output
+  public function testGetJSON()
+  {
+    $data = $this->getUserGroupMemberInfo(ApiVersion::V1);
+    $this->assertJsonStringEqualsJsonString(
+      json_encode($data['expectedArray']),
+      $data['obj']->getJSON()
+    );
+  }
+
+  // Test for Array output
+  public function testGetArrayV1()
+  {
+    $data = $this->getUserGroupMemberInfo(ApiVersion::V1);
+    $this->assertEquals($data['expectedArray'], $data['obj']->getArray(ApiVersion::V1));
+  }
+}
+


### PR DESCRIPTION
## Description
 This pull request introduces more unit test coverage for the models like Permissions, LicenseCandidate, Group, Decider,  FileInfo and Agent as reported in issue [#2755](https://github.com/fossology/fossology/issues/2773)

### Changes
**Enhanced existing test cases:**  Worked on the  current test suite to improve the coverage.
**Added new test cases:** Introduced additional tests to  validate all methods and member variables.

### How to Test ?

- Navigate to the ui_tests/api/models directory.
- Execute each test case individually.
- Verify that all tests pass without any errors or failures.

CC @shaheemazmalmmd @soham4abc @dushimsam @GMishx 