### PR TITLE
fix: replace exit with proper error handling in LicenseMainGetter.php and spdx.php

### DIFF
--- a/src/lib/php/Report/LicenseMainGetter.php
+++ b/src/lib/php/Report/LicenseMainGetter.php
@@ -42,7 +42,7 @@ class LicenseMainGetter extends ClearedGetterCommon
       // Null-check: if the license is missing, log and skip this ID.
       if ($allLicenseCols === null) {
         error_log("Error: License ID " . $originLicenseId . " not found in the database.");
-        exit;
+        continue; // Skip this license and continue with others
       }
       $allStatements[] = array(
         'licenseId' => $originLicenseId,

--- a/src/spdx/agent/spdx.php
+++ b/src/spdx/agent/spdx.php
@@ -383,9 +383,9 @@ class SpdxAgent extends Agent
       $mainLicense = $this->licenseDao->getLicenseById($reportedLicenseId, $this->groupId);
       if ($mainLicense === null) {
         error_log(
-            "spdx: Error: main license ID {$reportedLicenseId} not found; skipping."
+            "spdx: Warning: main license ID {$reportedLicenseId} not found; skipping."
         );
-        exit;
+        continue; // Skip this license and continue with the next one
       }
       $reportLicId = $mainLicense->getId() . "-" . md5($mainLicense->getText());
       $mainLicenses[] = $reportLicId;


### PR DESCRIPTION
Fixes #3061

… and spdx.php

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

**Null-check**:  
Checks if `$allLicenseCols` is `null`. This means the code tried to look up a license (using `$originLicenseId`), but there was no matching record in the database.

**Logging**:  
If the license is missing, it writes an error message to the PHP error log, including the license ID that was not found.

**Continue**:  
The `continue;` statement skips the rest of the current loop iteration and moves on to the next license in the list.  
This way, the missing license doesn’t stop the whole process—other licenses will still be processed.

### Changes Made

```php
if ($allLicenseCols === null) {
  error_log("Error: License ID " . $originLicenseId . " not found in the database.");
  continue; // Skip this license and continue with others
}


