### PR TITLE
feat(api): Add SPDX3 Format Support to API Report Endpoint

### DIFF
--- a/src/www/ui/api/Controllers/ReportController.php
+++ b/src/www/ui/api/Controllers/ReportController.php
@@ -17,6 +17,7 @@ use Fossology\DecisionExporter\UI\FoDecisionExporter;
 use Fossology\DecisionImporter\UI\AgentDecisionImporterPlugin;
 use Fossology\ReadmeOSS\UI\ReadMeOssPlugin;
 use Fossology\Spdx\UI\SpdxTwoGeneratorUi;
+use Fossology\Spdx\UI\SpdxThreeGeneratorUi;
 use Fossology\UI\Api\Exceptions\HttpBadRequestException;
 use Fossology\UI\Api\Exceptions\HttpErrorException;
 use Fossology\UI\Api\Exceptions\HttpForbiddenException;
@@ -54,7 +55,10 @@ class ReportController extends RestController
     'unifiedreport',
     'clixml',
     'decisionexporter',
-    'cyclonedx'
+    'cyclonedx',
+    'spdx3json',
+    'spdx3rdf',
+    'spdx3jsonld'
   );
 
   /**
@@ -139,6 +143,14 @@ class ReportController extends RestController
         $cyclonedxGenerator = $this->restHelper->getPlugin('ui_cyclonedx');
         list ($jobId, $jobQueueId) = $cyclonedxGenerator->scheduleAgent(
           $this->restHelper->getGroupId(), $upload);
+        break;
+      case $this->reportsAllowed[8]:
+      case $this->reportsAllowed[9]:
+      case $this->reportsAllowed[10]:
+        /** @var SpdxThreeGeneratorUi $spdx3Generator */
+        $spdx3Generator = $this->restHelper->getPlugin('ui_spdx3');
+        list ($jobId, $jobQueueId, $error) = $spdx3Generator->scheduleAgent(
+          $this->restHelper->getGroupId(), $upload, $reportFormat);
         break;
       default:
         throw new HttpInternalServerErrorException("Some error occured!");

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -4424,6 +4424,9 @@ paths:
               - unifiedreport
               - clixml
               - cyclonedx
+              - spdx3json
+              - spdx3rdf
+              - spdx3jsonld
         - name: groupName
           description: The group name to chose while generating a report
           in: header

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -4261,6 +4261,9 @@ paths:
               - unifiedreport
               - clixml
               - cyclonedx
+              - spdx3json
+              - spdx3rdf
+              - spdx3jsonld
         - name: groupName
           description: The group name to chose while generating a report
           in: query

--- a/src/www/ui_tests/api/Controllers/ReportControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/ReportControllerTest.php
@@ -51,7 +51,11 @@ class ReportControllerTest extends \PHPUnit\Framework\TestCase
     'readmeoss',
     'unifiedreport',
     'clixml',
-    'decisionexporter'
+    'decisionexporter',
+    'cyclonedx',
+    'spdx3json',
+    'spdx3rdf',
+    'spdx3jsonld'
   );
 
   /**
@@ -115,6 +119,18 @@ class ReportControllerTest extends \PHPUnit\Framework\TestCase
   private $decisionExporterPlugin;
 
   /**
+   * @var M\MockInterface $cyclonedxPlugin
+   * CycloneDXGeneratorUi mock
+   */
+  private $cyclonedxPlugin;
+
+  /**
+   * @var M\MockInterface $spdx3Plugin
+   * SpdxThreeGeneratorUi mock
+   */
+  private $spdx3Plugin;
+
+  /**
    * @var DbManager $dbManager
    * DbManager mock
    */
@@ -151,6 +167,8 @@ class ReportControllerTest extends \PHPUnit\Framework\TestCase
     $this->clixmlPlugin = M::mock('CliXmlGeneratorUi');
     $this->unifiedPlugin = M::mock('FoUnifiedReportGenerator');
     $this->decisionExporterPlugin = M::mock('DecisionExporterAgentPlugin');
+    $this->cyclonedxPlugin = M::mock('CycloneDXGeneratorUi');
+    $this->spdx3Plugin = M::mock('SpdxThreeGeneratorUi');
     $this->downloadPlugin = M::mock('ui_download');
 
     $this->dbHelper->shouldReceive('getDbManager')->andReturn($this->dbManager);
@@ -172,6 +190,10 @@ class ReportControllerTest extends \PHPUnit\Framework\TestCase
       ->andReturn($this->unifiedPlugin);
     $this->restHelper->shouldReceive('getPlugin')
       ->withArgs(['agent_fodecisionexporter'])->andReturn($this->decisionExporterPlugin);
