### PR TITLE
feat(release): add job to upload nomos binary

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -161,3 +161,41 @@ jobs:
         file: utils/automation/Dockerfile.ci
         labels: |
           org.opencontainers.image.version=${{ steps.get_release.outputs.tag_name }}.0
+
+  nomossa-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y build-essential pkg-config libglib2.0-dev \
+          libjson-c-dev librpm-dev libboost-all-dev libxslt1-dev
+
+      - name: Setup CMake
+        uses: lukka/get-cmake@v4.0.3
+
+      - name: Build Nomossa
+        run: |
+          mkdir -p nomossa-build
+          cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DAGENTS="nomos" -DBUILD_SHARED_LIBS="off" -DCMAKE_EXE_LINKER_FLAGS="-static" -B nomossa-build -S . -G Ninja
+          ninja -C ./nomossa-build/ nomossa
+
+      - name: Get release info
+        id: get_release
+        uses: bruceadams/get-release@v1.3.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Nomossa Binary
+        uses: shogo82148/actions-upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: nomossa-build/src/nomos/agent/nomossa
+          asset_name: FOSSology-nomossa
+          asset_content_type: application/octet-stream
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          overwrite: true


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This PR introduces a GitHub Actions job that builds the nomossa binary and uploads it as a release asset.

### Changes
- Installs build dependencies.
- Compiles nomossa with CMake.
- Uploads the binary as FOSSology-nomossa to the release.

