### PR TITLE
fix(user): add SPDX/OSSelot defaults to user creation

### DIFF
--- a/src/lib/php/common-users.php
+++ b/src/lib/php/common-users.php
@@ -26,11 +26,12 @@
  * \param string $agentList user_agent_list
  * \param int    $Folder root_folder_fk
  * \param int    $default_bucketpool_fk default is empty
+ * \param string $spdxSettings spdx_settings
  *
  * \return error: exit (1)
  */
 function add_user($User, $Desc, $Hash, $Perm, $Email, $Email_notify, $Upload_visibility,
-                  $agentList, $Folder, $default_bucketpool_fk='')
+                  $agentList, $Folder, $default_bucketpool_fk='', $spdxSettings=null)
 {
   global $container;
   $dbManager = $container->get('db.manager');
@@ -39,10 +40,17 @@ function add_user($User, $Desc, $Hash, $Perm, $Email, $Email_notify, $Upload_vis
     $default_bucketpool_fk = null;
   }
 
-  $dbManager->prepare($stmt='users.insert',$sql="INSERT INTO users
-         (user_name,user_desc,user_seed,user_pass,user_perm,user_email,
-          email_notify,upload_visibility,user_agent_list,root_folder_fk,default_folder_fk) VALUES ($1,$2,$3,$4,$5,$6,  $7,$8,$9,$10,$11)");
-  $dbManager->execute($stmt,array ($User,$Desc,'Seed',$Hash,$Perm,$Email,  $Email_notify,$Upload_visibility,$agentList,$Folder,$Folder));
+  if ($dbManager->existsColumn('users', 'spdx_settings') && $spdxSettings !== null) {
+    $dbManager->prepare($stmt='users.insert',$sql="INSERT INTO users
+           (user_name,user_desc,user_seed,user_pass,user_perm,user_email,
+            email_notify,upload_visibility,user_agent_list,root_folder_fk,default_folder_fk,spdx_settings) VALUES ($1,$2,$3,$4,$5,$6,  $7,$8,$9,$10,$11,$12)");
+    $dbManager->execute($stmt,array ($User,$Desc,'Seed',$Hash,$Perm,$Email,  $Email_notify,$Upload_visibility,$agentList,$Folder,$Folder,$spdxSettings));
+  } else {
+    $dbManager->prepare($stmt='users.insert',$sql="INSERT INTO users
+           (user_name,user_desc,user_seed,user_pass,user_perm,user_email,
+            email_notify,upload_visibility,user_agent_list,root_folder_fk,default_folder_fk) VALUES ($1,$2,$3,$4,$5,$6,  $7,$8,$9,$10,$11)");
+    $dbManager->execute($stmt,array ($User,$Desc,'Seed',$Hash,$Perm,$Email,  $Email_notify,$Upload_visibility,$agentList,$Folder,$Folder));
+  }
 
   /* Make sure it was added */
   $row = $dbManager->getSingleRow("SELECT * FROM users WHERE user_name = $1",array($User),$stmt='users.get');

--- a/src/www/ui/template/user_add.html.twig
+++ b/src/www/ui/template/user_add.html.twig
@@ -88,6 +88,27 @@
       <th width="25%">{{ "Default bucket pool"| trans }}</th>
       <td>{{ bucketPool }}</td>
     </tr>
+    <tr class="classic">
+      <th width="25%">
+        {{ "Enable OSSelot export by default"|trans }}
+        <img src="images/info_16.png" data-toggle="tooltip" title="{{ 'When enabled, SPDX and ReadMeOSS exports will be OSSelot-compatible: custom licenses will be emitted as LicenseRef-<ShortName> (dropping &quot;-fossology-&quot;), ReadMeOSS will strip all LicenseRef- prefixes, and every license&apos;s full text will be included.'|trans }}" alt="" class="info-bullet"/>
+      </th>
+      <td><input type="checkbox" name="osselot_export_enabled" id="osselotExportEnabledCheckbox"></td>
+    </tr>
+    <tr class="classic">
+      <th width="25%">
+        {{ "Show SPDX license comments by default"|trans }}
+        <img src="images/info_16.png" data-toggle="tooltip" title="{{ 'When enabled, SPDX reports will include license comments by default.'|trans }}" alt="" class="info-bullet"/>
+      </th>
+      <td><input type="checkbox" name="spdx_license_comment_default" id="spdxLicenseCommentDefaultCheckbox"></td>
+    </tr>
+    <tr class="classic">
+      <th width="25%">
+        {{ "Ignore files with no info in SPDX by default"|trans }}
+        <img src="images/info_16.png" data-toggle="tooltip" title="{{ 'When enabled, SPDX reports will ignore files with no license information by default.'|trans }}" alt="" class="info-bullet"/>
+      </th>
+      <td><input type="checkbox" name="ignore_files_wo_info_default"></td>
+    </tr>
   </table><P />
   <br />
   <input type="submit" value="{{ 'Add User'|trans }}"/>

--- a/src/www/ui/user-add.php
+++ b/src/www/ui/user-add.php
@@ -53,6 +53,14 @@ class user_add extends DefaultPlugin
     $agentList = is_null($request->get('user_agent_list')) ? userAgents() : $request->get('user_agent_list');
     $default_bucketpool_fk = $request->get('default_bucketpool_fk');
 
+    $spdxSettings = null;
+    if ($this->dbManager->existsColumn('users', 'spdx_settings')) {
+      $osselotEnabled = !empty($request->get('osselot_export_enabled')) ? 'checked' : 'unchecked';
+      $spdxCommentEnabled = !empty($request->get('spdx_license_comment_default')) ? 'checked' : 'unchecked';
+      $ignoreFilesEnabled = !empty($request->get('ignore_files_wo_info_default')) ? 'checked' : 'unchecked';
+      $spdxSettings = "$osselotEnabled,$spdxCommentEnabled,$ignoreFilesEnabled";
+    }
+
     /* Make sure username looks valid */
     if (empty($User)) {
       $text = _("Username must be specified. Not added.");
@@ -116,7 +124,7 @@ class user_add extends DefaultPlugin
     }
 
     $ErrMsg = add_user($User, $Desc, $Hash, $Perm, $Email, $Email_notify, $Upload_visibility,
-      $agentList, $Folder, $default_bucketpool_fk);
+      $agentList, $Folder, $default_bucketpool_fk, $spdxSettings);
 
     return ($ErrMsg);
   } // Add()


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
Add SPDX and OSSelot default settings to user creation form to ensure new users have proper license reporting configurations from the start.

### Changes

  - Modified add_user() function in src/lib/php/common-users.php to accept and store SPDX settings parameter 
  - Added three checkboxes to user creation form 
  - Updated src/www/ui/user-add.php to process the new SPDX settings

## How to test

  1. Navigate to Admin → Users → Add User page
  2. Verify three new SPDX-related checkboxes appear in the form with tooltips
  3. Create a new user with different combinations of checkbox settings
  4. Verify the user is created successfully and settings are stored in the database
  5. Check that the new user's SPDX export preferences match the selected defaults