### PR TITLE
fix(nomos): update lgpl-2.1-or-later license identification

### DIFF
--- a/src/nomos/agent/generator/STRINGS.in
+++ b/src/nomos/agent/generator/STRINGS.in
@@ -3719,7 +3719,7 @@
 #####
 %ENTRY% _LT_LGPLref1
 %KEY% "distribut"
-%STR% "you (can|may) r?e?-?distribute (it a|a)nd/or modify it under the terms =SOME= (lgpl|lesser GNU general public licen[cs]e|GNU (lesser|library|lesser lesser) (gpl|(general p|p)ublic licen[cs]e))"
+%STR% "you (can|may) r?e?-?distribute (it a|a)nd/or modify it under the terms =SOME= (lgpl|lesser GNU general public( l|l)icen[cs]e|GNU (lesser|library|lesser lesser) (gpl|(general p|p)ublic( l|l)icen[cs]e))"
 #####
 # Don't make the obvious string-search optimization here.  There really ARE
 # references to "GPL General Lesser Public License".
@@ -9954,7 +9954,7 @@ k
 #
 %ENTRY% _PHR_LGPL21_OR_LATER_1
 %KEY% "(\<gnu|free\>|l?gpl)"
-%STR% "(lgp(l|l licen[cs]e)|gnu (lesser|library|lesser lesser) (general p|p)ublic licen[cs]e|gnu general (lesser|library) public licen[cs]e) =SOME= (v|[^_-]version )2\.?1 =SOME= or =SOME= (later|newer|subsequent|more recent)"
+%STR% "(lgp(l|l licen[cs]e)|gnu (lesser|library|lesser lesser) (general p|p)ublic( l|l)icen[cs]e|gnu general (lesser|library) public( l|l)icen[cs]e) =SOME= (v|[^_-]version )2\.?1 =SOME= or =SOME= (later|newer|subsequent|more recent)"
 #
 %ENTRY% _PHR_LGPL21_OR_LATER_2
 %KEY% "licen[cs]"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

fix(nomos): update lgpl-2.1-or-later license identification

## Changes

Updated regex for lgpl-2.1-or-later in `STRING.in` file to handle cases where there is no space between **public** and **license** in case of lgpl-2.1-or-later license like text.

<img width="486" height="197" alt="image" src="https://github.com/user-attachments/assets/982d7cd0-da1d-4484-874c-e8c36c792301" />

CC: @shaheemazmalmmd @Kaushl2208 
