### PR TITLE
feat(ui): add dependencies tab for file includers

### DIFF
--- a/src/lib/php/Util/FileIncluderExtractor.php
+++ b/src/lib/php/Util/FileIncluderExtractor.php
@@ -1,0 +1,235 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Contribution for GSoC
+ 
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\Lib\Util;
+
+/**
+ * Utility class to extract file includers/dependencies from source files
+ */
+class FileIncluderExtractor
+{
+  /**
+   * Extract includers from file content based on file type
+   * @param string $content File content
+   * @param string $filename Filename to help detect type
+   * @return array Array of includer information
+   */
+  public function extractIncluders($content, $filename)
+  {
+    if (empty($content)) {
+      return [];
+    }
+
+    $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+    $includers = [];
+
+    // Figure out what kind of file this is and parse accordingly
+    switch ($extension) {
+      case 'c':
+      case 'h':
+      case 'cpp':
+      case 'hpp':
+      case 'cc':
+        $includers = $this->parseCIncludes($content);
+        break;
+
+      case 'py':
+        $includers = $this->parsePythonImports($content);
+        break;
+
+      case 'js':
+      case 'ts':
+        $includers = $this->parseJavaScriptRequires($content);
+        break;
+
+      case 'go':
+        $includers = $this->parseGoImports($content);
+        break;
+
+      default:
+        // Dockerfile won't have an extension, check the name
+        $basename = basename($filename);
+        if (strcasecmp($basename, 'Dockerfile') === 0) {
+          $includers = $this->parseDockerfileFrom($content);
+        }
+        break;
+    }
+
+    return $includers;
+  }
+
+  /**
+   * Parse C/C++ #include statements
+   */
+  private function parseCIncludes($content)
+  {
+    $includers = [];
+    $lines = explode("\n", $content);
+
+    foreach ($lines as $lineNum => $line) {
+      // Look for #include statements (both <> and "" styles)
+      if (preg_match('/^\s*#\s*include\s*[<"]([^>"]+)[>"]/', $line, $matches)) {
+        $includers[] = [
+          'type' => 'include',
+          'value' => trim($matches[1]),
+          'line' => $lineNum + 1
+        ];
+      }
+    }
+
+    return $includers;
+  }
+
+  /**
+   * Parse Python import statements
+   */
+  private function parsePythonImports($content)
+  {
+    $includers = [];
+    $lines = explode("\n", $content);
+    
+    foreach ($lines as $lineNum => $line) {
+      $trimmed = trim($line);
+      
+      // Skip comments and empty lines
+      if (empty($trimmed) || $trimmed[0] === '#') {
+        continue;
+      }
+      
+      // Match 'import module' or 'import module as alias'
+      if (preg_match('/^import\s+([a-zA-Z0-9_., ]+)/', $trimmed, $matches)) {
+        $modules = explode(',', $matches[1]);
+        foreach ($modules as $module) {
+          $module = trim($module);
+          // Remove 'as' aliases
+          $module = preg_replace('/\s+as\s+.*$/', '', $module);
+          $includers[] = [
+            'type' => 'import',
+            'value' => trim($module),
+            'line' => $lineNum + 1
+          ];
+        }
+      }
+      
+      // Match 'from module import ...'
+      if (preg_match('/^from\s+([a-zA-Z0-9_.]+)\s+import/', $trimmed, $matches)) {
+        $includers[] = [
+          'type' => 'from',
+          'value' => trim($matches[1]),
+          'line' => $lineNum + 1
+        ];
+      }
+    }
+    
+    return $includers;
+  }
+
+  /**
+   * Parse JavaScript/TypeScript require() and import statements
+   */
+  private function parseJavaScriptRequires($content)
+  {
+    $includers = [];
+    $lines = explode("\n", $content);
+    
+    foreach ($lines as $lineNum => $line) {
+      $trimmed = trim($line);
+      
+      // Match require('module') or require("module")
+      if (preg_match('/require\s*\(\s*[\'"]([^\'"]+)[\'"]\s*\)/', $trimmed, $matches)) {
+        $includers[] = [
+          'type' => 'require',
+          'value' => $matches[1],
+          'line' => $lineNum + 1
+        ];
+      }
+      
+      // Match ES6 import statements: import ... from 'module'
+      if (preg_match('/import\s+.*from\s+[\'"]([^\'"]+)[\'"]/', $trimmed, $matches)) {
+        $includers[] = [
+          'type' => 'import',
+          'value' => $matches[1],
+          'line' => $lineNum + 1
+        ];
+      }
+    }
+    
+    return $includers;
+  }
+
+  /**
+   * Parse Go import statements
+   */
+  private function parseGoImports($content)
+  {
+    $includers = [];
+    $lines = explode("\n", $content);
+    $inImportBlock = false;
+    
+    foreach ($lines as $lineNum => $line) {
+      $trimmed = trim($line);
+      
+      // Start of import block
+      if (preg_match('/^import\s*\(/', $trimmed)) {
+        $inImportBlock = true;
+        continue;
+      }
+      
+      // End of import block
+      if ($inImportBlock && $trimmed === ')') {
+        $inImportBlock = false;
+        continue;
+      }
+      
+      // Inside import block
+      if ($inImportBlock) {
+        if (preg_match('/"([^"]+)"/', $trimmed, $matches)) {
+          $includers[] = [
+            'type' => 'import',
+            'value' => $matches[1],
+            'line' => $lineNum + 1
+          ];
+        }
+      }
+      
+      // Single line import
+      if (preg_match('/^import\s+"([^"]+)"/', $trimmed, $matches)) {
+        $includers[] = [
+          'type' => 'import',
+          'value' => $matches[1],
+          'line' => $lineNum + 1
+        ];
+      }
+    }
+    
+    return $includers;
+  }
+
+  /**
+   * Parse Dockerfile FROM statements
+   */
+  private function parseDockerfileFrom($content)
+  {
+    $includers = [];
+    $lines = explode("\n", $content);
+    
+    foreach ($lines as $lineNum => $line) {
+      $trimmed = trim($line);
+      
+      // Match FROM statements
+      if (preg_match('/^FROM\s+([^\s]+)/i', $trimmed, $matches)) {
+        $includers[] = [
+          'type' => 'FROM',
+          'value' => $matches[1],
+          'line' => $lineNum + 1
+        ];
+      }
+    }
+    
+    return $includers;
+  }
+}

