### PR TITLE
feat(rest): add option to schedule copyrightfp

### DIFF
--- a/src/decider/ui/DeciderAgentPlugin.php
+++ b/src/decider/ui/DeciderAgentPlugin.php
@@ -43,8 +43,7 @@ class DeciderAgentPlugin extends AgentPlugin
     if ($ninkaUi=plugin_find('agent_ninka')) {
       $vars['isNinkaInstalled'] = $ninkaUi->isNinkaInstalled();
     }
-    $vars['isSpacyInstalled'] = file_exists("/home/" .
-      $SysConf['DIRECTORIES']['PROJECTUSER'] . "/pythondeps/bin/spacy");
+    $vars['isSpacyInstalled'] = $this->isSpacyInstalled();
     $licenseTypes = array_map('trim', explode(',',
         $SysConf['SYSCONFIG']['LicenseTypes']));
     $vars['licenseTypes'] = array_combine($licenseTypes, $licenseTypes);
@@ -200,6 +199,17 @@ class DeciderAgentPlugin extends AgentPlugin
       return $licenseType;
     }
     return "";
+  }
+
+  /**
+   * Check if spacy is installed?
+   * @return bool True if installed, false otherwise
+   */
+  public function isSpacyInstalled()
+  {
+    global $SysConf;
+    return file_exists("/home/" .
+      $SysConf['DIRECTORIES']['PROJECTUSER'] . "/pythondeps/bin/spacy");
   }
 }
 

--- a/src/www/ui/api/Helper/UploadHelper.php
+++ b/src/www/ui/api/Helper/UploadHelper.php
@@ -27,6 +27,7 @@ use Fossology\UI\Api\Helper\UploadHelper\HelperToUploadSrvPage;
 use Fossology\UI\Api\Helper\UploadHelper\HelperToUploadUrlPage;
 use Fossology\UI\Api\Helper\UploadHelper\HelperToUploadVcsPage;
 use Fossology\UI\Api\Models\Analysis;
+use Fossology\UI\Api\Models\ApiVersion;
 use Fossology\UI\Api\Models\Decider;
 use Fossology\UI\Api\Models\FileLicenses;
 use Fossology\UI\Api\Models\Findings;
@@ -35,7 +36,6 @@ use Fossology\UI\Api\Models\Reuser;
 use Fossology\UI\Api\Models\Scancode;
 use Fossology\UI\Api\Models\ScanOptions;
 use Fossology\UI\Api\Models\UploadSummary;
-use Fossology\UI\Api\Models\ApiVersion;
 use Fossology\UI\Page\BrowseLicense;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use UIExportList;
@@ -114,6 +114,9 @@ class UploadHelper
   public function handleScheduleAnalysis($uploadId, $folderId, $scanOptionsJSON,
                                          $newUpload = false, $apiVersion = ApiVersion::V1)
   {
+    global $container;
+    $restHelper = $container->get('helper.restHelper');
+
     $parametersSent = false;
     $analysis = new Analysis();
 
@@ -123,6 +126,7 @@ class UploadHelper
     }
 
     $decider = new Decider();
