### PR TITLE
test(models): added more unit tests for group,job,scancode.etc

### DIFF
--- a/src/www/ui_tests/api/Models/AnalysisTest.php
+++ b/src/www/ui_tests/api/Models/AnalysisTest.php
@@ -143,7 +143,7 @@ class AnalysisTest extends \PHPUnit\Framework\TestCase
   /**
    * @param $version version to test
    * @return void
-   * -# Test the data format returned by Upload::getArray($version) model 
+   * -# Test the data format returned by Upload::getArray($version) model
    */
   private function testDataFormat($version)
   {
@@ -183,5 +183,122 @@ class AnalysisTest extends \PHPUnit\Framework\TestCase
     $actualObject->setReso(true);
 
     $this->assertEquals($expectedArray, $actualObject->getArray($version));
+  }
+
+  ////// New Getter and Setter Tests //////
+
+  /**
+   * @test
+   * -# Test getter for bucket
+   */
+  public function testGetBucket()
+  {
+    $analysis = new Analysis(true);
+    $this->assertTrue($analysis->getBucket());
+  }
+
+  /**
+   * @test
+   * -# Test setter for bucket
+   */
+  public function testSetBucket()
+  {
+    $analysis = new Analysis();
+    $analysis->setBucket(true);
+    $this->assertTrue($analysis->getBucket());
+  }
+
+  /**
+   * @test
+   * -# Test getter for copyright
+   */
+  public function testGetCopyright()
+  {
+    $analysis = new Analysis(false, true);
+    $this->assertTrue($analysis->getCopyright());
+  }
+
+  /**
+   * @test
+   * -# Test setter for copyright
+   */
+  public function testSetCopyright()
+  {
+    $analysis = new Analysis();
+    $analysis->setCopyright(true);
+    $this->assertTrue($analysis->getCopyright());
+  }
+
+  /**
+   * @test
+   * -# Test getter for ecc
+   */
+  public function testGetEcc()
+  {
+    $analysis = new Analysis(false, false, true);
+    $this->assertTrue($analysis->getEcc());
+  }
+
+  /**
+   * @test
+   * -# Test setter for ecc
+   */
+  public function testSetEcc()
+  {
+    $analysis = new Analysis();
+    $analysis->setEcc(true);
+    $this->assertTrue($analysis->getEcc());
+  }
+
+  /**
+   * @test
+   * -# Test getter for keyword
+   */
+  public function testGetKeyword()
+  {
+    $analysis = new Analysis(false, false, false, true);
+    $this->assertTrue($analysis->getKeyword());
+  }
+
+  /**
+   * @test
+   * -# Test setter for keyword
+   */
+  public function testSetKeyword()
+  {
+    $analysis = new Analysis();
+    $analysis->setKeyword(true);
+    $this->assertTrue($analysis->getKeyword());
+  }
+
+  /**
+   * @test
+   * -# Test getter for mimetype
+   */
+  public function testGetMime()
+  {
+    $analysis = new Analysis(false, false, false, false, true);
+    $this->assertTrue($analysis->getMime());
+  }
+
+  /**
+   * @test
+   * -# Test setter for mimetype
+   */
+  public function testSetMime()
+  {
+    $analysis = new Analysis();
+    $analysis->setMime(true);
+    $this->assertTrue($analysis->getMime());
+  }
+
+  /**
+   * @test
+   * -# Test getter for monk
+   */
+  public function testGetMonk()
+  {
+    $analysis = new Analysis(false, false, false, false, false, true);
+    $this->assertTrue($analysis->getMonk());
   }
 }

