### PR TITLE
fix(spdx): ensure valid SPDX ID generation for license candidates during RDF import

### DIFF
--- a/src/reportImport/agent/ReportImportSink.php
+++ b/src/reportImport/agent/ReportImportSink.php
@@ -173,7 +173,7 @@ class ReportImportSink
           $this->userId,
           false,
           0,
-          $licenseCandidate->getShortName()
+          null
         );
         return $licenseId;
       }


### PR DESCRIPTION
## **Description**

Fix SPDX ID assignment for license candidates created during RDF import , Fixes #3153.

## **Changes**

* Updated the last parameter in `updateCandidate()` from
  `$licenseCandidate->getShortName()` → `null`.
* This allows the `convertToSpdxId()` method to properly prepend the `LicenseRef-fossology-` prefix for non-standard licenses.


