### PR TITLE
fix(explorer): correct directory status for 'To be discussed' items

### DIFF
--- a/src/www/ui/async/AjaxExplorer.php
+++ b/src/www/ui/async/AjaxExplorer.php
@@ -19,6 +19,7 @@ use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Dao\UploadDao;
 use Fossology\Lib\Data\AgentRef;
 use Fossology\Lib\Data\ClearingDecision;
+use Fossology\Lib\Data\DecisionScopes;
 use Fossology\Lib\Data\DecisionTypes;
 use Fossology\Lib\Data\LicenseRef;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
@@ -58,9 +59,14 @@ class AjaxExplorer extends DefaultPlugin
   private $filesThatShouldStillBeCleared;
   /** @var array [uploadtree_id]=>cnt */
   private $filesToBeCleared;
+  /** @var array [uploadtree_id]=>cnt */
+  private $filesTBD;
   /** @var UploadTreeProxy $alreadyClearedUploadTreeView
    * DB proxy view to hold upload tree entries for already cleared files */
   private $alreadyClearedUploadTreeView;
+  /** @var UploadTreeProxy $tbdUploadTreeView
+   * DB proxy view to hold upload tree entries for TBD files */
+  private $tbdUploadTreeView;
   /** @var UploadTreeProxy $noLicenseUploadTreeView
    * DB proxy view to hold upload tree entries for files with no license */
   private $noLicenseUploadTreeView;
@@ -87,7 +93,9 @@ class AjaxExplorer extends DefaultPlugin
     $this->clearingFilter = $this->getObject('businessrules.clearing_decision_filter');
     $this->filesThatShouldStillBeCleared = [];
     $this->filesToBeCleared = [];
+    $this->filesTBD = [];
     $this->alreadyClearedUploadTreeView = NULL;
+    $this->tbdUploadTreeView = NULL;
     $this->noLicenseUploadTreeView = NULL;
     $this->cacheClearedCounter = [];
   }
@@ -97,6 +105,9 @@ class AjaxExplorer extends DefaultPlugin
     // Destruct the proxy views before exiting
     if ($this->alreadyClearedUploadTreeView !== NULL) {
       $this->alreadyClearedUploadTreeView->unmaterialize();
+    }
+    if ($this->tbdUploadTreeView !== NULL) {
+      $this->tbdUploadTreeView->unmaterialize();
     }
     if ($this->noLicenseUploadTreeView !== NULL) {
       $this->noLicenseUploadTreeView->unmaterialize();
@@ -458,7 +469,14 @@ class AjaxExplorer extends DefaultPlugin
 
     $filesCleared = $filesToBeCleared - $filesThatShouldStillBeCleared;
 
-    $img = ($filesCleared == $filesToBeCleared) ? 'green' : 'red';
+    $filesTBD = array_key_exists($childItemTreeBounds->getItemId()
+        , $this->filesTBD) ? $this->filesTBD[$childItemTreeBounds->getItemId()] : 0;
+
+    if ($filesThatShouldStillBeCleared > 0) {
+      $img = ($filesThatShouldStillBeCleared == $filesTBD) ? 'yellow' : 'red';
+    } else {
+      $img = 'green';
+    }
 
     // override green/red flag with grey flag in case of no_license_found scanner finding
     if (!empty($licenseList) && empty($editedLicenseList)) {
@@ -551,6 +569,28 @@ class AjaxExplorer extends DefaultPlugin
       $this->noLicenseUploadTreeView->materialize();
     }
 
+    if ($this->tbdUploadTreeView === NULL) {
+      $uploadId = $itemTreeBounds->getUploadId();
+      $applyGlobal = $this->uploadDao->getGlobalDecisionSettingsFromInfo($uploadId);
+      $globalSql = ($applyGlobal == 1) ?
+        "((ut.uploadtree_pk = cd.uploadtree_fk AND cd.group_fk = $groupId AND cd.scope = " . DecisionScopes::ITEM . ") OR (cd.pfile_fk = ut.pfile_fk AND cd.scope=" . DecisionScopes::REPO . "))" :
+        "(ut.uploadtree_pk = cd.uploadtree_fk AND cd.group_fk = $groupId)";
+
+      $decisionQuery = "(SELECT cd.decision_type FROM clearing_decision cd WHERE $globalSql ORDER BY cd.clearing_decision_pk DESC LIMIT 1)";
+      $tbdFilter = "AND $decisionQuery = " . DecisionTypes::TO_BE_DISCUSSED;
+
+      $this->tbdUploadTreeView = new UploadTreeProxy(
+        $uploadId,
+        $options = array(
+          UploadTreeProxy::OPT_SKIP_THESE => "noLicense",
+          UploadTreeProxy::OPT_ITEM_FILTER => $tbdFilter,
+          UploadTreeProxy::OPT_GROUP_ID => $groupId,
+          UploadTreeProxy::OPT_AGENT_SET => $agentIds
+        ), $itemTreeBounds->getUploadTreeTableName(),
+        $viewName = 'tbd_uploadtree' . $uploadId);
+      $this->tbdUploadTreeView->materialize();
+    }
+
     $this->updateFilesToBeCleared($isFlat, $itemTreeBounds);
     $allDecisions = $this->clearingDao->getFileClearingsFolder($itemTreeBounds,
       $groupId, $isFlat);
@@ -581,6 +621,9 @@ class AjaxExplorer extends DefaultPlugin
       $this->filesToBeCleared = array_replace($this->filesToBeCleared,
         $this->noLicenseUploadTreeView->countMaskedNonArtifactChildren(
           $itemId));
+      $this->filesTBD = array_replace($this->filesTBD,
+        $this->tbdUploadTreeView->countMaskedNonArtifactChildren(
+          $itemId));
     } else {
       $this->filesThatShouldStillBeCleared = array_replace(
         $this->filesThatShouldStillBeCleared,
@@ -588,6 +631,8 @@ class AjaxExplorer extends DefaultPlugin
           $itemTreeBounds));
       $this->filesToBeCleared = array_replace($this->filesToBeCleared,
         $this->noLicenseUploadTreeView->getNonArtifactDescendants($itemTreeBounds));
+      $this->filesTBD = array_replace($this->filesTBD,
+        $this->tbdUploadTreeView->getNonArtifactDescendants($itemTreeBounds));
     }
   }
 }


### PR DESCRIPTION


### **Description**
This PR fixes the directory status logic to correctly display the "To be discussed" (Yellow) status when a directory contains no "Open" (Red) files but has at least one "To be discussed" file.

#### **Problem**
Previously, directories remained Red even if all files were reviewed, as long as some were marked Yellow.

#### **Solution**
Refactored `AjaxExplorer.php` to include recursive counts for TBD files using `UploadTreeProxy`'s item filter. Priority is now correctly given to the Yellow status when no un-reviewed files remain.

#### **Validation**
Local verification in Docker confirmed the fix. (Screenshots attached below).

<img width="1470" height="956" alt="Screenshot 2026-02-17 at 7 40 02 PM" src="https://github.com/user-attachments/assets/3df6024b-693d-428b-9ecf-bec452f76c67" />
<img width="1470" height="956" alt="Screenshot 2026-02-17 at 8 13 29 PM" src="https://github.com/user-attachments/assets/0ae5f151-b06e-4e3c-ba38-dfe7ca339145" />
