### PR TITLE
Docs: Add php.ini upload limit instruction (Fixes #3235)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,3 +211,6 @@ the GNU Lesser General Public License version 2.1, [LGPL-2.1](<https://tldrlegal
 
 Please see the LICENSE file included with this software for the full texts of
 these licenses.
+
+**Note:** Regardless of the installation type, ensure you increase `upload_max_filesize` and `memory_limit` in your `php.ini` configuration to handle large uploads.
+ See [Configuring PHP](https://github.com/fossology/fossology/wiki/Configuring-PHP) in the wiki for details.


### PR DESCRIPTION
## Description
Added a note in `README.md` to guide users about increasing `upload_max_filesize` and `memory_limit` in `php.ini`. This helps resolve issues with large file uploads during local installation on Windows/Linux.

### Changes
* Updated `README.md` installation section.
* Added a warning note regarding PHP configuration.

## How to test
1. Open `README.md`.
2. Scroll down to the Installation section.
3. Verify that the note about `php.ini` is present.

Closes #3235