### PR TITLE
feat(reuser): add “Reuse from OSSelot” option to upload UI and import pipeline

### DIFF
--- a/src/lib/php/Util/OsselotLookupHelper.php
+++ b/src/lib/php/Util/OsselotLookupHelper.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * OsselotLookupHelper.php
+ *
+ * A utility class to interact with both the OSSelot REST API and the
+ * Open-Source-Compliance GitHub repository for package analysis data.
+ *
+ * @package Fossology\Lib\Util
+ */
+
+namespace Fossology\Lib\Util;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\RequestOptions;
+
+class OsselotLookupHelper
+{
+  private string $baseUrl;
+  private Client $client;
+  private string $cacheDir;
+  private int $cacheTtl = 86400;
+
+  public function __construct()
+  {
+      $this->baseUrl = 'https://rest.osselot.org/';
+      $this->client = new Client([
+          'timeout'         => 300,
+          'connect_timeout' => 5,
+      ]);
+
+      $baseCache = $GLOBALS['SysConf']['DIRECTORIES']['cache'] ?? sys_get_temp_dir();
+      $this->cacheDir = rtrim($baseCache, '/\\') . '/util/osselot';
+
+    if (!is_dir($this->cacheDir)) {
+        @mkdir($this->cacheDir, 0755, true);
+    }
+  }
+
+    /**
+     * Fetches the list of versions for a given package from the OSSelot curated API.
+     *
+     * @param string $pkgName Package identifier to look up (e.g., "angular").
+     * @return array List of version strings; empty if none found or on error.
+     */
+  public function getVersions(string $pkgName): array
+  {
+    if (empty($pkgName)) {
+        return [];
+    }
+
+      $apiUrl = "https://www.osselot.org/curated.php?" . rawurlencode($pkgName);
+
+    try {
+        $response = $this->client->get($apiUrl, [
+            'headers' => [
+                'Accept'     => 'text/plain, text/html, */*',
+                'User-Agent' => 'Fossology-OsselotHelper',
+            ],
+            'timeout' => 30,
+            'connect_timeout' => 10,
+        ]);
+
+      if ($response->getStatusCode() !== 200) {
+        return [];
+      }
+
+        $responseBody = (string)$response->getBody();
+      if (empty($responseBody)) {
+          return [];
+      }
+
+        $versions = [];
+        $lines = explode("\n", trim($responseBody));
+
+      foreach ($lines as $line) {
+          $line = trim($line);
+        if (empty($line)) {
+            continue;
+        }
+
+        if (preg_match('/^' . preg_quote($pkgName, '/') . '\/version-(.+)$/', $line, $matches)) {
+            $version = trim($matches[1]);
+          if (!empty($version)) {
+              $versions[] = $version;
+          }
+        }
+      }
+
+        $versions = array_unique($versions);
+        sort($versions, SORT_NATURAL);
+
+        return $versions;
+
+    } catch (\Exception $e) {
+        return [];
+    }
+  }
+
+    /**
+     * Downloads (or retrieves from cache) the SPDX RDF/XML file for a
+     * given package/version and returns the local cache pathname,
+     * or null if all attempts fail.
+     *
+     * @param string $pkgName Package identifier
+     * @param string $version Version string
+     * @return string|null Path to cached file or null on failure
+     * @throws \InvalidArgumentException When package name or version is invalid
+     * @throws \RuntimeException When cache operations fail
+     */
+  public function fetchSpdxFile(string $pkgName, string $version): ?string
+  {
+    if (empty($pkgName) || empty($version)) {
+        throw new \InvalidArgumentException('Package name and version cannot be empty');
+    }
+
+      $safeName  = preg_replace('/[^a-zA-Z0-9_.\-]/', '_', $pkgName);
+      $safeVer   = preg_replace('/[^a-zA-Z0-9_.\-]/', '_', $version);
+      $cacheFile = "{$this->cacheDir}/{$safeName}_{$safeVer}.rdf";
+
+    if (is_file($cacheFile) && (time() - filemtime($cacheFile) < $this->cacheTtl)) {
+        return $cacheFile;
+    }
+
+      $relPath = sprintf(
+          '%s/version-%s/%s-%s.spdx.rdf.xml',
+          rawurlencode($pkgName),
+          rawurlencode($version),
+          rawurlencode($pkgName),
+          rawurlencode($version)
+      );
+
+      $githubRoot = 'https://raw.githubusercontent.com/Open-Source-Compliance/package-analysis/main/analysed-packages';
+      $candidates = [
+          "{$githubRoot}/{$relPath}",
+          "{$githubRoot}/{$relPath}.gz",
+          str_replace('raw.githubusercontent.com', 'osselot.org', "{$githubRoot}/{$relPath}"),
+      ];
+
+      $options = [
+          RequestOptions::HEADERS => [
+              'Accept'     => 'application/rdf+xml, application/xml, text/xml',
+              'User-Agent' => 'Fossology-OsselotHelper',
+          ],
+          RequestOptions::HTTP_ERRORS => false,
+          RequestOptions::CONNECT_TIMEOUT => 10,
+          RequestOptions::TIMEOUT => 30,
+      ];
+
+      foreach ($candidates as $url) {
+        try {
+            $response = $this->client->get($url, $options);
+
+          if ($response->getStatusCode() !== 200) {
+            continue;
+          }
+
+            $body = (string) $response->getBody();
+          if (empty($body)) {
+              continue;
+          }
+
+          if (str_ends_with($url, '.gz')) {
+              $decompressed = @gzdecode($body);
+            if ($decompressed === false) {
+                continue;
+            }
+              $body = $decompressed;
+          }
+
+          if (!$this->isValidXml($body)) {
+              continue;
+          }
+
+          if (!is_dir($this->cacheDir)) {
+              @mkdir($this->cacheDir, 0755, true);
+          }
+
+          if (file_put_contents($cacheFile, $body) !== false) {
+              return $cacheFile;
+          }
+
+        } catch (\Exception $e) {
+            continue;
+        }
+      }
+
+      return null;
+  }
+    /**
+     * Basic XML validation
+     */
+  private function isValidXml(string $content): bool
+  {
+      $previousUseInternalErrors = libxml_use_internal_errors(true);
+      libxml_clear_errors();
+
+      $doc = simplexml_load_string($content);
+      $errors = libxml_get_errors();
+
+      libxml_use_internal_errors($previousUseInternalErrors);
+      libxml_clear_errors();
+
+      return $doc !== false && empty($errors);
+  }
+
+    /**
+     * Clears the cache directory.
+     *
+     * @return bool True on success, false on failure.
+     */
+  public function clearCache(): bool
+  {
+    if (!is_dir($this->cacheDir)) {
+        return true;
+    }
+
+    foreach (glob($this->cacheDir . '/*.rdf') as $file) {
+      if (is_file($file)) {
+          unlink($file);
+      }
+    }
+
+      return true;
+  }
+}

