### PR TITLE
fix(docker): ensure REPODIR has setgid group permissions

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,6 +11,13 @@
 
 set -o errexit -o nounset -o pipefail
 
+# Ensure repository directory permissions (setgid for group inheritance)
+# Do not hardcode or create REPODIR here; only adjust permissions if it is configured and exists.
+if [ -n "${FOSSOLOGY_REPO_PATH:-}" ] && [ -d "$FOSSOLOGY_REPO_PATH" ]; then
+  chgrp fossy "$FOSSOLOGY_REPO_PATH" 2>/dev/null || true
+  chmod 2770 "$FOSSOLOGY_REPO_PATH" 2>/dev/null || true
+fi
+
 db_host="${FOSSOLOGY_DB_HOST:-localhost}"
 db_name="${FOSSOLOGY_DB_NAME:-fossology}"
 db_user="${FOSSOLOGY_DB_USER:-fossy}"


### PR DESCRIPTION
Fixes #1115

## Description
Ensure the repository directory used by FOSSology Docker containers
(`/srv/fossology/repository`) always has correct **group ownership** and the **setgid**
bit so new files inherit the `fossy` group. This prevents permission issues on fresh
installs and on NFS/EFS-backed volumes where group inheritance can be missing.

The change is **idempotent** and safe to run on every container start.

## Changes
- Ensure `/srv/fossology/repository` exists on startup
- Set group owner to `fossy` (non-fatal if `chgrp` cannot be applied in some envs)
- Apply `2770` permissions to enable setgid group inheritance

## Local testing
- [x] `docker compose down`
- [x] `docker compose up -d --build`
- [x] Verified repo directory perms inside container:
  - [x] `ls -ld /srv/fossology/repository` shows `drwxrws---`
  - [x] `stat -c '%A %U %G %n' /srv/fossology/repository` shows group `fossy`
- [x] `docker compose restart`
- [x] Re-verified permissions after restart (idempotency check)


## How to test
1. Rebuild and start:
   ```bash
   docker compose up -d --build
2. Exec into the running container (pick fossology-web-1 or any fossology-* container):
   ```bash
   docker ps --format "table {{.Names}}\t{{.Status}}"
   docker exec -it fossology-web-1 bash
3. Check repository permissions:
   ```bash
   ls -ld /srv/fossology/repository
   stat -c '%A %U %G %n' /srv/fossology/repository
4. Expected:

- Directory mode includes setgid: drwxrws---
- Group is fossy

5. Restart and confirm it stays the same:
   ```bash
   exit
   docker compose restart
   docker exec -it fossology-web-1 bash -lc "ls -ld /srv/fossology/repository && stat -c '%A %U %G %n' 
   /srv/fossology/repository"

