### PR TITLE
fix(delagent): improve email notification message for deleted uploads

### DIFF
--- a/src/scheduler/agent/job.c
+++ b/src/scheduler/agent/job.c
@@ -178,6 +178,7 @@ job_t* job_init(GTree* job_list, GSequence* job_queue,
   job->lock            = NULL;
   job->idx             = 0;
   job->message         = NULL;
+  job->upload_name     = NULL;
   job->priority        = priority;
   job->verbose         = 0;
   job->parent_id       = parent_id;
@@ -223,6 +224,7 @@ void job_destroy(job_t* job)
   g_list_free(job->finished_agents);
   g_list_free(job->failed_agents);
   g_free(job->message);
+  g_free(job->upload_name);
   g_free(job->agent_type);
   g_free(job->required_host);
   g_free(job->data);

--- a/src/scheduler/agent/job.h
+++ b/src/scheduler/agent/job.h
@@ -66,13 +66,14 @@ typedef struct
     uint32_t   idx;       ///< The current index into the sql results
 
     /* information about job status */
-    gchar*   message;   ///< Message that will be sent with job notification email
-    int32_t  priority;  ///< Importance of the job, maps directory to unix priority
-    int32_t  verbose;   ///< The verbose level for all of the agents in this job
-    int32_t  parent_id; ///< The identifier for the parent of this job (its queue id)
-    int32_t  id;        ///< The identifier for this job
-    int32_t  user_id;   ///< The id of the user that created the job
-    int32_t  group_id;  ///< The id of the group that created the job
+    gchar*   message;      ///< Message that will be sent with job notification email
+    gchar*   upload_name;  ///< Name of the upload associated with this job (used for delagent)
+    int32_t  priority;     ///< Importance of the job, maps directory to unix priority
+    int32_t  verbose;      ///< The verbose level for all of the agents in this job
+    int32_t  parent_id;    ///< The identifier for the parent of this job (its queue id)
+    int32_t  id;           ///< The identifier for this job
+    int32_t  user_id;      ///< The id of the user that created the job
+    int32_t  group_id;     ///< The id of the group that created the job
 } job_t;
 
 /* ************************************************************************** */


### PR DESCRIPTION
When delagent deletes an upload, the scheduler generates a confirmation email. Previously, the email contained a confusing generic message showing the job ID instead of the actual upload name, especially when the upload had already been deleted from the database.

This commit:
- Adds an 'upload_name' field to the job_t structure to store the upload filename before deletion
- Fetches and stores the upload name when a delagent job is created
- Updates the email notification message to display the upload name instead of the job ID when available
- Falls back to the generic message only if the upload name is not available

Fixes #249: delagent confusing status message

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Please describe the changes in your pull request in few words here.

### Changes

List the changes done to fix a bug or introducing a new feature.

## How to test

Describe the steps required to test the changes proposed in the pull request.

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)
