### PR TITLE
fix(dco): ignore dependabot user only

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -141,5 +141,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: "--exclude-pattern '.*@github.com|.*dependabot.*@users.noreply.github.com'"
+          args: "--exclude-pattern '.*dependabot\[bot\]@users.noreply.github.com'"
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix DCO check to ignore only dependabot user, making it more specific.

Original ignore was added in #3073