### PR TITLE
feat(ui): add confirmation dialog for export downloads

### DIFF
--- a/src/lib/php/Util/DownloadUtil.php
+++ b/src/lib/php/Util/DownloadUtil.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Siemens AG
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\Lib\Util;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class DownloadUtil
+{
+  /**
+   * Creates a response with download confirmation
+   * @param string $downloadUrl The URL to download from
+   * @param string $fileName The name of the file to be downloaded
+   * @param string $referer The page to redirect to after download
+   * @return Response
+   */
+  public static function getDownloadConfirmationResponse($downloadUrl, $fileName, $referer)
+  {
+    if (empty($referer)) {
+      $referer = "?mod=browse";
+    }
+
+    $script = '<script>
+      if (confirm("Do you want to download the file ' . $fileName . '?")) {
+        fetch("' . $downloadUrl . '")
+          .then(response => response.blob())
+          .then(blob => {
+            const url = window.URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = "' . $fileName . '";
+            document.body.appendChild(a);
+            a.click();
+            window.URL.revokeObjectURL(url);
+            document.body.removeChild(a);
+            window.location.href = "' . $referer . '";
+          });
+      } else {
+        window.location.href = "' . $referer . '";
+      }
+    </script>';
+
+    return new Response($script, Response::HTTP_OK, ['Content-Type' => 'text/html']);
+  }
+
+  /**
+   * Creates a response for file download
+   * @param string $content The file content
+   * @param string $fileName The name of the file
+   * @param string $contentType The content type of the file
+   * @return Response
+   */
+  public static function getDownloadResponse($content, $fileName, $contentType = 'text/csv')
+  {
+    $headers = array(
+      'Content-type' => $contentType . ', charset=UTF-8',
+      'Content-Disposition' => 'attachment; filename=' . $fileName,
+      'Pragma' => 'no-cache',
+      'Cache-Control' => 'no-cache, must-revalidate, maxage=1, post-check=0, pre-check=0',
+      'Expires' => 'Expires: Thu, 19 Nov 1981 08:52:00 GMT'
+    );
+
+    return new Response($content, Response::HTTP_OK, $headers);
+  }
+}

--- a/src/www/ui/page/AdminAllLicenseToCSV.php
+++ b/src/www/ui/page/AdminAllLicenseToCSV.php
@@ -9,6 +9,7 @@ namespace Fossology\UI\Page;
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Plugin\DefaultPlugin;
+use Fossology\Lib\Util\DownloadUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -19,10 +20,10 @@ class AdminAllLicenseToCSV extends DefaultPlugin
   function __construct()
   {
     parent::__construct(self::NAME, array(
-        self::TITLE => "Admin All Groups License CSV Export",
-        self::MENU_LIST => "Admin::License Admin::CSV Export All",
-        self::REQUIRES_LOGIN => true,
-        self::PERMISSION => Auth::PERM_ADMIN
+      self::TITLE => "Admin All Groups License CSV Export",
+      self::MENU_LIST => "Admin::License Admin::CSV Export All",
+      self::REQUIRES_LOGIN => true,
+      self::PERMISSION => Auth::PERM_ADMIN
     ));
   }
 
@@ -32,17 +33,18 @@ class AdminAllLicenseToCSV extends DefaultPlugin
    */
   protected function handle(Request $request)
   {
+    $confirmed = $request->get('confirmed', false);
+    $referer = $request->headers->get('referer');
+    $fileName = "fossology-license-export-" . date("YMj-Gis") . '.csv';
+
+    if (!$confirmed) {
+      $downloadUrl = "?mod=" . self::NAME . "&rf=" . $request->get('rf') . "&confirmed=true";
+      return DownloadUtil::getDownloadConfirmationResponse($downloadUrl, $fileName, $referer);
+    }
+
     $licenseCsvExport = new \Fossology\Lib\Application\LicenseCsvExport($this->getObject('db.manager'));
     $content = $licenseCsvExport->createCsv(intval($request->get('rf')), true);
-    $fileName = "fossology-license-export-".date("YMj-Gis");
-    $headers = array(
-        'Content-type' => 'text/csv, charset=UTF-8',
-        'Content-Disposition' => 'attachment; filename='.$fileName.'.csv',
-        'Pragma' => 'no-cache',
-        'Cache-Control' => 'no-cache, must-revalidate, maxage=1, post-check=0, pre-check=0',
-        'Expires' => 'Expires: Thu, 19 Nov 1981 08:52:00 GMT');
-
-    return new Response($content, Response::HTTP_OK, $headers);
+    return DownloadUtil::getDownloadResponse($content, $fileName);
   }
 }
 

--- a/src/www/ui/page/AdminAllLicenseToJSON.php
+++ b/src/www/ui/page/AdminAllLicenseToJSON.php
@@ -9,6 +9,7 @@ namespace Fossology\UI\Page;
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Plugin\DefaultPlugin;
+use Fossology\Lib\Util\DownloadUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -19,10 +20,10 @@ class AdminAllLicenseToJSON extends DefaultPlugin
   function __construct()
   {
     parent::__construct(self::NAME, array(
-        self::TITLE => "Admin All Groups License JSON Export",
-        self::MENU_LIST => "Admin::License Admin::JSON Export All",
-        self::REQUIRES_LOGIN => true,
-        self::PERMISSION => Auth::PERM_ADMIN
+      self::TITLE => "Admin All Groups License JSON Export",
+      self::MENU_LIST => "Admin::License Admin::JSON Export All",
+      self::REQUIRES_LOGIN => true,
+      self::PERMISSION => Auth::PERM_ADMIN
     ));
   }
 
