### PR TITLE
fix(auth): handle missing LDAP env vars in external auth

### DIFF
--- a/src/lib/php/common-auth.php
+++ b/src/lib/php/common-auth.php
@@ -45,7 +45,10 @@ function auth_external_check()
   }
   if ($EXT_AUTH_ENABLE) {
     $EXT_AUTH_USER_KW = $GLOBALS['SysConf']['EXT_AUTH']['CONF_EXT_AUTH_ENV_USER'];
-    $EXT_AUTH_USER = $GLOBALS['_SERVER']["{$EXT_AUTH_USER_KW}"];
+    $EXT_AUTH_USER = null;
+    if (isset($GLOBALS['_SERVER']["{$EXT_AUTH_USER_KW}"])) {
+      $EXT_AUTH_USER = $GLOBALS['_SERVER']["{$EXT_AUTH_USER_KW}"];
+    }
     if (isset($EXT_AUTH_USER) && !empty($EXT_AUTH_USER)) {
       if ($GLOBALS['SysConf']['EXT_AUTH']['CONF_EXT_AUTH_LOWERCASE_USER']) {
           $EXT_AUTH_USER = strtolower($EXT_AUTH_USER);
@@ -54,9 +57,9 @@ function auth_external_check()
       $out['loginAuthExternal']       = $EXT_AUTH_USER;
       $out['passwordAuthExternal']    = sha1($EXT_AUTH_USER);
       $EXT_AUTH_MAIL_KW = $GLOBALS['SysConf']['EXT_AUTH']['CONF_EXT_AUTH_ENV_MAIL'];
-      $out['emailAuthExternal']       = $GLOBALS['_SERVER']["{$EXT_AUTH_MAIL_KW}"];
+      $out['emailAuthExternal']       = isset($GLOBALS['_SERVER']["{$EXT_AUTH_MAIL_KW}"]) ? $GLOBALS['_SERVER']["{$EXT_AUTH_MAIL_KW}"] : '';
       $EXT_AUTH_DESC_KW = $GLOBALS['SysConf']['EXT_AUTH']['CONF_EXT_AUTH_ENV_DESC'];
-      $out['descriptionAuthExternal'] = $GLOBALS['_SERVER']["{$EXT_AUTH_DESC_KW}"];
+      $out['descriptionAuthExternal'] = isset($GLOBALS['_SERVER']["{$EXT_AUTH_DESC_KW}"]) ? $GLOBALS['_SERVER']["{$EXT_AUTH_DESC_KW}"] : '';
       return $out;
     }
   }


### PR DESCRIPTION
- Add isset() checks before accessing AUTHENTICATE_UID, AUTHENTICATE_MAIL, and AUTHENTICATE_DESC environment variables
- Prevent PHP 'Undefined array key' warnings that cause scheduler agents to be killed
- Maintain backward compatibility with existing LDAP configurations
- Set empty string defaults for missing email and description variables

Fixes #3032

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Please describe the changes in your pull request in few words here.

### Changes

List the changes done to fix a bug or introducing a new feature.

## How to test

Describe the steps required to test the changes proposed in the pull request.

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)
