### PR TITLE
refactor(menu): shift system load from banner to menu for better usage

### DIFF
--- a/src/lib/php/UI/template/components/menu.html.twig
+++ b/src/lib/php/UI/template/components/menu.html.twig
@@ -5,7 +5,6 @@
 {% if bannerMsg %}
   <div class="alert alert-danger" id="topBanner">
     <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-  {{ systemLoad }}
   {{ bannerMsg }}
   </div>
 {% endif %}
@@ -32,6 +31,7 @@
         <small><a href="{{ logOutUrl }}"><b>logout</b></a></small>
         <table style="text-align: left;">
           <tr>
+            <th rowspan="2" style="background:none;padding-right:5px;">{{ systemLoad }}</th>
             <td align="right"><small>{{ 'User'|trans }}:</small></td>
             <td>{{ userName }}</td>
           </tr>

--- a/src/lib/php/common-dir.php
+++ b/src/lib/php/common-dir.php
@@ -341,7 +341,7 @@ $ShowBox=1, $ShowMicro=NULL, $Enumerate=-1, $PreText='', $PostText='', $uploadtr
 
   if (! empty($ShowMicro)) {
     $MenuDepth = 0; /* unused: depth of micro menu */
-    $V .= menu_to_1html(menu_find($ShowMicro,$MenuDepth),1);
+    $V .= menu_to_1html(menu_find($ShowMicro,$MenuDepth),0);
   }
 
   if ($Enumerate >= 0) {


### PR DESCRIPTION
## Description

shift system load from banner to menu for better usage

## How to test

<img width="1853" height="502" alt="image" src="https://github.com/user-attachments/assets/a7cf2a4e-1348-41f6-b690-d7c2c31bdbc2" />
