### PR TITLE
feat(test): Extend CI to test PHP 7.4–8.4 and update static checks

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -120,6 +120,10 @@ jobs:
       matrix:
         config:
           - {
+            php: "8.2",
+            phpunit: "^11.5.55",
+          }
+          - {
             php: "8.1",
             phpunit: "^10.0.12",
           }
@@ -181,15 +185,24 @@ jobs:
           ./utils/prepare-test -afty
           composer install --working-dir=src
           mkdir coverage
+      - name: Determine PHPUnit config based on PHP version
+        run: |
+          if [ "${{ matrix.config.php }}" = "8.2" ]; then
+            echo "MIGRATED_CONFIG=src/phpunit.82.xml" >> $GITHUB_ENV
+            echo "Using src/phpunit.82.xml for PHP 8.2"
+          else
+            echo "MIGRATED_CONFIG=src/phpunit.xml" >> $GITHUB_ENV
+            echo "Using src/phpunit.xml for PHP ${{ matrix.config.php }}"
+          fi
       - name: PHPUnit test suit
         env:
           PGHOST: 127.0.0.1
           PGPORT: 5432
         run: |
-          phpunit -csrc/phpunit.xml --testsuite="Fossology PhpUnit Test Suite" --colors=always --coverage-clover ./coverage/unit-clover.xml
+          phpunit -c ${MIGRATED_CONFIG} --testsuite="Fossology PhpUnit Test Suite" --colors=always --coverage-clover ./coverage/unit-clover.xml
       - name: PHPUnit agent test suit
         env:
           PGHOST: 127.0.0.1
           PGPORT: 5432
         run: |
-          phpunit -csrc/phpunit.xml --testsuite="Fossology PhpUnit Agent Test Suite" --colors=always --coverage-clover ./coverage/agent-clover.xml
+          phpunit -c ${MIGRATED_CONFIG} --testsuite="Fossology PhpUnit Agent Test Suite" --colors=always --coverage-clover ./coverage/agent-clover.xml

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -120,6 +120,14 @@ jobs:
       matrix:
         config:
           - {
+            php: "8.4",
+            phpunit: "^13.0.5",
+          }
+          - {
+            php: "8.3",
+            phpunit: "^12.5.14",
+          }
+          - {
             php: "8.2",
             phpunit: "^11.5.55",
           }
@@ -187,12 +195,12 @@ jobs:
           mkdir coverage
       - name: Determine PHPUnit config based on PHP version
         run: |
-          if [ "${{ matrix.config.php }}" = "8.2" ]; then
-            echo "MIGRATED_CONFIG=src/phpunit.82.xml" >> $GITHUB_ENV
-            echo "Using src/phpunit.82.xml for PHP 8.2"
-          else
+          if [ "${{ matrix.config.php }}" = "8.1" ] || [ "${{ matrix.config.php }}" = "7.4" ]; then
             echo "MIGRATED_CONFIG=src/phpunit.xml" >> $GITHUB_ENV
-            echo "Using src/phpunit.xml for PHP ${{ matrix.config.php }}"
+            echo "Using legacy src/phpunit.xml for PHP ${{ matrix.config.php }}"
+          else
+            echo "MIGRATED_CONFIG=src/phpunit.82.xml" >> $GITHUB_ENV
+            echo "Using src/phpunit.82.xml for PHP ${{ matrix.config.php }}"
           fi
       - name: PHPUnit test suit
         env:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -123,6 +123,10 @@ jobs:
       matrix:
         config:
           - {
+            php: "8.2",
+            phpunit: "^11.5.55",
+          }
+          - {
             php: "8.1",
             phpunit: "^10.0.12",
           }
@@ -184,15 +188,24 @@ jobs:
           ./utils/prepare-test -afty
           composer install --working-dir=src
           mkdir coverage
+      - name: Determine PHPUnit config based on PHP version
+        run: |
+          if [ "${{ matrix.config.php }}" = "8.2" ]; then
+            echo "MIGRATED_CONFIG=src/phpunit.82.xml" >> $GITHUB_ENV
+            echo "Using src/phpunit.82.xml for PHP 8.2"
+          else
+            echo "MIGRATED_CONFIG=src/phpunit.xml" >> $GITHUB_ENV
+            echo "Using src/phpunit.xml for PHP ${{ matrix.config.php }}"
+          fi
       - name: PHPUnit test suit
         env:
           PGHOST: 127.0.0.1
           PGPORT: 5432
         run: |
-          phpunit -csrc/phpunit.xml --testsuite="Fossology PhpUnit Test Suite" --colors=always --coverage-clover ./coverage/unit-clover.xml
+          phpunit -c ${MIGRATED_CONFIG} --testsuite="Fossology PhpUnit Test Suite" --colors=always --coverage-clover ./coverage/unit-clover.xml
       - name: PHPUnit agent test suit
         env:
           PGHOST: 127.0.0.1
           PGPORT: 5432
         run: |
-          phpunit -csrc/phpunit.xml --testsuite="Fossology PhpUnit Agent Test Suite" --colors=always --coverage-clover ./coverage/agent-clover.xml
+          phpunit -c ${MIGRATED_CONFIG} --testsuite="Fossology PhpUnit Agent Test Suite" --colors=always --coverage-clover ./coverage/agent-clover.xml

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -123,16 +123,24 @@ jobs:
       matrix:
         config:
           - {
+            php: "8.4",
+            phpunit: "^13.3.1",
+          }
+          - {
+            php: "8.3",
+            phpunit: "^12.5.33",
+          }
+          - {
             php: "8.2",
-            phpunit: "^11.5.55",
+            phpunit: "^11.5.56",
           }
           - {
             php: "8.1",
-            phpunit: "^10.0.12",
+            phpunit: "^10.5.64",
           }
           - {
             php: "7.4",
-            phpunit: "^9.6.3",
+            phpunit: "^9.6.36",
           }
     services:
       postgres:
