### PR TITLE
Removed unnecessary log

### DIFF
--- a/src/reuser/agent/ReuserAgent.php
+++ b/src/reuser/agent/ReuserAgent.php
@@ -130,7 +130,7 @@ class ReuserAgent extends Agent
   protected function reuseConfSettings($uploadId, $reusedUploadId)
   {
     if (!$this->uploadDao->insertReportConfReuse($uploadId, $reusedUploadId)) {
-      echo "INFO :: Report configuration for select upload doesn't exists. Unable to copy!!!";
+      
     }
     $this->heartbeat(1);
     return true;


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

Fixes #2027 

removed redundant log outputs in the re-use agent
echo statement resulted in excessive logs
