### PR TITLE
enabled partial file searching

### DIFF
--- a/src/lib/php/Dao/FolderDao.php
+++ b/src/lib/php/Dao/FolderDao.php
@@ -69,19 +69,19 @@ class FolderDao
   }
 
   public function getFolderId($folderName, $parentFolderId = self::TOP_LEVEL)
-  {
-    $statementName = __METHOD__;
-    $this->dbManager->prepare($statementName,
-        "SELECT folder_pk FROM folder, foldercontents fc"
-       ." WHERE LOWER(folder_name)=LOWER($1) AND fc.parent_fk=$2 AND fc.foldercontents_mode=$3 AND folder_pk=child_id");
-    $res = $this->dbManager->execute($statementName, array( $folderName, $parentFolderId, self::MODE_FOLDER));
-    $rows= $this->dbManager->fetchAll($res);
+{
+  $statementName = __METHOD__;
+  $this->dbManager->prepare($statementName,
+      "SELECT folder_pk FROM folder, foldercontents fc"
+     ." WHERE LOWER(folder_name) LIKE LOWER($1) AND fc.parent_fk=$2 AND fc.foldercontents_mode=$3 AND folder_pk=child_id");
+  $res = $this->dbManager->execute($statementName, array('%' . $folderName . '%', $parentFolderId, self::MODE_FOLDER));
+  $rows = $this->dbManager->fetchAll($res);
 
-    $rootFolder = !empty($rows) ? intval($rows[0]['folder_pk']) : null;
-    $this->dbManager->freeResult($res);
+  $rootFolder = !empty($rows) ? intval($rows[0]['folder_pk']) : null;
+  $this->dbManager->freeResult($res);
 
-    return $rootFolder;
-  }
+  return $rootFolder;
+}
 
   public function insertFolderContents($parentId, $foldercontentsMode, $childId)
   {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

Fixes #2954 

## Description
Fossology only finds folders if you type the exact name.
This PR enables the file search with partial name of the file 
### Changes

Fossology used = in the search.
I changed it to LIKE, which allows partial matching.
Added (%) This makes search for folders even if you type only part of the name


