### PR TITLE
fix: prevent nomos CLI from connecting to DB when not required (#1299)

### DIFF
--- a/src/lib/c/libfossscheduler.c
+++ b/src/lib/c/libfossscheduler.c
@@ -34,6 +34,7 @@ int userID;          ///< The id of the user that created the job
 int groupID;         ///< The id of the group of the user that created the job
 int jobId;           ///< The id of the job
 char* module_name = NULL;   ///< The name of the agent
+int should_connect_to_db = 1; /// Default: connect to DB unless explicitly disabled
 
 /** Check for an agent in DB */
 const static char* sql_check = "\
@@ -252,8 +253,8 @@ void fo_scheduler_connect_conf(int* argc, char** argv, PGconn** db_conn, char** 
     fo_config_free(version);
   }
 
-  /* create the database connection */
-  if (db_conn)
+  /* create the database connection only if needed */
+  if (db_conn && should_connect_to_db)  // Add a condition
   {
     db_config = g_strdup_printf("%s/Db.conf", sysconfigdir);
     (*db_conn) = fo_dbconnect(db_config, &db_error);

--- a/src/nomos/agent/nomos_utils.c
+++ b/src/nomos/agent/nomos_utils.c
@@ -11,6 +11,8 @@
 #include "nomos_utils.h"
 #include "nomos.h"
 
+extern int should_connect_to_db;  /* Global variable to control DB connection */
+
 #define FUNCTION
 
 /**
@@ -508,6 +510,8 @@ FUNCTION void parseLicenseList()
  */
 FUNCTION void Usage(char *Name)
 {
+  /* Disable database connection when showing usage */
+  should_connect_to_db = 0;
   printf("Usage: %s [options] [file [file [...]]\n", Name);
   printf("  -h   :: help (print this message), then exit.\n");
   printf("  -i   :: initialize the database, then exit.\n");
@@ -1016,7 +1020,3 @@ inline bool clearLastElementOfLicenceBuffer(){
     g_array_remove_index(cur.indexList, cur.indexList->len -1);
   return true;
 }
-
-
-
-


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This pull request addresses **issue #1299** by preventing the `nomos` CLI from attempting to read the `Db.conf` file when a database connection is not required. Specifically, the CLI no longer tries to open a DB connection when displaying the help message (`-h` flag), which previously caused a permission error.

### Changes

- Introduced a global flag `should_connect_to_db` in `libfossscheduler.c` to control whether a database connection should be initiated.
- Modified the `Usage()` function in `nomos.utils.c` to set `should_connect_to_db = 0` when the help command (`-h`) is used.
- Updated the `fo_scheduler_connect_conf()` function to respect this flag, ensuring the database connection is only attempted when necessary.

---

## How to test

1. **Display Help Message (`-h`):**  
   Run the following command to verify that the help message is displayed without any DB connection attempt or permission error:
   ```bash
   ./src/nomos/agent/nomos -h
![Screenshot from 2025-02-01 12-09-39](https://github.com/user-attachments/assets/e6a5d1c5-92a6-4ce7-a0ba-d61899fb1d5a)