--- a/src/www/ui_tests/api/Models/ApiVersionTest.php
+++ b/src/www/ui_tests/api/Models/ApiVersionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ SPDX-FileCopyrightText: © 2024 Valens Niyonsenga <valensniyonsenga2003@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for ApiVersion model
+ */
+namespace Fossology\UI\Api\Test\Models;
+
+
+use Fossology\UI\Api\Models\ApiVersion;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+class ApiVersionTest extends TestCase
+{
+  /**
+   * Test that getVersion returns the correct version when ATTRIBUTE_NAME is set.
+   */
+  public function testGetVersionReturnsSetVersion()
+  {
+    $requestMock = $this->createMock(ServerRequestInterface::class);
+    $requestMock->method('getAttribute')
+      ->with(ApiVersion::ATTRIBUTE_NAME, ApiVersion::V1)
+      ->willReturn(ApiVersion::V2);
+
+    $this->assertEquals(ApiVersion::V2, ApiVersion::getVersion($requestMock));
+  }
+
+  /**
+   * Test that getVersion returns the default version (V1) when ATTRIBUTE_NAME is not set.
+   */
+  public function testGetVersionReturnsDefaultVersion()
+  {
+    $requestMock = $this->createMock(ServerRequestInterface::class);
+    $requestMock->method('getAttribute')
+      ->with(ApiVersion::ATTRIBUTE_NAME, ApiVersion::V1)
+      ->willReturn(ApiVersion::V1);
+
+    $this->assertEquals(ApiVersion::V1, ApiVersion::getVersion($requestMock));
+  }
+}

--- a/src/www/ui_tests/api/Models/BulkHistoryTest.php
+++ b/src/www/ui_tests/api/Models/BulkHistoryTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ SPDX-FileCopyrightText: © 2024 Valens Niyonsenga <valensniyonsenga2003@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for BulkHistory model
+ */
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\BulkHistory;
+use PHPUnit\Framework\TestCase;
+
+class BulkHistoryTest extends TestCase
+{
+  /**
+   * Provides test data and an instance of the BulkHistory class.
+   *
+   * @return array An associative array containing:
+   *  - `expectedArray`: The expected array structure.
+   *  - `obj`: The instance of BulkHistory being tested.
+   */
+  private function getBulkHistoryInfo()
+  {
+    $expectedArray = [
+      "bulkId" => 4,
+      "clearingEventId" => 3,
+      "text" => "BulkHistory text",
+      "matched" => false,
+      "tried" => false,
+      "addedLicenses" => [],
+      "removedLicenses" => []
+    ];
+    $obj = new BulkHistory(4, 3, "BulkHistory text", false, false, [], []);
+    return [
+      'expectedArray' => $expectedArray,
+      'obj' => $obj
+    ];
+  }
+
+  /**
+   * Tests BulkHistory::getArray() method.
+   *
+   * This method validates that the `getArray` method returns the correct data structure.
+   */
+  public function testDataFormat()
+  {
+    $expectedArray = $this->getBulkHistoryInfo()['expectedArray'];
+    $bulkHistory = $this->getBulkHistoryInfo()['obj'];
+    $this->assertEquals($expectedArray, $bulkHistory->getArray());
+  }
+
+  /**
+   * Tests BulkHistory::setBulkId() and getBulkId() methods.
+   *
+   * This method verifies that the `setBulkId` method correctly updates the bulkId property,
+   * and that the `getBulkId` method returns the updated value.
+   */
+  public function testSetAndGetBulkId()
+  {
+    $info = $this->getBulkHistoryInfo();
+    $bulkHistory = $info['obj'];
+    $bulkId = 5;
+    $bulkHistory->setBulkId($bulkId);
+    $this->assertEquals($bulkId, $bulkHistory->getBulkId());
+  }
+
+  /**
+   * Tests BulkHistory::setClearingEventId() and getClearingEventId() methods.
+   *
+   * This method verifies that the `setClearingEventId` method correctly updates the clearingEventId property,
+   * and that the `getClearingEventId` method returns the updated value.
+   */
+  public function testSetAndGetClearingEventId()
+  {
+    $info = $this->getBulkHistoryInfo();
+    $bulkHistory = $info['obj'];
+    $clearingEventId = 6;
+    $bulkHistory->setClearingEventId($clearingEventId);
+    $this->assertEquals($clearingEventId, $bulkHistory->getClearingEventId());
+  }
+
+  /**
+   * Tests BulkHistory::setText() and getText() methods.
+   *
+   * This method verifies that the `setText` method correctly updates the text property,
+   * and that the `getText` method returns the updated value.
+   */
+  public function testSetAndGetText()
+  {
+    $info = $this->getBulkHistoryInfo();
+    $bulkHistory = $info['obj'];
+    $text = "Updated text";
+    $bulkHistory->setText($text);
+    $this->assertEquals($text, $bulkHistory->getText());
+  }
+
+  /**
+   * Tests BulkHistory::setMatched() and getMatched() methods.
+   *
+   * This method verifies that the `setMatched` method correctly updates the matched property,
+   * and that the `getMatched` method returns the updated value.
+   */
+  public function testSetAndGetMatched()
+  {
+    $info = $this->getBulkHistoryInfo();
+    $bulkHistory = $info['obj'];
+    $matched = true;
+    $bulkHistory->setMatched($matched);
+    $this->assertEquals($matched, $bulkHistory->getMatched());
+  }
+
+  /**
+   * Tests BulkHistory::setTried() and getTried() methods.
+   *
+   * This method verifies that the `setTried` method correctly updates the tried property,
+   * and that the `getTried` method returns the updated value.
+   */
+  public function testSetAndGetTried()
+  {
+    $info = $this->getBulkHistoryInfo();
+    $bulkHistory = $info['obj'];
+    $tried = true;
+    $bulkHistory->setTried($tried);
+    $this->assertEquals($tried, $bulkHistory->getTried());
+  }
+
+  /**
+   * Tests BulkHistory::setAddedLicenses() and getAddedLicenses() methods.
+   *
+   * This method verifies that the `setAddedLicenses` method correctly updates the addedLicenses property,
+   * and that the `getAddedLicenses` method returns the updated value.
+   */
+  public function testSetAndGetAddedLicenses()
+  {
+    $info = $this->getBulkHistoryInfo();
+    $bulkHistory = $info['obj'];
+    $addedLicenses = ['LicenseA', 'LicenseB'];
+    $bulkHistory->setAddedLicenses($addedLicenses);
+    $this->assertEquals($addedLicenses, $bulkHistory->getAddedLicenses());
+  }
+
+  /**
+   * Tests BulkHistory::setRemovedLicenses() and getRemovedLicenses() methods.
+   *
+   * This method verifies that the `setRemovedLicenses` method correctly updates the removedLicenses property,
+   * and that the `getRemovedLicenses` method returns the updated value.
+   */
+  public function testSetAndGetRemovedLicenses()
+  {
+    $info = $this->getBulkHistoryInfo();
+    $bulkHistory = $info['obj'];
+    $removedLicenses = ['LicenseX', 'LicenseY'];
+    $bulkHistory->setRemovedLicenses($removedLicenses);
+    $this->assertEquals($removedLicenses, $bulkHistory->getRemovedLicenses());
+  }
+}

