### PR TITLE
fix(utils): Replace hardcoded FIXME paths with correct pathinclude.ph…

### DIFF
--- a/utils/fedora/get-fsrc.php
+++ b/utils/fedora/get-fsrc.php
@@ -37,7 +37,7 @@
 // FIXME: $path = '/usr/local/fossology/agents';
 set_include_path(get_include_path() . PATH_SEPARATOR . $path);
 
-require_once("FIXMETOBERELATIVE/pathinclude.php");
+require_once("/usr/share/fossology/php/pathinclude.php");
 global $WEBDIR;
 require_once("$WEBDIR/common/common-cli.php");
 

--- a/utils/freshmeat/diffm.php
+++ b/utils/freshmeat/diffm.php
@@ -50,7 +50,7 @@
 * file that will be used by get-projects to retrieve them from the net.
 *
 */
-require_once("FIXMETOBERELATIVE/pathinclude.php");
+require_once("/usr/share/fossology/php/pathinclude.php");
 require_once("$LIBDIR/lib_projxml.h.php");
 
 $usage = <<< USAGE

--- a/utils/freshmeat/get-projects.php
+++ b/utils/freshmeat/get-projects.php
@@ -46,7 +46,7 @@
  *    for that case.
  */
 // pathinclude below is dependent on having fossology installed.
-require_once "FIXMETOBERELATIVE/pathinclude.php";       // brings in global $PROJECTSTATEDIR +
+require_once "/usr/share/fossology/php/pathinclude.php";       // brings in global $PROJECTSTATEDIR +
 global $LIBDIR;
 global $INCLUDEDIR;
 require_once("$LIBDIR/lib_projxml.h.php");

--- a/utils/freshmeat/mk_fmdirs.php
+++ b/utils/freshmeat/mk_fmdirs.php
@@ -44,7 +44,7 @@
  * associate folders with each other....
  */
 
-require_once("FIXMETOBERELATIVE/pathinclude.php");
+require_once("/usr/share/fossology/php/pathinclude.php");
 /* the items below no longer exist, my this code is old.... */
 require_once("$PHPDIR/webcommon.h.php");
 require_once("$PHPDIR/jobs.h.php");

--- a/utils/freshmeat/mktop1k.php
+++ b/utils/freshmeat/mktop1k.php
@@ -25,7 +25,7 @@
  */
 
 // FIXME: this should bet a global from pathinclude? $LIBDIR = '/usr/local/lib';
-require_once("FIXMETOBERELATIVE/pathinclude.php");
+require_once("/usr/share/fossology/php/pathinclude.php");
 require_once("$LIBDIR/lib_projxml.h.php");
 //require_once("./lib_projxml.h.php");            // dev copy
 


### PR DESCRIPTION
Replace the hardcoded 'FIXMETOBERELATIVE/pathinclude.php' placeholder paths with the correct system path '/usr/share/fossology/php/pathinclude.php' in utility scripts.

This fixes broken include statements that would cause fatal errors when these scripts are executed. The change aligns with the path used by other working CLI scripts in the codebase.

Files changed:
- utils/freshmeat/mk_fmdirs.php
- utils/freshmeat/diffm.php
- utils/freshmeat/get-projects.php
- utils/freshmeat/mktop1k.php
- utils/fedora/get-fsrc.php

Fixes #3120

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

// Before (broken):
require_once("FIXMETOBERELATIVE/pathinclude.php");

// After (fixed):
require_once("/usr/share/fossology/php/pathinclude.php");

## How to test

Describe the steps required to test the changes proposed in the pull request.

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)
