### PR TITLE
feat(driver): implement existsColumn method for SQLite

### DIFF
--- a/src/lib/php/Db/Driver/SqliteE.php
+++ b/src/lib/php/Db/Driver/SqliteE.php
@@ -94,7 +94,7 @@ class SqliteE implements Driver
    */
   public function getLastError()
   {
-    return SQLite3::lastErrorMsg();
+    return $this->dbConnection->lastErrorMsg();
   }
 
   /**
@@ -189,7 +189,7 @@ class SqliteE implements Driver
   public function existsTable($tableName)
   {
     $sql = "SELECT count(*) cnt FROM sqlite_master WHERE type='table' AND name='$tableName'";
-    $row = SQLite3::querySingle($sql);
+    $row = $this->dbConnection->querySingle($sql, true);
     if (! $row && $this->isConnected()) {
       throw new \Exception($this->getLastError());
     } else if (!$row) {
@@ -205,8 +205,18 @@ class SqliteE implements Driver
    */
   public function existsColumn($tableName, $columnName)
   {
-    // TODO: Implement existsColumn() method.
-    throw new \Exception("Method not implemented yet!");
+    $sql = "PRAGMA table_info($tableName)";
+    $result = $this->query($sql);
+
+    while ($row = $this->fetchArray($result)) {
+      if ($row['name'] === $columnName) {
+        $this->freeResult($result);
+        return true;
+      }
+    }
+
+    $this->freeResult($result);
+    return false;
   }
 
   /**
@@ -220,6 +230,6 @@ class SqliteE implements Driver
     $this->prepare($stmt,$sql);
     $res = $this->execute($stmt,$params);
     $this->freeResult($res);
-    return SQLiteDatabase::lastInsertRowid();
+    return $this->dbConnection->lastInsertRowid();
   }
 }

--- a/src/lib/php/Test/test/TestLiteDbTest.php
+++ b/src/lib/php/Test/test/TestLiteDbTest.php
@@ -37,4 +37,24 @@ class TestLiteDbTest extends \PHPUnit\Framework\TestCase
     assertThat($tag1,hasKey('perm'));
     assertThat($tag1['perm'],is(10));
   }
+
+  /**
+   * Test existsColumn functionality
+   */
+  public function testExistsColumn()
+  {
+    $testDb = new TestLiteDb();
+    // Use existing helper to create the standard 'tag' table
+    $testDb->createPlainTables(array('tag'));
+    $dbManager = $testDb->getDbManager();
+
+    // Check 1: 'tag_pk' column should exist in 'tag' table
+    $this->assertTrue($dbManager->existsColumn('tag', 'tag_pk'), "Column 'tag_pk' should exist");
+
+    // Check 2: 'tag_desc' column should exist in 'tag' table
+    $this->assertTrue($dbManager->existsColumn('tag', 'tag_desc'), "Column 'tag_desc' should exist");
+
+    // Check 3: 'dummy' column should NOT exist
+    $this->assertFalse($dbManager->existsColumn('tag', 'dummy'), "Column 'dummy' should NOT exist");
+  }
 }


### PR DESCRIPTION
Implemented the `existsColumn` method in `SqliteE.php` using `PRAGMA table_info`.
This resolves the TODO comment to implement this missing method.