@@ -190,12 +198,12 @@ jobs:
           mkdir coverage
       - name: Determine PHPUnit config based on PHP version
         run: |
-          if [ "${{ matrix.config.php }}" = "8.2" ]; then
-            echo "MIGRATED_CONFIG=src/phpunit.82.xml" >> $GITHUB_ENV
-            echo "Using src/phpunit.82.xml for PHP 8.2"
-          else
+          if [ "${{ matrix.config.php }}" = "8.1" ] || [ "${{ matrix.config.php }}" = "7.4" ]; then
             echo "MIGRATED_CONFIG=src/phpunit.xml" >> $GITHUB_ENV
-            echo "Using src/phpunit.xml for PHP ${{ matrix.config.php }}"
+            echo "Using legacy src/phpunit.xml for PHP ${{ matrix.config.php }}"
+          else
+            echo "MIGRATED_CONFIG=src/phpunit.82.xml" >> $GITHUB_ENV
+            echo "Using src/phpunit.82.xml for PHP ${{ matrix.config.php }}"
           fi
       - name: PHPUnit test suit
         env:

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get update
           echo PATH="/usr/lib/ccache/:$PATH" >> $GITHUB_ENV
           echo COMPOSER_HOME="$HOME/.composer/" >> $GITHUB_ENV
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: Setup PHP 7.4
@@ -45,6 +45,13 @@ jobs:
           extensions: gettext, mbstring, json, xml, pgsql, curl, uuid, posix, sqlite3
       - name: Composer check on PHP 8.1
         run: composer validate --no-check-all --working-dir=src --strict
+      - name: Setup PHP 8.2
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: gettext, mbstring, json, xml, pgsql, curl, uuid, posix, sqlite3
+      - name: Composer check on PHP 8.2
+        run: composer validate --no-check-all --working-dir=src --strict
 
   code-analysis:
     runs-on: ubuntu-22.04
@@ -55,7 +62,7 @@ jobs:
           sudo apt-get install -y cppcheck
           echo PATH="/usr/lib/ccache/:$PATH" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: Static Code Analysis
@@ -69,7 +76,7 @@ jobs:
         with:
           php-version: '8.1'
           extensions: gettext, mbstring, gd, json, xml, zip, pgsql, curl, uuid, posix, sqlite3
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: PHP Codesniffer
@@ -88,7 +95,7 @@ jobs:
           php-version: '8.1'
           extensions: gettext, mbstring, gd, json, xml, zip, pgsql, curl, uuid, posix, sqlite3, dom
           tools: sebastian/phpcpd:6.0.3
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: Copy/Paste detector
@@ -101,7 +108,7 @@ jobs:
   openapi-lint:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup default rules
         run: |
           echo '{"extends": ["spectral:oas"]}' > .spectral.json
@@ -113,7 +120,7 @@ jobs:
   REUSE-Compliance-Check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v5
 
@@ -121,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -52,6 +52,20 @@ jobs:
           extensions: gettext, mbstring, json, xml, pgsql, curl, uuid, posix, sqlite3
       - name: Composer check on PHP 8.2
         run: composer validate --no-check-all --working-dir=src --strict
+      - name: Setup PHP 8.3
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: gettext, mbstring, json, xml, pgsql, curl, uuid, posix, sqlite3
+      - name: Composer check on PHP 8.3
+        run: composer validate --no-check-all --working-dir=src --strict
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: gettext, mbstring, json, xml, pgsql, curl, uuid, posix, sqlite3
+      - name: Composer check on PHP 8.4
+        run: composer validate --no-check-all --working-dir=src --strict
 
   code-analysis:
     runs-on: ubuntu-22.04
@@ -89,7 +103,7 @@ jobs:
     runs-on: ubuntu-22.04
     continue-on-error: true
     steps:
-      - name: Setup PHP
+      - name: Setup PHP 8.1
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
@@ -150,4 +164,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           args: --exclude-pattern '.*dependabot\[bot\]@users\.noreply\.github\.com'
-

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -55,6 +55,20 @@ jobs:
           extensions: gettext, mbstring, json, xml, pgsql, curl, uuid, posix, sqlite3
       - name: Composer check on PHP 8.2
         run: composer validate --no-check-all --working-dir=src --strict
+      - name: Setup PHP 8.3
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: gettext, mbstring, json, xml, pgsql, curl, uuid, posix, sqlite3
+      - name: Composer check on PHP 8.3
+        run: composer validate --no-check-all --working-dir=src --strict
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: gettext, mbstring, json, xml, pgsql, curl, uuid, posix, sqlite3
+      - name: Composer check on PHP 8.4
+        run: composer validate --no-check-all --working-dir=src --strict
 
   code-analysis:
     runs-on: ubuntu-22.04
@@ -92,7 +106,7 @@ jobs:
     runs-on: ubuntu-22.04
     continue-on-error: true
     steps:
-      - name: Setup PHP
+      - name: Setup PHP 8.1
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
@@ -158,4 +172,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           args: --exclude-pattern '.*dependabot\[bot\]@users\.noreply\.github\.com'
-

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -28,7 +28,7 @@ jobs:
           sudo apt-get update
           echo PATH="/usr/lib/ccache/:$PATH" >> $GITHUB_ENV
           echo COMPOSER_HOME="$HOME/.composer/" >> $GITHUB_ENV
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: Setup PHP 7.4
@@ -48,6 +48,13 @@ jobs:
           extensions: gettext, mbstring, json, xml, pgsql, curl, uuid, posix, sqlite3
       - name: Composer check on PHP 8.1
         run: composer validate --no-check-all --working-dir=src --strict
+      - name: Setup PHP 8.2
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: gettext, mbstring, json, xml, pgsql, curl, uuid, posix, sqlite3
+      - name: Composer check on PHP 8.2
+        run: composer validate --no-check-all --working-dir=src --strict
 
   code-analysis:
     runs-on: ubuntu-22.04
