### PR TITLE
add "parent folder"  at move content page

### DIFF
--- a/src/www/ui/css/custom.css
+++ b/src/www/ui/css/custom.css
@@ -1,0 +1,9 @@
+label, select {
+    display: block;
+    width: 100%;
+  }
+  
+  #foldercontent {
+    min-height: 150px;
+  }
+  

--- a/src/www/ui/css/custom.css
+++ b/src/www/ui/css/custom.css
@@ -1,9 +1,6 @@
-label, select {
+#folderselectText, #foldercontent {
     display: block;
     width: 100%;
-  }
-  
-  #foldercontent {
-    min-height: 150px;
+    min-width: 100%;
   }
   

--- a/src/www/ui/template/admin_content_move.html.twig
+++ b/src/www/ui/template/admin_content_move.html.twig
@@ -7,11 +7,11 @@
   {{ parent() }}
   <link rel="stylesheet" href="css/jquery.treeview.css"/>
   <link rel="stylesheet" href="css/select2.min.css"/>
-  <link rel="stylesheet" href="css/custom.css"/> 
+  <link rel="stylesheet" href="css/custom.css">
 {% endblock %}
 
 {% block content %}
-{{ 'Select a folder on the left hand side to move or copy content to a different folder hi'|trans }}
+{{ 'Select a folder on the left hand side to move or copy content to a different folder'|trans }}
 <table>
   <tr style="vertical-align:top;">
     <td id="sidetree">
@@ -22,17 +22,9 @@
       <form name="formy" method="post">
         <input type="hidden" name="fromFolder" id="fromFolder" value="-1"/>
 
-        <label id="folderselectText" for="foldercontent">{{ 'Select or folders you wish to move'|trans }}:<br/>
-        <select name="foldercontent[]" id="foldercontent" multiple="multiple" size="20">
-          {% if folderContent is not empty %}
-        {% for file in folderContent %}
-      <option value="{{ file.id }}">{{ file.name }}</option>
-    {% endfor %}
-  {% else %}
-    <option disabled>{{ 'No files to move'|trans }}</option>
-  {% endif %}
-</select>
-
+        <label for="foldercontent">{{ 'Select uploads or folders you wish to move'|trans }}:<br/>
+          <select name="foldercontent[]" id="foldercontent" multiple="multiple" size="20">
+          </select>
         </label>
         <br/>
         <br/>

--- a/src/www/ui/template/admin_content_move.html.twig
+++ b/src/www/ui/template/admin_content_move.html.twig
@@ -7,10 +7,11 @@
   {{ parent() }}
   <link rel="stylesheet" href="css/jquery.treeview.css"/>
   <link rel="stylesheet" href="css/select2.min.css"/>
+  <link rel="stylesheet" href="css/custom.css"/> 
 {% endblock %}
 
 {% block content %}
-{{ 'Select a folder on the left hand side to move or copy content to a different folder'|trans }}
+{{ 'Select a folder on the left hand side to move or copy content to a different folder hi'|trans }}
 <table>
   <tr style="vertical-align:top;">
     <td id="sidetree">
@@ -21,9 +22,17 @@
       <form name="formy" method="post">
         <input type="hidden" name="fromFolder" id="fromFolder" value="-1"/>
 
-        <label for="foldercontent">{{ 'Select uploads or folders you wish to move'|trans }}:<br/>
-          <select name="foldercontent[]" id="foldercontent" multiple="multiple" size="20">
-          </select>
+        <label id="folderselectText" for="foldercontent">{{ 'Select or folders you wish to move'|trans }}:<br/>
+        <select name="foldercontent[]" id="foldercontent" multiple="multiple" size="20">
+          {% if folderContent is not empty %}
+        {% for file in folderContent %}
+      <option value="{{ file.id }}">{{ file.name }}</option>
+    {% endfor %}
+  {% else %}
+    <option disabled>{{ 'No files to move'|trans }}</option>
+  {% endif %}
+</select>
+
         </label>
         <br/>
         <br/>

--- a/src/www/ui/template/admin_content_move.js.twig
+++ b/src/www/ui/template/admin_content_move.js.twig
@@ -14,22 +14,36 @@ $("#tree").treeview({
 $(document).ready(function() {
   $('.clickable-folder').click(function(event){
     folder = $(this).attr('data-folder');
+    var folderName = $(this).text().trim();
     $('#fromFolder').val(folder);
+
+    var folderchild = $('#foldercontent');
+    folderchild.empty(); // Clear previous options
+
+    // Add the selected folder as the first option
+
+    var selectedOption = document.createElement("option");
+    selectedOption.innerHTML = folderName;
+    selectedOption.disabled = true; 
+    folderchild.append(selectedOption); // Append selected folder first
+
+    // Get child folders and append to dropdown
+
     $.getJSON("?mod=foldercontents&folder=" + folder{% if removable is defined %} + "&removable=1"{% endif %})
-        .done(function (data) {
-          var folderchild = $('#foldercontent');
-          folderchild.empty();
-          $.each(data, function (key, value) {
-            var option = document.createElement("option");
-            option.innerHTML = value;
-            option.value = key;
-            folderchild.append(option);
-          });
-          sortList('#foldercontent option');
-        })
-        .fail(failed);
+      .done(function (data) {
+        $.each(data, function (key, value) {
+          var option = document.createElement("option");
+          option.innerHTML = '&nbsp;&nbsp;' + value; // Add spce to separate parent and childs
+          option.value = key;
+          folderchild.append(option); 
+        });
+         sortList('#foldercontent option'); 
+      })
+      .fail(failed);
+
     return false;
   });
+
   $('#foldercontent').click(function(event){
     if (this.value == -1) {
       $('#movebutton').attr('disabled',true);
@@ -41,4 +55,3 @@ $(document).ready(function() {
 
   $('.clickable-folder').first().trigger('click');
 });
-


### PR DESCRIPTION
<<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Added the root folder at the top of the selection list instead of displaying "Nothing to move." This change allows users to easily identify the root folder and move its contents.

### Changes

- Added the root folder as the first option in the folder selection dropdown.
- Ensured the root folder is selectable for moving content.
- Improved usability by preventing confusion when no folder was previously displayed.

![Screenshot from 2025-03-04 03-16-28](https://github.com/user-attachments/assets/d1d0d38e-3801-4f0a-a2c1-8516214c6dcf)

## How to test

1. Navigate to the move and copy selection .
2. Click on any folder to display its contents.
3. Verify that the selected folder appears at the top of the list and then it's childs.
4. Ensure that selecting and moving the parent folder works as expected.

This PR fixes #2963  


Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)
