### PR TITLE
feat(oidc): allow configuring OIDC sysconfig via fossology.conf

### DIFF
--- a/install/defconf/fossology.conf.in
+++ b/install/defconf/fossology.conf.in
@@ -127,8 +127,43 @@ CONF_EXT_AUTH_NEW_USER_AGENT_LIST=
 ; password : to allow passwords for login
 ; external : passwords are not allowed
 provider = password
+
 ; REST API token should be one of
 ; token : to allow FOSSology tokens for use
 ; oauth : to allow only oauth tokens
 ; both  : to allow both FOSSology and oauth tokens
 resttoken = token
+
+
+; -----------------------------------------------------------------------------
+; OIDC overrides (config-as-code)
+; Values in this section override the sysconfig table values at runtime.
+; This allows configuration without using the web UI, e.g. for Docker/K8s.
+;
+; NOTE: Only non-empty values override DB sysconfig values.
+; -----------------------------------------------------------------------------
+[OIDC]
+
+; If OidcAppName is set, the OIDC login option will be displayed on the login page.
+; Example:
+;OidcAppName = "My SSO"
+;OidcIssuer = "https://idp.example.com/"
+;OidcAuthorizeURL = "https://idp.example.com/oauth2/v1/authorize"
+;OidcAccessTokenURL = "https://idp.example.com/oauth2/v1/token"
+;OidcResourceURL = "https://idp.example.com/oauth2/v1/userinfo"
+;OidcJwksURL = "https://idp.example.com/oauth2/v1/keys"
+;OidcLogoutURL = "https://idp.example.com/logout"
+;OidcResourceOwnerId = "email"
+;OidcClientIdClaim = "client_id"
+;OidcClientId = "xxxxx"
+;OidcSecret = "yyyyy"
+;OidcScope = "openid email profile"
+;OidcRedirectURL = "https://fossology.example.com/oauth/callback"
+;OidcDiscoveryURL = "https://idp.example.com/.well-known/openid-configuration"
+;OidcPrompt = "login"
+;OidcTokenType = "Bearer"
+;OidcAppId = ""
+;OidcDesc = "OIDC Login"
+;OidcJwkAlgInject = "false"
+;OidcOverrides = ""
+


### PR DESCRIPTION
Fixes #2225

## What
Allow configuring OpenID Connect (OIDC) sysconfig values via `fossology.conf` using a `[SYSCONFIG]` section.

## Why
OIDC settings are currently stored in the `sysconfig` DB table and typically configured through the Web UI.  
This makes config-as-code deployments (Docker/Kubernetes/automated installs) difficult.  
This change enables file-based configuration while keeping existing DB behavior as fallback.

## How
- When loading sysconfig values from the DB, do not overwrite keys that already exist in `$SysConf['SYSCONFIG']` with a non-empty value (loaded from `fossology.conf`).
- Add example `[SYSCONFIG]` entries for OIDC keys in `install/defconf/fossology.conf.in`.
- Backward compatible: if `[SYSCONFIG]` values are not provided, sysconfig DB values continue to apply.

## Testing
Local Docker-based testing is currently blocked on Windows due to DISM error `14098`. Relying on CI for validation.

## How to test
1. Set `OidcAppName` in DB sysconfig (Admin → Sysconfig → OauthSupport).
2. Set a different value in `fossology.conf` under `[SYSCONFIG]`.
3. Restart FOSSology and confirm the config-file value takes precedence.
4. Remove the config entry and confirm fallback to DB values.
5. (Optional) Confirm the OIDC login option label matches `OidcAppName` on the login page.

