### PR TITLE
docs(ui): clarify current UI directory structure

### DIFF
--- a/src/www/ui/README.txt
+++ b/src/www/ui/README.txt
@@ -2,6 +2,24 @@ SPDX-FileCopyrightText: © 2008 Hewlett-Packard Development Company, L.P.
 
 SPDX-License-Identifier: GPL-2.0-only
 
+UI directory structure (current source tree)
+
+The legacy documentation may refer to paths like ui/common, ui/plugins, ui/template.
+In the current Fossology source tree, the classic web UI lives under:
+
+  src/www/ui/
+
+High-level overview of commonly present UI subdirectories:
+  src/www/ui/              - UI plugins (PHP)
+  src/www/ui/template/     - Twig templates
+  src/www/ui/images/       - UI images/assets
+  src/www/ui/css/          - UI stylesheets
+  src/www/ui/scripts/      - UI JavaScript
+
+This list provides a high-level orientation of the UI layout.
+Other subdirectories may exist and evolve over time as the UI implementation
+changes. The src/www/ui/ directory itself is the authoritative reference.
+
 Plugins have prefixes for maintenance convenience.
   "core-"  :: These are core plugins that are used by other plugins.
               Core plugins may not generate any UI output.
@@ -16,7 +34,7 @@ functionality or implementation.
 
 All plugins must end with ".php" in order to be loaded.
 The load order:
-  - Initialize(): called in indeterminant order.  This function must NOT
+  - Initialize(): called in indeterminate order.  This function must NOT
     depend on other plugins.  (In most cases, stick with the template so
     it won't do anything.)
   - Then plugins are sorted:
@@ -27,4 +45,3 @@ The load order:
       that depend on them.
   - After sorting, PostInitialize() is called. This can use any dependent
     modules.
-


### PR DESCRIPTION
Fixes #1953

### Description
The UI architecture documentation referenced legacy paths (e.g. `ui/common`, `ui/plugins`)
that no longer exist in the current Fossology source tree. This caused confusion for
contributors trying to locate the UI code.

This PR clarifies where the classic web UI actually lives today and documents the
current source-of-truth paths.

### Changes
- Documented the current UI location under `src/www/ui/`
- Added a short directory map explaining common UI subdirectories
- Clarified that older `ui/*` paths are legacy references

### Tested locally
- [x] Verified file formatting and SPDX headers
- [x] Confirmed paths reflect current repository layout
- [x] No runtime or build changes (documentation-only)

### How to Test
1. Open `src/www/ui/README.txt`
2. Review the “UI directory structure (current source tree)” section
3. Confirm that paths correctly point to `src/www/ui/` and related subdirectories

No functional or behavioral changes are introduced.
