### PR TITLE
docs(readme): fix minor typos and broken links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ This closes #22
 
 All commits not submitted via GitHub pull request shall contain a
 Signed-off-by line, also known as the **Developer Certificate of Origin (DCO)**
-as we know it from the Linux Kernel [Documenation/SubmittingPatches](https://www.kernel.org/doc/Documentation/process/submitting-patches.rst)
+as we know it from the Linux Kernel [Documentation/SubmittingPatches](https://www.kernel.org/doc/Documentation/process/submitting-patches.rst)
 
 ```none
     Signed-off-by: Peace Fun Ingenium <peacefun.ingenium@example.com>

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ and developer docs on [Github Wiki](https://github.com/fossology/fossology/wiki)
 
 Mailing lists, FAQs, Release Notes, and other useful info are available
 by clicking the documentation tab on the project website. We encourage
-all users to join the mailing list and participate in discussions.
-There is also a #fossology IRC channel on the freenode IRC network if
-you'd like to talk to other FOSSology users and developers.
+all users to join the mailing list and participate in discussions. You can also join FOSSOlogy's official space on Slack: [Join Slack](https://join.slack.com/t/fossology/shared_invite/enQtNzI0OTEzMTk0MjYzLTYyZWQxNDc0N2JiZGU2YmI3YmI1NjE4NDVjOGYxMTVjNGY3Y2MzZmM1OGZmMWI5NTRjMzJlNjExZGU2N2I5NGY)
+
+If you'd like to talk to other FOSSology users and developers.
 See [Contact Us](https://www.fossology.org/about/contact/)
 
 ## Contributing

--- a/src/ninka/README.md
+++ b/src/ninka/README.md
@@ -2,15 +2,13 @@
 
      SPDX-License-Identifier: GPL-2.0-only
 -->
-Introduction
---------------
+## Introduction
 
 Ninka is license identification tool that identifies the license(s)
 under which a source file is made available.
 
 This FOSSology plugin is a wrapper for the Ninka tool. 
 
-Download
---------------
+## Download
 
 https://github.com/dmgerman/ninka

--- a/src/ojo/README.md
+++ b/src/ojo/README.md
@@ -2,8 +2,7 @@
 
      SPDX-License-Identifier: GPL-2.0-only
 -->
-Introduction
---------------
+## Introduction
 
 Ojo license identification agent, identifies the license(s) with the below format
 <!-- REUSE-IgnoreStart -->

--- a/src/scancode/README.md
+++ b/src/scancode/README.md
@@ -3,7 +3,7 @@
      SPDX-License-Identifier: GPL-2.0-only
 -->
 
-### ScanCode Toolkit
+## ScanCode Toolkit
 ScanCode Toolkit is a very established license scanner. It is a simple python based command line scanner that runs on Windows, Linux, and Mac. It implements a number of different approaches and integrates these into one application for identifying and classifying license-relevant content in packages.
 
 A wrapper has been used to wrap ScanCode around FOSSology.

--- a/src/scanoss/README.md
+++ b/src/scanoss/README.md
@@ -4,9 +4,9 @@
      SPDX-License-Identifier: GPL-2.0-only
 -->
 ![scanoss.com](https://www.openchainproject.org/wp-content/uploads/sites/15/2021/10/scanoss.png)
-# [SCANOSS](www.scanoss.com) Agent for FOSSOLOGY
+# [SCANOSS](https://www.scanoss.com) Agent for FOSSOLOGY
 This agent lets the user to search code snippets over more that 250M URLs.
-For each snippet or full file, the agent can provide information about version, license and copyrigth from free osskb.org service or by an on premisse server for SCANOSS Platform.
+For each snippet or full file, the agent can provide information about version, license and copyright from free osskb.org service or by an on-premise server for SCANOSS Platform.
 
 ## Usage
 1. From Fossology main menu, select *Upload* > *From File*
@@ -24,7 +24,7 @@ The SCANOSS scan returns this information as a summary:
 - PURL
 - Path inside the repository 
 
-Each file is fingerprinted and sent to [osskb.org](osskb.org) server. **Only** fingerprints are sent, so your code keeps **CONFIDENTIAL**
+Each file is fingerprinted and sent to [osskb.org](https://www.osskb.org) server. **Only** fingerprints are sent, so your code keeps **CONFIDENTIAL**
 Results are organized and placed on Fossology tables and SCANOSS Agent own tables.
 
 ## Configuration 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Few Agent Readme and Contributing guidelines had broken links and typos.

### Changes

Updated `Readme.md` and `Contributing.md` file with typos.

Closes #3144 