+    $this->restHelper->shouldReceive('getPlugin')
+      ->withArgs(array('ui_cyclonedx'))->andReturn($this->cyclonedxPlugin);
+    $this->restHelper->shouldReceive('getPlugin')
+      ->withArgs(array('ui_spdx3'))->andReturn($this->spdx3Plugin);
 
     $container->shouldReceive('get')->withArgs(array(
       'helper.restHelper'))->andReturn($this->restHelper);
@@ -278,6 +300,12 @@ class ReportControllerTest extends \PHPUnit\Framework\TestCase
       ->withArgs([$this->groupId, $upload])->andReturn([32, 33, ""]);
     $this->decisionExporterPlugin->shouldReceive('scheduleAgent')
       ->withArgs([$this->groupId, $upload])->andReturn([32, 33]);
+    $this->cyclonedxPlugin->shouldReceive('scheduleAgent')
+      ->withArgs([$this->groupId, $upload])->andReturn([32, 33]);
+    $this->spdx3Plugin->shouldReceive('scheduleAgent')
+      ->withArgs([$this->groupId, $upload, M::anyOf($this->reportsAllowed[8],
+        $this->reportsAllowed[9], $this->reportsAllowed[10])])
+      ->andReturn([32, 33, ""]);
 
     $expectedResponse = new Info(201, "http://localhost/repo/api/v1/report/32",
       InfoType::INFO);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description
This PR adds support for SPDX3 report formats (`spdx3json`, `spdx3rdf`, `spdx3jsonld`) to the FOSSology REST API `/report` endpoint. Previously, SPDX3 reports were only available through the UI, not via the API.

## Problem Statement
The FOSSology API's `/report` endpoint was missing support for SPDX3 formats, even though:
- The SPDX3 UI plugin (`SpdxThreeGeneratorUi`) exists and is functional
- The SPDX agent supports SPDX3 generation (since v4.5.0)
- Users requested this feature for API integration

Currently supported formats were limited to: `spdx2`, `spdx2tv`, `readmeoss`, `unifiedreport`, `clixml`, `cyclonedx`, and `dep5`.

## Solution
Extended the API to accept and handle three SPDX3 report formats:
- **spdx3json** - SPDX3 in JSON format
- **spdx3rdf** - SPDX3 in RDF/XML format  
- **spdx3jsonld** - SPDX3 in JSON-LD format

## Changes Made

### 1. API Controller (`src/www/ui/api/Controllers/ReportController.php`)
- Added `SpdxThreeGeneratorUi` import
- Extended `$reportsAllowed` array to include `spdx3json`, `spdx3rdf`, `spdx3jsonld`
- Added switch cases (indices 8, 9, 10) to handle SPDX3 formats
- Calls `ui_spdx3` plugin with the appropriate `reportFormat` parameter

### 2. Unit Tests (`src/www/ui_tests/api/Controllers/ReportControllerTest.php`)
- Updated test `$reportsAllowed` array with new SPDX3 formats
- Added `$spdx3Plugin` and `$cyclonedxPlugin` mock variables
- Added mock expectations for `ui_spdx3` plugin in `testGetReportAllFormats()`
- Ensures all three SPDX3 formats are tested

### 3. API Documentation
- **openapi.yaml** - Added SPDX3 formats to `/report` GET endpoint `reportFormat` parameter enum
- **openapiv2.yaml** - Added same formats for API v2 compatibility

## Usage Examples

### REST API Request

#### Before (Not supported)
```
bash
curl -X GET "http://localhost/repo/api/v1/report" \
  -H "uploadId: 123" \
  -H "reportFormat: spdx3json"
```
### Would return 400 Bad Request: reportFormat must be from [dep5,spdx2,spdx2tv,readmeoss,unifiedreport,clixml,decisionexporter,cyclonedx]

### After
## SPDX3 JSON format
```
curl -X GET "http://localhost/repo/api/v1/report" \
  -H "uploadId: 123" \
  -H "reportFormat: spdx3json"
```
### Returns 201 Created with download link

## SPDX3 RDF format
```
curl -X GET "http://localhost/repo/api/v1/report" \
  -H "uploadId: 123" \
  -H "reportFormat: spdx3rdf"
```

## SPDX3 JSON-LD format
```
curl -X GET "http://localhost/repo/api/v1/report" \
  -H "uploadId: 123" \
  -H "reportFormat: spdx3jsonld"
```
## Closing discussion [#3102](https://github.com/fossology/fossology/discussions/3102)

@shaheemazmalmmd @Kaushl2208 @its-sushant 

