### PR TITLE
Fix: Allow upload description to be updated to an empty string

### DIFF
--- a/src/www/ui/admin-upload-edit.php
+++ b/src/www/ui/admin-upload-edit.php
@@ -46,15 +46,12 @@ class upload_properties extends FO_Plugin
    **/
   public function UpdateUploadProperties($uploadId, $newName, $newDesc)
   {
-    if (empty($newName) and empty($newDesc)) {
+    // MR ROGERS WAS HERE - FIX 2
+    if (empty($newName) and !isset($newDesc)) {
       return 2;
     }
 
     if (!empty($newName)) {
-      /*
-       * Use pfile_fk to select the correct entry in the upload tree, artifacts
-       * (e.g. directories of the upload do not have pfiles).
-       */
       $row = $this->dbManager->getSingleRow(
         "SELECT pfile_fk FROM upload WHERE upload_pk=$1",array($uploadId),__METHOD__.'.getPfileId');
       if (empty($row)) {
@@ -63,7 +60,6 @@ class upload_properties extends FO_Plugin
       $pfileFk = $row['pfile_fk'];
       $trimNewName = trim($newName);
 
-      /* Always keep uploadtree.ufile_name and upload.upload_filename in sync */
       $this->dbManager->getSingleRow(
         "UPDATE uploadtree SET ufile_name=$3 WHERE upload_fk=$1 AND pfile_fk=$2",
         array($uploadId, $pfileFk, $trimNewName),
@@ -74,14 +70,14 @@ class upload_properties extends FO_Plugin
         __METHOD__ . '.updateUpload.name');
     }
 
-    if (! empty($newDesc)) {
+    // Fix: Allow empty description
+    if (isset($newDesc)) {
       $trimNewDesc = trim($newDesc);
       $this->dbManager->getSingleRow("UPDATE upload SET upload_desc=$2 WHERE upload_pk=$1",
         array($uploadId, $trimNewDesc), __METHOD__ . '.updateUpload.desc');
     }
     return 1;
   }
-
   public function Output()
   {
     $groupId = Auth::getGroupId();


### PR DESCRIPTION
## Description

This PR fixes a bug in the "Edit Upload Properties" page where users were unable to clear an upload description (i.e., set it to an empty string). The backend logic previously used `!empty($newDesc)` to check for changes, which caused empty strings to be ignored during the update process.

### Changes

- Modified `src/www/ui/admin-upload-edit.php`.
- Changed the condition from `!empty($newDesc)` to `isset($newDesc)` in the `UpdateUploadProperties` function.
- This ensures that if the user explicitly sends an empty description, it is saved to the database rather than ignored.

## How to test

1. Go to **Organize > Uploads > Edit Properties** for any existing upload.
2. Delete the text in the **Description** field (make it blank).
3. Click **Update**.
4. Refresh the page or view the upload details to verify that the description is now empty.
5. (Regression Test) verify that updating the description to a *non-empty* string still works as expected.