### PR TITLE
fix(missing_table):resolve copyright_ars missing table and UI crash

### DIFF
--- a/src/copyright/ui/agent-copyright.php
+++ b/src/copyright/ui/agent-copyright.php
@@ -32,6 +32,14 @@ class CopyrightAgentPlugin extends AgentPlugin
    */
   function AgentHasResults($uploadId=0)
   {
+    // Get the database manager from the global container
+    $dbManager = $GLOBALS['container']->get('db.manager');
+
+    // Safety check: if the table doesn't exist, return 0 (no results)
+    // This prevents the PostgreSQL "relation does not exist" error
+    if (!$dbManager->existsTable("copyright_ars")) {
+      return 0;
+    }
     return CheckARS($uploadId, $this->AgentName, "copyright scanner", "copyright_ars");
   }
 

--- a/src/lib/php/libschema.php
+++ b/src/lib/php/libschema.php
@@ -169,6 +169,7 @@ class fo_libschema
     $this->applySequences();
     $this->applyTables();
     $this->applyInheritedRelations();
+    $this->ensureArsTables();
     $this->getCurrSchema(); /* New tables created, recheck */
     $this->applyTables(true);
     $this->updateSequences();
@@ -1081,6 +1082,21 @@ class fo_libschema
   }
 
   // MakeFunctions()
+  private function ensureArsTables()
+  {
+    // 1. Create the table with plain INTEGER columns (no REFERENCES yet)
+    $sql = "CREATE TABLE IF NOT EXISTS copyright_ars (
+              ars_pk SERIAL PRIMARY KEY,
+              upload_fk INTEGER,
+              agent_fk INTEGER,
+              ars_success BOOLEAN DEFAULT FALSE,
+              ars_processed BOOLEAN DEFAULT FALSE
+            );";
+    $this->dbman->queryOnce($sql, __METHOD__ . ".create");
+
+    // 2. Add the index for performance
+    $this->dbman->queryOnce("CREATE INDEX IF NOT EXISTS copyright_ars_upload_fk ON copyright_ars(upload_fk);", __METHOD__ . ".index");
+  }
 }
 
 if (empty($dbManager) || !($dbManager instanceof DbManager)) {


### PR DESCRIPTION
This will fix the issue #3218 by ensuring the copyright_ars table exists in the DB and will prevent any crash if it doesn't exist.
