### PR TITLE
feat(upload): Add ignore folder for specific uploads

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -174,7 +174,7 @@ jobs:
           libjson-c-dev librpm-dev libboost-all-dev libxslt1-dev
 
       - name: Setup CMake
-        uses: lukka/get-cmake@v4.0.3
+        uses: lukka/get-cmake@v4.1.1
 
       - name: Build Nomossa
         run: |

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -166,7 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -68,7 +68,7 @@ jobs:
         rm -rf src/vendor
 
     - name: Get CMake v3.23.0
-      uses: lukka/get-cmake@v4.1.1
+      uses: lukka/get-cmake@v4.1.2
 
     - name: Fetch tags
       run: |
@@ -174,7 +174,7 @@ jobs:
           libjson-c-dev librpm-dev libboost-all-dev libxslt1-dev
 
       - name: Setup CMake
-        uses: lukka/get-cmake@v4.1.1
+        uses: lukka/get-cmake@v4.1.2
 
       - name: Build Nomossa
         run: |

--- a/src/lib/php/UI/template/include/upload.html.twig
+++ b/src/lib/php/UI/template/include/upload.html.twig
@@ -53,22 +53,16 @@
       </li>
       <li>
         <div class="form-group">
-          <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="excludefolder" value="1"/>
-          {{ 'Ignore Configured Folders:'|trans }} {{ configureExcludeFolders|join(', ') }}
-          <img src="images/info_16.png" data-toggle="tooltip" title="{{'Configure folders from Admin-Customize-Exclude-Files from scanning'|trans}}" alt="" class="info-bullet"/>
-        </div>
-      </li>
-      <li>
-        <div class="form-group">
-          <label for="excludefolderSpecificInput">
-            Folder/s to ignore for this upload:
-          </label>
-          <input type="text" class="browse-upload-checkbox" id="excludefolderSpecificInput"/>
-          <button type="button" class="btn btn-default btn-sm" onclick="addSpecificFolder()">Add</button>
-          <input type="hidden" name="excludefolderSpecific" id="excludefolderSpecific" />
-          <div id="specificFoldersList" style="margin-top:8px;">
-            <strong>Added Folders:</strong> <span id="addedFolders"></span>
+          <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
+            <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="excludefolder" value="1" style="margin-right: 6px;"/>
+            <span style="white-space: nowrap;">{{ 'Ignore Configured Folders:'|trans }}</span>
+            <div id="chipsContainer" class="form-control" style="height: auto; min-height: 38px; display: flex; flex-wrap: wrap; align-items: center; padding: 5px 12px; max-width: 350px; margin: 0;">
+              <div id="excludeFoldersChips" style="display: flex; flex-wrap: wrap; align-items: center;"></div>
+              <input type="text" id="excludeFolderChipInput" style="border: none; outline: none; box-shadow: none; flex-grow: 1; flex-shrink: 1; min-width: 80px; max-width: 180px; width: 140px; padding: 0; margin-left: 8px; background: transparent;" placeholder="Add folder to ignore..." autocomplete="off"/>
+            </div>
+            <img src="images/info_16.png" data-toggle="tooltip" title="{{'Configure folders from Admin-Customize-Exclude-Files from scanning'|trans}}" alt="" class="info-bullet" style="margin-left: 6px;"/>
           </div>
+          <input type="hidden" name="excludefolderSpecific" id="excludefolderSpecific" />
         </div>
       </li>
       <li>
@@ -119,18 +113,53 @@
     });
   </script>
   <script>
-    let specificFolders = [];
-
-    function addSpecificFolder() {
-      const input = document.getElementById('excludefolderSpecificInput');
-      const value = input.value.trim();
-      if (value) {
-        specificFolders.push(value);
-        document.getElementById('excludefolderSpecific').value = specificFolders.join(',');
-        document.getElementById('addedFolders').innerText = specificFolders.join(', ');
-        input.value = '';
-      }
+    // Chips-based exclude folders logic
+    let excludeFolders = [];
+    // Initialize from backend-provided folders
+    {% if configureExcludeFolders %}
+      excludeFolders = `{{ configureExcludeFolders }}`.split(',').filter(f => f.trim() !== '');
+    {% endif %}
+    function renderExcludeFolderChips() {
+      const chipsDiv = document.getElementById('excludeFoldersChips');
+      chipsDiv.innerHTML = '';
+      excludeFolders.forEach((folder, idx) => {
+        const chip = document.createElement('span');
+        chip.className = 'badge';
+        chip.style = 'margin-right:6px;padding:6px 10px;font-size:14px;display:inline-block;background-color:#e0e3e8;color:#333;border-radius:12px;';
+        chip.textContent = folder;
+        const closeBtn = document.createElement('span');
+        closeBtn.innerHTML = '&times;';
+        closeBtn.style = 'margin-left:8px;cursor:pointer;font-weight:bold;';
+        closeBtn.onclick = function() {
+          excludeFolders.splice(idx, 1);
+          updateExcludeFoldersInput();
+          renderExcludeFolderChips();
+        };
+        chip.appendChild(closeBtn);
+        chipsDiv.appendChild(chip);
+      });
     }
+    function updateExcludeFoldersInput() {
+      document.getElementById('excludefolderSpecific').value = excludeFolders.join(',');
+    }
+    // Add chip on Enter key in input
+    document.addEventListener('DOMContentLoaded', function() {
+      const input = document.getElementById('excludeFolderChipInput');
+      input.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          const value = input.value.trim();
+          if (value && !excludeFolders.includes(value)) {
+            excludeFolders.push(value);
+            updateExcludeFoldersInput();
+            renderExcludeFolderChips();
+            input.value = '';
+          }
+        }
+      });
+      renderExcludeFolderChips();
+      updateExcludeFoldersInput();
+    });
   </script>
   {% for aFoot in parmAgentFoots %}
     <script type="text/javascript">{{ aFoot }}  </script>

