### PR TITLE
fix(docker): Runtime dependency not found for compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: © mishra.gaurav@siemens.com
 # SPDX-FileCopyrightText: © 2016-2017 TNG Technology Consulting GmbH
 # SPDX-FileCopyrightText: © maximilian.huber@tngtech.com
+# SPDX-FileCopyrightText: © kaushlendra-pratap.singh@siemens.com
 #
 # SPDX-License-Identifier: FSFAP
 #
@@ -47,8 +48,8 @@ RUN mkdir -p /fossology/dependencies-for-runtime \
  && cp -R /fossology/src /fossology/utils /fossology/dependencies-for-runtime/
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
- && DEBIAN_FRONTEND=noninteractive /fossology/utils/fo-installdeps --build -y \
- && DEBIAN_FRONTEND=noninteractive /fossology/install/fo-install-pythondeps --build -y \
+ && DEBIAN_FRONTEND=noninteractive /fossology/utils/fo-installdeps --buildtime -y \
+ && DEBIAN_FRONTEND=noninteractive /fossology/install/fo-install-pythondeps --buildtime -y \
  && rm -rf /var/lib/apt/lists/*
 
 COPY . .
@@ -88,7 +89,6 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
       python3-psycopg2 \
       python3-requests \
       python3-pip \
-      libyaml-cpp0.7 \
  && DEBIAN_FRONTEND=noninteractive /fossology/utils/fo-installdeps --offline --runtime -y \
  && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y
 

--- a/src/compatibility/mod_deps
+++ b/src/compatibility/mod_deps
@@ -95,9 +95,9 @@ if [[ $RUNTIME ]]; then
         bullseye)
           apt-get $YesOpt install libjsoncpp24 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0 libyaml-cpp0.6;;
         bookworm)
-          apt-get $YesOpt install libjsoncpp24 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0 libyaml-cpp0.7;;
+          apt-get $YesOpt install libjsoncpp25 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0 libyaml-cpp0.7;;
         sid)
-          apt-get $YesOpt install libjsoncpp24 libboost-filesystem1.83.0 libboost-program-options1.83.0 libboost-regex1.83.0 libyaml-cpp0.8;;
+          apt-get $YesOpt install libjsoncpp26 libboost-filesystem1.83.0 libboost-program-options1.83.0 libboost-regex1.83.0 libyaml-cpp0.8;;
         focal)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.71.0 libboost-program-options1.71.0 libboost-regex1.71.0 libyaml-cpp0.6;;
         jammy)


### PR DESCRIPTION


<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
`libjsoncpp24` is the package that was not supported in `debian-bookworm`. Fix the correct name of the package in different debian codenames.

### Changes

1. Fix correct version of a dependency in `debian-bookworm`
2. Fix flag `--build` should be `--buildtime`
3. Remove the explicit installation of the runtime dependency `libyaml-cpp0.7`

## How to test

- Build and Run the Docker Image (Master Branch).
- Upload a Component and Run the Compatibility Agent. The agent should fail.
- Switch to the Feature Branch.
- Rebuild and Run the Updated Docker Image.
- Upload a Component and Run the Compatibility Agent. The agent should pass.

cc @shaheemazmalmmd @its-sushant @GMishx 

CLOSES: #2986 
