### PR TITLE
feat(import): Import Obligations From LicenseDB

### DIFF
--- a/src/lib/php/Application/ObligationCsvImport.php
+++ b/src/lib/php/Application/ObligationCsvImport.php
@@ -101,14 +101,9 @@ class ObligationCsvImport
         $jsonContent = fread($handle, filesize($filename));
         $data = json_decode($jsonContent, true);
         if ($data === null && json_last_error() !== JSON_ERROR_NONE) {
-          $msg .= "Error decoding JSON: " . json_last_error_msg()."\n";
+          $msg .= "Error decoding JSON: " . json_last_error_msg() . "\n";
         }
-        foreach ($data as $row) {
-          $log = $this->handleCsvObligation($this->handleRowJson($row));
-          if (!empty($log)) {
-            $msg .= "$log\n";
-          }
-        }
+        $msg = $this->importJsonData($data, $msg);
         $msg .= _('Read json').(":". count($data) ." ")._('obligations');
       }
     } catch(\Exception $e) {
@@ -353,5 +348,21 @@ class ObligationCsvImport
     $this->dbManager->getSingleRow('UPDATE obligation_ref SET ob_classification=$2, ob_modifications=$3, ob_comment=$4 where ob_pk=$1',
       array($exists, $row['classification'], $row['modifications'], $row['comment']),
       __METHOD__ . '.updateOtherOb');
+  }
+
+  /**
+   * @param $data
+   * @param string $msg
+   * @return string
+   */
+  public function importJsonData($data, string $msg): string
+  {
+    foreach ($data as $row) {
+      $log = $this->handleCsvObligation($this->handleRowJson($row));
+      if (!empty($log)) {
+        $msg .= "$log\n";
+      }
+    }
+    return $msg;
   }
 }

--- a/src/lib/php/Util/HttpUtils.php
+++ b/src/lib/php/Util/HttpUtils.php
@@ -9,6 +9,8 @@
 namespace Fossology\Lib\Util;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
 
 class HttpUtils
 {
@@ -45,7 +47,28 @@ class HttpUtils
       'http_errors' => false,
       'proxy' => $proxy,
       'base_uri' => $baseUri,
-      'headers' => $headers
+      'headers' => $headers,
     ]);
+  }
+
+  /**
+   * Checks the health status of the license database by sending a GET request to a specified health endpoint.
+   * Returns a boolean result indicating whether the database is reachable and healthy.
+   * Implements error handling for HTTP request failures.
+   *
+   * @return bool True if the database health check succeeds with an HTTP 200 response, false otherwise.
+   */
+  public static function checkLicenseDBHealth(string $getHealth, $guzzleClient)
+  {
+    try {
+      $response = $guzzleClient->get($getHealth);
+      if ($response->getStatusCode() === 200) {
+        return true;
+      }
+    } catch (RequestException|GuzzleException $e) {
+      return false;
+    }
+
+    return false;
   }
 }

--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -597,10 +597,16 @@ function Populate_sysconfig()
     "null");
 
   $variable = "LicenseDBContent";
-  $prompt = _('Export endpoint');
+  $prompt = _('Export endpoint Licenses');
   $desc = _('Endpoint to Export licenses in JSON e.g. /licenses/export');
   $valueArray[$variable] = array("'$variable'", "'/licenses/export'", "'$prompt'",
     strval(CONFIG_TYPE_TEXT), "'LicenseDB'", "3", "'$desc'", "null", "null");
+
+  $variable = "LicenseDBContentObligations";
+  $prompt = _('Export endpoint Obligations');
+  $desc = _('Endpoint to Export Obligations in JSON e.g. /obligations/export');
+  $valueArray[$variable] = array("'$variable'", "'/obligations/export'", "'$prompt'",
+    strval(CONFIG_TYPE_TEXT), "'LicenseDB'", "4", "'$desc'", "null", "null");
 
   $variable = "LicenseDBToken";
   $prompt = _('Auth token For LicenseDB');

