### PR TITLE
fix: prevent unintended insertion into fileIdsMapReverse

### DIFF
--- a/src/scancode/agent/scancode_utils.cc
+++ b/src/scancode/agent/scancode_utils.cc
@@ -132,7 +132,12 @@ bool processUploadId(const State &state, int uploadId,
 
       if (isSuccessful) {
         string fileName = scancodeValue["file"].asString();
-        unsigned long fileId = fileIdsMapReverse[fileName];
+        unsigned long fileId = 0;  // preserve old behavior
+
+        auto it = fileIdsMapReverse.find(fileName);
+        if (it != fileIdsMapReverse.end()) {
+            fileId = it->second;
+        }
         if (!matchFileWithLicenses(state, threadLocalDatabaseHandler,
                                    scanResults[i], fileName, fileId)) {
           errors = true;


### PR DESCRIPTION
Replace operator[] with find() to avoid implicit default insertion when fileName is missing. Adds explicit error handling instead.

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix unintended insertion into `fileIdsMapReverse` caused by the use of
`operator[]`.

Previously, accessing the map using:

```cpp
unsigned long fileId = fileIdsMapReverse[fileName];
operator[] would insert a default value if fileName was missing.
```
Map could be unintentionally modified.
Potential hidden bugs during parallel execution.

After
```cpp
string fileName = scancodeValue["file"].asString();
auto it = fileIdsMapReverse.find(fileName);
if (it == fileIdsMapReverse.end()) {
  LOG_ERROR("File name '%s' not found in file IDs map\n", fileName.c_str());
  errors = true;
  continue;
}
unsigned long fileId = it->second;
```
closing issue #3338 