### PR TITLE
fix(api): Jobs no longer displayed wrongly as queued

### DIFF
--- a/src/www/ui/api/Helper/DbHelper.php
+++ b/src/www/ui/api/Helper/DbHelper.php
@@ -304,7 +304,7 @@ FROM $tableName WHERE $idRowName = $1", [$id],
           ELSE 'Completed'
         END AS job_status
       FROM job j
-      LEFT JOIN jobqueue jq ON j.job_pk=jq.jq_job_fk
+      RIGHT JOIN jobqueue jq ON j.job_pk=jq.jq_job_fk
       GROUP BY j.job_pk, j.job_queued, j.job_name, j.job_upload_fk, j.job_user_fk, j.job_group_fk
     )";
   }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fixed a bug of the previous PR #2870 from me. This caused jobs to be displayed as "queued" if the do not have any item inside the `jobqueue` table.

### Changes
* `DbHelper.php`: Changed the `join statement` from `left` to `right` to make sure only jobs with at least one queue item are displayed as queued.

