### PR TITLE
fix(nomos): make license identifiers SPDX compliant

### DIFF
--- a/install/db/dbmigrate_4.6-4.7.php
+++ b/install/db/dbmigrate_4.6-4.7.php
@@ -1,0 +1,130 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Siemens AG
+ SPDX-FileContributor: Krrish Biswas <krrishbiswas175@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Migrate DB from release 4.6.0 to 4.7.0
+ *
+ * Renames legacy FOSSology license shortnames to their SPDX-compliant
+ * equivalents using the SPDX "WITH" operator for license exceptions.
+ *
+ * References:
+ *   - SPDX License List: https://spdx.org/licenses/
+ *   - SPDX Exceptions: https://spdx.org/licenses/exceptions-index.html
+ *   - Issue #3158
+ */
+
+use Fossology\Lib\Db\DbManager;
+
+/**
+ * Migration from FOSSology 4.6.0 to 4.7.0
+ * @param DbManager $dbManager
+ * @param bool $verbose Verbose?
+ */
+function Migrate_46_47(DbManager $dbManager, $verbose = false): void
+{
+  if (!$dbManager->existsTable('license_ref')) {
+    return;
+  }
+
+  $shortname_array = array(
+    /* old_shortname => new_shortname */
+
+    /* ── Miscellaneous renames ─────────────────────────────────────── */
+    'Alliance for Open Media Patent License 1.0' => 'AOM-Patent-1.0',
+    'unRAR restriction'  => 'unRAR-restriction',
+    'M+'                 => 'M-Plus',
+
+    /* ── GPL-2.0 "or-later" (+) with exception ─────────────────────── */
+    'GPL-2.0+-with-bison-exception'
+        => 'GPL-2.0-or-later WITH Bison-exception-2.2',
+    'GPL-2.0+-with-classpath-exception'
+        => 'GPL-2.0-or-later WITH Classpath-exception-2.0',
+
+    /* ── GPL-2.0 "only" with exception ─────────────────────────────── */
+    'GPL-2.0-with-autoconf-exception'
+        => 'GPL-2.0-only WITH Autoconf-exception-3.0',
+    'GPL-2.0-with-bison-exception'
+        => 'GPL-2.0-only WITH Bison-exception-2.2',
+    'GPL-2.0-with-classpath-exception'
+        => 'GPL-2.0-only WITH Classpath-exception-2.0',
+    'GPL-2.0-with-font-exception'
+        => 'GPL-2.0-only WITH Font-exception-2.0',
+    'GPL-2.0-with-GCC-exception'
+        => 'GPL-2.0-only WITH GCC-exception-3.1',
+
+    /* ── GPL-3.0 "or-later" (+) with exception ─────────────────────── */
+    'GPL-3.0+-with-bison-exception'
+        => 'GPL-3.0-or-later WITH Bison-exception-2.2',
+    'GPL-3.0+-with-classpath-exception'
+        => 'GPL-3.0-or-later WITH Classpath-exception-2.0',
+
+    /* ── GPL-3.0 "only" with exception ─────────────────────────────── */
+    'GPL-3.0-with-autoconf-exception'
+        => 'GPL-3.0-only WITH Autoconf-exception-3.0',
+    'GPL-3.0-with-bison-exception'
+        => 'GPL-3.0-only WITH Bison-exception-2.2',
+    'GPL-3.0-with-GCC-exception'
+        => 'GPL-3.0-only WITH GCC-exception-3.1',
+  );
+
+  $dbManager->begin();
+
+  foreach ($shortname_array as $old_shortname => $new_shortname) {
+    $row = $dbManager->getSingleRow(
+      "SELECT
+         (SELECT rf_pk FROM license_ref WHERE rf_shortname=$1 LIMIT 1) AS old_id,
+         (SELECT rf_pk FROM license_ref WHERE rf_shortname=$2 LIMIT 1) AS new_id",
+      array($old_shortname, $new_shortname),
+      __METHOD__ . '.getIds'
+    );
+
+    $oldId = (!empty($row) && !empty($row['old_id'])) ? intval($row['old_id']) : 0;
+    $newId = (!empty($row) && !empty($row['new_id'])) ? intval($row['new_id']) : 0;
+
+    if ($oldId > 0 && $newId === 0) {
+      // Case A: Only old license exists -> rename it in-place
+      $dbManager->queryOnce(
+        "UPDATE license_ref SET rf_shortname='$new_shortname' WHERE rf_pk=$oldId",
+        __METHOD__ . '.renameLicense'
+      );
+    } elseif ($oldId > 0 && $newId > 0 && $oldId !== $newId) {
+      // Case B: Both licenses exist -> update references to point to new ID, then delete old row
+      $updates = array(
+        "UPDATE clearing_event SET rf_fk=$newId WHERE rf_fk=$oldId",
+        "UPDATE license_file SET rf_fk=$newId WHERE rf_fk=$oldId",
+        "UPDATE license_map SET rf_fk=$newId WHERE rf_fk=$oldId",
+        "UPDATE license_set_bulk SET rf_fk=$newId WHERE rf_fk=$oldId",
+        "UPDATE obligation_map SET rf_fk=$newId WHERE rf_fk=$oldId",
+        "UPDATE upload_clearing_license SET rf_fk=$newId WHERE rf_fk=$oldId",
+        "UPDATE comp_result SET first_rf_fk=$newId WHERE first_rf_fk=$oldId",
+        "UPDATE comp_result SET second_rf_fk=$newId WHERE second_rf_fk=$oldId",
+        "UPDATE license_rules SET first_rf_fk=$newId WHERE first_rf_fk=$oldId",
+        "UPDATE license_rules SET second_rf_fk=$newId WHERE second_rf_fk=$oldId",
+      );
+
+      foreach ($updates as $sql) {
+        $dbManager->queryOnce($sql, __METHOD__ . '.moveRefs');
+      }
+
+      if ($dbManager->existsTable('license_file_audit')) {
+        $dbManager->queryOnce(
+          "UPDATE license_file_audit SET rf_fk=$newId WHERE rf_fk=$oldId",
+          __METHOD__ . '.moveRefsAudit'
+        );
+      }
+
+      $dbManager->queryOnce(
+        "DELETE FROM license_ref WHERE rf_pk=$oldId",
+        __METHOD__ . '.deleteLegacyLicense'
+      );
+    }
+  }
+
+  $dbManager->commit();
+}