--- a/src/www/ui/page/AdminObligationFromCSV.php
+++ b/src/www/ui/page/AdminObligationFromCSV.php
@@ -8,10 +8,14 @@
 
 namespace Fossology\UI\Page;
 
-use Fossology\Lib\Application\LicenseCsvImport;
+use Fossology\Lib\Application\ObligationCsvImport;
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Plugin\DefaultPlugin;
+use Fossology\Lib\Util\HttpUtils;
 use Fossology\UI\Api\Models\ApiVersion;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,71 +30,36 @@ class AdminObligationFromCSV extends DefaultPlugin
   const FILE_INPUT_NAME = 'file_input';
   const FILE_INPUT_NAME_V2 = 'fileInput';
 
+  /**
+   * @var Client $guzzleClient
+   */
+  private $guzzleClient;
+  /**
+   * @var array
+   */
+  private $sysconfig;
+
   function __construct()
   {
+    global $SysConf;
     parent::__construct(self::NAME, array(
-        self::TITLE => "Admin Obligation Import",
-        self::MENU_LIST => "Admin::Obligation Admin::Obligation Import",
-        self::REQUIRES_LOGIN => true,
-        self::PERMISSION => Auth::PERM_ADMIN
+      self::TITLE => "Admin Obligation Import",
+      self::MENU_LIST => "Admin::Obligation Admin::Obligation Import",
+      self::REQUIRES_LOGIN => true,
+      self::PERMISSION => Auth::PERM_ADMIN
     ));
-  }
+    /** @var ObligationCsvImport $obligationsCsvImport */
+    $this->obligationsCsvImport = $GLOBALS['container']->get('app.obligation_csv_import');
+    $this->sysconfig = $SysConf['SYSCONFIG'];
+    $this->configuration = [
+      'url' => trim($this->sysconfig['LicenseDBURL']),
+      'uri' => trim($this->sysconfig['LicenseDBBaseURL']),
+      'content' => trim($this->sysconfig['LicenseDBContentObligations']),
+      'maxtime' => intval($this->sysconfig['LicenseDBSleep']),
+      'token' => trim($this->sysconfig['LicenseDBToken'])
+    ];
 
