### PR TITLE
fix(reportImport): (Re-)enable import of SPDX 2.2 documents

### DIFF
--- a/src/reportImport/agent/ReportImportAgent.php
+++ b/src/reportImport/agent/ReportImportAgent.php
@@ -242,7 +242,7 @@ class ReportImportAgent extends Agent
      */
       $parse = new SpdxTwoImportSource($reportFilename);
       $version = $parse->getVersion();
-      if($version == "2.3"){
+      if($version == "2.2" || $version == "2.3"){
         $importSource = new SpdxTwoImportSource($reportFilename);
         if($importSource->parse()) {
           return $importSource;


### PR DESCRIPTION

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
Up to now it (still) has been possible to import SPDX version 2.2 based documents. With the merge of the changes for SPDX version 3.0 (b35ba4784ebe9f8bd7a435a27478805efc2ac2a8) the import of SPDX 2.2 is not possible anymore due to an explicit check for version 2.3. Since there so was no change to the relevant import code in this commit, there shouldn't be any reason to disallow the import of SPDX 2.2.

### Changes
Check for SPDX version 2.2 OR SPDX version 2.3 when importing an SPDX RDF report.

## How to test

Take any version after commit b35ba4784ebe9f8bd7a435a27478805efc2ac2a8 and try to import an SPDX RDF file, stating specVersion 2.2. Nothing will be imported. With this change, the import will work.