--- a/src/www/ui_tests/api/Models/FolderTest.php
+++ b/src/www/ui_tests/api/Models/FolderTest.php
@@ -45,4 +45,56 @@ class FolderTest extends \PHPUnit\Framework\TestCase
     $this->assertEquals($expectedParent, $parentFolder->getArray());
     $this->assertEquals($expectedChild, $childFolder->getArray());
   }
+
+  /**
+   * Tests Folder::getId() and Folder::setId() methods.
+   *
+   * This method verifies that the setId method correctly updates the folder ID,
+   * and that the getId method returns the correct value.
+   */
+  public function testSetAndGetId()
+  {
+    $folder = new Folder(1, 'name', 'description', null);
+    $folder->setId(10);
+    $this->assertEquals(10, $folder->getId());
+  }
+
+  /**
+   * Tests Folder::getName() and Folder::setName() methods.
+   *
+   * This method verifies that the setName method correctly updates the folder name,
+   * and that the getName method returns the correct value.
+   */
+  public function testSetAndGetName()
+  {
+    $folder = new Folder(1, 'name', 'description', null);
+    $folder->setName('newName');
+    $this->assertEquals('newName', $folder->getName());
+  }
+
+  /**
+   * Tests Folder::getDescription() and Folder::setDescription() methods.
+   *
+   * This method verifies that the setDescription method correctly updates the folder description,
+   * and that the getDescription method returns the correct value.
+   */
+  public function testSetAndGetDescription()
+  {
+    $folder = new Folder(1, 'name', 'description', null);
+    $folder->setDescription('newDescription');
+    $this->assertEquals('newDescription', $folder->getDescription());
+  }
+
+  /**
+   * Tests Folder::getParent() and Folder::setParent() methods.
+   *
+   * This method verifies that the setParent method correctly updates the parent ID,
+   * and that the getParent method returns the correct value.
+   */
+  public function testSetAndGetParent()
+  {
+    $folder = new Folder(1, 'name', 'description', null);
+    $folder->setParent(5);
+    $this->assertEquals(5, $folder->getParent());
+  }
 }

