### PR TITLE
fix(wget_agent): add FOSSOLOGY_SKIP_CHOWN for NFSv4 compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,16 +7,16 @@
 # SPDX-License-Identifier: FSFAP
 #
 # Description: Recipe for setting up a multi container FOSSology
-#              Docker setup with separate Database instance
+# Docker setup with separate Database instance
 services:
   scheduler:
     build:
       context: .
       dockerfile: Dockerfile
       args:
-      - http_proxy
-      - https_proxy
-      - no_proxy
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: fossology
     restart: unless-stopped
     environment:
@@ -24,6 +24,7 @@ services:
       - FOSSOLOGY_DB_NAME=fossology
       - FOSSOLOGY_DB_USER=fossy
       - FOSSOLOGY_DB_PASSWORD=fossy
+      - FOSSOLOGY_SKIP_CHOWN=true
     command: scheduler
     depends_on:
       - db
@@ -39,9 +40,9 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-      - http_proxy
-      - https_proxy
-      - no_proxy
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: fossology
     restart: unless-stopped
     environment:
@@ -50,6 +51,7 @@ services:
       - FOSSOLOGY_DB_USER=fossy
       - FOSSOLOGY_DB_PASSWORD=fossy
       - FOSSOLOGY_SCHEDULER_HOST=scheduler
+      - FOSSOLOGY_SKIP_CHOWN=true
     command: web
     ports:
       - "8081:80"
@@ -80,6 +82,9 @@ services:
       retries: 5
       # start-period: 10s
 
+
 volumes:
   database:
   repository:
+
+  

--- a/src/wget_agent/agent/wget_agent.c
+++ b/src/wget_agent/agent/wget_agent.c
@@ -112,10 +112,22 @@ void DBLoadGold()
     SafeExit(56);
   }
 
+  // MODIFIED: Added FOSSOLOGY_SKIP_CHOWN environment variable check
   if ((int)ForceGroup > 0)
   {
     rc = chown(GlobalTempFile,-1,ForceGroup);
-    if (rc) LOG_ERROR("chown failed on %s, error: %s", GlobalTempFile, strerror(errno));
+    if (rc) 
+    {
+      if (getenv("FOSSOLOGY_SKIP_CHOWN") != NULL)
+      {
+        LOG_WARNING("chown failed on %s (ignored due to FOSSOLOGY_SKIP_CHOWN): %s", 
+                    GlobalTempFile, strerror(errno));
+      }
+      else
+      {
+        LOG_ERROR("chown failed on %s, error: %s", GlobalTempFile, strerror(errno));
+      }
+    }
   }
 
   if (!Sum)
@@ -147,10 +159,23 @@ void DBLoadGold()
     }
     /* Put the file in the "files" repository too */
     Path = fo_RepMkPath("gold",Unique);
+    
+    // MODIFIED: Added FOSSOLOGY_SKIP_CHOWN environment variable check
     if ((int)ForceGroup >= 0)
     {
       rc = chown(Path,-1,ForceGroup);
-      if (rc) LOG_ERROR("chown failed on %s, error: %s", Path, strerror(errno));
+      if (rc) 
+      {
+        if (getenv("FOSSOLOGY_SKIP_CHOWN") != NULL)
+        {
+          LOG_WARNING("chown failed on %s (ignored due to FOSSOLOGY_SKIP_CHOWN): %s", 
+                      Path, strerror(errno));
+        }
+        else
+        {
+          LOG_ERROR("chown failed on %s, error: %s", Path, strerror(errno));
+        }
+      }
     }
   } /* if GlobalImportGold */
   else /* if !GlobalImportGold */
@@ -176,10 +201,22 @@ void DBLoadGold()
     SafeExit(6);
   }
 
+  // MODIFIED: Added FOSSOLOGY_SKIP_CHOWN environment variable check
   if ((int)ForceGroup >= 0)
   {
     rc = chown(Path,-1,ForceGroup);
-    if (rc) LOG_ERROR("chown failed on %s, error: %s", Path, strerror(errno));
+    if (rc) 
+    {
+      if (getenv("FOSSOLOGY_SKIP_CHOWN") != NULL)
+      {
+        LOG_WARNING("chown failed on %s (ignored due to FOSSOLOGY_SKIP_CHOWN): %s", 
+                    Path, strerror(errno));
+      }
+      else
+      {
+        LOG_ERROR("chown failed on %s, error: %s", Path, strerror(errno));
+      }
+    }
   }
 
   if (Path != GlobalTempFile)


### PR DESCRIPTION
## Problem

Upload fails on NFSv4 volumes where `chown()` returns `Operation not permitted` due to NFSv4 identity mapping restrictions.

**Error:**
```
ERROR: chown failed on /srv/fossology/uploads/..., error: Operation not permitted
FATAL: Failed to import ...
```
This prevents FOSSology deployment in Docker Swarm environments using NFS storage.

## Solution

Added optional `FOSSOLOGY_SKIP_CHOWN` environment variable to allow uploads to continue when `chown()` fails.

### Changes Made

1. src/wget_agent/agent/wget_agent.c
Modified 3 chown() call sites in DBLoadGold() function:

2. **`docker-compose.yml`**: Added environment variable to scheduler and web services

## Behavior
- Without `FOSSOLOGY_SKIP_CHOWN`** (default): Original behavior, backward compatible
- With `FOSSOLOGY_SKIP_CHOWN=true`**: `chown()` failure logs WARNING, upload continues

##Testing
1 . Restart containers
     docker-compose down
     docker-compose up -d
2 . Verify env variable
     docker exec fossology_scheduler_1 env | grep FOSSOLOGY_SKIP_CHOWN
     # FOSSOLOGY_SKIP_CHOWN=true
3. Create & upload test file
    echo "NFSv4 Fix Test - $(date)" > ~/Desktop/test.txt
4.Check logs after upload
    docker logs fossology_scheduler_1 2>&1 | grep -i chown | tail -20
5.Result - Upload succeeds 

Fixes #3129
