### PR TITLE
Fix: Allow clearing Upload Description and Comment fields

### DIFF
--- a/src/www/ui/admin-upload-edit.php
+++ b/src/www/ui/admin-upload-edit.php
@@ -46,7 +46,7 @@ class upload_properties extends FO_Plugin
    **/
   public function UpdateUploadProperties($uploadId, $newName, $newDesc)
   {
-    if (empty($newName) and empty($newDesc)) {
+    if (is_null($newName) && is_null($newDesc)) {
       return 2;
     }
 
@@ -74,7 +74,7 @@ class upload_properties extends FO_Plugin
         __METHOD__ . '.updateUpload.name');
     }
 
-    if (! empty($newDesc)) {
+    if (!is_null($newDesc)) {
       $trimNewDesc = trim($newDesc);
       $this->dbManager->getSingleRow("UPDATE upload SET upload_desc=$2 WHERE upload_pk=$1",
         array($uploadId, $trimNewDesc), __METHOD__ . '.updateUpload.desc');
@@ -94,9 +94,9 @@ class upload_properties extends FO_Plugin
       $folder_pk = $rootFolder->getId();
     }
 
-    $NewName = GetArrayVal("newname", $_POST);
-    $NewDesc = GetArrayVal("newdesc", $_POST);
-    $upload_pk = GetArrayVal("upload_pk", $_POST);
+    $NewName = GetParm("newname", PARM_TEXT);
+    $NewDesc = GetParm("newdesc", PARM_TEXT);
+    $upload_pk = GetParm("upload_pk", PARM_INTEGER);
     if (empty($upload_pk)) {
       $upload_pk = GetParm('upload', PARM_INTEGER);
     }

--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -734,8 +734,7 @@ class UploadController extends RestController
     // Handle update of description
     if (
       $isJsonRequest &&
-      array_key_exists("uploadDescription", $bodyContent) &&
-      strlen(trim($bodyContent["uploadDescription"])) > 0
+      array_key_exists("uploadDescription", $bodyContent)
     ) {
       $newDescription = trim($bodyContent["uploadDescription"]);
     }

--- a/src/www/ui/async/AjaxBrowse.php
+++ b/src/www/ui/async/AjaxBrowse.php
@@ -88,7 +88,7 @@ class AjaxBrowse extends DefaultPlugin
     } else if (! empty($uploadId) && ! empty($direction)) {
       $uploadBrowseProxy = new UploadBrowseProxy($groupId, $this->userPerm, $this->dbManager);
       $uploadBrowseProxy->moveUploadToInfinity($uploadId, $direction == 'top');
-    } else if (!empty($uploadId) && !empty($commentText) && !empty($statusId)) {
+    } else if (!empty($uploadId) && !is_null($commentText) && !empty($statusId)) {
       $uploadBrowseProxy = new UploadBrowseProxy($groupId, $this->userPerm, $this->dbManager);
       $uploadBrowseProxy->setStatusAndComment($uploadId, $statusId, $commentText);
     } else {


### PR DESCRIPTION
Fixes #6435

- In admin-upload-edit.php, allow empty strings for description by using is_null check and GetParm.
- In AjaxBrowse.php, allow empty comments by using is_null check.
- In UploadController.php, allow empty descriptions via API.

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Please describe the changes in your pull request in few words here.

### Changes

List the changes done to fix a bug or introducing a new feature.

## How to test

Describe the steps required to test the changes proposed in the pull request.

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)
