### PR TITLE
fix(db): Migration Was failing due to Old views and Tables

### DIFF
--- a/src/lib/php/libschema.php
+++ b/src/lib/php/libschema.php
@@ -505,21 +505,21 @@ class fo_libschema
    */
   function dropViews($catalog)
   {
-    $sql = "SELECT view_name,table_name,column_name
-        FROM information_schema.view_column_usage
-        WHERE table_catalog='$catalog'
-        ORDER BY view_name,table_name,column_name";
+    $sql = "SELECT view_name,vcs.table_name,column_name
+            FROM information_schema.view_column_usage AS vcs
+            INNER JOIN information_schema.views AS v
+              ON vcs.view_name = v.table_name
+            WHERE vcs.table_catalog='$catalog'
+              AND v.table_schema = 'public'
+            ORDER BY view_name,vcs.table_name,column_name;";
     $stmt = __METHOD__;
     $this->dbman->prepare($stmt, $sql);
     $result = $this->dbman->execute($stmt);
     while ($row = $this->dbman->fetchArray($result)) {
       $View = $row['view_name'];
       $table = $row['table_name'];
-      if (empty($this->schema['TABLE'][$table])) {
-        continue;
-      }
       $column = $row['column_name'];
-      if (empty($this->schema['TABLE'][$table][$column])) {
+      if (empty($this->schema['TABLE'][$table]) || empty($this->schema['TABLE'][$table][$column])) {
         $sql = "DROP VIEW \"$View\";";
         $this->applyOrEchoOnce($sql);
       }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Due to data persistence from older versions, There are few views and columns that are creating problems with the migrations. 

### Changes

1. Dropping Views Logic --> Drop view if either table or column doesnt exist
2. The SQL statement was giving all the views (System or User), which system views are not supposed to be deleted.

## How to test

1. Install old version of fossology (3.0.0)
3. Do some clearing and some operations
4. Install the latest release version(with the same Database as 3.0.0)

![image](https://github.com/user-attachments/assets/35596760-1046-49ed-bd3d-aced8ff78693)

Was successfully able to migrate.

CC: @GMishx @shaheemazmalmmd 


