### PR TITLE
refactor(report): Remove datetime from report names

### DIFF
--- a/src/clixml/agent/clixml.php
+++ b/src/clixml/agent/clixml.php
@@ -18,6 +18,7 @@ use Fossology\Lib\Report\LicenseMainGetter;
 use Fossology\Lib\Report\ObligationsGetter;
 use Fossology\Lib\Report\OtherGetter;
 use Fossology\Lib\Report\XpClearedGetter;
+use Fossology\Lib\Report\ReportUtils;
 use Twig\Environment;
 
 include_once(__DIR__ . "/version.php");
@@ -68,6 +69,11 @@ class CliXml extends Agent
    */
   private $licenseDNUGetter;
 
+  /** @var ReportUtils $reportutils
+   * ReportUtils object
+   */
+  private $reportutils;
+
   /** @var string */
   protected $outputFormat = self::DEFAULT_OUTPUT_FORMAT;
 
@@ -92,6 +98,7 @@ class CliXml extends Agent
     $this->licenseMainGetter = new LicenseMainGetter();
     $this->obligationsGetter = new ObligationsGetter();
     $this->otherGetter = new OtherGetter();
+    $this->reportutils = new ReportUtils();
     $this->agentSpecifLongOptions[] = self::UPLOAD_ADDS.':';
     $this->agentSpecifLongOptions[] = self::OUTPUT_FORMAT_KEY.':';
   }
@@ -171,7 +178,7 @@ class CliXml extends Agent
 
   protected function getUri($fileBase)
   {
-    $fileName = $fileBase. strtoupper($this->outputFormat)."_".$this->packageName.'_'.date("Y-m-d_H:i:s");
+    $fileName = $fileBase. strtoupper($this->outputFormat)."_".$this->packageName;
     return $fileName .".xml";
   }
 
@@ -492,9 +499,7 @@ class CliXml extends Agent
 
   protected function updateReportTable($uploadId, $jobId, $fileName)
   {
-    $this->dbManager->insertTableRow('reportgen',
-            array('upload_fk'=>$uploadId, 'job_fk'=>$jobId, 'filepath'=>$fileName),
-            __METHOD__);
+    $this->reportutils->updateOrInsertReportgenEntry($uploadId, $jobId, $fileName);
   }
 
   /**

--- a/src/cyclonedx/agent/cyclonedx.php
+++ b/src/cyclonedx/agent/cyclonedx.php
@@ -141,7 +141,7 @@ class CycloneDXAgent extends Agent
    */
   protected function getUri($fileBase)
   {
-    $fileName = $fileBase. strtoupper($this->outputFormat)."_".$this->packageName.'_'.date("Y-m-d_H:i:s");
+    $fileName = $fileBase. strtoupper($this->outputFormat)."_".$this->packageName;
     return $fileName .".json" ;
   }
 
@@ -340,9 +340,7 @@ class CycloneDXAgent extends Agent
    */
   protected function updateReportTable($uploadId, $jobId, $fileName)
   {
-    $this->dbManager->insertTableRow('reportgen',
-            ['upload_fk'=>$uploadId, 'job_fk'=>$jobId, 'filepath'=>$fileName],
-            __METHOD__);
+    $this->reportutils->updateOrInsertReportgenEntry($uploadId, $jobId, $fileName);
   }
 
   /**

--- a/src/lib/php/Dao/ShowJobsDao.php
+++ b/src/lib/php/Dao/ShowJobsDao.php
@@ -376,4 +376,19 @@ class ShowJobsDao
     $statement = __METHOD__ . ".getAllUnFinishedJobs";
     return $this->dbManager->getRows($sql, [], $statement);
   }
+
+  /**
+   * @param $jobId
+   * @return bool
+   */
+  public function isJobIdPresentInReportGen($jobId)
+  {
+    $statementName = __METHOD__ . "forJobIdCheck";
+    $row = $this->dbManager->getSingleRow(
+      "SELECT 1 FROM reportgen WHERE job_fk = $1",
+      array($jobId),
+      $statementName
+    );
+    return !empty($row);
+  }
 }

--- a/src/lib/php/Report/ReportUtils.php
+++ b/src/lib/php/Report/ReportUtils.php
@@ -287,4 +287,32 @@ class ReportUtils
     }
     return $filesWithLicenses;
   }
