### PR TITLE
feat(api): Added sort and status filter options to jobs endpoint

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -3231,6 +3231,25 @@ paths:
             type: integer
             minimum: 1
           in: header
+        - name: sort
+          required: false
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+          in: query
+        - name: status
+          description: Returns only jobs with the selected status.
+          required: false
+          schema:
+            type: string
+            enum:
+              - Processing
+              - Queued
+              - Completed
+              - Failed
+          in: query
         - name: upload
           required: false
           schema:
@@ -3308,6 +3327,25 @@ paths:
             type: integer
             minimum: 1
           in: header
+        - name: status
+          description: Returns only jobs with the selected status.
+          required: false
+          schema:
+            type: string
+            enum:
+              - Processing
+              - Queued
+              - Completed
+              - Failed
+          in: query
+        - name: sort
+          required: false
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+          in: query
       responses:
         '200':
           description: OK

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -3151,6 +3151,17 @@ paths:
       summary: Gets all jobs created by the logged in user
       description: Returns all jobs with their status created by the logged in user
       parameters:
+        - name: status
+          description: Returns only jobs with the selected status.
+          required: false
+          schema:
+            type: string
+            enum:
+              - Processing
+              - Queued
+              - Completed
+              - Failed
+          in: query
         - name: limit
           required: false
           schema:
@@ -3162,6 +3173,14 @@ paths:
           schema:
             type: integer
             minimum: 1
+          in: query
+        - name: sort
+          required: false
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
           in: query
         - name: upload
           required: false
@@ -3228,6 +3247,17 @@ paths:
       summary: Gets all jobs created by all users
       description: Returns all jobs with their status created by every user. This API returns a response only if the requesting user is an Admin.
       parameters:
+        - name: status
+          description: Returns only jobs with the selected status.
+          required: false
+          schema:
+            type: string
+            enum:
+              - Processing
+              - Queued
+              - Completed
+              - Failed
+          in: query
         - name: limit
           required: false
           schema:
@@ -3239,6 +3269,14 @@ paths:
           schema:
             type: integer
             minimum: 1
+          in: query
+        - name: sort
+          required: false
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
           in: query
       responses:
         '200':

--- a/src/www/ui_tests/api/Controllers/JobControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/JobControllerTest.php
@@ -176,7 +176,7 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
     $userId = 2;
     $user = $this->getUsers([$userId]);
     $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
-    $this->dbHelper->shouldReceive('getUserJobs')->withArgs(array(null, 2, 0, 1))
+    $this->dbHelper->shouldReceive('getUserJobs')->withArgs(array(2, NULL, 'ASC', 0, 1))
       ->andReturn([[$job], 1]);
     $actualResponse = $this->jobController->getJobs($request, $response, []);
     $expectedResponse = $job->getArray(ApiVersion::V1);
@@ -217,7 +217,7 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
     $userId = 2;
     $user = $this->getUsers([$userId]);
     $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
-    $this->dbHelper->shouldReceive('getUserJobs')->withArgs(array(null, 2, 1, 2))
+    $this->dbHelper->shouldReceive('getUserJobs')->withArgs(array(2, null, "ASC", 1, 2))
     ->andReturn([[$jobTwo], 2]);
     $actualResponse = $this->jobController->getJobs($request, $response, []);
     $expectedResponse = $jobTwo->getArray(ApiVersion::V1);
@@ -265,7 +265,7 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
     ['text' => 'ReadMeOss', 'link' => 'http://localhost/repo/api/v1/report/16']);
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(["job", "job_pk", 12])->andReturn(true);
-    $this->dbHelper->shouldReceive('getJobs')->withArgs(array(12, 0, 1))
+    $this->dbHelper->shouldReceive('getJobs')->withArgs(array(12, NULL, 'ASC', 0, 1, NULL))
       ->andReturn([[$job], 1]);
     $this->jobDao->shouldReceive('getChlidJobStatus')->withArgs(array(12))
       ->andReturn(['45' => 0]);
