### PR TITLE
fix(ui): rename Copy to Alias and add tooltip

### DIFF
--- a/src/www/ui/template/admin_content_move.html.twig
+++ b/src/www/ui/template/admin_content_move.html.twig
@@ -34,7 +34,8 @@
         <br/>
         <br/>
 
-        <input type="submit" name="move" value="{{ 'Move'|trans }}"/> &nbsp; <input type="submit" name="copy" value="{{ 'Copy'|trans }}"/>
+        <span title="{{ 'Move: Transfers folder or upload to another location.\nAlias: Creates a shared folder reference. Changes in one appear everywhere.'|trans }}">ℹ</span>
+        <input type="submit" name="move" value="{{ 'Move'|trans }}"/> &nbsp; <input type="submit" name="copy" value="{{ 'Alias'|trans }}"/>
       </form>
     </td>
   </tr>


### PR DESCRIPTION
## Description

Renames the "Copy" action to "Alias" on the content_move page and adds a tooltip explaining the alias behavior.

## Changes

- Renamed UI label from "Copy" to "Alias".
- Added tooltip explaining that Alias creates a shared folder and changes in one location appear in all aliases.
- No backend logic changes.

## How to test

1. Open Fossology Web UI.
2. Navigate to Organize → Folders → Move or Copy.
3. Verify the button label shows "Alias".
4. Hover over the Alias button and confirm tooltip text is displayed.

Fixes #613
