### PR TITLE
Fix(pkgagenterror): pkgagent printing html encoded characters

### DIFF
--- a/src/www/ui/template/ui-view-info.html.twig
+++ b/src/www/ui/template/ui-view-info.html.twig
@@ -228,9 +228,9 @@
     </table>
   {% endif %}
 {% endblock %}
-{% block javascripts %}
+{% block foot %}
   {{ parent() }}
-  <script>
+  <script type="text/javascript">
     document.addEventListener('DOMContentLoaded', function() {
       document.querySelectorAll('.pkg-value').forEach(el => {
         const encoded = el.getAttribute('data-encoded');

--- a/src/www/ui/template/ui-view-info.html.twig
+++ b/src/www/ui/template/ui-view-info.html.twig
@@ -58,14 +58,14 @@
           <tr>
             <td align="right">{{ entry.count|e }}</td>
             <td>{{ entry.type|e }}</td>
-            <td>{{ entry.value|e }}</td>
+            <td class="pkg-value" data-encoded="{{ entry.value|e }}"></td>
           </tr>
         {% endfor %}
         {% for require in packageRequires %}
           <tr>
             <td align="right">{{ require.count|e }}</td>
             <td>{{ require.type|e }}</td>
-            <td><a href="{{ require.value|e }}">{{ require.value|e }}</a></td>
+            <td><a href="{{ require.value|e }}" class="pkg-value" data-encoded="{{ require.value|e }}"></a></td>
           </tr>
         {% endfor %}
       </table>
@@ -227,4 +227,17 @@
       </tr>
     </table>
   {% endif %}
+{% endblock %}
+{% block javascripts %}
+  {{ parent() }}
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      document.querySelectorAll('.pkg-value').forEach(el => {
+        const encoded = el.getAttribute('data-encoded');
+        const txt = document.createElement('textarea');
+        txt.innerHTML = encoded;
+        el.textContent = txt.value;
+      });
+    });
+  </script>
 {% endblock %}

--- a/src/www/ui/ui-view-info.php
+++ b/src/www/ui/ui-view-info.php
@@ -432,7 +432,6 @@ class ui_view_info extends FO_Plugin
           $Count++;
           $vars['packageEntries'][] = $entry;
         }
-        pg_free_result($result);
 
         $sql = "SELECT * FROM pkg_deb_req WHERE pkg_fk = $1;";
         $this->dbManager->prepare(__METHOD__ . "getPkg_rpm_req", $sql);
@@ -469,7 +468,6 @@ class ui_view_info extends FO_Plugin
           $Count++;
           $vars['packageEntries'][] = $entry;
         }
-        pg_free_result($result);
 
         $sql = "SELECT * FROM pkg_deb_req WHERE pkg_fk = $1;";
         $this->dbManager->prepare(__METHOD__ . "getPkg_rpm_req", $sql);

--- a/src/www/ui/ui-view-info.php
+++ b/src/www/ui/ui-view-info.php
@@ -26,7 +26,6 @@ class ui_view_info extends FO_Plugin
    * User DAO to use
    */
   private $userDao;
-
   function __construct()
   {
     $this->Name    = "view_info";
@@ -394,7 +393,7 @@ class ui_view_info extends FO_Plugin
           $entry = [];
           $entry['count'] = $Count;
           $entry['type'] = _($key);
-          $entry['value'] = htmlentities($R["$value"]);
+          $entry['value'] = htmlspecialchars($R["$value"], ENT_QUOTES|ENT_HTML5, 'UTF-8');
           $Count++;
           $vars['packageEntries'][] = $entry;
         }
@@ -407,7 +406,7 @@ class ui_view_info extends FO_Plugin
           $entry = [];
           $entry['count'] = $Count;
           $entry['type'] = _("Requires");
-          $entry['value'] = htmlentities($R['req_value']);
+          $entry['value'] = htmlspecialchars($R["$value"], ENT_QUOTES|ENT_HTML5, 'UTF-8');
           $Count++;
           $vars['packageRequires'][] = $entry;
         }
@@ -429,7 +428,7 @@ class ui_view_info extends FO_Plugin
           $entry = [];
           $entry['count'] = $Count;
           $entry['type'] = _($key);
-          $entry['value'] = htmlentities($R["$value"]);
+          $entry['value'] = htmlspecialchars($R["$value"], ENT_QUOTES|ENT_HTML5, 'UTF-8');
           $Count++;
           $vars['packageEntries'][] = $entry;
         }
@@ -443,7 +442,7 @@ class ui_view_info extends FO_Plugin
           $entry = [];
           $entry['count'] = $Count;
           $entry['type'] = _("Depends");
-          $entry['value'] = htmlentities($R['req_value']);
+          $entry['value'] = htmlspecialchars($R["$value"], ENT_QUOTES|ENT_HTML5, 'UTF-8');
           $Count++;
           $vars['packageRequires'][] = $entry;
         }
@@ -466,7 +465,7 @@ class ui_view_info extends FO_Plugin
           $entry = [];
           $entry['count'] = $Count;
           $entry['type'] = _($key);
-          $entry['value'] = htmlentities($R["$value"]);
+          $entry['value'] = htmlspecialchars($R["$value"], ENT_QUOTES|ENT_HTML5, 'UTF-8');
           $Count++;
           $vars['packageEntries'][] = $entry;
         }
@@ -480,7 +479,7 @@ class ui_view_info extends FO_Plugin
           $entry = [];
           $entry['count'] = $Count;
           $entry['type'] = _("Build-Depends");
-          $entry['value'] = htmlentities($R['req_value']);
+          $entry['value'] = htmlspecialchars($R["$value"], ENT_QUOTES|ENT_HTML5, 'UTF-8');
           $Count++;
           $vars['packageRequires'][] = $entry;
         }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

This PR fixes the issue #1704 

## Description
This PR addresses the issue where package metadata, particularly in Debian source packages, is being displayed with double-encoded HTML entities. For example, angle brackets were showing as `&amp;lt;` and `&amp;gt;` instead of their proper representation.

### Changes
- Removed all `htmlentities()` calls in the `ShowPackageInfo()` function
- this prevents double-encoding of metadata that's already encoded when stored or retrieved from the database
- Affects display of RPM, Debian binary, and Debian source package metadata

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)
