### PR TITLE
fix(spdx): sanitize invalid characters in LicenseRef identifiers

### DIFF
--- a/src/lib/php/Data/LicenseRef.php
+++ b/src/lib/php/Data/LicenseRef.php
@@ -117,10 +117,18 @@ class LicenseRef
       $spdxLicense = $spdxId;
     }
     if (StringOperation::stringStartsWith($spdxLicense, self::SPDXREF_PREFIX)) {
-      // License ref can not end with a '+'
-      $spdxLicense = preg_replace('/\+$/', '-or-later', $spdxLicense);
+      // LicenseRef idstrings cannot contain '+'; replace with '-or-later' to
+      // preserve the SPDX "or later" semantic (handles both trailing and
+      // mid-string positions)
+      $spdxLicense = preg_replace('/\+/', '-or-later', $spdxLicense);
     }
-    return self::replaceSpaces($spdxLicense);
+    $spdxLicense = self::replaceSpaces($spdxLicense);
+
+    if (StringOperation::stringStartsWith($spdxLicense, self::SPDXREF_PREFIX)) {
+      $spdxLicense = SpdxLicenseValidator::sanitizeLicenseRef($spdxLicense);
+    }
+
+    return $spdxLicense;
   }
 
   /**

--- a/src/lib/php/Data/SpdxLicenseValidator.php
+++ b/src/lib/php/Data/SpdxLicenseValidator.php
@@ -1,0 +1,88 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2025 Sandip Mandal
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\Lib\Data;
+
+/**
+ * @class SpdxLicenseValidator
+ * @brief Validate and sanitize SPDX LicenseRef identifiers
+ */
+class SpdxLicenseValidator
+{
+  const VALID_IDSTRING_PATTERN = '/^[a-zA-Z0-9.\-]+$/';
+
+  public static function isValidLicenseRef(string $licenseId): bool
+  {
+    if (empty($licenseId) || !self::isLicenseRef($licenseId)) {
+      return false;
+    }
+
+    $idstring = self::extractIdstring($licenseId);
+    return !empty($idstring) && preg_match(self::VALID_IDSTRING_PATTERN, $idstring);
+  }
+
+  public static function isLicenseRef(string $licenseId): bool
+  {
+    return strpos($licenseId, LicenseRef::SPDXREF_PREFIX) === 0;
+  }
+
+  public static function extractIdstring(string $licenseId): string
+  {
+    if (!self::isLicenseRef($licenseId)) {
+      return '';
+    }
+    return substr($licenseId, strlen(LicenseRef::SPDXREF_PREFIX));
+  }
+
+  public static function getValidationErrors(string $licenseId): array
+  {
+    if (empty($licenseId)) {
+      return ["License identifier is empty"];
+    }
+
+    if (!self::isLicenseRef($licenseId)) {
+      return [];
+    }
+
+    $idstring = self::extractIdstring($licenseId);
+    if (empty($idstring)) {
+      return ["LicenseRef- prefix found but no idstring follows"];
+    }
+
+    $invalidChars = [];
+    for ($i = 0; $i < strlen($idstring); $i++) {
+      $char = $idstring[$i];
+      if (!preg_match('/[a-zA-Z0-9.\-]/', $char) && !in_array($char, $invalidChars)) {
+        $invalidChars[] = $char;
+      }
+    }
+
+    if (!empty($invalidChars)) {
+      return ["Contains invalid characters: " . implode(', ', array_map(fn($c) => "'$c'", $invalidChars))];
+    }
+
+    return [];
+  }
+
+  public static function sanitizeLicenseRef(string $licenseId): string
+  {
+    if (empty($licenseId) || !self::isLicenseRef($licenseId)) {
+      return $licenseId;
+    }
+
+    $idstring = self::extractIdstring($licenseId);
+    if (empty($idstring)) {
+      return $licenseId;
+    }
+
+    $sanitized = preg_replace('/[^a-zA-Z0-9.\-]/', '-', $idstring);
+    $sanitized = preg_replace('/-+/', '-', $sanitized);
+    $sanitized = trim($sanitized, '-');
+
+    return empty($sanitized) ? $licenseId : LicenseRef::SPDXREF_PREFIX . $sanitized;
+  }
+}

