### PR TITLE
fix(ui): avoid crash when job queue failure callback is undefined

### DIFF
--- a/src/www/ui/scripts/job-queue-poll.js
+++ b/src/www/ui/scripts/job-queue-poll.js
@@ -20,9 +20,15 @@ function updateCheckSuccess(data) {
       return null;
     }
     else if ((data[jqId]) && (data[jqId].end_bits > 1)) {
+    if (typeof callbackfail === "function") {
       callbackfail(jqId);
+      } 
+    else {
+      console.warn("Job failed but no failure callback provided. Job ID: ", jqId);
+      }
       return null;
     }
+    
     else {
       return val;
     }


### PR DESCRIPTION
### Summary

The job queue polling code assumes that a failure callback is always present and
invokes it unconditionally when a job finishes with a failure state.

In some cases, only a success callback is provided. When such a job fails, this
leads to a runtime JavaScript error (`callbackfail is not a function`) and
disrupts the UI.

### Fix

This change verifies that a failure callback exists before calling it. If no
failure callback is provided, the failure is handled gracefully without causing
a JavaScript error or breaking the UI.

### Related Issue


Since this is first PR, according to new rules , proof of installation->
<img width="1864" height="734" alt="image" src="https://github.com/user-attachments/assets/e18c0b6e-f4d9-40f5-8ed2-74f815f9e81a" />
<img width="917" height="682" alt="image" src="https://github.com/user-attachments/assets/0488acf7-d856-49d1-9193-ca5d4ed5bdda" />


Fixes #1595
