### PR TITLE
fix(docker): add missing dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
       python3-psycopg2 \
       python3-requests \
       python3-pip \
+      libyaml-cpp0.7 \
  && DEBIAN_FRONTEND=noninteractive /fossology/utils/fo-installdeps --offline --runtime -y \
  && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add missing `libyaml-cpp` dependency in `Dockerfile`

## How to test

- Build and Run the Docker Image (Master Branch)
- Upload a Component and Run the Compatibility Agent. The agent should fail.
- Switch to the Feature Branch.
- Rebuild and Run the Updated Docker Image.
- Upload a Component and Run the Compatibility Agent. The agent should pass.

### Closes #2986 

CC: @shaheemazmalmmd @Kaushl2208 

