### PR TITLE
fix(db): Name change Conflict in View/Table

### DIFF
--- a/src/lib/php/libschema.php
+++ b/src/lib/php/libschema.php
@@ -164,6 +164,8 @@ class fo_libschema
     $this->applyOrEchoOnce('BEGIN');
     $this->getCurrSchema();
     $errlev = error_reporting(E_ERROR | E_WARNING | E_PARSE);
+    $this->dropViews($catalog);
+    $this->dropConstraints();
     $this->applySequences();
     $this->applyTables();
     $this->applyInheritedRelations();


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

FOSSology Release 4.1.0 had some Schema changes in "Agent" Table. Which now when migration to other versions raises some conflicts regarding : `cannot alter the column used by a view or a rule`

### Changes

While running migrations: Steps to Drop Views and Constraint before applying changes are now in place.

## How to test

1. Install FOSSology version 4.1.0
2. Upload and Run some agents.
3. Install the new version of FOSSology 4.5.0, Run Install scripts.
4. Connect to `fossology` DB  , Describe table `agent`. Column `agent_rev` should be of `text` type now.

