### PR TITLE
fix(ci): dco check not running on push event on main

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -137,5 +137,7 @@ jobs:
           configFile: ./commitlint.config.mjs
 
       - name: DCO Check
-        uses: tisonkun/actions-dco@v1.1
+        uses: christophebedard/dco-check@0.5.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Action for DCO check earlier was limited to work on Pull Requests Only. The check was also needed for push to `main` branch as well.

### Changes

Updated the older action `tisonkun/actions-dco@v1.1`  ---> `christophebedard/dco-check@0.5.0`
Which allows the check on both PRs and Merge Commits.

## How to test

1. Static Checks Stage on the main branch should not fail

CC: @GMishx 