-  /**
-   * @param Request $request
-   * @return Response
-   */
-  protected function handle (Request $request)
-  {
-    $vars = array();
-
-    if ($request->isMethod('POST')) {
-      $uploadFile = $request->files->get(self::FILE_INPUT_NAME);
-      $delimiter = $request->get('delimiter')?:',';
-      $enclosure = $request->get('enclosure')?:'"';
-      $vars['message'] = $this->handleFileUpload($uploadFile,$delimiter,$enclosure);
-    }
-
-    $vars[self::KEY_UPLOAD_MAX_FILESIZE] = ini_get(self::KEY_UPLOAD_MAX_FILESIZE);
-    $vars['baseUrl'] = $request->getBaseUrl();
-    $vars['license_csv_import'] = false;
-
-    return $this->render("admin_license_from_csv.html.twig", $this->mergeWithDefault($vars));
-  }
-
-  /**
-   * @param UploadedFile $uploadedFile
-   * @return null|string|array
-   */
-  public function handleFileUpload($uploadedFile,$delimiter=',',$enclosure='"', $fromRest=false)
-  {
-    $errMsg = '';
-    if (! ($uploadedFile instanceof UploadedFile)) {
-      $errMsg = _("No file selected");
-    } elseif ($uploadedFile->getSize() == 0 && $uploadedFile->getError() == 0) {
-      $errMsg = _("Larger than upload_max_filesize ") . ini_get(self::KEY_UPLOAD_MAX_FILESIZE);
-    } elseif ($uploadedFile->getClientOriginalExtension() != 'csv'
-           && $uploadedFile->getClientOriginalExtension() != 'json') {
-      $errMsg = _('Invalid extension ') .
-          $uploadedFile->getClientOriginalExtension() . ' of file ' .
-          $uploadedFile->getClientOriginalName();
-    }
-    if (! empty($errMsg)) {
-      if ($fromRest) {
-        return array(false, $errMsg, 400);
-      }
-      return $errMsg;
-    }
-    /** @var LicenseCsvImport */
-    $obligationCsvImport = $this->getObject('app.obligation_csv_import');
-    $obligationCsvImport->setDelimiter($delimiter);
-    $obligationCsvImport->setEnclosure($enclosure);
-
-    $res = $obligationCsvImport->handleFile($uploadedFile->getRealPath(), $uploadedFile->getClientOriginalExtension());
-    if ($fromRest) {
-      return array(true, $res, 200);
-    }
-    return $res;
+    $this->guzzleClient = HttpUtils::getGuzzleClient($SysConf, $this->configuration['uri'], $this->configuration['token']);
   }
 
   /**
@@ -103,6 +72,113 @@ class AdminObligationFromCSV extends DefaultPlugin
     } else {
       return $this::FILE_INPUT_NAME;
     }
+  }
+
+  /**
+   * @param Request $request
+   * @return Response
+   */
+  protected function handle(Request $request)
+  {
+    $vars = array();
+    if (!$request->isMethod('POST')) {
+      $getHealth = $this->configuration['url'] . $this->configuration['uri'] . "/health";
+      $vars['licenseDBHealth'] = HttpUtils::checkLicenseDBHealth($getHealth, $this->guzzleClient);
+    }
+    if ($request->isMethod('POST')) {
+      if ($request->get('importFrom') === 'licensedb') {
+        $startTime = microtime(true);
+        $vars['message'] = $this->handleLicenseDbObligationImport();
+        $fetchLicenseTime = microtime(true) - $startTime;
+        $this->fileLogger->debug("Fetching Obligations and Check time took: " . sprintf("%0.3fms", 1000 * $fetchLicenseTime));
+        $this->fileLogger->debug("****************** Message From LicenseDB import [" . date('Y-m-d H:i:s') . "] ******************");
+        $this->fileLogger->debug($vars["message"]);
+        $this->fileLogger->debug("****************** End Message From LicenseDB import ******************");
+      } else {
+        $uploadFile = $request->files->get(self::FILE_INPUT_NAME);
+        $delimiter = $request->get('delimiter') ?: ',';
+        $enclosure = $request->get('enclosure') ?: '"';
+        $vars['message'] = $this->handleFileUpload($uploadFile, $delimiter, $enclosure);
+      }
+    }
+
+    $vars[self::KEY_UPLOAD_MAX_FILESIZE] = ini_get(self::KEY_UPLOAD_MAX_FILESIZE);
+    $vars['baseUrl'] = $request->getBaseUrl();
+    $vars['license_csv_import'] = false;
+
+    if (!empty(trim($this->configuration['url']))) {
+      $vars['baseURL'] = !empty($this->configuration['uri']);
+      $vars['authToken'] = !empty($this->configuration['token']);
+      $vars['exportEndpoint'] = !empty($this->configuration['content']);
+      return $this->render("admin_license_from_licensedb.html.twig", $this->mergeWithDefault($vars));
+    } else {
+      return $this->render("admin_license_from_csv.html.twig", $this->mergeWithDefault($vars));
+    }
+  }
+
+  /**
+   * Handles the import of obligation data from a database by sending a GET request to a specified URL,
+   * decoding the retrieved JSON response, and passing the data to the CSV import logic.
+   * Provides appropriate error handling for HTTP request failures and JSON decoding errors.
+   *
+   * @return string A message indicating the result of the operation, including error messages if applicable.
+   */
+  public function handleLicenseDbObligationImport()
+  {
+    $msg = '<br>';
+    $data = null;
+    $finalURL = $this->configuration['url'] . $this->configuration['uri'] . $this->configuration['content'];
+    try {
+      $startTimeReq = microtime(true);
+      $response = $this->guzzleClient->get($finalURL);
+      $fetchLicenseTimeReq = microtime(true) - $startTimeReq;
+      $this->fileLogger->debug("LicenseDB req:' took " . sprintf("%0.3fms", 1000 * $fetchLicenseTimeReq));
+      if ($response->getStatusCode() == 200) {
+        $data = json_decode($response->getBody()->getContents());
+      }
+
+      if ($data === null) {
+        if (json_last_error() !== JSON_ERROR_NONE) {
+          return $msg . "Error decoding JSON: " . json_last_error_msg() . "\n";
+        }
+        return $msg . "No Obligations Found";
+      }
+      if (empty($data)) {
+        return $msg . "There are no Obligations Present in LicenseDB";
+      }
+      return $this->obligationsCsvImport->importJsonData($data, $msg);
+    } catch (RequestException|GuzzleException $e) {
+      return $msg . _('Something Went Wrong, check if host is accessible') . ': ' . $e->getMessage();
+    }
+  }
+
+  /**
+   * @param UploadedFile $uploadedFile
+   * @return null|string|array
+   */
+  public function handleFileUpload($uploadedFile, $delimiter = ',', $enclosure = '"', $fromRest = false)
+  {
+    $errMsg = '';
+    if (!($uploadedFile instanceof UploadedFile)) {
+      $errMsg = _("No file selected");
+    } elseif ($uploadedFile->getSize() == 0 && $uploadedFile->getError() == 0) {
+      $errMsg = _("Larger than upload_max_filesize ") . ini_get(self::KEY_UPLOAD_MAX_FILESIZE);
+    } elseif ($uploadedFile->getClientOriginalExtension() != 'csv'
+      && $uploadedFile->getClientOriginalExtension() != 'json') {
+      $errMsg = _('Invalid extension ') .
+        $uploadedFile->getClientOriginalExtension() . ' of file ' .
+        $uploadedFile->getClientOriginalName();
+    }
+    if (!empty($errMsg)) {
+      if ($fromRest) {
+        return array(false, $errMsg, 400);
+      }
+      return $errMsg;
+    }
+    $this->obligationsCsvImport->setDelimiter($delimiter);
+    $this->obligationsCsvImport->setEnclosure($enclosure);
+
+    return array(true, $this->obligationsCsvImport->handleFile($uploadedFile->getRealPath(), $uploadedFile->getClientOriginalExtension()), 200);
   }
 }
 

