### PR TITLE
Fix: Ignore URLs/E-mail Addresses in Example Domains and Specific TLDs #228

### DIFF
--- a/src/copyright/agent/copyright.conf
+++ b/src/copyright/agent/copyright.conf
@@ -7,9 +7,9 @@
 # Description: this file holds the regex configurations for the Copyright agent
 url=(?:(:?ht|f)tps?\:\/\/[^\s\<]+[^\<\.\,\s])
 EMAILPART=[\w\-\.\+]{1,100}
-TLD=[a-zA-Z]{2,12}
-email=[\<\(]?(__EMAILPART__@__EMAILPART__\.__TLD__)[\>\)]?
-website=(?:http|https|ftp)\://[a-zA-Z0-9\-\.]+\.__TLD__(:[a-zA-Z0-9]*)?/?([a-zA-Z0-9\-\._\?\,'/\\+&amp;%\$#\=~])*[^\.\,\)\(\s]
+TLD=[a-zA-Z]{2,12}(?<!test)(?<!invalid)
+email=[\<\(]?(__EMAILPART__@__EMAILPART__\.__TLD__)(?<!example\.(com|net|org))[\>\)]?
+website=(?:http|https|ftp)\://[a-zA-Z0-9\-\.]+\.__TLD__(?<!example\.(com|net|org))(:[a-zA-Z0-9]*)?/?([a-zA-Z0-9\-\._\?\,'/\\+&amp;%\$#\=~])*[^\.\,\)\(\s]
 #' <-- to solve syntax highlighting problems in some editors
 SPACES=[\t ]+
 SPACESALL=[[:space:]]*


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This PR updates the regex configurations in the copyright agent to exclude URLs and email addresses associated with test domains (example.com, example.net, and example.org) and specific TLDs (test, invalid). This enhancement improves the quality of the data by filtering out irrelevant entries.

### Changes

- Added negative lookbehind assertions to exclude example domains (`example.com`, `example.net`, `example.org`).
- Updated TLD pattern to exclude test TLDs (`test`, `invalid`).

## How to test

1. Update the `src/copyright/agent/copyright.conf` file with the new configurations.
2. Run the copyright agent on test data that includes URLs and email addresses from `example.com`, `example.net`, `example.org`, `test`, and `invalid`.
3. Verify that the agent does not report URLs or email addresses from these domains and TLDs.
4. Ensure other valid domains and TLDs are still reported correctly.
