### PR TITLE
trim and sanitize file search

### DIFF
--- a/src/lib/php/BusinessRules/AgentLicenseEventProcessor.php
+++ b/src/lib/php/BusinessRules/AgentLicenseEventProcessor.php
@@ -18,7 +18,7 @@ use Fossology\Lib\Data\LicenseMatch;
 use Fossology\Lib\Data\LicenseRef;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
 use Fossology\Lib\Proxy\LatestScannerProxy;
-
+use Monolog\Logger;
 /**
  * @class AgentLicenseEventProcessor
  * @brief Handle events related to license findings
@@ -34,6 +34,9 @@ class AgentLicenseEventProcessor
   /** @var AgentDao $agentDao
    * Agent DAO object */
   private $agentDao;
+  /** @var Logger Logger instance */
+private $logger;
+
 
   /**
    * Constructor for the event processor
@@ -89,6 +92,10 @@ class AgentLicenseEventProcessor
       $licenseRef = $licenseMatch->getLicenseRef();
       $licenseId = $licenseRef->getId();
       if ($licenseRef->getShortName() === "No_license_found") {
+        $this->logger->warning("No license match found", [
+          'file' => $itemTreeBounds->getUploadId()
+      ]);
+      
         continue;
       }
       $agentRef = $licenseMatch->getAgentRef();

--- a/src/lib/php/BusinessRules/AgentLicenseEventProcessor.php
+++ b/src/lib/php/BusinessRules/AgentLicenseEventProcessor.php
@@ -18,7 +18,7 @@ use Fossology\Lib\Data\LicenseMatch;
 use Fossology\Lib\Data\LicenseRef;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
 use Fossology\Lib\Proxy\LatestScannerProxy;
-use Monolog\Logger;
+
 /**
  * @class AgentLicenseEventProcessor
  * @brief Handle events related to license findings
@@ -34,9 +34,6 @@ class AgentLicenseEventProcessor
   /** @var AgentDao $agentDao
    * Agent DAO object */
   private $agentDao;
-  /** @var Logger Logger instance */
-private $logger;
-
 
   /**
    * Constructor for the event processor
@@ -92,10 +89,6 @@ private $logger;
       $licenseRef = $licenseMatch->getLicenseRef();
       $licenseId = $licenseRef->getId();
       if ($licenseRef->getShortName() === "No_license_found") {
-        $this->logger->warning("No license match found", [
-          'file' => $itemTreeBounds->getUploadId()
-      ]);
-      
         continue;
       }
       $agentRef = $licenseMatch->getAgentRef();

--- a/src/lib/php/Dao/SearchHelperDao.php
+++ b/src/lib/php/Dao/SearchHelperDao.php
@@ -65,8 +65,12 @@ class SearchHelperDao
     }
 
     $SQLBase = "SELECT DISTINCT uploadtree_pk, parent, upload_fk, uploadtree.pfile_fk, ufile_mode, ufile_name FROM uploadtree";
-    $SQLWhere = " ";
+    $SQLWhere = " WHERE 1=1";
     $SQLOrderLimitOffset = "";
+    $Filename = trim($Filename);
+    $tag = trim($tag);
+    $License = trim($License);
+    $Copyright = trim($Copyright);
 
     if ($searchtype != "directory") {
       if (!empty($License)) {


### PR DESCRIPTION

the search inputs filename, license, copyright, etc. were used without proper sanitization, making them prone to SQL injection risks.


Applied trim to remove extra spaces in Filename, License, Copyright, and tag.