### PR TITLE
fix: Allow Clearing of Upload Description and Comment

### DIFF
--- a/src/www/ui/admin-upload-edit.php
+++ b/src/www/ui/admin-upload-edit.php
@@ -74,10 +74,15 @@ class upload_properties extends FO_Plugin
         __METHOD__ . '.updateUpload.name');
     }
 
-    if (! empty($newDesc)) {
-      $trimNewDesc = trim($newDesc);
-      $this->dbManager->getSingleRow("UPDATE upload SET upload_desc=$2 WHERE upload_pk=$1",
-        array($uploadId, $trimNewDesc), __METHOD__ . '.updateUpload.desc');
+    if ($newDesc !== null) { 
+      if (empty($newDesc)) {
+        $this->dbManager->getSingleRow("UPDATE upload SET upload_desc=NULL WHERE upload_pk=$1",
+            array($uploadId), __METHOD__ . '.updateUpload.desc');
+      } else {
+        $trimNewDesc = trim($newDesc);
+        $this->dbManager->getSingleRow("UPDATE upload SET upload_desc=$2 WHERE upload_pk=$1",
+          array($uploadId, $trimNewDesc), __METHOD__ . '.updateUpload.desc');
+      }
     }
     return 1;
   }

--- a/src/www/ui/admin-upload-edit.php
+++ b/src/www/ui/admin-upload-edit.php
@@ -74,7 +74,7 @@ class upload_properties extends FO_Plugin
         __METHOD__ . '.updateUpload.name');
     }
 
-    if ($newDesc !== null) { 
+    if ($newDesc !== null) {
       if (empty($newDesc)) {
         $this->dbManager->getSingleRow("UPDATE upload SET upload_desc=NULL WHERE upload_pk=$1",
             array($uploadId), __METHOD__ . '.updateUpload.desc');

--- a/src/www/ui/async/AjaxBrowse.php
+++ b/src/www/ui/async/AjaxBrowse.php
@@ -88,7 +88,7 @@ class AjaxBrowse extends DefaultPlugin
     } else if (! empty($uploadId) && ! empty($direction)) {
       $uploadBrowseProxy = new UploadBrowseProxy($groupId, $this->userPerm, $this->dbManager);
       $uploadBrowseProxy->moveUploadToInfinity($uploadId, $direction == 'top');
-    } else if (!empty($uploadId) && !empty($commentText) && !empty($statusId)) {
+    } else if (!empty($uploadId) && !empty($statusId)) {
       $uploadBrowseProxy = new UploadBrowseProxy($groupId, $this->userPerm, $this->dbManager);
       $uploadBrowseProxy->setStatusAndComment($uploadId, $statusId, $commentText);
     } else {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This PR resolves the issue where users were unable to clear the description and comment of an uploaded file. Previously, attempting to remove or leave these description or comment empty did not properly update the stored values.

## Changes
### For Upload Description
-   **File Modified:** `src/www/ui/admin-upload-edit.php`.
-   Replaced `if (!empty($newDesc)) {...}` with `if ($newDesc !== null) {...}` to ensure changes are always processed.
-   Added a condition `if (empty($newDesc)) {...}` under `if ($newDesc !== null) {...}` to explicitly allow clearing the description.

### For Upload Comment
- **File Modified:** `src/www/ui/async/AjaxBrowse.php`.
- Removed the check for `!empty($commentText)`, allowing empty comments to be saved.

## How to test
### For Upload Description
-   Navigate to `Organize` -> `Uploads` -> `Edit Properties`.
-   Remove any existing description.
-   Go to the `Browse` tab and verify that the description is cleared.

### For Upload Comment
- Navigate to the `Browse` tab.
- Double-click on any existing comment.
- Clear the comment and click `Ok`.
- Verify that the comment is successfully removed.

fixes #3002
