### PR TITLE
fix(api): align POST /uploads response with OpenAPI schema

### DIFF
--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -526,10 +526,10 @@ class UploadController extends RestController
       $info =  $uploadHelper->handleScheduleAnalysis(intval($uploadId),
         intval($folderId), $scanOptions, true);
       if ($info->getCode() == 201) {
-        $info = new Info($info->getCode(), intval($uploadId), $info->getType());
+        $info = new Info($info->getCode(), (string)($uploadId), $info->getType());
       }
     } else {
-      $info = new Info(201, intval($uploadId), InfoType::INFO);
+      $info = new Info(201, (string)($uploadId), InfoType::INFO);
     }
     if (array_key_exists("mainLicense", $reqBody) &&
         ! empty($reqBody["mainLicense"])) {


### PR DESCRIPTION
## OpenAPI mismatch for `POST /uploads` response
Fixes #1683
### 🐞 Problem
When making a `POST` request to `/uploads`, the API returns the upload ID in the `message` field as an **integer**.  
However, according to `openapi.yaml`, the `message` field in the `Info` object is defined as a **string**.

This causes a mismatch between the documented API schema and the actual runtime behavior.

### 📍 Root Cause
In `UploadController::postUpload`, the upload ID was passed as an integer when creating the `Info` response object.

### ✅ Solution
Ensure the upload ID is **always returned as a string** by explicitly casting it before creating the `Info` object.

This aligns the runtime response with the OpenAPI specification and keeps ID types consistent across endpoints.
<img width="407" height="48" alt="image" src="https://github.com/user-attachments/assets/ab5894a8-e4fa-42d5-be59-92dfcd38dc76" />





