### PR TITLE
chore(docker): Removed version attribute from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@
 #
 # Description: Recipe for setting up a multi container FOSSology
 #              Docker setup with separate Database instance
-version: '3.5'
 services:
   scheduler:
     build:


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

In this pull request I have removed The version attribute in docker-compose.yml as it is deprecated and no longer required with the latest Docker Compose. Removing it aligns with current best practices and prevents warnings.

### Changes

Changed docker-compose.yml removing the version attribute

## How to test

In your local FOSSology instance, trying running docker compose up with this commit.

Fixes: [issue#3004](https://github.com/fossology/fossology/issues/3004)