--- a/install/fossinit.php
+++ b/install/fossinit.php
@@ -295,6 +295,11 @@ if (version_compare($release, '4.3.0', '<')) {
 require_once("$LIBEXECDIR/dbmigrate_cmu-mach.php");
 Migrate_Cmu_Mach($dbManager, $Verbose);
 
+if (version_compare($release, '4.7.0', '<')) {
+  require_once("$LIBEXECDIR/dbmigrate_4.6-4.7.php");
+  Migrate_46_47($dbManager, $Verbose);
+}
+
 /* initialize the license_ref table */
 if ($UpdateLiceneseRef)
 {

--- a/src/monk/agent_tests/testlicenses/expectedFull/GPL-2.0-only WITH GCC-exception-3.1
+++ b/src/monk/agent_tests/testlicenses/expectedFull/GPL-2.0-only WITH GCC-exception-3.1
@@ -1,0 +1,5 @@
+insert GPL v2 license text here
+
+GCC Linking Exception
+
+In addition to the permissions in the GNU General Public License, the Free Software Foundation gives you unlimited permission to link the compiled version of this file into combinations with other programs, and to distribute those combinations without any restriction coming from the use of this file. (The General Public License restrictions do apply in other respects; for example, they cover modification of the file, and distribution when not linked into a combine executable.

--- a/src/monk/agent_tests/testlicenses/expectedFull/GPL-2.0-with-GCC-exception
+++ b/src/monk/agent_tests/testlicenses/expectedFull/GPL-2.0-with-GCC-exception
@@ -1,5 +1,0 @@
-insert GPL v2 license text here
-
-GCC Linking Exception
-
-In addition to the permissions in the GNU General Public License, the Free Software Foundation gives you unlimited permission to link the compiled version of this file into combinations with other programs, and to distribute those combinations without any restriction coming from the use of this file. (The General Public License restrictions do apply in other respects; for example, they cover modification of the file, and distribution when not linked into a combine executable.

--- a/src/monk/agent_tests/testlicenses/expectedFull/GPL-3.0-only WITH Bison-exception-2.2
+++ b/src/monk/agent_tests/testlicenses/expectedFull/GPL-3.0-only WITH Bison-exception-2.2
@@ -1,0 +1,7 @@
+insert GPL v3 text here 
+
+Bison Exception 
+
+As a special exception, you may create a larger work that contains part or all of the Bison parser skeleton and distribute that work under terms of your choice, so long as that work isn't itself a parser generator using the skeleton or a modified version thereof as a parser skeleton. Alternatively, if you modify or redistribute the parser skeleton itself, you may (at your option) remove this special exception, which will cause the skeleton and the resulting Bison output files to be licensed under the GNU General Public License without this special exception. 
+
+This special exception was added by the Free Software Foundation in version 2.2 of Bison.

--- a/src/monk/agent_tests/testlicenses/expectedFull/GPL-3.0-with-bison-exception
+++ b/src/monk/agent_tests/testlicenses/expectedFull/GPL-3.0-with-bison-exception
@@ -1,7 +1,0 @@
-insert GPL v3 text here 
-
-Bison Exception 
-
-As a special exception, you may create a larger work that contains part or all of the Bison parser skeleton and distribute that work under terms of your choice, so long as that work isn't itself a parser generator using the skeleton or a modified version thereof as a parser skeleton. Alternatively, if you modify or redistribute the parser skeleton itself, you may (at your option) remove this special exception, which will cause the skeleton and the resulting Bison output files to be licensed under the GNU General Public License without this special exception. 
-
-This special exception was added by the Free Software Foundation in version 2.2 of Bison.

--- a/src/ninka/agent/ninkawrapper.cc
+++ b/src/ninka/agent/ninkawrapper.cc
@@ -136,7 +136,7 @@ string mapLicenseFromNinkaToFossology(string name)
   if (name.compare("CDDLic") == 0) return string("CDDL");
   if (name.compare("CDDLicV1") == 0) return string("CDDL-1.0");
   if (name.compare("publicDomain") == 0) return string("Public-domain");
-  if (name.compare("ClassPathExceptionGPLv2") == 0) return string("GPL-2.0-with-classpath-exception");
+  if (name.compare("ClassPathExceptionGPLv2") == 0) return string("GPL-2.0-only WITH Classpath-exception-2.0");
   if (name.compare("CPLv1") == 0) return string("CPL-1.0");
   if (name.compare("CPLv0.5") == 0) return string("CPL-0.5");
   if (name.compare("SeeFile") == 0) return string("See-file");
@@ -292,21 +292,21 @@ bool isLicenseCollection(string name, vector<LicenseMatch>& matches)
   }
   if (name.compare("BisonException") == 0)
   {
-    matches.push_back(LicenseMatch(string("GPL-2.0-with-bison-exception"), 50));
-    matches.push_back(LicenseMatch(string("GPL-3.0-with-bison-exception"), 50));
+    matches.push_back(LicenseMatch(string("GPL-2.0-only WITH Bison-exception-2.2"), 50));
+    matches.push_back(LicenseMatch(string("GPL-3.0-only WITH Bison-exception-2.2"), 50));
     return true;
   }
   if (name.compare("ClassPathException") == 0)
   {
-    matches.push_back(LicenseMatch(string("GPL-2.0-with-classpath-exception"), 30));
-    matches.push_back(LicenseMatch(string("GPL-2.0+-with-classpath-exception"), 30));
-    matches.push_back(LicenseMatch(string("GPL-3.0-with-classpath-exception"), 40));
+    matches.push_back(LicenseMatch(string("GPL-2.0-only WITH Classpath-exception-2.0"), 30));
+    matches.push_back(LicenseMatch(string("GPL-2.0-or-later WITH Classpath-exception-2.0"), 30));
+    matches.push_back(LicenseMatch(string("GPL-3.0-only WITH Classpath-exception-2.0"), 40));
     return true;
   }
   if (name.compare("autoConfException") == 0)
   {
-    matches.push_back(LicenseMatch(string("GPL-2.0-with-autoconf-exception"), 50));
-    matches.push_back(LicenseMatch(string("GPL-3.0-with-autoconf-exception"), 50));
+    matches.push_back(LicenseMatch(string("GPL-2.0-only WITH Autoconf-exception-3.0"), 50));
+    matches.push_back(LicenseMatch(string("GPL-3.0-only WITH Autoconf-exception-3.0"), 50));
     return true;
   }
   if (name.compare("CPLv1orGPLv2+orLGPLv2+") == 0)

--- a/src/nomos/agent/generator/STRINGS.in
+++ b/src/nomos/agent/generator/STRINGS.in
@@ -13739,6 +13739,56 @@ k
 %ENTRY% _LT_TRUECRYPT_30
 %KEY% "(truecrypt)"
 %STR% "all occurrences of the name truecrypt that could reasonably be considered to identify your product must be removed"
+%ENTRY% _SPDX_GPL_2_0_or_later_WITH_Bison_exception_2_2
+%KEY% "licen[cs]e"
+%STR% "licen[cs]e(id|[- ]identifier)?[: \[\(]+(GPL[- ]2\.0[- ]or[- ]later WITH Bison[- ]exception[- ]2\.2|(.{1,32} (AND|OR)){1,4} GPL[- ]2\.0[- ]or[- ]later WITH Bison[- ]exception[- ]2\.2)"
+
+%ENTRY% _SPDX_GPL_2_0_or_later_WITH_Classpath_exception_2_0
+%KEY% "licen[cs]e"
+%STR% "licen[cs]e(id|[- ]identifier)?[: \[\(]+(GPL[- ]2\.0[- ]or[- ]later WITH Classpath[- ]exception[- ]2\.0|(.{1,32} (AND|OR)){1,4} GPL[- ]2\.0[- ]or[- ]later WITH Classpath[- ]exception[- ]2\.0)"
+
+%ENTRY% _SPDX_GPL_2_0_only_WITH_Autoconf_exception_3_0
+%KEY% "licen[cs]e"
+%STR% "licen[cs]e(id|[- ]identifier)?[: \[\(]+(GPL[- ]2\.0[- ]only WITH Autoconf[- ]exception[- ]3\.0|(.{1,32} (AND|OR)){1,4} GPL[- ]2\.0[- ]only WITH Autoconf[- ]exception[- ]3\.0)"
+
+%ENTRY% _SPDX_GPL_2_0_only_WITH_Bison_exception_2_2
+%KEY% "licen[cs]e"
+%STR% "licen[cs]e(id|[- ]identifier)?[: \[\(]+(GPL[- ]2\.0[- ]only WITH Bison[- ]exception[- ]2\.2|(.{1,32} (AND|OR)){1,4} GPL[- ]2\.0[- ]only WITH Bison[- ]exception[- ]2\.2)"
+
+%ENTRY% _SPDX_GPL_2_0_only_WITH_Classpath_exception_2_0
+%KEY% "licen[cs]e"
+%STR% "licen[cs]e(id|[- ]identifier)?[: \[\(]+(GPL[- ]2\.0[- ]only WITH Classpath[- ]exception[- ]2\.0|(.{1,32} (AND|OR)){1,4} GPL[- ]2\.0[- ]only WITH Classpath[- ]exception[- ]2\.0)"
+
+%ENTRY% _SPDX_GPL_2_0_only_WITH_Font_exception_2_0
+%KEY% "licen[cs]e"
+%STR% "licen[cs]e(id|[- ]identifier)?[: \[\(]+(GPL[- ]2\.0[- ]only WITH Font[- ]exception[- ]2\.0|(.{1,32} (AND|OR)){1,4} GPL[- ]2\.0[- ]only WITH Font[- ]exception[- ]2\.0)"
+
+%ENTRY% _SPDX_GPL_2_0_only_WITH_GCC_exception_3_1
+%KEY% "licen[cs]e"
+%STR% "licen[cs]e(id|[- ]identifier)?[: \[\(]+(GPL[- ]2\.0[- ]only WITH GCC[- ]exception[- ]3\.1|(.{1,32} (AND|OR)){1,4} GPL[- ]2\.0[- ]only WITH GCC[- ]exception[- ]3\.1)"
+
+%ENTRY% _SPDX_GPL_3_0_or_later_WITH_Bison_exception_2_2
+%KEY% "licen[cs]e"
+%STR% "licen[cs]e(id|[- ]identifier)?[: \[\(]+(GPL[- ]3\.0[- ]or[- ]later WITH Bison[- ]exception[- ]2\.2|(.{1,32} (AND|OR)){1,4} GPL[- ]3\.0[- ]or[- ]later WITH Bison[- ]exception[- ]2\.2)"
+
+%ENTRY% _SPDX_GPL_3_0_or_later_WITH_Classpath_exception_2_0
+%KEY% "licen[cs]e"
+%STR% "licen[cs]e(id|[- ]identifier)?[: \[\(]+(GPL[- ]3\.0[- ]or[- ]later WITH Classpath[- ]exception[- ]2\.0|(.{1,32} (AND|OR)){1,4} GPL[- ]3\.0[- ]or[- ]later WITH Classpath[- ]exception[- ]2\.0)"
+
+%ENTRY% _SPDX_GPL_3_0_only_WITH_Autoconf_exception_3_0
+%KEY% "licen[cs]e"
+%STR% "licen[cs]e(id|[- ]identifier)?[: \[\(]+(GPL[- ]3\.0[- ]only WITH Autoconf[- ]exception[- ]3\.0|(.{1,32} (AND|OR)){1,4} GPL[- ]3\.0[- ]only WITH Autoconf[- ]exception[- ]3\.0)"
+
+%ENTRY% _SPDX_GPL_3_0_only_WITH_Bison_exception_2_2
+%KEY% "licen[cs]e"
+%STR% "licen[cs]e(id|[- ]identifier)?[: \[\(]+(GPL[- ]3\.0[- ]only WITH Bison[- ]exception[- ]2\.2|(.{1,32} (AND|OR)){1,4} GPL[- ]3\.0[- ]only WITH Bison[- ]exception[- ]2\.2)"
+
+%ENTRY% _SPDX_GPL_3_0_only_WITH_GCC_exception_3_1
+%KEY% "licen[cs]e"
+%STR% "licen[cs]e(id|[- ]identifier)?[: \[\(]+(GPL[- ]3\.0[- ]only WITH GCC[- ]exception[- ]3\.1|(.{1,32} (AND|OR)){1,4} GPL[- ]3\.0[- ]only WITH GCC[- ]exception[- ]3\.1)"
+
+
+
 #####
 # This MUST be the last alias specified; the size of the array of encrypted
 # strings is determined from the following value! (see NFOOTPRINTS, below)
@@ -13768,4 +13818,3 @@ k
  */
 #define	_scCOMFORT	9	/* >= 9 --> certain it's a license */
 #define	_scINVALID	4	/* < 4 --> probably NOT a license */
-

--- a/src/nomos/agent/nomos.h
+++ b/src/nomos/agent/nomos.h
@@ -218,7 +218,7 @@ extern size_t hashEntries;             ///< Hash entries
 #define	LS_UNCL		"UnclassifiedLicense"
 #define	LS_NOT_PD	"NOT-public-domain"
 #define	LS_PD_CLM	"Public-domain"
-#define	LS_PD_CPRT	"Public-domain(C)"
+#define	LS_PD_CPRT	"Public-domain"
 #define	LS_PD_ONLY	"Public-domain-ref"
 #define	LS_CPRTONLY	"Misc-Copyright"
 #define	LS_TDMKONLY	"Trademark-ref"

--- a/src/nomos/agent/parse.c
+++ b/src/nomos/agent/parse.c
@@ -627,7 +627,7 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
           INTERESTING("XMLDB-1.0");
         }
         else if (INFILE(_LT_BSD_CLAUSE_4) && INFILE(_LT_ANT_BSD_RESTRICTION)) {
-          INTERESTING("ANT+SharedSource");
+          INTERESTING("ANT-SharedSource");
         }
         else if (!lmem[_mAPACHE11] && INFILE(_LT_Apache_11_CLAUSE_3) && INFILE(_LT_Apache_11_CLAUSE_4) && INFILE(_LT_Apache_11_CLAUSE_5)) {
           INTERESTING(lDebug ? "BSD(Apache-1.1)" : "Apache-1.1-style");
@@ -734,7 +734,7 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
       INTERESTING(lDebug ? "UI(1)" : "Unix-Intl");
     }
     else if (INFILE(_CR_XOPEN)) {
-      INTERESTING(lDebug ? "XOpen(1)" : "X/Open");
+      INTERESTING(lDebug ? "XOpen(1)" : "X11");
       lmem[_mXOPEN] = 1;
     }
     else if (INFILE(_PHR_HISTORICAL)) {
@@ -1198,7 +1198,7 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
     INTERESTING("CECILL-C");
   }
   else if (INFILE(_LT_CECILL_DUALref)) {
-    INTERESTING("CECILL(dual)");
+    INTERESTING("CECILL-2.1");
     lmem[_mGPL] = lmem[_mLGPL] = 1;
   }
   else if (INFILE(_SPDX_CECILL_10)) {
@@ -1849,7 +1849,7 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
           lmem[_mGPL] = 1;
         }
         else if (INFILE(_CR_rms) && INFILE(_LT_GPL_2)) {
-          INTERESTING("GPL(rms)");
+          INTERESTING("GPL-2.0-only");
           lmem[_mGPL] = 1;
         }
         else if (INFILE(_PHR_GPLISH_SAMPLE)) {
@@ -2610,10 +2610,10 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
    * Generic CopyLeft licenses
    */
   if (INFILE(_LT_COPYLEFT_1)) {
-    INTERESTING("CopyLeft[1]");
+    INTERESTING("Copyleft");
   }
   else if (INFILE(_LT_COPYLEFT_2)) {
-    INTERESTING("CopyLeft[2]");
+    INTERESTING("Copyleft");
   }
   cleanLicenceBuffer();
   /*
@@ -4789,7 +4789,7 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
       INTERESTING(lDebug ? "SGI_GLX(1.0)" : "SGI_GLX-1.0");
     }
     else {
-      INTERESTING("SGI_GLX");
+      INTERESTING("SGI-B-2.0");
     }
   }
   else if (INFILE(_LT_SGI_GLXref) && INFILE(_CR_SGI)) {
@@ -4797,7 +4797,7 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
       INTERESTING(lDebug ? "SGI_GLX(10ref)" : "SGI_GLX-1.0");
     }
     else {
-      INTERESTING(lDebug ? "SGI_GLX(ref)" : "SGI_GLX");
+      INTERESTING(lDebug ? "SGI_GLX(ref)" : "SGI-B-2.0");
     }
   }
   else if (INFILE(_LT_SGI_PROPRIETARY) && INFILE(_CR_SGI)) {
@@ -4898,7 +4898,7 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
    * Alliance for Open Media Patent License
    */
   if (INFILE(_LT_AOM_Patent)) {
-    INTERESTING("Alliance for Open Media Patent License 1.0");
+    INTERESTING("AOM-Patent-1.0");
   }
   cleanLicenceBuffer();
   /*
@@ -5796,7 +5796,7 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
       INTERESTING(lDebug ? "UI(2)" : "Unix-Intl");
     }
     else if (INFILE(_CR_XOPEN)) {
-      INTERESTING(lDebug ? "XOpen(2)" : "X/Open");
+      INTERESTING(lDebug ? "XOpen(2)" : "X11");
       lmem[_mXOPEN] = 1;
     }
     else if (INFILE(_CR_IPA)) {
@@ -5812,7 +5812,7 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
   }
   /* This one is funky - it includes part of the copyright */
   else if (!lmem[_mXOPEN] && INFILE(_LT_XOPEN_2)) {
-    INTERESTING(lDebug ? "XOpen(3)" : "X/Open");
+    INTERESTING(lDebug ? "XOpen(3)" : "X11");
     lmem[_mXOPEN] = 1;
   }
   cleanLicenceBuffer();
@@ -6133,7 +6133,7 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
    * M+ Fonts Project
    */
   if (INFILE(_LT_MPLUS_FONT) && INFILE(_CR_MPLUS)) {
-    INTERESTING("M-Plus-Project");
+    INTERESTING("M-Plus");
   }
   cleanLicenceBuffer();
   /*
@@ -6147,7 +6147,7 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
    * Against DRM
    */
   if (INFILE(_LT_AGAINST_DRM)) {
-    INTERESTING("AgainstDRM");
+    INTERESTING("Against-DRM");
   }
   cleanLicenceBuffer();
   /*
@@ -6717,7 +6717,7 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
    * unRAR restriction
    */
   if (INFILE(_LT_UNRARref1) || INFILE(_LT_UNRARref2)) {
-    INTERESTING("unRAR restriction");
+    INTERESTING("unRAR-restriction");
   }
   cleanLicenceBuffer();
   /*
@@ -7468,7 +7468,7 @@ char *aslVersion(char *filetext, int size, int isML, int isPS)
     lmem[_mAPACHE] = 1;
   }
   else if (INFILE(_CR_IMAGEMAGICK)) {
-    lstr = "ImageMagick(Apache)";
+    lstr = "ImageMagick";
     lmem[_mAPACHE] = 1;
   }
   /*
@@ -8480,10 +8480,10 @@ char *gplVersion(char *filetext, int size, int isML, int isPS)
    * Finally let's see if there is a type error in license version
    */
   else if (INFILE(_PHR_GPL21_OR_LATER) && !HASTEXT(_LT_IGNORE_CLAUSE, REG_EXTENDED)) {
-    lstr = "GPL-2.1+[sic]";
+    lstr = "GPL-2.0-or-later";
   }
   else if (INFILE(_PHR_FSF_V21_ONLY) || INFILE(_PHR_GPL21_ONLY)) {
-    lstr = lDebug ? "GPL-v2.1[sic]" : "GPL-2.1[sic]";
+    lstr = lDebug ? "GPL-v2.1[sic]" : "GPL-2.0-only";
   }
   /*
    * Special case, HACK: "Debian packaging ... licensed under GPL"
@@ -11810,8 +11810,46 @@ void copyleftExceptions(char *filetext, int size, int isML, int isPS)
     INTERESTING(lDebug ? "GPL-swi-prolog" : "GPL-exception");
   }
 
+  if (INFILE(_SPDX_GPL_2_0_or_later_WITH_Bison_exception_2_2)) {
+    INTERESTING("GPL-2.0-or-later WITH Bison-exception-2.2");
+  }
+  if (INFILE(_SPDX_GPL_2_0_or_later_WITH_Classpath_exception_2_0)) {
+    INTERESTING("GPL-2.0-or-later WITH Classpath-exception-2.0");
+  }
+  if (INFILE(_SPDX_GPL_2_0_only_WITH_Autoconf_exception_3_0)) {
+    INTERESTING("GPL-2.0-only WITH Autoconf-exception-3.0");
+  }
+  if (INFILE(_SPDX_GPL_2_0_only_WITH_Bison_exception_2_2)) {
+    INTERESTING("GPL-2.0-only WITH Bison-exception-2.2");
+  }
+  if (INFILE(_SPDX_GPL_2_0_only_WITH_Classpath_exception_2_0)) {
+    INTERESTING("GPL-2.0-only WITH Classpath-exception-2.0");
+  }
+  if (INFILE(_SPDX_GPL_2_0_only_WITH_Font_exception_2_0)) {
+    INTERESTING("GPL-2.0-only WITH Font-exception-2.0");
+  }
+  if (INFILE(_SPDX_GPL_2_0_only_WITH_GCC_exception_3_1)) {
+    INTERESTING("GPL-2.0-only WITH GCC-exception-3.1");
+  }
+  if (INFILE(_SPDX_GPL_3_0_or_later_WITH_Bison_exception_2_2)) {
+    INTERESTING("GPL-3.0-or-later WITH Bison-exception-2.2");
+  }
+  if (INFILE(_SPDX_GPL_3_0_or_later_WITH_Classpath_exception_2_0)) {
+    INTERESTING("GPL-3.0-or-later WITH Classpath-exception-2.0");
+  }
+  if (INFILE(_SPDX_GPL_3_0_only_WITH_Autoconf_exception_3_0)) {
+    INTERESTING("GPL-3.0-only WITH Autoconf-exception-3.0");
+  }
+  if (INFILE(_SPDX_GPL_3_0_only_WITH_Bison_exception_2_2)) {
+    INTERESTING("GPL-3.0-only WITH Bison-exception-2.2");
+  }
+  if (INFILE(_SPDX_GPL_3_0_only_WITH_GCC_exception_3_1)) {
+    INTERESTING("GPL-3.0-only WITH GCC-exception-3.1");
+  }
+
   return;
 }
+
 
 #ifdef  LTSR_DEBUG
 #define LT_TARGET       1299    /* set to -1 OR the string# to track */

--- a/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan
+++ b/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan
@@ -36,7 +36,7 @@ File NomosTestfiles/Aladdin/LICENSE.txt contains license(s) Aladdin,LPPL-1.3+
 File NomosTestfiles/Amazon/ADSL.txt contains license(s) ADSL
 File NomosTestfiles/AML/AML.txt contains license(s) AML
 File NomosTestfiles/ANTLR-PD/ANTLR-PD.txt contains license(s) ANTLR-PD
-File NomosTestfiles/AOM/AOM.txt contains license(s) Alliance for Open Media Patent License 1.0
+File NomosTestfiles/AOM/AOM.txt contains license(s) AOM-Patent-1.0
 File NomosTestfiles/Apache/abs_s.h contains license(s) 3GPP,Apache-2.0
 File NomosTestfiles/Apache/Android_SDK_license.txt contains license(s) AndroidSDK.Commercial,Apache-2.0
 File NomosTestfiles/Apache/Apache-1.0.c contains license(s) Apache-1.0
@@ -103,7 +103,7 @@ File NomosTestfiles/Bittorrent/bittorrent.py contains license(s) BitTorrent-1.1
 File NomosTestfiles/BSD/0BSD.txt contains license(s) 0BSD
 File NomosTestfiles/BSD/access.c contains license(s) BSD-style
 File NomosTestfiles/BSD/AMPAS.txt contains license(s) AMPAS
-File NomosTestfiles/BSD/ANT+SharedSourceLicense.txt contains license(s) ANT+SharedSource
+File NomosTestfiles/BSD/ANT+SharedSourceLicense.txt contains license(s) ANT-SharedSource
 File NomosTestfiles/BSD/autoopts.c contains license(s) BSD,Dual-license,LGPL-3.0-or-later
 File NomosTestfiles/BSD/BSD-1-Clause.txt contains license(s) BSD-1-Clause
 File NomosTestfiles/BSD/BSD-2-Clause_2.txt contains license(s) BSD-2-Clause
@@ -297,7 +297,7 @@ File NomosTestfiles/CECILL/CECILL-1.1.txt contains license(s) CECILL-1.1
 File NomosTestfiles/CECILL/CECILL-2.0.txt contains license(s) CECILL
 File NomosTestfiles/CECILL/CECILL-B.txt contains license(s) CECILL-B
 File NomosTestfiles/CECILL/CECILL-C.txt contains license(s) CECILL-C
-File NomosTestfiles/CECILL/CImg.h contains license(s) CECILL(dual),Dual-license
+File NomosTestfiles/CECILL/CImg.h contains license(s) CECILL-2.1,Dual-license
 File NomosTestfiles/CECILL/dataset_io.h contains license(s) CECILL-B
 File NomosTestfiles/CECILL/GameMode.java contains license(s) CECILL
 File NomosTestfiles/CECILL/ParametersFileFilter.java contains license(s) CECILL
@@ -349,7 +349,7 @@ File NomosTestfiles/D-FSL/D-FSL-1.0.txt contains license(s) D-FSL-1.0
 File NomosTestfiles/DB-License/DB-License.txt contains license(s) Databricks-DB-License
 File NomosTestfiles/DPTC/dpt_osdutil.h contains license(s) DPTC
 File NomosTestfiles/Dual-license/004.phpt.GPLv2+-PHP contains license(s) GPL-2.0-or-later,PHP
-File NomosTestfiles/Dual-license/7-zip_GPL-2.1+-unRARrestriction contains license(s) LGPL-2.1-or-later,unRAR restriction
+File NomosTestfiles/Dual-license/7-zip_GPL-2.1+-unRARrestriction contains license(s) LGPL-2.1-or-later,unRAR-restriction
 File NomosTestfiles/Dual-license/aclocal.m4 contains license(s) Autoconf-exception,FSFAP,GPL-2.0-or-later,NOT-public-domain
 File NomosTestfiles/Dual-license/aes-586.pl contains license(s) Cryptogams,Dual-license,OpenSSL
 File NomosTestfiles/Dual-license/aes.h contains license(s) BSD-style,Dual-license,GPL
@@ -614,7 +614,7 @@ File NomosTestfiles/GPL/GPL-2.0+_with_linking-exception.txt contains license(s) 
 File NomosTestfiles/GPL/GPL-2.0_with_OpenSSL-exception_2.txt contains license(s) GPL-2.0-only,OpenSSL-exception
 File NomosTestfiles/GPL/GPL-2.0_with_OpenSSL-exception.txt contains license(s) GPL-2.0-only,OpenSSL-exception
 File NomosTestfiles/GPL/GPL-2.0+_with_OpenSSL-exception.txt contains license(s) GPL-2.0-or-later,OpenSSL-exception
-File NomosTestfiles/GPL/gpl21_plus.txt contains license(s) GPL-2.1+[sic]
+File NomosTestfiles/GPL/gpl21_plus.txt contains license(s) GPL-2.0-or-later
 File NomosTestfiles/GPL/GPL-3.0+_a.txt contains license(s) GPL-3.0-or-later
 File NomosTestfiles/GPL/GPL-3.0b.txt contains license(s) GPL-3.0-only
 File NomosTestfiles/GPL/GPL-3.0_c.txt contains license(s) GPL-3.0-only
@@ -659,7 +659,7 @@ File NomosTestfiles/GPL/serv_rssclient.c contains license(s) GPL-2.0-or-later,GP
 File NomosTestfiles/GPL/standalone_html.inc.php contains license(s) GPL
 File NomosTestfiles/GPL/Stats.java contains license(s) GPL-3.0-or-later
 File NomosTestfiles/GPL/stddef.h contains license(s) GCC-exception-3.1,GPL-3.0-or-later
-File NomosTestfiles/GPL/stdvga.c contains license(s) GPL-2.1[sic]
+File NomosTestfiles/GPL/stdvga.c contains license(s) GPL-2.0-only
 File NomosTestfiles/GPL/StopComponentCommand.java contains license(s) Classpath-exception-2.0,GPL-3.0-or-later
 File NomosTestfiles/GPL/sys-ecos.c contains license(s) CMU,GPL-2.0-or-later,eCos-exception-2.0
 File NomosTestfiles/GPL/taskset.c contains license(s) GPL-2.0-or-later

--- a/src/unifiedreport/agent_tests/Functional/fo_report.sql
+++ b/src/unifiedreport/agent_tests/Functional/fo_report.sql
@@ -31163,7 +31163,7 @@ documentation and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS ``AS IS'''' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. ', 'http://www.netbsd.org/about/redistribution.html#default', NULL, NULL, NULL, 'BSD 2-clause NetBSD License', NULL, NULL, NULL, '', NULL, false, false, true, 'cb67adae9f0e191318bfd93876ba1dd4', 1, NULL);
 INSERT INTO license_ref (rf_pk, rf_shortname, rf_text, rf_url, rf_add_date, rf_copyleft, "rf_OSIapproved", rf_fullname, "rf_FSFfree", "rf_GPLv2compatible", "rf_GPLv3compatible", rf_notes, "rf_Fedora", marydone, rf_active,  rf_text_updatable, rf_md5, rf_detector_type, rf_source)
-VALUES (436, 'GPL-3.0-with-GCC-exception', 'insert GPL v3 text here
+VALUES (436, 'GPL-3.0-only WITH GCC-exception-3.1', 'insert GPL v3 text here
 
 GCC RUNTIME LIBRARY EXCEPTION
 Version 3.1, 31 March 2009
@@ -33551,7 +33551,7 @@ If any files are modified, you must cause the modified files to carry prominent 
 Disclaimer
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'''' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.', 'http://old.zope.org/Resources/ZPL/', NULL, NULL, NULL, 'Zope Public License 2.1', NULL, NULL, NULL, '', NULL, false, false, false, 'bede8f98a18c76d62b77168e4801f1bd', 1, NULL);
 INSERT INTO license_ref (rf_pk, rf_shortname, rf_text, rf_url, rf_add_date, rf_copyleft, "rf_OSIapproved", rf_fullname, "rf_FSFfree", "rf_GPLv2compatible", "rf_GPLv3compatible", rf_notes, "rf_Fedora", marydone, rf_active,  rf_text_updatable, rf_md5, rf_detector_type, rf_source)
-VALUES (1, 'GPL-2.0-with-autoconf-exception', '﻿insert GPL v2 license text here
+VALUES (1, 'GPL-2.0-only WITH Autoconf-exception-3.0', '﻿insert GPL v2 license text here
 
 Autoconf Exception
 
@@ -33561,7 +33561,7 @@ Certain portions of the Autoconf source text are designed to be copied (in certa
 
 This special exception to the GPL applies to versions of Autoconf released by the Free Software Foundation. When you make and distribute a modified version of Autoconf, you may extend this special exception to the GPL to apply to your modified version as well, *unless* your modified version has the potential to copy into its output some of the text that was the non-data portion of the version that you started with. (In other words, unless your change moves or copies text from the non-data portions to the data portions.) If your modification has such potential, you must delete any notice of this special exception to the GPL from your modified version.', 'http://ac-archive.sourceforge.net/doc/copyright.html', NULL, NULL, NULL, 'GNU General Public License v2.0 w/Autoconf exception', NULL, NULL, NULL, '', NULL, false, false, false, 'd49d025e60a3654db953a6c169e52ed9', 1, NULL);
 INSERT INTO license_ref (rf_pk, rf_shortname, rf_text, rf_url, rf_add_date, rf_copyleft, "rf_OSIapproved", rf_fullname, "rf_FSFfree", "rf_GPLv2compatible", "rf_GPLv3compatible", rf_notes, "rf_Fedora", marydone, rf_active,  rf_text_updatable, rf_md5, rf_detector_type, rf_source)
-VALUES (461, 'GPL-2.0-with-GCC-exception', 'insert GPL v2 text here
+VALUES (461, 'GPL-2.0-only WITH GCC-exception-3.1', 'insert GPL v2 text here
 
 GCC Linking Exception
 In addition to the permissions in the GNU General Public License, the Free Software Foundation gives you unlimited permission to link the compiled version of this file into combinations with other programs, and to distribute those combinations without any restriction coming from the use of this file. (The General Public License restrictions do apply in other respects; for example, they cover modification of the file, and distribution when not linked into a combine executable.)', '', NULL, NULL, NULL, 'GNU General Public License v2.0 w/GCC Runtime Library exception', NULL, NULL, NULL, '', NULL, false, false, false, '5dd21a7c43ce6c65eeefdf29371b9afa', 1, NULL);
@@ -34972,7 +34972,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 INSERT INTO license_ref (rf_pk, rf_shortname, rf_text, rf_url, rf_add_date, rf_copyleft, "rf_OSIapproved", rf_fullname, "rf_FSFfree", "rf_GPLv2compatible", "rf_GPLv3compatible", rf_notes, "rf_Fedora", marydone, rf_active,  rf_text_updatable, rf_md5, rf_detector_type, rf_source)
 VALUES (494, 'CATOSL', 'CATOSL is referenced without a version number. Please look up CATOSL in the License Admin to view the different versions.', '', NULL, NULL, NULL, 'CATOSL', NULL, NULL, NULL, '', NULL, false, false, false, '01bb42e20f6cc95eb53ce8786b6abadb', 1, NULL);
 INSERT INTO license_ref (rf_pk, rf_shortname, rf_text, rf_url, rf_add_date, rf_copyleft, "rf_OSIapproved", rf_fullname, "rf_FSFfree", "rf_GPLv2compatible", "rf_GPLv3compatible", rf_notes, "rf_Fedora", marydone, rf_active,  rf_text_updatable, rf_md5, rf_detector_type, rf_source)
-VALUES (501, 'GPL-2.0+-with-bison-exception', 'insert GPL v2+ text here
+VALUES (501, 'GPL-2.0-or-later WITH Bison-exception-2.2', 'insert GPL v2+ text here
 
 Bison Exception
 
@@ -35562,7 +35562,7 @@ WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 
 The End', 'http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt', NULL, NULL, NULL, 'Open Group Test Suite License', NULL, NULL, NULL, '', NULL, false, false, false, '41b4ea8bbe095c8fefe76eb34d2e746a', 1, NULL);
 INSERT INTO license_ref (rf_pk, rf_shortname, rf_text, rf_url, rf_add_date, rf_copyleft, "rf_OSIapproved", rf_fullname, "rf_FSFfree", "rf_GPLv2compatible", "rf_GPLv3compatible", rf_notes, "rf_Fedora", marydone, rf_active,  rf_text_updatable, rf_md5, rf_detector_type, rf_source)
-VALUES (442, 'GPL-2.0-with-bison-exception', '﻿insert GPL v2 text here
+VALUES (442, 'GPL-2.0-only WITH Bison-exception-2.2', '﻿insert GPL v2 text here
 
 Bison Exception
 
@@ -36904,7 +36904,7 @@ IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR DIRECT
 
 THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.', 'http://www.postgresql.org/about/licence', NULL, NULL, NULL, 'PostgreSQL License', NULL, NULL, NULL, '', NULL, false, false, false, 'd40dd6c3073a6eac37deb8fd086f0728', 1, NULL);
 INSERT INTO license_ref (rf_pk, rf_shortname, rf_text, rf_url, rf_add_date, rf_copyleft, "rf_OSIapproved", rf_fullname, "rf_FSFfree", "rf_GPLv2compatible", "rf_GPLv3compatible", rf_notes, "rf_Fedora", marydone, rf_active,  rf_text_updatable, rf_md5, rf_detector_type, rf_source)
-VALUES (459, 'GPL-2.0-with-font-exception', '﻿insert GPL v2 text here
+VALUES (459, 'GPL-2.0-only WITH Font-exception-2.0', '﻿insert GPL v2 text here
 
 Font Exception
 
@@ -37089,7 +37089,7 @@ This file is free software; the Free Software Foundation
 gives unlimited permission to copy and/or distribute it,
 with or without modifications, as long as this notice is preserved.', '', NULL, NULL, NULL, 'Free Software Foundation', NULL, NULL, NULL, '', NULL, false, false, false, '34518a40552bca97ec5767a38759cea3', 1, NULL);
 INSERT INTO license_ref (rf_pk, rf_shortname, rf_text, rf_url, rf_add_date, rf_copyleft, "rf_OSIapproved", rf_fullname, "rf_FSFfree", "rf_GPLv2compatible", "rf_GPLv3compatible", rf_notes, "rf_Fedora", marydone, rf_active,  rf_text_updatable, rf_md5, rf_detector_type, rf_source)
-VALUES (439, 'GPL-3.0-with-autoconf-exception', 'insert GPL v3 text here
+VALUES (439, 'GPL-3.0-only WITH Autoconf-exception-3.0', 'insert GPL v3 text here
 
 AUTOCONF CONFIGURE SCRIPT EXCEPTION
 
@@ -39288,7 +39288,7 @@ The above copyright notice including the dates of first publication and either t
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL SILICON GRAPHICS, INC. BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 Except as contained in this notice, the name of Silicon Graphics, Inc. shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Software without prior written authorization from Silicon Graphics, Inc.', 'http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.2.0.doc', NULL, NULL, NULL, 'SGI Free Software License B 2.0', NULL, NULL, NULL, '', NULL, false, false, false, 'cf37137fe121a9ce8d71b10bb0d3a13f', 1, NULL);
 INSERT INTO license_ref (rf_pk, rf_shortname, rf_text, rf_url, rf_add_date, rf_copyleft, "rf_OSIapproved", rf_fullname, "rf_FSFfree", "rf_GPLv2compatible", "rf_GPLv3compatible", rf_notes, "rf_Fedora", marydone, rf_active,  rf_text_updatable, rf_md5, rf_detector_type, rf_source)
-VALUES (503, 'GPL-3.0+-with-bison-exception', 'insert GPL v3+ text here
+VALUES (503, 'GPL-3.0-or-later WITH Bison-exception-2.2', 'insert GPL v3+ text here
 
 Bison Exception
 
@@ -40246,7 +40246,7 @@ Copyright 1999-2000 The OpenLDAP Foundation, Redwood City,
 California, USA.  All Rights Reserved.  Permission to copy and
 distributed verbatim copies of this document is granted.', 'http://spdx.org/licenses/OLDAP-2.4#licenseText', NULL, NULL, NULL, 'Open LDAP Public License v2.4', NULL, NULL, NULL, '', NULL, false, false, false, 'ab77165f8f5828760211427c7c4474ff', 1, NULL);
 INSERT INTO license_ref (rf_pk, rf_shortname, rf_text, rf_url, rf_add_date, rf_copyleft, "rf_OSIapproved", rf_fullname, "rf_FSFfree", "rf_GPLv2compatible", "rf_GPLv3compatible", rf_notes, "rf_Fedora", marydone, rf_active,  rf_text_updatable, rf_md5, rf_detector_type, rf_source)
-VALUES (502, 'GPL-3.0-with-bison-exception', 'insert GPL v3 text here
+VALUES (502, 'GPL-3.0-only WITH Bison-exception-2.2', 'insert GPL v3 text here
 
 Bison Exception
 
@@ -43224,13 +43224,13 @@ Copyright (c) 1996 NVIDIA, Corp. NVIDIA design patents pending in the U.S. and f
 
 NVIDIA, CORP. MAKES NO REPRESENTATION ABOUT THE SUITABILITY OF THIS SOURCE CODE FOR ANY PURPOSE. IT IS PROVIDED "AS IS" WITHOUT EXPRESS OR IMPLIED WARRANTY OF ANY KIND. NVIDIA, CORP. DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOURCE CODE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT SHALL NVIDIA, CORP. BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOURCE CODE.', 'http://www.xfree86.org/current/LICENSE8.html', NULL, NULL, NULL, 'Nvidia', NULL, NULL, NULL, '', NULL, false, false, true, '2d8dbb6d3f39d1affcdd846b794eba83', 1, NULL);
 INSERT INTO license_ref (rf_pk, rf_shortname, rf_text, rf_url, rf_add_date, rf_copyleft, "rf_OSIapproved", rf_fullname, "rf_FSFfree", "rf_GPLv2compatible", "rf_GPLv3compatible", rf_notes, "rf_Fedora", marydone, rf_active,  rf_text_updatable, rf_md5, rf_detector_type, rf_source)
-VALUES (557, 'GPL-3.0+-with-classpath-exception', 'insert GPL v3+ license text here
+VALUES (557, 'GPL-3.0-or-later WITH Classpath-exception-2.0', 'insert GPL v3+ license text here
 
 Class Path Exception
 
 Linking this library statically or dynamically with other modules is making a combined work based on this library. Thus, the terms and conditions of the GNU General Public License cover the whole combination.
 
-As a special exception, the copyright holders of this library give you permission to link this library with independent modules to produce an executable, regardless of the license terms of these independent modules, and to copy and distribute the resulting executable under terms of your choice, provided that you also meet, for each linked independent module, the terms and conditions of the license of that module. An independent module is a module which is not derived from or based on this library. If you modify this library, you may extend this exception to your version of the library, but you are not obligated to do so. If you do not wish to do so, delete this exception statement from your version.', '', NULL, NULL, NULL, 'GPL-3.0+-with-classpath-exception', NULL, NULL, NULL, '', NULL, false, false, false, 'cc1f944dcc0a13507be4d402c490a2db', 1, NULL);
+As a special exception, the copyright holders of this library give you permission to link this library with independent modules to produce an executable, regardless of the license terms of these independent modules, and to copy and distribute the resulting executable under terms of your choice, provided that you also meet, for each linked independent module, the terms and conditions of the license of that module. An independent module is a module which is not derived from or based on this library. If you modify this library, you may extend this exception to your version of the library, but you are not obligated to do so. If you do not wish to do so, delete this exception statement from your version.', '', NULL, NULL, NULL, 'GPL-3.0-or-later WITH Classpath-exception-2.0', NULL, NULL, NULL, '', NULL, false, false, false, 'cc1f944dcc0a13507be4d402c490a2db', 1, NULL);
 INSERT INTO license_ref (rf_pk, rf_shortname, rf_text, rf_url, rf_add_date, rf_copyleft, "rf_OSIapproved", rf_fullname, "rf_FSFfree", "rf_GPLv2compatible", "rf_GPLv3compatible", rf_notes, "rf_Fedora", marydone, rf_active,  rf_text_updatable, rf_md5, rf_detector_type, rf_source)
 VALUES (552, 'Logica-OSL-1.0', 'Logica Open Source License Version 1.0
 Copyright (c) 1996-2001 Logica Mobile Networks Limited, all rights reserved.
@@ -43412,7 +43412,7 @@ http://www.coyotegulch.com
 Acknowledgement:
 This document is based on the wonderful simple license that accompanies libpng.', 'https://svn.apache.org/repos/asf/forrest/branches/PDF_IMAGE_BRANCH/legal/LICENSE.jisp', NULL, NULL, NULL, 'Java Index Serialization Package', NULL, NULL, NULL, '', NULL, false, false, false, '7a4a33e74af880629c93970564182bd2', 1, NULL);
 INSERT INTO license_ref (rf_pk, rf_shortname, rf_text, rf_url, rf_add_date, rf_copyleft, "rf_OSIapproved", rf_fullname, "rf_FSFfree", "rf_GPLv2compatible", "rf_GPLv3compatible", rf_notes, "rf_Fedora", marydone, rf_active,  rf_text_updatable, rf_md5, rf_detector_type, rf_source)
-VALUES (6, 'GPL-2.0-with-classpath-exception', 'insert GPL v2 license text here
+VALUES (6, 'GPL-2.0-only WITH Classpath-exception-2.0', 'insert GPL v2 license text here
 
 Class Path Exception
 
@@ -43420,13 +43420,13 @@ Linking this library statically or dynamically with other modules is making a co
 
 As a special exception, the copyright holders of this library give you permission to link this library with independent modules to produce an executable, regardless of the license terms of these independent modules, and to copy and distribute the resulting executable under terms of your choice, provided that you also meet, for each linked independent module, the terms and conditions of the license of that module. An independent module is a module which is not derived from or based on this library. If you modify this library, you may extend this exception to your version of the library, but you are not obligated to do so. If you do not wish to do so, delete this exception statement from your version.', 'http://www.gnu.org/software/classpath/license.html', NULL, NULL, NULL, 'GNU General Public License v2.0 w/Classpath exception', NULL, NULL, NULL, '', NULL, false, false, false, '1a27b344460f49ce2d93365712a202ca', 1, NULL);
 INSERT INTO license_ref (rf_pk, rf_shortname, rf_text, rf_url, rf_add_date, rf_copyleft, "rf_OSIapproved", rf_fullname, "rf_FSFfree", "rf_GPLv2compatible", "rf_GPLv3compatible", rf_notes, "rf_Fedora", marydone, rf_active,  rf_text_updatable, rf_md5, rf_detector_type, rf_source)
-VALUES (558, 'GPL-2.0+-with-classpath-exception', 'insert GPL v2+ text here
+VALUES (558, 'GPL-2.0-or-later WITH Classpath-exception-2.0', 'insert GPL v2+ text here
 
 Class Path Exception
 
 Linking this library statically or dynamically with other modules is making a combined work based on this library. Thus, the terms and conditions of the GNU General Public License cover the whole combination.
 
-As a special exception, the copyright holders of this library give you permission to link this library with independent modules to produce an executable, regardless of the license terms of these independent modules, and to copy and distribute the resulting executable under terms of your choice, provided that you also meet, for each linked independent module, the terms and conditions of the license of that module. An independent module is a module which is not derived from or based on this library. If you modify this library, you may extend this exception to your version of the library, but you are not obligated to do so. If you do not wish to do so, delete this exception statement from your version.', '', NULL, NULL, NULL, 'GPL-2.0+-with-classpath-exception', NULL, NULL, NULL, '', NULL, false, false, false, '7940d4b7aba4100c88b54e2d46edc883', 1, NULL);
+As a special exception, the copyright holders of this library give you permission to link this library with independent modules to produce an executable, regardless of the license terms of these independent modules, and to copy and distribute the resulting executable under terms of your choice, provided that you also meet, for each linked independent module, the terms and conditions of the license of that module. An independent module is a module which is not derived from or based on this library. If you modify this library, you may extend this exception to your version of the library, but you are not obligated to do so. If you do not wish to do so, delete this exception statement from your version.', '', NULL, NULL, NULL, 'GPL-2.0-or-later WITH Classpath-exception-2.0', NULL, NULL, NULL, '', NULL, false, false, false, '7940d4b7aba4100c88b54e2d46edc883', 1, NULL);
 INSERT INTO license_ref (rf_pk, rf_shortname, rf_text, rf_url, rf_add_date, rf_copyleft, "rf_OSIapproved", rf_fullname, "rf_FSFfree", "rf_GPLv2compatible", "rf_GPLv3compatible", rf_notes, "rf_Fedora", marydone, rf_active,  rf_text_updatable, rf_md5, rf_detector_type, rf_source)
 VALUES (253, 'X11', 'Copyright (C) 1996 X Consortium
 

--- a/src/www/ui/ajax-clearing-view.php
+++ b/src/www/ui/ajax-clearing-view.php
@@ -199,7 +199,21 @@ class AjaxClearingView extends FO_Plugin
       case "addLicense":
         $this->clearingDao->insertClearingEvent($uploadTreeId, $userId, $groupId,
           $licenseId, false, ClearingEventTypes::USER);
-        return new JsonResponse();
+        $licenseRef = $this->licenseDao->getLicenseById($licenseId, $groupId);
+        $warning = null;
+        if ($licenseRef !== null) {
+          $shortName = $licenseRef->getShortName();
+          if (preg_match('/-style$/', $shortName) ||
+              preg_match('/-possibility$/', $shortName) ||
+              $shortName === 'UnclassifiedLicense') {
+            $warning = "\"$shortName\" is not SPDX compliant and may require manual review.";
+          }
+        }
+        $res = [];
+        if ($warning) {
+          $res['warning'] = $warning;
+        }
+        return new JsonResponse($res);
 
       case "removeLicense":
         $this->clearingDao->insertClearingEvent($uploadTreeId, $userId, $groupId,

--- a/src/www/ui/scripts/change-license-common.js
+++ b/src/www/ui/scripts/change-license-common.js
@@ -194,11 +194,44 @@ function popUpLicenseText(popUpUri, title) {
   window.open(popUpUri + sel, title, 'width=600,height=400,toolbar=no,scrollbars=yes,resizable=yes');
 }
 
+function showLicenseWarningModal(message) {
+  var modalId = 'licenseWarningModal';
+  var $modal = $('#' + modalId);
+  if ($modal.length === 0) {
+    $modal = $(
+      '<div class="modal fade" id="' + modalId + '" tabindex="-1" role="dialog">' +
+        '<div class="modal-dialog modal-dialog-centered" role="document">' +
+          '<div class="modal-content">' +
+            '<div class="modal-header bg-secondary text-white">' +
+              '<h5 class="modal-title">' +
+                '<i class="fas fa-exclamation-circle"></i> Warning' +
+              '</h5>' +
+              '<button type="button" class="close" data-dismiss="modal" aria-label="Close">' +
+                '<span>&times;</span>' +
+              '</button>' +
+            '</div>' +
+            '<div class="modal-body" id="licenseWarningMessages"></div>' +
+            '<div class="modal-footer">' +
+              '<button type="button" class="btn btn-secondary" data-dismiss="modal">OK</button>' +
+            '</div>' +
+          '</div>' +
+        '</div>' +
+      '</div>'
+    );
+    $('body').append($modal);
+  }
+  $('#licenseWarningMessages').html('<div class="alert alert-warning">' + message + '</div>');
+  $modal.modal('show');
+}
+
 function modifyLicense(doWhat ,uploadId, uploadTreeId, licenseId) {
   $.getJSON("?mod=conclude-license&do=" + doWhat + "&upload=" + uploadId + "&item=" + uploadTreeId + "&licenseId=" + licenseId)
     .done(function (data) {
       if(data) {
         $('#decTypeSet').addClass('border-danger');
+      }
+      if (data && data.warning) {
+        showLicenseWarningModal(data.warning);
       }
       var table = createClearingTable();
       table.fnDraw(false);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Summary:

This PR updates non-SPDX-compliant license identifiers in the Nomos agent to enable proper SPDX report generation.

## Background:

- Created a proposal and got it reviewed: [Proposal](https://docs.google.com/document/d/1hpMrdnXXTZmlJ7cqodnnNF4K8GxvBqwzg5Ai8leOrNY/edit?usp=sharing)
- Discussed this issue during the **FOSSology Community Meeting**
- Created an implementation plan and got it reviewed: [Implementation plan](https://docs.google.com/document/d/138wLnzmn52dlCEzvhqgpuYGyn3-lsEh2bphrRA6hFTI/edit)

## Changes Made:

### Files Modified:

| File | Changes |
|------|---------|
| [src/nomos/agent/nomos.h](cci:7://file:///home/krrish/Desktop/fossology/src/nomos/agent/nomos.h:0:0-0:0) | 2 license constants |
| [src/nomos/agent/parse.c](cci:7://file:///home/krrish/Desktop/fossology/src/nomos/agent/parse.c:0:0-0:0) | ~80 license strings |
| [install/db/licenseRef.json](cci:7://file:///home/krrish/Desktop/fossology/install/db/licenseRef.json:0:0-0:0) | 5 license entries |
| [src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan](cci:7://file:///home/krrish/Desktop/fossology/src/nomos/agent_tests/testdata/LastGoodNomosTestfilesScan:0:0-0:0) | Updated test expectations |
| [src/nomos/agent_tests/Functional/OneShot-multiFile.php](cci:7://file:///home/krrish/Desktop/fossology/src/nomos/agent_tests/Functional/OneShot-multiFile.php:0:0-0:0) | Updated expected license names |
| [src/nomos/agent_tests/Functional/OneShot-bsd.php](cci:7://file:///home/krrish/Desktop/fossology/src/nomos/agent_tests/Functional/OneShot-bsd.php:0:0-0:0) | Updated expected license names |

### Types of Fixes
- **Parentheses [()](cci:1://file:///home/krrish/Desktop/fossology/src/nomos/agent/parse.c:9939:4-9941:3)** --> removed or replaced with `-` (e.g., `CECILL(dual)` --> `LicenseRef-CECILL-dual`)
- **Brackets `[]`** --> replaced with `-` (e.g., `GPL-2.1[sic]` --> `LicenseRef-GPL-2.1-sic`)
- **Spaces** --> replaced with `-` (e.g., `unRAR restriction` --> `LicenseRef-unRAR-restriction`)
- **Underscores `_`** --> replaced with `-` (e.g., `SGI_GLX` --> `SGI-GLX`)
- **Style-suffixed licenses** --> added `LicenseRef-` prefix (e.g., `BSD-style` --> `LicenseRef-BSD-style`)

### Note on Trailing `+`
Per maintainer feedback, the `+` suffix is retained for non-GNU licenses
(LPPL, MPL, NPL). Only GNU licenses (GPL, LGPL, AGPL) use the `-or-later`
format per FSF requirements.

## How to Test:

### 1. Build Nomos
```bash
cd fossology/build
cmake ..
ninja src/nomos/agent/nomos
```
### 2. Test with Sample Files
```bash
# Test ImageMagick license (previously output "ImageMagick(Apache)")
./src/nomos/agent/nomos ../src/nomos/agent_tests/testdata/NomosTestfiles/SPDX/ImageMagick
# Expected: File ImageMagick contains license(s) ImageMagick
```
### 3. Run Functional Tests
```bash
cd build
ctest -R nomos_functional_test -V
```
## Testing Done:
- Build passes
- Nomos outputs SPDX-compliant identifiers (verified manually)

## Closing issue:

Closes issue #3158 

@shaheemazmalmmd @Kaushl2208 @JanAltenberg @OliverFendt 