--- a/src/www/ui_tests/api/Models/GroupPermissionsTest.php
+++ b/src/www/ui_tests/api/Models/GroupPermissionsTest.php
@@ -1,0 +1,146 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Valens Niyonsenga <valensniyonsenga2003@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for GroupPermission model
+ */
+namespace Fossology\UI\Api\Test\Models;
+
+
+use Fossology\UI\Api\Models\ApiVersion;
+use Fossology\UI\Api\Models\GroupPermission;
+use Monolog\Test\TestCase;
+
+class GroupPermissionsTest extends TestCase
+{
+  /**
+   * Provides test data and an instance of the GroupPermission class.
+   *
+   * @return array An associative array containing:
+   *  - `expectedArray`: The expected array structure.
+   *  - `obj`: The instance of Group being tested.
+   */
+  private function getGroupPermissionInfo($version = ApiVersion::V2)
+  {
+    $expectedArray = null;
+    if ($version == ApiVersion::V1)
+    {
+      $expectedArray = [
+        "perm" => "Group perm",
+        "group_pk"  => 4,
+        "group_name" => "fossy",
+      ];
+    } else {
+      $expectedArray = [
+        "perm" => "Group perm",
+        "groupPk"  => 4,
+        "groupName" => "fossy",
+      ];
+    }
+    $obj = new GroupPermission("Group perm",4,"fossy");
+    return [
+      'expectedArray' => $expectedArray,
+      'obj' => $obj
+    ];
+  }
+  /**
+   * @test
+   * -# Test data model returned by GroupPermission::getArray($version) when API version is V1
+   */
+  public function testDataFormatV1()
+  {
+    $this->testDataFormat(ApiVersion::V1);
+  }
+
+  /**
+   * @test
+   * -# Test data model returned by GroupPermission::getArray($version) when API version is V2
+   */
+  public function testDataFormatV2()
+  {
+    $this->testDataFormat(ApiVersion::V2);
+  }
+
+  /**
+   * -# Test the data format returned by GroupPermission::getArray($version) model
+   */
+  private function testDataFormat($version)
+  {
+    $info = $this->getGroupPermissionInfo($version);
+    $expectedArray = $info['expectedArray'];
+    $groupPermission = $info['obj'];
+    $this->assertEquals($expectedArray, $groupPermission->getArray($version));
+  }
+  /**
+   * Tests GroupPermission::getPerm() method.
+   *
+   * This method validates that the `getPerm` method returns the correct permission value.
+   */
+  public function testGetPerm()
+  {
+    $groupPermission = new GroupPermission("Group perm", "4", "fossy");
+    $this->assertEquals("Group perm", $groupPermission->getPerm());
+  }
+
+  /**
+   * Tests GroupPermission::setPerm() method.
+   *
+   * This method validates that the `setPerm` method correctly updates the permission value.
+   */
+  public function testSetPerm()
+  {
+    $groupPermission = new GroupPermission("Group perm", "4", "fossy");
+    $groupPermission->setPerm("New perm");
+    $this->assertEquals("New perm", $groupPermission->getPerm());
+  }
+
+  /**
+   * Tests GroupPermission::getGroupPk() method.
+   *
+   * This method validates that the `getGroupPk` method returns the correct group ID value.
+   */
+  public function testGetGroupPk()
+  {
+    $groupPermission = new GroupPermission("Group perm", "4", "fossy");
+    $this->assertEquals("4", $groupPermission->getGroupPk());
+  }
+
+  /**
+   * Tests GroupPermission::setGroupPk() method.
+   *
+   * This method validates that the `setGroupPk` method correctly updates the group ID value.
+   */
+  public function testSetGroupPk()
+  {
+    $groupPermission = new GroupPermission("Group perm", "4", "fossy");
+    $groupPermission->setGroupPk("10");
+    $this->assertEquals("10", $groupPermission->getGroupPk());
+  }
+
+  /**
+   * Tests GroupPermission::getGroupName() method.
+   *
+   * This method validates that the `getGroupName` method returns the correct group name value.
+   */
+  public function testGetGroupName()
+  {
+    $groupPermission = new GroupPermission("Group perm", "4", "fossy");
+    $this->assertEquals("fossy", $groupPermission->getGroupName());
+  }
+
+  /**
+   * Tests GroupPermission::setGroupName() method.
+   *
+   * This method validates that the `setGroupName` method correctly updates the group name value.
+   */
+  public function testSetGroupName()
+  {
+    $groupPermission = new GroupPermission("Group perm", "4", "fossy");
+    $groupPermission->setGroupName("newName");
+    $this->assertEquals("newName", $groupPermission->getGroupName());
+  }
+}