+
+  /**
+   * Update or insert an entry in the reportgen table.
+   *
+   * This function checks if an entry with the specified upload_fk and filepath
+   * exists in the reportgen table. If it exists, it updates the job_fk for that row.
+   * If it does not exist, a new row is inserted with the provided values.
+   *
+   * @param int $upload_fk  Foreign key for the upload.
+   * @param int $job_fk     ID of the job to be updated or inserted.
+   * @param string $filepath  Filepath associated with the entry.
+   */
+  public function updateOrInsertReportgenEntry($upload_fk, $job_fk, $filepath)
+  {
+    $sqlCheck = "SELECT 1 FROM reportgen WHERE upload_fk = $1 AND filepath = $2";
+    $row = $this->dbManager->getSingleRow($sqlCheck, [$upload_fk, $filepath],
+      __METHOD__.'.checkReportgenEntry');
+
+    if (!empty($row)) {
+      $sqlUpdate = "UPDATE reportgen SET job_fk = $1 WHERE upload_fk = $2 AND filepath = $3";
+      $this->dbManager->getSingleRow($sqlUpdate, [$job_fk, $upload_fk, $filepath],
+        __METHOD__.'.updateReportgen');
+    } else {
+      $this->dbManager->insertTableRow('reportgen',
+        ['upload_fk' => $upload_fk, 'job_fk' => $job_fk, 'filepath' => $filepath],
+        __METHOD__);
+    }
+  }
 }

--- a/src/readmeoss/agent/readmeoss.php
+++ b/src/readmeoss/agent/readmeoss.php
@@ -40,6 +40,7 @@ use Fossology\Lib\Dao\UploadDao;
 use Fossology\Lib\Report\LicenseClearedGetter;
 use Fossology\Lib\Report\XpClearedGetter;
 use Fossology\Lib\Report\LicenseMainGetter;
+use Fossology\Lib\Report\ReportUtils;
 
 include_once(__DIR__ . "/version.php");
 
@@ -67,6 +68,11 @@ class ReadmeOssAgent extends Agent
    */
   private $licenseMainGetter;
 
+  /** @var ReportUtils $reportutils
+   * ReportUtils object
+   */
+  private $reportutils;
+
   /** @var UploadDao $uploadDao
    * UploadDao object
    */
@@ -82,6 +88,7 @@ class ReadmeOssAgent extends Agent
     $this->cpClearedGetter = new XpClearedGetter("copyright", "statement");
     $this->licenseClearedGetter = new LicenseClearedGetter();
     $this->licenseMainGetter = new LicenseMainGetter();
+    $this->reportutils = new ReportUtils();
 
     parent::__construct(README_AGENT_NAME, AGENT_VERSION, AGENT_REV);
 
@@ -147,7 +154,7 @@ class ReadmeOssAgent extends Agent
     $packageName = $this->uploadDao->getUpload($uploadId)->getFilename();
 
     $fileBase = $SysConf['FOSSOLOGY']['path']."/report/";
-    $fileName = $fileBase. "ReadMe_OSS_".$packageName.'_'.time().".txt" ;
+    $fileName = $fileBase. "ReadMe_OSS_".$packageName.".txt" ;
 
     foreach ($this->additionalUploadIds as $addUploadId) {
       $packageName .= ', ' . $this->uploadDao->getUpload($addUploadId)->getFilename();
@@ -172,7 +179,7 @@ class ReadmeOssAgent extends Agent
    */
   private function updateReportTable($uploadId, $jobId, $filename)
   {
-    $this->dbManager->insertTableRow('reportgen', array('upload_fk'=>$uploadId, 'job_fk'=>$jobId, 'filepath'=>$filename), __METHOD__);
+    $this->reportutils->updateOrInsertReportgenEntry($uploadId, $jobId, $filename);
   }
 
   /**

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -270,7 +270,7 @@ class SpdxTwoAgent extends Agent
   protected function getFileBasename($packageName)
   {
     if ($this->filebasename == null) {
-      $fileName = strtoupper($this->outputFormat)."_".$packageName.'_'.time();
+      $fileName = strtoupper($this->outputFormat)."_".$packageName;
       switch ($this->outputFormat) {
         case "spdx2":
           $fileName .= ".spdx.rdf";
@@ -604,9 +604,7 @@ class SpdxTwoAgent extends Agent
    */
   protected function updateReportTable($uploadId, $jobId, $fileName)
   {
-    $this->dbManager->insertTableRow('reportgen',
-            array('upload_fk'=>$uploadId, 'job_fk'=>$jobId, 'filepath'=>$fileName),
-            __METHOD__);
+    $this->reportutils->updateOrInsertReportgenEntry($uploadId, $jobId, $fileName);
   }
 
   /**

--- a/src/unifiedreport/agent/unifiedreport.php
+++ b/src/unifiedreport/agent/unifiedreport.php
@@ -104,6 +104,7 @@ use PhpOffice\PhpWord\IOFactory;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\SimpleType\JcTable;
 use PhpOffice\PhpWord\Style\Table;
+use Fossology\Lib\Report\ReportUtils;
 
 include_once(__DIR__ . "/version.php");
 include_once(__DIR__ . "/reportStatic.php");
@@ -170,6 +171,11 @@ class UnifiedReport extends Agent
    * obligationsGetter object
    */
   private $obligationsGetter;
+
+  /** @var ReportUtils $reportutils
+   * ReportUtils object
+   */
+  private $reportutils;
 
   /** @var OtherGetter $otherGetter
    * otherGetter object
@@ -253,6 +259,7 @@ class UnifiedReport extends Agent
     $this->licenseNonFunctionalCommentGetter = new LicenseNonFunctionalGetter(false);
     $this->otherGetter = new OtherGetter();
     $this->obligationsGetter = new ObligationsGetter();
+    $this->reportutils = new ReportUtils();
 
     parent::__construct(REPORT_AGENT_NAME, AGENT_VERSION, AGENT_REV);
 
@@ -947,7 +954,7 @@ class UnifiedReport extends Agent
       mkdir($fileBase, 0777, true);
     }
     umask(0022);
-    $fileName = $fileBase. "$packageName"."_clearing_report_".date("D_M_d_m_Y_h_i_s").".docx";
+    $fileName = $fileBase. "Clearing_Report_".$packageName.".docx";
     $objWriter = IOFactory::createWriter($phpWord, "Word2007");
     $objWriter->save($fileName);
 
@@ -963,8 +970,7 @@ class UnifiedReport extends Agent
    */
   private function updateReportTable($uploadId, $jobId, $filename)
   {
-    $this->dbManager->getSingleRow("INSERT INTO reportgen(upload_fk, job_fk, filepath) VALUES($1,$2,$3)",
-      array($uploadId, $jobId, $filename), __METHOD__);
+    $this->reportutils->updateOrInsertReportgenEntry($uploadId, $jobId, $filename);
   }
 }
 

