### PR TITLE
fix(nomossa): define should_connect_to_db

### DIFF
--- a/src/lib/c/libfossrepo.c
+++ b/src/lib/c/libfossrepo.c
@@ -873,7 +873,11 @@ int fo_RepImport(char* Source, char* Type, char* Filename, int Link)
       {
         /*** Oh no!  Write failed! ***/
         fclose(Fout);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+        // Used to close the pointer :-)
         fo_RepFclose(Fout);
+#pragma GCC diagnostic pop
         fo_RepRemove(Type,Filename);
         fprintf(stderr,"ERROR: Write failed -- type='%s' filename='%s'\n",Type,Filename);
         fclose(Fin);

--- a/src/lib/c/libfossscheduler.h
+++ b/src/lib/c/libfossscheduler.h
@@ -51,6 +51,7 @@ enum job_status
 * by the scheduler to enable different levels of verbose.
 */
 extern int agent_verbose;
+extern int should_connect_to_db;
 
 extern fo_conf* sysconfig;
 extern char* sysconfigdir;

--- a/src/nomos/agent/nomos_utils.c
+++ b/src/nomos/agent/nomos_utils.c
@@ -690,9 +690,6 @@ FUNCTION int updateLicenseHighlighting(cacheroot_t *pcroot){
   }
   PGresult *result;
 
-
-
-
 #ifdef GLOBAL_DEBUG
   printf("%s %s %i \n", cur.filePath,cur.compLic , cur.theMatches->len);
 #endif
@@ -714,9 +711,13 @@ FUNCTION int updateLicenseHighlighting(cacheroot_t *pcroot){
   for (i = 0; i < cur.keywordPositions->len; ++i)
   {
     MatchPositionAndType* ourMatchv = getMatchfromHighlightInfo(cur.keywordPositions, i);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+    // If uninitialized, the loop will not start
     result = fo_dbManager_ExecPrepared(
                 preparedKeywords,
                 cur.pFileFk, ourMatchv->start, ourMatchv->end - ourMatchv->start);
+#pragma GCC diagnostic pop
     if (result)
     {
       PQclear(result);
@@ -750,11 +751,15 @@ FUNCTION int updateLicenseHighlighting(cacheroot_t *pcroot){
         //! the license File ID was never set and we should not insert it in the database
         continue;
       }
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+      // If uninitialized, the loop will not start
       result = fo_dbManager_ExecPrepared(
                   preparedLicenses,
         ourLicence->licenseFileId,
         ourMatchv->start, ourMatchv->end - ourMatchv->start
       );
+#pragma GCC diagnostic pop
       if (result == NULL)
       {
         return (FALSE);

--- a/src/nomos/agent/standalone.c
+++ b/src/nomos/agent/standalone.c
@@ -10,6 +10,7 @@
 #include "standalone.h"
 
 int result = 0;
+int should_connect_to_db = 0;
 
 void  fo_scheduler_heart(int i){}
 void  fo_scheduler_connect(int* argc, char** argv, PGconn** db_conn){}

--- a/src/ununpack/agent/standalone.c
+++ b/src/ununpack/agent/standalone.c
@@ -16,6 +16,7 @@
 #include <errno.h>
 
 int result = 0;
+int should_connect_to_db = 0;
 
 void  fo_scheduler_heart(int i){}
 void  fo_scheduler_connect(int* argc, char** argv, PGconn** db_conn){}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Define `should_connect_to_db` for standalone agents.

Also ignore some of the wrong warnings.

### Changes

Define `should_connect_to_db` in `standalone.c`

## How to test

Build nomossa and ununpacksa agents.

See: https://github.com/fossology/fossology/actions/runs/15320904127/job/43104247330#step:8:4962