### PR TITLE
feat(core): introduce exclude folder functionality for ununpack

### DIFF
--- a/src/lib/php/UI/template/include/upload.html.twig
+++ b/src/lib/php/UI/template/include/upload.html.twig
@@ -53,6 +53,13 @@
       </li>
       <li>
         <div class="form-group">
+          <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="excludefolder" value="1"/>
+          {{ 'Ignore Configured Folders:'|trans }} {{ configureExcludeFolders|join(', ') }}
+          <img src="images/info_16.png" data-toggle="tooltip" title="{{'Configure folders from Admin-Customize-Exclude-Files from scanning'|trans}}" alt="" class="info-bullet"/>
+        </div>
+      </li>
+      <li>
+        <div class="form-group">
           <input type="radio" class="browse-upload-checkbox view-license-rc-size" name="public" value="private" {% if uploadVisibility == "private" %} checked="checked" {% endif %}/>
           {{ 'Visible only for active group'| trans }}
           <img src="images/info_16.png" data-toggle="tooltip" title="{{'which is the currently selected group'|trans}}" alt="" class="info-bullet"/><br/>

--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -619,6 +619,12 @@ function Populate_sysconfig()
   $valueArray[$variable] = array("'$variable'", "''", "'$prompt'",
     strval(CONFIG_TYPE_PASSWORD), "'LicenseDB'", "5", "'$desc'", "null", "null");
 
+  $variable = "ExcludeFolders";
+  $mimeTypeToSkip = _("Exclude Folders from scanning");
+  $mimeTypeDesc = _("Add comma (,) separated folder patterns to exclude from unpacking");
+  $valueArray[$variable] = array("'$variable'", "null", "'$mimeTypeToSkip'",
+    strval(CONFIG_TYPE_TEXT), "'Skip'", "1", "'$mimeTypeDesc'", "null", "null");
+
   /* Doing all the rows as a single insert will fail if any row is a dupe.
    So insert each one individually so that new variables get added.
   */
@@ -870,3 +876,4 @@ function get_system_load_average()
 
   return '<button type="button" aria-disabled="true" disabled class="btn '.$class.'">System Load</button>';
 }
+

--- a/src/ununpack/agent/ununpack.h
+++ b/src/ununpack/agent/ununpack.h
@@ -187,12 +187,13 @@ char *PathCheck(char *DirPath);
 void Usage (char *Name, char *Version);
 void deleteTmpFiles(char *dir);
 void SQLNoticeProcessor(void *arg, const char *message);
+int ShouldExclude(char *Filename, const char *ExcludePatterns);
+
 
 /* traverse.c */
-void TraverseStart (char *Filename, char *Label, char *NewDir, int Recurse);
+void TraverseStart (char *Filename, char *Label, char *NewDir, int Recurse, char *ExcludePatterns);
 void TraverseChild (int Index, ContainerInfo *CI, char *NewDir);
-int  Traverse (char *Filename, char *Basename, char *Label, char *NewDir,
-              int Recurse, ParentInfo *PI);
+int Traverse (char *Filename, char *Basename, char *Label, char *NewDir, int Recurse, ParentInfo *PI, char *ExcludePatterns);
 
 #endif
 

--- a/src/ununpack/agent/utils.c
+++ b/src/ununpack/agent/utils.c
@@ -1,5 +1,6 @@
 /*
  SPDX-FileCopyrightText: © 2011-2013 Hewlett-Packard Development Company, L.P.
+ SPDX-FileContributor: Kaushlendra Pratap <kaushlendra-pratap.singh@siemens.com>
 
  SPDX-License-Identifier: GPL-2.0-only
 */
@@ -1771,4 +1772,35 @@ void	Usage	(char *Name, char *Version)
  **/
  void SQLNoticeProcessor(void *arg, const char *message)
  {
+ }
+
+/**
+ * \brief Determines if a file or folder should be excluded.
+ *
+ * This function checks whether the supplied file name, `Filename`, contains any of the
+ * substrings listed in the comma-separated string `ExcludePatterns`. Each pattern is matched
+ * directly as a substring; no wildcard or directory-specific matching is performed.
+ *
+ * \param Filename The name of the file or folder to be examined.
+ * \param ExcludePatterns A comma-separated list of substrings used for determining exclusion.
+ * \returns 1 if a substring match is found (folder is to be excluded), or 0 otherwise.
+ */
+ int ShouldExclude(char *Filename, const char *ExcludePatterns)
+ {
+   if (!ExcludePatterns || !Filename) return 0;
+
+   char *patternsCopy = strdup(ExcludePatterns);
+   if (!patternsCopy) return 0;
+
+   char *pattern = strtok(patternsCopy, ",");
+   while (pattern != NULL) {
+     if (strstr(Filename, pattern)) {
+       if (Verbose) LOG_DEBUG("Excluding: %s (matched substring: %s)", Filename, pattern);
+       free(patternsCopy);
+       return 1;
+     }
+     pattern = strtok(NULL, ",");
+   }
+   free(patternsCopy);
+   return 0;
  }