--- a/src/www/ui/async/AjaxFileDependencies.php
+++ b/src/www/ui/async/AjaxFileDependencies.php
@@ -1,0 +1,268 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Contribution for GSoC
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\UI\Ajax;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Data\Tree\ItemTreeBounds;
+use Fossology\Lib\Plugin\DefaultPlugin;
+use Fossology\Lib\Proxy\UploadTreeProxy;
+use Fossology\Lib\Util\FileIncluderExtractor;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Ajax handler for file dependencies browser
+ */
+class AjaxFileDependencies extends DefaultPlugin
+{
+  const NAME = "ajax_file_dependencies";
+
+  private $uploadtree_tablename = "";
+  /** @var UploadDao */
+  private $uploadDao;
+  /** @var FileIncluderExtractor */
+  private $includerExtractor;
+
+  public function __construct()
+  {
+    parent::__construct(self::NAME, array(
+        self::TITLE => _("Ajax: File Dependencies"),
+        self::DEPENDENCIES => array("file_dependencies"),
+        self::PERMISSION => Auth::PERM_READ,
+        self::REQUIRES_LOGIN => false
+    ));
+
+    $this->uploadDao = $this->getObject('dao.upload');
+    $this->includerExtractor = new FileIncluderExtractor();
+  }
+
+  /**
+   * Handle Ajax request
+   * @param Request $request
+   * @return Response
+   */
+  protected function handle(Request $request)
+  {
+    $upload = intval($request->get("upload"));
+    $groupId = Auth::getGroupId();
+    
+    if (!$this->uploadDao->isAccessible($upload, $groupId)) {
+      throw new \Exception("Permission Denied");
+    }
+
+    $item = intval($request->get("item"));
+    $this->uploadtree_tablename = $this->uploadDao->getUploadtreeTableName($upload);
+    $itemTreeBounds = $this->uploadDao->getItemTreeBounds($item, $this->uploadtree_tablename);
+    $left = $itemTreeBounds->getLeft();
+    
+    if (empty($left)) {
+       throw new \Exception("Job unpack/adj2nest hasn't completed.");
+    }
+
+    $vars = $this->createFileListing($itemTreeBounds, $request);
+
+    return new JsonResponse(array(
+            'sEcho' => intval($request->get('sEcho')),
+            'aaData' => $vars['fileData'],
+            'iTotalRecords' => intval($request->get('totalRecords')),
+            'iTotalDisplayRecords' => $vars['iTotalDisplayRecords']
+          ) );
+  }
+
+  /**
+   * Create file listing with dependencies
+   * @param ItemTreeBounds $itemTreeBounds
+   * @param Request $request
+   * @return array
+   */
+  private function createFileListing($itemTreeBounds, $request)
+  {
+    $uploadId = $itemTreeBounds->getUploadId();
+    $isFlat = isset($_GET['flatten']);
+
+    if ($isFlat) {
+      $options = array(UploadTreeProxy::OPT_RANGE => $itemTreeBounds);
+    } else {
+      $options = array(UploadTreeProxy::OPT_REALPARENT => $itemTreeBounds->getItemId());
+    }
+
+    // Parse search parameters from DataTables
+    $searchMap = array();
+    foreach (explode(' ', $request->get('sSearch')) as $pair) {
+      $a = explode(':', $pair);
+      if (count($a) == 1) {
+        $searchMap['head'] = $pair;
+      } else {
+        $searchMap[$a[0]] = $a[1];
+      }
+    }
+
+    if (array_key_exists('ext', $searchMap) && strlen($searchMap['ext'])>=1) {
+      $options[UploadTreeProxy::OPT_EXT] = $searchMap['ext'];
+    }
+    if (array_key_exists('head', $searchMap) && strlen($searchMap['head'])>=1) {
+      $options[UploadTreeProxy::OPT_HEAD] = $searchMap['head'];
+    }
+
+    $descendantView = new UploadTreeProxy($uploadId, $options, $itemTreeBounds->getUploadTreeTableName(), 'uberItems');
+
+    $vars['iTotalDisplayRecords'] = $descendantView->count();
+
+    $columnNamesInDatabase = array($isFlat ? 'ufile_name' : 'lft');
+    $defaultOrder = array(array(0, "asc"));
+    $orderString = $this->getObject('utils.data_tables_utility')->getSortingString($_GET, $columnNamesInDatabase, $defaultOrder);
+
+    $offset = GetParm('iDisplayStart', PARM_INTEGER);
+    $limit = GetParm('iDisplayLength', PARM_INTEGER);
+    
+    if ($offset) {
+      $orderString .= " OFFSET $offset";
+    }
+    if ($limit) {
+      $orderString .= " LIMIT $limit";
+    }
+
+    // Get files from database
+    $sql = $descendantView->getDbViewQuery()." $orderString";
+    $dbManager = $this->getObject('db.manager');
+
+    $dbManager->prepare($stmt=__METHOD__.$orderString, $sql);
+    $res = $dbManager->execute($stmt, $descendantView->getParams());
+    $descendants = $dbManager->fetchAll($res);
+    $dbManager->freeResult($res);
+
+    if (empty($descendants)) {
+      $vars['fileData'] = array();
+      return $vars;
+    }
+
+    // Process each file and extract its dependencies
+    $tableData = array();
+    foreach ($descendants as $child) {
+      if (empty($child)) {
+        continue;
+      }
+      $tableData[] = $this->createFileDataRow($child, $uploadId, $isFlat);
+    }
+
+    $vars['fileData'] = $tableData;
+    return $vars;
+  }
+
+  /**
+   * Create a single row of file data with dependencies
+   * @param array $child
+   * @param int $uploadId
+   * @param boolean $isFlat
+   * @return array
+   */
+  private function createFileDataRow($child, $uploadId, $isFlat)
+  {
+    $fileId = $child['pfile_fk'];
+    $childUploadTreeId = $child['uploadtree_pk'];
+    $rawFileName = $child['ufile_name'];
+    $fileName = htmlspecialchars($rawFileName);
+
+    // Check if this is a directory or actual file
+    $isContainer = Iscontainer($child['ufile_mode']);
+
+    if ($isContainer) {
+      $linkUri = Traceback_uri()."?mod=file_dependencies&upload=$uploadId&item=$childUploadTreeId";
+      $fileName = "<a href='$linkUri'><span style='color: darkblue'> <b>$fileName</b> </span></a>";
+      $dependencies = "<i>directory</i>";
+    } else {
+      // Parse the actual file to find dependencies
+      if (!empty($fileId)) {
+        $dependencies = $this->extractFileDependencies($fileId, $rawFileName);
+      } else {
+        $dependencies = "";
+      }
+    }
+
+    return array($fileName, $dependencies);
+  }
+
+  /**
+   * Extract dependencies from a file
+   * @param int $pfileId
+   * @param string $filename
+   * @return string HTML formatted dependencies
+   */
+  private function extractFileDependencies($pfileId, $filename)
+  {
+    // Get file content from repository
+    $dbManager = $this->getObject('db.manager');
+    
+    $sql = "SELECT pfile_sha1, pfile_size FROM pfile WHERE pfile_pk = $1";
+    $result = $dbManager->getSingleRow($sql, array($pfileId), __METHOD__);
+    
+    if (empty($result)) {
+      return "";
+    }
+
+    $pfileSha1 = $result['pfile_sha1'];
+    $pfileSize = $result['pfile_size'];
+    
+    // Only process files under 1MB to avoid performance issues
+    if ($pfileSize > 1048576) {
+      return "<i>file too large</i>";
+    }
+
+    // Construct repository path from SHA1 hash
+    // FOSSology stores files as: /srv/fossology/repository/localhost/gold/XX/YY/ZZ/HASH.*
+    // Files have timestamp extensions like: HASH.sha1.12345.67890
+    $hash = $pfileSha1;
+    $path1 = substr($hash, 0, 2);
+    $path2 = substr($hash, 2, 2);
+    $path3 = substr($hash, 4, 2);
+    
+    $repoPath = '/srv/fossology/repository/localhost/gold';
+    $dirPath = "$repoPath/$path1/$path2/$path3";
+    
+    // Use glob to find file with any extensions
+    $pattern = "$dirPath/$hash*";
+    $files = glob($pattern);
+    
+    if (empty($files)) {
+      return "";
+    }
+    
+    $content = $files[0]; // Use first match
+
+    
+    // Read file content - files are gzip compressed even without extension
+    $fileContent = @file_get_contents("compress.zlib://$content");
+    
+    if ($fileContent === false) {
+      return "";
+    }
+
+    // Use our extractor
+    $includers = $this->includerExtractor->extractIncluders($fileContent, $filename);
+
+    if (empty($includers)) {
+      return "<i>none found</i>";
+    }
+
+    // Format as HTML list
+    $output = [];
+    foreach ($includers as $inc) {
+      $type = htmlspecialchars($inc['type']);
+      $value = htmlspecialchars($inc['value']);
+      $line = $inc['line'];
+      
+      $output[] = "<span title='Line $line'><code>$value</code> ($type)</span>";
+    }
+
+    return implode(", ", $output);
+  }
+}
+
+register_plugin(new AjaxFileDependencies());

