### PR TITLE
fix(ui): DataTables Pagination Showing Last Additions

### DIFF
--- a/src/decisionimporter/agent/DecisionImporterDataCreator.php
+++ b/src/decisionimporter/agent/DecisionImporterDataCreator.php
@@ -295,11 +295,10 @@ class DecisionImporterDataCreator
 
     if (!$this->agentDao->arsTableExists($agentName)) {
       // FIXME This requires the user to manually run the respective agent to get past this point
-      throw new UnexpectedValueException("No agent '$agentName' exists on server.");               
-    }                                                                                              
+      throw new UnexpectedValueException("No agent '$agentName' exists on server.");
+    }
     $latestAgentId = $this->agentDao->getCurrentAgentId($agentName);
     $this->createCxJobs($agentName, $jobId, $latestAgentId);
-                                                                                                   
     $cxExistSql = "SELECT " . $agentName . "_pk FROM $agentName WHERE pfile_fk = $1 AND agent_fk = $2 AND hash = $3;";
     $cxExistStatement = __METHOD__ . ".$agentName" . "Exist";
 

--- a/src/www/ui/scripts/admin-license-acknowledgements.js
+++ b/src/www/ui/scripts/admin-license-acknowledgements.js
@@ -102,7 +102,7 @@ $(document).ready(function() {
         'placeholder="Please enter a acknowledgement statement" ' +
         'class="newAcknowledgementInputs"></textarea>',
       '<input type="checkbox" checked disabled />'
-    ]).draw(false);
+    ]).draw(false).page("last").draw(false);
   });
 
   $(".licStdAckToggle").change(function(){

--- a/src/www/ui/scripts/admin-license-std-comments.js
+++ b/src/www/ui/scripts/admin-license-std-comments.js
@@ -102,7 +102,7 @@ $(document).ready(function() {
         'placeholder="Please enter a comment statement" ' +
         'class="newCommentInputs"></textarea>',
       '<input type="checkbox" checked disabled />'
-    ]).draw(false);
+    ]).draw(false).page("last").draw(false);
   });
 
   $(".licStdCommentToggle").change(function(){

--- a/src/www/ui/template/admin_license_compatibility_rules.js.twig
+++ b/src/www/ui/template/admin_license_compatibility_rules.js.twig
@@ -125,7 +125,7 @@ $(document).ready(function() {
         'placeholder="Please enter rule description" required="required" ' +
         'class="newRuleInputs" style="width:100%"></textarea>',
       '<img class="delete" src="images/space_16.png" onclick="" alt="delete">'
-    ]).draw(false);
+    ]).draw(false).page("last").draw(false);
     renderSelect2();
   });
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Data Tables in License Acknowledgement , Standard comments and Compatibility were not showing the last entry on the current page.

### Changes

Add calling last page on adding new row.

## How to test

1. Open Acknowledgements Standard comments page, License Admin > Compatibility.
2. Add entries more than current page limit.
3. The data table should show the last entry on the page (Jumps to new page if the current length \> the page limit)


Closes #2841 