--- a/src/www/ui_tests/api/Models/GroupTest.php
+++ b/src/www/ui_tests/api/Models/GroupTest.php
@@ -1,0 +1,96 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Valens Niyonsenga <valensniyonsenga2003@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for GroupTest model
+ */
+namespace Fossology\UI\Api\Test\Models;
+
+
+use Fossology\UI\Api\Models\Group;
+use PHPUnit\Framework\TestCase;
+
+class GroupTest extends TestCase
+{
+  /**
+   * Provides test data and an instance of the Group class.
+   *
+   * @return array An associative array containing:
+   *  - `expectedArray`: The expected array structure.
+   *  - `obj`: The instance of Group being tested.
+   */
+  private function getGroupInfo()
+  {
+    $expectedArray = [
+      "id"  => 4,
+      "name" => "fossy",
+    ];
+    $obj = new Group(4,"fossy");
+    return [
+      'expectedArray' => $expectedArray,
+      'obj' => $obj
+    ];
+  }
+
+  /**
+   * Tests Group::getArray() method.
+   *
+   * This method validates that the `getArray` method returns the correct data structure.
+   */
+  public function testDataFormat()
+  {
+    $expectedArray = $this->getGroupInfo()['expectedArray'];
+    $group = $this->getGroupInfo()['obj'];
+    $this->assertEquals($expectedArray, $group->getArray());
+  }
+
+  /**
+   * Tests Group::getId() method.
+   *
+   * This method validates that the `getId` method returns the correct ID value.
+   */
+  public function testGetId()
+  {
+    $group = new Group(4, "fossy");
+    $this->assertEquals(4, $group->getId());
+  }
+
+  /**
+   * Tests Group::setId() method.
+   *
+   * This method validates that the `setId` method correctly updates the ID value.
+   */
+  public function testSetId()
+  {
+    $group = new Group(4, "fossy");
+    $group->setId(10);
+    $this->assertEquals(10, $group->getId());
+  }
+
+  /**
+   * Tests Group::getName() method.
+   *
+   * This method validates that the `getName` method returns the correct name value.
+   */
+  public function testGetName()
+  {
+    $group = new Group(4, "fossy");
+    $this->assertEquals("fossy", $group->getName());
+  }
+
+  /**
+   * Tests Group::setName() method.
+   *
+   * This method validates that the `setName` method correctly updates the name value.
+   */
+  public function testSetName()
+  {
+    $group = new Group(4, "fossy");
+    $group->setName("newName");
+    $this->assertEquals("newName", $group->getName());
+  }
+}

--- a/src/www/ui_tests/api/Models/JobTest.php
+++ b/src/www/ui_tests/api/Models/JobTest.php
@@ -1,10 +1,12 @@
 <?php
+
 /*
  SPDX-FileCopyrightText: © 2020 Siemens AG
  Author: Gaurav Mishra <mishra.gaurav@siemens.com>
 
  SPDX-License-Identifier: GPL-2.0-only
 */
+
 /**
  * @file
  * @brief Tests for Job model
@@ -17,14 +19,14 @@ use Fossology\UI\Api\Models\ApiVersion;
 use Fossology\UI\Api\Models\Job;
 use Fossology\UI\Api\Models\JobQueue;
 use Mockery as M;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @class JobTest
  * @brief Test for Job model
  */
