### PR TITLE
fix(util): fix incorrect bSortable index in DataTables sorting

### DIFF
--- a/src/lib/php/Util/DataTablesUtility.php
+++ b/src/lib/php/Util/DataTablesUtility.php
@@ -60,7 +60,7 @@ class DataTablesUtility
       $colNumber = $inputArray[$whichCol];
       $sortedCols[] = intval($colNumber);
 
-      $isSortable = $inputArray['bSortable_' . $i];
+      $isSortable = $inputArray['bSortable_' . $colNumber];
       if ($isSortable !== "true") {
         continue;
       }


### PR DESCRIPTION
## Problem

`DataTablesUtility::getSortingParametersFromArrayImpl()` builds the SQL `ORDER BY`
clause for server-side DataTables requests.

While reviewing DataTables server-side parameters, I found that the sortability
check was performed using the sorting priority index (`i`) instead of the
actual column index (`iSortCol_X`):

`$isSortable = $inputArray['bSortable_' . $i];`

However, DataTables sends `bSortable_N` indexed by column number, not by
sorting order. This mismatch can cause columns to be incorrectly treated as
sortable or non-sortable, leading to silently wrong `ORDER BY` clauses.

---

## Context & Investigation

To validate the behavior, I traced the complete request flow:

- UI column configuration  in `ui-browse.js.twig`
- Server-side DataTables parameters
- Ajax entry points such as `AjaxBrowse.php`
- SQL `ORDER BY` construction in `DataTablesUtility`

Throughout this flow, the `bSortable_*` flags are consistently indexed by the
column number referenced by `iSortCol_X`, rather than by sorting priority.
The utility logic therefore needed to align with this convention.

---
