### PR TITLE
fix/3061-replace-exit-statements

### DIFF
--- a/src/lib/php/Report/LicenseMainGetter.php
+++ b/src/lib/php/Report/LicenseMainGetter.php
@@ -42,7 +42,7 @@ class LicenseMainGetter extends ClearedGetterCommon
       // Null-check: if the license is missing, log and skip this ID.
       if ($allLicenseCols === null) {
         error_log("Error: License ID " . $originLicenseId . " not found in the database.");
-        exit;
+        throw new \Exception("License ID " . $originLicenseId . " not found in the database.");
       }
       $allStatements[] = array(
         'licenseId' => $originLicenseId,

--- a/src/spdx/agent/spdx.php
+++ b/src/spdx/agent/spdx.php
@@ -385,7 +385,7 @@ class SpdxAgent extends Agent
         error_log(
             "spdx: Error: main license ID {$reportedLicenseId} not found; skipping."
         );
-        exit;
+        throw new \Exception("Main license ID {$reportedLicenseId} not found in the database.");
       }
       $reportLicId = $mainLicense->getId() . "-" . md5($mainLicense->getText());
       $mainLicenses[] = $reportLicId;


### PR DESCRIPTION
# Replace exit statements with proper error handling

## Description
This PR addresses issue #3061 by replacing abrupt `exit` statements with proper exception handling in two files:
1. `src/lib/php/Report/LicenseMainGetter.php`
2. `src/spdx/agent/spdx.php`

The changes ensure that when a license is not found in the database, the process doesn't terminate abruptly but instead throws an exception that can be properly handled by the calling code.

## Changes Made
1. In `LicenseMainGetter.php`:
   - Replaced `exit` with `throw new \Exception()` when a license is not found
   - Maintained error logging while adding proper exception handling
   - Error message clearly indicates which license ID was not found

2. In `spdx.php`:
   - Replaced `exit` with `throw new \Exception()` when a main license is not found
   - Preserved error logging functionality
   - Added descriptive error message for better debugging

## Benefits
- Prevents abrupt process termination
- Provides proper error feedback to requestors
- Maintains system stability
- Allows for graceful error handling by calling code
- Preserves error logging for debugging purposes

## Testing
The calling code should be updated to handle these exceptions appropriately using try-catch blocks. For example:
```php
try {
    $statements = $this->getStatements($uploadId, $uploadTreeTableName, $groupId);
} catch (\Exception $e) {
    error_log($e->getMessage());
    // Handle error appropriately
}
```

## Related Issues
Fixes #3061