### PR TITLE
fix(ui): upload file page facing race condition

### DIFF
--- a/src/lib/php/UI/Component/Menu.php
+++ b/src/lib/php/UI/Component/Menu.php
@@ -232,11 +232,10 @@ class Menu
     $vars['title'] = empty($title) ? _("Welcome to FOSSology") : $title;
     if ($hide_banner) {
       $vars['bannerMsg'] = "";
-      $vars['systemLoad'] = "";
     } else {
       $vars['bannerMsg'] = @$sysConfig['BannerMsg'];
-      $vars['systemLoad'] = get_system_load_average().'<br/>';
     }
+    $vars['systemLoad'] = get_system_load_average().'<br/>';
     $vars['logoLink'] =  $sysConfig['LogoLink']?: 'http://fossology.org';
     $vars['logoImg'] =  $sysConfig['LogoImage']?: 'images/fossology-logo.gif';
 

--- a/src/reuser/ui/template/agent_reuser.js.twig
+++ b/src/reuser/ui/template/agent_reuser.js.twig
@@ -35,8 +35,6 @@ function toggleDisabled() {
     fs.prop('disabled', !this.checked);
     this.checked ? fs.trigger('change') : reloadUploads('', '');
   });
-
-  reloadUploads('', '');
   registerFolderSelectorChange();
 }
 
@@ -126,17 +124,15 @@ function initializeOsselotFields() {
       
       if ($localSection.length > 0) {
         $localSection.show().css('display', 'block');
-        setTimeout(() => {
-          registerFolderSelectorChange();
-          const groupIndex = index || '';
-          reloadUploads('', groupIndex);
-          
-          const checkboxId = groupIndex ? `#reuseSearchInFolder${groupIndex}` : '#reuseSearchInFolder';
-          const $checkbox = $(checkboxId);
-          if ($checkbox.length > 0 && $checkbox.is(':checked')) {
-            $checkbox.trigger('click').trigger('click');
-          }
-        }, 100);
+        registerFolderSelectorChange();
+        const groupIndex = index || '';
+        reloadUploads('', groupIndex);
+        
+        const checkboxId = groupIndex ? `#reuseSearchInFolder${groupIndex}` : '#reuseSearchInFolder';
+        const $checkbox = $(checkboxId);
+        if ($checkbox.length > 0 && $checkbox.is(':checked')) {
+          $checkbox.trigger('click').trigger('click');
+        }
       }
     }
   }
@@ -202,9 +198,6 @@ function initializeOsselotFields() {
       success: function(data) {
         const versions = Array.isArray(data) ? data : [];
         renderVersionRadioButtons(versions, index);
-        setTimeout(() => {
-          syncHiddenField(index);
-        }, 100);
       },
       error: function() {
         $(containerId).html('<em>Error loading versions</em>');
@@ -233,9 +226,7 @@ function initializeOsselotFields() {
     
     $(document).on(`input${namespace} change${namespace}`, `#${packageId}`, function(e) {
         const value = $(this).val();
-        setTimeout(function() {
-            $(`[id^="osselot-package"]:not(#${packageId})`).val(value);
-        }, 10);
+        $(`[id^="osselot-package"]:not(#${packageId})`).val(value);
     });
     
     $(document).on(`click${namespace} keypress${namespace}`, `#${packageId}, #${fetchButtonId}`, function(e) {
@@ -263,10 +254,8 @@ function initializeOsselotFields() {
     
     setupOsselotEvents(indexStr);
     
-    setTimeout(() => {
-      const reuseSourceId = indexStr !== '' ? `#reuse-source${indexStr}` : '#reuse-source';
-      $(reuseSourceId).trigger('change');
-    }, 150);
+    const reuseSourceId = indexStr !== '' ? `#reuse-source${indexStr}` : '#reuse-source';
+    $(reuseSourceId).trigger('change');
     
     window.osselotInitialized[indexStr] = true;
   };
@@ -320,14 +309,6 @@ $(document).ready(function () {
       
       addNavItems(i, val.name, reuseNameTab, reuseTabContent);
     }
-    
-    setTimeout(function() {
-      for (let i = 0; i < allFiles.length; i++) {
-        if (typeof window.initializeOsselotForIndex === 'function') {
-          window.initializeOsselotForIndex(i);
-        }
-      }
-    }, 300);
     
     toggleDisabled();
   });

--- a/src/www/ui/template/upload_file.html.twig
+++ b/src/www/ui/template/upload_file.html.twig
@@ -423,14 +423,7 @@ $(document).ready(function() {
     });
     
     $("#fileUploader").on("change", function(e) {
-        setTimeout(function() {
-            if (window.currentReuseSource && window.currentReuseSource !== 'local') {
-                $('select[id^="reuse-source"]').val(window.currentReuseSource).trigger('change');
-            }
-        }, 500);
-    });
-
-    $("#fileUploader").on("change", function(e) {
+      $('#uploadWarningModal').modal('hide');
       checkDuplicateUploadWarning(e);
 
       var holder = $("#uploaddescriptions");
@@ -458,6 +451,9 @@ $(document).ready(function() {
         addNavItems(i, val.name, reuseNameTab, reuseTabContent);
       }
       toggleDisabled();
+      if (window.currentReuseSource && window.currentReuseSource !== 'local') {
+        $('select[id^="reuse-source"]').val(window.currentReuseSource);
+      }
     });
     $('#uploaddescriptions').on('hidden.bs.collapse', function () {
       $('#collapseDescription').find('button').text('+ expand');


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Race condition encountered in `Upload >> From File` page, Where multiple ajax triggers with dependency on setTimeout which eventually results in UI freeze and breaking. Under load when a single request `getUploads` can take more time, Blocking code can be deadly. 


## Changes

- `upload_file.html.twig` : was facing race condition on duplicate `#fileUploader` on change with a setTimeout()
-  `agent_reuser.js.twig`: Osselot based javascript functions were utilising a lot of setTimeout(), which deems unecessary, I have inspected it,  one of the handlers can be registered immediately, Similarly tried removing the setTimeout.

## How to test

1. Upload multiple uploads in a folder.
2. Try and upload a new component (Also a duplicate --> to check modal is working)
3. The UI should not break, Also check the reuse modal, everything rendering properly. (Check Local and Osselot Reuse working)
4. Try with multiple files as well.


CC: @GMishx @shaheemazmalmmd 