### PR TITLE
fix(markDirectoryAsDecisionTypeRec): Properly handle clearing state when removing irrelevant decisions

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -843,6 +843,13 @@ INSERT INTO clearing_decision (
       }
     } else {
       $this->dbManager->begin();
+      
+      $sql = $uploadTreeProxy->asCTE() .
+        ' SELECT uploadtree_pk FROM UploadTreeView;';
+      $itemRows = $this->dbManager->getRows($sql, $params,
+        __METHOD__ . ".getItemsForReset");
+      $uploadTreeTableName = $itemTreeBounds->getUploadTreeTableName();
+      
       $params[] = $decisionMark;
       $sql = $uploadTreeProxy->asCTE() .
         ' DELETE FROM clearing_decision WHERE clearing_decision_pk IN (
@@ -873,12 +880,49 @@ INSERT INTO clearing_decision (
         "clearing_decision_fk = ANY($1::int[]);";
       $this->dbManager->getSingleRow($delCdEventSql, array($clearingDecisions),
         __METHOD__ . ".deleteCdEvent");
+      
+      /** @var ClearingDecisionProcessor $clearingDecisionEventProcessor */
+      $clearingDecisionEventProcessor = $GLOBALS['container']->get(
+        'businessrules.clearing_decision_processor');
+      
+      foreach ($itemRows as $itemRow) {
+        $itemBounds = $this->uploadDao->getItemTreeBounds(
+          $itemRow['uploadtree_pk'], $uploadTreeTableName);
+        
+        $this->insertNullDecision($itemBounds, $userId, $groupId);
+      }
+      
       $this->dbManager->commit();
       $this->copyrightDao->updateTable($itemTreeBounds, '', '', $userId,
         'copyright', 'rollback');
     }
   }
 
+/**
+ * @param ItemTreeBounds $itemBounds
+ * @param int $userId
+ * @param int $groupId
+ */
+  protected function insertNullDecision(ItemTreeBounds $itemBounds, $userId, $groupId)
+  {
+    $uploadTreeId = $itemBounds->getItemId();
+    $uploadId = $itemBounds->getUploadId();
+    
+    /** @var ClearingDecisionProcessor $clearingDecisionProcessor */
+    $clearingDecisionProcessor = $GLOBALS['container']->get(
+      'businessrules.clearing_decision_processor');
+      
+    $noDecisionType = $clearingDecisionProcessor::NO_LICENSE_KNOWN_DECISION_TYPE;
+    
+    $sql = "INSERT INTO clearing_decision 
+            (uploadtree_fk, pfile_fk, user_fk, group_fk, decision_type, scope, date_added) 
+            SELECT $1, pfile_fk, $2, $3, $4, " . DecisionScopes::ITEM . ", now() 
+            FROM uploadtree 
+            WHERE uploadtree_pk = $1;";
+    
+    $this->dbManager->getSingleRow($sql, array($uploadTreeId, $userId, $groupId, $noDecisionType),
+      __METHOD__ . ".insertNullDecision");
+  }
   /**
    * @param int $uploadId
    * @param int $groupId


### PR DESCRIPTION
## Description
Fixes #2215 
### Problem
When a file with an identified license is marked as irrelevant and then the irrelevant decision is removed, the following issues occur:

- The "Clearing Status" incorrectly stays green
- The "Cleared / Open / Total" counters remain at 1 / 1 / 1
- The file appears as cleared when it's actually not cleared

This happens because when removing a decision type, the system doesn't properly reset the file's status to its original "no decision" state.

### Solution
Modified the `markDirectoryAsDecisionTypeRec` method in the `ClearingDao` class to properly handle the removal of decision types. When a decision type is removed, the method now:

- Captures the affected items before deleting the decisions
- Deletes the existing decisions as before
- Explicitly inserts a decision with the "no license known" decision type

## Changes
- Modified the `markDirectoryAsDecisionTypeRec` method to insert a null decision ("no license known") for each affected item after removing irrelevant decisions
- Added a new helper method `insertNullDecision` that correctly resets the clearing status by inserting a decision with the "no license known" decision type by using the existing `ClearingDecisionProcessor` instance to access the `NO_LICENSE_KNOWN_DECISION_TYPE` constant

## Proof of Work
### Before changes

https://github.com/user-attachments/assets/e43ec431-cc9d-4e0b-a481-e22bffcd2751

### After changes

https://github.com/user-attachments/assets/c017baef-8723-4959-b0e9-2a9a1126743e


## How to test

- Selected a cleared file with identified license
- Marked file as irrelevant
- Removed marked irrelevant decisions via Actions [Edit]
- Verified that "Edited Results" now show the correct state
- Verified that "Clearing Status" correctly shows as uncleared

