### PR TITLE
fix(spdxutils): fix export of spdxtv reports

### DIFF
--- a/src/spdx/agent/spdxutils.php
+++ b/src/spdx/agent/spdxutils.php
@@ -111,8 +111,8 @@ class SpdxUtils
           return $licenses[$index===0?1:0] . " OR " . $licenses[$index===2?1:2];
         }
       }
-      return implode(" AND ", $licenses);
     }
+    return implode(" AND ", $licenses);
   }
 
   /**


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
implodeLicenses() has been changed to be able to deal with Dual-license and custom text. This commit (6d9e289eb79e421266ce20b6f60a0de0dbb262a5) introduced a bug, which breaks the export of SPDXTV reports (handling of AND statements is not done correctly). This change fixes the issue, restoring the original behaviour and keeping the ability of handling Dual-license with custom text.

### Changes
Move the concatenation of license expressions with an AND statement to the correct position.