### PR TITLE
feat(oidc): Add client credentials flow for m2m communication between licensedb and fossology

### DIFF
--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -279,6 +279,12 @@ function Populate_sysconfig()
   $valueArray[$variable] = array("'$variable'", "null", "'$oidcPrompt'",
     strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "15", "'$oidcDesc'", "null", "null");
 
+  $variable = "OidcScope";
+  $prompt = _('OIDC Scope');
+  $desc = _('Scope of OIDC for client_credential grant. Used with LicenseDB.');
+  $valueArray[$variable] = array("'$variable'", "''", "'$prompt'",
+    strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "16", "'$oidcDesc'", "null", "null");
+
   /*  Banner Message */
   $variable = "BannerMsg";
   $bannerMsgPrompt = _('Banner message');
@@ -582,19 +588,18 @@ function Populate_sysconfig()
     strval(CONFIG_TYPE_TEXT), "'SSS'", "2", "'$desc'", "null", "null");
 
   /* LicenseDB config */
-  $variable = "LicenseDBURL";
-  $prompt = _('LicenseDB URL');
-  $desc = _('URL to LicenseDB Server');
-  $valueArray[$variable] = array("'$variable'",
-    "''", "'$prompt'",
-    strval(CONFIG_TYPE_TEXT), "'LicenseDB'", "1", "'$desc'", "'check_url'", "null");
-
   $variable = "LicenseDBBaseURL";
   $prompt = _('LicenseDB API base URI');
   $desc = _('Base URI for API calls e.g. /api/v1');
-  $valueArray[$variable] = array("'$variable'", "'/api/v1'",
-    "'$prompt'", strval(CONFIG_TYPE_TEXT), "'LicenseDB'", "2", "'$desc'", "null",
+  $valueArray[$variable] = array("'$variable'", "'http://localhost:8080/api/v1'",
+    "'$prompt'", strval(CONFIG_TYPE_TEXT), "'LicenseDB'", "1", "'$desc'", "null",
     "null");
+
+  $variable = "LicenseDBHealth";
+  $prompt = _('Health check');
+  $desc = _('Endpoint to check health of LicenseDB service');
+  $valueArray[$variable] = array("'$variable'", "'/health'", "'$prompt'",
+    strval(CONFIG_TYPE_TEXT), "'LicenseDB'", "2", "'$desc'", "null", "null");
 
   $variable = "LicenseDBContent";
   $prompt = _('Export endpoint Licenses');
@@ -610,7 +615,7 @@ function Populate_sysconfig()
 
   $variable = "LicenseDBToken";
   $prompt = _('Auth token For LicenseDB');
-  $desc = _('');
+  $desc = _("Token from LicenseDB. Do not set if using OIDC for LicenseDB and FOSSology communication.");
   $valueArray[$variable] = array("'$variable'", "''", "'$prompt'",
     strval(CONFIG_TYPE_PASSWORD), "'LicenseDB'", "5", "'$desc'", "null", "null");
 

--- a/src/www/ui/page/AdminLicenseFromCSV.php
+++ b/src/www/ui/page/AdminLicenseFromCSV.php
@@ -20,6 +20,7 @@ use GuzzleHttp\Exception\RequestException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use League\OAuth2\Client\Provider\GenericProvider;
 
 /**
  * \brief Upload a file from the users computer using the UI.
@@ -32,9 +33,10 @@ class AdminLicenseFromCSV extends DefaultPlugin
   const FILE_INPUT_NAME_V2 = 'fileInput';
 
   /**
-   * @var Client $guzzleClient
+   * @var GenericProvider $oidcProvider
    */
-  private $guzzleClient;
+  private $oidcProvider;
+
   /**
    * @var array
    */
@@ -51,15 +53,30 @@ class AdminLicenseFromCSV extends DefaultPlugin
     ));
     /** @var LicenseCsvImport $licenseCsvImport */
     $this->licenseCsvImport = $GLOBALS['container']->get('app.license_csv_import');
