### PR TITLE
feat(spdx): add per-upload EnableOsselotExport toggle which improve SPDX & ReadMeOSS exports for OSSelot report 

### DIFF
--- a/src/lib/php/Dao/test/UploadDaoTest.php
+++ b/src/lib/php/Dao/test/UploadDaoTest.php
@@ -32,7 +32,7 @@ class UploadDaoTest extends \PHPUnit\Framework\TestCase
     $this->dbManager = &$this->testDb->getDbManager();
 
     $this->testDb->createPlainTables(array('upload', 'uploadtree',
-      'report_info', 'upload_events'));
+      'report_info', 'upload_events', 'users'));
 
     $this->dbManager->prepare($stmt = 'insert.upload',
         "INSERT INTO upload (upload_pk, uploadtree_tablename) VALUES ($1, $2)");

--- a/src/lib/php/Proxy/test/UploadTreeProxyTest.php
+++ b/src/lib/php/Proxy/test/UploadTreeProxyTest.php
@@ -19,7 +19,7 @@ class UploadTreeProxyTest extends \PHPUnit\Framework\TestCase
   protected function setUp() : void
   {
     $this->testDb = new TestPgDb();
-    $this->testDb->createPlainTables( array('uploadtree', 'report_info') );
+    $this->testDb->createPlainTables( array('uploadtree', 'report_info', 'upload') );
     $this->dbManager = $this->testDb->getDbManager();
     $this->dbManager->queryOnce('ALTER TABLE uploadtree RENAME TO uploadtree_a');
     $this->testDb->insertData(array('uploadtree_a'));

--- a/src/spdx/agent/template/spdx2-document.xml.twig
+++ b/src/spdx/agent/template/spdx2-document.xml.twig
@@ -25,14 +25,21 @@
   <rdfs:comment>
     This document was created using license information and a generator from Fossology.
   </rdfs:comment>
-  {%- for licenseData in licenseList %}{% if licenseData.licenseObj.spdxId starts with 'LicenseRef-' or licenseData.licenseObj.shortName starts with 'LicenseRef-' ~%}
+  {%- for licenseData in licenseList -%}
+  {%- if licenseData.licenseObj.spdxId starts with 'LicenseRef-' or licenseData.licenseObj.shortName starts with 'LicenseRef-' or (EnableOsselotExport and licenseData.licenseObj.shortName != 'No_license_found') -%}
   <spdx:hasExtractedLicensingInfo>
-    {%- set licId=licenseData.licenseObj.spdxId %}
-    {% if licenseData.licenseObj.shortName starts with 'LicenseRef-' %}
-      {% set licId=licenseData.licenseObj.shortName %}
-    {%- endif ~%}
+    {%- set licId=licenseData.licenseObj.spdxId -%}
+    {% if licenseData.licenseObj.shortName starts with 'LicenseRef-' -%}
+      {% set licId=licenseData.licenseObj.shortName -%}
+    {%- endif -%}
+    {% if EnableOsselotExport and licId starts with 'LicenseRef-fossology-' -%}
+      {% set licId = licId | replace({'LicenseRef-fossology-':'LicenseRef-'}) -%}
+    {% endif -%}
+    {% if EnableOsselotExport and not (licId starts with 'LicenseRef-') -%}
+      {% set licId = 'LicenseRef-' ~ licId -%}
+    {% endif -%}
     <spdx:ExtractedLicensingInfo rdf:about="#{{ licId|replace({' ': '-'})|url_encode }}">
-      <spdx:licenseId>{{ licenseData.licenseObj.spdxId|replace({' ': '-'})|e }}</spdx:licenseId>
+      <spdx:licenseId>{{ licId|replace({' ': '-'})|e }}</spdx:licenseId>
       <spdx:name>{{ licenseData.licenseObj.fullName|e }}</spdx:name>
       <spdx:extractedText><![CDATA[
 {{ licenseData.licenseObj.text|replace({'\f':''})

--- a/src/spdx/agent/template/spdx2-file.xml.twig
+++ b/src/spdx/agent/template/spdx2-file.xml.twig
@@ -48,7 +48,13 @@
         {%- set licId=licenseList[res].licenseObj.spdxId %}
         {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
           {% set licId=licenseList[res].licenseObj.shortName %}
-        {%- endif ~%}
+        {%- endif %}
+        {% if EnableOsselotExport and licId starts with 'LicenseRef-fossology-' -%}
+          {% set licId = licId|replace({'LicenseRef-fossology-':'LicenseRef-'}) -%}
+        {% endif -%}
+        {% if EnableOsselotExport and not (licId starts with 'LicenseRef-') -%}
+          {% set licId = 'LicenseRef-' ~ licId -%}
+        {% endif %}
         <spdx:member rdf:resource="#{{ licId|replace({' ': '-'})|url_encode }}" />
       {%~ else %}
         {%~ if res not in textPrintedList and not licenseList[res].isTextPrinted() ~%}{# License to be printed #}
@@ -73,7 +79,13 @@
       {%- set licId=licenseList[res].licenseObj.spdxId %}
       {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
         {% set licId=licenseList[res].licenseObj.shortName %}
-      {%- endif ~%}
+      {%- endif %}
+      {% if EnableOsselotExport and licId starts with 'LicenseRef-fossology-' -%}
+        {% set licId = licId|replace({'LicenseRef-fossology-':'LicenseRef-'}) -%}
+      {% endif -%}
+      {% if EnableOsselotExport and not (licId starts with 'LicenseRef-') -%}
+        {% set licId = 'LicenseRef-' ~ licId -%}
+      {% endif -%}
     <spdx:licenseConcluded rdf:resource="#{{ licId|replace({' ': '-'})|url_encode }}" />
     {%~ else %}
       {%~ if res not in textPrintedList and not licenseList[res].isTextPrinted() ~%}{# License to be printed #}
@@ -104,7 +116,13 @@
       {%- set licId=licenseList[res].licenseObj.spdxId %}
       {% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
         {% set licId=licenseList[res].licenseObj.shortName %}
-      {%- endif ~%}
+      {%- endif %}
+      {% if EnableOsselotExport and licId starts with 'LicenseRef-fossology-' -%}
+        {% set licId = licId|replace({'LicenseRef-fossology-':'LicenseRef-'}) -%}
+      {% endif -%}
+      {% if EnableOsselotExport and not (licId starts with 'LicenseRef-') -%}
+        {% set licId = 'LicenseRef-' ~ licId -%}
+      {% endif -%}
     <spdx:licenseInfoInFile rdf:resource="#{{ licId|replace({' ': '-'})|url_encode }}" />
     {%~ else %}
       {%~ if res not in textPrintedList and not licenseList[res].isTextPrinted() ~%}{# License to be printed #}
@@ -136,3 +154,4 @@
 {%~ endfor %}
   </spdx:File>
 </spdx:hasFile>
+{{ "\n" }}

--- a/src/spdx/agent/template/spdx2tv-document.twig
+++ b/src/spdx/agent/template/spdx2tv-document.twig
@@ -42,11 +42,18 @@ LicenseListVersion: 3.22
 ## License Information
 ##-------------------------
 
-{% for licenseData in licenseList %}{% if licenseData.licenseObj.spdxId starts with 'LicenseRef-' or licenseData.licenseObj.shortName starts with 'LicenseRef-' ~%}
-{%- set licId=licenseData.licenseObj.spdxId %}
-{% if licenseData.licenseObj.shortName starts with 'LicenseRef-' %}
-  {% set licId=licenseData.licenseObj.shortName %}
-{%- endif ~%}
+{% for licenseData in licenseList -%}
+{%- if licenseData.licenseObj.spdxId starts with 'LicenseRef-' or licenseData.licenseObj.shortName starts with 'LicenseRef-' or (EnableOsselotExport and licenseData.licenseObj.shortName != 'No_license_found') -%}
+{%- set licId=licenseData.licenseObj.spdxId -%}
+{% if licenseData.licenseObj.shortName starts with 'LicenseRef-' -%}
+  {% set licId=licenseData.licenseObj.shortName -%}
+{%- endif -%}
+{% if EnableOsselotExport and licId starts with 'LicenseRef-fossology-' -%}
+  {% set licId = licId|replace({'LicenseRef-fossology-':'LicenseRef-'}) -%}
+{% endif -%}
+{% if EnableOsselotExport and not (licId starts with 'LicenseRef-') -%}
+  {% set licId = 'LicenseRef-' ~ licId -%}
+{% endif -%}
 LicenseID: {{ licId|replace({' ': '-'}) }}
 LicenseName: {{ licenseData.licenseObj.fullName }}
 ExtractedText: <text> {{ licenseData.licenseObj.text|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})

--- a/src/spdx/agent/template/spdx2tv-file.twig
+++ b/src/spdx/agent/template/spdx2tv-file.twig
@@ -11,42 +11,52 @@ SPDXID: SPDXRef-item{{ fileId }}
 FileChecksum: SHA1: {{ sha1 | lower }}
 FileChecksum: SHA256: {{ sha256 | lower }}
 FileChecksum: MD5: {{ md5 | lower }}
-{% if fileData.isCleared() %}
-{% if fileData.concludedLicenses|default is empty %}
+{% if fileData.isCleared() -%}
+{% if fileData.concludedLicenses|default is empty -%}
 LicenseConcluded: NONE
-{% else %}
+{% else -%}
+{% if EnableOsselotExport -%}
+{% set concludedLicensesString = concludedLicensesString
+    |replace({'LicenseRef-fossology-':'LicenseRef-'}) -%}
+{% endif -%}
 LicenseConcluded: {{ concludedLicensesString }}
-{% endif%}
-{% else %}
+{% endif -%}
+{% else -%}
 LicenseConcluded: NOASSERTION
-{% endif %}
-{% if licenseCommentState %}
-{% if fileData.comments is not empty %}
+{% endif -%}
+{% if licenseCommentState -%}
+{% if fileData.comments is not empty -%}
 LicenseComments: <text> {{ fileData.comments|join('\n')
   |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
   |replace({'\f':''}) }} </text>
-{% endif %}
-{% endif %}
-{% if fileData.scanners|default is empty %}
+{% endif -%}
+{% endif -%}
+{% if fileData.scanners|default is empty -%}
 LicenseInfoInFile: NOASSERTION
-{% else %}
-{% for res in fileData.scanners %}
-{%- set licId=licenseList[res].licenseObj.spdxId %}
-{% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' %}
-  {% set licId=licenseList[res].licenseObj.shortName %}
-{%- endif ~%}
+{% else -%}
+{% for res in fileData.scanners -%}
+{%- set licId=licenseList[res].licenseObj.spdxId -%}
+{% if licenseList[res].licenseObj.shortName starts with 'LicenseRef-' -%}
+  {% set licId=licenseList[res].licenseObj.shortName -%}
+{% endif -%}
+{% if EnableOsselotExport and licId starts with 'LicenseRef-fossology-' -%}
+  {% set licId = licId|replace({'LicenseRef-fossology-':'LicenseRef-'}) -%}
+{% endif -%}
+{% if EnableOsselotExport and not (licId starts with 'LicenseRef-') -%}
+  {% set licId = 'LicenseRef-' ~ licId -%}
+{% endif -%}
 LicenseInfoInFile: {{ licId|replace({' ':'-'})}}
-{% endfor %}
-{% endif %}
+{% endfor -%}
+{% endif -%}
 {# FileSize: 48 Kb (49173 bytes) #}
-{% if fileData.copyrights|default is empty %}
+{% if fileData.copyrights|default is empty -%}
 FileCopyrightText: NOASSERTION
-{% else %}
+{% else -%}
 FileCopyrightText: <text> {{ fileData.copyrights|join('\n')
   |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
   |replace({'\f':''}) }} </text>
-{% endif %}
-{% if fileData.acknowledgements|default is not empty %}
+{% endif -%}
+{% if fileData.acknowledgements|default is not empty -%}
 FileAttributionText: <text> {{ fileData.acknowledgements|join('\n')
   |replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
   |replace({'\f':''}) }} </text>

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -2243,6 +2243,10 @@
   $Schema["TABLE"]["users"]["group_fk"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"group_fk\" int4";
   $Schema["TABLE"]["users"]["group_fk"]["ALTER"] = "ALTER TABLE \"users\" ALTER COLUMN \"group_fk\" DROP NOT NULL";
 
+  $Schema["TABLE"]["users"]["spdx_settings"]["DESC"] = "COMMENT ON COLUMN \"users\".\"spdx_settings\" IS 'Comma-separated SPDX export settings: osselot_export,spdx_license_comment,ignore_files_wo_info as checked/unchecked values'";
+  $Schema["TABLE"]["users"]["spdx_settings"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"spdx_settings\" text DEFAULT 'unchecked,unchecked,unchecked'";
+  $Schema["TABLE"]["users"]["spdx_settings"]["ALTER"] = "ALTER TABLE \"users\" ALTER COLUMN \"spdx_settings\" DROP NOT NULL, ALTER COLUMN \"spdx_settings\" SET DEFAULT 'unchecked,unchecked,unchecked'";
+
   $Schema["TABLE"]["report_info"]["ri_pk"]["DESC"] = "";
   $Schema["TABLE"]["report_info"]["ri_pk"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_pk\" int4 DEFAULT nextval('report_info_pk_seq'::regclass)";
   $Schema["TABLE"]["report_info"]["ri_pk"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_pk\" SET NOT NULL, ALTER COLUMN \"ri_pk\" SET DEFAULT nextval('report_info_pk_seq'::regclass)";

--- a/src/www/ui/template/ui-report-conf.html.twig
+++ b/src/www/ui/template/ui-report-conf.html.twig
@@ -246,7 +246,7 @@
             {{ "Show SPDX license comments"|trans }}
           </td>
           <td align="left">
-            <input type="checkbox" class="browse-upload-checkbox view-license-rc-size"  name="spdxLicenseComment" value="spdxLicenseComment" {{ spdxLicenseComment }} />
+            <input type="checkbox" class="browse-upload-checkbox view-license-rc-size"  name="spdxLicenseComment" value="spdxLicenseComment" {{ spdxLicenseComment }} id="spdxLicenseCommentCheckbox" />
          </td>
         </tr>
         <tr>
@@ -255,6 +255,15 @@
           </td>
           <td align="left">
             <input type="checkbox" class="browse-upload-checkbox view-license-rc-size"  name="ignoreFilesWOInfo" value="ignoreFilesWOInfo" {{ ignoreFilesWOInfo }} />
+          </td>
+        </tr>
+        <tr>
+          <td align="left">
+            {{ "Enable OSSelot export"|trans }}
+            <img src="images/info_16.png" data-toggle="tooltip" title="{{ 'When enabled, SPDX and ReadMeOSS exports will be OSSelot-compatible: custom licenses will be emitted as LicenseRef-<ShortName> (dropping \"-fossology-\"), ReadMeOSS will strip all LicenseRef- prefixes, and every license\'s full text will be included.'|trans }}" alt="" class="info-bullet"/>
+          </td>
+          <td align="left">
+            <input type="checkbox" class="browse-upload-checkbox view-license-rc-size"  name="osselotExport" value="osselotExport" {{ osselotExport }} id="osselotExportCheckbox" />
           </td>
         </tr>
       </table>

--- a/src/www/ui/template/user_edit.html.twig
+++ b/src/www/ui/template/user_edit.html.twig
@@ -93,6 +93,27 @@
       <th width="25%">{{ "Default bucket pool"| trans }}</th>
       <td>{{ bucketPool }}</td>
     </tr>
+    <tr class="classic">
+      <th width="25%">
+        {{ "Enable OSSelot export by default"|trans }}
+        <img src="images/info_16.png" data-toggle="tooltip" title="{{ 'When enabled, SPDX and ReadMeOSS exports will be OSSelot-compatible by default: custom licenses will be emitted as LicenseRef-<ShortName> (dropping "-fossology-"), ReadMeOSS will strip all LicenseRef- prefixes, and every license\'s full text will be included.'|trans }}" alt="" class="info-bullet"/>
+      </th>
+      <td><input type="checkbox" name="osselot_export_enabled" id="osselotExportEnabledCheckbox" {% if osselotExportEnabled %}checked{% endif %}></td>
+    </tr>
+    <tr class="classic">
+      <th width="25%">
+        {{ "Show SPDX license comments by default"|trans }}
+        <img src="images/info_16.png" data-toggle="tooltip" title="{{ 'When enabled, SPDX reports will include license comments by default.'|trans }}" alt="" class="info-bullet"/>
+      </th>
+      <td><input type="checkbox" name="spdx_license_comment_default" id="spdxLicenseCommentDefaultCheckbox" {% if spdxLicenseCommentDefault %}checked{% endif %}></td>
+    </tr>
+    <tr class="classic">
+      <th width="25%">
+        {{ "Ignore files with no info in SPDX by default"|trans }}
+        <img src="images/info_16.png" data-toggle="tooltip" title="{{ 'When enabled, SPDX reports will ignore files with no license information by default.'|trans }}" alt="" class="info-bullet"/>
+      </th>
+      <td><input type="checkbox" name="ignore_files_wo_info_default" {% if ignoreFilesWOInfoDefault %}checked{% endif %}></td>
+    </tr>
     {%  if isSessionAdmin %}
       <tr class="classic">
         <th width="25%">{{ "Select user's default group."|trans }}</th>
@@ -499,6 +520,12 @@
         showOtherMonths : true,
         selectOtherMonths : true,
         showButtonPanel : true
+      });
+      
+      $('#osselotExportEnabledCheckbox').change(function() {
+        if ($(this).is(':checked')) {
+          $('#spdxLicenseCommentDefaultCheckbox').prop('checked', true);
+        }
       });
     });
   </script>

--- a/src/www/ui/ui-report-conf.php
+++ b/src/www/ui/ui-report-conf.php
@@ -84,7 +84,8 @@ class ui_report_conf extends FO_Plugin
    */
   private $checkBoxListSPDX = array(
     "spdxLicenseComment" => "spdxLicenseComment",
-    "ignoreFilesWOInfo" => "ignoreFilesWOInfo"
+    "ignoreFilesWOInfo" => "ignoreFilesWOInfo",
+    "osselotExport" => "osselotExport"
   );
 
 
@@ -177,6 +178,10 @@ class ui_report_conf extends FO_Plugin
       $listSPDXCheckbox = explode(',', $row['ri_spdx_selection']);
       foreach (array_keys($this->checkBoxListSPDX) as $key => $value) {
         $vars[$value] = $listSPDXCheckbox[$key];
+      }
+    } else {
+      foreach (array_keys($this->checkBoxListSPDX) as $key) {
+        $vars[$key] = 'unchecked';
       }
     }
 
@@ -462,6 +467,12 @@ class ui_report_conf extends FO_Plugin
           $('#copyrightRestrictionText').val('');
         } else {
           $('#copyrightRestrictionText').css('display', 'block');
+        }
+      });
+      
+      $('#osselotExportCheckbox').change(function() {
+        if ($(this).is(':checked')) {
+          $('#spdxLicenseCommentCheckbox').prop('checked', true);
         }
       });
     });

--- a/src/www/ui/user-edit.php
+++ b/src/www/ui/user-edit.php
@@ -190,6 +190,13 @@ class UserEditPage extends DefaultPlugin
     $vars['userDescription'] = $UserRec['user_desc'];
     $vars['userEMail'] = $UserRec["user_email"];
     $vars['eMailNotification'] = ($UserRec['email_notify'] == 'y');
+    $spdxSettings = isset($UserRec['spdx_settings']) ? explode(',', $UserRec['spdx_settings']) : ['unchecked', 'unchecked', 'unchecked'];
+    if (count($spdxSettings) < 3) {
+      $spdxSettings = array_pad($spdxSettings, 3, 'unchecked');
+    }
+    $vars['osselotExportEnabled'] = ($spdxSettings[0] === 'checked');
+    $vars['spdxLicenseCommentDefault'] = ($spdxSettings[1] === 'checked');
+    $vars['ignoreFilesWOInfoDefault'] = ($spdxSettings[2] === 'checked');
 
     if ($SessionIsAdmin) {
       $vars['allAccessLevels'] = array(
@@ -445,6 +452,14 @@ class UserEditPage extends DefaultPlugin
       }
       $UserRec['user_agent_list'] = is_null($request->get('user_agent_list')) ? userAgents() : $request->get('user_agent_list');
       $UserRec['default_bucketpool_fk'] = intval($request->get("default_bucketpool_fk"));
+
+      if ($this->dbManager->existsColumn('users', 'spdx_settings')) {
+        $osselotEnabled = !empty($request->get('osselot_export_enabled')) ? 'checked' : 'unchecked';
+        $spdxCommentEnabled = !empty($request->get('spdx_license_comment_default')) ? 'checked' : 'unchecked';
+        $ignoreFilesEnabled = !empty($request->get('ignore_files_wo_info_default')) ? 'checked' : 'unchecked';
+
+        $UserRec['spdx_settings'] = "$osselotEnabled,$spdxCommentEnabled,$ignoreFilesEnabled";
+      }
     }
     return $UserRec;
   }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors
     SPDX-License-Identifier: GPL-2.0-only
-->

## Description
This pull request introduces a new per‐upload configuration flag, **EnableOsselotExport**, under  
**Browse → Pfile → Conf → Report Configuration → SPDX Report Settings**. When checked for a given upload, all SPDX-based exports (SPDX-TV, SPDX RDF/XML) and the ReadMeOSS agent adopt OSSelot-compatible behavior (see issue #3057).

### Changes

- **Added per-upload OSSelot toggle**  
  ![Enable OSSelot Export checkbox](https://github.com/user-attachments/assets/2bb1927d-e280-46d2-b059-e9b6310f1853)  
  Introduced a third checkbox (“Enable OSSelot Export”).

- **SPDX-TV Export**  
  - In **License Information**, list **every** license (including those previously unprefixed).  
  - Rewrite custom licenses as `LicenseRef-See-file.LICENSE` (no `-fossology-`).  
    ![SPDX-TV before/after](https://github.com/user-attachments/assets/8bb6c601-6d93-43d4-9da2-3227cc8ede3a)  
  - Print each license’s full text. Include any license comments if present.  
    ![Full text and comments in SPDX-TV](https://github.com/user-attachments/assets/e813fc26-8817-4ba7-85f5-f7dbe8c4ae68)

- **SPDX RDF/XML Export**  
  - Apply identical logic: emit all licenses , strip `-fossology-`, prepend `LicenseRef-` when needed, and include full license text.  
    ![SPDX RDF/XML before/after 1](https://github.com/user-attachments/assets/b74a625d-6d83-40c3-bb6d-83a9bab9e493)  
    ![SPDX RDF/XML before/after 2](https://github.com/user-attachments/assets/f671d231-7d1e-4a47-8740-859c7afdfaee)

- **ReadMeOSS Output**  
  - Strip both `LicenseRef-fossology-` and `LicenseRef-` from each license line.   
    ![ReadMeOSS output without prefixes](https://github.com/user-attachments/assets/c3e8e188-395c-499e-82b1-216e4c54c33e)

## How to test

1. **Enable “Osselot Export” for a upload**  
   - Navigate to **Browse → Pfile → Conf → Report Configuration → SPDX Report Settings** for a given upload.  
   - Check **“Enable OSSelot Export”** and click **Save**.

2. **Generate ReadMeOSS**  
   - Verify that license lines appear **without** any `LicenseRef-…` prefix.  

3. **Generate SPDX-TV Export (.spdx)**  
   - Confirm that custom licenses are rewritten as `LicenseRef-<ShortName>` (no `-fossology-`).  
   - Every license’s full text should appear . License comments (if any) should also be included.

4. **Generate SPDX RDF/XML Export (.spdx.rdf)**  
   - verify `LicenseRef-<ShortName>` (no `-fossology-`) for licenses.  
   - Confirm that it contains the **entire** license text.

CC: @shaheemazmalmmd @JanAltenberg 
