### PR TITLE
feat(ui): add search option in con lic page text view

### DIFF
--- a/src/www/ui/css/search.css
+++ b/src/www/ui/css/search.css
@@ -1,0 +1,36 @@
+/*
+ SPDX-FileCopyrightText: © 2026 Siemens Healthineers AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+.clearing-search-bar {
+  background-color: #f5f5f5;
+  margin-bottom: 5px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: 10px;
+}
+
+.clearing-search-bar__input {
+  padding: 4px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  width: 250px;
+}
+
+.hi-search-match {
+  background-color: #ffcc00;
+  display: inline-block;
+  line-height: 1.1;
+  box-shadow: 0 0 0 2px #ffcc00, 0 0 5px rgba(0,0,0,0.5);
+  position: relative;
+  z-index: 999;
+  font-weight: bold;
+}
+
+.hi-search-match.active-match {
+  background-color: #ff6600;
+  box-shadow: 0 0 0 2px #ff6600, 0 0 5px rgba(0,0,0,0.5);
+}

--- a/src/www/ui/template/ui-clearing-view.html.twig
+++ b/src/www/ui/template/ui-clearing-view.html.twig
@@ -7,6 +7,7 @@
   {{ parent() }}
   <link rel="stylesheet" href="css/highlights.css"/>
   <link rel="stylesheet" href="css/spasht.css"/>
+  <link rel="stylesheet" href="css/search.css"/>
 {% endblock %}
 
 {% block content %}
@@ -16,6 +17,24 @@
         <td style="padding:0px; position:relative; height: 100%; width:50%">
           <div class="centered" style='padding:2px;'>
             {{ pageMenu }}
+            
+            <div class="clearing-search-bar" style="display:inline-flex;">
+                <input type="text" id="textSearchInput" class="clearing-search-bar__input" placeholder="Search in file..." value="{{ searchQuery }}">
+                <button class="btn btn-default btn-sm" id="btnTriggerSearch" title="Search">
+                     Search
+                </button>
+                <button class="btn btn-default btn-sm" id="btnPrevMatch" title="Previous Match" disabled>
+                    &uarr;
+                </button>
+                <button class="btn btn-default btn-sm" id="btnNextMatch" title="Next Match" disabled>
+                    &darr;
+                </button>
+                <span id="searchCountInfo" style="font-size: 0.9em; margin-left: 5px;"></span>
+                {% if searchQuery %}
+                   <button class="btn btn-xs btn-warning" id="btnClearSearch" title="Clear Search">X</button>
+                {% endif %}
+            </div>
+
             <button class="legendHider btn btn-default btn-sm">
               {{ 'Hide Legend'| trans }}
             </button>
@@ -23,12 +42,15 @@
               {{ 'Show Legend'| trans }}
             </button>
           </div>
-          <div class="boxnew" style="overflow:scroll;">{{ textView }}</div>
+          <div class="boxnew" id="fileTextView" style="overflow:scroll;">{{ textView }}</div>
           <div id="legendBox" name="legendBox" style="background-color:white; padding:2px; border:1px outset #222222; width:150px; position:absolute; right:17px; bottom:17px; ">
             <u><b>{{ 'Legend:'| trans }}</b></u><br/>
               {% for entry in legendData %}
                 <span style="{{ entry.style }}" class="{{ entry.class }}">{{ entry.text }}</span><br/>
               {% endfor %}
+              {% if searchQuery %}
+                <span class="hi-search-match" style="padding:0 3px;">Search Match</span><br/>
+              {% endif %}
           </div>
         </td>
         <td class="headerBox" style="min-width:100%;min-height:100%;">

--- a/src/www/ui/template/ui-clearing-view.js.twig
+++ b/src/www/ui/template/ui-clearing-view.js.twig
@@ -13,6 +13,8 @@ selectedLicensesTableColumns = [
 
 uploadId = {{ uploadId }};
 itemId = {{ itemId }};
+searchMatches = {{ searchMatches|json_encode|raw }};
+searchQuery = "{{ searchQuery }}";
 
 selectedLicensesTableConfig = {
   "bServerSide": true,
@@ -131,9 +133,162 @@ function createClearingHistoryDataTable() {
   otable = $('#ClearingHistoryDataModalTable').dataTable(addClearingHistoryTableConfig);
   return otable;
 }
+
+var searchMatches = searchMatches || [];
+var currentMatchIndex = -1;
+var currentPage = {{ currentPage }};
+
+const getMatchesOnPage = () => searchMatches.reduce((acc, m, i) => (m.page === currentPage ? [...acc, i] : acc), []);
+
+function initSearchNavigation() {
+  if (!searchMatches.length) return;
+  $("#btnNextMatch, #btnPrevMatch").prop("disabled", false);
+
+  const matchesOnPage = getMatchesOnPage();
+  const urlParams = new URLSearchParams(window.location.search);
+  const initialMatchIndex = parseInt(urlParams.get('matchIndex'));
+
+  if (matchesOnPage.length > 0) {
+    const target = (initialMatchIndex >= 0 && searchMatches[initialMatchIndex]?.page === currentPage) 
+                   ? initialMatchIndex : matchesOnPage[0];
+    navigateToMatch(target);
+  } else {
+    $("#searchCountInfo").text(`0 / ${searchMatches.length} (page ${currentPage + 1})`);
+  }
+}
+
+function navigateToMatch(index) {
+  if (!searchMatches.length) return;
+
+  currentMatchIndex = (index + searchMatches.length) % searchMatches.length;
+  const match = searchMatches[currentMatchIndex];
+
+  if (match.page !== currentPage) {
+    const url = new URL(window.location.href);
+    url.searchParams.set('page', match.page);
+    url.searchParams.set('search', searchQuery);
+    url.searchParams.set('matchIndex', currentMatchIndex);
+    window.location.href = url.href;
+    return;
+  }
+
+  const localIndex = getMatchesOnPage().indexOf(currentMatchIndex);
+
+  if (localIndex >= 0) {
+    $(".hi-search-match").removeClass("active-match");
+    const currentElements = $(`.hi-search-match[data-match-index='${localIndex}']`);
+
+    if (currentElements.length) {
+      currentElements.addClass("active-match");
+      const container = $("#fileTextView");
+      const scrollTop = currentElements.first().offset().top - container.offset().top + container.scrollTop() - (container.height() / 2);
+      container.animate({scrollTop}, 300);
+    }
+    $("#searchCountInfo").text(`${currentMatchIndex + 1} / ${searchMatches.length}`);
+  }
+}
+
+function performSearch() {
+  const term = $("#textSearchInput").val().trim();
+  if (term.length > 0 && term.length < 3) {
+    alert("Search term too short (min 3 chars)");
+    return;
+  }
+  if (term.length === 0) {
+    clearSearch();
+    return;
+  }
+
+  const url = new URL(window.location.href);
+  url.searchParams.set('search', term);
+  url.searchParams.set('page', '0');
+  url.searchParams.delete('matchIndex');
+  window.location.href = url.href;
+}
+
+function clearSearch() {
+  const url = new URL(window.location.href);
+  url.searchParams.delete('search');
+  url.searchParams.delete('matchIndex');
+  url.searchParams.set('page', '0');
+  window.location.href = url.href;
+}
+
+function highlightSearchMatches() {
+  const container = document.getElementById("fileTextView");
+  const searchText = "{{ searchQuery|e('js') }}";
+  if (!container || !searchText) return;
+
+  let allText = "";
+  const nodeMap = []; 
+  const treeWalker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, null, false);
+
+  while (treeWalker.nextNode()) {
+    const node = treeWalker.currentNode;
+    if (node.parentNode.classList.contains("hi-search-match")) continue;
+
+    [...node.nodeValue].forEach((char, i) => {
+      nodeMap.push({ node, index: i });
+      allText += char;
+    });
+  }
+
+  const regex = new RegExp(searchText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), "gi");
+  let match;
+  const matches = [];
+  while ((match = regex.exec(allText)) !== null) {
+    matches.push({ start: match.index, end: match.index + searchText.length });
+  }
+
+  matches.reverse().forEach((m, matchIdx) => {
+    const rangesToWrap = [];
+    let currentRange = null;
+
+    for (let i = m.start; i < m.end; i++) {
+      const map = nodeMap[i];
+      if (!currentRange || map.node !== currentRange.node) {
+        if (currentRange) rangesToWrap.push(currentRange);
+        currentRange = { node: map.node, start: map.index, end: map.index + 1 };
+      } else {
+        currentRange.end = map.index + 1;
+      }
+    }
+    if (currentRange) rangesToWrap.push(currentRange);
+
+    rangesToWrap.forEach(r => {
+      const range = document.createRange();
+      range.setStart(r.node, r.start);
+      range.setEnd(r.node, r.end);
+      const span = document.createElement('span');
+      span.className = "hi-search-match";
+      span.setAttribute("data-match-index", matches.length - 1 - matchIdx); 
+      range.surroundContents(span);
+    });
+  });
+}
+
 $(document).ready(function () {
   createClearingTable();
   createLicenseSelectionTable();
   $('[data-toggle="tooltip"]').tooltip();
-});
 
+  {% if searchQuery %}
+    highlightSearchMatches(); 
+  {% endif %}
+  initSearchNavigation();
+
+  $("#btnTriggerSearch").click(performSearch);
+  $("#textSearchInput").keypress(function(e) {
+    if(e.which == 13) { performSearch(); }
+  });
+  
+  $("#btnClearSearch").click(clearSearch);
+
+  $("#btnNextMatch").click(function() {
+    navigateToMatch(currentMatchIndex + 1);
+  });
+
+  $("#btnPrevMatch").click(function() {
+    navigateToMatch(currentMatchIndex - 1);
+  });
+});


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Implemented a new search and navigation feature for the file clearing view with support for cross-node highlighting.

## How to test

- **Search Overlapping Text**: Search for words that are already partially highlighted by agents.
- **Search Substrings**: Search for a substring within an existing highlighted phrase.
- **General Search & Navigation**: Perform a standard text search and use the up/down arrows. Verify that the "Match X of Y" counter updates correctly and the view auto-scrolls to the active match.

CC: @shaheemazmalmmd @Kaushl2208 
