### PR TITLE
Fix SPDXTV reports for handling of Dual-license with custom text set

### DIFF
--- a/src/spdx/agent/spdxutils.php
+++ b/src/spdx/agent/spdxutils.php
@@ -8,6 +8,7 @@
 namespace Fossology\Spdx;
 
 use Fossology\Lib\Data\LicenseRef;
+use Fossology\Lib\Util\StringOperation;
 
 /**
  * @class SpdxUtils
@@ -102,14 +103,14 @@ class SpdxUtils
     $licenses = self::addPrefixOnDemandList($licenses);
     sort($licenses, SORT_NATURAL | SORT_FLAG_CASE);
 
-    if (count($licenses) == 3 &&
-       ($index = array_search("Dual-license",$licenses)) !== false) {
-      return $licenses[$index===0?1:0] . " OR " . $licenses[$index===2?1:2];
-    } elseif (count($licenses) == 3 &&
-        ($index = array_search(LicenseRef::SPDXREF_PREFIX . "Dual-license", $licenses)) !== false) {
-      return $licenses[$index===0?1:0] . " OR " . $licenses[$index===2?1:2];
-    } else {
-      // Add prefixes where needed, enclose statements containing ' OR ' with parentheses
+    if (count($licenses) == 3) {
+      foreach ($licenses as $index => $lic) {
+        if (StringOperation::stringStartsWith($lic, "Dual-license") ||
+            StringOperation::stringStartsWith($lic, LicenseRef::SPDXREF_PREFIX . "Dual-license") ||
+            StringOperation::stringStartsWith($lic, LicenseRef::SPDXREF_PREFIX_FOSSOLOGY . "Dual-license")) {
+          return $licenses[$index===0?1:0] . " OR " . $licenses[$index===2?1:2];
+        }
+      }
       return implode(" AND ", $licenses);
     }
   }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

implodeLicenses() explicitely parses for "Dual-license". If a user decides to add a custom text for the Dual-license conclusion the license name will be Dual-license-MD5. In this case dual licensing is not reflected correctly in the SPDX2TV report. Instead of:

```
LicenseA OR LicenseB
```
it will be reflected as

```
LicenseA AND LicenseB AND LicenseRef-fossology-Dual-license-MD5
```

### Changes

Change the behaviour of implodeLicenses to look for the prefix Dual-license to fix the generation of SPDX2TV reports for Dual-license with custom text.


## How to test

1) Take latest master
2) Upload and scan a package
3) Conclude 2 different licenses and Dual-license for a specific file
4) Set a license text for Dual-license
5) Create a SPDX2TV report

Without the changes in this pull request Dual-license is not handled correctly (LicenseA AND LicenseB AND LicenseRef-fossology-Dual-license-MD5). With these changes applied, the resulting statement is correct (LicenseA OR LicenseB).
