### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,7 @@ RUN mkdir -p /var/log/apache2/ \
 COPY ./docker-entrypoint.sh /fossology/docker-entrypoint.sh
 RUN chmod +x /fossology/docker-entrypoint.sh
 ENTRYPOINT ["/fossology/docker-entrypoint.sh"]
+CMD ["apache2-foreground"]
 
 COPY --from=builder /etc/cron.d/fossology /etc/cron.d/fossology
 COPY --from=builder /etc/init.d/fossology /etc/init.d/fossology


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->
Description:
Missing CMD Instruction
The CMD instruction provides a default command that runs when the container starts. Right now, your Dockerfile only has an ENTRYPOINT. Without CMD, users must provide a command explicitly when running the container. If they don’t, the container will execute only the entrypoint script and then exit if it doesn’t start a long-running process. 
Changes made:
I added a cmd function to define default process after the entrypoint. 
How to test:
The entrypoint script runs first (for setup).
The container remains running with Apache by default. Users can override the default command when running the container


