### PR TITLE
fix(scheduler): guard against NULL agent owner to prevent scheduler crash

### DIFF
--- a/src/scheduler/agent/agent.c
+++ b/src/scheduler/agent/agent.c
@@ -57,15 +57,26 @@
 #define TEST_NULL(a, ret) if(!a) { \
   errno = EINVAL; ERROR("agent passed is NULL, cannot proceed"); return ret; }
 
-/** Prints the credential of the agent */
-#define AGENT_CREDENTIAL                                                 \
-  log_printf("JOB[%d].%s[%d.%s]: ", agent->owner->id, agent->type->name, \
-      agent->pid, agent->host->name)
+/** Prints the credential of the agent (null-safe) */
+#define AGENT_CREDENTIAL do {                               \
+  if(agent && agent->owner)                                 \
+    log_printf("JOB[%d].%s[%d.%s]: ", agent->owner->id,     \
+        agent->type ? agent->type->name : "?",              \
+        agent->pid, agent->host ? agent->host->name : "?"); \
+  else                                                      \
+    log_printf("AGENT[%s][pid=%d][host=%s]: ",              \
+        agent && agent->type ? agent->type->name : "?",     \
+        agent ? agent->pid : -1,                            \
+        agent && agent->host ? agent->host->name : "?");    \
+} while(0)
 
-/** Prints the credential to the agent log */
-#define AGENT_LOG_CREDENTIAL                                              \
-  con_printf(job_log(agent->owner), "JOB[%d].%s[%d.%s]: ",                \
-      agent->owner->id, agent->type->name, agent->pid, agent->host->name)
+/** Prints the credential to the agent log (null-safe) */
+#define AGENT_LOG_CREDENTIAL do {                                \
+  if(agent && agent->owner)                                      \
+    con_printf(job_log(agent->owner), "JOB[%d].%s[%d.%s]: ",     \
+        agent->owner->id, agent->type ? agent->type->name : "?", \
+        agent->pid, agent->host ? agent->host->name : "?");      \
+} while(0)
 
 /** ERROR macro specifically for agents */
 #define AGENT_ERROR(...) do {                       \
@@ -152,6 +163,12 @@ static int agent_close_fd(int* pid_ptr, agent_t* agent, agent_t* excepted)
 static int update(int* pid_ptr, agent_t* agent, gpointer unused)
 {
   TEST_NULL(agent, 0);
+  if (agent->owner == NULL)
+  {
+    log_printf("ERROR %s.%d: Agent pid %d has no owner; killing to prevent NULL deref\n", __FILE__, __LINE__, agent->pid);
+    agent_kill(agent);
+    return 0;
+  }
   int nokill = is_agent_special(agent, SAG_NOKILL) || is_meta_special(agent->type, SAG_NOKILL);
 
   if (agent->status == AG_SPAWNED || agent->status == AG_RUNNING || agent->status == AG_PAUSED)
@@ -665,6 +682,24 @@ static void* agent_spawn(agent_spawn_args* pass)
   char buffer[2048];          // character buffer
 
   /* spawn the new process */
+  if (agent->owner == NULL)
+  {
+    log_printf("ERROR %s.%d: Agent spawn requested but agent has no owner; aborting spawn.\n", __FILE__, __LINE__);
+
+    /* Close FILE* streams if they were opened by agent_init(). */
+    if (agent->read)  { fclose(agent->read);  agent->read = NULL; agent->from_child = -1; }
+    if (agent->write) { fclose(agent->write); agent->write = NULL; agent->to_child   = -1; }
+
+    /* from_child/to_child were already closed via fclose() above. */
+    if (agent->from_parent >= 0) { close(agent->from_parent); agent->from_parent = -1; }
+    if (agent->to_parent >= 0)   { close(agent->to_parent);   agent->to_parent   = -1; }
+
+    /* Mark failed and free the spawn args to avoid leaking the heap allocation */
+    agent->status = AG_FAILED;
+    g_free(pass);
+    return NULL;
+  }
+
   while ((agent->pid = fork()) < 0)
     sleep(rand() % CONF_fork_backoff_time);
 


### PR DESCRIPTION
Changes aims to prevent scheduler crashes caused by dereferencing a NULL agent->owner pointer. The changes make the agent logging macros null-safe and add defensive checks in critical code paths to handle potential NULL pointers gracefully.

 - Prevents dereferencing a NULL owner, which could otherwise lead to a SIGSEGV (segmentation fault) and crash the scheduler.
 - Protects against crashes and resource leaks when the agent invariant (missing owner) is violated, while ensuring that the agent lifecycle is still managed correctly by the scheduler.

**1) Null-Safety in Agent Logging Macros:**
The `AGENT_CREDENTIAL` and `AGENT_LOG_CREDENTIAL` macros have been modified to safely handle a NULL `agent->owner` by checking it before dereferencing. Additionally, a NULL check for `agent->type` is added to avoid dereferencing a NULL type.

**2) Agent Management and Memory Cleanup:**
In the `agent_spawn()` function, an early return is introduced if `agent->owner == NULL`. In this case:

- Open `FILE*` streams and file descriptors (FDs) are safely closed,
- The agent is marked as `AG_FAILED`,
- Any passed arguments (if any) are freed,
- NULL is returned to prevent memory and resource leaks.

**3) NULL Owner Check in update() Function:**
A NULL check for `agent->owner`'is added in the `update()` function to kill agents with NULL owners before attempting to use them, preventing the dereferencing of an invalid pointer.

 
Extends the solution/fix from PR: https://github.com/fossology/fossology/pull/3195