### PR TITLE
fix(report): CLIXml Report Showing Incorrect License Type

### DIFF
--- a/src/clixml/agent/clixml.php
+++ b/src/clixml/agent/clixml.php
@@ -373,7 +373,7 @@ class CliXml extends Agent
     for ($i=0; $i<$lenMainLics; $i++) {
       $count = 0 ;
       for ($j=0; $j<$lenTotalLics; $j++) {
-        if (!strcmp($contents["licenses"][$j]["content"], $contents["licensesMain"][$i]["content"])) {
+        if (!strcmp($contents["licenses"][$j]["licenseId"], $contents["licensesMain"][$i]["licenseId"])) {
           $count = 1;
           $mainlic[] =  $contents["licenses"][$j];
           unset($contents["licenses"][$j]);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

CLIXml Report generation faces issues while encountering Licenses with same SPDX-ID.


### Changes

Main License and Other License Comparison now depends on `licenseId` rather than `SPDX-ID`, SPDX-ID being not unique.


## How to test
1. Create a new license with a SPDX-ID that is common with some other license, E.g. `BSD-3-CLAUSE` common for licenses like: `BSD-3-CLAUSE` and `BSD-3-CLAUSE (Google Inc).
2. Upload a component
3. Do some clearing on the component, Mark one license as main license (preferrable whose spdx-id has been takes common for created license)
4. Download CLI-XML Report, Only the main license marked should be `global`

E.g.

![image](https://github.com/user-attachments/assets/3f3c3b1c-aa16-49ad-b9c8-d6331d1527e0)



PS: Other reports I have seen, Doesnt incorporate the same logic.(spdx, unified)


CC: @shaheemazmalmmd @its-sushant This needs rigorous testing :)