### PR TITLE
fix(install): add Linux Mint support to dependency installer

### DIFF
--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -88,7 +88,7 @@ echo "install core dependencies"
 if [[ $BUILDTIME ]]; then
    echo "*** Installing $DISTRO buildtime dependencies ***";
    case "$DISTRO" in
-      Debian|Ubuntu|Tuxedo)
+      Debian|Ubuntu|Tuxedo|Linuxmint)
          echo "DB: Installing build essential....."
          apt-get $YesOpt install \
             libmxml-dev curl libxml2-dev libcunit1-dev libicu-dev \
@@ -113,7 +113,7 @@ if [[ $BUILDTIME ]]; then
              apt-get $YesOpt install php-mbstring php-cli php-xml php-zip php-gd php-pgsql php-curl php-uuid php-sqlite3 php-yaml;;
            jammy)
              apt-get $YesOpt install php-mbstring php-cli php-xml php-zip php-gd php-pgsql php-curl php-uuid php-sqlite3 php-yaml;;
-           noble)
+           noble|wilma|zara)
              apt-get $YesOpt install php-mbstring php-cli php-xml php-zip php-gd php-pgsql php-curl php-uuid php-sqlite3 php-yaml;;
          esac
          if ! dpkg --get-selections | grep -q postgresql-server-dev; then  ## if postgresql-server-dev is not installed


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The dependency installer script (utils/fo-installdeps) failed on Linux Mint 22 (Wilma) because the distribution ID and codename were not recognized by the OS detection logic.

Since Linux Mint is based on Ubuntu, I added 'Linuxmint' and its current codenames (Wilma/Zara) to the existing Ubuntu case block. This allows the script to correctly identify the OS and install the necessary dependencies using apt.

### Changes

- Modified utils/fo-installdeps:

     - -   Added linuxmint to the distribution ID check.

     - - Added wilma and zara to the release codename check alongside Ubuntu codenames


## How to test

Describe the steps required to test the changes proposed in the pull request.

Run the dependency installer on a Linux Mint machine:
        ./utils/fo-installdeps -e

Verify that the script identifies the distro correctly (e.g., "distro is Ubuntu/Mint") instead of exiting with "distro not recognised".

Verify that apt-get install commands run successfully.

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)
