### PR TITLE
docs:update developer notes to reflect CMake build

### DIFF
--- a/src/nomos/agent/Notes
+++ b/src/nomos/agent/Notes
@@ -3,110 +3,34 @@
      SPDX-License-Identifier: GPL-2.0-only
 -->
 
-To Whom it May Concern: 
+Nomos Developer Notes
+=====================
 
+Build System
+------------
 
-What This Is and How to Work It
--------------------------------
+Nomos is integrated into the Fossology CMake build system and cannot be built independently.
+There is no standalone Makefile in this directory.
 
-This directory in the FOSSology source tree
-(agents/nomos) contains work for a new license analysis agent. This
-code originated from a standalone license-scanning tool called Nomos.
+To build Nomos, you must build Fossology from the repository root using CMake:
 
-At this point in time, the code is not integrated with the rest of FOSSology. 
-It uses it's own non-standard Makefile to build a single standalone 
-executable.
+    mkdir build
+    cd build
+    cmake ..
+    make
 
-To try it out...
+Dependencies
+------------
 
-   % make
-   % ./nomos <file_to_be_scanned>
+Building Nomos requires PostgreSQL development headers (for example, `libpq-dev` on Debian/Ubuntu).
+If these headers are missing, the CMake configuration step will fail or skip building the Nomos agent.
 
-The file to be scanned should be a regular file (binary or text). In
-particular, it should not be an archive. No unpacking is done; the file
-is scanned as is.
+Runtime Requirements
+--------------------
 
-There are currently no command-line options.
+Nomos is an internal Fossology agent and is not designed to be used as a standalone license scanner.
+It is intended to be executed by Fossology as part of its agent pipeline.
 
-
-Note About the Source Code and Impending Changes
-------------------------------------------------
-
-Because this code came from another tool similar to FOSSology, but with
-different structure and conventions, the process of converting it into 
-a full-fledged FOSSology agent is ongoing.
-
-With that in mind, comments with "CDB" in them are bread crumbs I've 
-left in places where I was unsure about a change I made or to note a potential
-refinement (CDB == my initials).
-
-
-
-To Do's
--------
-
-- Change all trace calls at beginning of functions to use traceFunc()
-  (defined in util.c)
- 
-- Either add a command-line option to set gl.ptswitch or remove all the
-  PROC_TRACE_SWITCH #ifdefs
-
-- Go back and edit CFLAGS options in Makefile to document and accurately
-  represent what is still operable.
-
-- Document all Makefile targets
-
-- Remove all HP_INTERNAL and CUSTOMER_VERSION references.
-
-- Check and remove all unused field of the gl global variable structure.
-
-- Migrate to standard FOSSology makefile structure and system.
- 
-
-
-Changes
--------
-
-[This is not at all complete. There have been a lot of changes.]
-
-- Changed ls_t to licSpec_t.
-- Changed lic_t to licText_t.
-
-
-Questions
----------
-
-- Where the hell is checkstrings script? Do we want it?
-- COMMIT_HASH #ifdef stolen from other agent code. Where does this get
-  #defined?
-- Why does nomos set the LANG environment variable?
-- Implications of removing custom magic file?
-- May want to re-add function validateTools someplace?
-- Do we want to keep the Log functionality, but just have the logfile
-  be in another place? (Right now, the log stuff has been removed.)
-- Do we really need the PROC_TRACE_SWITCH compile #define?
-
-
-#defines Used
--------------
-
-[Also incomplete.]
-
-BRIEF_LIST
-SHOW_LOCATION		Extra code to pinpoint license location. Should
-			always be true.
-PROC_TRACE
-PROC_TRACE_SWITCH	Gives command option for tracing on/off
-DEBUG
-GLOBAL_DEBUG		Debug access to global variable structure
-MEMORY_TRACING		Use Debug Malloc wrapper
-STOPWATCH		Performance Measurement
-TIMING			Performance Measurement (code has to be added to
-places where you want to measure).
-
-
-Changes made from my nomos_experimental version
------------------------------------------------
-
-Remove all code #ifdef'd by USE_MMAP 
-
+The Nomos binary expects a Fossology runtime environment and a configuration file (`fossology.conf`)
+at predefined locations. Running `./nomos` standalone is not supported and will fail or behave
+unpredictably without the proper Fossology environment.


### PR DESCRIPTION
## Description

This pull request updates the Nomos developer notes to accurately reflect the current build and runtime behavior of the Nomos agent.

The existing documentation referenced a standalone Makefile and did not document required dependencies or runtime configuration, which no longer matches the current implementation.

## Changes

- Updated Nomos developer notes to describe the CMake-based build process
- Removed references to a standalone Makefile
- Documented the requirement for PostgreSQL development headers
- Clarified that Nomos is an internal Fossology agent and not intended to run standalone
- Documented the dependency on the Fossology runtime environment and `fossology.conf`

## How to test

This is a documentation-only change.

- Review the updated `src/nomos/agent/Notes` file
- Verify that the instructions align with the current Fossology build and runtime behavior

Fixes #2795
