### PR TITLE
fix(adminObligationsImport): undefined variable throwing warning

### DIFF
--- a/src/www/ui/page/AdminObligationFromCSV.php
+++ b/src/www/ui/page/AdminObligationFromCSV.php
@@ -55,7 +55,6 @@ class AdminObligationFromCSV extends DefaultPlugin
       'url' => trim($this->sysconfig['LicenseDBURL']),
       'uri' => trim($this->sysconfig['LicenseDBBaseURL']),
       'content' => trim($this->sysconfig['LicenseDBContentObligations']),
-      'maxtime' => intval($this->sysconfig['LicenseDBSleep']),
       'token' => trim($this->sysconfig['LicenseDBToken'])
     ];
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Undefined variable `LicenseDBSleep` throwing PHP Warnings 

### Changes

Removed the Undefined Variable

## How to test

1. Build and Install the Branch
2. Run fo-postinstall
3. Check apache error.log should be no warnings

CC: @shaheemazmalmmd 
