### PR TITLE
fix: Internal Server Error in upload from file page

### DIFF
--- a/src/www/ui/page/UploadFilePage.php
+++ b/src/www/ui/page/UploadFilePage.php
@@ -97,12 +97,12 @@ class UploadFilePage extends UploadPageBase
     );
 
     $folderId = intval($request->get(self::FOLDER_PARAMETER_NAME));
-    $descriptions = $request->get(self::DESCRIPTION_INPUT_NAME);
+    $descriptions = $request->get(self::DESCRIPTION_INPUT_NAME, []);
     for ($i = 0; $i < count($descriptions); $i++) {
       $descriptions[$i] = stripslashes($descriptions[$i]);
       $descriptions[$i] = $this->basicShEscaping($descriptions[$i]);
     }
-    $uploadedFiles = $request->files->get(self::FILE_INPUT_NAME);
+    $uploadedFiles = $request->files->get(self::FILE_INPUT_NAME, []);
     $uploadFiles = [];
     for ($i = 0; $i < count($uploadedFiles); $i++) {
       $uploadFiles[] = [


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This pull request addresses potential issues where the description or file input name could be undefined or null. The changes ensure that the application doesn't encounter errors related to count() or undefined variables when handling the $descriptions and $uploadedFiles inputs.

## Changes

- Changed file -> src/www/ui/page/UploadFilePage.php
- Modified get call for descriptions:
```
$descriptions = $request->get(self::DESCRIPTION_INPUT_NAME), []);
```
- Modified get call for uploaded files:
```
$uploadedFiles = $request->files->get(self::FILE_INPUT_NAME, []);
```
- The empty [ ] parameter ensures that if the DESCRIPTION_INPUT_NAME or FILE_INPUT_NAME is missing or null in the request, the result will default to an empty array, avoiding errors when calling count() or processing files.
## How to test
- Go to Upload -> From file.
- Cick Upload without selecting any file.
- You will get the alert message (as in other upload types).

Cc @Kaushl2208 @GMishx @shaheemazmalmmd 

This closes #2906
