### PR TITLE
fix(adminLicenseRulesTable): disable pagination to keep creation form…

### DIFF
--- a/src/www/ui/template/admin_license_compatibility_rules.js.twig
+++ b/src/www/ui/template/admin_license_compatibility_rules.js.twig
@@ -2,7 +2,6 @@
 
    SPDX-License-Identifier: FSFAP
 #}
-
 <script type="text/javascript">
 {% import 'include/macros.html.twig' as macro %}
 
@@ -16,8 +15,8 @@ $(document).ready(function() {
 
   var t = $("#adminLicenseRulesTable").DataTable({
     "processing": true,
-    "paginationType": "listbox",
-    "order": [[ 0, 'asc' ]],
+    "paging": false,                   
+    "order": [[ 0, 'asc' ]],           
     "autoWidth": false,
     "columnDefs": [{
       "createdCell": function (cell) {


### PR DESCRIPTION
## Description

This pull request fixes an issue where the rule creation form would move to a new page when the rule count exceeded the displayed entries per page, causing confusion (#2841). The update modifies the pagination settings to ensure the form remains on the current page, simplifying the user experience.

### Changes

Adjusted pagination settings in admin_license_compatibility_rules.js.twig to keep the rule creation form on the same page regardless of the number of rules.

https://github.com/user-attachments/assets/e267eafc-9d2e-4cae-bdf0-a3c80dc4036a

## How to test

1. Go to Admin > License Admin > Compatibility Rules
2. Add enough rules to exceed the page limit (e.g., create more than 10 rules).
3. Verify that the creation form does not move to a new page, and remains accessible on the current page.

This pull request closes #2841.