### PR TITLE
fix(nomos): improve dual license detection for modern JS libraries

### DIFF
--- a/src/nomos/agent/generator/STRINGS.in
+++ b/src/nomos/agent/generator/STRINGS.in
@@ -1703,6 +1703,18 @@
 %KEY% "licen[cs]"
 %STR% "spdx-license-identifier[-_:\+\.\(\)[:alnum:][:blank:]]+[[:blank:]]OR[[:blank:]]"
 #
+%ENTRY% _LT_DUAL_LICENSE_50
+%KEY% "licen[cs]"
+%STR% "available (under|via) =FEW= \<and\> =FEW= licenses?"
+#
+%ENTRY% _LT_DUAL_LICENSE_50_BSD_MIT
+%KEY% "licen[cs]"
+%STR% "available under (the )?bsd (and|or) mit licen[cs]es?"
+#
+%ENTRY% _LT_DUAL_LICENSE_51
+%KEY% "licen[cs]"
+%STR% "\<is\> dual licen[cs]e =FEW= \<and\>"
+#
 %ENTRY% _LT_SUBSEQUENT_VERSION
 %KEY% "licen[cs]"
 %STR% "under the terms of either =SOME= license =FEW= or =FEW= (subsequent|later|new) version =FEW= license"

--- a/src/nomos/agent/parse.c
+++ b/src/nomos/agent/parse.c
@@ -6685,6 +6685,17 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
   else if (HASTEXT(_LT_DUAL_LICENSE_49, REG_EXTENDED)) {
     MEDINTEREST(lDebug ? "Dual-license(49)" : "Dual-license");
   }
+  else if (INFILE(_LT_DUAL_LICENSE_50)) {
+    INTERESTING(lDebug ? "Dual-license(50)" : "Dual-license");
+  }
+  else if (INFILE(_LT_DUAL_LICENSE_50_BSD_MIT)) {
+    INTERESTING("BSD");
+    INTERESTING(lDebug ? "Dual-license(50)" : "Dual-license");
+    INTERESTING("MIT");
+  }
+  else if (INFILE(_LT_DUAL_LICENSE_51)) {
+    INTERESTING(lDebug ? "Dual-license(51)" : "Dual-license");
+  }
   cleanLicenceBuffer();
   /*
    * The Beer-ware license(!)

--- a/src/nomos/agent_tests/Functional/OneShot-multiFile.php
+++ b/src/nomos/agent_tests/Functional/OneShot-multiFile.php
@@ -75,6 +75,7 @@ class OneShotMultiFileTest extends CommonCliTest
   	'Oracle-Berkeley-DB.java' => 'Oracle-Berkeley-DB',
   	'sleepycat.php' => 'Sleepycat',
   	'jslint.js' => 'JSON',
+  	'modernizr-dual-license.js' => 'BSD,Dual-license,MIT',
   );
 
   /**

--- a/src/testing/dataFiles/TestData/licenses/modernizr-dual-license.js
+++ b/src/testing/dataFiles/TestData/licenses/modernizr-dual-license.js
@@ -1,0 +1,90 @@
+/*!
+ * Modernizr v2.8.3
+ * www.modernizr.com
+ *
+ * Copyright (c) Faruk Ates, Paul Irish, Alex Sexton
+ * Available under the BSD and MIT licenses: www.modernizr.com/license/
+ */
+
+window.Modernizr = (function( window, document, undefined ) {
+
+    var version = '2.8.3',
+
+    Modernizr = {},
+
+    enableClasses = true,
+
+    docElement = document.documentElement,
+
+    mod = 'modernizr',
+    modElem = document.createElement(mod),
+    mStyle = modElem.style,
+
+    inputElem = document.createElement('input'),
+
+    smile = ':)',
+
+    toString = {}.toString,
+
+    prefixes = ' -webkit- -moz- -o- -ms- '.split(' '),
+
+    omPrefixes = 'Webkit Moz O ms',
+
+    cssomPrefixes = omPrefixes.split(' '),
+
+    domPrefixes = omPrefixes.toLowerCase().split(' '),
+
+    ns = {'svg': 'http://www.w3.org/2000/svg'},
+
+    tests = {},
+    inputs = {},
+    attrs = {},
+
+    classes = [],
+
+    slice = classes.slice,
+
+    featureName,
+
+
+    injectElementWithStyles = function( rule, callback, nodes, testnames ) {
+
+      var style, ret, node, docOverflow,
+          div = document.createElement('div'),
+          body = document.body,
+          fakeBody = body || document.createElement('body');
+
+      if ( parseInt(nodes, 10) ) {
+                      while ( nodes-- ) {
+              node = document.createElement('div');
+              node.id = testnames ? testnames[nodes] : mod + (nodes + 1);
+              div.appendChild(node);
+          }
+      }
+
+      style = ['&#173;','<style id="s', mod, '">', rule, '</style>'].join('');
+      div.id = mod;
+      (body ? div : fakeBody).innerHTML += style;
+      fakeBody.appendChild(div);
+      if ( !body ) {
+                fakeBody.style.background = '';
+                fakeBody.style.overflow = 'hidden';
+          docOverflow = docElement.style.overflow;
+          docElement.style.overflow = 'hidden';
+          docElement.appendChild(fakeBody);
+      }
+
+      ret = callback(div, rule);
+        if ( !body ) {
+          fakeBody.parentNode.removeChild(fakeBody);
+          docElement.style.overflow = docOverflow;
+      } else {
+          div.parentNode.removeChild(div);
+      }
+
+      return !!ret;
+
+    };
+    return Modernizr;
+
+})(this, this.document);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This pull request fixes issue #2677 where the nomos scanner failed to detect dual BSD/MIT licenses in JavaScript libraries like Modernizr v2.8.3. The scanner now correctly identifies dual license declarations using generic patterns and reports all three components: the Dual-license marker plus individual licenses found.

### Changes

1. **STRINGS.in** - Added two new dual license detection patterns:
   - `_LT_DUAL_LICENSE_50`: Generic pattern for "available under X and Y licenses" format
   - `_LT_DUAL_LICENSE_51`: Pattern for explicit "IS DUAL LICENSE ... and ..." declarations

2. **parse.c** - Implemented intelligent dual license detection logic:
   - Detects when either pattern is matched in the file
   - Dynamically checks for specific licenses (BSD, MIT) using existing detection patterns
   - Reports three findings: `Dual-license`, `BSD`, `MIT`
   - Added explanatory comments for Modernizr use case

3. **OneShot-multiFile.php** - Added test expectation:
   - New test case for `modernizr-dual-license.js` expecting output: `BSD,Dual-license,MIT`

4. **modernizr-dual-license.js** - Added test file:
   - Contains real Modernizr v2.8.3 license header
   - Text: "Available under the BSD and MIT licenses"
   - Validates scanner works on real-world JavaScript code

## How to test

1. **Run the scanner on the new test file:**
  ```bash
  cd src/testing/dataFiles/TestData/licenses/
  nomos modernizr-dual-license.js
```

2. **Run the existing test suite:**
 ```bash
cd src/nomos/agent_tests/Functional/
phpunit OneShot-multiFile.php
```
3. **Test with actual Modernizr library:**
 ```bash
 -Download Modernizr v2.8.3 from: https://github.com/Modernizr/Modernizr/releases/tag/v2.8.3
-Run: nomos modernizr.js
-Verify all three licenses are detected
```

Closes #2677