### PR TITLE
fix(obligations): Import Obligations From CSV failed due bad param passed

### DIFF
--- a/src/www/ui/page/AdminObligationFromCSV.php
+++ b/src/www/ui/page/AdminObligationFromCSV.php
@@ -116,7 +116,8 @@ class AdminObligationFromCSV extends DefaultPlugin
         $uploadFile = $request->files->get(self::FILE_INPUT_NAME);
         $delimiter = $request->get('delimiter') ?: ',';
         $enclosure = $request->get('enclosure') ?: '"';
-        $vars['message'] = $this->handleFileUpload($uploadFile, $delimiter, $enclosure);
+        $result = $this->handleFileUpload($uploadFile, $delimiter, $enclosure);
+        $vars['message'] = is_array($result) ? $result[1] : $result;
       }
     }
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Import Obligations From CSV functionality was failing due to passing an `array` when a `string` is expected.  Which was creating a issue with internal `nl2br` function (which expects string).  Hence the functionality failed with `Unexpected Type`

### Changes

`src/www/ui/page/AdminObligationsFromCSV.php`

- Changed handling mechanism of `handleFileUpload` response. 
- Included a basic conditional statement: If return type `array` then use the correct param from the array if `string` then directly assign to `vars["message"]`

## How to test
1. Use a valid Obligations csv to import
2. Go to Admin > Obligations Admin >Obligations Import
3. Press Upload
4. Obligations should be handled and the Response should be visible.

cc: @shaheemazmalmmd @GMishx 
