### PR TITLE
fix(db): multiple column creation due to constraint

### DIFF
--- a/install/fossinit.php
+++ b/install/fossinit.php
@@ -391,13 +391,18 @@ if($isUpdating && (empty($sysconfig['Release']) || $sysconfig['Release'] == "3.1
   $sysconfig['Release'] = "3.3.0";
 }
 
-$dbManager->begin();
-$dbManager->getSingleRow("DELETE FROM sysconfig WHERE variablename=$1",array('Release'),'drop.sysconfig.release');
-$dbManager->insertTableRow('sysconfig',
-  array('variablename'=>'Release','conf_value'=>$SysConf["BUILD"]["VERSION"],
-  'ui_label'=>'Release','vartype'=>2,'group_name'=>'Release','description'=>'')
-);
-$dbManager->commit();
+// Handle idempotency of this script by checking if the Release variable is set
+$new_version = $SysConf["BUILD"]["VERSION"] ?? '';
+if ($new_version !==''){
+  $dbManager->begin();
+  $dbManager->getSingleRow("DELETE FROM sysconfig WHERE variablename=$1",array('Release'),'drop.sysconfig.release');
+  $dbManager->insertTableRow('sysconfig',
+    array('variablename'=>'Release','conf_value'=>$SysConf["BUILD"]["VERSION"],
+    'ui_label'=>'Release','vartype'=>2,'group_name'=>'Release','description'=>'')
+  );
+  $dbManager->commit();
+}
+
 /* email/url/author data migration to other table */
 require_once("$LIBEXECDIR/dbmigrate_copyright-author.php");
 

--- a/src/lib/php/common-db.php
+++ b/src/lib/php/common-db.php
@@ -304,3 +304,41 @@ function GetLastSeq($seqname, $tablename)
   pg_free_result($result);
   return($mykey);
 }
+
+/**
+ * \brief Get constraints on a specific column.
+ *
+ * \param string $table  Table name
+ * \param string $column Column name
+ *
+ * \return array of constraint names
+ */
+function DB_ColumnConstraints($table, $column)
+{
+  global $PG_CONN;
+  $sql = "
+    SELECT con.conname
+    FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+    JOIN unnest(con.conkey) AS colnum(attnum) ON true
+    JOIN pg_attribute att
+      ON att.attrelid = rel.oid
+     AND att.attnum   = colnum.attnum
+    WHERE nsp.nspname = 'public'
+      AND rel.relname = $1
+      AND att.attname = $2
+  ";
+
+  $result = pg_query_params($PG_CONN, $sql, [$table, $column]);
+  DBCheckResult($result, $sql, __FILE__, __LINE__);
+
+  $constraints = [];
+  while ($row = pg_fetch_assoc($result)) {
+    $constraints[] = $row['conname'];
+  }
+
+  pg_free_result($result);
+  return $constraints;
+}
+

--- a/src/lib/php/libschema.php
+++ b/src/lib/php/libschema.php
@@ -310,6 +310,15 @@ class fo_libschema
             $rename = $column . '_old';
             $sql = "ALTER TABLE \"$table\" RENAME COLUMN \"$column\" TO \"$rename\"";
             $this->applyOrEchoOnce($sql);
+            // Check constraints on the renamed column
+            $constraints_on_column = DB_ColumnConstraints($table, $rename);
+            if (!empty($constraints_on_column)) {
+              // Drop constraints on the renamed column
+              foreach ($constraints_on_column as $conname) {
+                $sql = "ALTER TABLE \"$table\" DROP CONSTRAINT \"$conname\"";
+                $this->applyOrEchoOnce($sql);
+              }
+            }
           }
 
           $sql = $modification['ADD'];
@@ -354,6 +363,7 @@ class fo_libschema
     $newViews = !array_key_exists('VIEW', $this->currSchema);
     foreach ($this->schema['VIEW'] as $name => $sql) {
       if (empty($name) || (!$newViews &&
+          array_key_exists($name, $this->currSchema['VIEW']) &&
           $this->currSchema['VIEW'][$name] == $sql)) {
         continue;
       }
@@ -990,7 +1000,6 @@ class fo_libschema
     fclose($fout);
     return false;
   }
-
 
   /**
    * \brief Create any required DB functions.


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Multi Column creation due to constraints was hitting PHP Fatal error on few fossology database tables. Postgres was throwing error due to 1600 max column limitation hitting.

### Changes

1. `src/lib/php/common-db.php` : internal helper function to check constraints on a specific column of a table
2. `src/lib/php/libschema.php` : Logic to drop constraints before trying to drop the "_old" column
3. `install/fossinit.php`: due to lack of version file in docker based deployment, handling the VERSION variable gracefully. (Extra)

Closes #1809

cc: @GMishx @shaheemazmalmmd 
