### PR TITLE
 fix(licensedb): remove redundant usage of LicenseDBSleep

### DIFF
--- a/src/www/ui/page/AdminLicenseFromCSV.php
+++ b/src/www/ui/page/AdminLicenseFromCSV.php
@@ -55,7 +55,6 @@ class AdminLicenseFromCSV extends DefaultPlugin
       'url' => trim($this->sysconfig['LicenseDBURL']),
       'uri' => trim($this->sysconfig['LicenseDBBaseURL']),
       'content' => trim($this->sysconfig['LicenseDBContent']),
-      'maxtime' => intval($this->sysconfig['LicenseDBSleep']),
       'token' => trim($this->sysconfig['LicenseDBToken'])
     ];
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

fix(licensedb): remove redundant usage of LicenseDBSleep

CC: @Kaushl2208 @GMishx @shaheemazmalmmd 
