### PR TITLE
Security: Remove hardcoded database credentials (fixes #3199)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# FOSSology Environment Variables Configuration
+# SPDX-FileCopyrightText: © Fossology contributors
+# SPDX-License-Identifier: FSFAP
+#
+# Copy this file to .env and set your actual credentials.
+
+# PostgreSQL superuser credentials
+PG_USER=postgres
+PG_PASS=
+
+# Fossology database user
+FOSSY_USER=fossy
+FOSSY_PASS=fossy
+
+# Test database credentials
+TEST_DBUSER=fossologytest
+TEST_DBPASS=
+
+# UI test credentials
+TEST_USER=fossology
+TEST_PASSWORD=
+
+# SchemaSpy database credentials
+SCHEMSPY_DB_USER=fossy
+SCHEMSPY_DB_PASS=fossy
+
+# PostgreSQL connection host (optional)
+# PGHOST=localhost

--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,6 @@ cmake-build-debug
 
 #pycache
 **/__pycache__/
+
+# Environment variables file (contains sensitive credentials)
+.env

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: GPL-2.0-only AND LGPL-2.1-only
 $post_up_message = <<WELCOME
 Use your FOSSology at http://localhost:8081/repo/
-  user: fossy , password: fossy
+  Default user: fossy (see documentation for password)
 
 Or do a 'vagrant ssh' and look at '/fossology' for your source tree.
 

--- a/src/www/ui_tests/foss_ui.php
+++ b/src/www/ui_tests/foss_ui.php
@@ -16,7 +16,9 @@ class TestRepoLogin extends WebTestCase{
     $this->useProxy('http://web-proxy.fc.hp.com:8088', 'web-proxy', '');
     $this->assertTrue($this->get('http://repo.fossology.org/'));
     $this->assertAuthentication('Basic');
-    $this->authenticate('fossology', 'xxxxxxxx');
+    $testUser = getenv('TEST_USER') ?: 'fossology';
+    $testPassword = getenv('TEST_PASSWORD') ?: '';
+    $this->authenticate($testUser, $testPassword);
     $this->assertText('Software Repository Viewer');
   }
 }
@@ -26,7 +28,9 @@ class TestAboutMenu extends WebTestCase {
     $this->useProxy('http://web-proxy.fc.hp.com:8088', 'web-proxy', '');
     $this->assertTrue($this->get('http://repo.fossology.org/'));
     $this->assertAuthentication('Basic');
-    $this->authenticate('fossology', 'xxxxxxx');
+    $testUser = getenv('TEST_USER') ?: 'fossology';
+    $testPassword = getenv('TEST_PASSWORD') ?: '';
+    $this->authenticate($testUser, $testPassword);
     $this->assertText('Software Repository');
 
     $this->click('About');

--- a/utils/prepare-test
+++ b/utils/prepare-test
@@ -42,6 +42,10 @@ CreateFossyTest="N"
 PG_USER="postgres"
 PG_PASS=""
 
+FOSSY_USER=${FOSSY_USER:-fossy}
+FOSSY_PASS=${FOSSY_PASS:-fossy}
+TEST_DBUSER=${TEST_DBUSER:-fossologytest}
+
 # Use localhost as default host
 if [[ -z "${PGHOST}" ]]; then
   PGHOST="localhost"
@@ -110,23 +114,27 @@ if echo ${WarnAccept} | grep -q -e "^[yY]$" ; then
   fi
   if [[ "${CreateFossy}" == "Y" ]]; then
     if [[ -z "${PG_PASS}" ]]; then
-      sudo --preserve-env su --whitelist-environment="PGHOST" postgres -c "echo \"CREATE USER fossy WITH PASSWORD 'fossy' CREATEDB;\"|psql" || true >/dev/null
-      sudo --preserve-env su --whitelist-environment="PGHOST" postgres -c "echo 'CREATE DATABASE fossology; GRANT ALL PRIVILEGES ON DATABASE fossology TO fossy;'|psql" || true
+      sudo --preserve-env su --whitelist-environment="PGHOST" postgres -c "echo \"CREATE USER ${FOSSY_USER} WITH PASSWORD '${FOSSY_PASS}' CREATEDB;\"|psql" || true >/dev/null
+      sudo --preserve-env su --whitelist-environment="PGHOST" postgres -c "echo \"CREATE DATABASE fossology; GRANT ALL PRIVILEGES ON DATABASE fossology TO ${FOSSY_USER};\"|psql" || true
     else
-      echo "CREATE USER fossy WITH PASSWORD 'fossy' CREATEDB;"|PGPASSWORD="${PG_PASS}" psql -U ${PG_USER} || true >/dev/null
-      echo 'CREATE DATABASE fossology; GRANT ALL PRIVILEGES ON DATABASE fossology TO fossy;'|PGPASSWORD="${PG_PASS}" psql -U ${PG_USER} || true
+      echo "CREATE USER ${FOSSY_USER} WITH PASSWORD '${FOSSY_PASS}' CREATEDB;"|PGPASSWORD="${PG_PASS}" psql -U ${PG_USER} || true >/dev/null
+      echo "CREATE DATABASE fossology; GRANT ALL PRIVILEGES ON DATABASE fossology TO ${FOSSY_USER};"|PGPASSWORD="${PG_PASS}" psql -U ${PG_USER} || true
     fi
-    echo "${PGHOST}:*:*:fossy:fossy" >> ~/.pgpass
+    echo "${PGHOST}:*:*:${FOSSY_USER}:${FOSSY_PASS}" >> ~/.pgpass
     chmod 0600 ~/.pgpass
   fi
   if [[ "${CreateFossyTest}" == "Y" ]]; then
-    testDbPassword=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13)
-    if [[ -z "${PG_PASS}" ]]; then
-      sudo --preserve-env su --whitelist-environment="PGHOST" postgres -c "echo \"CREATE USER fossologytest WITH CREATEDB LOGIN PASSWORD '${testDbPassword}';\"|psql" || true >/dev/null
+    if [[ -z "${TEST_DBPASS}" ]]; then
+      testDbPassword=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13)
     else
