### PR TITLE
feat(core): adding support for Tuxedo

### DIFF
--- a/install/fo-install-pythondeps
+++ b/install/fo-install-pythondeps
@@ -116,7 +116,7 @@ echo "install python dependencies"
 if [[ $BUILDTIME && -z "$DEBIAN" ]]; then
   echo "*** Installing $DISTRO buildtime python dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         python3 python3-pip
       ;;
@@ -133,7 +133,7 @@ fi
 if [[ $RUNTIME && -z "$DEBIAN" ]]; then
   echo "*** Installing $DISTRO runtime python dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         python3 python3-pip python3-dev
       ;;

--- a/src/compatibility/mod_deps
+++ b/src/compatibility/mod_deps
@@ -65,7 +65,7 @@ CODENAME=$(lsb_release --codename --short)
 if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         libjsoncpp-dev libboost-system-dev libboost-filesystem-dev \
         libboost-program-options-dev libboost-regex-dev libyaml-cpp-dev
@@ -86,7 +86,7 @@ fi
 if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       case "$CODENAME" in
         stretch)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.62.0 libboost-program-options1.62.0 libboost-regex1.62.0 libyaml-cpp0.5v5;;

--- a/src/copyright/mod_deps
+++ b/src/copyright/mod_deps
@@ -65,7 +65,7 @@ CODENAME=$(lsb_release --codename --short)
 if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         libjsoncpp-dev libboost-system-dev libboost-filesystem-dev
       ;;
@@ -85,7 +85,7 @@ fi
 if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       case "$CODENAME" in
         stretch)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.62.0;;

--- a/src/delagent/mod_deps
+++ b/src/delagent/mod_deps
@@ -64,7 +64,7 @@ DISTRO=$(lsb_release --id --short)
 if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         libgcrypt20-dev libcrypt-dev
       ;;
@@ -78,7 +78,7 @@ fi
 if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         libgcrypt20 libcrypt1
       ;;

--- a/src/mimetype/mod_deps
+++ b/src/mimetype/mod_deps
@@ -64,7 +64,7 @@ DISTRO=$(lsb_release --id --short)
 if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         libmagic-dev
       ;;
@@ -78,7 +78,7 @@ fi
 if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         libmagic1
       ;;

--- a/src/nomos/mod_deps
+++ b/src/nomos/mod_deps
@@ -64,7 +64,7 @@ CODENAME=$(lsb_release --codename --short)
 if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         libjson-c-dev
       ;;
@@ -79,7 +79,7 @@ fi
 if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       case "$CODENAME" in
         stretch|buster|cosmic)
           apt-get $YesOpt install libjson-c3;;

--- a/src/ojo/mod_deps
+++ b/src/ojo/mod_deps
@@ -64,7 +64,7 @@ CODENAME=$(lsb_release --codename --short)
 if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         libjsoncpp-dev libboost-system-dev libboost-filesystem-dev \
         libboost-program-options-dev libboost-regex-dev
@@ -85,7 +85,7 @@ fi
 if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       case "$CODENAME" in
         stretch)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.62.0 libboost-program-options1.62.0 libboost-regex1.62.0;;

--- a/src/pkgagent/mod_deps
+++ b/src/pkgagent/mod_deps
@@ -64,7 +64,7 @@ DISTRO=$(lsb_release --id --short)
 if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         librpm-dev
       ;;
@@ -78,7 +78,7 @@ fi
 if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         rpm
       ;;

--- a/src/scancode/mod_deps
+++ b/src/scancode/mod_deps
@@ -62,7 +62,7 @@ CODENAME=$(lsb_release --codename --short)
 if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         libboost-program-options-dev libjsoncpp-dev \
         libbz2-1.0 xz-utils zlib1g libxml2-dev libxslt1-dev libpopt0
@@ -85,7 +85,7 @@ fi
 if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         libbz2-1.0 xz-utils zlib1g libxml2-dev libxslt1-dev libpopt0 \
         python3 python3-pip

--- a/src/scanoss/mod_deps
+++ b/src/scanoss/mod_deps
@@ -79,7 +79,7 @@ DISTRO=$(lsb_release --id --short)
 if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         libjson-c-dev
       ;;
@@ -93,7 +93,7 @@ fi
 if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         libjson-c-dev
       ;;