--- a/src/www/ui/async/AjaxShowJobs.php
+++ b/src/www/ui/async/AjaxShowJobs.php
@@ -274,40 +274,42 @@ class AjaxShowJobs extends \FO_Plugin
         $jobArr['jobQueue'][$key]['isReady'] = ($singleJobQueue['jq_end_bits'] ==
           1);
 
-        switch ($singleJobQueue['jq_type']) {
-          case 'readmeoss':
-            $jobArr['jobQueue'][$key]['download'] = "ReadMeOss";
-            break;
-          case 'spdx2':
-            $jobArr['jobQueue'][$key]['download'] = "SPDX2 report";
-            break;
-          case 'spdx2tv':
-            $jobArr['jobQueue'][$key]['download'] = "SPDX2 tag/value report";
-            break;
-          case 'spdx2csv':
-            $jobArr['jobQueue'][$key]['download'] = "SPDX2 CSV report";
-            break;
-          case 'dep5':
-            $jobArr['jobQueue'][$key]['download'] = "DEP5 copyright file";
-            break;
-          case 'reportImport':
-            $jobArr['jobQueue'][$key]['download'] = "uploaded SPDX2 report";
-            break;
-          case 'unifiedreport':
-            $jobArr['jobQueue'][$key]['download'] = "Unified Report";
-            break;
-          case 'clixml':
-            $jobArr['jobQueue'][$key]['download'] = "Clixml Report";
-            break;
-          case 'cyclonedx':
-            $jobArr['jobQueue'][$key]['download'] = "CycloneDX json Report";
-            break;
-          case 'decisionexporter':
-            $jobArr['jobQueue'][$key]['download'] = "FOSSology Decisions";
-            break;
-          default:
-            $jobArr['jobQueue'][$key]['download'] = "";
+        $reportName = "";
+        if ($this->showJobsDao->isJobIdPresentInReportGen($singleJobQueue['jq_job_fk'])) {
+          switch ($singleJobQueue['jq_type']) {
+            case 'readmeoss':
+              $reportName = "ReadMeOss";
+              break;
+            case 'spdx2':
+              $reportName = "SPDX2 report";
+              break;
+            case 'spdx2tv':
+              $reportName = "SPDX2 tag/value report";
+              break;
+            case 'spdx2csv':
+              $reportName = "SPDX2 CSV report";
+              break;
+            case 'dep5':
+              $reportName = "DEP5 copyright file";
+              break;
+            case 'reportImport':
+              $reportName = "uploaded SPDX2 report";
+              break;
+            case 'unifiedreport':
+              $reportName = "Unified Report";
+              break;
+            case 'clixml':
+              $reportName = "Clixml Report";
+              break;
+            case 'cyclonedx':
+              $reportName = "CycloneDX json Report";
+              break;
+            case 'decisionexporter':
+              $reportName = "FOSSology Decisions";
+              break;
+          }
         }
+        $jobArr['jobQueue'][$key]['download'] = $reportName;
       }
       if (! empty($jobs['upload'])) {
         $uploadArr = array(


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Remove datetime from report names.

### Changes

Merging this PR will remove the datatime from the report names in fossology.
| Original Filename                                                                                  | Formatted Filename                                                                   |
|----------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
| `CLIXML_cfitsio_4.0.0-1-ubuntu-combined.tar.bz2_2024-10-24_15:45:54.xml`                           | `CLIXML_cfitsio_4.0.0-1-ubuntu-combined.tar.bz2.xml`                                         |
| `cfitsio_4.0.0-1-ubuntu-combined.tar.bz2_clearing_report_Thu_Oct_24_10_2024_03_50_41.docx`         | `Clearing_Report_cfitsio_4.0.0-1-ubuntu-combined.tar.bz2.docx` |


CC: @shaheemazmalmmd @GMishx 
