### PR TITLE
fix(UI): improve duplicate file warning

### DIFF
--- a/src/www/ui/template/upload_file.html.twig
+++ b/src/www/ui/template/upload_file.html.twig
@@ -93,37 +93,59 @@
     function checkDuplicateUploadWarning(e) {
       const allFiles = e.target.files;
       const folderId = $("#uploadFolderSelector").val();
-      let messages = [];
-      let ajaxList = [];
-      let ajaxCall;
+      const messages = [];
+      const ajaxList = [];
+      
+      if (!$('#uploadWarningModal').length) {
+        $('body').append(`
+          <div class="modal fade" id="uploadWarningModal" tabindex="-1" role="dialog">
+            <div class="modal-dialog modal-dialog-centered" role="document">
+              <div class="modal-content">
+                <div class="modal-header bg-secondary text-white">
+                  <h5 class="modal-title">
+                    <i class="fas fa-exclamation-circle"></i> Duplicate Files Found
+                  </h5>
+                  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span>&times;</span>
+                  </button>
+                </div>
+                <div class="modal-body" id="warningMessages"></div>
+                <div class="modal-footer">
+                  <button type="button" class="btn btn-secondary" onclick="$('#fileUploader').val('')" data-dismiss="modal">Clear Selection</button>
+                  <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">Continue Anyway</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        `);
+      }
       for (let i = 0; i < allFiles.length; i++) {
         const uploadName = allFiles[i].name;
-        ajaxCall = $.ajax({
-          url : '?mod=foldercontents',
-          type : 'post',
-          dataType : 'json',
-          data : {"folder": folderId, "upload": uploadName},
-          success : function(data) {
+        const ajaxCall = $.ajax({
+          url: '?mod=foldercontents',
+          type: 'post',
+          dataType: 'json',
+          data: { "folder": folderId, "upload": uploadName },
+          success: function(data) {
             if (data.upload !== false) {
-              messages.push(`${uploadName} already uploaded at ${data.date}. ` +
-                `<a href='${data.upload}' target="blank">` +
-                'Check the upload</a>.');
+              messages.push(`
+                <div class="alert">
+                  <strong>${uploadName}</strong> was previously uploaded on ${data.date}
+                  <a href='${data.upload}' target="_blank" class="ml-2">
+                    View Upload
+                  </a>
+                </div>
+              `);
             }
           }
         });
         ajaxList.push(ajaxCall);
       }
-      // Wait for all ajax calls to resolve
-      $.when.apply($, ajaxList).then(function(){
-        $('#fileUploader').popover('dispose');
-        if (messages.length != 0) {
-          $('#fileUploader').popover({
-            "content": messages.join("<br />"), "html": true,
-            "title": "Warning!", "placement": "top", "trigger": "focus"
-          }).popover('show');
-          $('html, body').animate({
-            scrollTop: $('#fileUploader').offset().top
-          }, 100);
+
+      $.when.apply($, ajaxList).then(function() {
+        if (messages.length > 0) {
+          $('#warningMessages').html(messages.join(''));
+          $('#uploadWarningModal').modal('show');
         }
       });
     }


### PR DESCRIPTION
## Description
This pull request Fixes #2900 .  The current popover warning has several issues, such as inconsistent positioning, lack of visibility, and unclear actions for users.

The proposed solution replaces the popover with a centered, responsive modal dialog that:

Clearly displays duplicate files and their details (file name, upload date).
Provides actionable buttons:
"Continue Anyway": Proceeds with the upload.
"Clear Selection": Resets the file selection.
Enhances user experience with better visibility, accessibility, and mobile responsiveness.
## How to Test
Upload a new file: No warning modal should appear.
Upload an existing file: The warning modal should appear with duplicate file details and action buttons.
Test "Continue Anyway" and "Clear Selection" buttons to ensure they work as expected.
Verify responsiveness on different screen sizes (desktop, tablet, mobile).