-class JobTest extends \PHPUnit\Framework\TestCase
+class JobTest extends TestCase
 {
-
   /**
    * @test
    * -# Test data model returned by Job::getArray($version) when API version is V1
@@ -44,13 +46,15 @@ class JobTest extends \PHPUnit\Framework\TestCase
   }
 
   /**
-   * -# Test the data format returned by Job::getArray($version) model 
+   * -# Test the data format returned by Job::getArray($version) model
    */
   private function testDataFormat($version)
   {
     $jobQueue = new JobQueue(44, 'readmeoss', '2024-07-03 20:41:49', '2024-07-03 20:41:50',
       'Completed', 0, null, [], 0, true, false, true,
-      ['text' => 'ReadMeOss', 'link' => 'http://localhost/repo/api/v1/report/16']);
+      ['text' => 'ReadMeOss', 'link' => 'http://localhost/repo/api/v1/report/16']
+    );
+
     if ($version == ApiVersion::V2){
       $expectedStatus = [
         'id'        => 22,
@@ -63,13 +67,13 @@ class JobTest extends \PHPUnit\Framework\TestCase
         'status'    => 'Processing',
         'jobQueue'  => $jobQueue->getArray()
       ];
+
       global $container;
       $userDao = M::mock(UserDao::class);
       $container = M::mock('ContainerBuilder');
-      $container->shouldReceive('get')->withArgs(array(
-        "dao.user"))->andReturn($userDao);
-      $userDao->shouldReceive("getUserName")->with(2)->andReturn("fossy");
-      $userDao->shouldReceive("getGroupNameById")->with(2)->andReturn("fossy");
+      $container->shouldReceive('get')->with('dao.user')->andReturn($userDao);
+      $userDao->shouldReceive('getUserName')->with(2)->andReturn('fossy');
+      $userDao->shouldReceive('getGroupNameById')->with(2)->andReturn('fossy');
     } else {
       $expectedStatus = [
         'id'        => 22,
@@ -86,5 +90,113 @@ class JobTest extends \PHPUnit\Framework\TestCase
     $actualJob = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing', $jobQueue->getArray());
 
     $this->assertEquals($expectedStatus, $actualJob->getArray($version));
+  }
+
+  // Getter tests
+  public function testGetId()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $this->assertEquals(22, $job->getId());
+  }
+
+  public function testGetName()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $this->assertEquals('ojo', $job->getName());
+  }
+
+  public function testGetQueueDate()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $this->assertEquals('01-01-2020', $job->getQueueDate());
+  }
+
+  public function testGetUploadId()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $this->assertEquals(4, $job->getUploadId());
+  }
+
+  public function testGetUserId()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $this->assertEquals(2, $job->getUserId());
+  }
+
+  public function testGetGroupId()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $this->assertEquals(2, $job->getGroupId());
+  }
+
+  public function testGetEta()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $this->assertEquals(3, $job->getEta());
+  }
+
+  public function testGetStatus()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $this->assertEquals('Processing', $job->getStatus());
+  }
+
+  public function testGetJobQueue()
+  {
+    $jobQueue = new JobQueue(44, 'readmeoss', '2024-07-03 20:41:49', '2024-07-03 20:41:50',
+      'Completed', 0, null, [], 0, true, false, true,
+      ['text' => 'ReadMeOss', 'link' => 'http://localhost/repo/api/v1/report/16']
+    );
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing', $jobQueue->getArray());
+    $this->assertEquals($jobQueue->getArray(), $job->getJobQueue());
+  }
+
+  // Setter tests
+  public function testSetName()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $job->setName('newName');
+    $this->assertEquals('newName', $job->getName());
+  }
+
+  public function testSetQueueDate()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $job->setQueueDate('02-02-2020');
+    $this->assertEquals('02-02-2020', $job->getQueueDate());
+  }
+
+  public function testSetUploadId()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $job->setUploadId(5);
+    $this->assertEquals(5, $job->getUploadId());
+  }
+
+  public function testSetUserId()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $job->setUserId(3);
+    $this->assertEquals(3, $job->getUserId());
+  }
+
+  public function testSetGroupId()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $job->setGroupId(4);
+    $this->assertEquals(4, $job->getGroupId());
+  }
+  public function testSetEta()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $job->setEta(10);
+    $this->assertEquals(10, $job->getEta());
+  }
+
+  public function testSetStatus()
+  {
+    $job = new Job(22, 'ojo', '01-01-2020', 4, 2, 2, 3, 'Processing');
+    $job->setStatus('Completed');
+    $this->assertEquals('Completed', $job->getStatus());
   }
 }

