### PR TITLE
Avoid fatal error when copyright_ars table is missing

### DIFF
--- a/src/copyright/ui/agent-copyright.php
+++ b/src/copyright/ui/agent-copyright.php
@@ -30,10 +30,28 @@ class CopyrightAgentPlugin extends AgentPlugin
    * @copydoc Fossology::Lib::Plugin::AgentPlugin::AgentHasResults()
    * @see Fossology::Lib::Plugin::AgentPlugin::AgentHasResults()
    */
+  
   function AgentHasResults($uploadId=0)
-  {
+{
+    // Check if table exists first
+    global $pdo; // Assuming PDO object is available
+
+    try {
+        $stmt = $pdo->query("SELECT to_regclass('public.copyright_ars') AS tbl");
+        $result = $stmt->fetch();
+        if (!$result['tbl']) {
+            // Table does not exist yet
+            return false;
+        }
+    } catch (\Exception $e) {
+        // Something went wrong with DB, fail safely
+        return false;
+    }
+
+    // Table exists, call original CheckARS
     return CheckARS($uploadId, $this->AgentName, "copyright scanner", "copyright_ars");
-  }
+}
+
 
   /**
    * @copydoc Fossology\Lib\Plugin\AgentPlugin::AgentAdd()


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

This pull request fixes a fatal error (white page / HTTP 500) in the Copyright
View when the `copyright_ars` table does not exist.

The issue occurs when a user opens a scanned file in the Copyright/Email/ URL view before the copyright agent has been executed for the upload.

## Changes

- Added a defensive database check in `AgentHasResults()` to verify whether the
  `copyright_ars` table exists before accessing it.
- Used PostgreSQL’s `to_regclass()` function to safely detect the presence of the
  table without throwing SQL errors.
- Prevented fatal errors and white page issues by returning early when the table
  is missing or when a database exception occurs.
- Preserved existing behavior by calling `CheckARS()` only after confirming that
  the required ARS table is available.

## Snapshot of changed code
<img width="1336" height="743" alt="Screenshot 2026-01-03 191736" src="https://github.com/user-attachments/assets/d5d1f73e-d914-4c80-885d-69f81a70be31" />


## How to test

1. Start a fresh Fossology instance
2. Upload an input from File
3. Open the Copyright/email/url View 
4. Verify the page loads without a white page or HTTP 500 error
5. Run the copyright agent and confirm the view works as expected


Fixes #3218 