### PR TITLE
feat(ui): multi upload support for reuse

### DIFF
--- a/src/lib/php/UI/template/include/upload.html.twig
+++ b/src/lib/php/UI/template/include/upload.html.twig
@@ -85,9 +85,9 @@
     </p>
 
     <input type="submit" class="btn btn-default btn-sm" value="{{ 'Upload'| trans }}"/>
-    </div>
+  {% block popup %}
+  {% endblock %}
   </form>
-
 {% endblock %}
 
 {% block foot %}
@@ -96,9 +96,6 @@
   <script type="text/javascript">
     $(document).ready(function () {
       $('[data-toggle="tooltip"]').tooltip();
-      $('#uploadToReuse').select2({
-          "placeholder": "Select upload to reuse"
-      });
     });
   </script>
   {% for aFoot in parmAgentFoots %}

--- a/src/reuser/ui/agent-reuser.php
+++ b/src/reuser/ui/agent-reuser.php
@@ -30,6 +30,7 @@ include_once(dirname(__DIR__) . "/agent/version.php");
 class ReuserAgentPlugin extends AgentPlugin
 {
   const UPLOAD_TO_REUSE_SELECTOR_NAME = 'uploadToReuse';  ///< Form element name for main license to reuse
+  const REUSE_MODE = 'reuseMode';  ///< Form element name for main license to reuse
 
   /** @var UploadDao $uploadDao
    * Upload Dao object
@@ -98,7 +99,7 @@ class ReuserAgentPlugin extends AgentPlugin
     }
     $groupId = $request->get('groupId', Auth::getGroupId());
 
-    $getReuseValue = $request->get('reuseMode') ?: array();
+    $getReuseValue = $request->get(self::REUSE_MODE) ?: array();
     $reuserDependencies = array("agent_adj2nest");
 
     $reuseMode = UploadDao::REUSE_NONE;

--- a/src/reuser/ui/template/agent_reuser.html.twig
+++ b/src/reuser/ui/template/agent_reuser.html.twig
@@ -1,5 +1,5 @@
 {# SPDX-FileCopyrightText: © Fossology contributors
- 
+
    SPDX-License-Identifier: GPL-2.0-only
 #}
 {% import "include/macros.html.twig" as macro %}
@@ -13,26 +13,40 @@
       </span>
     </label>
     <img src="images/info_16.png" data-toggle="tooltip" title="{{ 'Copy clearing decisions if there is the same file hash between two files'|trans }}" alt="" class="info-bullet"/><br/>
-    <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" id="searchInFolder"/> {{ 'Select an already uploaded package for reuse in specific folder ' | trans }}
-    {% include 'reuse-folder.html.twig' with {'name': reuseFolderSelectorName, 'id': reuseFolderSelectorName} %}
+    <label>
+      <input type="checkbox" class="browse-upload-checkbox view-license-rc-size reuseSearchInFolder" id="reuseSearchInFolder" />
+      {{ 'Select an already uploaded package for reuse in specific folder ' | trans }}
+    </label>
+    {% include 'reuse-folder.html.twig' with {
+      'name': reuseFolderSelectorName,
+      'id': reuseFolderSelectorName
+    } %}
     <br/>
-    <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="reuseMode[]" value="reuseEnhanced"/>
-    {{ 'Enhanced reuse (slower)'|trans }}
-    <img src="images/info_16.png" data-toggle="tooltip" title="{{'Will copy a clearing decision if the two files differ by one line determined by a diff tool'|trans}}" alt="" class="info-bullet"/><br/>
+    <label>
+      <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="reuseMode[]" value="reuseEnhanced"/>
+      {{ 'Enhanced reuse (slower)'|trans }}
+      <img src="images/info_16.png" data-toggle="tooltip" title="{{'Will copy a clearing decision if the two files differ by one line determined by a diff tool'|trans}}" alt="" class="info-bullet"/>
+    </label><br/>
 
-    <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="reuseMode[]" value="reuseMain"/>
-    {{ 'Reuse main license/s'|trans }}
-    <img src="images/info_16.png" data-toggle="tooltip" title="{{'Will copy a main license decision(if any)'|trans}}" alt="" class="info-bullet"/><br/>
+    <label>
+      <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="reuseMode[]" value="reuseMain"/>
+      {{ 'Reuse main license/s'|trans }}
+      <img src="images/info_16.png" data-toggle="tooltip" title="{{'Will copy a main license decision(if any)'|trans}}" alt="" class="info-bullet"/>
+    </label><br/>
 
-    <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="reuseMode[]" value="reuseConf"/>
-    {{ 'Reuse report configuration settings'|trans }}
-    <img src="images/info_16.png" data-toggle="tooltip" title="{{'Use to copy all the information from conf page(if any)'|trans}}" alt="" class="info-bullet"/><br/>
+    <label>
+      <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="reuseMode[]" value="reuseConf"/>
+      {{ 'Reuse report configuration settings'|trans }}
+      <img src="images/info_16.png" data-toggle="tooltip" title="{{'Use to copy all the information from conf page(if any)'|trans}}" alt="" class="info-bullet"/>
+    </label><br/>
 
-    <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="reuseMode[]" value="reuseCopyright"/>
-    {{ 'Reuse deactivated copyrights'|trans }}
-    <img src="images/info_16.png" data-toggle="tooltip" title="{{'Use to copy edited and deactivated copyrights from the reused package'|trans}}" alt="" class="info-bullet"/><br/>
+    <label>
+      <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="reuseMode[]" value="reuseCopyright"/>
+      {{ 'Reuse deactivated copyrights'|trans }}
+      <img src="images/info_16.png" data-toggle="tooltip" title="{{'Use to copy edited and deactivated copyrights from the reused package'|trans}}" alt="" class="info-bullet"/>
+    </label><br/>
 
-    <label for="uploadReuse">{{ 'Upload to reuse'|trans }}:</label><br/>
+    <label for="{{ uploadToReuseSelectorName }}">{{ 'Upload to reuse'|trans }}:</label><br/>
     {{ macro.select(uploadToReuseSelectorName, folderUploads, uploadToReuseSelectorName, reuseUploadId, 'style="min-width:420px;"', 5) }}
   </div>
 </li>

--- a/src/reuser/ui/template/agent_reuser.js.twig
+++ b/src/reuser/ui/template/agent_reuser.js.twig
@@ -1,19 +1,22 @@
 {# SPDX-FileCopyrightText: © Fossology contributors
- 
+
    SPDX-License-Identifier: GPL-2.0-only
 #}
 $.getScript( "scripts/tools.js", function( data, textStatus, jqxhr ) {console.log( "Failure handler loaded." ); });
 
-$('#{{ reuseFolderSelectorName }}').change(function () {
-  var folderGroupPair = this.selectedOptions[0].value;
-  //noinspection JSAnnotator
-  reloadUploads('&{{ folderParameterName }}=' + folderGroupPair);
-});
+function registerFolderSelectorChange() {
+  $('[id^={{ reuseFolderSelectorName }}]').change(function () {
+    const groupIndex = $(this).attr('id').replace('{{ reuseFolderSelectorName }}', '');
+    var folderGroupPair = this.selectedOptions[0].value;
+    //noinspection JSAnnotator
+    reloadUploads('&{{ folderParameterName }}=' + folderGroupPair, groupIndex);
+  });
+}
 
-function reloadUploads(parameter) {
-  $.getJSON("?mod=plugin_reuser&do=getUploads" + parameter)
+function reloadUploads(folderGroupPair, groupIndex) {
+  $.getJSON("?mod=plugin_reuser&do=getUploads" + folderGroupPair)
     .done(function (data) {
-      var packageForReuse = $('#{{ uploadToReuseSelectorName }}');
+      var packageForReuse = $(`#{{ uploadToReuseSelectorName }}${groupIndex}`);
       packageForReuse.empty();
       $.each(data, function (key, value) {
         var option = document.createElement("option");
@@ -21,24 +24,25 @@ function reloadUploads(parameter) {
         option.value = key;
         packageForReuse.append(option);
       });
-      sortList('#{{ uploadToReuseSelectorName }} option');
+      sortList(`#{{ uploadToReuseSelectorName }}${groupIndex} option`);
     })
     .fail(failed);
 }
 
 function toggleDisabled() {
-  $('#searchInFolder').click(function () {
-    $('#{{ reuseFolderSelectorName }}').prop('disabled', !$(this).prop('checked'));
-    $('#{{ uploadToReuseSelectorName }}').empty();
+  $('.reuseSearchInFolder').click(function () {
+    const groupIndex = $(this).attr('id').replace('reuseSearchInFolder', '');
+    $(`#{{ reuseFolderSelectorName }}${groupIndex}`).prop('disabled', !$(this).prop('checked'));
+    {#$(`#{{ reuseFolderSelectorName }}${groupIndex}`).empty();#}
     if($(this).prop('checked')) {
-      $('#{{ reuseFolderSelectorName }}').change();
+      $(`#{{ reuseFolderSelectorName }}${groupIndex}`).trigger('change');
     }
     else {
-      reloadUploads("");
+      reloadUploads("", "");
     }
   });
-  reloadUploads("");
-
+  reloadUploads("", "");
+  registerFolderSelectorChange();
 }
 
 $(document).ready( function(){

--- a/src/reuser/ui/template/reuse-folder.html.twig
+++ b/src/reuser/ui/template/reuse-folder.html.twig
@@ -5,7 +5,7 @@
 {% if selected is not defined %}
   {% set selected = -1 %}
 {% endif %}
-<select class="ui-render-select2" disabled name="{{ name }}"{% if id is defined %} id="{{ id }}"{% endif %}>
+<select class="reuseGroupSelectorFolder" disabled name="{{ name }}"{% if id is defined %} id="{{ id }}"{% endif %}>
   {% for entry in folderStructure %}
     {% for entryReuse in entry.reuse %}
       <option value="{{ entry.folder.id }},{{ entryReuse.group_id }}"{% if selected == entry.folder.id %} selected="selected"{% endif %}>

--- a/src/www/ui/template/upload_file.html.twig
+++ b/src/www/ui/template/upload_file.html.twig
@@ -37,8 +37,54 @@
 {% endblock %}
 
 {% block uploadText %}
-  <div class="form-group" style="margin-left:2%	;">
+  <div class="form-group" style="margin-left:2%">
     <label for="pText">{{ 'After you press Upload, please be patient while your file is transferring.'| trans }}</label>
+  </div>
+{% endblock %}
+
+{% block popup %}
+  <div class="modal fade" id="reuseModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered modal-xl" style="max-width:1140px">
+        <div class="modal-content">
+
+          <!-- Modal Header -->
+          <div class="modal-header">
+            <h4 class="modal-title">{{ 'Reuse configuration'|trans }}</h4>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+
+          <!-- Modal body -->
+          <div class="modal-body">
+            <div class="container-fluid">
+              <div class="row">
+                <div class="col-3">
+                  <div style="max-height:70vh;overflow:hidden;overflow-y:auto">
+                    <div class="nav nav-pills flex-column text-truncate" id="reuse-name-tab" role="tablist" aria-orientation="vertical">
+                    </div>
+                  </div>
+                </div>
+                <div class="col">
+                  <div class="tab-content" id="reuse-tab-content">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Modal footer -->
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+          </div>
+        </div>
+      </div>
+  </div>
+  <div id="hiddenFormHolder" style="display:none">
+    {% for agent in hiddenAgentContents %}
+      {{ agent }}
+    {% endfor %}
+  </div>
 {% endblock %}
 
 {% block foot %}
@@ -47,9 +93,9 @@
     function checkDuplicateUploadWarning(e) {
       const allFiles = e.target.files;
       const folderId = $("#uploadFolderSelector").val();
-      var messages = new Array();
-      var ajaxList = new Array();
-      var ajaxCall;
+      let messages = [];
+      let ajaxList = [];
+      let ajaxCall;
       for (let i = 0; i < allFiles.length; i++) {
         const uploadName = allFiles[i].name;
         ajaxCall = $.ajax({
@@ -81,25 +127,54 @@
         }
       });
     }
-    function disableReuserOptions() {
-      if ($('#searchInFolder').length < 1) {
-        return;
-      }
-      var reuserdiv = $("#searchInFolder").parent();
-      reuserdiv.find("input").attr("disabled", true);
-      reuserdiv.find("select[id=uploadToReuse]").attr("disabled", true);
-      reuserdiv.addClass("text-muted");
-      $("#reusedisable").show();
+
+    function updateReuseIds(index, name, element, navContentDom) {
+      element.find("#reuseSearchInFolder").attr('id', `reuseSearchInFolder${index}`);
+      element.find("label[for='reuseSearchInFolder']").attr('for', `reuseSearchInFolder${index}`);
+      element.find("#reuseFolderSelectorName").attr('id', `reuseFolderSelectorName${index}`);
+      element.find("label[for='reuseFolderSelectorName']").attr('for', `reuseFolderSelectorName${index}`);
+      element.find("#uploadToReuse").attr('id', `uploadToReuse${index}`);
+      element.find("label[for='uploadToReuse']").attr('for', `uploadToReuse${index}`);
+      element.find("input,select").each(function (){
+        let fieldName = $(this).attr('name');
+        if (fieldName) {
+          if (fieldName.endsWith("[]")) {
+            $(this).attr('name', fieldName.replace("[]", `[${name}][]`));
+          } else {
+            $(this).attr('name', `${fieldName}[${name}]`)
+          }
+        }
+      });
+      element.find(`#reuseFolderSelectorName${index}`).select2({
+        width: 'style',
+        dropdownAutoWidth : true,
+        dropdownParent: navContentDom
+      });
+      element.find(`#uploadToReuse${index}`).select2({
+        "placeholder": "Select upload to reuse",
+        width: 'style',
+        dropdownAutoWidth : true,
+        dropdownParent: navContentDom
+      });
     }
-    function enableReuserOptions() {
-      if ($('#searchInFolder').length < 1) {
-        return;
+    function addNavItems(index, name, navItemDom, navContentDom) {
+      const navItem = $(`<a class='nav-link flex-sm-fill text-truncate' id='reuse-name-${index}' data-toggle='pill' href='#reuse-content-${index}' role='tab' aria-controls='reuse-content-${index}' aria-selected='false'>`);
+      navItem.append(name);
+
+      const panelContentProvider = $("#hiddenFormHolder").find("div.form-group");
+      const clonedPanel = panelContentProvider.clone();
+      updateReuseIds(index, name, clonedPanel, navContentDom);
+      const navPanel = $("<div class='container-fluid'>");
+      navPanel.append(clonedPanel);
+
+      const navContent = $(`<div class='tab-pane fade' id='reuse-content-${index}' role='tabpanel' aria-labelledby='reuse-name-${index}'>`);
+      navContent.append(navPanel);
+      if (index === 0) {
+        navItem.addClass("active").attr('aria-selected', true);
+        navContent.addClass("show active");
       }
-      var reuserdiv = $("#searchInFolder").parent();
-      reuserdiv.find("input").attr("disabled", false);
-      reuserdiv.find("select[id=uploadToReuse]").attr("disabled", false);
-      reuserdiv.removeClass("text-muted");
-      $("#reusedisable").hide();
+      navItemDom.append(navItem);
+      navContentDom.append(navContent);
     }
     $("#fileUploader").on("change", function(e) {
       checkDuplicateUploadWarning(e);
@@ -111,23 +186,24 @@
         $("#collapseDescription").show();
         $("#uploaddescriptions").collapse('hide');
       }
-      if (allFiles.length > 1) { // Disable reuser for multi file upload
-        disableReuserOptions();
-      } else {
-        enableReuserOptions();
-      }
+      const reuseNameTab = $("#reuse-name-tab");
+      const reuseTabContent = $("#reuse-tab-content");
+      reuseNameTab.html("");
+      reuseTabContent.html("");
       for (let i = 0; i < allFiles.length; i++) {
         const val = allFiles[i];
-        var tt = $("<h6 class='card-title'>").append(val.name);
-        var formg = $("<div class='form-group'>");
-        var ll = $(`<label for='desc${i}' class='card-text'>`).append("({{ 'Optional'|trans }}) {{ 'Enter a description of this file'| trans }}:");
+        const tt = $("<h6 class='card-title'>").append(val.name);
+        let formg = $("<div class='form-group'>");
+        const ll = $(`<label for='desc${i}' class='card-text'>`).append("({{ 'Optional'|trans }}) {{ 'Enter a description of this file'| trans }}:");
         formg.append(ll).append(`<input type='text' class='form-control' name='{{ descriptionInputName }}[${i}]' id='desc${i}'>`);
-        var body = $("<div class='card-body'>");
+        let body = $("<div class='card-body'>");
         body.append(tt).append(formg);
-        var html = $("<div class='card'>");
+        let html = $("<div class='card'>");
         html.append(body);
         holder.append(html);
-      };
+        addNavItems(i, val.name, reuseNameTab, reuseTabContent);
+      }
+      toggleDisabled();
     });
     $('#uploaddescriptions').on('hidden.bs.collapse', function () {
       $('#collapseDescription').find('button').text('+ expand');


### PR DESCRIPTION


<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description


When a multi file upload is done, This pull request looks into how to handle the reuse information regarding each of the upload.
In case of multi file upload, provide a modal to select reuse options for each upload. Multi file upload modal data and the mapping.
### Changes

1. Reuse Information Modal is created
2. Mapping of each upload to reuse information

## How to test

1. Open FOSSology User Interface.
2. Move to Upload From File Page
3. Select Multiple Files to Upload
4. Move to (Optional Reuse) --\> Should open a Reuse Modal
5. Select convenient uploads for reuse, Also select reuseMode options
6. Click Upload


