### PR TITLE
fix(LicenseAndObligation): Display license and obligation count and l…

### DIFF
--- a/src/lib/php/Report/LicenseObligationUtility.php
+++ b/src/lib/php/Report/LicenseObligationUtility.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2023 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\Lib\Report;
+
+use Fossology\Lib\Db\DbManager;
+
+/**
+ * Utility class for license and obligation information
+ */
+class LicenseObligationUtility
+{
+  /** @var DbManager */
+  private $dbManager;
+
+  /**
+   * Constructor
+   * @param DbManager $dbManager Database manager
+   */
+  public function __construct(DbManager $dbManager)
+  {
+    $this->dbManager = $dbManager;
+  }
+
+  /**
+   * @brief Get license and obligation counts and last updated info
+   * @return array Array with license and obligation information
+   */
+  public function getLicenseAndObligationInfo()
+  {
+    $licenseInfo = $obligationInfo = null;
+
+    try {
+      // Get license count
+      $sql = "SELECT count(*) AS license_count FROM license_ref WHERE rf_active = 't'";
+      $result = $this->dbManager->getSingleRow($sql, array(), __METHOD__ . '.licenseCount');
+      if ($result) {
+        $licenseInfo = array(
+          'count' => $result['license_count'],
+          'lastUpdated' => $this->getLastUpdateTime('license_ref')
+        );
+      }
+
+      // Get obligation count
+      $sql = "SELECT count(*) AS obligation_count FROM obligation_ref WHERE ob_active = 't'";
+      $result = $this->dbManager->getSingleRow($sql, array(), __METHOD__ . '.obligationCount');
+      if ($result) {
+        $obligationInfo = array(
+          'count' => $result['obligation_count'],
+          'lastUpdated' => $this->getLastUpdateTime('obligation_ref')
+        );
+      }
+    } catch (\Exception $e) {
+      
+    }
+
+    return array($licenseInfo, $obligationInfo);
+  }
+
+  /**
+   * @brief Get the last update time for a table
+   * @param string $tableName Table name to check
+   * @return string Formatted date string
+   */
+  public function getLastUpdateTime($tableName)
+  {
+    try {
+      $result = null;
+      if ($tableName === 'license_ref') {
+        $sql = "SELECT rf_ts FROM license_ref ORDER BY rf_ts DESC LIMIT 1";
+        $result = $this->dbManager->getSingleRow($sql, array(), __METHOD__ . '.licenseLastUpdate');
+        if ($result) {
+          return date('Y-m-d', strtotime($result['rf_ts']));
+        }
+      } elseif ($tableName === 'obligation_ref') {
+        $sql = "SELECT ob_pk, ob_modificator, ob_modified FROM obligation_ref ORDER BY ob_modified DESC LIMIT 1";
+        $result = $this->dbManager->getSingleRow($sql, array(), __METHOD__ . '.obligationLastUpdate');
+        if ($result) {
+          return date('Y-m-d', strtotime($result['ob_modified']));
+        }
+      }
+    } catch (\Exception $e) {
+
+    }
+    
+    return date('Y-m-d'); // Default to current date if no update time found
+  }
+} 

--- a/src/lib/php/UI/Component/Menu.php
+++ b/src/lib/php/UI/Component/Menu.php
@@ -9,6 +9,7 @@
 namespace Fossology\Lib\UI\Component;
 
 use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Report\LicenseObligationUtility;
 use Twig\Environment;
 
 class Menu
@@ -21,6 +22,9 @@ class Menu
   const BANNER_COOKIE = 'close_banner';
   var $MenuTarget = "treenav";
   protected $renderer;
