### PR TITLE
fix(ui): avoid redirecting license browser for empty directories

### DIFF
--- a/src/www/ui/page/BrowseLicense.php
+++ b/src/www/ui/page/BrowseLicense.php
@@ -193,7 +193,10 @@ class BrowseLicense extends DefaultPlugin
      * $ChildCount can also be zero if the directory is empty.
      * **************************************/
     if ($childCount == 0) {
-      return new RedirectResponse("?mod=view-license" . Traceback_parm_keep(array("upload", "item")));
+      $itemEntry = $this->uploadDao->getUploadEntry($itemTreeBounds->getItemId(), $this->uploadtree_tablename);
+      if ($itemEntry && !Isdir($itemEntry['ufile_mode'])) {
+        return new RedirectResponse("?mod=view-license" . Traceback_parm_keep(array("upload", "item")));
+      }
     }
 
     $vars['licenseUri'] = Traceback_uri() . "?mod=popup-license&rf=";


### PR DESCRIPTION
### Summary
- Fixed incorrect redirect in license browser for empty directories

### Problem
- `childCount == 0` was treated as a file
- Empty directories also have `childCount == 0`
- This caused unwanted redirect to `view-license`

### Fix
- When `childCount == 0`, fetch upload entry from DB
- Check `ufile_mode` to determine file vs directory
- Redirect only if the item is **not** a directory

### Result
- Files still redirect correctly
- Empty directories now remain in browser view

Fixes #3312