--- a/src/scheduler/mod_deps
+++ b/src/scheduler/mod_deps
@@ -63,7 +63,7 @@ DISTRO=$(lsb_release --id --short)
 if [[ $BUILDTIME ]]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         libglib2.0-dev
       ;;
@@ -78,7 +78,7 @@ fi
 if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         libglib2.0-0
       ;;

--- a/src/ununpack/mod_deps
+++ b/src/ununpack/mod_deps
@@ -64,7 +64,7 @@ DISTRO=$(lsb_release --id --short)
 if [ $BUILDTIME ]; then
   echo "*** Installing $DISTRO buildtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         libgcrypt20-dev
       ;;
@@ -78,7 +78,7 @@ fi
 if [ $RUNTIME ]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         bzip2 cabextract cpio genisoimage p7zip poppler-utils rpm tar \
         unzip gzip sleuthkit p7zip-full unrar-free libgcrypt20 zstd

--- a/src/wget_agent/mod_deps
+++ b/src/wget_agent/mod_deps
@@ -68,7 +68,7 @@ fi
 if [[ $RUNTIME ]]; then
   echo "*** Installing $DISTRO runtime dependencies ***";
   case "$DISTRO" in
-    Debian|Ubuntu)
+    Debian|Ubuntu|Tuxedo)
       apt-get $YesOpt install \
         subversion git wget
       ;;

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -88,7 +88,7 @@ echo "install core dependencies"
 if [[ $BUILDTIME ]]; then
    echo "*** Installing $DISTRO buildtime dependencies ***";
    case "$DISTRO" in
-      Debian|Ubuntu)
+      Debian|Ubuntu|Tuxedo)
          echo "DB: Installing build essential....."
          apt-get $YesOpt install \
             libmxml-dev curl libxml2-dev libcunit1-dev libicu-dev \
@@ -165,7 +165,7 @@ if [[ $RUNTIME ]]; then
    echo "*** installed. Consult with your system administrator. Or try ***";
    echo "*** apt-get install mail-transport-agent, pick one and install it***";
    case "$DISTRO" in
-      Debian|Ubuntu)
+      Debian|Ubuntu|Tuxedo)
         echo "doing runtime"
          apt-get $YesOpt install apache2
          apt-get $YesOpt install php-pear \

--- a/utils/prepare-test
+++ b/utils/prepare-test
@@ -130,7 +130,7 @@ if echo ${WarnAccept} | grep -q -e "^[yY]$" ; then
     chmod 0600 ~/.pgpass
   fi
   case "${DISTRO}" in
-    Debian|Ubuntu|LinuxMint)
+    Debian|Ubuntu|LinuxMint|Tuxedo)
       if dpkg-query --show --showformat='${db:Status-Status}' cppcheck | grep -q 'not-installed' ; then
         sudo apt-get install -q $YesOpt cppcheck
       else


### PR DESCRIPTION
Signed-off-by: Oliver Fendt (ofendt@googlemail.com)

<!-- SPDX-FileCopyrightText: © Oliver Fendt

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

The build from source procedure currently only supports Ubuntu and Debian (in the deb ecosystem). Tuxedo is the distro, which is installed on Tuxedo machines, it is a kind of Ubuntu derivate. I installed Fossology on my Tuxedo machine, it runs Tuxedo OS noble. In order to do that I had to modify the files listed below.
The "OS" is not contained in the name, therefore it is only Tuxedo

### Changes
adding Tuxedo as option when the distro is checked:

Debian|Ubuntu)
Debian|Ubuntu|Tuxedo)

resp:

Debian|Ubuntu|LinuxMint)
Debian|Ubuntu|LinuxMint|Tuxedo)

Files:

- src/copyright/mod_deps
- src/compatibility/mod_deps
- src/scanoss/mod_deps
- src/ojo/mod_deps
- src/nomos/mod_deps
- src/delagent/mod_deps
- src/scancode/mod_deps
- src/mimetype/mod_deps
- src/pkgagent/mod_deps
- src/ununpack/mod_deps
- src/wget_agent/mod_deps
- src/scheduler/mod_deps
- utils/fo-installdeps
- utils/prepare-test
- install/fo-install-pythondeps

## How to test

1. Install Tuxedo OS on your machine
2. clone fossology repo
3. install from source

