### PR TITLE
fix(api): enable JSON configuration support for external scanner agents

### DIFF
--- a/src/www/ui/api/Models/Analysis.php
+++ b/src/www/ui/api/Models/Analysis.php
@@ -60,6 +60,11 @@ class Analysis
    */
   private $ojo;
   /**
+   * @var boolean $scanoss
+   * Whether to schedule scanoss agent or not
+   */
+  private $scanoss;
+  /**
    * @var boolean $pkgagent
    * Whether to schedule reso agent or not
    */
@@ -69,6 +74,16 @@ class Analysis
    * Whether to schedule package agent or not
    */
   private $pkgagent;
+  /**
+   * @var boolean $ipra
+   * Whether to schedule ipra agent or not
+   */
+  private $ipra;
+  /**
+   * @var boolean $softwareHeritage
+   * Whether to schedule software heritage agent or not
+   */
+  private $softwareHeritage;
   /**
    * @var boolean $compatibility
    * Whether to schedule compatibility agent or not
@@ -87,11 +102,13 @@ class Analysis
    * @param boolean $pkgagent
    * @param boolean $ojo
    * @param boolean $reso
-   * @param boolean $pkgagent
    * @param boolean $compatibility
+   * @param boolean $scanoss
+   * @param boolean $ipra
+   * @param boolean $softwareHeritage
    */
   public function __construct($bucket = false, $copyright = false, $ecc = false, $keyword = false,
-    $mimetype = false, $monk = false, $nomos = false, $ojo = false, $reso = false, $pkgagent = false, $compatibility = false)
+    $mimetype = false, $monk = false, $nomos = false, $ojo = false, $reso = false, $pkgagent = false, $compatibility = false, $scanoss = false, $ipra = false, $softwareHeritage = false)
   {
     $this->bucket = $bucket;
     $this->copyright = $copyright;
@@ -101,9 +118,26 @@ class Analysis
     $this->monk = $monk;
     $this->nomos = $nomos;
     $this->ojo = $ojo;
+    $this->scanoss = $scanoss;
     $this->reso = $reso;
     $this->pkgagent = $pkgagent;
+    $this->ipra = $ipra;
+    $this->softwareHeritage = $softwareHeritage;
     $this->compatibility = $compatibility;
+  }
+
+  /**
+   * Helper function to set boolean properties from array
+   * @param array $array Source array containing boolean values
+   * @param array $propertyMap Map of array keys to object properties
+   */
+  private function setBooleanProperties($array, $propertyMap)
+  {
+    foreach ($propertyMap as $key => $property) {
+      if (array_key_exists($key, $array)) {
+        $this->$property = filter_var($array[$key], FILTER_VALIDATE_BOOLEAN);
+      }
+    }
   }
 
   /**
@@ -113,45 +147,24 @@ class Analysis
    */
   public function setUsingArray($analysisArray, $version = ApiVersion::V1)
   {
-    if (array_key_exists("bucket", $analysisArray)) {
-      $this->bucket = filter_var($analysisArray["bucket"],
-        FILTER_VALIDATE_BOOLEAN);
-    }
-    if (array_key_exists(($version == ApiVersion::V2? "copyrightEmailAuthor" : "copyright_email_author"), $analysisArray)) {
-      $this->copyright = filter_var($analysisArray[$version == ApiVersion::V2? "copyrightEmailAuthor" : "copyright_email_author"],
-        FILTER_VALIDATE_BOOLEAN);
-    }
-    if (array_key_exists("ecc", $analysisArray)) {
-      $this->ecc = filter_var($analysisArray["ecc"], FILTER_VALIDATE_BOOLEAN);
-    }
-    if (array_key_exists("keyword", $analysisArray)) {
-      $this->keyword = filter_var($analysisArray["keyword"],
-        FILTER_VALIDATE_BOOLEAN);
-    }
-    if (array_key_exists("mime", $analysisArray)) {
-      $this->mimetype = filter_var($analysisArray["mime"],
-        FILTER_VALIDATE_BOOLEAN);
-    }
-    if (array_key_exists("monk", $analysisArray)) {
-      $this->monk = filter_var($analysisArray["monk"], FILTER_VALIDATE_BOOLEAN);
-    }
-    if (array_key_exists("nomos", $analysisArray)) {
-      $this->nomos = filter_var($analysisArray["nomos"], FILTER_VALIDATE_BOOLEAN);
-    }
-    if (array_key_exists("ojo", $analysisArray)) {
-      $this->ojo = filter_var($analysisArray["ojo"], FILTER_VALIDATE_BOOLEAN);
-    }
-    if (array_key_exists("reso", $analysisArray)) {
-      $this->reso = filter_var($analysisArray["reso"], FILTER_VALIDATE_BOOLEAN);
-    }
-    if (array_key_exists("package", $analysisArray)) {
-      $this->pkgagent = filter_var($analysisArray["package"],
-        FILTER_VALIDATE_BOOLEAN);
-    }
-    if (array_key_exists("compatibility", $analysisArray)) {
-      $this->compatibility = filter_var($analysisArray["compatibility"],
-          FILTER_VALIDATE_BOOLEAN);
-    }
+    $propertyMap = [
+      'bucket' => 'bucket',
+      ($version == ApiVersion::V2 ? 'copyrightEmailAuthor' : 'copyright_email_author') => 'copyright',
+      'ecc' => 'ecc',
+      'keyword' => 'keyword',
+      'mime' => 'mimetype',
+      'monk' => 'monk',
+      'nomos' => 'nomos',
+      'ojo' => 'ojo',
+      'scanoss' => 'scanoss',
+      'reso' => 'reso',
+      ($version == ApiVersion::V2 ? "pkgagent" : "package") => 'pkgagent',
+      ($version == ApiVersion::V2 ? 'ipra' : 'patent') => 'ipra',
+      ($version == ApiVersion::V2 ? 'softwareHeritage' : "heritage") => 'softwareHeritage',
+      'compatibility' => 'compatibility'
+    ];
+
+    $this->setBooleanProperties($analysisArray, $propertyMap);
     return $this;
   }
 
