### PR TITLE
Optimize(getItemParent): optimize pgsql getItemParent func to avoid scan full table

### DIFF
--- a/src/lib/php/libschema.php
+++ b/src/lib/php/libschema.php
@@ -1032,31 +1032,48 @@ class fo_libschema
      * drop and recreate to change the return type.
      */
     $sql = 'drop function if exists getItemParent(integer);';
-    $this->applyOrEchoOnce($sql, $stmt = __METHOD__ . '.getItemParent.drop');
+    $this->applyOrEchoOnce($sql, $stmt = __METHOD__ . '.getItemParent.drop_old');
+
+    $sql = 'drop function if exists getItemParent(integer, integer);';
+    $this->applyOrEchoOnce($sql, $stmt = __METHOD__ . '.getItemParent.drop_new');
 
     $sql = '
-    CREATE OR REPLACE FUNCTION getItemParent(itemId Integer) RETURNS Integer AS $$
-    WITH RECURSIVE file_tree(uploadtree_pk, parent, jump, path, cycle) AS (
-        SELECT ut.uploadtree_pk, ut.parent,
-          true,
-          ARRAY[ut.uploadtree_pk],
-          false
-        FROM uploadtree ut
-        WHERE ut.uploadtree_pk = $1
-      UNION ALL
-        SELECT ut.uploadtree_pk, ut.parent,
-          ut.ufile_mode & (1<<28) != 0,
-          path || ut.uploadtree_pk,
-        ut.uploadtree_pk = ANY(path)
-        FROM uploadtree ut, file_tree ft
-        WHERE ut.uploadtree_pk = ft.parent AND jump AND NOT cycle
-      )
-   SELECT uploadtree_pk from file_tree ft WHERE NOT jump
-   $$
-   LANGUAGE SQL
-   STABLE
-   RETURNS NULL ON NULL INPUT
-      ';
+      CREATE OR REPLACE FUNCTION getItemParent(itemId Integer, uploadId Integer)
+      RETURNS Integer AS $$
+      DECLARE
+          target_table text;
+          query_sql text;
+          result_id integer;
+      BEGIN
+          target_table := \'uploadtree_\' || uploadId;
+          query_sql := format(\'
+              WITH RECURSIVE file_tree(uploadtree_pk, parent, jump, path, cycle) AS (
+                  SELECT ut.uploadtree_pk, ut.parent,
+                    true,
+                    ARRAY[ut.uploadtree_pk],
+                    false
+                  FROM %I ut
+                  WHERE ut.uploadtree_pk = %L
+                UNION ALL
+                  SELECT ut.uploadtree_pk, ut.parent,
+                    ut.ufile_mode & (1<<28) != 0,
+                    path || ut.uploadtree_pk,
+                  ut.uploadtree_pk = ANY(path)
+                  FROM %I ut, file_tree ft
+                  WHERE ut.uploadtree_pk = ft.parent
+                    AND jump AND NOT cycle
+                )
+            SELECT uploadtree_pk from file_tree ft WHERE NOT jump
+          \', target_table, itemId, target_table);
+          BEGIN
+              EXECUTE query_sql INTO result_id;
+          EXCEPTION WHEN undefined_table THEN
+              RETURN NULL;
+          END;
+          RETURN result_id;
+      END;
+      $$ LANGUAGE plpgsql STABLE STRICT;
+    ';
     $this->applyOrEchoOnce($sql, $stmt = __METHOD__ . '.getItemParent.create');
     return;
   }

--- a/src/ununpack/agent/ununpack.c
+++ b/src/ununpack/agent/ununpack.c
@@ -537,10 +537,42 @@ int	main(int argc, char *argv[])
       if (fo_checkPQcommand(pgConn, result, SQL, __FILE__ ,__LINE__)) SafeExit(113);
       PQclear(result);
 
-      snprintf(SQL,MAXSQL,"UPDATE %s SET realparent = getItemParent(uploadtree_pk) WHERE upload_fk = '%s'",uploadtree_tablename, Upload_Pk);
-      result =  PQexec(pgConn, SQL); /* UPDATE uploadtree */
-      if (fo_checkPQcommand(pgConn, result, SQL, __FILE__ ,__LINE__)) SafeExit(114);
-      PQclear(result);
+      int batch_size = 5000;
+      long last_pk = 0;
+      int rows_affected = 0;
+      do {
+    snprintf(SQL, MAXSQL,
+          "UPDATE %s AS t1 "
+          "SET realparent = getItemParent(t1.uploadtree_pk, %s) "
+          "FROM ( "
+          "    SELECT uploadtree_pk "
+          "    FROM %s "
+          "    WHERE upload_fk = '%s' "
+          "    AND uploadtree_pk > %ld "
+          "    ORDER BY uploadtree_pk ASC "
+          "    LIMIT %d "
+          ") AS t2 "
+          "WHERE t1.uploadtree_pk = t2.uploadtree_pk",
+          uploadtree_tablename,
+          Upload_Pk,
+          uploadtree_tablename,
+          Upload_Pk,
+          last_pk,
+          batch_size);
+
+    result = PQexec(pgConn, SQL);
+    if (fo_checkPQcommand(pgConn, result, SQL, __FILE__, __LINE__))
+        SafeExit(114);
+
+    rows_affected = atoi(PQcmdTuples(result));
+    PQclear(result);
+
+    if (rows_affected > 0) {
+        last_pk += batch_size;
+        printf("ununpack: processed batch, rows=%d\n", rows_affected);
+    }
+    } while (rows_affected > 0);
+
     }
 
     if (ars_pk) fo_WriteARS(pgConn, ars_pk, atoi(Upload_Pk), agent_pk, AgentARSName, 0, 1);


### PR DESCRIPTION
Pgsql getItemParent func optimization to receive one more extra parameter uploadId to force assign the target table for searching parentId to avoid scan full table.

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Related discusstion here:  https://github.com/fossology/fossology/issues/3194

### Changes

List the changes done to fix a bug or introducing a new feature.

## How to test

Describe the steps required to test the changes proposed in the pull request.

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)
