### PR TITLE
 improve comment and discription truncation with tooltip

### DIFF
--- a/src/www/ui/template/ui-browse.js.twig
+++ b/src/www/ui/template/ui-browse.js.twig
@@ -1,5 +1,4 @@
 {# SPDX-FileCopyrightText: © 2014-2018 Siemens AG
-
    SPDX-License-Identifier: FSFAP
 #}
 tableColumns = [
@@ -21,28 +20,82 @@ tableSorting = [
 var folder = {{ folder }};
 var browseTable;
 
-dataTableConfig =
-    {
-      "bServerSide": true,
-      "sAjaxSource": "?mod=browse-processPost",
-      "fnServerData": function (sSource, aoData, fnCallback) {
-          aoData.push({"name": "folder", "value": folder});
-          aoData.push({"name": "show", "value": "{{ show }}"});
-        aoData.push({"name": "assigneeSelected", "value": assigneeSelected});
-        aoData.push({"name": "statusSelected", "value": statusSelected});
-        $.getJSON(sSource, aoData, fnCallback).fail(failed);
-      },
-      "sPaginationType": "listbox",
-      "aoColumns": tableColumns,
-      "aaSorting": tableSorting,
-      "iDisplayLength": 50,
-      "bProcessing": true,
-      "bStateSave": true,
-      "bRetrieve": true
-    };
+// Function to truncate comments and apply tooltip styling
+function truncateComments() {
+  $('#browsetbl tbody tr').each(function() {
+    var commentCell = $(this).find('td:nth-child(4)'); // Adjust as needed
+    var descriptionCell = $(this).find('td:nth-child(1)');
+
+    // Truncate Comment Column (4th column)
+    var originalText = commentCell.text().trim();
+
+    if (originalText) {
+      var parts = originalText.split(',');
+      var commentText = parts[parts.length - 1].trim();
+
+      if (commentText.length > 40) {
+        commentCell.html('<span class="comment-tooltip" title="' +
+          commentText.replace(/"/g, '&quot;') + '">' +
+          commentText.substring(0, 40) + '...</span>');
+      } else {
+        commentCell.text(commentText);
+      }
+    } else {
+      commentCell.text('');
+    }
+
+    // Truncate <i> Tag inside First Column (1st column)
+    var iconTag = descriptionCell.find('i');
+    if (iconTag.length) {
+      var iconText = iconTag.text().trim();
+      if (iconText.length > 30) {
+        iconTag.html('<span class="comment-tooltip" title="' +
+          iconText.replace(/"/g, '&quot;') + '">' +
+          iconText.substring(0, 30) + '...</span>');
+      }
+    }
+  });
+
+  // Add tooltip styling
+  $('<style>')
+    .prop('type', 'text/css')
+    .html(`
+      .comment-tooltip {
+        cursor: help;
+        text-decoration: underline dotted;
+      }
+    `)
+    .appendTo('head');
+}
+
+
+// DataTable configuration
+var dataTableConfig = {
+  "bServerSide": true,
+  "sAjaxSource": "?mod=browse-processPost",
+  "fnServerData": function (sSource, aoData, fnCallback) {
+    // Append additional parameters to the AJAX request
+    aoData.push({"name": "folder", "value": folder});
+    aoData.push({"name": "show", "value": "{{ show }}"});
+    aoData.push({"name": "assigneeSelected", "value": assigneeSelected});
+    aoData.push({"name": "statusSelected", "value": statusSelected});
+    $.getJSON(sSource, aoData, fnCallback).fail(failed);
+  },
+  "sPaginationType": "listbox",
+  "aoColumns": tableColumns,
+  "aaSorting": tableSorting,
+  "iDisplayLength": 50,
+  "bProcessing": true,
+  "bStateSave": true,
+  "bRetrieve": true,
+  "fnDrawCallback": function() {
+    truncateComments(); // Call the truncation function after drawing the table
+  }
+};
 
 function createBrowseTable() {
   var otable = $('#browsetbl').DataTable(dataTableConfig);
+  truncateComments(); // Initial truncation after table creation
   return otable;
 }
 


### PR DESCRIPTION
Fixes : #2984 
## Description

Before implementing the `truncateComments` function, long text in the **comments section** caused UI issues. When users added lengthy descriptions, they overflowed the table layout, making it difficult to read and disrupting the design. This issue significantly affected usability and readability.



## Changes

To fix this issue, I implemented a **truncate function** that:
- Shortens the comment text to **40 characters**, followed by `"..."`.
-  Shortens the description  text to **30 characters**, followed by `"..."`.
- Displays the **full comment** as a tooltip when hovered.
- Ensures that if the comment is already short, it remains unchanged.
- 

## How to Test

1. Run the application and navigate to the table view.
2. Add a long comment (more than 40 characters) and check if it truncates.
3. Hover over the truncated text and ensure the full comment appears as a tooltip.
4. Verify that short comments remain unchanged.
5. Check that **i tags** in the description column are also truncated correctly.
6. Confirm that the table layout remains clean and readable.


### Expected Outcome
- No more layout-breaking due to long text.
- Users can still access full comments via tooltips.
- Improved UI consistency.



![Screenshot from 2025-03-10 14-04-09](https://github.com/user-attachments/assets/716556fb-4038-4cbe-9c8c-e3b89b2b357e)
![Screenshot from 2025-03-10 14-03-59](https://github.com/user-attachments/assets/39966381-61d4-44c2-b7ed-8f5bdb103bd2)
![Screenshot from 2025-03-10 14-03-48](https://github.com/user-attachments/assets/f1ae71e9-7acb-42d3-960a-0ceb69fe12b2)


Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)
