### PR TITLE
fix(Convert2BrowserTime): improve error handling and validation

### DIFF
--- a/src/lib/php/common-ui.php
+++ b/src/lib/php/common-ui.php
@@ -309,13 +309,35 @@ function Get1stUploadtreeID($upload)
  * \brief Convert the server time to browser time
  * \param time $server_time to be converted
  */
-function Convert2BrowserTime($server_time)
-{
-  $server_timezone = date_default_timezone_get();
-  $browser_time = new \DateTime($server_time, new \DateTimeZone($server_timezone));
-  if (array_key_exists("timezone", $_SESSION)) {
-    $tz = $_SESSION["timezone"];
-    $browser_time->setTimeZone(new \DateTimeZone($tz));
-  }
-  return $browser_time->format('Y-m-d H:i:s');
+function Convert2BrowserTime($server_time) {
+    try {
+        if (empty($server_time)) {
+            throw new \InvalidArgumentException('Server time cannot be empty');
+        }
+        $server_timezone = date_default_timezone_get();
+
+        try {
+            $browser_time = new \DateTime($server_time, new \DateTimeZone($server_timezone));
+        } catch (\Exception $e) {
+            error_log("Invalid server time format: $server_time");
+            return false;
+        }
+
+        if (session_status() === PHP_SESSION_ACTIVE && 
+            isset($_SESSION["timezone"])) {
+            $tz = $_SESSION["timezone"];
+
+            if (in_array($tz, timezone_identifiers_list())) {
+                $browser_time->setTimeZone(new \DateTimeZone($tz));
+            } else {
+                error_log("Invalid timezone in session: $tz. Falling back to server timezone.");
+                $browser_time->setTimeZone(new \DateTimeZone($server_timezone));
+            }
+        }
+
+        return $browser_time->format('Y-m-d H:i:s');
+    } catch (\Exception $e) {
+        error_log("Error in Convert2BrowserTime: " . $e->getMessage());
+        return false;
+    }
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
This pull request fixes issue #2988, which caused a 500 error when fetching uploaded files on the browse page. The issue was due to the Convert2BrowserTime function lacking proper validation and error handling.

## Changes

- Added validation for $server_time to prevent crashes when an empty or invalid value is passed.
- Ensured session status is checked before accessing $_SESSION["timezone"] to avoid undefined index errors.
- Verified the timezone against timezone_identifiers_list() to prevent exceptions from invalid timezones.
- Added error logging to improve debugging.

## How to test

- Ensure the application is running and accessible.
- Upload a file and navigate to the browse page.
- Verify that the uploaded files are displayed without triggering a 500 error.

