### PR TITLE
fix(clearing): prevent duplicate decisions in edit flow and global scope

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -349,7 +349,7 @@ class ClearingDao
     $uploadId = $itemTreeBounds->getUploadId();
     $uploadTreeTable = $this->uploadDao->getUploadtreeTableName($uploadId);
     $itemTreeBounds = $this->uploadDao->getItemTreeBounds($uploadTreeId, $uploadTreeTable);
-    // Check for identical global decision to prevent duplicates
+
     if ($scope == DecisionScopes::REPO) {
       $stmt = "SELECT pfile_fk FROM uploadtree WHERE uploadtree_pk = $1";
       $this->dbManager->prepare($stmt, $stmt);

--- a/src/www/ui/ajax-clearing-view.php
+++ b/src/www/ui/ajax-clearing-view.php
@@ -197,17 +197,13 @@ class AjaxClearingView extends FO_Plugin
           $this->doClearings($orderAscending, $groupId, $uploadId, $uploadTreeId));
 
       case "addLicense":
+        $this->clearingDao->insertClearingEvent($uploadTreeId, $userId, $groupId,
+          $licenseId, false, ClearingEventTypes::USER);
+        return new JsonResponse();
+
       case "removeLicense":
-        $isRemoved = ($action === "removeLicense");
-        $existingEvents = $this->clearingDao->getRelevantClearingEvents(
-          $this->uploadDao->getItemTreeBoundsFromUploadId($uploadTreeId, $uploadId), 
-          $groupId, false
-        );
-        
-        if (!isset($existingEvents[$licenseId]) || $existingEvents[$licenseId]->isRemoved() !== $isRemoved) {
-          $this->clearingDao->insertClearingEvent($uploadTreeId, $userId, $groupId,
-            $licenseId, $isRemoved, ClearingEventTypes::USER);
-        }
+        $this->clearingDao->insertClearingEvent($uploadTreeId, $userId, $groupId,
+          $licenseId, true, ClearingEventTypes::USER);
         return new JsonResponse();
 
       case "makeMainLicense":

--- a/src/www/ui/change-license-processPost.php
+++ b/src/www/ui/change-license-processPost.php
@@ -147,7 +147,6 @@ class changeLicenseProcessPost extends FO_Plugin
             return $this->errorJson("bad license");
           }
 
-          // Only insert event if no identical event exists or status differs
           if (!isset($existingEvents[$licenseId]) || $existingEvents[$licenseId]->isRemoved() !== $removed) {
             $this->clearingDao->insertClearingEvent($itemId, $userId, $groupId,
               $licenseId, $removed, ClearingEventTypes::USER, $reportInfo = '',


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description


This PR fixes the issue where duplicate clearing decisions were getting added when the same license was added from License Browser Edit.  
While working on this, I also noticed that when we set **"Clearing decision scope → Apply decision to all future occurrences of this file"** to true, the scope becomes global, and the clearing decision was getting added multiple times when we clicked the Submit button.

Closes #458

## How to reproduce

1. Conclude a license for a file.
2. Go to **License Browser → Edit** and add the same license again.
3. Observe that duplicate clearing decisions are created.
4. Enable **Apply decision to all future occurrences of this file** and click Submit multiple times.
5. Observe duplicate global decisions in Clearing History.

## Changes

- Added validation in [change-license-processPost.php](https://github.com/fossology/fossology/blob/master/src/www/ui/change-license-processPost.php) to prevent duplicate entries from License Browser Edit.
- Added validation in [ClearingDao.php](https://github.com/fossology/fossology/blob/master/src/lib/php/Dao/ClearingDao.php) to prevent duplicate global clearing decisions.

##Behaviour

### Before

https://github.com/user-attachments/assets/66a202f6-9dfa-4a19-9c11-aa5a9b7ec20c

<img width="1231" height="176" alt="Screenshot 2026-02-14 165243" src="https://github.com/user-attachments/assets/125fd81e-70bd-44b2-93d7-7be29696c13a" />

###After

https://github.com/user-attachments/assets/711ead6d-ec6e-4635-a7a3-02965ec487c8

<img width="1239" height="129" alt="Screenshot 2026-02-14 165213" src="https://github.com/user-attachments/assets/5af373e3-a260-4db2-a9d5-67e1efc764eb" />

### SQL query
```
SELECT
    cd.clearing_decision_pk,
    ut.ufile_name,
    lr.rf_shortname AS license_shortname,
    ce.removed,
    CASE 
        WHEN ce.removed = false THEN 'ADD'
        WHEN ce.removed = true THEN 'REMOVE'
    END AS event_action,
    cd.decision_type,
    cd.scope,
    cd.date_added
FROM clearing_decision cd
JOIN uploadtree ut
    ON cd.uploadtree_fk = ut.uploadtree_pk
JOIN clearing_decision_event cde
    ON cd.clearing_decision_pk = cde.clearing_decision_fk
JOIN clearing_event ce
    ON cde.clearing_event_fk = ce.clearing_event_pk
JOIN license_ref lr
    ON ce.rf_fk = lr.rf_pk
WHERE ut.ufile_name = 'idn2.c'
ORDER BY cd.date_added DESC;
```

@shaheemazmalmmd 