### PR TITLE
Fix: Search Not Working for 'Name' Column in Admin Standard License Comments

### DIFF
--- a/src/www/ui/scripts/admin-license-acknowledgements.js
+++ b/src/www/ui/scripts/admin-license-acknowledgements.js
@@ -17,28 +17,49 @@ $(document).ready(function() {
   var t = $("#adminLicenseAcknowledgementTable").DataTable({
     "processing": true,
     "paginationType": "listbox",
-    "order": [[ 1, 'asc' ]],
+    "order": [[1, 'asc']],  
     "autoWidth": false,
-    "columnDefs": [{
-      "createdCell": function (cell) {
-        $(cell).attr("style", "text-align:center");
-      },
-      "searchable": false,
-      "targets": [0]
-    },{
-      "orderable": false,
-      "targets": [0,2,3]
-    },{
-      "orderable": true,
-      "targets": [1]
+    "columnDefs": [
+        {
+            "createdCell": function (cell) {
+                $(cell).attr("style", "text-align:center");
+            },
+            "searchable": false, 
+            "orderable": false,
+            "targets": [0]  
+        },
+        {
+            "orderable": true,
+            "searchable": true,
+            "targets": [1],
+            "render": function (data, type, row) {
+                if (type === 'display') {
+                    return data;  
+                }
+                return $(data).val();  
+            }
+        },
+        {
+            "searchable": true,
+            "targets": [2]
     }],
   });
 
   t.on('order.dt search.dt', function () {
-    t.column(0, {search:'applied', order:'applied'}).nodes().each( function (cell, i) {
-      cell.innerHTML = i+1;
+    let rows = t.rows({ search: 'applied', order: 'applied' }).nodes();
+    let lastIndex = 1;
+    
+    $(rows).each(function (index, row) {
+        if ($(row).find(".newAcknowledgementInputs").length === 0) {
+            $(row).find("td:first").html(lastIndex++);
+        }
     });
-  }).draw();
+
+    let newRow = $("#adminLicenseAcknowledgementTable tbody tr").last();
+    if (newRow.find(".newAcknowledgementInputs").length > 0) {
+        newRow.find("td:first").html(lastIndex);
+    }
+}).draw();
 
   form.find("input[type=text],textarea").on("change", function(){
     $(this).addClass("inputChanged");
@@ -93,8 +114,11 @@ $(document).ready(function() {
   });
 
   $("#addLicAcknowledgement").on('click', function(){
-    t.row.add([
-      null,
+
+    var lastIndex = t.rows().count() + 1;
+
+    var rowNode = t.row.add([
+      lastIndex,
       '<input type="text" name="insertLicNames[]" ' +
         'placeholder="Please enter a name for the Acknowledgement" ' +
         'class="newAcknowledgementInputs" />',
@@ -102,7 +126,12 @@ $(document).ready(function() {
         'placeholder="Please enter a acknowledgement statement" ' +
         'class="newAcknowledgementInputs"></textarea>',
       '<input type="checkbox" checked disabled />'
-    ]).draw(false).page("last").draw(false);
+    ]).draw(false).node();
+
+    $(rowNode).appendTo("#adminLicenseAcknowledgementTable tbody");
+
+    $(rowNode).find("input, textarea").first().focus();
+
   });
 
   $(".licStdAckToggle").change(function(){

--- a/src/www/ui/scripts/admin-license-std-comments.js
+++ b/src/www/ui/scripts/admin-license-std-comments.js
@@ -17,28 +17,50 @@ $(document).ready(function() {
   var t = $("#adminLicenseCommentTable").DataTable({
     "processing": true,
     "paginationType": "listbox",
-    "order": [[ 1, 'asc' ]],
+    "order": [[1, 'asc']],  
     "autoWidth": false,
-    "columnDefs": [{
-      "createdCell": function (cell) {
-        $(cell).attr("style", "text-align:center");
-      },
-      "searchable": false,
-      "targets": [0]
-    },{
-      "orderable": false,
-      "targets": [0,2,3]
-    },{
-      "orderable": true,
-      "targets": [1]
+    "columnDefs": [
+        {
+            "createdCell": function (cell) {
+                $(cell).attr("style", "text-align:center");
+            },
+            "searchable": false, 
+            "orderable": false,
+            "targets": [0]  
+        },
+        {
+            "orderable": true,
+            "searchable": true,
+            "targets": [1],
+            "render": function (data, type, row) {
+                if (type === 'display') {
+                    return data;  
+                }
+                return $(data).val();  
+            }
+        },
+        {
+            "searchable": true,
+            "targets": [2]
     }],
   });
 
   t.on('order.dt search.dt', function () {
-    t.column(0, {search:'applied', order:'applied'}).nodes().each( function (cell, i) {
-      cell.innerHTML = i+1;
+    let rows = t.rows({ search: 'applied', order: 'applied' }).nodes();
+    let lastIndex = 1;
+    
+    $(rows).each(function (index, row) {
+        if ($(row).find(".newCommentInputs").length === 0) {
+            $(row).find("td:first").html(lastIndex++);
+        }
     });
-  }).draw();
+
+    let newRow = $("#adminLicenseCommentTable tbody tr").last();
+    if (newRow.find(".newCommentInputs").length > 0) {
+        newRow.find("td:first").html(lastIndex);
+    }
+}).draw();
+
 
   form.find("input[type=text],textarea").on("change", function(){
     $(this).addClass("inputChanged");
@@ -93,17 +115,24 @@ $(document).ready(function() {
   });
 
   $("#addStdLicComment").on('click', function(){
-    t.row.add([
-      null,
-      '<input type="text" name="insertStdLicNames[]" ' +
-        'placeholder="Please enter a name for the comment" ' +
-        'class="newCommentInputs" />',
-      '<textarea rows="7" cols="80" name="insertStdLicComments[]" ' +
-        'placeholder="Please enter a comment statement" ' +
-        'class="newCommentInputs"></textarea>',
-      '<input type="checkbox" checked disabled />'
-    ]).draw(false).page("last").draw(false);
-  });
+    
+    var lastIndex = t.rows().count() + 1;
+
+    var rowNode = t.row.add([
+        lastIndex,  
+        '<input type="text" name="insertStdLicNames[]" ' +
+          'placeholder="Please enter a name for the comment" ' +
+          'class="newCommentInputs" />',
+        '<textarea rows="7" cols="80" name="insertStdLicComments[]" ' +
+          'placeholder="Please enter a comment statement" ' +
+          'class="newCommentInputs"></textarea>',
+        '<input type="checkbox" checked disabled />'
+    ]).draw(false).node();
+
+    $(rowNode).appendTo("#adminLicenseCommentTable tbody");
+
+    $(rowNode).find("input, textarea").first().focus();
+});
 
   $(".licStdCommentToggle").change(function(){
     var changedBox = $(this);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

In the **Admin Standard License Comments** section, searching by the 'Name' column was not functioning correctly. The search only worked for the Comment column but ignored the Name input field. This issue occurred because DataTables was trying to search using the full HTML string of the input field instead of its actual value.The column is easily searchable because it is ```<textarea>```.

![Screenshot from 2025-03-16 03-17-50](https://github.com/user-attachments/assets/a5dd6e81-37bb-448f-85be-d94bac9cba58)


This fix ensures that when a search is performed, DataTables extracts the value of the input field inside the Name column instead of the raw HTML, allowing proper filtering.

### Changes

- Modified the DataTable configuration to properly extract the value from the **input field** in the "Name" column.
- Used ```render``` function to ensure searching works by returning the input field value instead of its HTML content.
- Ensured no visual changes, maintaining the original appearance.

## Changes Reflected

[Screencast from 2025-03-16 03-23-27.webm](https://github.com/user-attachments/assets/ab53dd61-a703-473f-8bef-410c4c8c7417)

## How to test

1. Navigate to **Admin Standard License Comments**.
2. Use the search bar to search for a comment by its name.
3. Verify that results now appear when searching by Name.
4. Ensure searching by Comment content still works as expected.

## Closes
Fixes issue [#3006 ] – "Search by Name Not Working in Admin Standard License Comments"