-    $this->sysconfig = $SysConf['SYSCONFIG'];
+    $this->sysconfig = $SysConf;
     $this->configuration = [
-      'url' => trim($this->sysconfig['LicenseDBURL']),
-      'uri' => trim($this->sysconfig['LicenseDBBaseURL']),
-      'content' => trim($this->sysconfig['LicenseDBContent']),
-      'token' => trim($this->sysconfig['LicenseDBToken'])
+      'uri' => trim($this->sysconfig['SYSCONFIG']['LicenseDBBaseURL']),
+      'content' => trim($this->sysconfig['SYSCONFIG']['LicenseDBContent']),
+      'health' => trim($this->sysconfig['SYSCONFIG']['LicenseDBHealth']),
+      'token' => empty(trim($this->sysconfig['SYSCONFIG']['LicenseDBToken'])) ? null : trim($this->sysconfig['SYSCONFIG']['LicenseDBToken']),
     ];
 
-    $this->guzzleClient = HttpUtils::getGuzzleClient($SysConf, $this->configuration['uri'], $this->configuration['token']);
+    if ($this->configuration['token'] == null) {
+      $this->oidcProvider = new GenericProvider([
+        "clientId" => trim($this->sysconfig['SYSCONFIG']['OidcAppId']),
+        "clientSecret" => trim($this->sysconfig['SYSCONFIG']['OidcSecret']),
+        "redirectUri" => trim($this->sysconfig['SYSCONFIG']['OidcRedirectURL']),
+        "urlAuthorize" => trim($this->sysconfig['SYSCONFIG']['OidcAuthorizeURL']),
+        "urlAccessToken" => trim($this->sysconfig['SYSCONFIG']['OidcAccessTokenURL']),
+        "urlResourceOwnerDetails" => trim($this->sysconfig['SYSCONFIG']['OidcResourceURL']),
+      ]);
+
+      if (isset($this->sysconfig['SYSCONFIG']['OidcScope'])) {
+        $this->configuration['scope'] = trim($this->sysconfig['SYSCONFIG']['OidcScope']);
+      }
+    } else {
+      $this->oidcProvider = null;
+    }
   }
 
   /**
@@ -82,8 +99,9 @@ class AdminLicenseFromCSV extends DefaultPlugin
   {
     $vars = array();
     if (!$request->isMethod('POST')) {
-      $getHealth = $this->configuration['url'] . $this->configuration['uri'] . "/health";
-      $vars['licenseDBHealth'] = HttpUtils::checkLicenseDBHealth($getHealth, $this->guzzleClient);
+      $getHealth = $this->configuration['uri'] . $this->configuration['health'];
+      $guzzleClient = HttpUtils::getGuzzleClient($this->sysconfig, $this->configuration['uri']);
+      $vars['licenseDBHealth'] = HttpUtils::checkLicenseDBHealth($getHealth, $guzzleClient);
     }
     if ($request->isMethod('POST')) {
       if ($request->get('importFrom') === 'licensedb') {
@@ -98,17 +116,20 @@ class AdminLicenseFromCSV extends DefaultPlugin
         $uploadFile = $request->files->get(self::FILE_INPUT_NAME);
         $delimiter = $request->get('delimiter') ?: ',';
         $enclosure = $request->get('enclosure') ?: '"';
-        $vars['message'] = $this->handleFileUpload($uploadFile, $delimiter,
-          $enclosure)[1];
+        $vars['message'] = $this->handleFileUpload(
+          $uploadFile,
+          $delimiter,
+          $enclosure
+        )[1];
       }
     }
     $vars[self::KEY_UPLOAD_MAX_FILESIZE] = ini_get(self::KEY_UPLOAD_MAX_FILESIZE);
     $vars['baseUrl'] = $request->getBaseUrl();
     $vars['license_csv_import'] = true;
 
-    if (!empty(trim($this->configuration['url']))) {
+    if (!empty(trim($this->configuration['uri']))) {
       $vars['baseURL'] = !empty($this->configuration['uri']);
-      $vars['authToken'] = !empty($this->configuration['token']);
+      $vars['tokenConfig'] = !empty($this->configuration['token']) || $this->oidcProvider != null;
       $vars['exportEndpoint'] = !empty($this->configuration['content']);
       return $this->render("admin_license_from_licensedb.html.twig", $this->mergeWithDefault($vars));
     } else {
@@ -127,18 +148,30 @@ class AdminLicenseFromCSV extends DefaultPlugin
   {
     $msg = '<br>';
     $data = null;
-    $finalURL = $this->configuration['url'] . $this->configuration['uri'] . $this->configuration['content'];
+    $finalURL = $this->configuration['uri'] . $this->configuration['content'];
     try {
       $startTimeReq = microtime(true);
-      $response = $this->guzzleClient->get($finalURL);
-      $fetchLicenseTimeReq = microtime(true) - $startTimeReq;
-      $this->fileLogger->debug("LicenseDB req:' took " . sprintf("%0.3fms", 1000 * $fetchLicenseTimeReq));
 
+      $accessToken = null;
+      if ($this->configuration['token'] != null) {
+        $accessToken = $this->configuration['token'];
+      } else {
+        $options = [];
+        if (isset($this->configuration['scope'])) {
+          $options['scope'] = $this->configuration['scope'];
+        }
+        $accessToken = $this->oidcProvider->getAccessToken('client_credentials', $options);
+      }
+      $guzzleClient = HttpUtils::getGuzzleClient($this->sysconfig, $this->configuration['uri'], $accessToken);
+      $response = $guzzleClient->get($finalURL);
+      $fetchLicenseTimeReq = microtime(true) - $startTimeReq;
+
+      $this->fileLogger->debug("LicenseDB req:' took " . sprintf("%0.3fms", 1000 * $fetchLicenseTimeReq));
       $data = HttpUtils::processHttpResponse($response);
       return $this->licenseCsvImport->importJsonData($data, $msg);
     } catch (HttpClientException $e) {
       return $msg . $e->getMessage();
-    } catch (RequestException|GuzzleException $e) {
+    } catch (RequestException | GuzzleException $e) {
       return $msg . _('Something Went Wrong, check if host is accessible') . ': ' . $e->getMessage();
     }
   }
@@ -157,8 +190,10 @@ class AdminLicenseFromCSV extends DefaultPlugin
     } elseif ($uploadedFile->getSize() == 0 && $uploadedFile->getError() == 0) {
       $errMsg = _("Larger than upload_max_filesize ") .
         ini_get(self::KEY_UPLOAD_MAX_FILESIZE);
-    } elseif ($uploadedFile->getClientOriginalExtension() != 'csv'
-      && $uploadedFile->getClientOriginalExtension() != 'json') {
+    } elseif (
+      $uploadedFile->getClientOriginalExtension() != 'csv'
+      && $uploadedFile->getClientOriginalExtension() != 'json'
+    ) {
       $errMsg = _('Invalid file extension ') .
         $uploadedFile->getClientOriginalExtension() . ' of file ' .
         $uploadedFile->getClientOriginalName();

--- a/src/www/ui/template/admin_license_from_licensedb.html.twig
+++ b/src/www/ui/template/admin_license_from_licensedb.html.twig
@@ -5,7 +5,7 @@
 {% extends "include/base.html.twig" %}
 
 {% block content %}
-  {% set isConfigMissing = not baseURL or not exportEndpoint or not authToken %}
+  {% set isConfigMissing = not baseURL or not exportEndpoint or not tokenConfig %}
   {% macro renderMissingConfigItem(textstring) %}
     <p>{{ textstring|trans }}</p>
   {% endmacro %}
@@ -19,8 +19,8 @@
     {% if not exportEndpoint %}
       {{ _self.renderMissingConfigItem('Export Endpoint is missing.') }}
     {% endif %}
-    {% if not authToken %}
-      {{ _self.renderMissingConfigItem('Auth Token for LicenseDB is missing.') }}
+    {% if not tokenConfig %}
+      {{ _self.renderMissingConfigItem('Auth Token for LicenseDB and OIDC Config is missing. At least one is required.') }}
     {% endif %}
 
     <button type="submit" class="btn btn-default" disabled>{{ 'Import'|trans }}</button>


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Implemented Machine to machine communication between licensedb and fossology. 
If there's a licensedb token in config, then that will be used. If it's not there and there's a oidc instance set up both in fossology and licensedb, then that will be used. If even that is not there, then license/obligation import takes place via file upload.

## How to test

In Admin>Customize, set up the licensedb config and oidc config.
In LicenseDB, register a client via the api /oidcClients.
In Admin>License Admin>License Import, click on Import.
In Admin>Obligation Admin>Obligation Import, click on Import.
