### PR TITLE
fix(cli): remove unconditional exit causing unreachable code

### DIFF
--- a/src/cli/fo_tagfoss.php
+++ b/src/cli/fo_tagfoss.php
@@ -72,7 +72,7 @@ while ($row = pg_fetch_assoc($result)) {
     $ToAntelink = array();
   }
 }
-exit;
+
 if (count($ToAntelink)) {
   $TaggedFileCount += QueryTag($ToAntelink, $tag_pk, $PrintOnly);
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fixes an unconditional `exit;` in a CLI script that caused remaining batch processing and the final summary output to be unreachable.

### Changes

- Removed an unconditional `exit;` that prematurely terminated execution in `src/cli/fo_tagfoss.php`.

## How to test


1. Run the `fo_tagfoss.php` CLI script on an upload containing more than one batch of files.
2. Verify that:
   - The final batch is processed.
   - The summary output is printed at the end.


Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)