@@ -307,7 +307,7 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
       ->withArgs(["upload", "upload_pk", 5])->andReturn(true);
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(['job', 'job_pk', 12])->andReturn(true);
-    $this->dbHelper->shouldReceive('getJobs')->withArgs(array(null, 0, 1, 5))
+    $this->dbHelper->shouldReceive('getJobs')->withArgs(array(null, null, "ASC", 0, 1, 5))
       ->andReturn([[$job], 1]);
     $this->jobDao->shouldReceive('getChlidJobStatus')->withArgs(array(12))
       ->andReturn(['45' => 0]);
@@ -364,42 +364,4 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
     $this->assertEquals(0, $result);
   }
 
-  /**
-   * @test
-   * -# Test JobController::getJobStatus()
-   * -# Setup one job with two complete children => result Completed
-   * -# Setup one job with one child processing and other in queue => result
-   *    Processing
-   * -# Setup one job with one child completed and one failed => result Failed
-   */
-  public function testGetJobStatus()
-  {
-    $jobCompleted = [1, 2];
-    $jobQueued = [3, 4];
-    $jobFailed = [5, 6];
-    $this->showJobsDao->shouldReceive('getDataForASingleJob')
-      ->withArgs([M::anyof(1, 2, 5)])
-      ->andReturn(["jq_endtext" => "Completed"]);
-    $this->showJobsDao->shouldReceive('getDataForASingleJob')
-      ->withArgs([3])->andReturn(["jq_endtext" => "Started"]);
-    $this->showJobsDao->shouldReceive('getDataForASingleJob')
-      ->withArgs([4])->andReturn(["jq_endtext" => "Processing",
-        "jq_endtime" => ""]);
-    $this->showJobsDao->shouldReceive('getDataForASingleJob')
-      ->withArgs([6])->andReturn(["jq_endtext" => "Failed",
-        "jq_endtime" => "01-01-2020 00:00:00"]);
-
-    $reflection = new \ReflectionClass(get_class($this->jobController));
-    $method = $reflection->getMethod('getJobStatus');
-    $method->setAccessible(true);
-
-    $result = $method->invokeArgs($this->jobController, [$jobCompleted]);
-    $this->assertEquals("Completed", $result);
-
-    $result = $method->invokeArgs($this->jobController, [$jobQueued]);
-    $this->assertEquals("Processing", $result);
-
-    $result = $method->invokeArgs($this->jobController, [$jobFailed]);
-    $this->assertEquals("Failed", $result);
-  }
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
Added the option to filter for statuses and sort the results for the following endpoints:
`/jobs` endpoint 
`/jobs/all` endpoint 

Also removed some duplicated code and cleaned up code a bit.

### Changes

* `JobController.php` Added status and sort queries for api v1 and v2 for the `/jobs` and `/jobs/all` endpoints. Cleaned up code a bit, removed now unused functions.
* `DbHelper.php`Added filter for status and sorting options, removed duplicated code, implemented new cte sql statement for getting the status along with the jobs to avoid getting the status for each job separately with a loop inside the `JobController.php` .
* `openapi.yaml` and `openapiv2.yaml`  added the `status` and `sort` options to the `/jobs` and `/jobs/all` endpoints
* `JobControllerTest.php` Removed no longer needed test, adjusted other tests


## How to test
Execute the `/jobs` and `/jobs/all` endpoint with the new optional options `sort` and/or `status`. This works for api v1 and v2.

The results will now be either sorted `DESC` or `ASC` if the `sort` was given (default=`ASC`)
Only results with the `status` set will be returned, if the `status` was sent (default is all jobs)

Possible options for `sort`: "ASC" and "DESC"
Possible options for `status`: "Processing", "Queued", "Completed" and "Failed"

![grafik](https://github.com/user-attachments/assets/8b6a2127-fb2a-4d2f-9aea-301f28ff86cb)

