### PR TITLE
UI fix Schedule an Analysis (Jobs->Schedule agents)

### DIFF
--- a/src/www/ui/template/agent_adder.html.twig
+++ b/src/www/ui/template/agent_adder.html.twig
@@ -34,8 +34,18 @@
      </li>
       <li> {{ "Select additional analysis."|trans }}<br/>
         <div id="agentsdiv">
-          <select multiple size="10" id="agents" name="agents[]"></select>
+          <select multiple size="10" id="agents" name="agents[]" disabled>
+            {% if availableAgents is not empty %}
+              {% for agent in availableAgents %}
+                <option value="{{ agent.id }}" disabled>{{ agent.name }}</option>
+              {% endfor %}
+            {% else %}
+              <option value="" disabled>{{ "No additional analysis available" | trans }}</option>
+            {% endif %}
+          </select>
         </div>
+
+
         {{ out }}
       </li> 
     </ol>
@@ -78,13 +88,26 @@
 
   {{ agentScript }}
   <script language="javascript">
-    function Agents_Reply()
-    {
-      if ((Agents.readyState==4) && (Agents.status==200))
-      {
-        document.getElementById('agentsdiv').innerHTML = Agents.responseText;
+    function Agents_Reply() {
+      if (Agents.readyState == 4 && Agents.status == 200) {
+        let responseText = Agents.responseText.trim();
+        let agentsDropdown = document.getElementById('agentsdiv');
+
+        if (responseText === '') {
+          agentsDropdown.innerHTML = `
+            <select multiple size="10" id="agents" name="agents[]" disabled>
+              <option value="" disabled>No additional analysis available</option>
+            </select>`;
+        } else {
+          agentsDropdown.innerHTML = `
+            <select multiple size="10" id="agents" name="agents[]" disabled>
+              ${responseText}
+            </select>`;
+        }
       }
     }
+
+
   </script>
   {{ outFoot }}
 {% endblock %}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This pull request improves the frontend by ensuring that the "Additional Analysis" section is always visible but disabled when no options are available. This prevents unnecessary whitespace and enhances user experience.

## Screeshots

### Before
![Screenshot from 2025-02-17 09-10-56](https://github.com/user-attachments/assets/eae47a83-18c6-48c3-b2a5-98451a1f1f11)

### After
![Screenshot from 2025-02-17 22-08-50](https://github.com/user-attachments/assets/31423849-8f67-4b29-9a7b-cb57efa642d6)


### Changes

1. Modified the ```agentsdiv``` section in the template to always display a disabled dropdown with available analysis options.

2. Updated the ```Agents_Reply()```JavaScript function to handle cases where no additional analysis options are available.

3. Ensured that when no options are present, a message "**No additional analysis available**" is shown in a disabled dropdown.

4. Improved UI consistency by preventing empty whitespace.

## How to test

1. Navigate to **Jobs > Schedule Agents** in the Fossology UI.

2. Observe the "**Select additional analysis**" section:

    -  If analysis options are available, they should be displayed but disabled.

    - If no options are available, a disabled dropdown with a message should be visible. 

3. Verify that the UI does not show blank space when additional analysis is unavailable.

4. Check that functionality remains unchanged when analysis options are available.

# Issue
https://github.com/fossology/fossology/issues/2916
