### PR TITLE
Improve dual-license detection and add test case

### DIFF
--- a/src/nomos/agent/generator/STRINGS.in
+++ b/src/nomos/agent/generator/STRINGS.in
@@ -1632,7 +1632,7 @@
 #
 %ENTRY% _LT_DUAL_LICENSE_30
 %KEY% "licen[cs]"
-%STR% "this (code|program|file) (may|can) be (used|r?e?distributed) under either of the following two licences"
+%STR% "this (code|program|file|documentation|software) (may|can) be (used|r?e?distributed) under either of the following two licences"
 #
 %ENTRY% _LT_DUAL_LICENSE_31
 %KEY% "licen[cs]"

--- a/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan
+++ b/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan
@@ -378,6 +378,7 @@ File NomosTestfiles/Dual-license/BSL-1.0_or_MIT.txt contains license(s) BSL-1.0,
 File NomosTestfiles/Dual-license/CDDL_or_GPL-2.0-with-classpath-exception.txt contains license(s) CDDL,Classpath-exception-2.0,Dual-license,GPL-2.0-only
 File NomosTestfiles/Dual-license/ClearBSD_or_GPL-2.0+.txt contains license(s) BSD-3-Clause-Clear,Dual-license,GPL-2.0-or-later
 File NomosTestfiles/Dual-license/CRYPTOGAMS.txt contains license(s) Cryptogams,Dual-license,GPL
+File NomosTestfiles/Dual-license/dual_doc_intro.txt contains license(s) BSL-1.0,Dual-license,MIT
 File NomosTestfiles/Dual-license/EPL-1.0_or_MPL-2.0_1.txt contains license(s) Dual-license,EPL-1.0,MPL-2.0
 File NomosTestfiles/Dual-license/EPL-1.0_or_MPL-2.0_2.txt contains license(s) Dual-license,EPL-1.0,MPL-2.0
 File NomosTestfiles/Dual-license/EPL-2.0_or_GPL-2.0_or_LGPL-2.1.txt contains license(s) Dual-license,EPL-2.0,GPL-2.0-or-later,LGPL-2.1-or-later

--- a/src/nomos/agent_tests/testdata/NomosTestfiles/Dual-license/dual_doc_intro.txt
+++ b/src/nomos/agent_tests/testdata/NomosTestfiles/Dual-license/dual_doc_intro.txt
@@ -1,0 +1,28 @@
+This documentation may be used under either of the following two licences:
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE. OF SUCH DAMAGE.
+
+Or:
+
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
Hi team,
This PR improves Nomos detection for dual-licensed files by expanding the pattern that detects introductory dual-license phrases.

**Problem**
Nomos previously detected only a narrow version of the phrase:
“This code may be used under either of the following two licences”

However, many real-world projects use variations such as:
“this program may be distributed under either…”
“this software can be used under either…”
“this file may be redistributed under either…”
“this documentation may be used under either…”
These variants were not detected, causing Nomos to miss several dual-license cases.

**What This PR Does**
1. Expands the detection pattern
Updated STRINGS.in with a more flexible regex:
this (code|program|file|documentation|software) (may|can) be (used|distributed|redistributed) under either of the following two licences

2. Regenerates Nomos search data
Rebuilt:
_strings.data
_autodata.c
libnomos.a
using: cd src/nomos/agent/generator
./GENSEARCHDATA

3. Adds a new test case
Added a new test file:  dual_doc_intro.txt
expected output: dual_doc_intro.txt.json

Fixes #3173

This change is backward-compatible. It does not affect other Nomos detections, as it only expands an existing dual-license phrase group.
Please review this PR and let me know if any additional variants should be included.
Thanks!