@@ -162,38 +175,27 @@ class Analysis
    */
   public function setUsingString($analysisString)
   {
-    if (stristr($analysisString, "bucket")) {
-      $this->bucket = true;
-    }
-    if (stristr($analysisString, "copyright")) {
-      $this->copyright = true;
-    }
-    if (stristr($analysisString, "ecc")) {
-      $this->ecc = true;
-    }
-    if (stristr($analysisString, "keyword")) {
-      $this->keyword = true;
-    }
-    if (stristr($analysisString, "mimetype")) {
-      $this->mimetype = true;
-    }
-    if (stristr($analysisString, "monk")) {
-      $this->monk = true;
-    }
-    if (stristr($analysisString, "nomos")) {
-      $this->nomos = true;
-    }
-    if (stristr($analysisString, "ojo")) {
-      $this->ojo = true;
-    }
-    if (stristr($analysisString, "reso")) {
-      $this->reso = true;
-    }
-    if (stristr($analysisString, "pkgagent")) {
-      $this->pkgagent = true;
-    }
-    if (stristr($analysisString, "compatibility")) {
-      $this->compatibility = true;
+    $propertyMap = [
+      'bucket' => 'bucket',
+      'copyright' => 'copyright',
+      'ecc' => 'ecc',
+      'keyword' => 'keyword',
+      'mimetype' => 'mimetype',
+      'monk' => 'monk',
+      'nomos' => 'nomos',
+      'ojo' => 'ojo',
+      'scanoss' => 'scanoss',
+      'reso' => 'reso',
+      'pkgagent' => 'pkgagent',
+      'ipra' => 'ipra',
+      'softwareHeritage' => 'softwareHeritage',
+      'compatibility' => 'compatibility'
+    ];
+
+    foreach ($propertyMap as $key => $property) {
+      if (stristr($analysisString, $key)) {
+        $this->$property = true;
+      }
     }
     return $this;
   }
@@ -266,6 +268,14 @@ class Analysis
   /**
    * @return boolean
    */
+  public function getScanoss()
+  {
+    return $this->scanoss;
+  }
+
+  /**
+   * @return boolean
+   */
   public function getReso()
   {
     return $this->reso;
@@ -274,9 +284,25 @@ class Analysis
   /**
    * @return boolean
    */
-  public function getPackage()
+  public function getPkgagent()
   {
     return $this->pkgagent;
+  }
+
+  /**
+   * @return boolean
+   */
+  public function getIpra()
+  {
+    return $this->ipra;
+  }
+
+  /**
+   * @return boolean
+   */
+  public function getSoftwareHeritage()
+  {
+    return $this->softwareHeritage;
   }
 
   /**
@@ -353,6 +379,14 @@ class Analysis
   }
 
   /**
+   * @param boolean $scanoss
+   */
+  public function setScanoss($scanoss)
+  {
+    $this->scanoss = filter_var($scanoss, FILTER_VALIDATE_BOOLEAN);
+  }
+
+  /**
    * @param boolean $reso
    */
   public function setReso($reso)
@@ -363,9 +397,25 @@ class Analysis
   /**
    * @param boolean $package
    */
-  public function setPackage($package)
+  public function setPkgagent($pkgagent)
   {
-    $this->pkgagent = filter_var($package, FILTER_VALIDATE_BOOLEAN);
+    $this->pkgagent = filter_var($pkgagent, FILTER_VALIDATE_BOOLEAN);
+  }
+
+  /**
+   * @param boolean $ipra
+   */
+  public function setIpra($ipra)
+  {
+    $this->ipra = filter_var($ipra, FILTER_VALIDATE_BOOLEAN);
+  }
+
+  /**
+   * @param boolean $softwareHeritage
+   */
+  public function setSoftwareHeritage($softwareHeritage)
+  {
+    $this->softwareHeritage = filter_var($softwareHeritage, FILTER_VALIDATE_BOOLEAN);
   }
 
   /**
@@ -392,8 +442,11 @@ class Analysis
         "monk"      => $this->monk,
         "nomos"     => $this->nomos,
         "ojo"       => $this->ojo,
+        "scanoss"   => $this->scanoss,
         "reso"      => $this->reso,
-        "package"   => $this->pkgagent,
+        "pkgagent"   => $this->pkgagent,
+        "ipra"    => $this->ipra,
+        "softwareHeritage" => $this->softwareHeritage,
         "compatibility" => $this->compatibility
       ];
     } else {
@@ -406,8 +459,11 @@ class Analysis
         "monk"      => $this->monk,
         "nomos"     => $this->nomos,
         "ojo"       => $this->ojo,
+        "scanoss"   => $this->scanoss,
         "reso"      => $this->reso,
         "package"   => $this->pkgagent,
+        "patent"    => $this->ipra,
+        "heritage" => $this->softwareHeritage,
         "compatibility" => $this->compatibility
       ];
     }

--- a/src/www/ui/api/Models/ApiVersion.php
+++ b/src/www/ui/api/Models/ApiVersion.php
@@ -30,4 +30,16 @@ class ApiVersion
   {
     return $request->getAttribute(self::ATTRIBUTE_NAME, self::V1);
   }
+
+  public static function getVersionFromUri(): int
+  {
+    $uri = $_SERVER['REQUEST_URI'];
+    $apiVersion = ApiVersion::V1;
+
+    if (strpos($uri, '/api/v2/') !== false) {
+      $apiVersion = ApiVersion::V2;
+    }
+
+    return $apiVersion;
+  }
 }

--- a/src/www/ui/api/Models/ScanOptions.php
+++ b/src/www/ui/api/Models/ScanOptions.php
@@ -15,6 +15,7 @@ namespace Fossology\UI\Api\Models;
 use Fossology\Lib\Auth\Auth;
 use Fossology\UI\Api\Exceptions\HttpForbiddenException;
 use Fossology\UI\Api\Exceptions\HttpNotFoundException;
+use Fossology\UI\Api\Models\ApiVersion;
 use Symfony\Component\HttpFoundation\Request;
 
 if (!class_exists("AgentAdder", false)) {
@@ -128,20 +129,49 @@ class ScanOptions
   private function prepareAgents(Request &$request)
   {
     $agentsToAdd = [];
-    foreach ($this->analysis->getArray() as $agent => $set) {
-      if ($set === true) {
-        if ($agent == "copyright_email_author") {
-          $agentsToAdd[] = "agent_copyright";
-          $request->request->set("Check_agent_copyright", 1);
-        } elseif ($agent == "patent") {
-          $agentsToAdd[] = "agent_ipra";
-          $request->request->set("Check_agent_ipra", 1);
-        } elseif ($agent == "package") {
-          $agentsToAdd[] = "agent_pkgagent";
-          $request->request->set("Check_agent_pkgagent", 1);
-        } else {
-          $agentsToAdd[] = "agent_$agent";
-          $request->request->set("Check_agent_$agent", 1);
+
+    $apiVersion = ApiVersion::getVersionFromUri();
+
+    if ($apiVersion == ApiVersion::V2) {
+      foreach ($this->analysis->getArray($apiVersion) as $agent => $set) {
+        if ($set === true) {
+          if ($agent == "copyrightEmailAuthor") {
+            $agentsToAdd[] = "agent_copyright";
+            $request->request->set("Check_agent_copyright", 1);
+          } elseif ($agent == "ipra") {
+            $agentsToAdd[] = "agent_ipra";
+            $request->request->set("Check_agent_ipra", 1);
+          } elseif ($agent == "pkgagent") {
+            $agentsToAdd[] = "agent_pkgagent";
+            $request->request->set("Check_agent_pkgagent", 1);
+          } elseif ($agent == "softwareHeritage") {
+            $agentsToAdd[] = "agent_shagent";
+            $request->request->set("Check_agent_shagent", 1);
+          } else {
+            $agentsToAdd[] = "agent_$agent";
+            $request->request->set("Check_agent_$agent", 1);
+          }
+        }
+      }
+    } else {
+      foreach ($this->analysis->getArray($apiVersion) as $agent => $set) {
+        if ($set === true) {
+          if ($agent == "copyright_email_author") {
+            $agentsToAdd[] = "agent_copyright";
+            $request->request->set("Check_agent_copyright", 1);
+          } elseif ($agent == "patent") {
+            $agentsToAdd[] = "agent_ipra";
+            $request->request->set("Check_agent_ipra", 1);
+          } elseif ($agent == "package") {
+            $agentsToAdd[] = "agent_pkgagent";
+            $request->request->set("Check_agent_pkgagent", 1);
+          } elseif ($agent == "heritage") {
+            $agentsToAdd[] = "agent_shagent";
+            $request->request->set("Check_agent_shagent", 1);
+          } else {
+            $agentsToAdd[] = "agent_$agent";
+            $request->request->set("Check_agent_$agent", 1);
+          }
         }
       }
     }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -5861,6 +5861,9 @@ components:
         ecc:
           type: boolean
           description: Should ECC Analysis be run on this upload.
+        patent:
+          type: boolean
+          description: Should IPRA Analysis be run on this upload.
         keyword:
           type: boolean
           description: Should keyword Analysis be run on this upload.

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -5789,6 +5789,9 @@ components:
         ecc:
           type: boolean
           description: Should ECC Analysis be run on this upload.
+        ipra:
+          type: boolean
+          description: Should IPRA Analysis be run on this upload.
         keyword:
           type: boolean
           description: Should keyword Analysis be run on this upload.
@@ -5804,13 +5807,13 @@ components:
         ojo:
           type: boolean
           description: Should OJO Analysis be run on this upload.
-        package:
+        pkgagent:
           type: boolean
           description: Should Package Analysis be run on this upload.
         reso:
           type: boolean
           description: Should REUSE.Software Analysis be run on this upload.
-        heritage:
+        softwareHeritage:
           type: boolean
           description: Should Software Heritage Analysis be run on this upload.
     Reuser:

--- a/src/www/ui_tests/api/Models/AnalysisTest.php
+++ b/src/www/ui_tests/api/Models/AnalysisTest.php
@@ -63,7 +63,13 @@ class AnalysisTest extends \PHPUnit\Framework\TestCase
         "mime" => false,
         "monk" => "false",
         "nomos" => 0,
-        "ojo" => (1==2)
+        "ojo" => (1==2),
+        "scanoss" => true,
+        "reso" => true,
+        "pkgagent" => false,
+        "ipra" => true,
+        "softwareHeritage" => true,
+        "compatibility" => false
       ];
     } else {
       $analysisArray = [
@@ -74,11 +80,17 @@ class AnalysisTest extends \PHPUnit\Framework\TestCase
         "mime" => false,
         "monk" => "false",
         "nomos" => 0,
-        "ojo" => (1==2)
+        "ojo" => (1==2),
+        "scanoss" => true,
+        "reso" => true,
+        "package" => false,
+        "patent" => true,
+        "heritage" => true,
+        "compatibility" => false
       ];
     }
 
-    $expectedObject = new Analysis(true, true, true, true);
+    $expectedObject = new Analysis(true, true, true, true, false, false, false, false, true, false, false, true, true, true);
 
     $actualObject = new Analysis();
     $actualObject->setUsingArray($analysisArray, $version);
@@ -94,26 +106,20 @@ class AnalysisTest extends \PHPUnit\Framework\TestCase
    */
   public function testSetUsingString()
   {
-    $analysisStringComma = "bucket, ecc, keyword";
-    $analysisStringSemi = "bucket;ecc;monk";
+    $analysisString = "bucket, ecc, keyword, scanoss, ipra, softwareHeritage";
 
-    $expectedObjectComma = new Analysis();
-    $expectedObjectComma->setBucket(true);
-    $expectedObjectComma->setEcc(true);
-    $expectedObjectComma->setKeyword(true);
+    $expectedObject = new Analysis();
+    $expectedObject->setBucket(true);
+    $expectedObject->setEcc(true);
+    $expectedObject->setKeyword(true);
+    $expectedObject->setScanoss(true);
+    $expectedObject->setIpra(true);
+    $expectedObject->setSoftwareHeritage(true);
 
-    $expectedObjectSemi = new Analysis();
-    $expectedObjectSemi->setBucket(true);
-    $expectedObjectSemi->setEcc(true);
-    $expectedObjectSemi->setMonk(true);
+    $actualObject = new Analysis();
+    $actualObject->setUsingString($analysisString);
 
-    $actualObjectComma = new Analysis();
-    $actualObjectComma->setUsingString($analysisStringComma);
-    $actualObjectSemi = new Analysis();
-    $actualObjectSemi->setUsingString($analysisStringSemi);
-
-    $this->assertEquals($expectedObjectComma, $actualObjectComma);
-    $this->assertEquals($expectedObjectSemi, $actualObjectSemi);
+    $this->assertEquals($expectedObject, $actualObject);
   }
 
   /**
@@ -149,40 +155,41 @@ class AnalysisTest extends \PHPUnit\Framework\TestCase
   {
     if($version==ApiVersion::V2){
       $expectedArray = [
-        "bucket"    => true,
+        "bucket"               => true,
         "copyrightEmailAuthor" => true,
-        "ecc"       => false,
-        "keyword"   => false,
-        "mimetype"  => true,
-        "monk"      => false,
-        "nomos"     => true,
-        "ojo"       => true,
-        "package"   => false,
-        "reso"      => true,
-        "compatibility" => false
+        "ecc"                  => true,
+        "keyword"              => true,
+        "mimetype"             => true,
+        "monk"                 => true,
+        "nomos"                => true,
+        "ojo"                  => true,
+        "scanoss"              => true,
+        "reso"                 => true,
+        "pkgagent"             => true,
+        "ipra"                 => true,
+        "softwareHeritage"     => true,
+        "compatibility"        => true
       ];
-    } else{
+    } else {
       $expectedArray = [
-        "bucket"    => true,
+        "bucket"                 => true,
         "copyright_email_author" => true,
-        "ecc"       => false,
-        "keyword"   => false,
-        "mimetype"  => true,
-        "monk"      => false,
-        "nomos"     => true,
-        "ojo"       => true,
-        "package"   => false,
-        "reso"      => true,
-        "compatibility" => false
+        "ecc"                    => true,
+        "keyword"                => true,
+        "mimetype"               => true,
+        "monk"                   => true,
+        "nomos"                  => true,
+        "ojo"                    => true,
+        "scanoss"                => true,
+        "reso"                   => true,
+        "package"                => true,
+        "patent"                 => true,
+        "heritage"               => true,
+        "compatibility"          => true
       ];
     }
-    $actualObject = new Analysis();
-    $actualObject->setBucket(true);
-    $actualObject->setCopyright(true);
-    $actualObject->setMime(true);
-    $actualObject->setNomos(true);
-    $actualObject->setOjo(true);
-    $actualObject->setReso(true);
+
+    $actualObject = new Analysis(true, true, true, true, true, true, true, true, true, true, true, true, true, true);
 
     $this->assertEquals($expectedArray, $actualObject->getArray($version));
   }
@@ -302,5 +309,40 @@ class AnalysisTest extends \PHPUnit\Framework\TestCase
   {
     $analysis = new Analysis(false, false, false, false, false, true);
     $this->assertTrue($analysis->getMonk());
+  }
+
+  public function testScanoss()
+  {
+    $analysis = new Analysis();
+    $analysis->setScanoss(true);
+    $this->assertTrue($analysis->getScanoss());
+  }
+
+  public function testIpra()
+  {
+    $analysis = new Analysis();
+    $analysis->setIpra(true);
+    $this->assertTrue($analysis->getIpra());
+  }
+
+  public function testSoftwareHeritage()
+  {
+    $analysis = new Analysis();
+    $analysis->setSoftwareHeritage(true);
+    $this->assertTrue($analysis->getSoftwareHeritage());
+  }
+
+  public function testPkgagent()
+  {
+    $analysis = new Analysis();
+    $analysis->setPkgagent(true);
+    $this->assertTrue($analysis->getPkgagent());
+  }
+
+  public function testCompatibility()
+  {
+    $analysis = new Analysis();
+    $analysis->setCompatibility(true);
+    $this->assertTrue($analysis->getCompatibility());
   }
 }

--- a/src/www/ui_tests/api/Models/ApiVersionTest.php
+++ b/src/www/ui_tests/api/Models/ApiVersionTest.php
@@ -43,4 +43,22 @@ class ApiVersionTest extends TestCase
 
     $this->assertEquals(ApiVersion::V1, ApiVersion::getVersion($requestMock));
   }
+
+  /**
+   * Test that getVersionFromUri returns V2 when URI contains /api/v2
+   */
+  public function testGetVersionFromUriV2()
+  {
+    $_SERVER['REQUEST_URI'] = '/api/v2/someEndpoint';
+    $this->assertEquals(ApiVersion::V2, ApiVersion::getVersionFromUri());
+  }
+
+  /**
+   * Test that getVersionFromUri returns V1 when URI contains /api/v2
+   */
+  public function testGetVersionFromUriV1()
+  {
+    $_SERVER['REQUEST_URI'] = '/api/v1/someEndpoint';
+    $this->assertEquals(ApiVersion::V1, ApiVersion::getVersionFromUri());
+  }
 }

--- a/src/www/ui_tests/api/Models/UserTest.php
+++ b/src/www/ui_tests/api/Models/UserTest.php
@@ -118,50 +118,56 @@ class UserTest extends \PHPUnit\Framework\TestCase
   {
     if($version==ApiVersion::V1){
       $expectedCurrentUser = [
-        "id"           => 2,
-        "name"         => 'fossy',
-        "description"  => 'super user',
-        "email"        => 'fossy@localhost',
-        "accessLevel"  => 'admin',
-        "rootFolderId" => 2,
-        "defaultGroup" => 0,
-        "emailNotification" => true,
-        "agents"       => [
-          "bucket"    => true,
+        "id"                       => 2,
+        "name"                     => 'fossy',
+        "description"              => 'super user',
+        "email"                    => 'fossy@localhost',
+        "accessLevel"              => 'admin',
+        "rootFolderId"             => 2,
+        "defaultGroup"             => 0,
+        "emailNotification"        => true,
+        "agents"                   => [
+          "bucket"                 => true,
           "copyright_email_author" => true,
-          "ecc"       => false,
-          "keyword"   => false,
-          "mimetype"  => false,
-          "monk"      => false,
-          "nomos"     => true,
-          "ojo"       => true,
-          "package"   => false,
-          "reso"      => false,
-          "compatibility" => false
+          "ecc"                    => false,
+          "keyword"                => false,
+          "mimetype"               => false,
+          "monk"                   => false,
+          "nomos"                  => true,
+          "ojo"                    => true,
+          "package"                => false,
+          "heritage"               => false,
+          "patent"                 => false,
+          "scanoss"                => false,
+          "reso"                   => false,
+          "compatibility"          => false
         ]
       ];
     } else{
       $expectedCurrentUser = [
-        "id"           => 2,
-        "name"         => 'fossy',
-        "description"  => 'super user',
-        "email"        => 'fossy@localhost',
-        "accessLevel"  => 'admin',
-        "rootFolderId" => 2,
-        "defaultGroup" => "fossy",
-        "emailNotification" => true,
-        "agents"       => [
-          "bucket"    => true,
+        "id"                     => 2,
+        "name"                   => 'fossy',
+        "description"            => 'super user',
+        "email"                  => 'fossy@localhost',
+        "accessLevel"            => 'admin',
+        "rootFolderId"           => 2,
+        "defaultGroup"           => "fossy",
+        "emailNotification"      => true,
+        "agents"                            => [
+          "bucket"               => true,
           "copyrightEmailAuthor" => true,
-          "ecc"       => false,
-          "keyword"   => false,
-          "mimetype"  => false,
-          "monk"      => false,
-          "nomos"     => true,
-          "ojo"       => true,
-          "package"   => false,
-          "reso"      => false,
-          "compatibility" => false
+          "ecc"                  => false,
+          "keyword"              => false,
+          "mimetype"             => false,
+          "monk"                 => false,
+          "nomos"                => true,
+          "ojo"                  => true,
+          "pkgagent"             => false,
+          "ipra"                 => false,
+          "softwareHeritage"     => false,
+          "scanoss"              => false,
+          "reso"                 => false,
+          "compatibility"        => false
         ]
       ];
     }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Currently, several scanner agents cannot be enabled through the JSON configuration file despite being listed in the configuration. The affected agents are:
- SCANOSS
- IPRA
- OJO
- pkgagent
- Software Heritage

While these agents appear as `true` in the JSON configuration, they do not execute during job runs, making the configuration ineffective.

### Changes

Updated Analysis.php and ScanOptions.php to support all agents.

1. Analysis.php: Modified logic to ensure compatibility with all agents.
2. ScanOptions.php: Adjusted configurations to align with the changes in Analysis.php, also modified to be compatible with both version 1 of rest API as well as version 2 of rest API.

These updates enhance agent support and improve overall system robustness.

## How to test

1. Open any endpoint tester.
2. Test for POST request on either /jobs endpoint or /uploads endpoint with either queries or headers depending on the rest API version you are using.

## Screenshots

![Screenshot from 2025-02-03 14-29-26](https://github.com/user-attachments/assets/bb1bb8c2-7d23-4e54-ac09-6831d0234235)

![Screenshot from 2025-02-03 14-29-41](https://github.com/user-attachments/assets/e03e2306-9383-4f80-bd35-ef693a37f1f6)

Fixes #2946 
