### PR TITLE
Fix tag input alignment and spacing 

### DIFF
--- a/src/www/ui/admin-tag.php
+++ b/src/www/ui/admin-tag.php
@@ -108,21 +108,38 @@ class admin_tag extends FO_Plugin
    */
   function ShowCreateTagPage()
   {
-    $VC = _("<h3>Create Tag:</h3>\n");
-    $VC.= "<form name='form' method='POST' action='" . Traceback_uri() ."?mod=admin_tag'>\n";
-    $VC .= "<p>";
-    $text = _("Tag");
-    $VC .= "$text: <input type='text' id='tag_name' name='tag_name' maxlength='32' utocomplete='off'/> ";
-    $VC .= "</p>";
-    $text = _("Tag description:");
-    $VC .= "<p>$text <input type='text' name='tag_desc'/></p>";
-    $text = _("Create");
-    $VC .= "<input type='hidden' name='action' value='add'/>\n";
-    $VC .= "<input type='submit' value='$text'>\n";
-    $VC .= "</form>\n";
-    return $VC;
+      $VC = _("<h3>Create Tag:</h3>\n");
+      $VC .= "<form name='form' method='POST' action='" . Traceback_uri() . "?mod=admin_tag' >\n";
+  
+      $VC .= "<div style='width: 100%; max-width: 500px; margin-top: 20px;'>";
+  
+      // Tag name input
+      $VC .= "<div style='margin-bottom: 20px;'>";
+      $VC .= "<label for='tag_name' style='display: block; font-weight: bold;'>" . _("1. Enter the new tag name:") . "</label>";
+      $VC .= "<input type='text' id='tag_name' name='tag_name' maxlength='32' autocomplete='off' 
+                  style='width: calc(50% - 25px); margin-left: 20px; padding: 8px; border: 1px solid #ccc; border-radius: 4px;' />";
+      $VC .= "</div>";
+  
+      // Tag description input
+      $VC .= "<div style='margin-bottom: 20px;'>";
+      $VC .= "<label for='tag_desc' style='display: block; font-weight: bold;'>" . _("2. Enter a meaningful description:") . "</label>";
+      $VC .= "<input type='text' id='tag_desc' name='tag_desc' 
+                  style='width: calc(100% - 20px); margin-left: 20px; padding: 8px; border: 1px solid #ccc; border-radius: 4px;' />";
+      $VC .= "</div>";
+  
+      // Submit button
+      $text = _("Create");
+      $VC .= "<input type='hidden' name='action' value='add'/>\n";
+      $VC .= "<input type='submit' value='$text' 
+                  style='margin-top: 10px; padding: 8px 16px;border-radius: 4px; cursor: pointer;' />\n";
+  
+      $VC .= "</div>";
+      $VC .= "</form>\n";
+  
+      return $VC;
   }
-
+  
+  
 
   public function Output()
   {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fixed the UI alignment issue on the **Create Tag** page. Adjusted input field spacing and positioning to ensure proper alignment.

![Screenshot from 2025-03-04 16-13-46](https://github.com/user-attachments/assets/bf67235b-fadb-4d25-ac16-9cadae982dec)


### Changes

- **Aligned input fields**: Tag name and description fields are now properly spaced and positioned.
- **Adjusted margin and padding**: Added left margin to the form and spacing between text labels and input fields.
- **Resized tag input field**: The tag input field is now **half of the available width** to improve readability.
![Screenshot from 2025-03-04 17-32-48](https://github.com/user-attachments/assets/8968e6b8-5ce5-4a9b-b968-5f68c8612aa7)

## How to test

1. Go to the **Create Tag** page.
2. Check if:
   - The text labels and input fields are aligned properly.
   - The tag input field is resized correctly.
3. Ensure no unintended style changes.

Closes #2980 