--- a/src/www/ui_tests/api/Models/ScanCodeTest.php
+++ b/src/www/ui_tests/api/Models/ScanCodeTest.php
@@ -1,0 +1,107 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Valens Niyonsenga <valensniyonsenga2003@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for ScanCode model
+ */
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\Scancode;
+use Monolog\Test\TestCase;
+
+class ScanCodeTest extends TestCase
+{
+  /**
+   * Provides test data and an instance of the ScanCode class.
+   *
+   * @return array An associative array containing:
+   *  - `expectedArray`: The expected array structure.
+   *  - `obj`: The instance of ScanCode being tested.
+   */
+  private function getScanCodeInfo()
+  {
+    $expectedArray = [
+      "license"  => false,
+      "copyright" => false,
+      "email" => false,
+      "url" => false
+    ];
+    $obj = new Scancode();
+    return [
+      'expectedArray' => $expectedArray,
+      'obj' => $obj
+    ];
+  }
+
+  /**
+   * Tests ScanCode::getArray() method.
+   *
+   * This method validates that the `getArray` method returns the correct data structure.
+   */
+  public function testDataFormat()
+  {
+    $expectedArray = $this->getScanCodeInfo()['expectedArray'];
+    $scanCode = $this->getScanCodeInfo()['obj'];
+    $this->assertEquals($expectedArray, $scanCode->getArray());
+  }
+
+  /**
+   * Tests ScanCode::setLicense() and getLicense() methods.
+   *
+   * This method verifies that the `setLicense` method correctly updates the license property,
+   * and that the `getLicense` method returns the updated value.
+   */
+  public function testSetAndGetLicense()
+  {
+    $info = $this->getScanCodeInfo();
+    $obj = $info['obj'];
+    $obj->setScanLicense(true);
+    $this->assertTrue($obj->getScanLicense());
+  }
+
+  /**
+   * Tests ScanCode::setCopyright() and getCopyright() methods.
+   *
+   * This method verifies that the `setCopyright` method correctly updates the copyright property,
+   * and that the `getCopyright` method returns the updated value.
+   */
+  public function testSetAndGetCopyright()
+  {
+    $info = $this->getScanCodeInfo();
+    $obj = $info['obj'];
+    $obj->setScanCopyright(true);
+    $this->assertTrue($obj->getScanCopyright());
+  }
+
+  /**
+   * Tests ScanCode::setEmail() and getEmail() methods.
+   *
+   * This method verifies that the `setEmail` method correctly updates the email property,
+   * and that the `getEmail` method returns the updated value.
+   */
+  public function testSetAndGetEmail()
+  {
+    $info = $this->getScanCodeInfo();
+    $obj = $info['obj'];
+    $obj->setScanEmail(true);
+    $this->assertTrue($obj->getScanEmail());
+  }
+
+  /**
+   * Tests ScanCode::setUrl() and getUrl() methods.
+   *
+   * This method verifies that the `setUrl` method correctly updates the url property,
+   * and that the `getUrl` method returns the updated value.
+   */
+  public function testSetAndGetUrl()
+  {
+    $info = $this->getScanCodeInfo();
+    $obj = $info['obj'];
+    $obj->setScanUrl(true);
+    $this->assertTrue($obj->getScanUrl());
+  }
+}

