### PR TITLE
feat(upload): add chipsbased UI for ignore folders

### DIFF
--- a/src/lib/php/UI/template/include/upload.html.twig
+++ b/src/lib/php/UI/template/include/upload.html.twig
@@ -53,9 +53,17 @@
       </li>
       <li>
         <div class="form-group">
-          <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="excludefolder" value="1"/>
-          {{ 'Ignore Configured Folders:'|trans }} {{ configureExcludeFolders|join(', ') }}
-          <img src="images/info_16.png" data-toggle="tooltip" title="{{'Configure folders from Admin-Customize-Exclude-Files from scanning'|trans}}" alt="" class="info-bullet"/>
+          <div style="display: flex; align-items: center;flex-wrap: wrap;">
+            <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="excludefolder" value="1" style="margin-right: 6px;"/>
+            {{ 'Ignore Configured Folders:'|trans }}
+            <div id="chipsContainer" class="form-control" style="height: auto; min-height: 38px; display: flex; flex-wrap: wrap; align-items: center; padding: 5px 12px; max-width: 70%; width: 65%; box-sizing: border-box; margin: 0; gap: 8px 12px;">
+              <div id="excludeFoldersChips" style="display: flex; flex-wrap: wrap; align-items: center; gap: 8px;">
+              </div>
+              <input type="text" id="excludeFolderChipInput" style="border: none; outline: none; box-shadow: none; flex-grow: 1; flex-shrink: 1; min-width: 80px; max-width: 180px; width: 140px; padding: 0; margin-left: 8px; background: transparent;" placeholder="Add folder to ignore..." autocomplete="off"/>
+            </div>
+            <img src="images/info_16.png" data-toggle="tooltip" title="{{'Configure folders from Admin-Customize-Exclude-Files from scanning'|trans}}" alt="" class="info-bullet" style="margin-left: 6px;"/>
+          </div>
+          <input type="hidden" name="excludefolderSpecific" id="excludefolderSpecific" />
         </div>
       </li>
       <li>
@@ -103,6 +111,97 @@
   <script type="text/javascript">
     $(document).ready(function () {
       $('[data-toggle="tooltip"]').tooltip();
+    });
+  </script>
+  <script>
+    // Chips-based exclude folders logic
+    let excludeFolders = [];
+    // Initialize from backend-provided folders. Ignore the placeholder "No Folder Configured".
+    {% if configureExcludeFolders and configureExcludeFolders != 'No Folder Configured' %}
+      excludeFolders = `{{ configureExcludeFolders }}`.split(',').map(f => f.trim()).filter(f => f !== '');
+    {% endif %}
+    function renderExcludeFolderChips() {
+      const chipsDiv = document.getElementById('excludeFoldersChips');
+      chipsDiv.innerHTML = '';
+      // remove any accidental placeholder
+      excludeFolders = excludeFolders.filter(f => f !== 'No Folder Configured');
+      excludeFolders.forEach((folder, idx) => {
+        const chip = document.createElement('span');
+        chip.className = 'badge';
+        // Add small bottom margin so wrapped lines have spacing (fallback for gap)
+        chip.style = 'margin-right:6px;margin-bottom:8px;padding:6px 10px;font-size:14px;display:inline-block;background-color:#e0e3e8;color:#333;border-radius:12px;';
+        chip.textContent = folder;
+        const closeBtn = document.createElement('span');
+        closeBtn.innerHTML = '&times;';
+        closeBtn.style = 'margin-left:8px;cursor:pointer;font-weight:bold;';
+        closeBtn.onclick = function() {
+          excludeFolders.splice(idx, 1);
+          updateExcludeFoldersInput();
+          renderExcludeFolderChips();
+        };
+        chip.appendChild(closeBtn);
+        chipsDiv.appendChild(chip);
+      });
+    }
+    function updateExcludeFoldersInput() {
+      document.getElementById('excludefolderSpecific').value = excludeFolders.join(',');
+    }
+    // Add chip on Enter key in input
+    document.addEventListener('DOMContentLoaded', function() {
+      const input = document.getElementById('excludeFolderChipInput');
+      const checkbox = document.querySelector('input[name="excludefolder"]');
+      input.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          const value = input.value.trim();
+          if (value && !excludeFolders.includes(value)) {
+            excludeFolders.push(value);
+            updateExcludeFoldersInput();
+            renderExcludeFolderChips();
+            input.value = '';
+            // If user added at least one folder, ensure the excludefolder checkbox is checked
+            try {
+              if (checkbox) checkbox.checked = true;
+            } catch (err) {}
+          }
+        }
+      });
+      // Prevent the checkbox from being checked if there are no folders configured
+      if (checkbox) {
+        checkbox.addEventListener('change', function(e) {
+          if (this.checked && excludeFolders.length === 0) {
+            // Do not allow enabling exclude-folder without any folder configured
+            this.checked = false;
+            input.focus();
+            // show a modal warning consistent with existing upload warnings
+            if (!$('#excludeWarningModal').length) {
+              $('body').append(`
+                <div class="modal fade" id="excludeWarningModal" tabindex="-1" role="dialog">
+                  <div class="modal-dialog modal-dialog-centered" role="document">
+                    <div class="modal-content">
+                      <div class="modal-header bg-secondary text-white">
+                        <h5 class="modal-title"><i class="fas fa-exclamation-circle"></i> {{ 'No Exclude Folders Configured'|trans }}</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                          <span>&times;</span>
+                        </button>
+                      </div>
+                      <div class="modal-body">
+                        {{ 'You have not configured any folders. Please do not check this option.'|trans }}
+                      </div>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">OK</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              `);
+            }
+            $('#excludeWarningModal').modal('show');
+          }
+        });
+      }
+      renderExcludeFolderChips();
+      updateExcludeFoldersInput();
     });
   </script>
   {% for aFoot in parmAgentFoots %}