--- a/src/www/ui/template/admin_license_from_licensedb.html.twig
+++ b/src/www/ui/template/admin_license_from_licensedb.html.twig
@@ -29,7 +29,7 @@
       <p><b>{{ 'Warning' }}</b>{{ ': Connection to LicenseDB was not successful. Please check the settings and try again.'|trans }}</p>
       <button type="submit" class="btn btn-default" disabled>{{ 'Import'|trans }}</button>
     {% else %}
-      <p><b>{{ 'License Import from LicenseDB is ready. Press Import to Begin.'|trans }}</b></p>
+      <p><b>{{ 'LicenseDB is ready. Press Import to Begin.'|trans }}</b></p>
       <form method="post">
         <input type="hidden" name="importFrom" value="licensedb" />
         <button type="submit" class="btn btn-default">{{ 'Import'|trans }}</button>


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

As LicenseDB is ready and hosted, Fossology needed a way to import Obligations From LicenseDB. Importing Licenses was already present.

### Changes

1. Added Obligation endpoint customization
2. Added logic to do http req and fetch the obligations
3. Added a logic if the Data coming is empty and How to handle that logic

## How to test

1. Set configuration Variables, If licenseDB URL is there and others are not: A simple warning message will be shown on the screen.
2. Get Auth Token from LicenseDB login API and update the LicenseDBToken. 
3. Import button will not be active if connection to LicenseDB was not successfull.
4. If LicenseDB is up and health is okay, Then Import button is enabled, Just press Import:
![image](https://github.com/user-attachments/assets/f1a7764c-0dbf-48e3-b725-9baf94f99c97)


CC: @GMishx @shaheemazmalmmd 
