### PR TITLE
fix(spdx2rdf): Fix validation errors

### DIFF
--- a/src/spdx/agent/template/spdx2-file.xml.twig
+++ b/src/spdx/agent/template/spdx2-file.xml.twig
@@ -139,7 +139,7 @@
   {%- endfor %}{# End printing license infos in file #}
 {%- endif %}
 {%~ if fileData.copyrights|default is empty %}
-    <spdx:copyrightText rdf:resource="http://spdx.org/rdf/terms#noassertion" />
+    <spdx:copyrightText>NOASSERTION</spdx:copyrightText>
 {%~ else %}
     <spdx:copyrightText><![CDATA[
   {%~ for cp in fileData.copyrights %}

--- a/src/spdx/agent/template/spdx2-package.xml.twig
+++ b/src/spdx/agent/template/spdx2-package.xml.twig
@@ -17,7 +17,7 @@
       <spdx:Package rdf:about="#SPDXRef-upload{{ packageId|url_encode }}">
         <spdx:name>{{ packageName }}</spdx:name>
         <spdx:packageFileName>{{ uploadName }}</spdx:packageFileName>
-        <spdx:downloadLocation rdf:resource="http://spdx.org/rdf/terms#noassertion" />
+        <spdx:downloadLocation>http://spdx.org/rdf/terms#noassertion</spdx:downloadLocation>
         <spdx:versionInfo>{{ packageVersion|e }}</spdx:versionInfo>
         {%- if releaseDate is not empty ~%}
         <spdx:releaseDate>{{ releaseDate }}</spdx:releaseDate>
@@ -98,7 +98,7 @@
         ]]></spdx:licenseComments>
         {% endif %}<spdx:licenseDeclared rdf:resource="http://spdx.org/rdf/terms#noassertion" />
         <spdx:licenseInfoFromFiles rdf:resource="http://spdx.org/rdf/terms#noassertion" />
-        <spdx:copyrightText rdf:resource="http://spdx.org/rdf/terms#noassertion" />
+        <spdx:copyrightText>NOASSERTION</spdx:copyrightText>
         {%- if generalAssessment is not empty ~%}
         <rdfs:comment><![CDATA[
           {{ generalAssessment|replace({']]>':']]><![CDATA[>'}) }}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
Validation (with recent SPDX java tools) of exported SPDX2 RDF documents fails with validation errors for copyrightText and downloadLocation for the NOASSERTION case:

```
<spdx:copyrightText rdf:resource="http://spdx.org/rdf/terms#noassertion" />
```
leads to
```
Relationship error: Error getting comment: Property http://spdx.org/rdf/terms#copyrightText is not of type String in XYZ in /srv/fossology/repository/report
```
and
```
<spdx:downloadLocation rdf:resource="http://spdx.org/rdf/terms#noassertion" />
```
leads to
```
Relationship error: Unable to get download location: Property http://spdx.org/rdfterms#downloadLocation is not of type String in /srv/fossology/repository/report
```

Both properties are data properties.

### Changes

This commit changes the templates accordingly to the value range expected by the specification. downloadLocation in this scenario will be reflected as:
```
<spdx:downloadLocation>http://spdx.org/rdf/terms#noassertion</spdx:downloadLocation>
```

This is what the spec says about downloadLocation:
<img width="3218" height="464" alt="grafik" src="https://github.com/user-attachments/assets/877b009f-138f-431a-a5a6-baaa6878df9d" />

and copyrightLocation will be reflected as:
```
<spdx:copyrightText>NOASSERTION</spdx:copyrightText>
```
This is what the spec says on copyrightText:
<img width="3223" height="464" alt="grafik" src="https://github.com/user-attachments/assets/8e95345f-ab61-4e77-be61-fc56548fe26b" />

All validation tests have been run with java spdx tools 2.0.2 and 2.0.4

## How to test

1. Upload a package / Scan for copyright and licenses
2. Export SPDX2 RDF
3. Validate with java spdx tools
4. Without these changes validation will fail for copyrights with noassertion and for the download location

@shaheemazmalmmd @GMishx: Would be great if you could double check the changes against the spec and verify if my interpretation is correct.

Many thanks in advance and let me know if I can support with further information :)