### PR TITLE
refactor(spdx): use combined operators for concatenation

### DIFF
--- a/src/spdx/agent/spdx.php
+++ b/src/spdx/agent/spdx.php
@@ -300,16 +300,16 @@ class SpdxAgent extends Agent
           $fileName .= ".txt";
           break;
         case "spdx3jsonld":
-          $fileName = $fileName .".jsonld";
+          $fileName .= ".jsonld";
           break;
         case "spdx3json":
-          $fileName = $fileName .".json";
+          $fileName .= ".json";
           break;
         case "spdx3rdf":
-          $fileName = $fileName .".spdx.rdf";
+          $fileName .= ".spdx.rdf";
           break;
         case "spdx3tv":
-          $fileName = $fileName .".spdx";
+          $fileName .= ".spdx";
           break;
       }
       $this->filebasename = $fileName;

--- a/src/testing/dataFiles/mailTo.php
+++ b/src/testing/dataFiles/mailTo.php
@@ -21,4 +21,4 @@ $others = "bob.gobeille@hp.com dong.ma@hp.com alex.dav.norton@hp.com  yao-bin.sh
 
 // the whole team, comment out as needed
 
-$mailTo = $mailTo . $others;
+$mailTo .= $others;


### PR DESCRIPTION
Refactored string concatenation in `src/spdx/agent/spdx.php` to use the combined operator (`.=`) instead of long-form assignment.

This change improves code readability and cleaner syntax.

Fixes #2121