--- a/src/www/ui/template/file-dependencies.html.twig
+++ b/src/www/ui/template/file-dependencies.html.twig
@@ -1,0 +1,32 @@
+{# SPDX-FileCopyrightText: © 2026 Contribution for GSoC
+
+   SPDX-License-Identifier: FSFAP
+#}
+{% extends "include/base.html.twig" %}
+
+{% block content %}
+  <table border="0" style="padding:2px; width:100%">
+    <tr>
+      <td style="padding-left:18px; vertical-align:top; height:100%; width:75%">
+        <table border="0" id="deplist" class="semibordered">
+          <thead>
+            <tr><th></th><th></th></tr>
+          </thead>
+          <tbody></tbody>
+          <tfoot></tfoot>
+        </table>
+  
+        {{ parent() }}
+      </td>
+    </tr>
+  </table>
+{% endblock %}
+
+{% block foot %}
+  {{ parent() }}
+  <script src="scripts/jquery.dataTables.min.js" type="text/javascript"></script>
+  <script src="scripts/jquery.dataTables.select.js" type="text/javascript"></script>
+  <script type="text/javascript">
+    {% include 'file-dependencies.js.twig' %}
+  </script>
+{% endblock %}

--- a/src/www/ui/template/file-dependencies.js.twig
+++ b/src/www/ui/template/file-dependencies.js.twig
@@ -1,0 +1,53 @@
+{# SPDX-FileCopyrightText: © 2026 Contribution for GSoC
+
+   SPDX-License-Identifier: FSFAP
+#}
+
+function createDepListTable() {
+  var depListTableConfig = {
+    "bServerSide": true,
+    "sAjaxSource": "?mod=ajax_file_dependencies",
+    "fnServerData": function (sSource, aoData, fnCallback) {
+      aoData.push({"name": "upload", "value": {{ uploadId }} });
+      aoData.push({"name": "item", "value": {{ itemId }} });
+      aoData.push({"name": "totalRecords", "value": {{ iTotalRecords }} });
+      {% if isFlat %}aoData.push({"name": "flatten", "value": "yes" });{% endif %}
+      $.getJSON(sSource, aoData, fnCallback)
+        .fail(function(jqXHR, textStatus, errorThrown) {
+          console.error("Failed to load dependencies:", textStatus, errorThrown);
+        });
+    },
+    "aoColumns": [
+      {"sTitle":"File","sClass":"left"},
+      {"sTitle":"Dependencies/Includers","sClass":"left","bSortable":false}
+    ],
+    "sPaginationType": "listbox",
+    "iDisplayLength": 50,
+    "bProcessing": true,
+    "bStateSave": true,
+    "bRetrieve": true,
+    "bPaginate": true,
+    "bFilter": true,
+    "bAutoWidth": true,
+    "oLanguage": {
+      "sInfo":"Showing _START_ to _END_ of _TOTAL_ files",
+      "sSearch":'_INPUT_<button class="btn btn-default btn-sm" onclick="clearSearchFiles();" title="{{ 'Clear file filter'|trans }}" >Clear</button>',
+      "sLengthMenu":'Display <select class="form-control-sm"><option value="10">10</option><option value="25">25</option><option value="50">50</option><option value="100">100</option></select> {#
+       #}   {{ 'files'|trans }} ({% if isFlat %}<a href="{{ fileSwitch }}">{{ 'tree view'|trans }}</a> {{ 'or'|trans }} <b>{{ 'flat'|trans }}</b>{#
+       #}{% else %}<b>{{ 'tree view'|trans }}</b> {{ 'or'|trans }} <a href="{{ fileSwitch }}">{{ 'flat'|trans }}</a>{% endif %})'
+      }
+  };
+
+  otable = $('#deplist').dataTable(depListTableConfig);
+}
+
+function clearSearchFiles() {
+  var table = $('#deplist').DataTable();
+  table.search('').draw();
+}
+
+$(document).ready(function () {
+  createDepListTable();
+  $('img').tooltip();
+  $("#deplist_length select").css('text-align','right');
+});

--- a/src/www/ui/ui-file-dependencies.php
+++ b/src/www/ui/ui-file-dependencies.php
@@ -1,0 +1,130 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Contribution for GSoC
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Plugin\DefaultPlugin;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Browse file dependencies/includers
+ */
+class ui_file_dependencies extends DefaultPlugin
+{
+  const NAME = "file_dependencies";
+
+  private $uploadtree_tablename = "";
+  /** @var UploadDao */
+  private $uploadDao;
+
+  public function __construct()
+  {
+    parent::__construct(self::NAME, array(
+        self::TITLE => _("File Dependencies"),
+        self::DEPENDENCIES => array("browse", "view"),
+        self::PERMISSION => Auth::PERM_READ,
+        self::REQUIRES_LOGIN => false
+    ));
+
+    global $container;
+    $this->uploadDao = $container->get('dao.upload');
+  }
+
+  /**
+   * Register menu entries
+   */
+  function RegisterMenus()
+  {
+    $text = _("Dependencies");
+    menu_insert("Browse-Pfile::Dependencies", 30, self::NAME, $text);
+
+    // Alright, let's add this to navigation if we have upload and item params
+    $URI = $this->getName() . Traceback_parm_keep(array("upload", "item", "show"));
+
+    $Item = GetParm("item", PARM_INTEGER);
+    $Upload = GetParm("upload", PARM_INTEGER);
+    
+    if (empty($Item) || empty($Upload)) {
+      return;
+    }
+
+    $viewURI = $this->getName() . Traceback_parm_keep(array("show", "format", "page", "upload", "item"));
+    $menuName = $this->Title;
+
+    if (GetParm("mod", PARM_STRING) == self::NAME) {
+      menu_insert("Browse::$menuName", 95);
+      menu_insert("View::$menuName", 95);
+      menu_insert("View-Meta::$menuName", 95);
+    } else {
+      menu_insert("Browse::$menuName", 95, $URI, $text);
+      menu_insert("View::$menuName", 95, $viewURI, $text);
+      menu_insert("View-Meta::$menuName", 95, $viewURI, $text);
+    }
+  }
+
+  /**
+   * Handle the request
+   * @param Request $request
+   * @return Response
+   */
+  protected function handle(Request $request)
+  {
+    $upload = intval($request->get("upload"));
+    $groupId = Auth::getGroupId();
+    
+    if (!$this->uploadDao->isAccessible($upload, $groupId)) {
+      return $this->flushContent(_("Permission Denied"));
+    }
+
+    $item = intval($request->get("item"));
+    
+    $vars['baseuri'] = Traceback_uri();
+    $vars['uploadId'] = $upload;
+    $this->uploadtree_tablename = $this->uploadDao->getUploadtreeTableName($upload);
+    
+    if ($request->get('show')=='quick') {
+      $item = $this->uploadDao->getFatItemId($item, $upload, $this->uploadtree_tablename);
+    }
+    
+    $vars['itemId'] = $item;
+
+    $itemTreeBounds = $this->uploadDao->getItemTreeBounds($item, $this->uploadtree_tablename);
+    $left = $itemTreeBounds->getLeft();
+    
+    if (empty($left)) {
+      return $this->flushContent(_("Job unpack/adj2nest hasn't completed."));
+    }
+
+    $vars['micromenu'] = Dir2Browse($this->getName(), $item, NULL, $showBox = 0, "Browse", -1, '', '', $this->uploadtree_tablename);
+
+    // Count files in directory
+    $isFlat = isset($_GET['flatten']);
+    $vars['isFlat'] = $isFlat;
+    $vars['iTotalRecords'] = $this->uploadDao->countNonArtifactDescendants($itemTreeBounds, $isFlat);
+    
+    $uri = Traceback_uri().'?mod='.$this->getName().Traceback_parm_keep(array('upload','folder','show','item'));
+    $vars['fileSwitch'] = $isFlat ? $uri : $uri."&flatten=yes";
+
+    $vars['content'] = js_url();
+
+    return $this->render("file-dependencies.html.twig", $this->mergeWithDefault($vars));
+  }
+
+  /**
+   * Render template string
+   * @param string $templateName
+   * @param array $vars
+   * @return string
+   */
+  public function renderString($templateName, $vars)
+  {
+    return $this->renderer->load($templateName)->render($vars);
+  }
+}
+
+register_plugin(new ui_file_dependencies());


### PR DESCRIPTION
## Description

This PR adds a new "Dependencies" tab to the file browser that shows import and include statements from source files. Makes it easier to understand what external dependencies a package is using.

### Changes

- Added [FileIncluderExtractor](cci:2://file:///c:/Users/hp/OneDrive/Desktop/fossology/src/lib/php/Util/FileIncluderExtractor.php:12:0-236:1) utility class that parses different file types to extract import/include statements
- Created new UI plugin [ui-file-dependencies.php](cci:7://file:///c:/Users/hp/OneDrive/Desktop/fossology/src/www/ui/ui-file-dependencies.php:0:0-0:0) for the Dependencies tab
- Implemented Ajax handler [AjaxFileDependencies.php](cci:7://file:///c:/Users/hp/OneDrive/Desktop/fossology/src/www/ui/async/AjaxFileDependencies.php:0:0-0:0) to fetch and parse file contents on-the-fly  
- Added Twig templates for the tab interface with DataTables integration
- Supports parsing C/C++ (`#include`), Python (`import`/`from`), JavaScript (`require`/`import`), Go (`import`), and Dockerfile (`FROM`) statements
- Files larger than 1MB are skipped to avoid performance issues

## How to test

1. Upload a package that contains source code files (e.g., a C project, Python package, or Node.js app)
2. Browse to the uploaded files in FOSSology
3. Click on the "Dependencies" tab in the menu
4. You should see a table listing files with their detected dependencies
5. Hover over dependencies to see the line number where they appear
6. Try filtering/searching using the DataTable controls
7. Test with different file types to verify parsing works correctly

For testing different file types:
- C files should show `#include` statements
- Python files should show `import` and `from` statements  
- JavaScript files should show `require()` and ES6 imports
- Dockerfiles should show `FROM` declarations

Closes #2072