### PR TITLE
refactor(scheduleAgents): refactor breaking alignment of lists

### DIFF
--- a/src/decider/ui/template/agent_decider.html.twig
+++ b/src/decider/ui/template/agent_decider.html.twig
@@ -7,9 +7,9 @@
 
 <li>
   <div class="form-group">
-    <label for="decider">{{ 'Automatic Concluded License Decider'|trans }}</label>
+    <label for="decider">{{ 'Automatic Concluded License Decider'|trans }}
     <img src="images/info_16.png" data-toggle="tooltip" title="{{ 'only for relevant files'|trans }}" alt="" class="info-bullet"/>
-    {{ ', based on'|trans }}
+    {{ ', based on'|trans }}</label>
     <br/>
     <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="deciderRules[]" value="nomosInMonk" id="nomosInMonk" />
     <label for="nomosInMonk">{{ ' Scanners matches if all Nomos findings are within the Monk findings'|trans }}</label>

--- a/src/www/ui/agent-add.php
+++ b/src/www/ui/agent-add.php
@@ -64,16 +64,16 @@ class AgentAdder extends DefaultPlugin
     $vars['uploadId'] = $uploadId;
 
     $parmAgentList = MenuHook::getAgentPluginNames("ParmAgents");
-    $out = '<ol>';
     $parmAgentFoots = '';
+    $paramAgentIncludes = '';
+    $out = '';
     foreach ($parmAgentList as $parmAgent) {
       $agent = plugin_find($parmAgent);
-      $out .= "<br/><b>".$agent->AgentName.":</b><br/>";
+      $out .= "<br/><b>".ucfirst($agent->AgentName).":</b><br/>";
       $out .= $agent->renderContent($vars);
       $parmAgentFoots .= $agent->renderFoot($vars);
       $paramAgentIncludes .= $agent->getScriptIncludes($vars);
     }
-    $out .= '</ol>';
     $vars['out'] = $out;
     $vars['outFoot'] = '<script language="javascript"> '.$parmAgentFoots.'</script>';
     $vars['paramIncludes'] = $paramAgentIncludes;

--- a/src/www/ui/template/agent_adder.html.twig
+++ b/src/www/ui/template/agent_adder.html.twig
@@ -11,12 +11,14 @@
   <form name="formy" method="post">
     {{ "Select an uploaded file for additional analysis."|trans }}
     <ol>
+      <br/>
       <li>{{"Select the folder containing the upload you wish to analyze"|trans}}:<br/>
         <select name="folder" onLoad="Uploads_Get('{{ baseUri }}?mod=upload_options&folder={{ folderId }}');"
                 onChange="Uploads_Get('{{ baseUri }}?mod=upload_options&folder=' + this.value);" class="ui-render-select2">
           {{ folderListOptions }}
         </select>
       </li>
+      <br/>
       <li>
         {{"Select the upload to analyze"|trans}}:<br/>
         <div id="uploaddiv">
@@ -29,9 +31,11 @@
           </select>
         </div>
       </li>
+      <br/>
       <li>
          <input type="checkbox" name="scm" value="1"/> {{ 'Ignore files with particular Mimetype'| trans }}<img src="images/info_16.png" title="{{'Configure mimetypes from Admin-Customize-Skip MimeTypes from scanning'|trans}}" alt="" class="info-bullet"/><br/>
      </li>
+     <br/>
       <li> {{ "Select additional analysis."|trans }}<br/>
         <div id="agentsdiv">
           <div class="no-agents-message">


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
Fix the alignment and numbering issues in schedule agent's page. also resolve few warnings that were getting created.

## How to test

* Check the page alignment.
* Schedule jobs from schedule agents page and test. 

Before the fix: 
<img width="1523" height="827" alt="image" src="https://github.com/user-attachments/assets/0ba3ee98-0df1-4d30-b068-d6738f75ccc2" />

After the fix:
<img width="973" height="848" alt="image" src="https://github.com/user-attachments/assets/a6f21dea-57e5-42eb-93f0-2089584a258d" />

