### PR TITLE
fix(treeview): exclude scancode, reportimport and spasht from schedul…

### DIFF
--- a/src/www/ui/template/browse_license-agent_selector.html.twig
+++ b/src/www/ui/template/browse_license-agent_selector.html.twig
@@ -23,15 +23,17 @@
 {% endif %}
 
 {% for s in scanners %}
-  <div style="border: 1px dashed gray;">
-  {% include 'browse_license-agent.html.twig' with {
-     'agentName':s.agentName,
-     'successfulAgents':s.successfulAgents,
-     'uploadId':s.uploadId,
-     'agentName':s.agentName,
-     'isAgentRunning':s.isAgentRunning,
-     'currentAgentId':s.currentAgentId,
-     'currentAgentRev':s.currentAgentRev}
-  %}
-  </div>
+  {% if s.agentName != 'scancode' and s.agentName != 'reportImport' and s.agentName != 'spasht' %}
+    <div style="border: 1px dashed gray;">
+    {% include 'browse_license-agent.html.twig' with {
+      'agentName':s.agentName,
+      'successfulAgents':s.successfulAgents,
+      'uploadId':s.uploadId,
+      'agentName':s.agentName,
+      'isAgentRunning':s.isAgentRunning,
+      'currentAgentId':s.currentAgentId,
+      'currentAgentRev':s.currentAgentRev}
+    %}
+    </div>
+  {% endif %}
 {% endfor %}


### PR DESCRIPTION


## How to test

* Upload a component without scheduling scancode, spasht.
* You should not be able to see schedule from tree-view.
