### PR TITLE
fix(copyright): advance search behaving erratically due to newline

### DIFF
--- a/src/copyright/ui/template/copyrighthist_scripts.html.twig
+++ b/src/copyright/ui/template/copyrighthist_scripts.html.twig
@@ -46,7 +46,7 @@
 
   function advanceSearchToRegex(search) {
     var val = $.fn.dataTable.util.escapeRegex(search.trim());
-    return val.replace(/\\\(\\\*\\\)/g, "(.*)");
+    return val.replace(/\\\(\\\*\\\)/g, "(.+)");
   }
 
   function testReplacement(table, type) {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Replace text functionality in copyright was behaving erratically because of "zero-or-more-matches" in javascript regex. 

### Changes

Changed the wildcard to "one-or-more-match" 

## How to test

1. Upload a component
2. Run copyright on the upload, Move to the copyright page
3. Select a copyright from the table, Create replacement text and `Test Replacement`

<img width="849" height="332" alt="image" src="https://github.com/user-attachments/assets/851c29b6-a774-40cc-809b-9de89b15e370" />