--- a/src/lib/php/UI/template/include/upload.html.twig
+++ b/src/lib/php/UI/template/include/upload.html.twig
@@ -60,6 +60,19 @@
       </li>
       <li>
         <div class="form-group">
+          <label for="excludefolderSpecificInput">
+            Folder/s to ignore for this upload:
+          </label>
+          <input type="text" class="browse-upload-checkbox" id="excludefolderSpecificInput"/>
+          <button type="button" class="btn btn-default btn-sm" onclick="addSpecificFolder()">Add</button>
+          <input type="hidden" name="excludefolderSpecific" id="excludefolderSpecific" />
+          <div id="specificFoldersList" style="margin-top:8px;">
+            <strong>Added Folders:</strong> <span id="addedFolders"></span>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="form-group">
           <input type="radio" class="browse-upload-checkbox view-license-rc-size" name="public" value="private" {% if uploadVisibility == "private" %} checked="checked" {% endif %}/>
           {{ 'Visible only for active group'| trans }}
           <img src="images/info_16.png" data-toggle="tooltip" title="{{'which is the currently selected group'|trans}}" alt="" class="info-bullet"/><br/>
@@ -104,6 +117,20 @@
     $(document).ready(function () {
       $('[data-toggle="tooltip"]').tooltip();
     });
+  </script>
+  <script>
+    let specificFolders = [];
+
+    function addSpecificFolder() {
+      const input = document.getElementById('excludefolderSpecificInput');
+      const value = input.value.trim();
+      if (value) {
+        specificFolders.push(value);
+        document.getElementById('excludefolderSpecific').value = specificFolders.join(',');
+        document.getElementById('addedFolders').innerText = specificFolders.join(', ');
+        input.value = '';
+      }
+    }
   </script>
   {% for aFoot in parmAgentFoots %}
     <script type="text/javascript">{{ aFoot }}  </script>

--- a/src/www/ui/page/UploadPageBase.php
+++ b/src/www/ui/page/UploadPageBase.php
@@ -127,6 +127,10 @@ abstract class UploadPageBase extends DefaultPlugin
         $unpackArgs .= ' ' . $excludeArgs;
       }
     }
+    if ($request->get('excludefolderSpecific')) {
+      $excludeFolders_specific = $this->sanitizeExcludePatterns($request->get('excludefolderSpecific')) ?? '';
+      $unpackArgs .= ',' . $excludeFolders_specific;
+    }
     $adj2nestDependencies = array();
     if ($wgetDependency) {
       $adj2nestDependencies = array(array('name'=>'agent_unpack','args'=>$unpackArgs,AgentPlugin::PRE_JOB_QUEUE=>array('wget_agent')));

--- a/src/www/ui/page/UploadPageBase.php
+++ b/src/www/ui/page/UploadPageBase.php
@@ -117,14 +117,17 @@ abstract class UploadPageBase extends DefaultPlugin
     $dummy = "";
 
     global $SysConf;
+    xdebug_break();
     $unpackArgs = intval($request->get('scm')) === 1 ? '-I' : '';
 
-    if (intval($request->get('excludefolder'))) {
-      $rawExclude = $SysConf['SYSCONFIG']['ExcludeFolders'] ?? '';
-      if (trim($rawExclude) !== '') {
-        $excludeFolders = $this->sanitizeExcludePatterns($rawExclude);
-        $excludeArgs = '-E ' . $excludeFolders;
-        $unpackArgs .= ' ' . $excludeArgs;
+    // Only process exclude folders if checkbox is checked
+    if (intval($request->get('excludefolder')) === 1) {
+      $userExclude = $request->get('excludefolderSpecific');
+      if ($userExclude) {
+        $sanitized = $this->sanitizeExcludePatterns($userExclude);
+        if ($sanitized !== '') {
+          $unpackArgs .= ' -E ' . $sanitized;
+        }
       }
     }
     if ($request->get('excludefolderSpecific')) {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

To extend the existing folder exclude functionality to accept the additional folder names per upload.
Idea is to also have a text(input) box to accept the folder name. which needs to be excluded.

### Changes

1. `upload.html.twig` : Add a text box field for user input (to exclude folder for specific upload
2. `UploadPageBase.php`: handle user input(if specific ignore folder is there) extend on top instance level ignore functionality

## How to test

1. Go to upload page
2. At point 7, a text box is placed for user inputs, User can type dynamic folders name which are not there for instance level ignore.
3. Select analysis
4. Upload
5. Check Browse page, mentioned folder should be ignored.

cc: @shaheemazmalmmd 

Screenshot:

<img width="477" height="78" alt="image" src="https://github.com/user-attachments/assets/56679e9b-05bc-43bc-864e-88f79539c180" />