+    $decider->setDeciderAgentPlugin($restHelper->getPlugin('agent_decider'));
     if (array_key_exists("decider", $scanOptionsJSON) && ! empty($scanOptionsJSON["decider"])) {
       $decider->setUsingArray($scanOptionsJSON["decider"], $apiVersion);
       $parametersSent = true;

--- a/src/www/ui/api/Models/Decider.php
+++ b/src/www/ui/api/Models/Decider.php
@@ -1,6 +1,7 @@
 <?php
 /*
  SPDX-FileCopyrightText: © 2017 Siemens AG
+ SPDX-FileCopyrightText: © 2025 Tiyasa Kundu <tiyasakundu20@gmail.com>
 
  SPDX-License-Identifier: GPL-2.0-only
 */
@@ -43,6 +44,21 @@ class Decider
    * Use this license type to create conclusions.
    */
   private $concludeLicenseType;
+  /**
+   * @var bool $copyrightDeactivation
+   * Run the copyright deactivation?
+   */
+  private $copyrightDeactivation;
+  /**
+   * @var bool $copyrightClutterRemoval
+   * Run the copyright clutter removal
+   */
+  private $copyrightClutterRemoval;
+
+  /**
+   * @var DeciderAgentPlugin $deciderAgentPlugin
+   */
+  private $deciderAgentPlugin;
 
   /**
    * Decider constructor.
@@ -52,16 +68,22 @@ class Decider
    * @param boolean $newScanner
    * @param boolean $ojoDecider
    * @param string  $concludeLicenseType
+   * @param boolean $copyrightDeactivation
+   * @param boolean $copyrightClutterRemoval
    */
   public function __construct($nomosMonk = false, $bulkReused = false,
                               $newScanner = false, $ojoDecider = false,
-                              $concludeLicenseType = "")
+                              $concludeLicenseType = "",
+                              $copyrightDeactivation = false,
+                              $copyrightClutterRemoval = false)
   {
     $this->setNomosMonk($nomosMonk);
     $this->setBulkReused($bulkReused);
     $this->setNewScanner($newScanner);
     $this->setOjoDecider($ojoDecider);
     $this->setConcludeLicenseType($concludeLicenseType);
+    $this->setCopyrightDeactivation($copyrightDeactivation);
+    $this->setCopyrightClutterRemoval($copyrightClutterRemoval);
   }
 
   /**
@@ -85,6 +107,12 @@ class Decider
     }
     if (array_key_exists(($version == ApiVersion::V2? "concludeLicenseType" : "conclude_license_type"), $deciderArray)) {
       $this->setConcludeLicenseType($deciderArray[$version == ApiVersion::V2? "concludeLicenseType" : "conclude_license_type"]);
+    }
+    if (array_key_exists(($version == ApiVersion::V2? "copyrightDeactivation" : "copyright_deactivation"), $deciderArray)) {
+      $this->setCopyrightDeactivation($deciderArray[$version == ApiVersion::V2? "copyrightDeactivation" : "copyright_deactivation"]);
+    }
+    if (array_key_exists(($version == ApiVersion::V2? "copyrightClutterRemoval" : "copyright_clutter_removal"), $deciderArray)) {
+      $this->setCopyrightClutterRemoval($deciderArray[$version == ApiVersion::V2? "copyrightClutterRemoval" : "copyright_clutter_removal"]);
     }
     return $this;
   }
@@ -128,6 +156,22 @@ class Decider
   public function getConcludeLicenseType()
   {
     return $this->concludeLicenseType;
+  }
+
+  /**
+   * @return bool
+   */
+  public function getCopyrightDeactivation()
+  {
+    return $this->copyrightDeactivation;
+  }
+
+  /**
+   * @return bool
+   */
+  public function getCopyrightClutterRemoval()
+  {
+    return $this->copyrightClutterRemoval;
   }
 
   ////// Setters //////
@@ -176,6 +220,38 @@ class Decider
   }
 
   /**
+   * @param DeciderAgentPlugin $deciderAgentPlugin
+   */
+  public function setDeciderAgentPlugin($deciderAgentPlugin)
+  {
+    $this->deciderAgentPlugin = $deciderAgentPlugin;
+  }
+
+  /**
+   * @param bool $copyrightDeactivation
+   */
+  public function setCopyrightDeactivation($copyrightDeactivation)
+  {
+    if ($this->deciderAgentPlugin && $this->deciderAgentPlugin->isSpacyInstalled()) {
+      $this->copyrightDeactivation = filter_var($copyrightDeactivation, FILTER_VALIDATE_BOOLEAN);
+    } else {
+      $this->copyrightDeactivation = false;
+    }
+  }
+
+  /**
+   * @param bool $copyrightClutterRemoval
+   */
+  public function setCopyrightClutterRemoval($copyrightClutterRemoval)
+  {
+    if ($this->deciderAgentPlugin && $this->deciderAgentPlugin->isSpacyInstalled()) {
+      $this->copyrightClutterRemoval = filter_var($copyrightClutterRemoval, FILTER_VALIDATE_BOOLEAN);
+    } else {
+      $this->copyrightClutterRemoval = false;
+    }
+  }
+
+  /**
    * Get decider as an array
    * @return array
    */
@@ -187,7 +263,9 @@ class Decider
         "bulkReused" => $this->bulkReused,
         "newScanner" => $this->newScanner,
         "ojoDecider" => $this->ojoDecider,
-        "concludeLicenseType" => $this->concludeLicenseType
+        "concludeLicenseType" => $this->concludeLicenseType,
+        "copyrightDeactivation" => $this->copyrightDeactivation,
+        "copyrightClutterRemoval" => $this->copyrightClutterRemoval
       ];
     } else {
       return [
@@ -195,7 +273,9 @@ class Decider
         "bulk_reused" => $this->bulkReused,
         "new_scanner" => $this->newScanner,
         "ojo_decider" => $this->ojoDecider,
-        "conclude_license_type" => $this->concludeLicenseType
+        "conclude_license_type" => $this->concludeLicenseType,
+        "copyright_deactivation" => $this->copyrightDeactivation,
+        "copyright_clutter_removal" => $this->copyrightClutterRemoval
       ];
     }
   }

--- a/src/www/ui/api/Models/ScanOptions.php
+++ b/src/www/ui/api/Models/ScanOptions.php
@@ -2,6 +2,7 @@
 /*
  SPDX-FileCopyrightText: © 2017 Siemens AG
  SPDX-FileCopyrightText: © 2021 Orange by Piotr Pszczola <piotr.pszczola@orange.com>
+ SPDX-FileCopyrightText: © 2025 Tiyasa Kundu <tiyasakundu20@gmail.com>
 
  SPDX-License-Identifier: GPL-2.0-only
 */
