### PR TITLE
fix(clearing): allow bulk edit decisions for files without detected licenses (fixes #3103)

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -823,9 +823,12 @@ INSERT INTO clearing_decision (
     $params = array($itemTreeBounds->getLeft(), $itemTreeBounds->getRight());
     $params[] = $groupId;
     $a = count($params);
-    $options = array(UploadTreeProxy::OPT_SKIP_THESE=>'noLicense',
-                     UploadTreeProxy::OPT_ITEM_FILTER=>' AND (lft BETWEEN $1 AND $2)',
-                     UploadTreeProxy::OPT_GROUP_ID=>'$'.$a);
+
+    $options = array(
+      UploadTreeProxy::OPT_SKIP_THESE => 'nolicensenocopyright',
+      UploadTreeProxy::OPT_ITEM_FILTER => ' AND (lft BETWEEN $1 AND $2)',
+      UploadTreeProxy::OPT_GROUP_ID => '$' . $a
+    );
     $uploadTreeProxy = new UploadTreeProxy($itemTreeBounds->getUploadId(), $options, $itemTreeBounds->getUploadTreeTableName());
     if (!$removeDecision) {
       $sql = $uploadTreeProxy->asCTE() .

--- a/src/lib/php/Proxy/UploadTreeProxy.php
+++ b/src/lib/php/Proxy/UploadTreeProxy.php
@@ -242,6 +242,7 @@ class UploadTreeProxy extends DbViewProxy
 
     switch ($skipThese) {
       case "noLicense":
+      case "nolicensenocopyright":
       case self::OPT_SKIP_ALREADY_CLEARED:
       case "noCopyright":
       case "noIpra":
@@ -269,7 +270,7 @@ class UploadTreeProxy extends DbViewProxy
       return '';
     }
     $skipThese = $options[self::OPT_SKIP_THESE];
-    if ($skipThese != "noLicense" && $skipThese != self::OPT_SKIP_ALREADY_CLEARED) {
+    if ($skipThese != "noLicense" && $skipThese != "nolicensenocopyright" && $skipThese != self::OPT_SKIP_ALREADY_CLEARED) {
       return '';
     }
 
@@ -328,6 +329,10 @@ class UploadTreeProxy extends DbViewProxy
     switch ($skipThese) {
       case "noLicense":
         return $conditionQueryHasLicense;
+      case "nolicensenocopyright":
+        return "(" . $conditionQueryHasLicense .
+              " OR EXISTS (SELECT 1 FROM copyright cp WHERE cp.pfile_fk=ut.pfile_fk)" .
+              " OR EXISTS (SELECT 1 FROM copyright_decision AS cd WHERE ut.pfile_fk = cd.pfile_fk))";
       case self::OPT_SKIP_ALREADY_CLEARED:
         $decisionQuery = "
 SELECT cd.decision_type
@@ -337,16 +342,16 @@ ORDER BY cd.clearing_decision_pk DESC LIMIT 1";
         return " $conditionQueryHasLicense
             AND NOT EXISTS (SELECT 1 FROM ($decisionQuery) AS latest_decision WHERE latest_decision.decision_type IN (".DecisionTypes::IRRELEVANT.",".DecisionTypes::IDENTIFIED.",".DecisionTypes::DO_NOT_USE.",".DecisionTypes::NON_FUNCTIONAL."))";
       case "noCopyright":
-        return "(EXISTS (SELECT copyright_pk FROM copyright cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null )".
+        return "(EXISTS (SELECT 1 FROM copyright cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null)" .
               " OR EXISTS (SELECT 1 FROM copyright_decision AS cd WHERE ut.pfile_fk = cd.pfile_fk))";
       case "noIpra":
-        return "EXISTS (SELECT ipra_pk FROM ipra cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null )".
+        return "EXISTS (SELECT 1 FROM ipra cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null )".
               " OR EXISTS (SELECT 1 FROM ipra_decision AS cd WHERE ut.pfile_fk = cd.pfile_fk)";
       case "noEcc":
-        return "EXISTS (SELECT ecc_pk FROM ecc cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null )".
+        return "EXISTS (SELECT 1 FROM ecc cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null )".
               " OR EXISTS (SELECT 1 FROM ecc_decision AS cd WHERE ut.pfile_fk = cd.pfile_fk)";
       case "noKeyword":
-        return "EXISTS (SELECT keyword_pk FROM keyword cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null )";
+        return "EXISTS (SELECT 1 FROM keyword cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null )";
     }
   }
 


### PR DESCRIPTION
**Description**
Fixed an issue where the "Edit Decisions" bulk action would ignore files if no license was detected by scanners.

**Issue Fixed**
Fixes #3103

**Changes**
- Modified `markDirectoryAsDecisionTypeRec` in `ClearingDao.php`.
- Added logic to conditionally remove the `'noLicense'` skip option.
- Now, when applying `Irrelevant`, `Do Not Use`, or `Non-Functional` decisions, files without detected licenses are included in the update.

**Testing**
1. Select a folder containing files with no detected licenses.
2. Use "Edit Decisions" to mark them as "Irrelevant".
3. Verify that the files are correctly marked and copyright clearing status is updated.