### PR TITLE
fix(util): make StringOperation::getCommonHead UTF-8 multibyte-safe

### DIFF
--- a/src/lib/php/Util/StringOperation.php
+++ b/src/lib/php/Util/StringOperation.php
@@ -17,15 +17,37 @@ class StringOperation
    */
   public static function getCommonHead($a, $b)
   {
+
+    if (function_exists('mb_strlen')) {
+      $encoding = 'UTF-8';
+      $headLength = 0;
+
+      $maxNumberOfCharsToCompare = min(
+        mb_strlen($a, $encoding),
+        mb_strlen($b, $encoding)
+      );
+
+      while ($headLength < $maxNumberOfCharsToCompare &&
+        mb_substr($a, $headLength, 1, $encoding) === mb_substr($b, $headLength, 1, $encoding)
+      ) {
+        $headLength++;
+      }
+
+      return mb_substr($a, 0, $headLength, $encoding);
+    }
+
     $headLength = 0;
     $maxNumberOfCharsToCompare = min(strlen($a), strlen($b));
-    while ($headLength < $maxNumberOfCharsToCompare &&
-      $a[$headLength] === $b[$headLength]) {
-      $headLength += 1;
-    }
-    return substr($a,0,$headLength);
-  }
 
+    while (
+      $headLength < $maxNumberOfCharsToCompare &&
+      $a[$headLength] === $b[$headLength]
+    ) {
+      $headLength++;
+    }
+
+    return substr($a, 0, $headLength);
+  }
   /**
    * Replace any non-printable characters with a given character
    * @param string $input   String to clean


### PR DESCRIPTION
## Description
### Problem

`StringOperation::getCommonHead()` previously compared strings **byte-by-byte**, which could lead to incorrect prefix detection for UTF-8 multibyte strings.
---

### Changes

- Make `StringOperation::getCommonHead()` UTF-8 multibyte-safe using `mb_*`
  functions when available
- Preserve existing byte-based behavior as a fallback for compatibility
- Add a regression test covering UTF-8 input

### Testing

- To validate the behavior difference between the old byte-based implementation
and the new multibyte-safe implementation, I used an emoji (`😀`) and a
truncated version of it


- In real-world scenarios (e.g., partial file reads, interrupted uploads, or corrupted input), a string may end inside a multibyte sequence. In such cases, byte-wise comparison can return a prefix that ends within a UTF-8 codepoint, producing invalid UTF-8 output.

- The old byte-based implementation compares raw bytes and can therefore
return a prefix that ends inside a multibyte character, producing
invalid UTF-8 output.

- The new implementation compares complete characters using `mb_*`
functions and avoids splitting inside character boundaries.



<img width="686" height="437" alt="image" src="https://github.com/user-attachments/assets/e4bd6633-fe7b-4779-9037-42d3a2a98b65" />


### With old code->
<img width="907" height="126" alt="image" src="https://github.com/user-attachments/assets/e019b184-2bb1-471c-9fdc-3e2854d1dd2f" />

### With the changes in PR->
<img width="946" height="211" alt="image" src="https://github.com/user-attachments/assets/3eec0a23-58cd-479c-93ad-28e631b4a421" />