@@ -225,6 +226,12 @@ class ScanOptions
     }
     if ($this->decider->getOjoDecider() === true) {
       $deciderRules[] = 'ojoNoContradiction';
+    }
+    if ($this->decider->getCopyrightDeactivation() === true) {
+      $deciderRules[] = 'copyrightDeactivation';
+    }
+    if ($this->decider->getCopyrightClutterRemoval() === true) {
+      $deciderRules[] = 'copyrightDeactivationClutterRemoval';
     }
     if (! empty($this->decider->getConcludeLicenseType())) {
       $deciderRules[] = 'licenseTypeConc';

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -5569,6 +5569,12 @@ components:
             Auto conclude license if they are of provided type.
             Omit the field or keep as empty string to not use this option.
           example: Permissive
+        copyright_deactivation:
+          type: boolean
+          description: Deactivate false positive copyrights (experimental).
+        copyright_clutter_removal:
+          type: boolean
+          description: Deactivate false positive copyrights and remove clutter from them (experimental).
     ScanOptions:
       type: object
       properties:

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: © 2017-2023 Siemens AG
 # SPDX-FileCopyrightText: © 2021 Orange by Piotr Pszczola <piotr.pszczola@orange.com>
+# SPDX-FileCopyrightText: © 2025 Tiyasa Kundu <tiyasakundu20@gmail.com>
 
 # SPDX-License-Identifier: GPL-2.0-only
 
@@ -5330,6 +5331,18 @@ components:
         ojoDecider:
           type: boolean
           description: Scanners matches if Ojo or REUSE.Software findings are no contradiction with other findings.
+        concludeLicenseType:
+          type: string
+          description: |
+            Auto conclude license if they are of provided type.
+            Omit the field or keep as empty string to not use this option.
+          example: Permissive
+        copyrightDeactivation:
+          type: boolean
+          description: Deactivate false positive copyrights (experimental).
+        copyrightClutterRemoval:
+          type: boolean
+          description: Deactivate false positive copyrights and remove clutter from them (experimental).
     ScanOptions:
       type: object
       properties:

--- a/src/www/ui_tests/api/Models/DeciderTest.php
+++ b/src/www/ui_tests/api/Models/DeciderTest.php
@@ -55,18 +55,22 @@ class DeciderTest extends \PHPUnit\Framework\TestCase
         "nomos_monk" => true,
         "bulk_reused" => false,
         "ojo_decider" => (1==1),
-        "conclude_license_type" => "   Permissive "
+        "conclude_license_type" => "   Permissive ",
+        "copyright_deactivation" => false,
+        "copyright_clutter_removal" => true
       ];
     } else {
       $deciderArray = [
         "nomosMonk" => true,
         "bulkReused" => false,
         "ojoDecider" => (1==1),
-        "concludeLicenseType" => "   Permissive "
+        "concludeLicenseType" => "   Permissive ",
+        "copyrightDeactivation" => false,
+        "copyrightClutterRemoval" => true
       ];
     }
 
-    $expectedObject = new Decider(true, false, false, true, "Permissive");
+    $expectedObject = new Decider(true, false, false, true, "Permissive", false, true);
 
     $actualObject = new Decider();
     $actualObject->setUsingArray($deciderArray, $version);
@@ -109,7 +113,9 @@ class DeciderTest extends \PHPUnit\Framework\TestCase
         "bulk_reused" => false,
         "new_scanner" => false,
         "ojo_decider" => true,
-        "conclude_license_type" => "Permissive"
+        "conclude_license_type" => "Permissive",
+        "copyright_deactivation" => false,
+        "copyright_clutter_removal" => false
       ];
     } else {
       $expectedArray = [
@@ -117,7 +123,9 @@ class DeciderTest extends \PHPUnit\Framework\TestCase
         "bulkReused" => false,
         "newScanner" => false,
         "ojoDecider" => true,
-        "concludeLicenseType" => "Permissive"
+        "concludeLicenseType" => "Permissive",
+        "copyrightDeactivation" => false,
+        "copyrightClutterRemoval" => false
       ];
     }
 


### PR DESCRIPTION
## Description
Add options to schedule copyright false positive deactivation and declutter options from decider agent.

### Changes

1. Add missing key `concludeLicenseType` in `openapiv2.yaml`
2. Add new options `copyrightDeactivation` and `copyrightClutterRemoval` allowing user to run the experimental copyright declutter agent.
3. Since the decider is experimental and might not be installed, use `deciderAgentPlugin->isSpacyInstalled()` to first check if agent is installed before sending request to agent from REST API.

## How to test

Schedule the decider agent with various options from REST API.