### PR TITLE
fix(ui): resolve legacy browse view issue

### DIFF
--- a/src/www/ui/template/ui-showjobs.js.twig
+++ b/src/www/ui/template/ui-showjobs.js.twig
@@ -98,7 +98,7 @@ function createTableForJob(job) {
   var uploadLink = "";
   if (job.upload !== null && job.upload.uploadItem != -1) {
     uploadLink = '<a title="{{ "Click to browse"|trans }}" ' +
-    'href="?mod=browse&upload=' + job.upload.uploadId + '&item=' +
+    'href="?mod=fileBrowse&upload=' + job.upload.uploadId + '&show=quick' +'&item=' +
     job.upload.uploadItem + '">' + job.upload.uploadName + '</a>';
   } else if (job.upload !== null && job.job.jobName == "Delete") {
     uploadLink = '<span style="color:black">' + job.upload.uploadName +


### PR DESCRIPTION
### Summary
This PR fixes the legacy browse redirection issue (#514) by routing the “Show Jobs” upload link to the minimal File Browser view instead of the legacy browse/license page.
- - -
### Details
- Updated `ui-showjobs.js.twig` Changed the upload name anchor to point to `?mod=fileBrowse&upload=<id>&show=quick&item=<id>` so users land on the streamlined “file-browse” page.
- Preserved existing behavior for deleted uploads and other edge cases.
Ensures a consistent, lightweight file view when navigating from Show Jobs, aligning with the intent discussed in #490.
- No functional changes beyond the navigation fix.
 - - -
### Testing
- Manually tested navigation from “Show Jobs” with multiple uploads:
  - Verified the anchor renders as `?mod=fileBrowse&...&show=quick&item=....`
  - Confirmed the page loads without JavaScript errors (DevTools console clear).
  - Checked behavior for single-file uploads: confirmed the designed redirect to view-license occurs when a node has no children.
- Verified no regressions in pagination, auto-refresh, and job action links.
- Cleared Twig cache and reloaded Apache to validate changes:
  - Removed /var/local/cache/fossology/*
  - Reloaded Apache
  - Hard-refreshed browser with cache disabled
- - -
### Related Issue
Closes #514
- - -
### Notes
 - No database changes included.
 - No temporary or local files (e.g., cookies.txt) are part of this PR.
 - If desired, a follow-up can update the single-job (“Geeky”) link in `showjobs.php` to also use `fileBrowse&show=quick` for full consistency. This PR focuses on the main Show Jobs list view.
- Ready for review and CI.