### PR TITLE
fix: exclude invalid characters from URL regex in copyright agent

### DIFF
--- a/src/copyright/agent/copyright.conf
+++ b/src/copyright/agent/copyright.conf
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: FSFAP
 #
 # Description: this file holds the regex configurations for the Copyright agent
-url=(?:(:?ht|f)tps?\:\/\/[^\s\<]+[^\<\.\,\s])
+url=(?:(?:ht|f)tps?://[^\s<>\"'`\[\]{}\\|\^]+?)(?=[\s<>\"'`\[\]{}\\]|$)
 EMAILPART=[\w\-\.\+]{1,100}
 TLD=[a-zA-Z]{2,12}(?<!test)(?<!invalid)
 email=[\<\(]?(__EMAILPART__@__EMAILPART__\.__TLD__)(?<!example\.(com|net|org))[\>\)]?


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The copyright agent's URL detection regex was capturing invalid URL characters as part of the matched URL. The pattern [^\s\<]+ is too permissive. 
It matches any character except whitespace and <, which means newlines, quotes, angle brackets and other non-URL-safe characters end up in the results. This creates false positives where http://example.com">' gets reported as a valid URL match when only http://example.com is actually valid.

The fix restricts the character set to only match RFC 3986 compliant URL characters, stopping the match at boundary characters that cannot appear in a URL. This is a minimal change that addresses the root cause without affecting any other detection logic.

### Changes

Modified `src/copyright/agent/copyright.conf`

## How to test

1. Create a test file containing URLs with trailing invalid characters:

```
/* Test cases */
const char *url1 = "http://xml.libexpat.org/entity.ent'>\n\"";
const char *url2 = "http://example.com\">";
const char *url3 = "http://example.com`";
const char *url4 = "http://example.com[bracket]";

/* Valid URLs should still work */
const char *url5 = "https://github.com/fossology/fossology";
const char *url6 = "http://example.com:8080/path?query=value&other=123";
```

2. Upload the test file through the FOSSology web interface
3. Run the copyright agent (Jobs > Copyright)
4. Verify the URLs detected in the Copyright/URL results:

- Invalid characters should NOT appear in captured URLs
- Valid URLs should be fully captured
- http://xml.libexpat.org/entity.ent (not http://xml.libexpat.org/entity.ent'>\n\")
- http://example.com (not http://example.com\")
- https://github.com/fossology/fossology (will remain unchanged)


Closes #317
