### PR TITLE
fix(UI bug): Show Button Not Appearing After Hiding Folder Navigation under Browse tab

### DIFF
--- a/src/www/ui/template/ui-browse.html.twig
+++ b/src/www/ui/template/ui-browse.html.twig
@@ -40,8 +40,8 @@
         <div style="text-align:center;" class="btn"><strong><u>{{ 'Folder Navigation'|trans }}</u></strong></div>
         {{ folderNav }}
       </td>
-      <td valign="top" style="background: #efefef; width:1px; font-family:monospace; word-break:break-all;" id="nav-shower" hidden>
-          &raquo;&nbsp;{{ 'Folder Navigation'|trans|replace({' ':'&nbsp;'}) }}&nbsp;&raquo;
+      <td valign="top" style="background:#efefef; width:100%; height:100%; font-family:monospace; display:none; cursor:pointer; justify-content:center; align-items:center; " id="nav-shower">
+          <span style="font-size:36px; ">&raquo;</span>
       </td>
       <td valign="top">
         <div style="text-align:center;font-size:large;"><strong><u>{{ 'Uploads'|trans }} {{ 'in'|trans }} <span id="current-folder">{{ folderName }}</span></u></strong></div>

--- a/src/www/ui/template/ui-browse.js.twig
+++ b/src/www/ui/template/ui-browse.js.twig
@@ -81,10 +81,10 @@ $(document).ready(function() {
 
 $('#nav-hider').click(function() {
   $('#nav-cell').hide('slow');
-  $('#nav-shower').show('slow');  
+  $('#nav-shower').css("display", "flex");  
 });
 $('#nav-shower').click(function() {
-  $('#nav-shower').hide('slow');
+  $('#nav-shower').hide();
   $('#nav-cell').show('slow');
 });
 


### PR DESCRIPTION
## Description
This PR resolves a minor UI bug related to issue #2879 . The issue was related to the visibility toggle not properly triggering the display of the "Show" button.

## Changes Made:

ui-browse.html.twig:
- Removed 'hidden' attribute from element of id = 'nav-shower' and added to it style="display none". 

ui-browse.js.twig:
- added $('#nav-shower').css("display", "flex"); 
- removed $('#nav-shower').show('slow'); 

When we show it with $('#nav-shower').show('slow'), the element might not behave properly due to the hidden property persisting. So I have changed its display style.

![Screenshot from 2024-12-19 12-28-38](https://github.com/user-attachments/assets/39551318-7ed1-49c3-816a-37a4f7b8ad90)

