### PR TITLE
feat(chore): remove support for Debian stretch and buster / Ubuntu focal

### DIFF
--- a/cmake/SetDefaults.cmake
+++ b/cmake/SetDefaults.cmake
@@ -119,8 +119,6 @@ if(DEFINED CMAKE_CXX_COMPILER)
 endif()
 find_package(Git REQUIRED)
 
-# libmagic, libgcrypt does not have pc module on Debian buster
-# json-c does not have cmake aware packages on Debian buster
 foreach(SCHE_LIBS
         glib-2.0 gthread-2.0 gio-2.0 gobject-2.0 rpm libxml-2.0 libxslt icu-uc
         json-c

--- a/src/compatibility/mod_deps
+++ b/src/compatibility/mod_deps
@@ -88,10 +88,6 @@ if [[ $RUNTIME ]]; then
   case "$DISTRO" in
     Debian|Ubuntu|Tuxedo)
       case "$CODENAME" in
-        stretch)
-          apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.62.0 libboost-program-options1.62.0 libboost-regex1.62.0 libyaml-cpp0.5v5;;
-        buster)
-          apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.67.0 libboost-program-options1.67.0 libboost-regex1.67.0 libyaml-cpp0.6;;
         bullseye)
           apt-get $YesOpt install libjsoncpp24 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0 libyaml-cpp0.6;;
         bookworm)
@@ -100,8 +96,6 @@ if [[ $RUNTIME ]]; then
           apt-get $YesOpt install libjsoncpp26 libboost-filesystem1.83.0 libboost-program-options1.83.0 libboost-regex1.83.0 libyaml-cpp0.8;;
         sid)
           apt-get $YesOpt install libjsoncpp26 libboost-filesystem1.83.0 libboost-program-options1.83.0 libboost-regex1.83.0 libyaml-cpp0.8;;
-        focal)
-          apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.71.0 libboost-program-options1.71.0 libboost-regex1.71.0 libyaml-cpp0.6;;
         jammy)
           apt-get $YesOpt install libjsoncpp25 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0 libyaml-cpp0.7;;
         noble)

--- a/src/copyright/mod_deps
+++ b/src/copyright/mod_deps
@@ -87,10 +87,6 @@ if [[ $RUNTIME ]]; then
   case "$DISTRO" in
     Debian|Ubuntu|Tuxedo)
       case "$CODENAME" in
-        stretch)
-          apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.62.0;;
-        buster)
-          apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.67.0;;
         bullseye)
           apt-get $YesOpt install libjsoncpp24 libboost-filesystem1.74.0;;
         bookworm)
@@ -99,8 +95,6 @@ if [[ $RUNTIME ]]; then
           apt-get $YesOpt install libjsoncpp26 libboost-filesystem1.83.0;;
         sid)
           apt-get $YesOpt install libjsoncpp25 libboost-filesystem1.74.0;;
-        focal)
-          apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.71.0;;
         jammy)
           apt-get $YesOpt install libjsoncpp25 libboost-filesystem1.74.0;;
         noble)

--- a/src/nomos/mod_deps
+++ b/src/nomos/mod_deps
@@ -81,14 +81,10 @@ if [[ $RUNTIME ]]; then
   case "$DISTRO" in
     Debian|Ubuntu|Tuxedo)
       case "$CODENAME" in
-        stretch|buster|cosmic)
-          apt-get $YesOpt install libjson-c3;;
         bullseye)
           apt-get $YesOpt install libjson-c5;;
         bookworm|trixie|sid)
           apt-get $YesOpt install libjson-c5;;
-        focal)
-          apt-get $YesOpt install libjson-c4;;
         jammy)
           apt-get $YesOpt install libjson-c5;;
         noble)

--- a/src/ojo/mod_deps
+++ b/src/ojo/mod_deps
@@ -87,10 +87,6 @@ if [[ $RUNTIME ]]; then
   case "$DISTRO" in
     Debian|Ubuntu|Tuxedo)
       case "$CODENAME" in
-        stretch)
-          apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.62.0 libboost-program-options1.62.0 libboost-regex1.62.0;;
-        buster)
-          apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.67.0 libboost-program-options1.67.0 libboost-regex1.67.0;;
         bullseye)
           apt-get $YesOpt install libjsoncpp24 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0;;
         bookworm)
@@ -99,8 +95,6 @@ if [[ $RUNTIME ]]; then
           apt-get $YesOpt install libjsoncpp26 libboost-filesystem1.83.0 libboost-program-options1.83.0 libboost-regex1.83.0;;
         sid)
           apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0;;
-        focal)
-          apt-get $YesOpt install libjsoncpp1 libboost-filesystem1.71.0 libboost-program-options1.71.0 libboost-regex1.71.0;;
         jammy)
           apt-get $YesOpt install libjsoncpp25 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0;;
         noble)

--- a/src/scancode/mod_deps
+++ b/src/scancode/mod_deps
@@ -90,10 +90,6 @@ if [[ $RUNTIME ]]; then
         libbz2-1.0 xz-utils zlib1g libxml2-dev libxslt1-dev libpopt0 \
         python3 python3-pip
       case "$CODENAME" in
-        stretch)
-          apt-get $YesOpt install libjsoncpp1 libboost-program-options1.62.0;;
-        buster)
-          apt-get $YesOpt install libjsoncpp1 libboost-program-options1.67.0;;
         bullseye)
           apt-get $YesOpt install libjsoncpp24 libboost-program-options1.74.0;;
         bookworm)
@@ -102,8 +98,6 @@ if [[ $RUNTIME ]]; then
           apt-get $YesOpt install libjsoncpp26 libboost-program-options1.83.0;;
         sid)
           apt-get $YesOpt install libjsoncpp1 libboost-program-options1.74.0;;
