### PR TITLE
fix(cmake): version ranging for fixing the policy errors

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -18,7 +18,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - 'debian:buster'
           - 'debian:bullseye'
           - 'debian:bookworm'
           - 'debian:trixie'
@@ -36,18 +35,14 @@ jobs:
         apt-get update
         apt-get install -y lsb-release sudo gpg ca-certificates
         ## Add repo for latest git
-        if case "${{ matrix.os }}" in debian*) true;; *) false;; esac; then
-          echo "deb http://deb.debian.org/debian $(lsb_release -cs)-backports main" > /etc/apt/sources.list.d/backport.list
-        else
+        if case "${{ matrix.os }}" in ubuntu*) true;; *) false;; esac; then
           apt-get install -y software-properties-common
           add-apt-repository $GIT_REPO -y
         fi
         apt-get update
         apt-get install git -y
         # Remove added repos
-        if case "${{ matrix.os }}" in debian*) true;; *) false;; esac; then
-          rm /etc/apt/sources.list.d/backport.list
-        else
+        if case "${{ matrix.os }}" in ubuntu*) true;; *) false;; esac; then
           add-apt-repository --remove $GIT_REPO -y
         fi
         apt-get update

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18...3.31 FATAL_ERROR)
 project(FOSSOLOGY)
 
 # ignore Anaconda compilers, which are typically not compatible with the system

--- a/cmake/SetDefaults.cmake
+++ b/cmake/SetDefaults.cmake
@@ -115,7 +115,7 @@ endif(NOT DEFINED ARE_DEFAULTS_SET)
 
 find_package(PostgreSQL REQUIRED)
 if(DEFINED CMAKE_CXX_COMPILER)
-    find_package(Boost REQUIRED regex system filesystem program_options)
+    find_package(Boost REQUIRED COMPONENTS regex system filesystem program_options NO_MODULE)
 endif()
 find_package(Git REQUIRED)
 

--- a/src/adj2nest/CMakeLists.txt
+++ b/src/adj2nest/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(adj2nest LANGUAGES C)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/buckets/CMakeLists.txt
+++ b/src/buckets/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(buckets LANGUAGES C)
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)
 

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(cli)
 
 set(FO_CWD ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/clixml/CMakeLists.txt
+++ b/src/clixml/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(clixml)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/compatibility/CMakeLists.txt
+++ b/src/compatibility/CMakeLists.txt
@@ -3,15 +3,12 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2024 Siemens AG
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(compatibility LANGUAGES CXX)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)
 
-find_package(jsoncpp REQUIRED
-    NAMES
-        jsoncpp jsoncpp_lib
-)
+pkg_check_modules(jsoncpp REQUIRED jsoncpp)
 
 find_package(yaml-cpp REQUIRED
     NAMES

--- a/src/compatibility/agent/CMakeLists.txt
+++ b/src/compatibility/agent/CMakeLists.txt
@@ -45,7 +45,7 @@ foreach (FO_COMP_TARGET compatibility compatibility_exec compatibility_cov
     endif ()
     target_link_libraries(${FO_COMP_TARGET}
             PRIVATE fossologyCPP ${icu-uc_LIBRARIES} ${Boost_LIBRARIES}
-            jsoncpp_lib yaml-cpp)
+            ${jsoncpp_LIBRARIES} yaml-cpp)
     if (${FO_COMP_TARGET} MATCHES "_exec$")
         string(REPLACE "_exec" "" FO_COMP_TARGET_R ${FO_COMP_TARGET})
         set_target_properties(${FO_COMP_TARGET}

--- a/src/compatibility/agent_tests/CMakeLists.txt
+++ b/src/compatibility/agent_tests/CMakeLists.txt
@@ -41,7 +41,7 @@ target_link_libraries(test_compatibility
         ${cppunit_LIBRARIES}
         ${icu-uc_LIBRARIES}
         ${Boost_LIBRARIES}
-        jsoncpp_lib
+        ${jsoncpp_LIBRARIES}
         yaml-cpp
 )
 

--- a/src/copyright/CMakeLists.txt
+++ b/src/copyright/CMakeLists.txt
@@ -3,14 +3,11 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(copyright LANGUAGES CXX C)
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)
 
-find_package(jsoncpp REQUIRED
-    NAMES
-        jsoncpp jsoncpp_lib
-)
+pkg_check_modules(jsoncpp REQUIRED jsoncpp)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/agent)
 

--- a/src/copyright/agent/CMakeLists.txt
+++ b/src/copyright/agent/CMakeLists.txt
@@ -22,7 +22,7 @@ foreach(COMMON_OBJ copyright regscan scanners cleanEntries regexConfProvider
         ${FO_CWD}/${COMMON_OBJ}.cc)
     target_link_libraries(${COMMON_OBJ}.cc.o
         PRIVATE fossologyCPP m ${icu-uc_LIBRARIES} stdc++
-        ${Boost_LIBRARIES} jsoncpp_lib)
+        ${Boost_LIBRARIES} ${jsoncpp_LIBRARIES})
     list(APPEND COMMON_COPY_OBJECTS ${COMMON_OBJ}.cc.o)
 endforeach()
 
