### PR TITLE
fix(apt): Mark fossology-spdx replaces fossology-spdx2

### DIFF
--- a/cmake/FoPackaging.cmake
+++ b/cmake/FoPackaging.cmake
@@ -586,6 +586,11 @@ This package contains the spdx agent programs and their resources.")
 set(CPACK_DEBIAN_SPDX_PACKAGE_DEPENDS
     "fossology-common")
 
+set(CPACK_DEBIAN_SPDX_PACKAGE_CONFLICTS
+    "fossology-spdx2 (< 4.5.0)")
+set(CPACK_DEBIAN_SPDX_PACKAGE_REPLACES
+    "fossology-spdx2")
+
 set(CPACK_DEBIAN_SPDX_PACKAGE_SECTION "utils")
 
 ## FOSSOLOGY-REPORTIMPORT PACKAGE


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

With version update and package name change, `spdx2` is now `spdx`. While installing the new version through Source, `utils/fo-cleanold` removes the old package and solves the issue. But the issue still persists for debian packages installation.

### Changes

1. **Added Package Conflicts**:
    - Set CPACK_DEBIAN_SPDX_PACKAGE_CONFLICTS to "fossology-spdx2 (< 4.5.0)".

2. **Added Package Replaces**:
    - Set CPACK_DEBIAN_SPDX_PACKAGE_REPLACES to "fossology-spdx2".

These changes are intended to improve package management and ensure that users are not left with incompatible versions of `fossology-spdx2`. By clearly defining conflicts and replacements, we enhance the installation and upgrade experience for users.

## How to test

1. Install  older version of FOSSology (atleast two version back) through debian package.
2. Then install 4.5.0, through debain package as well. The old package "fossology-spdx2" should be removed without any errors