--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -4,6 +4,7 @@
  SPDX-FileContributor: Gaurav Mishra <mishra.gaurav@siemens.com>
  SPDX-FileCopyrightText: © 2022 Soham Banerjee <sohambanerjee4abc@hotmail.com>
  SPDX-FileCopyrightText: © 2022, 2023 Samuel Dushimimana <dushsam100@gmail.com>
+ SPDX-FileContributor: Kaushlendra Pratap <kaushlendra-pratap.singh@siemens.com>
 
  SPDX-License-Identifier: GPL-2.0-only
 */
@@ -446,6 +447,7 @@ class UploadController extends RestController
       $applyGlobal = filter_var($reqBody['applyGlobal'] ?? null,
         FILTER_VALIDATE_BOOLEAN);
       $ignoreScm = $reqBody['ignoreScm'] ?? null;
+      $excludefolder = $reqBody['excludefolder'] ?? false;
     } else {
       $uploadType = $request->getHeaderLine('uploadType');
       $folderId = $request->getHeaderLine('folderId');
@@ -502,9 +504,15 @@ class UploadController extends RestController
         "Require location object if uploadType != file");
     }
 
-    $uploadResponse = $uploadHelper->createNewUpload($locationObject,
-      $folderId, $description, $public, $ignoreScm, $uploadType,
-      $applyGlobal);
+    if (ApiVersion::getVersion($request) == ApiVersion::V2) {
+      $uploadResponse = $uploadHelper->createNewUpload($locationObject,
+        $folderId, $description, $public, $ignoreScm, $uploadType,
+        $applyGlobal, $excludefolder);
+    } else {
+      $uploadResponse = $uploadHelper->createNewUpload($locationObject,
+        $folderId, $description, $public, $ignoreScm, $uploadType,
+        $applyGlobal);
+    }
     $status = $uploadResponse[0];
     $message = $uploadResponse[1];
     $statusDescription = $uploadResponse[2];

--- a/src/www/ui/api/Helper/CorsHelper.php
+++ b/src/www/ui/api/Helper/CorsHelper.php
@@ -24,7 +24,7 @@ class CorsHelper
     return $response
       ->withHeader('Access-Control-Allow-Origin', $SysConf['SYSCONFIG']['CorsOrigins'])
       ->withHeader('Access-Control-Expose-Headers', 'Look-at, X-Total-Pages, Retry-After')
-      ->withHeader('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Authorization, action, accesslevel, active, copyright, Content-Type, description, filename, filesizemax, filesizemin, folderDescription, folderId, folderName, groupName, ignoreScm, applyGlobal, license, limit, name, page, parent, parentFolder, public, reportFormat, searchType, tag, upload, uploadDescription, uploadId, uploadType')
+      ->withHeader('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Authorization, action, accesslevel, active, copyright, Content-Type, description, filename, filesizemax, filesizemin, folderDescription, folderId, folderName, groupName, ignoreScm, applyGlobal, license, limit, name, page, parent, parentFolder, public, reportFormat, searchType, tag, upload, uploadDescription, uploadId, uploadType, excludefolder')
       ->withHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS')
       ->withHeader('Access-Control-Allow-Credentials', 'true');
   }

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2017-2023 Siemens AG
 # SPDX-FileCopyrightText: © 2021 Orange by Piotr Pszczola <piotr.pszczola@orange.com>
 # SPDX-FileCopyrightText: © 2025 Tiyasa Kundu <tiyasakundu20@gmail.com>
+# SPDX-FileContributor: Kaushlendra Pratap <kaushlendra-pratap.singh@siemens.com>
 
 # SPDX-License-Identifier: GPL-2.0-only
 
@@ -5381,6 +5382,11 @@ components:
           default: false
           description: >
             Ignore SCM files (Git, SVN, TFS) and files with particular Mimetype
+        excludefolder:
+          type: boolean
+          default: false
+          description: >
+            Ignore Configured Folders from scanning. Admin->Customize->Exclude-Files 
         uploadType:
           type: string
           enum:

--- a/src/www/ui/page/UploadPageBase.php
+++ b/src/www/ui/page/UploadPageBase.php
@@ -101,6 +101,8 @@ abstract class UploadPageBase extends DefaultPlugin
       $skip = array("agent_unpack", "agent_adj2nest", "wget_agent");
       $vars['agentCheckBoxMake'] = AgentCheckBoxMake(-1, $skip);
     }
