### PR TITLE
Fix(phpfatalerror): fixed uncaught error to member function getRisk()

### DIFF
--- a/src/lib/php/Report/LicenseMainGetter.php
+++ b/src/lib/php/Report/LicenseMainGetter.php
@@ -39,13 +39,17 @@ class LicenseMainGetter extends ClearedGetterCommon
     $allStatements = array();
     foreach ($mainLicIds as $originLicenseId) {
       $allLicenseCols = $this->licenseDao->getLicenseById($originLicenseId, $groupId);
+      // Null-check: if the license is missing, log and skip this ID.
+      if ($allLicenseCols === null) {
+        error_log("Warning: License ID " . $originLicenseId . " not found in the database.");
+        continue;
+      }
       $allStatements[] = array(
         'licenseId' => $originLicenseId,
         'risk' => $allLicenseCols->getRisk(),
         'content' => $licenseMap->getProjectedSpdxId($originLicenseId),
         'text' => $allLicenseCols->getText(),
-        'name' => $licenseMap->getProjectedShortname($originLicenseId,
-            $allLicenseCols->getShortName())
+        'name' => $licenseMap->getProjectedShortname($originLicenseId, $allLicenseCols->getShortName())
       );
     }
     return $allStatements;

--- a/src/spdx/agent/spdx.php
+++ b/src/spdx/agent/spdx.php
@@ -225,13 +225,20 @@ class SpdxAgent extends Agent
     $this->licenseMap = new LicenseMap($this->dbManager, $this->groupId, LicenseMap::REPORT, true);
     $this->computeUri($uploadId);
 
+  
     $docLicense = $this->licenseDao->getLicenseByShortName(self::DATA_LICENSE);
+    if ($docLicense === null) {
+      error_log("Warning: License with short name " . self::DATA_LICENSE . " not found in the database. Using fallback license.");
+   
+      $docLicense = new License(0, self::DATA_LICENSE, "Fallback License", "Unknown", "No license text available", "", "", "");
+    }
     $docLicenseId = $docLicense->getId() . "-" . md5($docLicense->getText());
     $this->licensesInDocument[$docLicenseId] = (new SpdxLicenseInfo())
       ->setLicenseObj($docLicense)
       ->setListedLicense(true)
       ->setCustomText(false)
       ->setTextPrinted(true);
+    
 
     $packageNodes = $this->renderPackage($uploadId);
     $additionalUploadIds = array_key_exists(self::UPLOAD_ADDS,$args) ? explode(',',$args[self::UPLOAD_ADDS]) : array();
@@ -531,7 +538,7 @@ class SpdxAgent extends Agent
     foreach ($filesWithLicenses as $fileId => $fileNode) {
       $filesProceeded += 1;
       if (($filesProceeded&2047)==0) {
-        $this->heartbeat(0);
+        $this->heartbeat($filesProceeded - 0);
       }
       $fullPath = $treeDao->getFullPath($fileId, $treeTableName, 0);
       if (! empty($fileNode->getConcludedLicenses())) {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

This PR fixes the issue #2833 

## Description

To implement this issue I have added graceful fallback and null-checks
 - Adding Null Checks - Before invoking any method on a license object, the code now checks whether the object is null. If it is, the code either skips processing that record or logs a warning.
 - For critical cases if the license is not found, the code creates a fallback license object with default values.

This ensures that subsequent methods liked getId() or getText() can be made safely on the fallback object and the report generation continues without a fatal error.

## Changes

 - Null-Check in LicenseMainGetter.php:
Added a check for null after retrieving the license object. If it’s missing, the code logs a warning and skips processing that license instead of calling methods on a null object.

 - Fallback License in spdx.php:
Added a null-check , If it isn’t found, a fallback License object is created with default values so that subsequent method calls (like getId() and getText()) succeed.

## Testing

- Simulate a Missing License:
- Run a Test Upload:
- Monitor the Logs:
- Check your Fossology logs (e.g., with `tail -f /var/log/fossology/fossology.log`) for a warning message 
- Review the Generated Report:
