### PR TITLE
Allow non admin users to delete their own uploads files

### DIFF
--- a/src/delagent/ui/Page/AdminUploadDelete.php
+++ b/src/delagent/ui/Page/AdminUploadDelete.php
@@ -39,7 +39,7 @@ class AdminUploadDelete extends DefaultPlugin
     parent::__construct(self::NAME, array(
         self::TITLE => _("Delete Uploaded File"),
         self::MENU_LIST => "Organize::Uploads::Delete Uploaded File",
-        self::PERMISSION => Auth::PERM_ADMIN,
+        self::PERMISSION => Auth::PERM_WIRTE,
         self::REQUIRES_LOGIN => true
     ));
 
@@ -104,14 +104,16 @@ class AdminUploadDelete extends DefaultPlugin
     $uploadList = array();
     $folderList = FolderListUploads_perm($root_folder_pk, Auth::PERM_WRITE);
     foreach ($folderList as $L) {
-      $desc = $L['name'];
-      if (!empty($L['upload_desc'])) {
-        $desc .= " (" . $L['upload_desc'] . ")";
-      }
-      if (!empty($L['upload_ts'])) {
-        $desc .= " :: " . substr($L['upload_ts'], 0, 19);
-      }
-      $uploadList[$L['upload_pk']] = $desc;
+      if (!empty($L['is_editable']) && $L['is_editable']) {
+        $desc = $L['name'];
+        if (!empty($L['upload_desc'])) {
+            $desc .= " (" . $L['upload_desc'] . ")";
+        }
+        if (!empty($L['upload_ts'])) {
+            $desc .= " :: " . substr($L['upload_ts'], 0, 19);
+        }
+        $uploadList[$L['upload_pk']] = $desc;
+    }
     }
     $vars['uploadList'] = $uploadList;
 


### PR DESCRIPTION
## Description

before if you are the one who uploaded the file, you cannot delete the file unless you are is an admin user.
i made the changes that allows the user to delete their own upload files no need to be a admin user.

### Changes

Previously, only admin users had permission to delete uploads. Now, users with write permissions (Auth::PERM_WRITE) are allowed to delete uploads.

Added a condition to filter only editable uploads. Only uploads with the is_editable flag set to true are now included in the list, ensuring that non-editable uploads are not listed for deletion.

## How to test

Navigate to the admin page where uploads are listed for deletion.

Ensure that only editable uploads are listed.

Verify that non-editable uploads are not displayed.

Ensure the deletion process works for editable uploads and that all fields (name, description, timestamp) display correctly

CC: @shaheemazmalmmd @GMishx 