--- a/src/lib/php/Data/test/LicenseRefTest.php
+++ b/src/lib/php/Data/test/LicenseRefTest.php
@@ -48,6 +48,18 @@ class LicenseRefTest extends \PHPUnit\Framework\TestCase
   public function testDefaultSpdxId()
   {
     $licenseRef = new LicenseRef($this->id, $this->shortName, $this->fullName, "");
-    assertThat($licenseRef->getSpdxId(), is(LicenseRef::SPDXREF_PREFIX_FOSSOLOGY . $this->shortName));
+    assertThat($licenseRef->getSpdxId(), is("LicenseRef-fossology-shortName"));
+  }
+
+  public function testMidStringPlusConvertedToOrLater()
+  {
+    $licenseRef = new LicenseRef($this->id, "GPL-2.0+-with-bison-exception", $this->fullName, "");
+    assertThat($licenseRef->getSpdxId(), is("LicenseRef-fossology-GPL-2.0-or-later-with-bison-exception"));
+  }
+
+  public function testTrailingPlusStillConvertedToOrLater()
+  {
+    $licenseRef = new LicenseRef($this->id, "GPL-2.0+", $this->fullName, "");
+    assertThat($licenseRef->getSpdxId(), is("LicenseRef-fossology-GPL-2.0-or-later"));
   }
 }

--- a/src/spdx/agent/spdx.php
+++ b/src/spdx/agent/spdx.php
@@ -55,6 +55,7 @@ use Fossology\Lib\Data\LicenseRef;
 use Fossology\Lib\Data\Package\ComponentType;
 use Fossology\Lib\Data\Report\FileNode;
 use Fossology\Lib\Data\Report\SpdxLicenseInfo;
+use Fossology\Lib\Data\SpdxLicenseValidator;
 use Fossology\Lib\Data\Upload\Upload;
 use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Report\LicenseClearedGetter;
@@ -635,6 +636,7 @@ class SpdxAgent extends Agent
     $this->generateFileNodes($filesWithLicenses, $upload->getTreeTableName(), $uploadId);
     $this->declaredLicenseFileIds = array_unique(array_diff($this->declaredLicenseFileIds, $this->concludedLicenseFileIds));
     $this->concludedLicenseFileIds = array_unique($this->concludedLicenseFileIds);
+    $this->validateLicenseIdentifiers();
     $message = $this->renderString($this->getTemplateFile('document'),array(
         'documentName' => $fileBase,
         'uri' => $this->uri,
@@ -668,6 +670,35 @@ class SpdxAgent extends Agent
   protected function updateReportTable($uploadId, $jobId, $fileName)
   {
     $this->reportutils->updateOrInsertReportgenEntry($uploadId, $jobId, $fileName);
+  }
+
+  protected function validateLicenseIdentifiers()
+  {
+    $issues = [];
+    foreach ($this->licensesInDocument as $licenseInfo) {
+      $license = $licenseInfo->getLicenseObj();
+      $spdxId = $license->getSpdxId();
+      $shortName = $license->getShortName();
+
+      if (!SpdxLicenseValidator::isLicenseRef($spdxId)) {
+        continue;
+      }
+      if (preg_match('/[^a-zA-Z0-9.\-\s]/', $shortName)) {
+        $idstring = SpdxLicenseValidator::extractIdstring($spdxId);
+        $fossologyPrefix = substr(LicenseRef::SPDXREF_PREFIX_FOSSOLOGY,
+          strlen(LicenseRef::SPDXREF_PREFIX));
+        if (strpos($idstring, $fossologyPrefix) === 0) {
+          $idstring = substr($idstring, strlen($fossologyPrefix));
+        }
+        $issues[] = sprintf("  \"%s\" -> sanitized to \"%s\"",
+          $shortName, $idstring);
+      }
+    }
+
+    if (!empty($issues)) {
+      error_log("spdx: License shortnames with invalid SPDX characters were sanitized:\n"
+        . implode("\n", $issues));
+    }
   }
 
   /**


### PR DESCRIPTION
## Description                                                                                                                        
                                                                                                                                        
  Sanitizes invalid characters in SPDX LicenseRef identifiers during export. Per SPDX spec, idstring can only contain letters, numbers, hyphens, and periods. This fix ensures generated IDs are always valid.                                                                
                                                                                                                                        
  ### Changes                                                                                                                           
                                                                                                                                        
  - Added `SpdxLicenseValidator` class to validate and sanitize LicenseRef IDs                                                          
  - Updated `LicenseRef::convertToSpdxId()` to sanitize invalid characters                                                              
  - Added validation logging in SPDX agent to help users identify problematic licenses                                                  
                                                                                                                                        
  ## How to test                                                                                                                        
                                                                                                                                        
  1. Create a license candidate with invalid characters                                                     
  2. Upload a file and assign that license to it                                                                                        
  3. Run SPDX export                                                                                                                    
  4. Verify the output contains valid ID                                                      
  5. Check logs for validation warning message                                                                                          
                                                                                                                                        
  Fixes #3139 