@@ -32,17 +33,18 @@ class AdminAllLicenseToJSON extends DefaultPlugin
    */
   protected function handle(Request $request)
   {
+    $confirmed = $request->get('confirmed', false);
+    $referer = $request->headers->get('referer');
+    $fileName = "fossology-license-export-" . date("YMj-Gis") . '.json';
+
+    if (!$confirmed) {
+      $downloadUrl = "?mod=" . self::NAME . "&rf=" . $request->get('rf') . "&confirmed=true";
+      return DownloadUtil::getDownloadConfirmationResponse($downloadUrl, $fileName, $referer);
+    }
+
     $licenseCsvExport = new \Fossology\Lib\Application\LicenseCsvExport($this->getObject('db.manager'));
     $content = $licenseCsvExport->createCsv(intval($request->get('rf')), true, true);
-    $fileName = "fossology-license-export-".date("YMj-Gis");
-    $headers = array(
-        'Content-type' => 'text/json, charset=UTF-8',
-        'Content-Disposition' => 'attachment; filename='.$fileName.'.json',
-        'Pragma' => 'no-cache',
-        'Cache-Control' => 'no-cache, must-revalidate, maxage=1, post-check=0, pre-check=0',
-        'Expires' => 'Expires: Thu, 19 Nov 1981 08:52:00 GMT');
-
-    return new Response($content, Response::HTTP_OK, $headers);
+    return DownloadUtil::getDownloadResponse($content, $fileName, 'text/json');
   }
 }
 

--- a/src/www/ui/page/AdminLicenseToJSON.php
+++ b/src/www/ui/page/AdminLicenseToJSON.php
@@ -9,6 +9,7 @@ namespace Fossology\UI\Page;
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Plugin\DefaultPlugin;
+use Fossology\Lib\Util\DownloadUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -32,17 +33,18 @@ class AdminLicenseToJSON extends DefaultPlugin
    */
   protected function handle(Request $request)
   {
+    $confirmed = $request->get('confirmed', false);
+    $referer = $request->headers->get('referer');
+    $fileName = "fossology-license-export-" . date("YMj-Gis") . '.json';
+
+    if (!$confirmed) {
+      $downloadUrl = "?mod=" . self::NAME . "&rf=" . $request->get('rf') . "&confirmed=true";
+      return DownloadUtil::getDownloadConfirmationResponse($downloadUrl, $fileName, $referer);
+    }
+
     $licenseCsvExport = new \Fossology\Lib\Application\LicenseCsvExport($this->getObject('db.manager'));
     $content = $licenseCsvExport->createCsv(intval($request->get('rf')), false, true);
-    $fileName = "fossology-license-export-".date("YMj-Gis");
-    $headers = array(
-        'Content-type' => 'text/json, charset=UTF-8',
-        'Content-Disposition' => 'attachment; filename='.$fileName.'.json',
-        'Pragma' => 'no-cache',
-        'Cache-Control' => 'no-cache, must-revalidate, maxage=1, post-check=0, pre-check=0',
-        'Expires' => 'Expires: Thu, 19 Nov 1981 08:52:00 GMT');
-
-    return new Response($content, Response::HTTP_OK, $headers);
+    return DownloadUtil::getDownloadResponse($content, $fileName, 'text/json');
   }
 }
 

--- a/src/www/ui/page/AdminObligationToCSV.php
+++ b/src/www/ui/page/AdminObligationToCSV.php
@@ -9,6 +9,7 @@ namespace Fossology\UI\Page;
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Plugin\DefaultPlugin;
+use Fossology\Lib\Util\DownloadUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -32,17 +33,18 @@ class AdminObligationToCSV extends DefaultPlugin
    */
   protected function handle(Request $request)
   {
+    $confirmed = $request->get('confirmed', false);
+    $referer = $request->headers->get('referer');
+    $fileName = "fossology-obligations-export-" . date("YMj-Gis") . '.csv';
+
+    if (!$confirmed) {
+      $downloadUrl = "?mod=" . self::NAME . "&rf=" . $request->get('rf') . "&confirmed=true";
+      return DownloadUtil::getDownloadConfirmationResponse($downloadUrl, $fileName, $referer);
+    }
+
     $obligationCsvExport = new \Fossology\Lib\Application\ObligationCsvExport($this->getObject('db.manager'));
     $content = $obligationCsvExport->createCsv(intval($request->get('rf')));
-    $fileName = "fossology-obligations-export-".date("YMj-Gis");
-    $headers = array(
-        'Content-type' => 'text/csv, charset=UTF-8',
-        'Content-Disposition' => 'attachment; filename='.$fileName.'.csv',
-        'Pragma' => 'no-cache',
-        'Cache-Control' => 'no-cache, must-revalidate, maxage=1, post-check=0, pre-check=0',
-        'Expires' => 'Expires: Thu, 19 Nov 1981 08:52:00 GMT');
-
-    return new Response($content, Response::HTTP_OK, $headers);
+    return DownloadUtil::getDownloadResponse($content, $fileName, 'text/csv');
   }
 }
 


### PR DESCRIPTION
## Description
Add confirmation dialog before downloading export files to improve user experience.

## Changes
- Add confirmation dialog before initiating downloads
- Implement for license-admin CSV exports
- Improve UX for new users
- Test across multiple browsers
## How to test
1. Login to fossology server
2. Navigate to admin/license-admin/csv-export-all
3. Click on export
4. Verify that a confirmation dialog appears before download starts

## Related Issue
Fixes #2913

