### PR TITLE
fix(ui): fix tooltip for reuse modal in file upload page

### DIFF
--- a/src/www/ui/template/upload_file.html.twig
+++ b/src/www/ui/template/upload_file.html.twig
@@ -233,5 +233,8 @@
     $('#uploaddescriptions').on('shown.bs.collapse', function () {
       $('#collapseDescription').find('button').text('- collapse');
     });
+    $('#reuseModal').on('shown.bs.modal', function () {
+      $(this).find('[data-toggle="tooltip"]').tooltip();
+    });
   </script>
 {% endblock %}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

fix tooltip for reuse modal in file upload from file page

CC: @shaheemazmalmmd @Kaushl2208 
