### PR TITLE
fix(spdxutils): Fix handling of Dual-license in implodeLicenses()

### DIFF
--- a/src/spdx/agent/spdxutils.php
+++ b/src/spdx/agent/spdxutils.php
@@ -108,6 +108,9 @@ class SpdxUtils
     } elseif (count($licenses) == 3 &&
         ($index = array_search(LicenseRef::SPDXREF_PREFIX . "Dual-license", $licenses)) !== false) {
       return $licenses[$index===0?1:0] . " OR " . $licenses[$index===2?1:2];
+    } elseif (count($licenses) == 3 &&
+        ($index = array_search(LicenseRef::SPDXREF_PREFIX_FOSSOLOGY . "Dual-license", $licenses)) !== false) {
+      return $licenses[$index===0?1:0] . " OR " . $licenses[$index===2?1:2];
     } else {
       // Add prefixes where needed, enclose statements containing ' OR ' with parentheses
       return implode(" AND ", $licenses);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The function implodeLicenses() is supposed to concatenate licenses with AND or OR when creating an SPDX report. OR is being used in the case of Dual-license
```php
    if (count($licenses) == 3 &&
       ($index = array_search("Dual-license",$licenses)) !== false) {
      return $licenses[$index===0?1:0] . " OR " . $licenses[$index===2?1:2];
    } elseif (count($licenses) == 3 &&
        ($index = array_search(LicenseRef::SPDXREF_PREFIX . "Dual-license", $licenses)) !== false) {
      return $licenses[$index===0?1:0] . " OR " . $licenses[$index===2?1:2];
    } else {
      // Add prefixes where needed, enclose statements containing ' OR ' with parentheses
      return implode(" AND ", $licenses);
    }
```

Since Commit 68dbed209e we distinguish between SPDXREF_PREFIX and SPDXREF_PREFIX_FOSSOLOGY. implodeLicenses() doesn't check for SPDXREF_PREFIX_FOSSOLOGY, resulting in Dual-licensing not being reflected correctly. Instead of
```
LicenseA OR LicenseB
```
it will be reflected as:
```
LicenseA AND LicenseB AND LicenseRef-fossology-Dual-license
```

### Changes

Add a check for SPDXREF_PREFIX_FOSSOLOGY to implodeLicenses().

## How to test

1) Take any FOSSology release after 68dbed209e
2) Upload and scan a package
3) Conclude 2 different licenses and Dual-license for a specific file
4) Create a SPDX report

Without the changes in this pull request Dual-license is not handled correctly (LicenseA AND LicenseB AND LicenseRef-fossology-Dual-license). With these changes applied, the resulting statement is correct (LicenseA OR LicenseB).

## Note

The handling of Dual-license still has a know weakness, which is not being addressed in this PR: In the case of a custom license text being added to Dual-license when concluding the statement this won't be taken into account by implodeLicenses(), (once again) resulting in:
```
LicenseA AND LicenseB AND LicenseRef-fossology-Dual-license
```