### PR TITLE
feat(nomos): add identification for BSD style numpy license

### DIFF
--- a/src/nomos/agent/generator/STRINGS.in
+++ b/src/nomos/agent/generator/STRINGS.in
@@ -930,6 +930,10 @@
 %ENTRY% _LT_BSD_HTMLAREA_2
 %KEY% "distribut"
 %STR% "distributed under the same terms as htmlArea itself"
+#
+%ENTRY% _LT_BSD_NUMPY_TERMS
+%KEY% "licen[cs]"
+%STR% "permission to use modify and distribute this software is given under the terms of the numpy licen[cs]e"
 #####
 # ORIGINAL with those EXPENSIVE wild-cards:
 # re-?distribution -and use in source and binary forms =ANY= (is|are)

--- a/src/nomos/agent/parse.c
+++ b/src/nomos/agent/parse.c
@@ -975,6 +975,9 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
   else if (INFILE(_PHR_BSD_CLEAR_1)) {
     INTERESTING(lDebug ? "BSD-Clear(phr1)" : "BSD-3-Clause-Clear");
   }
+  else if (INFILE(_LT_BSD_NUMPY_TERMS)) {
+    INTERESTING("BSD-3-Clause");
+  }
   else if (INFILE(_PHR_BSD_3_CLAUSE_LBNL)) {
     INTERESTING("BSD-3-Clause-LBNL");
   }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add nomos identifier for BSD Style Numpy license.

### Changes

Update `STRINGS.in` with the exact match regex. Update `parse.c` to handle the identification of the `BSD-3-Clause-Numpy`


cc: @shaheemazmalmmd 