--- a/src/www/ui_tests/api/Models/UploadTest.php
+++ b/src/www/ui_tests/api/Models/UploadTest.php
@@ -23,6 +23,7 @@ use Fossology\UI\Api\Models\ApiVersion;
  */
 class UploadTest extends \PHPUnit\Framework\TestCase
 {
+
   /**
    * @test
    * -# Test the data format returned by Upload::getArray($version) model when $version is V1
@@ -42,7 +43,7 @@ class UploadTest extends \PHPUnit\Framework\TestCase
   /**
    * @param $version version to test
    * @return void
-   * -# Test the data format returned by Upload::getArray($version) model 
+   * -# Test the data format returned by Upload::getArray($version) model
    */
   private function testDataFormat($version)
   {

--- a/src/www/ui_tests/api/Models/UserGroupMemberTest.php
+++ b/src/www/ui_tests/api/Models/UserGroupMemberTest.php
@@ -1,0 +1,122 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Valens Niyonsenga <valensniyonsenga2003@gmail.com>
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for UserGroupMember model
+ */
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\Lib\Dao\UserDao;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Models\ApiVersion;
+use Fossology\UI\Api\Models\User;
+use Fossology\UI\Api\Models\UserGroupMember;
+use Monolog\Test\TestCase;
+use Mockery as M;
+class UserGroupMemberTest extends TestCase
+{
+
+  private $dbHelper;
+  private $restHelper;
+  private $userDao;
+  protected function setup(): void
+  {
+    global $container;
+    $container = M::mock('ContainerBuilder');
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->restHelper = M::mock(RestHelper::class);
+    $this->userDao = M::mock(UserDao::class);
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+    $this->restHelper->shouldReceive('getUserDao')->andReturn($this->userDao);
+  }
+  /**
+   * Provides test data and an instance of the UserGroupMember class.
+   *
+   * @return array An associative array containing:
+   *  - `expectedArray`: The expected array structure.
+   *  - `obj`: The instance of UserGroupMember being tested.
+   */
+  private function getUserGroupMemberInfo($version = ApiVersion::V2)
+  {
+
+    $user = new User(1, "fossy", "Admin user", "fossy@gmail.com", "admin", 4, "fossy@gmail.com", "monk", 3, null);
+    if ($version == ApiVersion::V1) {
+      $expectedArray = [
+        'user' => $user->getArray($version),
+        'group_perm' => 0
+      ];
+    } else {
+      $expectedArray = [
+        'user' => $user->getArray($version),
+        'groupPerm' => 0
+      ];
+    }
+
+    $obj = new UserGroupMember($user, $expectedArray['group_perm']);
+    return [
+      'expectedArray' => $expectedArray,
+      'obj' => $obj
+    ];
+  }
+
+  // Getter Tests
+  public function testGetUser()
+  {
+    $user = new User(1, "fossy", "Admin user", "fossy@gmail.com", "admin", 4, "fossy@gmail.com", "monk", 3, null);
+    $userGroupMember = new UserGroupMember($user, 3);
+    $this->assertEquals($user, $userGroupMember->getUser());
+  }
+
+  public function testGetGroupPerm()
+  {
+    $user = new User(1, "fossy", "Admin user", "fossy@gmail.com", "admin", 4, "fossy@gmail.com", "monk", 3, null);
+    $userGroupMember = new UserGroupMember($user, 3);
+    $this->assertEquals(3, $userGroupMember->getGroupPerm());
+  }
+
+  // Setter Tests
+  public function testSetUser()
+  {
+    $user1 = new User(1, "fossy", "Admin user", "fossy@gmail.com", "admin", 4, "fossy@gmail.com", 'monk', 3, null);
+    $user2 = new User(2, "newuser", "New user", "newuser@gmail.com", "user", 5, "newuser@gmail.com", 'monk', 4, null);
+    $userGroupMember = new UserGroupMember($user1, 3);
+
+    $userGroupMember->setUser($user2);
+    $this->assertEquals($user2, $userGroupMember->getUser());
+  }
+
+  public function testSetGroupPerm()
+  {
+    $user = new User(1, "fossy", "Admin user", "fossy@gmail.com", "admin", 4, "fossy@gmail.com", "monk", 3, null);
+    $userGroupMember = new UserGroupMember($user, 3);
+
+    $userGroupMember->setGroupPerm(5);
+    $this->assertEquals(5, $userGroupMember->getGroupPerm());
+  }
+
+  // Test for JSON output
+  public function testGetJSON()
+  {
+    $data = $this->getUserGroupMemberInfo(ApiVersion::V1);
+    $this->assertJsonStringEqualsJsonString(
+      json_encode($data['expectedArray']),
+      $data['obj']->getJSON()
+    );
+  }
+
+  // Test for Array output
+  public function testGetArrayV1()
+  {
+    $data = $this->getUserGroupMemberInfo(ApiVersion::V1);
+    $this->assertEquals($data['expectedArray'], $data['obj']->getArray(ApiVersion::V1));
+  }
+}


### PR DESCRIPTION
## Description
 This pull request introduces more  test cases for the models as reported in issue [#2791](https://github.com/fossology/fossology/issues/2791)

The following models are covered:

- ScanCode
- Upload
- Folder
- Group
- Group permissions
- ApiVersion
- Analysis
- BulkHistory
- Job
- UserGroupMember
- UploadSummary

### Changes
**Enhanced existing test cases:**  Worked on the  current test suite to improve the coverage.
**Added new test cases:** Introduced additional tests to  validate all methods and member variables.

### How to Test ?

- Navigate to the ui_tests/api/models directory.
- Execute each test case individually.
- Verify that all tests pass without any errors or failures.

CC @GMishx  @shaheemazmalmmd @soham4abc @dushimsam 