### PR TITLE
Fix utility scripts to locate pathinclude.php robustly

### DIFF
--- a/utils/fedora/get-fsrc.php
+++ b/utils/fedora/get-fsrc.php
@@ -37,7 +37,26 @@
 // FIXME: $path = '/usr/local/fossology/agents';
 set_include_path(get_include_path() . PATH_SEPARATOR . $path);
 
-require_once("FIXMETOBERELATIVE/pathinclude.php");
+// Try common locations for pathinclude.php and fail with helpful message if not found.
+$__path_candidates = array(
+  dirname(__FILE__) . '/../../src/lib/php/pathinclude.php',
+  dirname(__FILE__) . '/../../src/php/pathinclude.php',
+  dirname(__FILE__) . '/../php/pathinclude.php',
+  '/usr/local/share/fossology/php/pathinclude.php',
+  '/usr/share/fossology/php/pathinclude.php'
+);
+$__found = false;
+foreach ($__path_candidates as $__p) {
+  if (file_exists($__p)) {
+    require_once $__p;
+    $__found = true;
+    break;
+  }
+}
+if (! $__found) {
+  fwrite(STDERR, "FATAL: cannot find pathinclude.php. Please install Fossology or add pathinclude.php to your include path.\n");
+  exit(1);
+}
 global $WEBDIR;
 require_once("$WEBDIR/common/common-cli.php");
 

--- a/utils/freshmeat/diffm.php
+++ b/utils/freshmeat/diffm.php
@@ -50,7 +50,26 @@
 * file that will be used by get-projects to retrieve them from the net.
 *
 */
-require_once("FIXMETOBERELATIVE/pathinclude.php");
+// Try common locations for pathinclude.php and fail with helpful message if not found.
+$__path_candidates = array(
+  dirname(__FILE__) . '/../../src/lib/php/pathinclude.php',
+  dirname(__FILE__) . '/../../src/php/pathinclude.php',
+  dirname(__FILE__) . '/../php/pathinclude.php',
+  '/usr/local/share/fossology/php/pathinclude.php',
+  '/usr/share/fossology/php/pathinclude.php'
+);
+$__found = false;
+foreach ($__path_candidates as $__p) {
+  if (file_exists($__p)) {
+    require_once $__p;
+    $__found = true;
+    break;
+  }
+}
+if (! $__found) {
+  fwrite(STDERR, "FATAL: cannot find pathinclude.php. Please install Fossology or add pathinclude.php to your include path.\n");
+  exit(1);
+}
 require_once("$LIBDIR/lib_projxml.h.php");
 
 $usage = <<< USAGE

--- a/utils/freshmeat/get-projects.php
+++ b/utils/freshmeat/get-projects.php
@@ -46,7 +46,27 @@
  *    for that case.
  */
 // pathinclude below is dependent on having fossology installed.
-require_once "FIXMETOBERELATIVE/pathinclude.php";       // brings in global $PROJECTSTATEDIR +
+// Try common locations for pathinclude.php and fail with helpful message if not found.
+$__path_candidates = array(
+  dirname(__FILE__) . '/../../src/lib/php/pathinclude.php',
+  dirname(__FILE__) . '/../../src/php/pathinclude.php',
+  dirname(__FILE__) . '/../php/pathinclude.php',
+  '/usr/local/share/fossology/php/pathinclude.php',
+  '/usr/share/fossology/php/pathinclude.php'
+);
+$__found = false;
+foreach ($__path_candidates as $__p) {
+  if (file_exists($__p)) {
+    require_once $__p;
+    $__found = true;
+    break;
+  }
+}
+if (! $__found) {
+  fwrite(STDERR, "FATAL: cannot find pathinclude.php. Please install Fossology or add pathinclude.php to your include path.\n");
+  exit(1);
+}
+
 global $LIBDIR;
 global $INCLUDEDIR;
 require_once("$LIBDIR/lib_projxml.h.php");

--- a/utils/freshmeat/mk_fmdirs.php
+++ b/utils/freshmeat/mk_fmdirs.php
@@ -44,7 +44,26 @@
  * associate folders with each other....
  */
 
-require_once("FIXMETOBERELATIVE/pathinclude.php");
+// Try common locations for pathinclude.php and fail with helpful message if not found.
+$__path_candidates = array(
+  dirname(__FILE__) . '/../../src/lib/php/pathinclude.php',
+  dirname(__FILE__) . '/../../src/php/pathinclude.php',
+  dirname(__FILE__) . '/../php/pathinclude.php',
+  '/usr/local/share/fossology/php/pathinclude.php',
+  '/usr/share/fossology/php/pathinclude.php'
+);
+$__found = false;
+foreach ($__path_candidates as $__p) {
+  if (file_exists($__p)) {
+    require_once $__p;
+    $__found = true;
+    break;
+  }
+}
+if (! $__found) {
+  fwrite(STDERR, "FATAL: cannot find pathinclude.php. Please install Fossology or add pathinclude.php to your include path.\n");
+  exit(1);
+}
 /* the items below no longer exist, my this code is old.... */
 require_once("$PHPDIR/webcommon.h.php");
 require_once("$PHPDIR/jobs.h.php");

--- a/utils/freshmeat/mktop1k.php
+++ b/utils/freshmeat/mktop1k.php
@@ -25,7 +25,26 @@
  */
 
 // FIXME: this should bet a global from pathinclude? $LIBDIR = '/usr/local/lib';
-require_once("FIXMETOBERELATIVE/pathinclude.php");
+// Try common locations for pathinclude.php and fail with helpful message if not found.
+$__path_candidates = array(
+  dirname(__FILE__) . '/../../src/lib/php/pathinclude.php',
+  dirname(__FILE__) . '/../../src/php/pathinclude.php',
+  dirname(__FILE__) . '/../php/pathinclude.php',
+  '/usr/local/share/fossology/php/pathinclude.php',
+  '/usr/share/fossology/php/pathinclude.php'
+);
+$__found = false;
+foreach ($__path_candidates as $__p) {
+  if (file_exists($__p)) {
+    require_once $__p;
+    $__found = true;
+    break;
+  }
+}
+if (! $__found) {
+  fwrite(STDERR, "FATAL: cannot find pathinclude.php. Please install Fossology or add pathinclude.php to your include path.\n");
+  exit(1);
+}
 require_once("$LIBDIR/lib_projxml.h.php");
 //require_once("./lib_projxml.h.php");            // dev copy
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix utility scripts failing at runtime due to a hardcoded and invalid `pathinclude.php` require path.

Several scripts referenced `FIXMETOBERELATIVE/pathinclude.php`, which caused fatal errors when running
the utilities outside a very specific directory layout (e.g. system installs, WSL, or CI).

## Changes

- Replaced the hardcoded `require_once("FIXMETOBERELATIVE/pathinclude.php")` with a robust lookup
  mechanism.
- Added checks for `pathinclude.php` in common repository-relative and system install locations.
- Improved error handling by emitting a clear, actionable message when `pathinclude.php` cannot be found.

Updated scripts:
- `get-projects.php`
- `mk_fmdirs.php`
- `diffm.php`
- `mktop1k.php`
- `get-fsrc.php`

Closing issue #3290 
