### PR TITLE
Fix apache symlink upgrade

### DIFF
--- a/debian/fossology.postinst
+++ b/debian/fossology.postinst
@@ -24,17 +24,23 @@ case "$1" in
     ENABLED="/etc/apache2/sites-enabled/fossology.conf"
     AVAILABLE="/etc/apache2/sites-available/fossology.conf"
 
-    # Fix legacy Apache layout from FOSSology 3.x upgrades
+    # Clean legacy symlink if it exists
     if [ -L "$ENABLED" ] && [ ! -e "$AVAILABLE" ]; then
-        TARGET=$(readlink "$ENABLED")
+        echo "Removing legacy Apache symlink..."
 
-        echo "Fixing legacy Apache symlink for FOSSology..."
+        rm -f "$ENABLED"
+    fi
 
-        ln -s "$TARGET" "$AVAILABLE"
+    # Enable site properly using a2ensite
+    if [ -e "$AVAILABLE" ]; then
+        echo "Enabling FOSSology site with a2ensite..."
+
+        a2ensite fossology.conf >/dev/null 2>&1 || true
     fi
 
     /usr/lib/fossology/fo-postinstall --agent --debian
     ;;
+
 
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
## Description

Fix Apache site configuration handling during upgrades from FOSSology 3.x to 4.x.

Older make-based installations may leave a legacy symlink in
/etc/apache2/sites-enabled without a corresponding file in
/etc/apache2/sites-available. This causes the installation to fail when
fo-postinstall is executed.

This PR cleans up the legacy symlink and enables the site using a2ensite,
ensuring a proper and standard Apache configuration.

### Changes

- Detect legacy Apache symlink from older installations
- Remove invalid sites-enabled symlink if present
- Enable FOSSology site using a2ensite
- Prevent installation failure during upgrades
- Align Apache configuration handling with Debian standards

## How to test

1. Install FOSSology 3.11 using make-based packages on Debian 10
2. Ensure:
   - /etc/apache2/sites-enabled/fossology.conf exists
   - /etc/apache2/sites-available/fossology.conf is missing
3. Upgrade to FOSSology 4.x using Debian packages
4. Verify installation completes successfully
5. Confirm that the site is enabled via a2ensite and Apache starts normally

Fixes #2556 