@@ -70,7 +70,7 @@ foreach(FO_COPY_TARGET copyright_lib copyright copyright_cov_lib copyright_cov
     endif()
     target_link_libraries(${FO_COPY_TARGET}
         PRIVATE fossologyCPP m ${icu-uc_LIBRARIES} stdc++
-        ${Boost_LIBRARIES} jsoncpp_lib ${COPY_LIBS})
+        ${Boost_LIBRARIES} ${jsoncpp_LIBRARIES} ${COPY_LIBS})
 endforeach()
 target_compile_options(copyright_cov PRIVATE ${FO_COV_FLAGS})
 set_target_properties(copyright_lib PROPERTIES OUTPUT_NAME copyright)

--- a/src/copyright/agent_tests/CMakeLists.txt
+++ b/src/copyright/agent_tests/CMakeLists.txt
@@ -20,7 +20,7 @@ target_sources(test_copyright
         ${FO_CWD}/Unit/test_regexConfProvider.cc)
 target_link_libraries(test_copyright
     PRIVATE
-        copyright_lib dl ${cppunit_LIBRARIES} jsoncpp_lib)
+        copyright_lib dl ${cppunit_LIBRARIES} ${jsoncpp_LIBRARIES})
 target_include_directories(test_copyright 
     PRIVATE ${FO_CWD}/../agent ${glib_INCLUDE_DIRS} ${jsoncpp_INCLUDE_DIRS}
     ${PostgreSQL_INCLUDE_DIRS} ${FO_CLIB_SRC} ${FO_CXXLIB_SRC})

--- a/src/cyclonedx/CMakeLists.txt
+++ b/src/cyclonedx/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2023 Sushant Kumar <sushantmishra02102002@gmail.com>
 #]============================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(cyclonedx)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/debug/CMakeLists.txt
+++ b/src/debug/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(debug)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/decider/CMakeLists.txt
+++ b/src/decider/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(decider)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/deciderjob/CMakeLists.txt
+++ b/src/deciderjob/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(deciderjob)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/decisionexporter/CMakeLists.txt
+++ b/src/decisionexporter/CMakeLists.txt
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: © 2022 Siemens AG
 SPDX-FileContributor: Gaurav Mishra <mishra.gaurav@siemens.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(decisionexporter)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/decisionimporter/CMakeLists.txt
+++ b/src/decisionimporter/CMakeLists.txt
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: © 2022 Siemens AG
 SPDX-FileContributor: Gaurav Mishra <mishra.gaurav@siemens.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(decisionimporter)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/delagent/CMakeLists.txt
+++ b/src/delagent/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(delagent LANGUAGES C)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/demomod/CMakeLists.txt
+++ b/src/demomod/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(demomod LANGUAGES C)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/example_wc_agent/CMakeLists.txt
+++ b/src/example_wc_agent/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(wc_agent LANGUAGES C)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/genvendor/CMakeLists.txt
+++ b/src/genvendor/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(genvendor)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)
 

--- a/src/lib/c/CMakeLists.txt
+++ b/src/lib/c/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(libc LANGUAGES C)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/SetDefaults.cmake)

--- a/src/lib/cpp/CMakeLists.txt
+++ b/src/lib/cpp/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(libcpp LANGUAGES CXX C)
 
 set(FO_CWD ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/lib/php/CMakeLists.txt
+++ b/src/lib/php/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(libphp)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/SetDefaults.cmake)

--- a/src/maintagent/CMakeLists.txt
+++ b/src/maintagent/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(maintagent LANGUAGES C)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/mimetype/CMakeLists.txt
+++ b/src/mimetype/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(mimetype LANGUAGES C)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/monk/CMakeLists.txt
+++ b/src/monk/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(monk LANGUAGES C)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/ninka/CMakeLists.txt
+++ b/src/ninka/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(ninka LANGUAGES CXX)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/nomos/CMakeLists.txt
+++ b/src/nomos/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(nomos LANGUAGES C)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/ojo/CMakeLists.txt
+++ b/src/ojo/CMakeLists.txt
@@ -3,15 +3,12 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(ojo LANGUAGES CXX)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)
 
