### PR TITLE
feat(scanoss): Adds proxy support

### DIFF
--- a/src/scanoss/agent/main.c
+++ b/src/scanoss/agent/main.c
@@ -235,6 +235,20 @@ int main(int argc, char *argv[])
       if (RebuildUpload(upload_pk,tempFolder) != 0) /* process the upload_pk code */{
           LOG_ERROR("Error processing upload\n");
       } else {
+        char *proxy_url;
+        proxy_url=NULL;
+        proxy_url= fo_config_get(sysconfig, "FOSSOLOGY", "https_proxy", NULL); 
+        if (proxy_url==NULL) {
+            proxy_url= fo_config_get(sysconfig, "FOSSOLOGY", "http_proxy", NULL); 
+        }
+        
+        if (proxy_url!=NULL) { 
+          if (setenv("https_proxy", proxy_url, 1) != 0) {
+            perror("Error setting https_proxy env-var");
+            return 1;
+          }
+          LOG_NOTICE("Using proxy configuration:%s\n", proxy_url)
+        }
         ScanFolder(tempFolder);
         ParseResults(tempFolder);
         char cmdRemove[600];


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

This PR adds  proxy support for scanoss agent. The agent sets environment variable https_proxy with any value defined on http_proxy or https_proxy variables defined on fossology.conf file. The following configurations are supported:
- http_proxy = http://\<host>:\<port>
- http_proxy = http://\<user>:\<password>@\<host>:\<port>

### Changes

Followed guidelines from wget agent and added routines to set the environment variables

## How to test
1. Open fossology.conf file
2. Uncomment and set the right proxy addeess:port on http_proxy or https_proxy. Depending on the proxy configuration, potentially need to set up the credentials.
3. Reload scheduler configuration