--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -377,6 +377,12 @@ function Populate_sysconfig()
   $valueArray[$variable] = array("'$variable'", "'$contextValue'", "'$contextNamePrompt'",
     strval(CONFIG_TYPE_TEXTAREA), "'ReportText'", "4", "'$contextDesc'", "null", "null");
 
+  $variable         = "EnableOsselotReuse";
+  $prompt           = ("Enable OSSelot Reuse");
+  $desc             = ("When enabled, shows the OSSelot-based reuse option in the Reuser plugin");
+  $valueArray[$variable] = array("'$variable'","true","'$prompt'",
+      strval(CONFIG_TYPE_BOOL),"'ReportText'","5","'$desc'","'check_boolean'","null");
+      
   /*  "Upload from server"-configuration  */
   $variable = "UploadFromServerWhitelist";
   $contextNamePrompt = _("Whitelist for serverupload");

--- a/src/reuser/ui/agent-reuser.php
+++ b/src/reuser/ui/agent-reuser.php
@@ -18,6 +18,7 @@ use Fossology\Lib\Dao\PackageDao;
 use Fossology\Lib\Dao\UploadDao;
 use Fossology\Lib\Plugin\AgentPlugin;
 use Fossology\Lib\Util\StringOperation;
+use Fossology\Lib\Util\OsselotLookupHelper;
 use Fossology\Scancode\Ui\ScancodesAgentPlugin;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -100,16 +101,18 @@ class ReuserAgentPlugin extends AgentPlugin
    */
   public function scheduleAgent($jobId, $uploadId, &$errorMsg, $request)
   {
-    $reuseUploadPair = explode(',',
-      $request->get(self::UPLOAD_TO_REUSE_SELECTOR_NAME), 2);
+    if ($request->get('reuseSource') === 'osselot') {
+        return $this->scheduleOsselotImportDirect($jobId, $uploadId, $errorMsg, $request);
+    }
+
+    $reuseUploadPair = explode(',', $request->get(self::UPLOAD_TO_REUSE_SELECTOR_NAME), 2);
     if (count($reuseUploadPair) == 2) {
       list($reuseUploadId, $reuseGroupId) = $reuseUploadPair;
     } else {
       $errorMsg .= 'no reuse upload id given';
-      return - 1;
+      return -1;
     }
     $groupId = $request->get('groupId', Auth::getGroupId());
-
     $getReuseValue = $request->get(self::REUSE_MODE) ?: array();
     $reuserDependencies = array("agent_adj2nest");
 
@@ -142,6 +145,99 @@ class ReuserAgentPlugin extends AgentPlugin
 
     return $this->doAgentAdd($jobId, $uploadId, $errorMsg,
       $reuserDependencies, $uploadId, null, $request);
+  }
+
+  private function scheduleOsselotImportDirect(int $jobId, int $uploadId, string &$errorMsg, Request $request): int
+  {
+    $pkg = trim((string) $request->get('osselotPackage'));
+    $ver = trim((string) $request->get('osselotVersions'));
+    if (empty($pkg) || empty($ver)) {
+        $errorMsg .= 'Package name and version are required';
+        return -1;
+    }
+    try {
+        $helper = new OsselotLookupHelper();
+        $cachedPath = $helper->fetchSpdxFile($pkg, $ver);
+
+      if (!$cachedPath || !is_file($cachedPath) || !is_readable($cachedPath)) {
+          throw new \RuntimeException("Could not fetch or read SPDX file for {$pkg}:{$ver}");
+      }
+
+        global $SysConf;
+        $fileBase = $SysConf['FOSSOLOGY']['path'] . "/ReportImport/";
+
+      if (!is_dir($fileBase) && !mkdir($fileBase, 0755, true)) {
+          throw new \RuntimeException('Failed to create ReportImport directory');
+      }
+
+        $originalName = basename($cachedPath);
+      if (!str_ends_with($originalName, '.rdf.xml')) {
+          $baseName = pathinfo($originalName, PATHINFO_FILENAME);
+          $originalName = str_ends_with($originalName, '.rdf') ?
+              $baseName . '.rdf.xml' : $originalName . '.rdf.xml';
+      }
+
+        $targetFile = time() . '_' . random_int(0, getrandmax()) . '_' . $originalName;
+        $targetPath = $fileBase . $targetFile;
+
+      if (!copy($cachedPath, $targetPath)) {
+          throw new \RuntimeException('Failed to copy SPDX file');
+      }
+
+        $reportImportAgent = plugin_find('agent_reportImport');
+      if (!$reportImportAgent || !method_exists($reportImportAgent, 'addReport') ||
+            !method_exists($reportImportAgent, 'setAdditionalJqCmdArgs') ||
+            !method_exists($reportImportAgent, 'AgentAdd')) {
+          throw new \RuntimeException('agent_reportImport plugin not available or missing methods');
+      }
+
+        $importReq = new Request();
+
+        $addNewLicensesAs = $request->get('osselotAddNewLicensesAs', 'candidate');
+      if (!in_array($addNewLicensesAs, ['candidate', 'approved', 'rejected'], true)) {
+          $addNewLicensesAs = 'candidate';
+      }
+        $importReq->request->set('addNewLicensesAs', $addNewLicensesAs);
+
+        $booleanOptions = [
+            'addLicenseInfoFromInfoInFile', 'addLicenseInfoFromConcluded',
+            'addConcludedAsDecisions', 'addConcludedAsDecisionsOverwrite',
+            'addConcludedAsDecisionsTBD', 'addCopyrights'
+        ];
+
+        foreach ($booleanOptions as $key) {
+            $fullKey = 'osselot' . ucfirst($key);
+            $importReq->request->set($key, $request->get($fullKey) ? 'true' : 'false');
+        }
+
+        $licenseMatch = $request->get('osselotLicenseMatch', 'spdxid');
+        if (!in_array($licenseMatch, ['spdxid', 'name', 'text'], true)) {
+            $licenseMatch = 'spdxid';
+        }
+        $importReq->request->set('licenseMatch', $licenseMatch);
+
+        $jqCmdArgs = $reportImportAgent->addReport($targetFile);
+        $additionalArgs = $reportImportAgent->setAdditionalJqCmdArgs($importReq);
+        $jqCmdArgs .= $additionalArgs;
+
+        $error = "";
+        $dependencies = array();
+        $jobQueueId = $reportImportAgent->AgentAdd($jobId, $uploadId, $error, $dependencies, $jqCmdArgs);
+
+        if ($jobQueueId < 0) {
+            throw new \RuntimeException("Cannot schedule job: " . $error);
+        }
+
+        return intval($jobQueueId);
+
+    } catch (\Throwable $e) {
+      if (isset($targetPath) && file_exists($targetPath)) {
+          unlink($targetPath);
+      }
+        $errorMsg .= $e->getMessage();
+        error_log("OSSelot import error: " . $e->getMessage());
+        return -1;
+    }
   }
 
   /**

--- a/src/reuser/ui/reuser-plugin.php
+++ b/src/reuser/ui/reuser-plugin.php
@@ -15,6 +15,7 @@ use Fossology\Lib\Plugin\DefaultPlugin;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Fossology\Lib\Util\OsselotLookupHelper;
 
 include_once(__DIR__ . "/../agent/version.php");
 
@@ -76,17 +77,28 @@ class ReuserPlugin extends DefaultPlugin
   protected function handle(Request $request)
   {
     $this->folderDao->ensureTopLevelFolder();
-    list($folderId, $trustGroupId) = $this->getFolderIdAndTrustGroup($request->get(self::FOLDER_PARAMETER_NAME));
-    $ajaxMethodName = $request->get('do');
+    $ajax = $request->get('do');
 
-    if ($ajaxMethodName == "getUploads") {
-      $uploadsById = "";
-      if (empty($folderId) || empty($trustGroupId)) {
-        $uploadsById = $this->getAllUploads();
-      } else {
-        $uploadsById = $this->prepareFolderUploads($folderId, $trustGroupId);
-      }
-      return new JsonResponse($uploadsById, JsonResponse::HTTP_OK);
+    if ($ajax === 'getUploads') {
+        list($fid, $tgid) = $this->getFolderIdAndTrustGroup($request->get(self::FOLDER_PARAMETER_NAME, ''));
+        $uploads = (empty($fid) || empty($tgid))
+            ? $this->getAllUploads()
+            : $this->prepareFolderUploads($fid, $tgid);
+        return new JsonResponse($uploads, JsonResponse::HTTP_OK);
+    }
+
+    if ($ajax === 'getOsselotVersions') {
+        $pkg = trim($request->get('pkg', $request->get('osselotPackage', '')));
+        if ($pkg === '') {
+            return new JsonResponse([], JsonResponse::HTTP_OK);
+        }
+        $helper = new OsselotLookupHelper();
+        try {
+            $versions = $helper->getVersions($pkg);
+        } catch (\Exception $e) {
+            $versions = [];
+        }
+        return new JsonResponse($versions, JsonResponse::HTTP_OK);
     }
 
     return new Response('called without valid method', Response::HTTP_METHOD_NOT_ALLOWED);
@@ -118,6 +130,8 @@ class ReuserPlugin extends DefaultPlugin
    */
   public function renderContent(&$vars)
   {
+    global $SysConf;
+    $osselotAvailable = (array_key_exists('EnableOsselotReuse', $SysConf['SYSCONFIG'])) ? $SysConf['SYSCONFIG']["EnableOsselotReuse"] : '';
     if (!array_key_exists('folderStructure', $vars)) {
       $rootFolderId = $this->folderDao->getRootFolder(Auth::getUserId())->getId();
       $vars['folderStructure'] = $this->folderDao->getFolderStructure($rootFolderId);
@@ -136,6 +150,9 @@ class ReuserPlugin extends DefaultPlugin
     $vars['folderParameterName'] = self::FOLDER_PARAMETER_NAME;
     $vars['uploadToReuseSelectorName'] = self::UPLOAD_TO_REUSE_SELECTOR_NAME;
     $vars['folderUploads'] = $this->prepareFolderUploads($folderId, $trustGroupId);
+    $vars['osselotAvailable'] = $osselotAvailable;
+    $vars['defaultPkgName']  = '';
+    $vars['userIsAdmin']     = Auth::isAdmin();
 
     $renderer = $this->getObject('twig.environment');
     return $renderer->load('agent_reuser.html.twig')->render($vars);
@@ -148,9 +165,13 @@ class ReuserPlugin extends DefaultPlugin
    */
   public function renderFoot(&$vars)
   {
+    global $SysConf;
+    $osselotAvailable = (array_key_exists('EnableOsselotReuse', $SysConf['SYSCONFIG'])) ? $SysConf['SYSCONFIG']["EnableOsselotReuse"] : '';
     $vars['reuseFolderSelectorName'] = self::REUSE_FOLDER_SELECTOR_NAME;
     $vars['folderParameterName'] = self::FOLDER_PARAMETER_NAME;
     $vars['uploadToReuseSelectorName'] = self::UPLOAD_TO_REUSE_SELECTOR_NAME;
+    $vars['osselotAvailable']           = $osselotAvailable;
+
     $renderer = $this->getObject('twig.environment');
     return $renderer->load('agent_reuser.js.twig')->render($vars);
   }

--- a/src/reuser/ui/template/agent_reuser.html.twig
+++ b/src/reuser/ui/template/agent_reuser.html.twig
@@ -1,7 +1,5 @@
 {# SPDX-FileCopyrightText: © Fossology contributors
-
-   SPDX-License-Identifier: GPL-2.0-only
-#}
+   SPDX-License-Identifier: GPL-2.0-only #}
 {% import "include/macros.html.twig" as macro %}
 
 <li>
@@ -13,40 +11,178 @@
       </span>
     </label>
     <img src="images/info_16.png" data-toggle="tooltip" title="{{ 'Copy clearing decisions if there is the same file hash between two files'|trans }}" alt="" class="info-bullet"/><br/>
-    <label>
-      <input type="checkbox" class="browse-upload-checkbox view-license-rc-size reuseSearchInFolder" id="reuseSearchInFolder" />
-      {{ 'Select an already uploaded package for reuse in specific folder ' | trans }}
-    </label>
-    {% include 'reuse-folder.html.twig' with {
-      'name': reuseFolderSelectorName,
-      'id': reuseFolderSelectorName
-    } %}
-    <br/>
-    <label>
-      <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="reuseMode[]" value="reuseEnhanced"/>
-      {{ 'Enhanced reuse (slower)'|trans }}
-      <img src="images/info_16.png" data-toggle="tooltip" title="{{'Will copy a clearing decision if the two files differ by one line determined by a diff tool'|trans}}" alt="" class="info-bullet"/>
-    </label><br/>
+    
+    <div class="form-group">
+      <label for="reuse-source">{{ 'Reuse source'|trans }}:</label>
+      <select id="reuse-source" name="reuseSource" class="form-control"
+              style="width: 200px; display:inline-block;">
+        <option value="local">{{ 'Local reports'|trans }}</option>
+        {% if osselotAvailable %}
+          <option value="osselot">{{ 'Reuse from OSSelot'|trans }}</option>
+        {% endif %}
+      </select>
+      {% if osselotAvailable %}
+        <img src="images/info_16.png"
+             data-toggle="tooltip"
+             title="{{ 'Fetch curated license analysis from OSSelot database for this package'|trans }}"
+             alt=""
+             class="info-bullet"/>
+      {% endif %}
+    </div>
 
-    <label>
-      <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="reuseMode[]" value="reuseMain"/>
-      {{ 'Reuse main license/s'|trans }}
-      <img src="images/info_16.png" data-toggle="tooltip" title="{{'Will copy a main license decision(if any)'|trans}}" alt="" class="info-bullet"/>
-    </label><br/>
+    <div id="local-reuse-section">
+      <label>
+        <input type="checkbox" class="browse-upload-checkbox view-license-rc-size reuseSearchInFolder" id="reuseSearchInFolder" />
+        {{ 'Select an already uploaded package for reuse in specific folder ' | trans }}
+      </label>
+      {% include 'reuse-folder.html.twig' with {
+        'name': reuseFolderSelectorName,
+        'id': reuseFolderSelectorName
+      } %}
+      <br/>
+      <label>
+        <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="reuseMode[]" value="reuseEnhanced"/>
+        {{ 'Enhanced reuse (slower)'|trans }}
+        <img src="images/info_16.png" data-toggle="tooltip" title="{{'Will copy a clearing decision if the two files differ by one line determined by a diff tool'|trans}}" alt="" class="info-bullet"/>
+      </label><br/>
+      
+      <label>
+        <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="reuseMode[]" value="reuseMain"/>
+        {{ 'Reuse main license/s'|trans }}
+        <img src="images/info_16.png" data-toggle="tooltip" title="{{'Will copy a main license decision(if any)'|trans}}" alt="" class="info-bullet"/>
+      </label><br/>
+      
+      <label>
+        <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="reuseMode[]" value="reuseConf"/>
+        {{ 'Reuse report configuration settings'|trans }}
+        <img src="images/info_16.png" data-toggle="tooltip" title="{{'Use to copy all the information from conf page(if any)'|trans}}" alt="" class="info-bullet"/>
+      </label><br/>
+      
+      <label>
+        <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="reuseMode[]" value="reuseCopyright"/>
+        {{ 'Reuse deactivated copyrights'|trans }}
+        <img src="images/info_16.png" data-toggle="tooltip" title="{{'Use to copy edited and deactivated copyrights from the reused package'|trans}}" alt="" class="info-bullet"/>
+      </label><br/>
+      
+      <label for="{{ uploadToReuseSelectorName }}">{{ 'Upload to reuse'|trans }}:</label><br/>
+      {{ macro.select(uploadToReuseSelectorName, folderUploads, uploadToReuseSelectorName, reuseUploadId, 'style="min-width:420px;"', 5) }}
+    </div>
 
-    <label>
-      <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="reuseMode[]" value="reuseConf"/>
-      {{ 'Reuse report configuration settings'|trans }}
-      <img src="images/info_16.png" data-toggle="tooltip" title="{{'Use to copy all the information from conf page(if any)'|trans}}" alt="" class="info-bullet"/>
-    </label><br/>
+    {% if osselotAvailable %}
+    <div id="osselot-reuse-section" style="display:none;">
+      <div class="form-group">
+        <label for="osselot-package">{{ 'Package name'|trans }}:</label>
+        <input type="text"
+               id="osselot-package"
+               name="osselotPackage"
+               class="form-control"
+               style="width: 300px; display:inline-block;"
+               placeholder="{{ 'Enter package name and press Enter'|trans }}"
+               value="{{ defaultPkgName|default('') }}"/>
+        <button type="button"
+                id="osselot-fetch-versions"
+                class="btn btn-secondary btn-sm"
+                style="margin-left: .5em;">
+          {{ 'Fetch Versions'|trans }}
+        </button>
+        <img src="images/info_16.png"
+             data-toggle="tooltip"
+             title="{{ 'Enter the package name as it appears in OSSelot database'|trans }}"
+             alt=""
+             class="info-bullet"/>
+      </div>
 
-    <label>
-      <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="reuseMode[]" value="reuseCopyright"/>
-      {{ 'Reuse deactivated copyrights'|trans }}
-      <img src="images/info_16.png" data-toggle="tooltip" title="{{'Use to copy edited and deactivated copyrights from the reused package'|trans}}" alt="" class="info-bullet"/>
-    </label><br/>
+      <div class="form-group">
+        <label>{{ 'Versions'|trans }}:</label>
+        <span id="osselot-version-loading" style="display:none;">
+          <img src="images/ajax-loader.gif" alt="Loading…"/>
+          {{ 'Loading versions…'|trans }}
+        </span>
 
-    <label for="{{ uploadToReuseSelectorName }}">{{ 'Upload to reuse'|trans }}:</label><br/>
-    {{ macro.select(uploadToReuseSelectorName, folderUploads, uploadToReuseSelectorName, reuseUploadId, 'style="min-width:420px;"', 5) }}
+        <div id="osselot-version-checkboxes"
+             class="osselot-version-list"
+             style="max-height:160px; overflow:auto; border:1px solid #ced4da;
+                    border-radius:.25rem; padding:.5em;">
+          <em>{{ 'Enter package name first'|trans }}</em>
+        </div>
+
+        <input type="hidden" name="osselotVersions" id="osselot-versions-hidden" value=""/>
+      </div>
+      
+      <div class="form-group">
+        <strong>{{ 'Import options'|trans }}:</strong>
+        
+        <div style="margin-left: 20px; margin-top: 10px;">
+          <div>
+            <strong>{{ 'Create new licenses as'|trans }}:</strong>
+            <div style="margin-left: 20px;">
+              <label>
+                <input type="radio" id="osselot-addNewLicensesAs-candidate" name="osselotAddNewLicensesAs" value="candidate" checked="checked">
+                {{ 'License candidate'|trans }}
+              </label><br/>
+              {% if userIsAdmin %}
+              <label>
+                <input type="radio" id="osselot-addNewLicensesAs-license" name="osselotAddNewLicensesAs" value="license">
+                {{ 'New license'|trans }}
+              </label>
+              {% endif %}
+            </div>
+          </div>
+
+          <div style="margin-top: 10px;">
+            <strong>{{ 'Match license using'|trans }}:</strong>
+            <div style="margin-left: 20px;">
+              <label>
+                <input type="radio" id="osselot-licenseMatch-shortname" name="osselotLicenseMatch" value="shortname">
+                {{ 'Shortname'|trans }}
+              </label><br/>
+              <label>
+                <input type="radio" id="osselot-licenseMatch-spdxid" name="osselotLicenseMatch" value="spdxid" checked="checked">
+                {{ 'SPDX ID'|trans }}
+              </label>
+            </div>
+          </div>
+
+          <div style="margin-top: 10px;">
+            <strong>{{ 'Add the License Info as findings from'|trans }}:</strong>
+            <div style="margin-left: 20px;">
+              <label>
+                <input type="checkbox" name="osselotAddLicenseInfoFromInfoInFile" value="true" checked="checked"/>
+                {{ 'SPDX tag of type licenseInfoInFile'|trans }}
+              </label><br/>
+              <label>
+                <input type="checkbox" name="osselotAddLicenseInfoFromConcluded" value="true" />
+                {{ 'SPDX tag of type licenseConcluded'|trans }}
+              </label>
+            </div>
+          </div>
+
+          <div style="margin-top: 10px;">
+            <label>
+              <input type="checkbox" name="osselotAddConcludedAsDecisions" value="true" checked="checked"/>
+              {{ 'Add concluded licenses as decisions'|trans }}
+            </label>
+            <div style="margin-left: 20px;">
+              <label style="color: gray;">
+                <input type="checkbox" name="osselotAddConcludedAsDecisionsOverwrite" value="true" checked="checked" onclick="return false;"/>
+                {{ 'Also overwrite existing decisions'|trans }}
+              </label><br/>
+              <label>
+                <input type="checkbox" name="osselotAddConcludedAsDecisionsTBD" value="true" checked="checked"/>
+                {{ 'Import as "to be discussed"'|trans }}
+              </label>
+            </div>
+          </div>
+
+          <div style="margin-top: 10px;">
+            <label>
+              <input type="checkbox" name="osselotAddCopyrights" value="true"/>
+              {{ 'Add the copyright information as textfindings'|trans }}
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+    {% endif %}
   </div>
 </li>

--- a/src/reuser/ui/template/agent_reuser.js.twig
+++ b/src/reuser/ui/template/agent_reuser.js.twig
@@ -2,6 +2,7 @@
 
    SPDX-License-Identifier: GPL-2.0-only
 #}
+let osselotVersions = []; 
 function registerFolderSelectorChange() {
   $('[id^={{ reuseFolderSelectorName }}]').change(function () {
     const groupIndex = $(this).attr('id').replace('{{ reuseFolderSelectorName }}', '');
@@ -28,22 +29,231 @@ function reloadUploads(folderGroupPair, groupIndex) {
 
 function toggleDisabled() {
   $('.reuseSearchInFolder').click(function () {
-    const groupIndex = $(this).attr('id').replace('reuseSearchInFolder', '');
-    const folderSelector = $(`#{{ reuseFolderSelectorName }}${groupIndex}`);
-    folderSelector.prop('disabled', !$(this).prop('checked'));
-
-    if ($(this).prop('checked')) {
-      folderSelector.trigger('change');
-    } else {
-      reloadUploads("", "");
-    }
+    const gi = $(this).attr('id').replace('reuseSearchInFolder', '');
+    const fs = $(`#{{ reuseFolderSelectorName }}${gi}`);
+    fs.prop('disabled', !this.checked);
+    this.checked ? fs.trigger('change') : reloadUploads('', '');
   });
 
-  reloadUploads("", "");
+  reloadUploads('', '');
   registerFolderSelectorChange();
+}
+
+window.osselotInitialized = window.osselotInitialized || {};
+
+function initializeOsselotFields() {
+
+  function toggleReuseSource(index = '') {
+    const reuseSourceId = index !== '' ? `#reuse-source${index}` : '#reuse-source';
+    const localSectionId = index !== '' ? `#local-reuse-section${index}` : '#local-reuse-section';
+    const osselotSectionId = index !== '' ? `#osselot-reuse-section${index}` : '#osselot-reuse-section';
+    
+    const $reuseSource = $(reuseSourceId);
+    if ($reuseSource.length === 0) return;
+    
+    const selectedValue = $reuseSource.val();
+    const $osselotSection = $(osselotSectionId);
+    const $localSection = $(localSectionId);
+    
+    $localSection.hide();
+    $osselotSection.hide();
+    
+    if (selectedValue === 'osselot') {
+      if ($osselotSection.length > 0) {
+        $osselotSection.show().css('display', 'block');
+      }
+    } else {
+      if ($localSection.length > 0) {
+        $localSection.show().css('display', 'block');
+      }
+    }
+  }
+
+  function renderVersionRadioButtons(versions, index = '') {
+    const containerId = index !== '' ? `#osselot-version-checkboxes${index}` : '#osselot-version-checkboxes';
+    const $box = $(containerId);
+    
+    if ($box.length === 0) return;
+    
+    $box.empty();
+    
+    if (!versions.length) {
+      $box.append(`<em>No versions found for this package</em>`);
+      return;
+    }
+    
+    let html = '';
+    const radioName = index !== '' ? `osselotVersionRadio[${index}]` : 'osselotVersionRadio';
+    
+    versions.forEach((version, versionIndex) => {
+      const radioId = `osselot-version-${versionIndex}${index ? '-' + index : ''}`;
+      const isChecked = versionIndex === 0 ? 'checked' : '';
+      html += `<label style="display:block; margin-bottom:5px;">
+                 <input type="radio" id="${radioId}" 
+                        name="${radioName}" value="${version}" 
+                        class="osselot-version-radio" data-index="${index}"
+                        ${isChecked}> 
+                 ${version}
+               </label>`;
+    });
+    
+    $box.html(html);
+    syncHiddenField(index);
+  }
+
+  function syncHiddenField(index = '') {
+    const hiddenId = index !== '' ? `#osselot-versions-hidden${index}` : '#osselot-versions-hidden';
+    const radioName = index !== '' ? `osselotVersionRadio[${index}]` : 'osselotVersionRadio';
+    
+    const selected = $(`input[name="${radioName}"]:checked`).val() || '';
+    $(hiddenId).val(selected);
+  }
+
+  function fetchOsselotVersions(index = '') {
+    const packageId = index !== '' ? `#osselot-package${index}` : '#osselot-package';
+    const loadingId = index !== '' ? `#osselot-version-loading${index}` : '#osselot-version-loading';
+    
+    const pkg = $(packageId).val().trim();
+    const $load = $(loadingId);
+
+    if (!pkg) return;
+
+    $load.show();
+    const containerId = index !== '' ? `#osselot-version-checkboxes${index}` : '#osselot-version-checkboxes';
+    $(containerId).html('<em>Loading...</em>');
+
+    $.ajax({
+      url: '?mod=plugin_reuser&do=getOsselotVersions',
+      method: 'GET',
+      data: { pkg: pkg },
+      dataType: 'json',
+      success: function(data) {
+        const versions = Array.isArray(data) ? data : [];
+        renderVersionRadioButtons(versions, index);
+        setTimeout(() => {
+          syncHiddenField(index);
+        }, 100);
+      },
+      error: function() {
+        $(containerId).html('<em>Error loading versions</em>');
+      },
+      complete: function() {
+        $load.hide();
+      }
+    });
+  }
+
+  function setupOsselotEvents(index = '') {
+    const indexStr = String(index);
+    const reuseSourceId = indexStr !== '' ? `reuse-source${indexStr}` : 'reuse-source';
+    const packageId = indexStr !== '' ? `osselot-package${indexStr}` : 'osselot-package';
+    const fetchButtonId = indexStr !== '' ? `osselot-fetch-versions${indexStr}` : 'osselot-fetch-versions';
+
+    const namespace = indexStr !== '' ? `.osselot${indexStr}` : '.osselot';
+    $(document).off(namespace);
+    
+    const $reuseSource = $(`#${reuseSourceId}`);
+    if ($reuseSource.length === 0) return;
+    
+    $(document).on(`change${namespace}`, `#${reuseSourceId}`, function() {
+        toggleReuseSource(indexStr);
+    });
+    
+    $(document).on(`input${namespace} change${namespace}`, `#${packageId}`, function() {
+        const value = $(this).val();
+        $('[id^="osselot-package"]').val(value);
+    });
+    
+    $(document).on(`click${namespace} keypress${namespace}`, `#${packageId}, #${fetchButtonId}`, function(e) {
+        if (e.type === 'click' || e.which === 13) {
+            e.preventDefault();
+            fetchOsselotVersions(indexStr);
+        }
+    });
+  }
+
+  $(document).on('change', '.osselot-version-radio', function () {
+    const idx = $(this).data('index') ?? '';
+    syncHiddenField(idx);
+  });
+
+  if (!window.osselotInitialized['']) {
+    setupOsselotEvents();
+    window.osselotInitialized[''] = true;
+  }
+  
+  window.initializeOsselotForIndex = function(index) {
+    const indexStr = String(index);
+    
+    if (window.osselotInitialized[indexStr]) return;
+    
+    setupOsselotEvents(indexStr);
+    
+    setTimeout(() => {
+      const reuseSourceId = indexStr !== '' ? `#reuse-source${indexStr}` : '#reuse-source';
+      $(reuseSourceId).trigger('change');
+    }, 150);
+    
+    window.osselotInitialized[indexStr] = true;
+  };
+
+  window.resetOsselotInitialization = function(index = null) {
+    if (index !== null) {
+      delete window.osselotInitialized[index];
+    } else {
+      window.osselotInitialized = {};
+    }
+  };
 }
 
 $(document).ready(function () {
   toggleDisabled();
+  initializeOsselotFields();
+  
+  window.osselotInitialized = {};
+  
+  $("#fileUploader").on("change", function(e) {
+    window.osselotInitialized = {};
+    
+    const allFiles = e.target.files;
+    
+    var holder = $("#uploaddescriptions");
+    holder.html("");
+    
+    if (allFiles.length > 10) {
+      $("#collapseDescription").show();
+      $("#uploaddescriptions").collapse('hide');
+    }
+    
+    const reuseNameTab = $("#reuse-name-tab");
+    const reuseTabContent = $("#reuse-tab-content");
+    reuseNameTab.html("");
+    reuseTabContent.html("");
+    
+    for (let i = 0; i < allFiles.length; i++) {
+      const val = allFiles[i];
+      
+      const tt = $("<h6 class='card-title'>").append(val.name);
+      let formg = $("<div class='form-group'>");
+      const ll = $(`<label for='desc${i}' class='card-text'>`).append("(Optional) Enter a description of this file:");
+      formg.append(ll).append(`<input type='text' class='form-control' name='descriptionInputName[${i}]' id='desc${i}'>`);
+      let body = $("<div class='card-body'>");
+      body.append(tt).append(formg);
+      let html = $("<div class='card'>");
+      html.append(body);
+      holder.append(html);
+      
+      addNavItems(i, val.name, reuseNameTab, reuseTabContent);
+    }
+    
+    setTimeout(function() {
+      for (let i = 0; i < allFiles.length; i++) {
+        if (typeof window.initializeOsselotForIndex === 'function') {
+          window.initializeOsselotForIndex(i);
+        }
+      }
+    }, 300);
+    
+    toggleDisabled();
+  });
 });
-

--- a/src/www/ui/page/UploadFilePage.php
+++ b/src/www/ui/page/UploadFilePage.php
@@ -11,6 +11,7 @@ namespace Fossology\UI\Page;
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\UI\MenuHook;
 use Fossology\Reuser\ReuserAgentPlugin;
+use Fossology\Lib\Util\OsselotLookupHelper;
 use Symfony\Component\HttpFoundation\File\Exception\FileException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
@@ -226,6 +227,73 @@ class UploadFilePage extends UploadPageBase
   private function getRequestForReuse(Request $request, string $originalFileName)
   {
     $reuseRequest = clone $request;
+
+    $reuseSourceRaw = $request->get('reuseSource', 'local');
+    $reuseSource = is_array($reuseSourceRaw) ? reset($reuseSourceRaw) : $reuseSourceRaw;
+    
+    $osselotPackageRaw = $request->get('osselotPackage');
+    $osselotPackage = is_array($osselotPackageRaw) ? reset($osselotPackageRaw) : $osselotPackageRaw;
+    
+    if ($reuseSource === 'osselot') {
+        $reuseRequest->request->set('osselotPackage', $osselotPackage);
+        
+        $versionRadio = $request->get('osselotVersionRadio', []);
+        $selectedVersion = '';
+        
+        if (is_array($versionRadio)) {
+            $selectedVersion = reset($versionRadio);
+        } elseif (is_string($versionRadio)) {
+            $selectedVersion = $versionRadio;
+        }
+        
+        if (empty($selectedVersion)) {
+            $hiddenVersions = $request->get('osselotVersions', '');
+            if (!empty($hiddenVersions)) {
+                $selectedVersion = is_array($hiddenVersions) ? reset($hiddenVersions) : $hiddenVersions;
+            }
+        }
+        
+        $reuseRequest->request->set('osselotVersions', $selectedVersion);
+        
+        $osselotScalarFields = [
+            'osselotAddNewLicensesAs',
+            'osselotLicenseMatch'
+        ];
+        
+        foreach ($osselotScalarFields as $field) {
+            $value = $request->get($field);
+            $finalValue = is_array($value) ? reset($value) : $value;
+            $reuseRequest->request->set($field, $finalValue);
+        }
+        
+        $osselotCheckboxFields = [
+            'osselotAddLicenseInfoFromInfoInFile',
+            'osselotAddLicenseInfoFromConcluded',
+            'osselotAddConcludedAsDecisions',
+            'osselotAddConcludedAsDecisionsOverwrite',
+            'osselotAddConcludedAsDecisionsTBD',
+            'osselotAddCopyrights'
+        ];
+        
+        foreach ($osselotCheckboxFields as $field) {
+            $value = $request->get($field);
+            $finalValue = null;
+            
+            if (is_array($value)) {
+                $firstValue = reset($value);
+                $finalValue = ($firstValue === 'true' || $firstValue === true) ? 'true' : null;
+            } else {
+                $finalValue = ($value === 'true' || $value === true) ? 'true' : null;
+            }
+            
+            $reuseRequest->request->set($field, $finalValue);
+        }
+        
+        $reuseRequest->request->set('reuseSource', 'osselot');
+        
+        return $reuseRequest;
+    }
+    
     $reuseSelector = $reuseRequest->get(ReuserAgentPlugin::UPLOAD_TO_REUSE_SELECTOR_NAME);
     $reuseMode = $reuseRequest->get(ReuserAgentPlugin::REUSE_MODE);
 

--- a/src/www/ui/template/upload_file.html.twig
+++ b/src/www/ui/template/upload_file.html.twig
@@ -150,54 +150,219 @@
       });
     }
 
-    function updateReuseIds(index, name, element, navContentDom) {
-      element.find("#reuseSearchInFolder").attr('id', `reuseSearchInFolder${index}`);
-      element.find("label[for='reuseSearchInFolder']").attr('for', `reuseSearchInFolder${index}`);
-      element.find("#reuseFolderSelectorName").attr('id', `reuseFolderSelectorName${index}`);
-      element.find("label[for='reuseFolderSelectorName']").attr('for', `reuseFolderSelectorName${index}`);
-      element.find("#uploadToReuse").attr('id', `uploadToReuse${index}`);
-      element.find("label[for='uploadToReuse']").attr('for', `uploadToReuse${index}`);
-      element.find("input,select").each(function (){
-        let fieldName = $(this).attr('name');
-        if (fieldName) {
-          if (fieldName.endsWith("[]")) {
-            $(this).attr('name', fieldName.replace("[]", `[${name}][]`));
-          } else {
-            $(this).attr('name', `${fieldName}[${name}]`)
-          }
+function updateReuseIds(index, name, element, navContentDom) {
+    const originalValues = {};
+    
+    element.find('input, select').each(function() {
+        const $el = $(this);
+        const id = $el.attr('id');
+        
+        if (id) {
+            if ($el.is(':radio')) {
+                originalValues[id] = $el.is(':checked');
+            } else if ($el.is(':checkbox')) {
+                originalValues[id] = $el.is(':checked');
+            } else {
+                originalValues[id] = $el.val();
+            }
         }
-      });
-      element.find(`#reuseFolderSelectorName${index}`).select2({
-        width: 'style',
-        dropdownAutoWidth : true,
-        dropdownParent: navContentDom
-      });
-      element.find(`#uploadToReuse${index}`).select2({
-        "placeholder": "Select upload to reuse",
-        width: 'style',
-        dropdownAutoWidth : true,
-        dropdownParent: navContentDom
-      });
-    }
-    function addNavItems(index, name, navItemDom, navContentDom) {
-      const navItem = $(`<a class='nav-link flex-sm-fill text-truncate' id='reuse-name-${index}' data-toggle='pill' href='#reuse-content-${index}' role='tab' aria-controls='reuse-content-${index}' aria-selected='false'>`);
-      navItem.append(name);
+    });
+    
+    element.find("#reuseSearchInFolder").attr('id', `reuseSearchInFolder${index}`);
+    element.find("label[for='reuseSearchInFolder']").attr('for', `reuseSearchInFolder${index}`);
+    element.find("#reuseFolderSelectorName").attr('id', `reuseFolderSelectorName${index}`);
+    element.find("label[for='reuseFolderSelectorName']").attr('for', `reuseFolderSelectorName${index}`);
+    element.find("#uploadToReuse").attr('id', `uploadToReuse${index}`);
+    element.find("label[for='uploadToReuse']").attr('for', `uploadToReuse${index}`);
+    
+    element.find("#osselot-download-report").attr("id", `osselot-download-report${index}`);
+    element.find("#osselot-download-confirm").attr("id", `osselot-download-confirm${index}`);
 
-      const panelContentProvider = $("#hiddenFormHolder").find("div.form-group");
-      const clonedPanel = panelContentProvider.clone();
-      updateReuseIds(index, name, clonedPanel, navContentDom);
-      const navPanel = $("<div class='container-fluid'>");
-      navPanel.append(clonedPanel);
-
-      const navContent = $(`<div class='tab-pane fade' id='reuse-content-${index}' role='tabpanel' aria-labelledby='reuse-name-${index}'>`);
-      navContent.append(navPanel);
-      if (index === 0) {
-        navItem.addClass("active").attr('aria-selected', true);
-        navContent.addClass("show active");
-      }
-      navItemDom.append(navItem);
-      navContentDom.append(navContent);
+    const reuseSource = element.find("#reuse-source");
+    if (reuseSource.length > 0) {
+        const currentValue = reuseSource.val();
+        reuseSource.attr('id', `reuse-source${index}`);
+        reuseSource.val(currentValue);
     }
+    
+    const osselotPackage = element.find("#osselot-package");
+    if (osselotPackage.length > 0) {
+        const originalValue = osselotPackage.val() || '';
+        osselotPackage.attr('id', `osselot-package${index}`);
+        osselotPackage.val(originalValue);
+    }
+    
+    element.find("#osselot-fetch-versions").attr('id', `osselot-fetch-versions${index}`);
+    element.find("#osselot-version-checkboxes").attr('id', `osselot-version-checkboxes${index}`);
+    element.find("#osselot-versions-hidden").attr('id', `osselot-versions-hidden${index}`);
+    element.find("#osselot-version-loading").attr('id', `osselot-version-loading${index}`);
+    element.find("#local-reuse-section").attr('id', `local-reuse-section${index}`);
+    element.find("#osselot-reuse-section").attr('id', `osselot-reuse-section${index}`);
+    
+    element.find("#osselot-addNewLicensesAs-candidate").attr('id', `osselot-addNewLicensesAs-candidate${index}`);
+    element.find("#osselot-addNewLicensesAs-license").attr('id', `osselot-addNewLicensesAs-license${index}`);
+    element.find("#osselot-licenseMatch-shortname").attr('id', `osselot-licenseMatch-shortname${index}`);
+    element.find("#osselot-licenseMatch-spdxid").attr('id', `osselot-licenseMatch-spdxid${index}`);
+    
+    element.find("label[for='osselot-addNewLicensesAs-candidate']").attr('for', `osselot-addNewLicensesAs-candidate${index}`);
+    element.find("label[for='osselot-addNewLicensesAs-license']").attr('for', `osselot-addNewLicensesAs-license${index}`);
+    element.find("label[for='osselot-licenseMatch-shortname']").attr('for', `osselot-licenseMatch-shortname${index}`);
+    element.find("label[for='osselot-licenseMatch-spdxid']").attr('for', `osselot-licenseMatch-spdxid${index}`);
+    
+    if (index === 0) {
+        const $addAsCandidate = element.find('input[name="osselotAddNewLicensesAs"][value="candidate"]');
+        if ($addAsCandidate.length && !element.find('input[name="osselotAddNewLicensesAs"]:checked').length) {
+            $addAsCandidate.prop('checked', true);
+        }
+        
+        const $matchBySpdxId = element.find('input[name="osselotLicenseMatch"][value="spdxid"]');
+        if ($matchBySpdxId.length && !element.find('input[name="osselotLicenseMatch"]:checked').length) {
+            $matchBySpdxId.prop('checked', true);
+        }
+    } else {
+        element.find("input,select").each(function() {
+            let fieldName = $(this).attr('name');
+            if (fieldName && !fieldName.includes('[')) {
+                if (fieldName === 'descriptionInputName') {
+                    return;
+                }
+                
+                // Handle osselotVersionRadio separately (radio button, not array)
+                if (fieldName === 'osselotVersionRadio') {
+                    $(this).attr('name', `${fieldName}[${index}]`);
+                    return;
+                }
+                
+                if (fieldName.endsWith('[]')) {
+                    const baseFieldName = fieldName.replace('[]', '');
+                    $(this).attr('name', `${baseFieldName}[${index}][]`);
+                } else {
+                    $(this).attr('name', `${fieldName}[${index}]`);
+                    
+                    if ($(this).is(':radio')) {
+                        const originalId = $(this).attr('id')?.replace(index, '');
+                        if (originalValues[originalId]) {
+                            $(this).prop('checked', true);
+                        }
+                    }
+                }
+            }
+        });
+    }
+    
+    element.find(':checkbox').each(function() {
+        const currentId = $(this).attr('id');
+        const originalId = currentId?.replace(index, '');
+        if (originalValues[originalId] !== undefined) {
+            $(this).prop('checked', originalValues[originalId]);
+        }
+    });
+    
+    const folderSelector = element.find(`#reuseFolderSelectorName${index}`);
+    if (folderSelector.length > 0) {
+        folderSelector.select2({
+            width: 'style',
+            dropdownAutoWidth: true,
+            dropdownParent: navContentDom
+        });
+    }
+    
+    const uploadSelector = element.find(`#uploadToReuse${index}`);
+    if (uploadSelector.length > 0) {
+        uploadSelector.select2({
+            "placeholder": "Select upload to reuse",
+            width: 'style',
+            dropdownAutoWidth: true,
+            dropdownParent: navContentDom
+        });
+    }
+}
+
+function addNavItems(index, name, navItemDom, navContentDom) {
+  const navItem = $(`<a class='nav-link flex-sm-fill text-truncate' id='reuse-name-${index}' data-toggle='pill' href='#reuse-content-${index}' role='tab' aria-controls='reuse-content-${index}' aria-selected='false'>`);
+  navItem.append(name);
+
+  const panelContentProvider = $("#hiddenFormHolder").find("li").first();
+  
+  if (panelContentProvider.length === 0) {
+    return;
+  }
+  
+  const clonedPanel = panelContentProvider.clone();
+  updateReuseIds(index, name, clonedPanel, navContentDom);
+  
+  const navPanel = $("<div class='container-fluid'>");
+  navPanel.append(clonedPanel);
+
+  const navContent = $(`<div class='tab-pane fade' id='reuse-content-${index}' role='tabpanel' aria-labelledby='reuse-name-${index}'>`);
+  navContent.append(navPanel);
+  
+  if (index === 0) {
+    navItem.addClass("active").attr('aria-selected', true);
+    navContent.addClass("show active");
+  }
+  
+  navItemDom.append(navItem);
+  navContentDom.append(navContent);
+  
+  if (typeof window.initializeOsselotForIndex === 'function') {
+    window.initializeOsselotForIndex(index);
+  }
+}
+
+$(document).ready(function() {
+    window.currentReuseSource = 'local';
+    
+    $(document).on('change', 'select[id^="reuse-source"]', function() {
+        const newValue = $(this).val();
+        window.currentReuseSource = newValue;
+        
+        $('select[id^="reuse-source"]').each(function() {
+            if ($(this).val() !== newValue) {
+                $(this).val(newValue).trigger('change.select2');
+            }
+        });
+        
+        $('input[name="reuseSource"][type="hidden"]').val(newValue);
+    });
+    
+    $('form').on('submit', function(e) {
+        const $form = $(this);
+        const $reuseSelects = $form.find('select[id^="reuse-source"]');
+        
+        if ($reuseSelects.length > 0) {
+            const reuseValue = $reuseSelects.first().val() || window.currentReuseSource;
+            
+            const hasOsselotPackage = $form.find('input[id^="osselot-package"]').filter(function() {
+                return $(this).val() && $(this).val().trim() !== '';
+            }).length > 0;
+            
+            if (hasOsselotPackage || reuseValue === 'osselot') {
+                $reuseSelects.val('osselot');
+                
+                if (!$form.find('input[name="reuseSource"][type="hidden"]').length) {
+                    $('<input>').attr({
+                        type: 'hidden',
+                        name: 'reuseSource',
+                        value: 'osselot'
+                    }).appendTo($form);
+                } else {
+                    $form.find('input[name="reuseSource"][type="hidden"]').val('osselot');
+                }
+                
+                $form.find('select[name="reuseSource"]').val('osselot');
+            }
+        }
+    });
+    
+    $("#fileUploader").on("change", function(e) {
+        setTimeout(function() {
+            if (window.currentReuseSource && window.currentReuseSource !== 'local') {
+                $('select[id^="reuse-source"]').val(window.currentReuseSource).trigger('change');
+            }
+        }, 500);
+    });
+
     $("#fileUploader").on("change", function(e) {
       checkDuplicateUploadWarning(e);
 
@@ -236,5 +401,6 @@
     $('#reuseModal').on('shown.bs.modal', function () {
       $(this).find('[data-toggle="tooltip"]').tooltip();
     });
+});
   </script>
 {% endblock %}


### PR DESCRIPTION


<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This pull request introduces a new “Reuse from OSSelot” option in FOSSology’s upload workflow, allowing users to pull curated SPDX license data from the OSSelot reports and automatically import it into their new upload. The feature is entirely opt-in and guarded by a configuration flag, so existing workflows remain unchanged unless explicitly enabled.

### Changes
1. **UI Enhancements**

   * Add a “Reuse source” selector on the upload page with “Local” vs. “OSSelot” options
   * Show package name & version inputs,with import option checkboxes
   
2. **Backend Integration**

   * **`OsselotLookupHelper`**: new utility class to call OSSelot’s REST API, cache SPDX RDF files.
   * **ReuserPlugin AJAX endpoint** (`getOsselotVersions`): returns curated version lists for a given package
   * **UploadFilePage** enhancements: on form submission, detect OSSelot reuse, fetch the SPDX file, and schedule the existing ReportImport agent with user-selected import options

3. **Configuration**
   * New boolean SysConfig flag to toggle the feature on/off


## How to test

1. Ensure `Enable OSSelot Reuse` is **true** in your SysConfig.
2. Go to **Upload → Add file**, select **Reuse from OSSelot** in reuse configuration tab.
3. Enter a known OSSelot package name, choose a version from the populated dropdown.
4. Toggle your desired import modes and submit.
5. After upload, verify under **License Browser** that licenses are already populated and in recent jobs check that report import agent also get scheduled.

