### PR TITLE
Missing Caching for Composer Dependencies

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -92,6 +92,24 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
+            
+      - name: Install PHP_CodeSniffer
+        run: |
+          curl -sS https://getcomposer.org/installer | php
+          php composer.phar require --dev squizlabs/php_codesniffer
+          
+      - name: Run PHP_CodeSniffer
+        run: |
+          ./vendor/bin/phpcs --standard=PSR12 src/ --ignore=*/tests/*
+
+      - name: Install PHPStan
+        run: |
+          curl -sS https://getcomposer.org/installer | php
+          php composer.phar require --dev phpstan/phpstan
+          
+      - name: Run PHPStan
+        run: |
+          ./vendor/bin/phpstan analyse src --level=max
     
       - name: Install Dependencies
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -80,9 +80,30 @@ jobs:
       - name: Fetch tags
         run: |
           git fetch --tags
-
+          
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v4
+        with:
+          php-version: '8.0'
+          
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+    
       - name: Install Dependencies
         run: |
+          composer install --no-progress --prefer-dist
           sudo apt update
           sudo apt install -y libboost-system-dev libboost-filesystem-dev \
               libcppunit-dev libcunit1-dev libdbd-sqlite3-perl libjsoncpp-dev \
@@ -91,7 +112,10 @@ jobs:
           sudo ./utils/fo-installdeps --everything -y
           echo PATH="/usr/lib/ccache/:$PATH" >> $GITHUB_ENV
           echo COMPOSER_HOME="$HOME/.composer/" >> $GITHUB_ENV
-
+          
+      - name: Run build/test
+        run: ./build-or-test-script.sh
+        
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -158,15 +158,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 50
+    - name: Get composer cache directory
+      id: composer-cache
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
     - name: Cache Composer dependencies
       uses: actions/cache@v4
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
+        restore-keys: ${{ runner.os }}-composer-
       - name: Install Dependencies
         run: |
+          composer install --prefer-dist
           sudo apt update
           sudo apt install -y libboost-system-dev libboost-filesystem-dev \
                 libcppunit-dev libcunit1-dev libdbd-sqlite3-perl libjsoncpp-dev \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -159,7 +159,7 @@ jobs:
         with:
           fetch-depth: 50
           - name: Cache Composer dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.composer/cache
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -81,14 +81,6 @@ jobs:
         run: |
           git fetch --tags
           
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v4
-        with:
-          php-version: '8.0'
-          
       - name: Get composer cache directory
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
@@ -112,10 +104,7 @@ jobs:
           sudo ./utils/fo-installdeps --everything -y
           echo PATH="/usr/lib/ccache/:$PATH" >> $GITHUB_ENV
           echo COMPOSER_HOME="$HOME/.composer/" >> $GITHUB_ENV
-          
-      - name: Run build/test
-        run: ./build-or-test-script.sh
-        
+
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -158,7 +158,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 50
-          - name: Cache Composer dependencies
+    - name: Cache Composer dependencies
       uses: actions/cache@v4
       with:
         path: ~/.composer/cache

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -161,7 +161,7 @@ jobs:
     - name: Cache Composer dependencies
       uses: actions/cache@v4
       with:
-        path: ~/.composer/cache
+        path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
         restore-keys: |
           ${{ runner.os }}-composer-


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The workflow installs Composer dependencies (composer install --working-dir=src), but it doesn't use caching for Composer, which can speed up the build process in subsequent runs.

### Changes

Added caching for Composer dependencies to avoid reinstalling them every time the workflow runs. This can save a lot of time, especially for larger projects.

## How to test

Added on line 161

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)