-find_package(jsoncpp REQUIRED
-    NAMES
-        jsoncpp jsoncpp_lib
-)
+pkg_check_modules(jsoncpp REQUIRED jsoncpp)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/agent)
 configure_file(${FO_CMAKEDIR}/TestInstall.make.in ${CMAKE_CURRENT_BINARY_DIR}/TestInstall.make

--- a/src/ojo/agent/CMakeLists.txt
+++ b/src/ojo/agent/CMakeLists.txt
@@ -42,7 +42,7 @@ foreach(FO_OJO_TARGET ojo ojo_exec ojo_cov ojo_cov_exec)
         target_compile_options(${FO_OJO_TARGET} PRIVATE ${FO_COV_FLAGS})
     endif()
     target_link_libraries(${FO_OJO_TARGET}
-        PRIVATE fossologyCPP ${icu-uc_LIBRARIES} ${Boost_LIBRARIES} jsoncpp_lib)
+        PRIVATE fossologyCPP ${icu-uc_LIBRARIES} ${Boost_LIBRARIES} ${jsoncpp_LIBRARIES})
     if(${FO_OJO_TARGET} MATCHES "_exec$")
         string(REPLACE "_exec" "" FO_OJO_TARGET_R ${FO_OJO_TARGET})
         set_target_properties(${FO_OJO_TARGET}

--- a/src/pkgagent/CMakeLists.txt
+++ b/src/pkgagent/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(pkgagent LANGUAGES C)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/readmeoss/CMakeLists.txt
+++ b/src/readmeoss/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(readmeoss)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/regexscan/CMakeLists.txt
+++ b/src/regexscan/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(regexscan LANGUAGES C)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/reportImport/CMakeLists.txt
+++ b/src/reportImport/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(reportImport)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/reso/CMakeLists.txt
+++ b/src/reso/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(reso)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/reuser/CMakeLists.txt
+++ b/src/reuser/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(reuser)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/scancode/CMakeLists.txt
+++ b/src/scancode/CMakeLists.txt
@@ -3,15 +3,12 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2022 Gaurav Mishra <mishra.gaurav@siemens.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(scancode)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)
 
-find_package(jsoncpp REQUIRED
-    NAMES
-        jsoncpp jsoncpp_lib
-)
+pkg_check_modules(jsoncpp REQUIRED jsoncpp)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/agent)
 generate_version()

--- a/src/scancode/agent/CMakeLists.txt
+++ b/src/scancode/agent/CMakeLists.txt
@@ -41,7 +41,7 @@ foreach(FO_SCANCODE_TARGET scancode scancode_exec scancode_cov scancode_cov_exec
         target_compile_options(${FO_SCANCODE_TARGET} PRIVATE ${FO_COV_FLAGS})
     endif()
     target_link_libraries(${FO_SCANCODE_TARGET}
-        PRIVATE fossologyCPP ${icu-uc_LIBRARIES} ${Boost_LIBRARIES} jsoncpp_lib)
+        PRIVATE fossologyCPP ${icu-uc_LIBRARIES} ${Boost_LIBRARIES} ${jsoncpp_LIBRARIES})
     if(${FO_SCANCODE_TARGET} MATCHES "_exec$")
         string(REPLACE "_exec" "" FO_SCANCODE_TARGET_R ${FO_SCANCODE_TARGET})
         set_target_properties(${FO_SCANCODE_TARGET}

--- a/src/scanoss/CMakeLists.txt
+++ b/src/scanoss/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2023 SCANOSS.COM
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(scanoss LANGUAGES C)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/scanoss/agent/CMakeLists.txt
+++ b/src/scanoss/agent/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FO_CWD ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FO_C_FLAGS}")
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 include_directories(
     ${glib_INCLUDE_DIRS}

--- a/src/scheduler/CMakeLists.txt
+++ b/src/scheduler/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(scheduler LANGUAGES C)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/softwareHeritage/CMakeLists.txt
+++ b/src/softwareHeritage/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(softwareHeritage)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/spasht/CMakeLists.txt
+++ b/src/spasht/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(spasht)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/spdx/CMakeLists.txt
+++ b/src/spdx/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(spdx)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/unifiedreport/CMakeLists.txt
+++ b/src/unifiedreport/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(unifiedreport)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/ununpack/CMakeLists.txt
+++ b/src/ununpack/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(ununpack LANGUAGES C)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/wget_agent/CMakeLists.txt
+++ b/src/wget_agent/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(wget_agent LANGUAGES C)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/SetDefaults.cmake)

--- a/src/www/CMakeLists.txt
+++ b/src/www/CMakeLists.txt
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-2.0-only
 SPDX-FileCopyrightText: © 2021 Avinal Kumar <avinal.xlvii@gmail.com>
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(www)
 # set defaults
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

New `cmake` version introduces new policy ranges. Fixed the version requirements. Took `json_cpp` as pre-installed library. Fixed FindBoost Module Warning.

### Changes

CMakeLists.txts are updated with the correct minimum version. 
Required changes are done for `json_cpp`
Removed Debian:buster as one of the os from Release stage.

## How to test

1. Use latest cmake version: (v4.2.1) to build the project.
2. It should build without any errors or warnings.

Extension of #3136 
