### PR TITLE
fix(ui): show copyright if only scancode data is available

### DIFF
--- a/src/copyright/ui/HistogramBase.php
+++ b/src/copyright/ui/HistogramBase.php
@@ -45,6 +45,7 @@ abstract class HistogramBase extends FO_Plugin
     $this->renderer = $container->get('twig.environment');
 
     $this->vars['name']=$this->Name;
+    $this->additionalAgentName = "scancode";
   }
 
   /**
@@ -229,9 +230,11 @@ abstract class HistogramBase extends FO_Plugin
     /* advanced interface allowing user to select dataset (agent version) */
     $dataset = $this->agentName."_dataset";
     $arsCopyrighttable = $this->agentName."_ars";
+    $additionalArsCopyrighttable = $this->additionalAgentName."_ars";
     /* get proper agent_id */
 
     $agentId[] = LatestAgentpk($uploadId, $arsCopyrighttable);
+    $additionalAgentId[] = LatestAgentpk($uploadId, $additionalArsCopyrighttable);
     if ($this->agentName == "copyright") {
       $arsResotable = "reso_ars";
       // $agentId[] = LatestAgentpk($uploadId, $arsResotable);
@@ -240,7 +243,7 @@ abstract class HistogramBase extends FO_Plugin
       }
     }
 
-    if (empty($agentId) || $agentId[0] == 0) {
+    if ((empty($agentId) || $agentId[0] == 0) && (empty($additionalAgentId) || $additionalAgentId[0] == 0)) {
       /* schedule copyright */
       $OutBuf .= ActiveHTTPscript("Schedule");
       $OutBuf .= "<script language='javascript'>\n";


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Show copyright if only scancode data is available

### Changes

Allow copyright page to show copyright data even thought only scancode findings are present.

## How to test

- Upload a new component to fossology.
- Run only scancode copyright agent.
- Navigate to copyright result page of the component.
- Should show the scancode data.

CC: @shaheemazmalmmd @Kaushl2208 
