### PR TITLE
feat(api): fixed patch upload by id endpoint

### DIFF
--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -648,7 +648,6 @@ class UploadController extends RestController
   public function updateUpload($request, $response, $args)
   {
     $id = intval($args['id']);
-    $query = $request->getQueryParams();
     $userDao = $this->restHelper->getUserDao();
     $userId = $this->restHelper->getUserId();
     $groupId = $this->restHelper->getGroupId();
@@ -667,7 +666,7 @@ class UploadController extends RestController
 
     $assignee = null;
     $status = null;
-    $comment = null;
+    $comment = '';
     $newName = null;
     $newDescription = null;
 
@@ -680,8 +679,8 @@ class UploadController extends RestController
     }
 
     // Handle assignee info
-    if (array_key_exists(self::FILTER_ASSIGNEE, $query)) {
-      $assignee = filter_var($query[self::FILTER_ASSIGNEE], FILTER_VALIDATE_INT);
+    if (array_key_exists(self::FILTER_ASSIGNEE, $bodyContent)) {
+      $assignee = filter_var($bodyContent[self::FILTER_ASSIGNEE], FILTER_VALIDATE_INT);
       $userList = $userDao->getUserChoices($groupId);
       if (!array_key_exists($assignee, $userList)) {
         throw new HttpNotFoundException(
@@ -689,20 +688,38 @@ class UploadController extends RestController
       }
       $uploadBrowseProxy->updateTable("assignee", $id, $assignee);
     }
-    // Handle new status
-    if (
-      array_key_exists(self::FILTER_STATUS, $query) &&
-      in_array(strtolower($query[self::FILTER_STATUS]), self::VALID_STATUS)
-    ) {
-      $newStatus = strtolower($query[self::FILTER_STATUS]);
-      $comment = '';
+
+    // Handle comment validation
+    if (array_key_exists("comment", $bodyContent)) {
+      if (!is_string($bodyContent["comment"])) {
+        throw new HttpBadRequestException("Comment must be a string.");
+      }
+      $comment = trim($bodyContent["comment"]);
+    }
+
+    // Handle update of new status
+    if (array_key_exists(self::FILTER_STATUS, $bodyContent)) {
+      $newStatus = strtolower($bodyContent[self::FILTER_STATUS]);
+
+      // Validate status type
+      if (!in_array($newStatus, self::VALID_STATUS)) {
+        throw new HttpBadRequestException("Invalid status type. Status must be one of: " . implode(", ", self::VALID_STATUS));
+      }
+
+      // For closed or rejected status, comment is mandatory
       if (in_array($newStatus, ["closed", "rejected"])) {
-        if ($isJsonRequest && array_key_exists("comment", $bodyContent)) {
-          $comment = $bodyContent["comment"];
-        } else {
-          $comment = $bodyContent;
+        if (!array_key_exists("comment", $bodyContent)) {
+          throw new HttpBadRequestException("Comment is required for '$newStatus' status.");
+        }
+        if (!is_string($bodyContent["comment"])) {
+          throw new HttpBadRequestException("Comment must be a string.");
+        }
+        $comment = trim($bodyContent["comment"]);
+        if (empty($comment)) {
+          throw new HttpBadRequestException("Comment cannot be empty for '$newStatus' status.");
         }
       }
+
       $status = 0;
       if ($newStatus == self::VALID_STATUS[1]) {
         $status = UploadStatus::IN_PROGRESS;
@@ -715,22 +732,23 @@ class UploadController extends RestController
       }
       $uploadBrowseProxy->setStatusAndComment($id, $status, $comment);
     }
+
     // Handle update of name
     if (
-      $isJsonRequest &&
       array_key_exists(self::FILTER_NAME, $bodyContent) &&
       strlen(trim($bodyContent[self::FILTER_NAME])) > 0
     ) {
       $newName = trim($bodyContent[self::FILTER_NAME]);
     }
+
     // Handle update of description
     if (
-      $isJsonRequest &&
       array_key_exists("uploadDescription", $bodyContent) &&
       strlen(trim($bodyContent["uploadDescription"])) > 0
     ) {
       $newDescription = trim($bodyContent["uploadDescription"]);
     }
+
     if ($newName != null || $newDescription != null) {
       /** @var \upload_properties $uploadProperties */
       $uploadProperties = $this->restHelper->getPlugin('upload_properties');

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -549,59 +549,60 @@ paths:
       tags:
         - Upload
         - Organize
-      description: Update an upload information
+      description: Update an upload information (status, assignee, name, description)
       parameters:
-        - name: status
-          description: New status of the upload
-          in: query
-          required: false
-          schema:
-            type: string
-            enum:
-              - Open
-              - InProgress
-              - Closed
-              - Rejected
-          example: Closed
-        - name: assignee
-          description: New assignee for the project
-          in: query
-          required: false
+        - name: id
+          in: path
+          description: Upload ID to update
+          required: true
           schema:
             type: integer
       requestBody:
-        description: >
-          Comment on the status, required for Closed and Rejected states.
-          Use the application/json for advanced usage.
+        description: Upload update parameters
+        required: true
         content:
-          text/plain:
-            schema:
-              description: The comment for new status
-              type: string
-              example: "The upload cleared for use."
           application/json:
             schema:
               type: object
               properties:
+                status:
+                  type: string
+                  enum:
+                    - Open
+                    - InProgress
+                    - Closed
+                    - Rejected
+                  description: New status of the upload
+                  example: Closed
+                assignee:
+                  type: integer
+                  description: ID of new assignee for the upload
+                  example: 3
                 comment:
                   type: string
-                  description: The comment for new status
+                  description: Required when status is 'Closed' or 'Rejected'.
                   example: "The upload cleared for use."
                 name:
                   type: string
-                  description: New name of the upload.
+                  description: New name for the upload
                   example: my_edited_upload.zip
                 uploadDescription:
                   type: string
-                  description: Updated description for the upload.
+                  description: New description for the upload
                   example: This is updated description.
       responses:
         '202':
-          description: Upload will be updated
+          description: Upload updated successfully
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Info'
+        '400':
+          description: Bad request when invalid name/description provided
+        '403':
+          description: Forbidden when user is not admin/advisor
+        '404':
+          description: Not found when assignee doesn't have permission
         default:
           $ref: '#/components/responses/defaultResponse'
     put:

--- a/src/www/ui_tests/api/Controllers/UploadControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadControllerTest.php
@@ -1183,50 +1183,69 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
   }
 
   /**
-   * @test
-   * -# Test for UploadController::updateUpload()
-   * -# Check if response status is 202
-   */
-  public function testUpdateUpload()
-  {
-    $upload = 2;
-    $assignee = 4;
-    $status = UploadStatus::REJECTED;
-    $comment = "Not helpful";
-
-    $resource = fopen('data://text/plain;base64,' .
-      base64_encode($comment), 'r+');
-    $body = $this->streamFactory->createStreamFromResource($resource);
-    $request = new Request("POST", new Uri("HTTP", "localhost", 80,
-      "/uploads/$upload", UploadController::FILTER_STATUS . "=Rejected&" .
-      UploadController::FILTER_ASSIGNEE . "=$assignee"),
-      new Headers(), [], [], $body);
-
-    $this->userDao->shouldReceive('isAdvisorOrAdmin')
-      ->withArgs([$this->userId, $this->groupId])
-      ->andReturn(true);
-    $this->userDao->shouldReceive('getUserChoices')
-      ->withArgs([$this->groupId])
-      ->andReturn([$this->userId => "fossy", $assignee => "friendly-fossy"]);
-    $this->dbManager->shouldReceive('getSingleRow')
-      ->withArgs([M::any(), [$assignee, $this->groupId, $upload], M::any()]);
-    $this->dbManager->shouldReceive('getSingleRow')
-      ->withArgs([M::any(), [$status, $comment, $this->groupId, $upload],
-        M::any()]);
-    $this->dbManager->shouldReceive('getSingleRow')
-      ->withArgs([M::any(), [$upload], M::any()])
-      ->andReturn(["exists" => ""]);
-
-    $info = new Info(202, "Upload updated successfully.", InfoType::INFO);
-    $expectedResponse = (new ResponseHelper())->withJson($info->getArray(),
-      $info->getCode());
-    $actualResponse = $this->uploadController->updateUpload($request,
-      new ResponseHelper(), ['id' => $upload]);
-    $this->assertEquals($expectedResponse->getStatusCode(),
-      $actualResponse->getStatusCode());
-    $this->assertEquals($this->getResponseJson($expectedResponse),
-      $this->getResponseJson($actualResponse));
-  }
+ * @test
+ * -# Test for UploadController::updateUpload()
+ * -# Check if response status is 202
+ */
+public function testUpdateUpload()
+{
+  $upload = 2;
+  $assignee = 4;
+  $status = UploadStatus::REJECTED;
+  $comment = "Not helpful";
+  
+  $requestBody = [
+    UploadController::FILTER_STATUS => "Rejected",
+    UploadController::FILTER_ASSIGNEE => $assignee,
+    "comment" => $comment
+  ];
+  $jsonBody = json_encode($requestBody);
+  
+  $resource = fopen('data://text/plain;base64,' . base64_encode($jsonBody), 'r+');
+  $body = $this->streamFactory->createStreamFromResource($resource);
+  
+  $headers = new Headers();
+  $headers->setHeader('Content-Type', 'application/json');
+  
+  $request = new Request(
+    "POST",
+    new Uri("HTTP", "localhost", 80, "/uploads/$upload"),
+    $headers,
+    [],
+    [],
+    $body
+  );
+  
+  $this->userDao->shouldReceive('isAdvisorOrAdmin')
+    ->withArgs([$this->userId, $this->groupId])
+    ->andReturn(true);
+    
+  $this->userDao->shouldReceive('getUserChoices')
+    ->withArgs([$this->groupId])
+    ->andReturn([$this->userId => "fossy", $assignee => "friendly-fossy"]);
+    
+  $this->dbManager->shouldReceive('getSingleRow')
+    ->withArgs([M::any(), [$assignee, $this->groupId, $upload], M::any()]);
+    
+  $this->dbManager->shouldReceive('getSingleRow')
+    ->withArgs([M::any(), [$status, $comment, $this->groupId, $upload], M::any()]);
+    
+  $this->dbManager->shouldReceive('getSingleRow')
+    ->withArgs([M::any(), [$upload], M::any()])
+    ->andReturn(["exists" => ""]);
+    
+  $info = new Info(202, "Upload updated successfully.", InfoType::INFO);
+  $expectedResponse = (new ResponseHelper())->withJson($info->getArray(), $info->getCode());
+  
+  $actualResponse = $this->uploadController->updateUpload(
+    $request,
+    new ResponseHelper(),
+    ['id' => $upload]
+  );
+  
+  $this->assertEquals($expectedResponse->getStatusCode(), $actualResponse->getStatusCode());
+  $this->assertEquals($this->getResponseJson($expectedResponse), $this->getResponseJson($actualResponse));
+}
 
   /**
    * @test
@@ -1251,6 +1270,282 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
       ->withArgs([$this->userId, $this->groupId])
       ->andReturn(false);
     $this->expectException(HttpForbiddenException::class);
+
+    $this->uploadController->updateUpload($request, new ResponseHelper(),
+      ['id' => $upload]);
+  }
+
+  /**
+   * @test
+   * -# Test for UploadController::updateUpload() with invalid status
+   * -# Check if response status is 400
+   */
+  public function testUpdateUploadInvalidStatus()
+  {
+    $upload = 2;
+    $requestBody = [
+      UploadController::FILTER_STATUS => "invalid_status"
+    ];
+    $jsonBody = json_encode($requestBody);
+    
+    $resource = fopen('data://text/plain;base64,' . base64_encode($jsonBody), 'r+');
+    $body = $this->streamFactory->createStreamFromResource($resource);
+    
+    $headers = new Headers();
+    $headers->setHeader('Content-Type', 'application/json');
+    
+    $request = new Request(
+      "POST",
+      new Uri("HTTP", "localhost", 80, "/uploads/$upload"),
+      $headers,
+      [],
+      [],
+      $body
+    );
+    
+    $this->userDao->shouldReceive('isAdvisorOrAdmin')
+      ->withArgs([$this->userId, $this->groupId])
+      ->andReturn(true);
+      
+    $this->expectException(HttpBadRequestException::class);
+    $this->expectExceptionMessage("Invalid status type. Status must be one of: open, inprogress, closed, rejected");
+
+    $this->uploadController->updateUpload($request, new ResponseHelper(),
+      ['id' => $upload]);
+  }
+
+  /**
+   * @test
+   * -# Test for UploadController::updateUpload() with closed status but missing comment
+   * -# Check if response status is 400
+   */
+  public function testUpdateUploadClosedStatusMissingComment()
+  {
+    $upload = 2;
+    $requestBody = [
+      UploadController::FILTER_STATUS => "closed"
+    ];
+    $jsonBody = json_encode($requestBody);
+    
+    $resource = fopen('data://text/plain;base64,' . base64_encode($jsonBody), 'r+');
+    $body = $this->streamFactory->createStreamFromResource($resource);
+    
+    $headers = new Headers();
+    $headers->setHeader('Content-Type', 'application/json');
+    
+    $request = new Request(
+      "POST",
+      new Uri("HTTP", "localhost", 80, "/uploads/$upload"),
+      $headers,
+      [],
+      [],
+      $body
+    );
+    
+    $this->userDao->shouldReceive('isAdvisorOrAdmin')
+      ->withArgs([$this->userId, $this->groupId])
+      ->andReturn(true);
+      
+    $this->expectException(HttpBadRequestException::class);
+    $this->expectExceptionMessage("Comment is required for 'closed' status.");
+
+    $this->uploadController->updateUpload($request, new ResponseHelper(),
+      ['id' => $upload]);
+  }
+
+  /**
+   * @test
+   * -# Test for UploadController::updateUpload() with rejected status but missing comment
+   * -# Check if response status is 400
+   */
+  public function testUpdateUploadRejectedStatusMissingComment()
+  {
+    $upload = 2;
+    $requestBody = [
+      UploadController::FILTER_STATUS => "rejected"
+    ];
+    $jsonBody = json_encode($requestBody);
+    
+    $resource = fopen('data://text/plain;base64,' . base64_encode($jsonBody), 'r+');
+    $body = $this->streamFactory->createStreamFromResource($resource);
+    
+    $headers = new Headers();
+    $headers->setHeader('Content-Type', 'application/json');
+    
+    $request = new Request(
+      "POST",
+      new Uri("HTTP", "localhost", 80, "/uploads/$upload"),
+      $headers,
+      [],
+      [],
+      $body
+    );
+    
+    $this->userDao->shouldReceive('isAdvisorOrAdmin')
+      ->withArgs([$this->userId, $this->groupId])
+      ->andReturn(true);
+      
+    $this->expectException(HttpBadRequestException::class);
+    $this->expectExceptionMessage("Comment is required for 'rejected' status.");
+
+    $this->uploadController->updateUpload($request, new ResponseHelper(),
+      ['id' => $upload]);
+  }
+
+  /**
+   * @test
+   * -# Test for UploadController::updateUpload() with closed status but empty comment
+   * -# Check if response status is 400
+   */
+  public function testUpdateUploadClosedStatusEmptyComment()
+  {
+    $upload = 2;
+    $requestBody = [
+      UploadController::FILTER_STATUS => "closed",
+      "comment" => "   "  // Empty/whitespace comment
+    ];
+    $jsonBody = json_encode($requestBody);
+    
+    $resource = fopen('data://text/plain;base64,' . base64_encode($jsonBody), 'r+');
+    $body = $this->streamFactory->createStreamFromResource($resource);
+    
+    $headers = new Headers();
+    $headers->setHeader('Content-Type', 'application/json');
+    
+    $request = new Request(
+      "POST",
+      new Uri("HTTP", "localhost", 80, "/uploads/$upload"),
+      $headers,
+      [],
+      [],
+      $body
+    );
+    
+    $this->userDao->shouldReceive('isAdvisorOrAdmin')
+      ->withArgs([$this->userId, $this->groupId])
+      ->andReturn(true);
+      
+    $this->expectException(HttpBadRequestException::class);
+    $this->expectExceptionMessage("Comment cannot be empty for 'closed' status.");
+
+    $this->uploadController->updateUpload($request, new ResponseHelper(),
+      ['id' => $upload]);
+  }
+
+  /**
+   * @test
+   * -# Test for UploadController::updateUpload() with rejected status but empty comment
+   * -# Check if response status is 400
+   */
+  public function testUpdateUploadRejectedStatusEmptyComment()
+  {
+    $upload = 2;
+    $requestBody = [
+      UploadController::FILTER_STATUS => "rejected",
+      "comment" => ""  // Empty comment
+    ];
+    $jsonBody = json_encode($requestBody);
+    
+    $resource = fopen('data://text/plain;base64,' . base64_encode($jsonBody), 'r+');
+    $body = $this->streamFactory->createStreamFromResource($resource);
+    
+    $headers = new Headers();
+    $headers->setHeader('Content-Type', 'application/json');
+    
+    $request = new Request(
+      "POST",
+      new Uri("HTTP", "localhost", 80, "/uploads/$upload"),
+      $headers,
+      [],
+      [],
+      $body
+    );
+    
+    $this->userDao->shouldReceive('isAdvisorOrAdmin')
+      ->withArgs([$this->userId, $this->groupId])
+      ->andReturn(true);
+      
+    $this->expectException(HttpBadRequestException::class);
+    $this->expectExceptionMessage("Comment cannot be empty for 'rejected' status.");
+
+    $this->uploadController->updateUpload($request, new ResponseHelper(),
+      ['id' => $upload]);
+  }
+
+  /**
+   * @test
+   * -# Test for UploadController::updateUpload() with comment that's not a string
+   * -# Check if response status is 400
+   */
+  public function testUpdateUploadCommentNotString()
+  {
+    $upload = 2;
+    $requestBody = [
+      UploadController::FILTER_STATUS => "closed",
+      "comment" => 123  // Non-string comment
+    ];
+    $jsonBody = json_encode($requestBody);
+    
+    $resource = fopen('data://text/plain;base64,' . base64_encode($jsonBody), 'r+');
+    $body = $this->streamFactory->createStreamFromResource($resource);
+    
+    $headers = new Headers();
+    $headers->setHeader('Content-Type', 'application/json');
+    
+    $request = new Request(
+      "POST",
+      new Uri("HTTP", "localhost", 80, "/uploads/$upload"),
+      $headers,
+      [],
+      [],
+      $body
+    );
+    
+    $this->userDao->shouldReceive('isAdvisorOrAdmin')
+      ->withArgs([$this->userId, $this->groupId])
+      ->andReturn(true);
+      
+    $this->expectException(HttpBadRequestException::class);
+    $this->expectExceptionMessage("Comment must be a string.");
+
+    $this->uploadController->updateUpload($request, new ResponseHelper(),
+      ['id' => $upload]);
+  }
+
+  /**
+   * @test
+   * -# Test for UploadController::updateUpload() with comment that's not a string in general case
+   * -# Check if response status is 400
+   */
+  public function testUpdateUploadGeneralCommentNotString()
+  {
+    $upload = 2;
+    $requestBody = [
+      "comment" => ["not", "a", "string"]  // Non-string comment
+    ];
+    $jsonBody = json_encode($requestBody);
+    
+    $resource = fopen('data://text/plain;base64,' . base64_encode($jsonBody), 'r+');
+    $body = $this->streamFactory->createStreamFromResource($resource);
+    
+    $headers = new Headers();
+    $headers->setHeader('Content-Type', 'application/json');
+    
+    $request = new Request(
+      "POST",
+      new Uri("HTTP", "localhost", 80, "/uploads/$upload"),
+      $headers,
+      [],
+      [],
+      $body
+    );
+    
+    $this->userDao->shouldReceive('isAdvisorOrAdmin')
+      ->withArgs([$this->userId, $this->groupId])
+      ->andReturn(true);
+      
+    $this->expectException(HttpBadRequestException::class);
+    $this->expectExceptionMessage("Comment must be a string.");
 
     $this->uploadController->updateUpload($request, new ResponseHelper(),
       ['id' => $upload]);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This PR modifies the updateUpload method in UploadController to properly handle all parameters from the request body instead of query parameters. This allows users to update upload status, assignee, name, and description via a single JSON payload, making the API more RESTful and consistent with the Swagger documentation.

### Changes

- Modified updateUpload method to read all parameters from the request body instead of query parameters
- Simplified the handling of comments for status changes
- Updated test cases to use proper JSON request format
- Fixed the API documentation to match the implementation
- Ensured proper status code (202) is returned with success message

## How to test

1. Test the API endpoint by sending a PATCH request to repo/api/v2/uploads/{uploadId} with a JSON body containing any of the following fields:
{
  "status": "Closed",
  "assignee": 3,
  "comment": "Upload reviewed and closed",
  "name": "new_upload_name.zip",
  "uploadDescription": "Updated description"
}
2. Verify that each field properly updates in the UI (http://localhost/repo/?mod=browse)

![Screenshot from 2025-04-30 14-46-08](https://github.com/user-attachments/assets/ef35e389-9c53-415b-a2db-506d9a769f22)

Fixes: [issue#3041](https://github.com/fossology/fossology/issues/3041)