--- a/src/www/ui/page/UploadPageBase.php
+++ b/src/www/ui/page/UploadPageBase.php
@@ -119,12 +119,14 @@ abstract class UploadPageBase extends DefaultPlugin
     global $SysConf;
     $unpackArgs = intval($request->get('scm')) === 1 ? '-I' : '';
 
-    if (intval($request->get('excludefolder'))) {
-      $rawExclude = $SysConf['SYSCONFIG']['ExcludeFolders'] ?? '';
-      if (trim($rawExclude) !== '') {
-        $excludeFolders = $this->sanitizeExcludePatterns($rawExclude);
-        $excludeArgs = '-E ' . $excludeFolders;
-        $unpackArgs .= ' ' . $excludeArgs;
+    // Only process exclude folders if checkbox is checked
+    if (intval($request->get('excludefolder')) === 1) {
+      $userExclude = $request->get('excludefolderSpecific');
+      if ($userExclude) {
+        $sanitized = $this->sanitizeExcludePatterns($userExclude);
+        if ($sanitized !== '') {
+          $unpackArgs .= ' -E ' . $sanitized;
+        }
       }
     }
     $adj2nestDependencies = array();


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only-->

## Description

This pull request updates the "Exclude Folders" functionality in the upload UI and backend logic to use a unified chips-based mechanism. Users can now add or remove folders to be excluded from scanning using a single chips input. The backend processes the list only if the "Ignore Configured Folders" checkbox is checked, and all folder entries are sanitized before being passed to the unpack agent.

### Changes

- `upload.html.twig`:
    - The chips UI and input for excluding folders are now combined into a single, compact flex container.
    - The input and chips are visually grouped, and the input does not stretch across the screen.
    - The "Ignore Configured Folders" label, chips container, and tooltip are aligned in a single row.
    - The "Folders to ignore for this upload" section was removed; only one unified input is used.

- `UploadPageBase.php`:
    - The backend now checks if the "Ignore Configured Folders" checkbox (excludefolder) is checked.
    - If checked, it retrieves the list of folders from excludefolderSpecific, sanitizes them, and passes them as the -E argument to the unpack agent.
    - The logic for merging configured and user folders was removed; only the user-managed list from the chips UI is used.

## How to test
1. Go to upload page
2. At point 6, a chips based UI with pre-cofigured folders loaded is there, User can add new or remove folders.
3. Checkbox should be checked
4. Select analysis
5. Upload
6. Check Browse page, mentioned folder should be ignored.


Screenshot:
<img width="649" height="55" alt="image" src="https://github.com/user-attachments/assets/5b0ceab4-ff2d-4bd4-af2d-72d84f824221" />

