### PR TITLE
test(rest): part 1 — document REST API PHPUnit tests and clean test output

### DIFF
--- a/src/www/ui_tests/api/Controllers/FolderControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/FolderControllerTest.php
@@ -1234,7 +1234,6 @@ namespace Fossology\UI\Api\Test\Controllers
       $this->folderContentPlugin->shouldReceive('handle');
 
       $actualResponse = $this->folderController->getUnlinkableFolderContents(null,new ResponseHelper(),["id" => $id]);
-      var_dump($actualResponse);
       $this->assertEquals(200,$actualResponse->getStatusCode());
     }
 

--- a/src/www/ui_tests/api/Controllers/JobControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/JobControllerTest.php
@@ -16,6 +16,7 @@ use Fossology\Lib\Dao\JobDao;
 use Fossology\Lib\Dao\ShowJobsDao;
 use Fossology\UI\Api\Controllers\JobController;
 use Fossology\UI\Api\Exceptions\HttpNotFoundException;
+use Fossology\UI\Api\Exceptions\HttpBadRequestException;
 use Fossology\UI\Api\Helper\ResponseHelper;
 use Fossology\UI\Api\Models\ApiVersion;
 use Fossology\UI\Api\Models\Job;
@@ -362,6 +363,28 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
     $result = $method->invokeArgs($this->jobController,
       [$completedJob, $completedUpload]);
     $this->assertEquals(0, $result);
+  }
+
+    /**
+   * @test
+   * -# Test JobController::getJobs() with invalid limit/page
+   * -# Check if response is 400
+   */
+  public function testGetJobsInvalidLimitOrPage()
+  {
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('limit', '-1');
+    $body = $this->streamFactory->createStream();
+    $request = new Request("GET", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+
+    $response = new ResponseHelper();
+
+    $userId = 2;
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+
+    $this->expectException(HttpBadRequestException::class);
+    $this->jobController->getJobs($request, $response, []);
   }
 
 }

--- a/src/www/ui_tests/api/README.md
+++ b/src/www/ui_tests/api/README.md
@@ -1,0 +1,20 @@
+<!-- SPDX-FileCopyrightText: © Fossology contributors
+     SPDX-License-Identifier: GPL-2.0-only
+-->
+
+# REST API PHPUnit tests
+
+This directory contains PHPUnit tests for the REST API controllers, helpers and models.
+
+## Prerequisites
+
+- PHP with required extensions for Fossology
+- Composer dependencies installed in `src/` (so `src/vendor/` exists)
+
+## Run only the REST API test suite
+
+From the `src/` directory:
+
+```sh
+php vendor/bin/phpunit -c www/ui_tests/api/tests.xml --testsuite "Fossology PhpUnit REST API"
+```


### PR DESCRIPTION
Related to #1590  (Part 1)

## Description
Part 1 of the REST API test improvements: establish a clean, easy-to-run baseline for existing REST API PHPUnit tests by documenting the run command and removing stray debug output.

## Changes
- Added `src/www/ui_tests/api/README.md` documenting how to run the REST API PHPUnit suite locally
- Removed leftover `var_dump()` debug output from `FolderControllerTest.php`

## Tested locally
- [x] Ran REST API PHPUnit suite:
  - `php vendor/bin/phpunit -c www/ui_tests/api/tests.xml --testsuite "Fossology PhpUnit REST API"`

## How to test
From the `src/` directory:
```sh
php vendor/bin/phpunit -c www/ui_tests/api/tests.xml --testsuite "Fossology PhpUnit REST API"
