### PR TITLE
fix(util): correctly filter '.' and '..' segments in pURL subpath

### DIFF
--- a/src/lib/php/Util/PurlOperations.php
+++ b/src/lib/php/Util/PurlOperations.php
@@ -31,7 +31,7 @@ class PurlOperations
       $subpaths = explode("/", $subpath);
       $subpath = [];
       foreach ($subpaths as $sp) {
-        if ($sp != "." || $sp != "..") {
+        if ($sp != "." && $sp != "..") {
           $subpath[] = urldecode($sp);
         }
       }


### PR DESCRIPTION


## Description

This pull request fixes an incorrect condition in the pURL subpath parsing logic which caused relative path segments (. and ..) to be preserved instead of being filtered out.
As a result, subpaths were not normalized as required by the pURL specification.

The change ensures that . and .. segments are correctly removed when parsing pURL subpaths, without affecting common pURLs that do not contain subpaths.

### Changes

-- Fix logical condition used while filtering pURL subpath segments

-- Correctly exclude . and .. segments during subpath normalization

-- Preserve existing behavior for all other valid subpath segme

## Validation

The fix was validated locally using a small isolated PHP script that directly invokes
PurlOperations::fromString() from the command line.

The following example pURLs were used to verify behavior:

pkg:npm/lodash@4.17.21#./lib/../fp

Before the fix: subpath was returned as ./lib/../fp

After the fix: subpath is correctly normalized to lib/fp

pkg:generic/foo@1.0#okok./..

After the fix: subpath is returned as okok.

The script was executed from the repository root in an isolated environment, and the terminal output before and after the fix is attached as a screenshot for reference.

Before:
<img width="810" height="160" alt="image" src="https://github.com/user-attachments/assets/352f66d6-63b1-42ff-b63e-476b5c25fd88" />


After:
<img width="797" height="170" alt="image" src="https://github.com/user-attachments/assets/1ad2fb61-bdfd-4b5c-88ee-58230914e223" />

