### PR TITLE
fix(scanoss): fix race condition by adding PID to temp directories

### DIFF
--- a/src/scanoss/agent/main.c
+++ b/src/scanoss/agent/main.c
@@ -228,7 +228,7 @@ int main(int argc, char *argv[])
       if (upload_pk == 0)
         continue;
       char  tempFolder[512];
-      sprintf(tempFolder,"%s/%d",baseTMP,upload_pk);
+      sprintf(tempFolder, "%s/%d-%d", baseTMP, upload_pk, getpid());
       mkdir(tempFolder, 0700);
       if (RebuildUpload(upload_pk,tempFolder) != 0) /* process the upload_pk code */{
           LOG_ERROR("Error processing upload\n");
@@ -281,7 +281,7 @@ int main(int argc, char *argv[])
     }
 
     char tempFolder[512];
-    sprintf(tempFolder, "%s/%ld", baseTMP, time(NULL));
+    sprintf(tempFolder, "%s/%ld-%d", baseTMP, time(NULL), getpid());
     mkdir(tempFolder, 0700);
     sprintf(outputFile, "%s/result.json", tempFolder);
 


### PR DESCRIPTION
Multiple concurrent SCANOSS agents were writing to same temp directory Caused file conflicts, JSON parsing errors, and libcrypto.so.3 crashes Fixed by appending process ID to ensure unique directories per process Tested with 5 parallel agents with 100% success (was 0-20% before) Fixed #3109

## Description
Fixed a race condition in the SCANOSS agent that caused crashes when multiple instances ran concurrently in scheduler mode.

### Changes
Modified src/scanoss/agent/main.c to add process ID (PID) to temp directory paths
Line 231: Changed sprintf(tempFolder,"%s/%d",baseTMP,upload_pk) to sprintf(tempFolder, "%s/%d-%d", baseTMP, upload_pk, getpid())
Line 284: Changed sprintf(tempFolder, "%s/%ld", baseTMP, time(NULL)) to sprintf(tempFolder, "%s/%ld-%d", baseTMP, time(NULL), getpid())
This ensures each SCANOSS process gets a unique temporary directory, preventing file conflicts

## How to test

 1. Download test file
wget http://deb.debian.org/debian/pool/main/h/haveged/haveged_1.9.14.orig.tar.gz


```
for i in {1..5}; do
  scanoss -C haveged_1.9.14.orig.tar.gz 2>&1 | grep "Writing results" &
done
wait
```

Before fix (collision):
```
Writing results to /tmp/scanoss/1765549487/result.json...
Writing results to /tmp/scanoss/1765549487/result.json...
Writing results to /tmp/scanoss/1765549487/result.json...
```
All 5 processes write to the same directory which leads to race condition

After fix :

```
Writing results to /tmp/scanoss/1765605895-19800/result.json...
Writing results to /tmp/scanoss/1765605895-19802/result.json...
Writing results to /tmp/scanoss/1765605895-19803/result.json...
Writing results to /tmp/scanoss/1765605895-19799/result.json...
Writing results to /tmp/scanoss/1765605895-19801/result.json...

```

Fixes #3109 
Signed-off-by: Taanvi Khevaria 
taanvikhevaria@gmail.com