+    $vars['configureExcludeFolders'] = ($exclude = $this->sanitizeExcludePatterns($SysConf['SYSCONFIG']['ExcludeFolders'] ?? '')) ? $exclude : "No Folder Configured";
+
     return $this->handleView($request, $vars);
   }
 
@@ -113,7 +115,18 @@ abstract class UploadPageBase extends DefaultPlugin
       $jobId = JobAddJob($userId, $groupId, $fileName, $uploadId);
     }
     $dummy = "";
-    $unpackArgs = intval($request->get('scm')) == 1 ? '-I' : '';
+
+    global $SysConf;
+    $unpackArgs = intval($request->get('scm')) === 1 ? '-I' : '';
+
+    if (intval($request->get('excludefolder'))) {
+      $rawExclude = $SysConf['SYSCONFIG']['ExcludeFolders'] ?? '';
+      if (trim($rawExclude) !== '') {
+        $excludeFolders = $this->sanitizeExcludePatterns($rawExclude);
+        $excludeArgs = '-E ' . $excludeFolders;
+        $unpackArgs .= ' ' . $excludeArgs;
+      }
+    }
     $adj2nestDependencies = array();
     if ($wgetDependency) {
       $adj2nestDependencies = array(array('name'=>'agent_unpack','args'=>$unpackArgs,AgentPlugin::PRE_JOB_QUEUE=>array('wget_agent')));
@@ -273,5 +286,48 @@ abstract class UploadPageBase extends DefaultPlugin
       $parmList[$deciderKey] = $parmList[$reuserKey];
       $parmList[$reuserKey] = $temp;
     }
+  }
+  /**
+   * Sanitize a comma-separated list of exclude path patterns.
+   *
+   * This function processes a string of comma-separated path patterns and returns
+   * a sanitized list as a comma-separated string. It:
+   *   - Trims whitespace from each pattern.
+   *   - Skips empty patterns, relative paths (e.g., '.', '..', './', '../'),
+   *     and patterns containing special characters: ?, ", ,, {, }, :.
+   *   - Ensures that each valid pattern ends with a forward slash ('/').
+   *
+   * Examples:
+   *   Input:  "folder1, ./temp, ../secret, folder2, file?, folder3/"
+   *   Output: "folder1/,folder2/,folder3/"
+   *
+   * @param string $patternStr Comma-separated path patterns to sanitize.
+   *
+   * @return string Comma-separated string of valid, sanitized, and normalized patterns,
+   *                each ending with a trailing slash ('/').
+   */
+  private function sanitizeExcludePatterns($patternStr)
+  {
+    $patterns = explode(',', $patternStr);
+    $sanitized = [];
+
+    foreach ($patterns as $pattern) {
+      $trimmed = trim($pattern);
+      // Skip empty strings, relative paths (./, ../), or ones with special characters
+      if (
+        $trimmed === '' ||
+        preg_match('#(^|/)(\.\.?)(/|$)|^[/.?]+$|[?,"{}:]#', $trimmed)
+      ) {
+        continue;
+      }
+
+      // Ensure the pattern ends with "/"
+      if (substr($trimmed, -1) !== '/') {
+        $trimmed .= '/';
+      }
+
+      $sanitized[] = $trimmed;
+    }
+    return implode(',', $sanitized);
   }
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Introduce a pattern based approach to ignore specific folders unpacking and scanning

### Changes

1. `src/lib/php/common-sysconfig.php` : Added a new configuration variable `ExcludeFolders` to the `sysconfig` table. This variable allows users to specify a comma-separated list of patterns for files or folders to exclude during unpacking.
2. `src/ununpack/agent/traverse.c` : Integrated the `ShouldExclude` function into the Traverse function to skip processing files or directories that match the exclusion patterns.
3. `src/ununpack/agent/ununpack.c` : Include handing a new Flag "-E"
4. `src/ununpack/agent/ununpack.h` : Declaration and Updating of functions
5. `src/ununpack/agent/utils.c` : Added a utility function `ShouldExclude` to determine if a file or folder should be excluded based on the provided exclusion patterns. This function checks if the filename contains any substring from a comma-separated list of patterns.
6. `src/www/ui/page/UploadPageBase.php` : Updated the `postUploadAddJobs` method to pass the `ExcludeFolders` configuration as an argument to the unpacking agent. Introduce `sanitizeExcludePatterns` which does user input sanitization.

## How to test

1. Intoduce a pattern in customise column **Exclude Folders from scanning** e.g. "tests/,lib/" etc etc.
2. Upload a component and schedule scanning as usual. Check Ignore folder box.
3. The provided folder should be excluded from scanning.



Closes: #2848 

cc: @shaheemazmalmmd @its-sushant 
