### PR TITLE
fix(jsload) : Reuser agent not being scheduled

### DIFF
--- a/src/decider/ui/DeciderAgentPlugin.php
+++ b/src/decider/ui/DeciderAgentPlugin.php
@@ -60,6 +60,11 @@ class DeciderAgentPlugin extends AgentPlugin
     return "";
   }
 
+  public function getScriptIncludes(&$vars)
+  {
+    return "";
+  }
+
   /**
    * @brief Schedule decider agent
    * @param int $jobId

--- a/src/reuser/ui/agent-reuser.php
+++ b/src/reuser/ui/agent-reuser.php
@@ -71,6 +71,17 @@ class ReuserAgentPlugin extends AgentPlugin
   }
 
   /**
+   * @brief Get script tags to include before rendering foot
+   * @param array $vars Variables for twig template
+   * @return string Rendered JS includes
+   */
+  public function getScriptIncludes(&$vars)
+  {
+    $reuserPlugin = plugin_find('plugin_reuser');
+    return $reuserPlugin->getScriptIncludes($vars);
+  }
+
+  /**
    * @copydoc Fossology::Lib::Plugin::AgentPlugin::preInstall()
    * @see Fossology::Lib::Plugin::AgentPlugin::preInstall()
    */

--- a/src/reuser/ui/reuser-plugin.php
+++ b/src/reuser/ui/reuser-plugin.php
@@ -156,6 +156,16 @@ class ReuserPlugin extends DefaultPlugin
   }
 
   /**
+   * @brief Render JS inclues
+   * @param array $vars
+   * @return string
+   */
+  public function getScriptIncludes(&$vars)
+  {
+    return '<script src="scripts/tools.js" type="text/javascript"></script>';
+  }
+
+  /**
    * @brief For a given folder id, collect all uploads
    *
    * Creates an array of uploads with `<upload_id,group_id>` as the key and

--- a/src/reuser/ui/template/agent_reuser.js.twig
+++ b/src/reuser/ui/template/agent_reuser.js.twig
@@ -2,57 +2,48 @@
 
    SPDX-License-Identifier: GPL-2.0-only
 #}
-$.getScript("scripts/tools.js")
-  .done(function () {
-    console.log("Failure handler loaded.");
-
-    function registerFolderSelectorChange() {
-      $('[id^={{ reuseFolderSelectorName }}]').change(function () {
-        const groupIndex = $(this).attr('id').replace('{{ reuseFolderSelectorName }}', '');
-        const folderGroupPair = this.selectedOptions[0].value;
-        reloadUploads('&{{ folderParameterName }}=' + folderGroupPair, groupIndex);
-      });
-    }
-
-    function reloadUploads(folderGroupPair, groupIndex) {
-      $.getJSON("?mod=plugin_reuser&do=getUploads" + folderGroupPair)
-        .done(function (data) {
-          const packageForReuse = $(`#{{ uploadToReuseSelectorName }}${groupIndex}`);
-          packageForReuse.empty();
-          $.each(data, function (key, value) {
-            const option = document.createElement("option");
-            option.innerHTML = value;
-            option.value = key;
-            packageForReuse.append(option);
-          });
-          sortList(`#{{ uploadToReuseSelectorName }}${groupIndex} option`);
-        })
-        .fail(failed);
-    }
-
-    function toggleDisabled() {
-      $('.reuseSearchInFolder').click(function () {
-        const groupIndex = $(this).attr('id').replace('reuseSearchInFolder', '');
-        const folderSelector = $(`#{{ reuseFolderSelectorName }}${groupIndex}`);
-        folderSelector.prop('disabled', !$(this).prop('checked'));
-
-        if ($(this).prop('checked')) {
-          folderSelector.trigger('change');
-        } else {
-          reloadUploads("", "");
-        }
-      });
-
-      reloadUploads("", "");
-      registerFolderSelectorChange();
-    }
-
-    $(document).ready(function () {
-      toggleDisabled();
-    });
-
-  })
-  .fail(function () {
-    console.error("Failed to load tools.js");
+function registerFolderSelectorChange() {
+  $('[id^={{ reuseFolderSelectorName }}]').change(function () {
+    const groupIndex = $(this).attr('id').replace('{{ reuseFolderSelectorName }}', '');
+    const folderGroupPair = this.selectedOptions[0].value;
+    reloadUploads('&{{ folderParameterName }}=' + folderGroupPair, groupIndex);
   });
+}
+
+function reloadUploads(folderGroupPair, groupIndex) {
+  $.getJSON("?mod=plugin_reuser&do=getUploads" + folderGroupPair)
+    .done(function (data) {
+      const packageForReuse = $(`#{{ uploadToReuseSelectorName }}${groupIndex}`);
+      packageForReuse.empty();
+      $.each(data, function (key, value) {
+        const option = document.createElement("option");
+        option.innerHTML = value;
+        option.value = key;
+        packageForReuse.append(option);
+      });
+      sortList(`#{{ uploadToReuseSelectorName }}${groupIndex} option`);
+    })
+    .fail(failed);
+}
+
+function toggleDisabled() {
+  $('.reuseSearchInFolder').click(function () {
+    const groupIndex = $(this).attr('id').replace('reuseSearchInFolder', '');
+    const folderSelector = $(`#{{ reuseFolderSelectorName }}${groupIndex}`);
+    folderSelector.prop('disabled', !$(this).prop('checked'));
+
+    if ($(this).prop('checked')) {
+      folderSelector.trigger('change');
+    } else {
+      reloadUploads("", "");
+    }
+  });
+
+  reloadUploads("", "");
+  registerFolderSelectorChange();
+}
+
+$(document).ready(function () {
+  toggleDisabled();
+});
 

--- a/src/scancode/ui/agent-scancode.php
+++ b/src/scancode/ui/agent-scancode.php
@@ -44,6 +44,11 @@ class ScancodesAgentPlugin extends AgentPlugin
     return "";
   }
 
+  public function getScriptIncludes(&$vars)
+  {
+    return "";
+  }
+
   /**
    * @brief Schedule scancode agent
    *

--- a/src/www/ui/agent-add.php
+++ b/src/www/ui/agent-add.php
@@ -71,10 +71,12 @@ class AgentAdder extends DefaultPlugin
       $out .= "<br/><b>".$agent->AgentName.":</b><br/>";
       $out .= $agent->renderContent($vars);
       $parmAgentFoots .= $agent->renderFoot($vars);
+      $paramAgentIncludes .= $agent->getScriptIncludes($vars);
     }
     $out .= '</ol>';
     $vars['out'] = $out;
     $vars['outFoot'] = '<script language="javascript"> '.$parmAgentFoots.'</script>';
+    $vars['paramIncludes'] = $paramAgentIncludes;
 
     return $this->render('agent_adder.html.twig', $this->mergeWithDefault($vars));
   }

--- a/src/www/ui/template/agent_adder.html.twig
+++ b/src/www/ui/template/agent_adder.html.twig
@@ -86,5 +86,6 @@
       }
     }
   </script>
+  {{ paramIncludes }}
   {{ outFoot }}
 {% endblock %}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

A wait callback function was added to load the `tools.js` file in the one of the bug fix : #3038 , Due to the wait function some other functionalities required by Upload Schedule Reuse, the folder loading feature was disabled. As mentioned in this issue: #3047 

### Changes

1. Introduced a Script loading function which loads the required `tools.js` before the rendering of footer.
2. Removed the wait and loading of the `tools.js` directly into `agent_adder.html.twig`

## How to test
1. Upload a component
2. Select reuse options (Select an already uploaded package for reuse in specific folder, Enhanced reuse (slower), Reuse main license/s) (The folderselector should not be disabled now)
3. Select another component as the upload to reuse
4. Start the upload and Check the scheduled jobs
5. Also Check for `Jobs > Schedule Agents` , everything there should also work for Reuse.

Closes: #3047 