+  
+  /** @var LicenseObligationUtility */
+  private $licenseObligationUtility;
 
   public function __construct(Environment $renderer)
   {
@@ -31,6 +35,10 @@ class Menu
     menu_insert("Main::Help", -1);
     menu_insert("Main::Help::Documentation", 0, NULL, NULL, NULL, "<a href='https://github.com/fossology/fossology/wiki'>Documentation</a>");
     $this->renderer = $renderer;
+    
+    global $container;
+    $dbManager = $container->get("db.manager");
+    $this->licenseObligationUtility = new LicenseObligationUtility($dbManager);
   }
 
   /**
@@ -263,6 +271,11 @@ class Menu
           'commitDate' => $SysConf['BUILD']['COMMIT_DATE'],
           'branchName' => $SysConf['BUILD']['BRANCH']
       );
+      
+      // Get license and obligation information
+      list($licenseInfo, $obligationInfo) = $this->getLicenseAndObligationInfo();
+      $vars['licenseInfo'] = $licenseInfo;
+      $vars['obligationInfo'] = $obligationInfo;
     }
 
     if (!$vars['isLoggedOut']) {
@@ -296,5 +309,24 @@ class Menu
     } else {
       $vars['singleGroup'] = @$_SESSION['GroupName'];
     }
+  }
+
+  /**
+   * @brief Get license and obligation information
+   * @return array Array with license and obligation information
+   */
+  private function getLicenseAndObligationInfo()
+  {
+    return $this->licenseObligationUtility->getLicenseAndObligationInfo();
+  }
+
+  /**
+   * @brief Get the last update time for a table
+   * @param string $tableName Table name to check
+   * @return string Formatted date string
+   */
+  private function getLastUpdateTime($tableName)
+  {
+    return $this->licenseObligationUtility->getLastUpdateTime($tableName);
   }
 }

--- a/src/lib/php/UI/template/components/menu.html.twig
+++ b/src/lib/php/UI/template/components/menu.html.twig
@@ -23,7 +23,11 @@
       {% if versionInfo %}<br/>
         {# versionInfo contains all the variables defined at build time in the [BUILD] section of /VERSION #}
         {% set extractVersion = versionInfo.version|split('-') %}
-        <span id="versionInfo" style="font-size: xx-small; color: gray;">Version: [{{ extractVersion[0] }}], Branch: [{{ versionInfo.branchName }}], Commit: [#{{ versionInfo.commitHash }}] {{ versionInfo.commitDate }} built @ {{ versionInfo.buildDate }}</span>
+        <span id="versionInfo" style="font-size: xx-small; color: gray;">
+          Version: [{{ extractVersion[0] }}], Branch: [{{ versionInfo.branchName }}], Commit: [#{{ versionInfo.commitHash }}] {{ versionInfo.commitDate }} built @ {{ versionInfo.buildDate }}
+          {% if licenseInfo %} | Licenses: [{{ licenseInfo.count }}] last updated: {{ licenseInfo.lastUpdated }}{% endif %}
+          {% if obligationInfo %} | Obligations: [{{ obligationInfo.count }}] last updated: {{ obligationInfo.lastUpdated }}{% endif %}
+        </span>
       {% endif %}</td>
     <td align="right" valign="bottom">
       {% if isLoggedOut %}

--- a/src/spdx/agent/template/spdx2tv-document.twig
+++ b/src/spdx/agent/template/spdx2tv-document.twig
@@ -28,6 +28,8 @@ Creator: Organization: {{ organisation }}
 {% endif %}
 CreatorComment: <text>
 This document was created using license information and a generator from Fossology.
+{% if licenseInfo %}License count: {{ licenseInfo.count }}, Last updated: {{ licenseInfo.lastUpdated }}{% endif %}
+{% if obligationInfo %}Obligation count: {{ obligationInfo.count }}, Last updated: {{ obligationInfo.lastUpdated }}{% endif %}
 </text>
 Created: {{ 'now'|date('Y-m-d\\TH:i:s\\Z', 'UTC') }}
 LicenseListVersion: 3.22


### PR DESCRIPTION

## Description

This PR adds **license** and **obligation** metadata (count and last updated date) to the FOSSology UI header area and includes this information in the metadata of the SPDX, Unified Report, and CLI 2.0.

### Changes

- Added license and obligation count information to the FOSSology UI header alongside version information
- Created a utility class to provide consistent license and obligation information across different parts of the application
- Added license and obligation metadata to **SPDX** report
- Added license and obligation metadata to **Unified** Report
- Added license and obligation metadata to **CLI 2.0** output
- Used existing structure for displaying the information in a consistent format

## Expected Result

![image](https://github.com/user-attachments/assets/26b7b776-9239-4017-8dc7-2c55db4482c2)


## How to test

- Login to FOSSology and verify that license and obligation information appears in the header area
- Check if the obligation counter increases on adding a new obligation.

Closes: #1243 
