### PR TITLE
fix(delagent): remove duplicate Close button in delete notification

### DIFF
--- a/src/delagent/ui/Page/AdminUploadDelete.php
+++ b/src/delagent/ui/Page/AdminUploadDelete.php
@@ -159,7 +159,7 @@ class AdminUploadDelete extends DefaultPlugin
 
     $displayMessage .= "Deletion of " .
             (sizeof($uploadpks) - sizeof($errorMessages)) . " projects queued";
-    return DisplayMessage($displayMessage);
+    return $displayMessage;
   }
 
   /**


### PR DESCRIPTION
- Removed DisplayMessage() wrapper in AdminUploadDelete.php to prevent double rendering of notification container.
- Ensured notification UI is consistent with single-file deletion.

Fixes #3188

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
This PR fixes a UI bug where two "Close" buttons were displayed in the success notification when deleting multiple files/projects.

### Changes
Bug fix (non-breaking change which fixes an issue)

## How to test
Selected multiple uploads in Organize > Uploads.
Clicked Delete.
Verified that the success notification now displays a single "Close" button.