@@ -58,7 +65,7 @@ jobs:
           sudo apt-get install -y cppcheck
           echo PATH="/usr/lib/ccache/:$PATH" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: Static Code Analysis
@@ -72,7 +79,7 @@ jobs:
         with:
           php-version: '8.1'
           extensions: gettext, mbstring, gd, json, xml, zip, pgsql, curl, uuid, posix, sqlite3
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: PHP Codesniffer
@@ -91,7 +98,7 @@ jobs:
           php-version: '8.1'
           extensions: gettext, mbstring, gd, json, xml, zip, pgsql, curl, uuid, posix, sqlite3, dom
           tools: sebastian/phpcpd:6.0.3
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: Copy/Paste detector
@@ -104,7 +111,7 @@ jobs:
   openapi-lint:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup default rules
         run: |
           echo '{"extends": ["spectral:oas"]}' > .spectral.json
@@ -116,7 +123,7 @@ jobs:
   REUSE-Compliance-Check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v5
 
@@ -129,7 +136,7 @@ jobs:
       statuses: write       # christophebedard/dco-check posts commit statuses
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/src/lib/php/Application/CustomTextImportTest.php
+++ b/src/lib/php/Application/CustomTextImportTest.php
@@ -310,6 +310,7 @@ class CustomTextImportTest extends \PHPUnit\Framework\TestCase
    *
    * @dataProvider parseBooleanProvider
    */
