### PR TITLE
fix(decider): parse multiple arguments correctly

### DIFF
--- a/src/decider/agent/DeciderAgent.php
+++ b/src/decider/agent/DeciderAgent.php
@@ -175,7 +175,7 @@ class DeciderAgent extends Agent
     $args = $this->args;
     $this->activeRules = array_key_exists('r', $args) ? intval($args['r']) : self::RULES_ALL;
     $this->licenseType = array_key_exists('t', $args) ?
-        $this->getLicenseType(trim($args['t'])) : "";
+        $this->getLicenseType(str_replace(["'", '"'], "", $args['t'])) : "";
     $this->licenseMap = new LicenseMap($this->dbManager, $this->groupId, $this->licenseMapUsage);
 
     if (array_key_exists("r", $args) && (($this->activeRules&self::RULES_COPYRIGHT_FALSE_POSITIVE)== self::RULES_COPYRIGHT_FALSE_POSITIVE)) {

--- a/src/scheduler/agent/agent.c
+++ b/src/scheduler/agent/agent.c
@@ -594,7 +594,34 @@ static void shell_parse(char* confdir, int user_id, int group_id, char* input, c
   (*argv)[idx++] = g_strdup_printf("--groupID=%d", group_id);
   (*argv)[idx++] = "--scheduler_start";
   if (jq_cmd_args)
-    (*argv)[idx++] = jq_cmd_args;
+  {
+    const char *start = jq_cmd_args;
+    const char *current = jq_cmd_args;
+    gboolean in_quotes = FALSE;
+
+    while (*current != '\0')
+    {
+      if (*current == '\'' || *current == '"')
+        in_quotes = !in_quotes;
+      else if (*current == ' ' && !in_quotes)
+      {
+        if (current > start)
+        {
+          int len = current - start;
+          char *arg = g_strndup(start, len);
+          (*argv)[idx++] = arg;
+        }
+        start = current + 1;
+      }
+      current++;
+    }
+
+    if (current > start)
+    {
+      char *arg = g_strndup(start, current - start);
+      (*argv)[idx++] = arg;
+    }
+  }
   (*argc) = idx;
 }
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

fix(decider): parse multiple arguments correctly

### Changes

- Add multiple arguments parsing in scheduler
- fix decider agent to correctly read string argument

CC: @GMishx @shaheemazmalmmd @Kaushl2208 
