### PR TITLE
docs: clarify install wiki pointer

### DIFF
--- a/install/INSTALL
+++ b/install/INSTALL
@@ -4,4 +4,4 @@
 -->
 FOSSology Installation Documentation
 
-This has been moved to https://github.com/fossology/fossology/wiki/Install-from-Source
+Installation instructions are maintained on the wiki: https://github.com/fossology/fossology/wiki/Install-from-Source


### PR DESCRIPTION
This pull request makes a minor update to the installation documentation. The change clarifies that installation instructions are maintained on the project's wiki.