-        focal)
-          apt-get $YesOpt install libjsoncpp1 libboost-program-options1.71.0;;
         jammy)
           apt-get $YesOpt install libjsoncpp25 libboost-program-options1.74.0;;
         noble)

--- a/utils/fo-installdeps
+++ b/utils/fo-installdeps
@@ -97,10 +97,6 @@ if [[ $BUILDTIME ]]; then
             libboost-program-options-dev libpq-dev composer patch devscripts \
             libdistro-info-perl libcppunit-dev libomp-dev cmake ninja-build
          case "$CODENAME" in
-           stretch)
-             apt-get $YesOpt install php-mbstring php7.0-cli php7.0-xml php7.0-zip php7.0-gd php7.0-pgsql php7.0-curl php7.0-uuid php7.0-sqlite3 php7.0-yaml;;
-           buster)
-             apt-get $YesOpt install php-mbstring php7.3-cli php7.3-xml php7.3-zip php7.3-gd php7.3-pgsql php7.3-curl php7.3-uuid php7.3-sqlite3 php7.3-yaml;;
            bullseye)
              apt-get $YesOpt install php7.4-mbstring php7.4-cli php7.4-xml php7.4-zip php7.4-gd php7.4-pgsql php7.4-curl php7.4-uuid php7.4-sqlite3 php7.4-yaml;;
            bookworm)
@@ -109,8 +105,6 @@ if [[ $BUILDTIME ]]; then
              apt-get $YesOpt install php8.4-mbstring php8.4-cli php8.4-xml php8.4-zip php8.4-gd php8.4-pgsql php8.4-curl php8.4-uuid php8.4-sqlite3 php8.4-yaml;;
            sid)
              apt-get $YesOpt install php-mbstring php-cli php-xml php-zip php-gd php-pgsql php-curl php-uuid php-sqlite3 php-yaml;;
-           focal)
-             apt-get $YesOpt install php-mbstring php-cli php-xml php-zip php-gd php-pgsql php-curl php-uuid php-sqlite3 php-yaml;;
            jammy)
              apt-get $YesOpt install php-mbstring php-cli php-xml php-zip php-gd php-pgsql php-curl php-uuid php-sqlite3 php-yaml;;
            noble)
@@ -118,10 +112,6 @@ if [[ $BUILDTIME ]]; then
          esac
          if ! dpkg --get-selections | grep -q postgresql-server-dev; then  ## if postgresql-server-dev is not installed
            case "$CODENAME" in
-              stretch)
-                apt-get $YesOpt install postgresql-server-dev-9.6;;
-              buster)
-                apt-get $YesOpt install postgresql-server-dev-11;;
               bullseye)
                 apt-get $YesOpt install postgresql-server-dev-13;;
               bookworm)
@@ -130,8 +120,6 @@ if [[ $BUILDTIME ]]; then
                 apt-get $YesOpt install postgresql-server-dev-17;;
               sid)
                 apt-get $YesOpt install postgresql-server-dev-16;;
-              focal)
-                apt-get $YesOpt install postgresql-server-dev-12;;
               jammy)
                 apt-get $YesOpt install postgresql-server-dev-14;;
               noble)
@@ -181,14 +169,6 @@ if [[ $RUNTIME ]]; then
             subversion git \
             dpkg-dev php-uuid php-yaml
          case "$CODENAME" in
-            stretch)
-               apt-get $YesOpt install postgresql-9.6 php7.0 php7.0-pgsql libapache2-mod-php7.0 php7.0-pgsql \
-                 php7.0-cli php7.0-curl php7.0-xml php7.0-zip php7.0-mbstring php7.0-uuid php-gettext s-nail libboost-program-options1.62.0 \
-                 libboost-regex1.62.0 libicu57;;
-            buster)
-               apt-get $YesOpt install postgresql-11 php7.3 php7.3-pgsql libapache2-mod-php7.3 php7.3-pgsql \
-                 php7.3-cli php7.3-curl php7.3-xml php7.3-zip php7.3-mbstring php7.3-uuid php-gettext s-nail libboost-program-options1.67.0 \
-                 libboost-regex1.67.0 libicu63;;
             bullseye)
                apt-get $YesOpt install postgresql-13 php7.4 php7.4-pgsql \
                libapache2-mod-php7.4 php7.4-pgsql php7.4-cli php7.4-curl \
@@ -207,9 +187,6 @@ if [[ $RUNTIME ]]; then
             sid)
                apt-get $YesOpt install postgresql php php-pgsql php-cli php-curl php-xml php-zip php-mbstring php-uuid php-gettext s-nail \
                  libboost-program-options1.74.0 libboost-regex1.74.0 libicu67;;
-            focal)
-               apt-get $YesOpt install postgresql php php-pgsql php-cli php-curl php-xml php-zip php-mbstring php-uuid s-nail \
-                 libboost-program-options1.71.0 libboost-regex1.71.0 libicu66;;
             jammy)
                apt-get $YesOpt install postgresql-14 php8.1 php8.1-pgsql \
                libapache2-mod-php8.1 php8.1-pgsql php8.1-cli php8.1-curl \


### PR DESCRIPTION
Drop Debian stretch and buster support from installer and module dependency scripts
Drop Ubuntu fossy focal  support from installer and module dependency scripts

Remove references and per-codename package branches for end-of-life Debian and Ubuntu releases from installer helper and module mod_deps scripts to avoid attempts to install unavailable packages and simplify maintenance.

**Changes**

- Updated installer helper: fo-installdeps — removed stretch/buster/focal case arms for buildtime/runtime and postgresql mappings.
- Updated module dependency files: removed stretch/buster/focal branches
- Removed comment in cmake/SetDefaults.cmake (function afterwards did not reflect this)