+  #[\PHPUnit\Framework\Attributes\DataProvider('parseBooleanProvider')]
   public function testParseBoolean($input, bool $expected): void
   {
     $result = Reflectory::invokeObjectsMethodnameWith(
@@ -320,7 +321,7 @@ class CustomTextImportTest extends \PHPUnit\Framework\TestCase
     $this->assertSame($expected, $result);
   }
 
-  public function parseBooleanProvider(): array
+  public static function parseBooleanProvider(): array
   {
     return [
       ['true',   true],

--- a/src/lib/php/Application/test/CustomTextEscapingTest.php
+++ b/src/lib/php/Application/test/CustomTextEscapingTest.php
@@ -15,14 +15,16 @@ class CustomTextEscapingTest extends \PHPUnit\Framework\TestCase
 {
   /**
    * @test
-   * @dataProvider roundTripProvider
    */
-  public function testEscapeThenUnescapeRoundTrips(string $original, string $expectedAfterCrlfNormalization): void
+  public function testEscapeThenUnescapeRoundTrips(): void
   {
-    $escaped = CustomTextEscaping::escapeNewlines($original);
-    $restored = CustomTextEscaping::unescapeNewlines($escaped);
+    foreach (self::roundTripProvider() as $testCase) {
+      [$original, $expectedAfterCrlfNormalization] = $testCase;
+      $escaped = CustomTextEscaping::escapeNewlines($original);
+      $restored = CustomTextEscaping::unescapeNewlines($escaped);
 
-    $this->assertSame($expectedAfterCrlfNormalization, $restored);
+      $this->assertSame($expectedAfterCrlfNormalization, $restored);
+    }
   }
 
   public static function roundTripProvider(): array

--- a/src/lib/php/Application/test/CustomTextImportTest.php
+++ b/src/lib/php/Application/test/CustomTextImportTest.php
@@ -238,15 +238,16 @@ class CustomTextImportTest extends \PHPUnit\Framework\TestCase
    * @test
    * -# Call parseBoolean with various truthy and falsy string/bool values.
    * -# Verify each maps to the expected bool.
-   *
-   * @dataProvider parseBooleanProvider
    */
-  public function testParseBoolean($input, bool $expected): void
+  public function testParseBoolean(): void
   {
-    $result = Reflectory::invokeObjectsMethodnameWith(
-      $this->importer, 'parseBoolean', [$input]
-    );
-    $this->assertSame($expected, $result);
+    foreach (self::parseBooleanProvider() as $testCase) {
+      [$input, $expected] = $testCase;
+      $result = Reflectory::invokeObjectsMethodnameWith(
+        $this->importer, 'parseBoolean', [$input]
+      );
+      $this->assertSame($expected, $result);
+    }
   }
 
   public static function parseBooleanProvider(): array

--- a/src/lib/php/Dao/test/CompatibilityDaoTest.php
+++ b/src/lib/php/Dao/test/CompatibilityDaoTest.php
@@ -10,6 +10,7 @@
  */
 namespace Fossology\Lib\Dao;
 
+use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Test\TestPgDb;
 use Mockery as M;
@@ -39,10 +40,6 @@ class CompatibilityDaoTest extends TestCase
   /** @var int $assertCountBefore */
   private $assertCountBefore;
 
-  /** @var M\MockInterface $authClass
-   *       Alias mock of the Auth class */
-  private $authClass;
-
   /** @var int $firstLicenseId
    *       Id of a license present in license_ref */
   private $firstLicenseId;
@@ -68,8 +65,7 @@ class CompatibilityDaoTest extends TestCase
     $this->firstLicenseId = intval($licenses[0]['rf_pk']);
     $this->secondLicenseId = intval($licenses[1]['rf_pk']);
 
-    $this->authClass = M::mock('alias:Fossology\Lib\Auth\Auth');
-    $this->authClass->shouldReceive('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $this->compatibilityDao = new CompatibilityDao($this->dbManager,
       new Logger("test"), M::mock(LicenseDao::class), M::mock(AgentDao::class));

--- a/src/lib/php/Dao/test/LicenseAcknowledgementDaoTest.php
+++ b/src/lib/php/Dao/test/LicenseAcknowledgementDaoTest.php
@@ -22,6 +22,8 @@ use PHPUnit\Runner\Version as PHPUnitVersion;
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
 class LicenseAcknowledgementDaoTest extends TestCase
 {
 
@@ -58,7 +60,7 @@ class LicenseAcknowledgementDaoTest extends TestCase
     $this->testDb->alterTables(["license_std_acknowledgement"]);
     $this->testDb->insertData(["users", "license_std_acknowledgement"]);
     $this->authClass = \Mockery::mock('alias:Fossology\Lib\Auth\Auth');
-    $this->authClass->expects('getUserId')->andReturn(2);
+    $this->authClass->shouldReceive('getUserId')->andReturn(2);
   }
 
   protected function tearDown() : void
@@ -67,6 +69,7 @@ class LicenseAcknowledgementDaoTest extends TestCase
       \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
     $this->testDb = null;
     $this->dbManager = null;
+    \Mockery::close();
   }
 
   /**

--- a/src/lib/php/Dao/test/LicenseAcknowledgementDaoTest.php
+++ b/src/lib/php/Dao/test/LicenseAcknowledgementDaoTest.php
@@ -11,6 +11,7 @@
  */
 namespace Fossology\Lib\Dao;
 
+use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Db\DbManager;
 use PHPUnit\Framework\TestCase;
 use Fossology\Lib\Test\TestPgDb;
@@ -22,6 +23,8 @@ use PHPUnit\Runner\Version as PHPUnitVersion;
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
 class LicenseAcknowledgementDaoTest extends TestCase
 {
 
@@ -45,8 +48,6 @@ class LicenseAcknowledgementDaoTest extends TestCase
   /** @var int $assertCountBefore */
   private $assertCountBefore;
 
-  private $authClass;
-
   protected function setUp() : void
   {
     $this->testDb = new TestPgDb("licenseacknowledgementdao");
@@ -57,8 +58,8 @@ class LicenseAcknowledgementDaoTest extends TestCase
     $this->testDb->createSequences(["license_std_acknowledgement_la_pk_seq"]);
     $this->testDb->alterTables(["license_std_acknowledgement"]);
     $this->testDb->insertData(["users", "license_std_acknowledgement"]);
-    $this->authClass = \Mockery::mock('alias:Fossology\Lib\Auth\Auth');
-    $this->authClass->expects('getUserId')->andReturn(2);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $GLOBALS['SysConf']['auth'][Auth::USER_ID] = 2;
   }
 
   protected function tearDown() : void
@@ -67,6 +68,7 @@ class LicenseAcknowledgementDaoTest extends TestCase
       \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
     $this->testDb = null;
     $this->dbManager = null;
+    \Mockery::close();
   }
 
   /**
@@ -136,7 +138,7 @@ class LicenseAcknowledgementDaoTest extends TestCase
    */
   public function testUpdateAcknowledgementAsAdmin()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+      $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $returnVal = $this->licenseAcknowledgementDao->updateAcknowledgement(2,
       "Updated acknowledgement #1", "This acknowledgement is updated!");
@@ -164,7 +166,7 @@ class LicenseAcknowledgementDaoTest extends TestCase
    */
   public function testUpdateAcknowledgementAsNonAdmin()
   {
-    $this->authClass->expects('isAdmin')->andReturn(false);
+      $_SESSION[Auth::USER_LEVEL] = Auth::PERM_NONE;
 
     $returnVal = $this->licenseAcknowledgementDao->updateAcknowledgement(3,
       "Updated acknowledgement #2", "This acknowledgement is updated!");
@@ -183,7 +185,7 @@ class LicenseAcknowledgementDaoTest extends TestCase
    */
   public function testUpdateAcknowledgementAsAdminInvalidId()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $this->expectException(\UnexpectedValueException::class);
     $this->licenseAcknowledgementDao->updateAcknowledgement(-1,
@@ -200,7 +202,7 @@ class LicenseAcknowledgementDaoTest extends TestCase
    */
   public function testUpdateAcknowledgementFromArrayAsAdmin()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+       $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $newValues = [];
     $newValues[3]['name'] = "Updated acknowledgement #2";
@@ -237,7 +239,7 @@ class LicenseAcknowledgementDaoTest extends TestCase
    */
   public function testUpdateAcknowledgementFromArrayAsNonAdmin()
   {
-    $this->authClass->expects('isAdmin')->andReturn(false);
+       $_SESSION[Auth::USER_LEVEL] = Auth::PERM_NONE;
 
     $newValues = [];
     $newValues[5]['name'] = "Updated acknowledgement #4";
@@ -258,7 +260,7 @@ class LicenseAcknowledgementDaoTest extends TestCase
    */
   public function testUpdateAcknowledgementFromArrayInvalidId()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $newValues = [];
     $newValues[-1]['name'] = "Updated acknowledgement #4";
@@ -279,7 +281,7 @@ class LicenseAcknowledgementDaoTest extends TestCase
    */
   public function testUpdateAcknowledgementFromArrayInvalidFields()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $newValues = [];
     $newValues[5]['naaaaame'] = "Updated acknowledgement #4";
@@ -300,7 +302,7 @@ class LicenseAcknowledgementDaoTest extends TestCase
    */
   public function testUpdateAcknowledgementFromArrayEmptyArray()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $newValues = [];
 
@@ -318,7 +320,7 @@ class LicenseAcknowledgementDaoTest extends TestCase
    */
   public function testUpdateAcknowledgementFromArrayEmptyValues()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $newValues = [3 => []];
 
@@ -368,7 +370,7 @@ class LicenseAcknowledgementDaoTest extends TestCase
    */
   public function testInsertAcknowledgementAsAdmin()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $returnVal = $this->licenseAcknowledgementDao->insertAcknowledgement(
       "Inserted acknowledgement #1", "This first inserted acknowledgement!");
@@ -396,7 +398,7 @@ class LicenseAcknowledgementDaoTest extends TestCase
    */
   public function testInsertAcknowledgementAsNonAdmin()
   {
-    $this->authClass->expects('isAdmin')->andReturn(false);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_NONE;
 
     $returnVal = $this->licenseAcknowledgementDao->insertAcknowledgement(
       "Inserted acknowledgement #1", "This first inserted acknowledgement!");
@@ -411,7 +413,7 @@ class LicenseAcknowledgementDaoTest extends TestCase
    */
   public function testInsertAcknowledgementEmptyValues()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $returnVal = $this->licenseAcknowledgementDao->insertAcknowledgement("",
       "       ");
@@ -427,7 +429,7 @@ class LicenseAcknowledgementDaoTest extends TestCase
    */
   public function testToggleAcknowledgementAsAdmin()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $returnVal = $this->licenseAcknowledgementDao->toggleAcknowledgement(5);
     $this->assertTrue($returnVal);
@@ -444,7 +446,7 @@ class LicenseAcknowledgementDaoTest extends TestCase
    */
   public function testToggleAcknowledgementAsNonAdmin()
   {
-    $this->authClass->expects('isAdmin')->andReturn(false);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_NONE;
 
     $returnVal = $this->licenseAcknowledgementDao->toggleAcknowledgement(5);
     $this->assertFalse($returnVal);
@@ -458,7 +460,7 @@ class LicenseAcknowledgementDaoTest extends TestCase
    */
   public function testToggleAcknowledgementInvalidId()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $this->expectException(\UnexpectedValueException::class);
 

--- a/src/lib/php/Dao/test/LicenseStdCommentDaoTest.php
+++ b/src/lib/php/Dao/test/LicenseStdCommentDaoTest.php
@@ -22,6 +22,8 @@ use PHPUnit\Runner\Version as PHPUnitVersion;
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
 class LicenseStdCommentDaoTest extends TestCase
 {
 
@@ -58,7 +60,7 @@ class LicenseStdCommentDaoTest extends TestCase
     $this->testDb->alterTables(["license_std_comment"]);
     $this->testDb->insertData(["users", "license_std_comment"]);
     $this->authClass = \Mockery::mock('alias:Fossology\Lib\Auth\Auth');
-    $this->authClass->expects('getUserId')->andReturn(2);
+    $this->authClass->shouldReceive('getUserId')->andReturn(2);
   }
 
   protected function tearDown() : void
@@ -67,6 +69,7 @@ class LicenseStdCommentDaoTest extends TestCase
       \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
     $this->testDb = null;
     $this->dbManager = null;
+    \Mockery::close();
   }
 
   /**

--- a/src/lib/php/Dao/test/LicenseStdCommentDaoTest.php
+++ b/src/lib/php/Dao/test/LicenseStdCommentDaoTest.php
@@ -11,6 +11,7 @@
  */
 namespace Fossology\Lib\Dao;
 
+use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Db\DbManager;
 use PHPUnit\Framework\TestCase;
 use Fossology\Lib\Test\TestPgDb;
@@ -22,6 +23,8 @@ use PHPUnit\Runner\Version as PHPUnitVersion;
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
 class LicenseStdCommentDaoTest extends TestCase
 {
 
@@ -45,8 +48,6 @@ class LicenseStdCommentDaoTest extends TestCase
   /** @var int $assertCountBefore */
   private $assertCountBefore;
 
-  private $authClass;
-
   protected function setUp() : void
   {
     $this->testDb = new TestPgDb("licensestdcommentdao");
@@ -57,8 +58,8 @@ class LicenseStdCommentDaoTest extends TestCase
     $this->testDb->createSequences(["license_std_comment_lsc_pk_seq"]);
     $this->testDb->alterTables(["license_std_comment"]);
     $this->testDb->insertData(["users", "license_std_comment"]);
-    $this->authClass = \Mockery::mock('alias:Fossology\Lib\Auth\Auth');
-    $this->authClass->expects('getUserId')->andReturn(2);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $GLOBALS['SysConf']['auth'][Auth::USER_ID] = 2;
   }
 
   protected function tearDown() : void
@@ -67,6 +68,7 @@ class LicenseStdCommentDaoTest extends TestCase
       \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
     $this->testDb = null;
     $this->dbManager = null;
+    \Mockery::close();
   }
 
   /**
@@ -136,7 +138,7 @@ class LicenseStdCommentDaoTest extends TestCase
    */
   public function testUpdateCommentAsAdmin()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+      $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $returnVal = $this->licenseStdCommentDao->updateComment(2,
       "Updated comment #1", "This comment is updated!");
@@ -164,7 +166,7 @@ class LicenseStdCommentDaoTest extends TestCase
    */
   public function testUpdateCommentAsNonAdmin()
   {
-    $this->authClass->expects('isAdmin')->andReturn(false);
+      $_SESSION[Auth::USER_LEVEL] = Auth::PERM_NONE;
 
     $returnVal = $this->licenseStdCommentDao->updateComment(3,
       "Updated comment #2", "This comment is updated!");
@@ -183,7 +185,7 @@ class LicenseStdCommentDaoTest extends TestCase
    */
   public function testUpdateCommentAsAdminInvalidId()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $this->expectException(\UnexpectedValueException::class);
     $this->licenseStdCommentDao->updateComment(- 1, "Invalid comment #1",
@@ -200,7 +202,7 @@ class LicenseStdCommentDaoTest extends TestCase
    */
   public function testUpdateCommentFromArrayAsAdmin()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+       $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $newValues = [];
     $newValues[3]['name'] = "Updated comment #2";
@@ -237,7 +239,7 @@ class LicenseStdCommentDaoTest extends TestCase
    */
   public function testUpdateCommentFromArrayAsNonAdmin()
   {
-    $this->authClass->expects('isAdmin')->andReturn(false);
+       $_SESSION[Auth::USER_LEVEL] = Auth::PERM_NONE;
 
     $newValues = [];
     $newValues[5]['name'] = "Updated comment #4";
@@ -258,7 +260,7 @@ class LicenseStdCommentDaoTest extends TestCase
    */
   public function testUpdateCommentFromArrayInvalidId()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $newValues = [];
     $newValues[-1]['name'] = "Updated comment #4";
@@ -279,7 +281,7 @@ class LicenseStdCommentDaoTest extends TestCase
    */
   public function testUpdateCommentFromArrayInvalidFields()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $newValues = [];
     $newValues[5]['naaaaame'] = "Updated comment #4";
@@ -300,7 +302,7 @@ class LicenseStdCommentDaoTest extends TestCase
    */
   public function testUpdateCommentFromArrayEmptyArray()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $newValues = [];
 
@@ -318,7 +320,7 @@ class LicenseStdCommentDaoTest extends TestCase
    */
   public function testUpdateCommentFromArrayEmptyValues()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $newValues = [3 => []];
 
@@ -368,7 +370,7 @@ class LicenseStdCommentDaoTest extends TestCase
    */
   public function testInsertCommentAsAdmin()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $returnVal = $this->licenseStdCommentDao->insertComment("Inserted comment #1",
       "This first inserted comment!");
@@ -396,7 +398,7 @@ class LicenseStdCommentDaoTest extends TestCase
    */
   public function testInsertCommentAsNonAdmin()
   {
-    $this->authClass->expects('isAdmin')->andReturn(false);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_NONE;
 
     $returnVal = $this->licenseStdCommentDao->insertComment("Inserted comment #1",
       "This first inserted comment!");
@@ -411,7 +413,7 @@ class LicenseStdCommentDaoTest extends TestCase
    */
   public function testInsertCommentEmptyValues()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $returnVal = $this->licenseStdCommentDao->insertComment("",
       "       ");
@@ -427,7 +429,7 @@ class LicenseStdCommentDaoTest extends TestCase
    */
   public function testToggleCommentAsAdmin()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $returnVal = $this->licenseStdCommentDao->toggleComment(5);
     $this->assertTrue($returnVal);
@@ -444,7 +446,7 @@ class LicenseStdCommentDaoTest extends TestCase
    */
   public function testToggleCommentAsNonAdmin()
   {
-    $this->authClass->expects('isAdmin')->andReturn(false);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_NONE;
 
     $returnVal = $this->licenseStdCommentDao->toggleComment(5);
     $this->assertFalse($returnVal);
@@ -458,7 +460,7 @@ class LicenseStdCommentDaoTest extends TestCase
    */
   public function testToggleCommentInvalidId()
   {
-    $this->authClass->expects('isAdmin')->andReturn(true);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $this->expectException(\UnexpectedValueException::class);
 

--- a/src/lib/php/Report/ClearedGetterCommon.php
+++ b/src/lib/php/Report/ClearedGetterCommon.php
@@ -116,19 +116,19 @@ abstract class ClearedGetterCommon
   {
     $uniqueArray = array();
     foreach ($findings as $item) {
-      $contentKey = $item['content'];
+      $contentKey = array_key_exists('content', $item) ? $item['content'] : '';
       if (!isset($uniqueArray[$contentKey])) {
         $uniqueArray[$contentKey] = array(
-          "licenseId" => $item["licenseId"],
-          "content" => $item["content"],
-          "text" => $item["text"],
+          "licenseId" => array_key_exists('licenseId', $item) ? $item['licenseId'] : '',
+          "content" => $contentKey,
+          "text" => array_key_exists('text', $item) ? $item['text'] : '',
           "files" => array(),
           "hash" => array(),
-          "comments" => $item["comments"]
+          "comments" => array_key_exists('comments', $item) ? $item['comments'] : ''
           );
       }
-      $uniqueArray[$contentKey]['files'] = array_merge($uniqueArray[$contentKey]['files'], $item['files']);
-      $uniqueArray[$contentKey]['hash'] = array_merge($uniqueArray[$contentKey]['hash'], $item['hash']);
+      $uniqueArray[$contentKey]['files'] = array_merge($uniqueArray[$contentKey]['files'], (array)($item['files'] ?? array()));
+      $uniqueArray[$contentKey]['hash'] = array_merge($uniqueArray[$contentKey]['hash'], (array)($item['hash'] ?? array()));
     }
     return array_values($uniqueArray);
   }
@@ -169,10 +169,10 @@ abstract class ClearedGetterCommon
 
       if ($agentCall == "license") {
         $this->groupBy = "text";
-        $groupBy = md5($statement[$this->groupBy].$statement["content"]);
+        $groupBy = md5($text . $content);
       } else {
         $this->groupBy = "content";
-        $groupBy = $statement[$this->groupBy];
+        $groupBy = $content;
       }
 
       if (empty($comments) && array_key_exists($groupBy, $statements)) {

--- a/src/monk/agent_tests/Functional/cliTest.php
+++ b/src/monk/agent_tests/Functional/cliTest.php
@@ -98,6 +98,7 @@ class cliTest extends \PHPUnit\Framework\TestCase
   /**
    * @dataProvider providerWhetherToUseStandalone
    */
+  #[\PHPUnit\Framework\Attributes\DataProvider('providerWhetherToUseStandalone')]
   public function testRunMonkScan($standalone)
   {
     $this->setUpTables();
@@ -152,6 +153,7 @@ class cliTest extends \PHPUnit\Framework\TestCase
   /**
    * @dataProvider providerWhetherToUseStandalone
    */
+  #[\PHPUnit\Framework\Attributes\DataProvider('providerWhetherToUseStandalone')]
   public function testRunMultipleMonkScansFulls($standalone)
   {
     $this->setUpTables();
@@ -176,6 +178,7 @@ class cliTest extends \PHPUnit\Framework\TestCase
   /**
    * @dataProvider providerWhetherToUseStandalone
    */
+  #[\PHPUnit\Framework\Attributes\DataProvider('providerWhetherToUseStandalone')]
   public function testRunMultipleMonkScansDiff($standalone)
   {
     $this->setUpTables();
@@ -199,6 +202,7 @@ class cliTest extends \PHPUnit\Framework\TestCase
   /**
    * @dataProvider providerWhetherToUseStandalone
    */
+  #[\PHPUnit\Framework\Attributes\DataProvider('providerWhetherToUseStandalone')]
   public function testRunMonkHelpMode($standalone)
   {
     $this->setUpTables();
@@ -219,6 +223,7 @@ class cliTest extends \PHPUnit\Framework\TestCase
   /**
    * @dataProvider providerWhetherToUseStandalone
    */
+  #[\PHPUnit\Framework\Attributes\DataProvider('providerWhetherToUseStandalone')]
   public function testRunMonkScansWithNegativeMatch($standalone)
   {
     $this->setUpTables();
@@ -237,6 +242,7 @@ class cliTest extends \PHPUnit\Framework\TestCase
   /**
    * @dataProvider providerWhetherToUseStandalone
    */
+  #[\PHPUnit\Framework\Attributes\DataProvider('providerWhetherToUseStandalone')]
   public function testRunMonkScansWithNegativeMatchVerbose($standalone)
   {
     $this->setUpTables();

--- a/src/monk/agent_tests/Functional/schedulerTest.php
+++ b/src/monk/agent_tests/Functional/schedulerTest.php
@@ -5,6 +5,8 @@
  SPDX-License-Identifier: GPL-2.0-only
 */
 
+namespace Fossology\Monk\Test;
+
 use Fossology\Lib\Dao\ClearingDao;
 use Fossology\Lib\Dao\HighlightDao;
 use Fossology\Lib\Dao\LicenseDao;
@@ -19,7 +21,7 @@ use Fossology\Lib\Test\TestInstaller;
 use Fossology\Lib\Test\TestPgDb;
 use Monolog\Logger;
 
-class MonkScheduledTest extends \PHPUnit\Framework\TestCase
+class SchedulerTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestPgDb */
   private $testDb;

--- a/src/nomos/agent_tests/testdata/NomosTestfiles/AGPL/JsonMapper.php
+++ b/src/nomos/agent_tests/testdata/NomosTestfiles/AGPL/JsonMapper.php
@@ -106,7 +106,7 @@ class JsonMapper
         continue;
       }
 
-      if ($type{0} != '\\') {
+      if ($type[0] != '\\') {
         //create a full qualified namespace
         if ($strNs != '') {
           $type = '\\' . $strNs . '\\' . $type;
@@ -130,7 +130,7 @@ class JsonMapper
       }
 
       if ($array !== null) {
-        if ($subtype{0} != '\\') {
+        if ($subtype[0] != '\\') {
           //create a full qualified namespace
           if ($strNs != '') {
             $subtype = $strNs . '\\' . $subtype;

--- a/src/ojo/agent_tests/Functional/schedulerTest.php
+++ b/src/ojo/agent_tests/Functional/schedulerTest.php
@@ -9,6 +9,9 @@
  * @file
  * @brief Functional test cases for ojo agent using scheduler
  */
+
+namespace Fossology\Ojo\Test;
+
 require_once "SchedulerTestRunnerCli.php";
 require_once "SchedulerTestRunnerScheduler.php";
 
@@ -23,10 +26,10 @@ use Fossology\Ojo\Test\SchedulerTestRunnerCli;
 use Fossology\Ojo\Test\SchedulerTestRunnerScheduler;
 
 /**
- * @class OjoScheduledTest
+ * @class SchedulerTest
  * @brief Functional test cases for ojo agent using scheduler
  */
-class OjoScheduledTest extends \PHPUnit\Framework\TestCase
+class SchedulerTest extends \PHPUnit\Framework\TestCase
 {
 
   /**
@@ -217,7 +220,7 @@ class OjoScheduledTest extends \PHPUnit\Framework\TestCase
    * @return number -1 if right is small, 1 is left is small or 0 if both are
    *         equal
    */
-  private function compareMatches($left, $right)
+  public static function compareMatches($left, $right)
   {
     $leftFile = basename($left["file"]);
     $rightFile = basename($right["file"]);
@@ -250,7 +253,7 @@ class OjoScheduledTest extends \PHPUnit\Framework\TestCase
    * @param array $right Right match
    * @return number strcmp of left filename and right filename
    */
-  private function compareMatchesFiles($left, $right)
+  public static function compareMatchesFiles($left, $right)
   {
     return strcmp($left["file"], $right["file"]);
   }
@@ -366,12 +369,12 @@ class OjoScheduledTest extends \PHPUnit\Framework\TestCase
     $jsonFromOutput = json_decode($output, true);
 
     // Sort the data to reduce differences
-    usort($jsonFromFile, array('OjoScheduledTest', 'compareMatchesFiles'));
-    usort($jsonFromOutput, array('OjoScheduledTest', 'compareMatchesFiles'));
+    usort($jsonFromFile, array(self::class, 'compareMatchesFiles'));
+    usort($jsonFromOutput, array(self::class, 'compareMatchesFiles'));
 
     // Find the difference
     $jsonDiff = array_udiff($jsonFromFile, $jsonFromOutput,
-      array('OjoScheduledTest', 'compareMatches'));
+      array(self::class, 'compareMatches'));
 
     $outputDiff = "JSON does not match regression test file.\n";
     $outputDiff .= "Following are the results not in regression test file.\n";

--- a/src/phpunit.82.xml
+++ b/src/phpunit.82.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- SPDX-FileCopyrightText: © Fossology contributors
+
+     SPDX-License-Identifier: GPL-2.0-only
+-->
+<phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  bootstrap="./phpunit-bootstrap.php"
+  colors="true" backupGlobals="true"
+  beStrictAboutTestsThatDoNotTestAnything="false"
+  failOnWarning="false" stopOnFailure="false"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+  cacheDirectory=".phpunit.cache">
+  <coverage>
+    <report>
+      <clover outputFile="../clover.xml"/>
+    </report>
+  </coverage>
+  <php>
+    <env name="SYSCONFDIR" value="src/lib/php/tests/sysconfigDirTest"/>
+  </php>
+  <logging/>
+  <testsuites>
+    <testsuite name="Fossology PhpUnit Test Suite">
+      <directory suffix="Test.php">lib/php</directory>
+      <file>www/ui_tests/startUpTest.php</file>
+      <directory suffix="Test.php">www/ui_tests/api</directory>
+      <file>cli/tests/test_fo_copyright_list.php</file>
+    </testsuite>
+    <testsuite name="Fossology PhpUnit Agent Test Suite">
+      <directory suffix="Test.php">copyright/agent_tests/Functional</directory>
+      <directory suffix="Test.php">decider/agent_tests</directory>
+      <directory suffix="Test.php">deciderjob/agent_tests/Functional</directory>
+      <directory suffix="Test.php">monk/agent_tests/Functional</directory>
+      <directory suffix="Test.php">ojo/agent_tests/Functional</directory>
+      <directory suffix="Test.php">reuser/agent_tests/Functional</directory>
+      <directory suffix="Test.php">spdx/agent_tests</directory>
+      <directory suffix="Test.php">clixml/agent_tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+  </source>
+</phpunit>

--- a/src/phpunit.82.xml
+++ b/src/phpunit.82.xml
@@ -9,7 +9,7 @@
   colors="true" backupGlobals="true"
   beStrictAboutTestsThatDoNotTestAnything="false"
   failOnWarning="false" stopOnFailure="false"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
   cacheDirectory=".phpunit.cache">
   <coverage>
     <report>

--- a/src/spdx/agent/CMakeLists.txt
+++ b/src/spdx/agent/CMakeLists.txt
@@ -30,3 +30,7 @@ foreach(SPDX_INSTALL spdx spdx2 spdx2tv dep5 spdx2csv spdx3jsonld spdx3json spdx
 endforeach()
 
 add_symlink(${PROJECT_NAME} ${FO_LIBEXECDIR}/fo_wrapper ${FO_MODDIR}/${PROJECT_NAME}/agent)
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/agent)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/spdx.wrapper.in ${CMAKE_CURRENT_BINARY_DIR}/agent/spdx @ONLY)
+file(CHMOD ${CMAKE_CURRENT_BINARY_DIR}/agent/spdx PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)

--- a/src/spdx/agent/spdx.wrapper.in
+++ b/src/spdx/agent/spdx.wrapper.in
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © Fossology contributors
+
+# SPDX-License-Identifier: GPL-2.0-only
+
+# Wrapper to invoke the PHP-based spdx agent in the same directory.
+php "$(dirname "$0")/spdx.php" "$@"

--- a/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
@@ -924,6 +924,8 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
    * -# Check if response status is 200
    * -# Check if response body is matches the expected response body
    */
+  #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+  #[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
   public function testImportLicenseV1()
   {
     $this->testImportLicense(ApiVersion::V1);
@@ -936,6 +938,8 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
    * -# Check if response status is 200
    * -# Check if response body is matches the expected response body
    */
+  #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+  #[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
   public function testImportLicenseV2()
   {
     $this->testImportLicense();

--- a/src/www/ui_tests/api/Controllers/UploadControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadControllerTest.php
@@ -60,6 +60,8 @@ function TryToDelete($uploadpk, $user_pk, $group_pk, $uploadDao)
  * @class UploadControllerTest
  * @brief Unit tests for UploadController
  */
+#[\PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses]
+#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
 class UploadControllerTest extends \PHPUnit\Framework\TestCase
 {
   /**


### PR DESCRIPTION
Add PHP 8.2, 8.3 and 8.4 entries to build-test matrix / Fix some tests

Issue for discussion: #3285

This PR extends and includes all changes from #3370
If only this one will be merged it obsoletes the 3370 which only adds fixes and introduction of PHP 8.2

## build-test.yml
 - Added matrix entries for PHP 8.2 / PHPUnit 11, 8.3 / PHPUnit 12, and 8.4 / PHPUnit 13
 - Added a Determine PHPUnit config step that selects
	-- phpunit.xml (PHP 7.4 / 8.1 with PHPUnit 9/10 — no behaviour change)
    -- phpunit.82.xml (supports PHP 8.2 + 8.3 + 8.4)

## Test compatibility fixes are needed
 - PHPUnit 12 removed docblock annotation support (@dataProvider, @runInSeparateProcess, @runTestsInSeparateProcesses)
 - The 'fix' is to add the equivalent PHP 8 attribute beside each annotation. PHP 7.x tokenizes #[…] as a single-line comment and ignores it, so we do not break it.
 
 ## Result matrix - PHPUnit test suit
as per 2026-08-17
| PHP | PHPUnit | Tests | Assertions | Deprecations | PHPUnit Deprecations | PHPUnit Notices |
|---|---:|---:|---:|---:|---:|---:|
| 7.4 | 9.6.36 | 1,252 | 3,840 | 0 | 0 | 0 |
| 8.1 | 10.5.12 | 1,252 | 3,840 | 19 | 0 | 0 |
| 8.2 | 11.5.56 | 1,252 | 3,844 | 77 | 4,084 | 0 |
| 8.3 | 12.5.33 | 1,252 | 3,844 | 77 | 0 | 16 |
| 8.4 | 13.3.1 | 1,252 | 3,844 | 373 | 5 | 16 |

and for comparison from a regular run as per current config:
| PHP | PHPUnit | Tests | Assertions | Deprecations | PHPUnit Deprecations | PHPUnit Notices |
|---|---:|---:|---:|---:|---:|---:|
| 7.4 | **9.6.3** | 1,252 | 3,840 | 0 | 0 | 0 |
| 8.1 | **10.0.12** | 1,252 | 3,840 | **1** | 0 | 0 |
