### PR TITLE
fix(browse): Resolve comment truncation inconsistency in DataTables

### DIFF
--- a/src/www/ui/template/ui-browse.js.twig
+++ b/src/www/ui/template/ui-browse.js.twig
@@ -6,11 +6,45 @@ tableColumns = [
   {"sTitle": "{{ "Upload Name and Description"|trans }}", "sClass": "left"},
   {"sTitle": "{{ "Action"|trans }}", "sClass": "center", "bSortable": false, "bSearchable": false},
   {"sTitle": "{{ "Status"|trans }}", "sClass": "center", "bSortable": false, "bSearchable": false},
-  {"sTitle": "{{ "Comment"|trans }}", "sClass": "center cc", "bSortable": false, "bSearchable": false, "mRender": 2},
+  {"sTitle": "{{ "Comment"|trans }}", "sClass": "center cc", "bSortable": false, "bSearchable": false, "mRender": function(data) {
+    if (data && data.length > 40) {
+      return '<span class="comment-tooltip" title="' + data.replace(/"/g, '&quot;') + '">' + 
+             data.substring(0, 40) + '...</span>';
+    }
+    return data || '';
+  }},
   {"sTitle": "{{ "Main licenses"|trans }}", "sClass": "center", "bSearchable": false, "bSortable": false},
   {"sTitle": "{{ "Upload Date"|trans }}", "sClass": "center", "sType": "string", "bSearchable": false},
   {"sTitle": "{{ "Assigned to"|trans }}", "sClass": "center", "bSearchable": false}
 ];
+
+function truncateComments() {
+  $('#browsetbl tbody tr').each(function() {
+    var commentCell = $(this).find('td:nth-child(4)');
+    var originalText = commentCell.text();
+    
+    var commentText = originalText;
+    var idPrefixMatch = originalText.match(/^\d+,\d+,\s*/);
+    
+    if (idPrefixMatch) {
+      commentText = originalText.substring(idPrefixMatch[0].length);
+    }
+
+    if (commentText && commentText !== '') {
+      if (commentText.length > 40) {
+        commentCell.html('<span data-toggle="tooltip" data-placement="top" title="' + 
+          commentText.replace(/"/g, '&quot;') + '">' + 
+          commentText.substring(0, 40) + '...</span>');
+      } else {
+        commentCell.text(commentText);
+      }
+    } else {
+      commentCell.text('');
+    }
+  });
+
+  $('[data-toggle="tooltip"]').tooltip();
+}
 
 tableSorting = [
   [5, "desc"],
@@ -38,11 +72,15 @@ dataTableConfig =
       "iDisplayLength": 50,
       "bProcessing": true,
       "bStateSave": true,
-      "bRetrieve": true
+      "bRetrieve": true,
+      "fnDrawCallback": function() {
+        truncateComments();
+      }
     };
 
 function createBrowseTable() {
   var otable = $('#browsetbl').DataTable(dataTableConfig);
+  truncateComments();
   return otable;
 }
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fixes comment rendering issue in the upload browse table
- Improves comment truncation logic in DataTables
- Ensures consistent comment display across table updates
- Allows user to see truncated comments with hovering of the comment cell in a title box.

### Changes

Modified ui-browse.js.twig in order properly truncate comments in the browse table in the browse tab.

## Screen Recording

[Screencast from 05-03-25 05:51:23 PM IST.webm](https://github.com/user-attachments/assets/82047dc3-5538-4747-a53f-f321409bec09)

## How to test

- Login to your FOSSology instance
- upload a file using the upload tab
- navigate to browse section using the navigation bar
- first try adding a comment which is less than 40 characters long, The comment should be completely visible.
- Then try adding a comment which is more than 40 characters long, the comment should be truncated after 40 characters with "..." at the end. 

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
Fixes: [issue#2984](https://github.com/fossology/fossology/issues/2984)