### PR TITLE
chore(ci): remove EOL image and update dependency installation

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -101,8 +101,8 @@ jobs:
           fail-fast: true
 
       - name: Install additional Dependencies
-        if: ${{ matrix.config.cc == 'gcc-8' }}
-        run: sudo apt install -y gcc-8 g++-8
+        if: ${{ matrix.config.cc == 'gcc-9' }}
+        run: sudo apt install -y gcc-9 g++-9
 
       - name: Configure and Generate CMake Project
         run: |

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -21,7 +21,6 @@ jobs:
           - 'debian:bullseye'
           - 'debian:bookworm'
           - 'debian:trixie'
-          - 'ubuntu:focal'
           - 'ubuntu:jammy'
           - 'ubuntu:noble'
 
@@ -63,7 +62,7 @@ jobs:
         ./install/scripts/install-spdx-tools.sh
         rm -rf src/vendor
 
-    - name: Get CMake v3.23.0
+    - name: Get CMake
       uses: lukka/get-cmake@v4.1.2
 
     - name: Fetch tags


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Ubuntu focal is way ahead of its EOL. Removed the support for the image. There is an update in GitHub runner image dependency for Ubuntu 22.04 and Ubuntu 24.04, update the `build-test` pipeline to handle that.

### Changes

1. Removed Ubuntu Focal Support for FOSSology
2. Update the correct Cmake  (name+version)
3. Update gcc installation with exact version number.

## How to test

All CI stages should pass. There should be no Ubuntu Focal artifacts at release stage.

cc: @GMishx @shaheemazmalmmd 
