### PR TITLE
fix(browse): fixed comment and description handling for deletion

### DIFF
--- a/src/www/ui/admin-upload-edit.php
+++ b/src/www/ui/admin-upload-edit.php
@@ -46,15 +46,15 @@ class upload_properties extends FO_Plugin
    **/
   public function UpdateUploadProperties($uploadId, $newName, $newDesc)
   {
-    if (empty($newName) and empty($newDesc)) {
+    if (!isset($newName) && !isset($newDesc)) {
       return 2;
     }
 
     if (!empty($newName)) {
       /*
-       * Use pfile_fk to select the correct entry in the upload tree, artifacts
-       * (e.g. directories of the upload do not have pfiles).
-       */
+      * Use pfile_fk to select the correct entry in the upload tree, artifacts
+      * (e.g. directories of the upload do not have pfiles).
+      */
       $row = $this->dbManager->getSingleRow(
         "SELECT pfile_fk FROM upload WHERE upload_pk=$1",array($uploadId),__METHOD__.'.getPfileId');
       if (empty($row)) {
@@ -74,7 +74,7 @@ class upload_properties extends FO_Plugin
         __METHOD__ . '.updateUpload.name');
     }
 
-    if (! empty($newDesc)) {
+    if (isset($newDesc)) {
       $trimNewDesc = trim($newDesc);
       $this->dbManager->getSingleRow("UPDATE upload SET upload_desc=$2 WHERE upload_pk=$1",
         array($uploadId, $trimNewDesc), __METHOD__ . '.updateUpload.desc');
@@ -95,7 +95,7 @@ class upload_properties extends FO_Plugin
     }
 
     $NewName = GetArrayVal("newname", $_POST);
-    $NewDesc = GetArrayVal("newdesc", $_POST);
+    $NewDesc = array_key_exists("newdesc", $_POST) ? $_POST["newdesc"] : null;
     $upload_pk = GetArrayVal("upload_pk", $_POST);
     if (empty($upload_pk)) {
       $upload_pk = GetParm('upload', PARM_INTEGER);
@@ -105,13 +105,16 @@ class upload_properties extends FO_Plugin
       $text = _("Permission Denied");
       return "<h2>$text</h2>";
     }
-    $rc = $this->UpdateUploadProperties($upload_pk, $NewName, $NewDesc);
-    if ($rc == 0) {
-      $text = _("Nothing to Change");
-      $this->vars['message'] = $text;
-    } else if ($rc == 1) {
-      $text = _("Upload Properties successfully changed");
-      $this->vars['message'] = $text;
+
+    if (array_key_exists("upload_pk", $_POST)) {
+      $rc = $this->UpdateUploadProperties($upload_pk, $NewName, $NewDesc);
+      if ($rc == 0) {
+        $text = _("Nothing to Change");
+        $this->vars['message'] = $text;
+      } else if ($rc == 1) {
+        $text = _("Upload Properties successfully changed");
+        $this->vars['message'] = $text;
+      }
     }
 
     $this->vars['folderStructure'] = $folderStructure;

--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -726,8 +726,7 @@ class UploadController extends RestController
     // Handle update of description
     if (
       $isJsonRequest &&
-      array_key_exists("uploadDescription", $bodyContent) &&
-      strlen(trim($bodyContent["uploadDescription"])) > 0
+      array_key_exists("uploadDescription", $bodyContent)
     ) {
       $newDescription = trim($bodyContent["uploadDescription"]);
     }

--- a/src/www/ui/async/AjaxBrowse.php
+++ b/src/www/ui/async/AjaxBrowse.php
@@ -88,7 +88,7 @@ class AjaxBrowse extends DefaultPlugin
     } else if (! empty($uploadId) && ! empty($direction)) {
       $uploadBrowseProxy = new UploadBrowseProxy($groupId, $this->userPerm, $this->dbManager);
       $uploadBrowseProxy->moveUploadToInfinity($uploadId, $direction == 'top');
-    } else if (!empty($uploadId) && !empty($commentText) && !empty($statusId)) {
+    } else if (!empty($uploadId) && isset($commentText) && !empty($statusId)) {
       $uploadBrowseProxy = new UploadBrowseProxy($groupId, $this->userPerm, $this->dbManager);
       $uploadBrowseProxy->setStatusAndComment($uploadId, $statusId, $commentText);
     } else {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This PR fixes the issue where users cannot clear upload descriptions and comments by submitting empty strings. The current implementation incorrectly prevents empty strings from being processed, causing the UI to retain previous values when users attempt to clear these fields.

### Changes

Modified AjaxBrowse.php and admin-upload-edit.php to properly handle empty string submission.

## How to test

1. **For Upload Description:**
   - Navigate to `Organize` -> `Uploads` -> `Edit Properties`
   - Clear text in the Upload Description field
   - Click on `Edit` button
   - Verify the description is properly cleared

2. **For Upload Comment:**
   - Navigate to `Browse` tab
   - Locate an upload and double-click on the Comment cell
   - Either clear the text field and click `OK`
   - Verify the comment field is properly cleared

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
Fixes: [issue#3002](https://github.com/fossology/fossology/issues/3002)
