### PR TITLE
fix(scheduler): update default email client from mailx to s-nail

### DIFF
--- a/src/scheduler/agent/database.c
+++ b/src/scheduler/agent/database.c
@@ -43,7 +43,7 @@
 #define DEFAULT_HEADER  "FOSSology scan complete\nmessage:\"" ///< Default email header
 #define DEFAULT_FOOTER  "\""                  ///< Default email footer
 #define DEFAULT_SUBJECT "FOSSology scan complete\n" ///< Default email subject
-#define DEFAULT_COMMAND "/usr/bin/mailx"      ///< Default email command to use
+#define DEFAULT_COMMAND "/usr/bin/s-nail"     ///< Default email command to use
 
 #define min(x, y) (x < y ? x : y)     ///< Return the minimum of x, y
 

--- a/src/testing/functional/testFOSSology.php
+++ b/src/testing/functional/testFOSSology.php
@@ -347,7 +347,7 @@ if (array_key_exists("a", $options)) {
 
 		if(array_key_exists('e', $options)) {
 			$last = exec("./textReport.php -f $reportHome |
-    mailx -s \"test results\" $mailTo ",$tossme, $rptGen);
+    s-nail -s \"test results\" $mailTo ",$tossme, $rptGen);
 		}
 		$last = system("./textReport.php -f $reportHome", $rtn);
 		if($last === FALSE) {


### PR DESCRIPTION
## Summary
- Updates the default email client fallback from `/usr/bin/mailx` to `/usr/bin/s-nail`
- Updates test script to use `s-nail` instead of `mailx`

Fixes #1614

## Why
Modern Linux distributions (Debian Buster+, Ubuntu Bionic+) no longer include `mailx` and instead provide `s-nail` at `/usr/bin/s-nail`. The configuration file was already updated to use `s-nail`, but the C code fallback still referenced the old `mailx` path.

## Changes
| File | Change |
|------|--------|
| `src/scheduler/agent/database.c` | Changed `DEFAULT_COMMAND` from `/usr/bin/mailx` to `/usr/bin/s-nail` |
| `src/testing/functional/testFOSSology.php` | Changed `mailx` to `s-nail` in email test |

## Test Plan
- [ ] CI build passes
- [ ] Email notifications work on Debian Buster+ / Ubuntu Bionic+