### PR TITLE
fix(clearing): avoid duplicate decisions in edit flow and global scope

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -335,8 +335,10 @@ class ClearingDao
    * @param int $groupId
    * @param int $decType
    * @param int $scope
+   * @param array $eventIds
+   * @param bool $checkDuplicates
    */
-  public function createDecisionFromEvents($uploadTreeId, $userId, $groupId, $decType, $scope, $eventIds)
+  public function createDecisionFromEvents($uploadTreeId, $userId, $groupId, $decType, $scope, $eventIds, $checkDuplicates = true)
   {
     if ( ($scope == DecisionScopes::REPO) &&
          !empty($this->getCandidateLicenseCountForCurrentDecisions($uploadTreeId))) {
@@ -347,6 +349,16 @@ class ClearingDao
     $uploadId = $itemTreeBounds->getUploadId();
     $uploadTreeTable = $this->uploadDao->getUploadtreeTableName($uploadId);
     $itemTreeBounds = $this->uploadDao->getItemTreeBounds($uploadTreeId, $uploadTreeTable);
+    if ($scope == DecisionScopes::REPO && $checkDuplicates) {
+      $stmt = "SELECT pfile_fk FROM uploadtree WHERE uploadtree_pk = $1";
+      $this->dbManager->prepare($stmt, $stmt);
+      $res = $this->dbManager->execute($stmt, array($uploadTreeId));
+      $row = $this->dbManager->fetchArray($res);
+      $this->dbManager->freeResult($res);
+      if ($row && $this->hasIdenticalGlobalDecision($row['pfile_fk'], $groupId, $decType, $eventIds)) {
+        return;
+      }
+    }
 
     if ($this->isDecisionCheck($uploadTreeId, $groupId, DecisionTypes::IRRELEVANT)) {
       $this->copyrightDao->updateTable($itemTreeBounds, '', '', $userId, 'copyright', 'rollback');
@@ -436,6 +448,59 @@ INSERT INTO clearing_decision (
     }
     $this->dbManager->freeResult($res);
     return $events;
+  }
+
+  /**
+   * @param int $pfileId
+   * @param int $groupId
+   * @param int $decisionType
+   * @param array $eventIds Array of clearing event IDs to compare
+   * @return bool True if identical global decision exists
+   */
+  public function hasIdenticalGlobalDecision($pfileId, $groupId, $decisionType, $eventIds = null)
+  {
+    $stmt = __METHOD__;
+
+    $sql = "SELECT 1
+            FROM clearing_decision cd
+            WHERE cd.pfile_fk = $1
+              AND cd.group_fk = $2
+              AND cd.scope = $3
+              AND cd.decision_type = $4
+              AND cd.decision_type != $5";
+
+    $params = array(
+        $pfileId,
+        $groupId,
+        DecisionScopes::REPO,
+        $decisionType,
+        DecisionTypes::WIP
+    );
+
+    if ($eventIds !== null && !empty($eventIds)) {
+        $eventCount = count($eventIds);
+        $eventIdList = implode(',', array_map('intval', $eventIds));
+
+        $sql .= " AND cd.clearing_decision_pk IN (
+                    SELECT cde.clearing_decision_fk
+                    FROM clearing_decision_event cde
+                    WHERE cde.clearing_event_fk IN ($eventIdList)
+                    GROUP BY cde.clearing_decision_fk
+                    HAVING COUNT(DISTINCT cde.clearing_event_fk) = $6
+                  )";
+
+        $params[] = $eventCount;
+    }
+
+    $sql .= " LIMIT 1";
+
+    $this->dbManager->prepare($stmt, $sql);
+    $res = $this->dbManager->execute($stmt, $params);
+
+    $row = $this->dbManager->fetchArray($res);
+    $this->dbManager->freeResult($res);
+
+    return $row !== false;
   }
 
   /**

--- a/src/reportImport/agent/ReportImportSink.php
+++ b/src/reportImport/agent/ReportImportSink.php
@@ -269,7 +269,9 @@ class ReportImportSink
         $this->groupId,
         $this->configuration->getConcludeLicenseDecisionType(),
         DecisionScopes::ITEM,
-        $eventIds);
+        $eventIds,
+        false  // Import call: disable duplicate prevention to allow importing decisions
+      );
     }
   }
 

--- a/src/www/ui/change-license-processPost.php
+++ b/src/www/ui/change-license-processPost.php
@@ -137,14 +137,18 @@ class changeLicenseProcessPost extends FO_Plugin
         if (! is_array($licenses)) {
           return $this->errorJson("bad license array");
         }
+        $itemBounds = $this->uploadDao->getItemTreeBounds($itemId);
+        $existingEvents = $this->clearingDao->getRelevantClearingEvents($itemBounds, $groupId, false);
         foreach ($licenses as $licenseId) {
           if (intval($licenseId) <= 0) {
             return $this->errorJson("bad license");
           }
 
-          $this->clearingDao->insertClearingEvent($itemId, $userId, $groupId,
-            $licenseId, $removed, ClearingEventTypes::USER, $reportInfo = '',
-            $comment = '', $acknowledgement = '', $jobId);
+          if (!isset($existingEvents[$licenseId]) || $existingEvents[$licenseId]->isRemoved() !== $removed) {
+            $this->clearingDao->insertClearingEvent($itemId, $userId, $groupId,
+              $licenseId, $removed, ClearingEventTypes::USER, $reportInfo = '',
+              $comment = '', $acknowledgement = '', $jobId);
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description


This PR fixes the issue where duplicate clearing decisions were getting added when the same license was added from License Browser Edit.  
While working on this, I also noticed that when we set **"Clearing decision scope → Apply decision to all future occurrences of this file"** to true, the scope becomes global, and the clearing decision was getting added multiple times when we clicked the Submit button.

Closes #458

## How to reproduce

1. Conclude a license for a file.
2. Go to **License Browser → Edit** and add the same license for this file again.
3. Observe that duplicate clearing decisions are created.
4. Enable **Apply decision to all future occurrences of this file** and click Submit multiple times.
5. Observe duplicate global decisions in Clearing History.

## Changes

- Added validation in [change-license-processPost.php](https://github.com/fossology/fossology/blob/master/src/www/ui/change-license-processPost.php) to prevent duplicate entries from License Browser Edit.
- Added validation in [ClearingDao.php](https://github.com/fossology/fossology/blob/master/src/lib/php/Dao/ClearingDao.php) to prevent duplicate global clearing decisions.

## Behaviour

### Before

https://github.com/user-attachments/assets/4a15e3e2-a990-4b25-be15-3b181e26fb83

<img width="1266" height="177" alt="image" src="https://github.com/user-attachments/assets/003d9b47-c1c0-42fe-a721-deee90cce08f" />


### After

https://github.com/user-attachments/assets/4f9bcd8c-2827-43d2-a84e-76066b69fae0

<img width="1266" height="117" alt="image" src="https://github.com/user-attachments/assets/ccadb829-38df-455d-b1c6-a9b6b26ae9c3" />

### SQL query
```
SELECT
    cd.clearing_decision_pk,
    ut.ufile_name,
    lr.rf_shortname AS license_shortname,
    ce.removed,
    CASE 
        WHEN ce.removed = false THEN 'ADD'
        WHEN ce.removed = true THEN 'REMOVE'
    END AS event_action,
    cd.decision_type,
    cd.scope,
    cd.date_added
FROM clearing_decision cd
JOIN uploadtree ut
    ON cd.uploadtree_fk = ut.uploadtree_pk
JOIN clearing_decision_event cde
    ON cd.clearing_decision_pk = cde.clearing_decision_fk
JOIN clearing_event ce
    ON cde.clearing_event_fk = ce.clearing_event_pk
JOIN license_ref lr
    ON ce.rf_fk = lr.rf_pk
WHERE ut.ufile_name = 'idn2.c'
ORDER BY cd.date_added DESC;
```

@shaheemazmalmmd 