### PR TITLE
feat(multi-file report): Fix issue with report generation

### DIFF
--- a/src/clixml/agent/clixml.php
+++ b/src/clixml/agent/clixml.php
@@ -32,6 +32,11 @@ class CliXml extends Agent
   const AVAILABLE_OUTPUT_FORMATS = "xml";
   const UPLOAD_ADDS = "uploadsAdd";
 
+  /** @var array $additionalUploads
+   * Array of addtional uploads
+   */
+  private $additionalUploads = [];
+
   /** @var UploadDao */
   private $uploadDao;
 
@@ -79,6 +84,15 @@ class CliXml extends Agent
 
   function __construct()
   {
+    $args = getopt("", array(self::UPLOAD_ADDS.'::'));
+
+    if (array_key_exists(self::UPLOAD_ADDS, $args)) {
+      $uploadsString = $args[self::UPLOAD_ADDS];
+      if (!empty($uploadsString)) {
+          $this->additionalUploads = explode(',', $uploadsString);
+      }
+    }
+
     parent::__construct('clixml', AGENT_VERSION, AGENT_REV);
 
     $this->uploadDao = $this->container->get('dao.upload');
@@ -178,7 +192,12 @@ class CliXml extends Agent
 
   protected function getUri($fileBase)
   {
-    $fileName = $fileBase. strtoupper($this->outputFormat)."_".$this->packageName;
+    if (count($this->additionalUploads) > 0) {
+      $fileName = $fileBase . "multifile" . "_" . strtoupper($this->outputFormat);
+    } else {
+      $fileName = $fileBase. strtoupper($this->outputFormat)."_".$this->packageName;
+    }
+
     return $fileName .".xml";
   }
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This pull request fixes issues with generating bulk CLIXML and Cyclone DX reports for "whole folder" or "marked uploads" in the Browsing tab.

### Changes

In this pull request, changes were made in cyclonedx.php and clixml.php file.
- In both the files I used $addUploads array which was passed into these file using command line arguments to judge whether the report generated was for mutli uploads or single upload.
- I used two different naming conventions for multifile report generation and single file report generation.

## How to test

### Test Procedure 
- Log into your FOSSology instance.
- Upload at least two different files through the Upload tab.
- Wait for the uploads to complete processing.

#### Single File Report Testing
- Navigate to the Browse tab.
- Select only one file/upload.
- Generate both CLIXML and CycloneDX reports for this single selection.
- Verify that the downloaded report filename follow the format: OUTPUT-FORMAT_PACKAGE-NAME.extension
- Example: CYCLONEDX_JSON_Twig-3.19.0.tar.gz.json and CLIXML_Twig-3.19.0.tar.gz.xml

#### Multiple File Report Testing
- Navigate to the Browse Tab .
- Select at least two files/uploads using the checkboxes.
- Click on "marked uploads".
- Generate both CLIXML and CycloneDX reports for these multiple selections.
- Verify that the downloaded report filenames follow the format: multifile_OUPUT-FORMAT.extension.
- Example: multifile_CYCLONEDX_JSON.json and multifile_CLIXML.xml

Fixes: [issue#2844](https://github.com/fossology/fossology/issues/2844)
