### PR TITLE
fix(ui): improve ajax error messages

### DIFF
--- a/src/copyright/ui/template/copyrighthist_scripts.html.twig
+++ b/src/copyright/ui/template/copyrighthist_scripts.html.twig
@@ -23,7 +23,17 @@
         $("#deleteHashDecision" + type + hash).hide();
         $("#undoDeleteHashDecision" + type + hash).attr("style","display:inline !important;");
       },
-      error: function() { alert('error'); }
+      error: function(xhr, status, error) {
+        var errorMessage = 'Failed to delete hash decision';
+        if (xhr.responseJSON && xhr.responseJSON.error) {
+          errorMessage += ': ' + xhr.responseJSON.error;
+        } else if (xhr.responseText) {
+          errorMessage += ': ' + xhr.responseText;
+        } else {
+          errorMessage += ': ' + error;
+        }
+        alert(errorMessage);
+      }
     });
   }
 
@@ -40,7 +50,17 @@
         $("#undoDeleteHashDecision" + type + hash).hide();
         $("#deleteHashDecision" + type + hash).attr("style","display:inline !important;");
       },
-      error: function() { alert('error'); }
+      error: function(xhr, status, error) {
+        var errorMessage = 'Failed to undo hash decision';
+        if (xhr.responseJSON && xhr.responseJSON.error) {
+          errorMessage += ': ' + xhr.responseJSON.error;
+        } else if (xhr.responseText) {
+          errorMessage += ': ' + xhr.responseText;
+        } else {
+          errorMessage += ': ' + error;
+        }
+        alert(errorMessage);
+      }
     });
   }
 

--- a/src/copyright/ui/template/ui-xp-view_rhs.html.twig
+++ b/src/copyright/ui/template/ui-xp-view_rhs.html.twig
@@ -115,7 +115,17 @@
           $("#actionsOf" + pk + " .basicActions").hide();
           $("#actionsOf" + pk + " .undoActions").attr("style","display:inline !important;");
         },
-        error: function() { alert('error'); }
+        error: function(xhr, status, error) {
+          var errorMessage = 'Failed to delete decision';
+          if (xhr.responseJSON && xhr.responseJSON.error) {
+            errorMessage += ': ' + xhr.responseJSON.error;
+          } else if (xhr.responseText) {
+            errorMessage += ': ' + xhr.responseText;
+          } else {
+            errorMessage += ': ' + error;
+          }
+          alert(errorMessage);
+        }
       });
     }
 
@@ -132,7 +142,17 @@
           $("#actionsOf" + pk + " .basicActions").attr("style","display:inline !important;");
           $("#actionsOf" + pk + " .undoActions").hide();
         },
-        error: function() { alert('error'); }
+        error: function(xhr, status, error) {
+          var errorMessage = 'Failed to undo decision';
+          if (xhr.responseJSON && xhr.responseJSON.error) {
+            errorMessage += ': ' + xhr.responseJSON.error;
+          } else if (xhr.responseText) {
+            errorMessage += ': ' + xhr.responseText;
+          } else {
+            errorMessage += ': ' + error;
+          }
+          alert(errorMessage);
+        }
       });
     }
   </script>

--- a/src/www/ui/template/admin_license_candidate.html.twig
+++ b/src/www/ui/template/admin_license_candidate.html.twig
@@ -92,7 +92,17 @@
                 });
               }
             },
-            error: function() { alert('error'); }
+            error: function(xhr, status, error) {
+              var errorMessage = 'Failed to load license text';
+              if (xhr.responseJSON && xhr.responseJSON.error) {
+                errorMessage += ': ' + xhr.responseJSON.error;
+              } else if (xhr.responseText) {
+                errorMessage += ': ' + xhr.responseText;
+              } else {
+                errorMessage += ': ' + error;
+              }
+              alert(errorMessage);
+            }
           });
           },
         Cancel: function() {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Improved AJAX error handling in UI templates.
Earlier, failed AJAX requests only showed a generic alert('error'), which was not helpful for users or debugging.
Now the alerts show a meaningful message along with server-provided error details when available.

### Changes

Replaced generic alert('error') in AJAX error callbacks with detailed error messages.

Added operation-specific error context (e.g., delete/undo decision, load license text).

Shows backend error from xhr.responseJSON.error or fallback to xhr.responseText.

## How to test

Navigate to the affected UI pages (delete/undo decision flows, license candidate/admin actions).

Simulate an AJAX failure (example: stop the backend service or make the endpoint return an error).

Trigger the related action and verify:

Instead of a generic error alert, a detailed message is shown.

If the server returns an error response, it is included in the alert message.

Note: This PR is not linked to an existing GitHub issue.