-      echo "CREATE USER fossologytest WITH CREATEDB LOGIN PASSWORD '${testDbPassword}';"|PGPASSWORD="${PG_PASS}" psql -U ${PG_USER} || true >/dev/null
+      testDbPassword="${TEST_DBPASS}"
     fi
-    echo "${PGHOST}:*:*:fossologytest:${testDbPassword}" >> ~/.pgpass
+    if [[ -z "${PG_PASS}" ]]; then
+      sudo --preserve-env su --whitelist-environment="PGHOST" postgres -c "echo \"CREATE USER ${TEST_DBUSER} WITH CREATEDB LOGIN PASSWORD '${testDbPassword}';\"|psql" || true >/dev/null
+    else
+      echo "CREATE USER ${TEST_DBUSER} WITH CREATEDB LOGIN PASSWORD '${testDbPassword}';"|PGPASSWORD="${PG_PASS}" psql -U ${PG_USER} || true >/dev/null
+    fi
+    echo "${PGHOST}:*:*:${TEST_DBUSER}:${testDbPassword}" >> ~/.pgpass
     chmod 0600 ~/.pgpass
   fi
   case "${DISTRO}" in

--- a/utils/schemaspy.run
+++ b/utils/schemaspy.run
@@ -3,10 +3,12 @@
 
 # SPDX-License-Identifier: FSFAP
 #
-# cron script for running schemaspy.  NOTE you must supply the db, 
-# user and password. They are xxxxx for now.
+# cron script for running schemaspy
 #
+SCHEMSPY_DB_USER=${SCHEMSPY_DB_USER:-fossy}
+SCHEMSPY_DB_PASS=${SCHEMSPY_DB_PASS:-fossy}
+
 java -jar /usr/local/bin/schemaSpy_4.1.1.jar -t pgsql \
 -cp /usr/local/share/postgresql-8.4-701.jdbc3.jar \
--db fossology -s public -host localhost -u xxxx -p xxxx -o /var/www/schemaspy
+-db fossology -s public -host localhost -u "${SCHEMSPY_DB_USER}" -p "${SCHEMSPY_DB_PASS}" -o /var/www/schemaspy
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Replaces hardcoded database credentials with environment variables to address security issue #3199.

### Changes

- `utils/schemaspy.run`: Use `SCHEMSPY_DB_USER` and `SCHEMSPY_DB_PASS` env vars
- `utils/prepare-test`: Use `FOSSY_USER`, `FOSSY_PASS`, `TEST_DBUSER`, `TEST_DBPASS` env vars
- `Vagrantfile`: Remove credentials from welcome message
- `src/www/ui_tests/foss_ui.php`: Use `TEST_USER` and `TEST_PASSWORD` env vars
- Added `.env.example` template file
- Added `.env` to `.gitignore`

Backward compatible - defaults preserved for initial setup.

## How to test

1. Test with defaults (should work as before):
   ```bash
   ./utils/schemaspy.run
   ./utils/prepare-test -f
   ```

2. Test with custom env vars:
   ```bash
   export FOSSY_USER=myuser
   export FOSSY_PASS=mypass
   ./utils/prepare-test -f
   ```

3. Verify `.env.example` exists and `.env` is in `.gitignore`

Closes #3199

