### PR TITLE
fix(copyright): preventing 'é' from being detected as ©

### DIFF
--- a/src/copyright/agent/copyright.conf
+++ b/src/copyright/agent/copyright.conf
@@ -25,7 +25,7 @@ author=(?:__author__)[:]?
 author=__author____SPACESALL____NAMESLIST__\.?
 author=__author__|(?<=<author>)(.*?)(?=<\/author>)
 #
-COPYSYM=(?:\(c\)|&copy;|\xA9|\xC2\xA9|\$\xB8|\xE2\x92\xB8|\$\xD2|\xE2\x93\x92|\$\x9E|\xE2\x92\x9E)
+COPYSYM=(?:\(c\)|&copy;|(?<!\xC3)\xA9|\xC2\xA9|\$\xB8|\xE2\x92\xB8|\$\xD2|\xE2\x93\x92|\$\x9E|\xE2\x92\x9E)
 REG_COPYRIGHT=(?:spdx-filecopyrighttext|copyright)(?:ed|s)?[[:space:]:]*|__COPYSYM__[ \t]+([[:alnum:] ][^\0]{0,2}){5,}
 REG_EXCEPTION=\bcopyrights?(?:[ \t/\\\*\+#"\.-]+)(?:licen[cs]es?|notices?|holders?|and|statements?|owners?)[ \t\.,][^\0]*
 REG_NON_BLANK=.*(?:[[:alpha:]][[:alpha:]]|[[:digit:]][[:digit:]]).*


### PR DESCRIPTION
Fixes #1813 

## Description
 the issue where the Copyright agent mistakenly detects  **"é + space"** as the copyright symbol **"©"**.

### Changes
Added a **negative lookbehind** (`(?<!\xC3)\xA9`) to ensure that **A9 is not matched when come after C3** 


## How to test
 `"Votre compte a été suspendu"`  **Should NOT be detected as copyright**  

