### PR TITLE
fix(api): fix /tree/view endpoint parameter check

### DIFF
--- a/src/www/ui/api/Controllers/UploadTreeController.php
+++ b/src/www/ui/api/Controllers/UploadTreeController.php
@@ -353,6 +353,14 @@ class UploadTreeController extends RestController
     $uploadTreeId = intval($args['itemId']);
     $uploadId = intval($args['id']);
     $query = $request->getQueryParams();
+
+    $queryKeys = array_keys($query);
+    $allowedKeys = ['showQuick', 'agentId', 'flatten', 'scanLicenseFilter', 'editedLicenseFilter', 'sort', 'page', 'limit', 'tagId', 'search', 'filterOpen'];
+    $diff = array_diff($queryKeys, $allowedKeys);
+    if (count($diff) > 0) {
+      throw new HttpBadRequestException("Invalid query parameter(s) : " . implode(",", $diff));
+    }
+
     $agentId = $query['agentId'] ?? null;
     $flatten = $query['flatten'] ?? null;
     $scanFilter = $query['scanLicenseFilter'] ?? null;
@@ -399,12 +407,6 @@ class UploadTreeController extends RestController
     }
     if ($limit != null && (!is_numeric($limit) || intval($limit) < 1)) {
       throw new HttpBadRequestException("limit should be positive integer Greater or Equal to 1");
-    }
-    $queryKeys = array_keys($query);
-    $allowedKeys = ['showQuick', 'agentId', 'flatten', 'scanLicenseFilter', 'editedLicenseFilter', 'sort', 'tagId', 'search', 'filterOpen'];
-    $diff = array_diff($queryKeys, $allowedKeys);
-    if (count($diff) > 0) {
-      throw new HttpBadRequestException("Invalid query parameter(s) : " . implode(",", $diff));
     }
 
     if ($editedFilter !== null) {


### PR DESCRIPTION
## Description
Fix the list of allowed query parameters in `/uploads/{id}/item/{itemId}/tree/view`

### Changes
1. Added missing `page` and `limit` to the list of allowed query parameters.
2. Rearranged the check for parameters before usage.

## How to Test
Fire `GET /uploads/{id}/item/{itemId}/tree/view?page=2&limit=3&flatten=true`
and verify that all query parameters are processed correctly without errors.