### PR TITLE
Fix: LicenseDB Pull mechanism Error Handling Improvement

### DIFF
--- a/src/lib/php/Exceptions/HttpClientException.php
+++ b/src/lib/php/Exceptions/HttpClientException.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2025 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\Lib\Exceptions;
+
+/**
+ * @class HttpClientException
+ * @brief Exception when Guzzle client response is not as expected
+ */
+class HttpClientException extends \Exception
+{
+}

--- a/src/www/ui/page/AdminObligationFromCSV.php
+++ b/src/www/ui/page/AdminObligationFromCSV.php
@@ -10,6 +10,7 @@ namespace Fossology\UI\Page;
 
 use Fossology\Lib\Application\ObligationCsvImport;
 use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Exceptions\HttpClientException;
 use Fossology\Lib\Plugin\DefaultPlugin;
 use Fossology\Lib\Util\HttpUtils;
 use Fossology\UI\Api\Models\ApiVersion;
@@ -132,20 +133,11 @@ class AdminObligationFromCSV extends DefaultPlugin
       $response = $this->guzzleClient->get($finalURL);
       $fetchLicenseTimeReq = microtime(true) - $startTimeReq;
       $this->fileLogger->debug("LicenseDB req:' took " . sprintf("%0.3fms", 1000 * $fetchLicenseTimeReq));
-      if ($response->getStatusCode() == 200) {
-        $data = json_decode($response->getBody()->getContents());
-      }
 
-      if ($data === null) {
-        if (json_last_error() !== JSON_ERROR_NONE) {
-          return $msg . "Error decoding JSON: " . json_last_error_msg() . "\n";
-        }
-        return $msg . "No Obligations Found";
-      }
-      if (empty($data)) {
-        return $msg . "There are no Obligations Present in LicenseDB";
-      }
+      $data = HttpUtils::processHttpResponse($response);
       return $this->obligationsCsvImport->importJsonData($data, $msg);
+    } catch (HttpClientException $e) {
+      return $msg . $e->getMessage();
     } catch (RequestException|GuzzleException $e) {
       return $msg . _('Something Went Wrong, check if host is accessible') . ': ' . $e->getMessage();
     }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

License and Obligation Pull feature from LicenseDB was not handling the exceptions better:
In case of anything other than `status=200`, it was showing generic mesg which is difficult to debug and handle.

### Changes

Introduce switch cases for multiple `status_codes`.
In files:
1. AdminObligationFromCSV.php
2. AdminLicenseFromCSV.php

## How to test

1. Setup LicenseDB server.
2. Give details of the server in `Admin > Customize`, Fille these customize information: ![image](https://github.com/user-attachments/assets/893b0a6b-7e8f-4dcf-b981-c10e6db3d3fb)
3. Play around these information, To get several Response codes from server like 404, 500, 401 etc.
4. Go to `Admin > License Admin > License Import` Check various Outputs given.


cc: @shaheemazmalmmd @GMishx 

