### PR TITLE
fix(config): update TLD regex length in copyright.conf

### DIFF
--- a/src/copyright/agent/copyright.conf
+++ b/src/copyright/agent/copyright.conf
@@ -7,7 +7,7 @@
 # Description: this file holds the regex configurations for the Copyright agent
 url=(?:(?:ht|f)tps?://[^\s<>\"'`\[\]{}\\|\^]+?)(?=[\s<>\"'`\[\]{}\\]|$)
 EMAILPART=[\w\-\.\+]{1,100}
-TLD=[a-zA-Z]{2,12}(?<!test)(?<!invalid)
+TLD=[a-zA-Z]{2,24}(?<!test)(?<!invalid)
 email=[\<\(]?(__EMAILPART__@__EMAILPART__\.__TLD__)(?<!example\.(com|net|org))[\>\)]?
 website=(?:http|https|ftp)\://[a-zA-Z0-9\-\.]+\.__TLD__(?<!example\.(com|net|org))(:[a-zA-Z0-9]*)?/?([a-zA-Z0-9\-\._\?\,'/\\+&amp;%\$#\=~])*[^\.\,\)\(\s]
 #' <-- to solve syntax highlighting problems in some editors


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Extend the allowed top-level domain (TLD) length used by the Copyright agent regex to support modern gTLDs.

### Changes

- Expanded the TLD regex length from {2,12} to {2,24}.

## How to test

Describe the steps required to test the changes proposed in the pull request.

Run the Copyright agent on a repository or file containing:
- An email address using a long gTLD (e.g. user@company.international)

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)

Check it out: 
- [gTLD](https://data.iana.org/TLD/tlds-alpha-by-domain.txt)
