### PR TITLE
fix(pagination): navigate to first page when out of range

### DIFF
--- a/src/www/ui/template/browse_file.js.twig
+++ b/src/www/ui/template/browse_file.js.twig
@@ -16,6 +16,12 @@ function createDirlistTable() {
       aoData.push({"name": "conFilter", "value": $('#conFilter').val() });
       aoData.push({"name": "openCBoxFilter", "value": $('#openCBoxFilter').prop('checked')});
       {% if isFlat %}aoData.push({"name": "flatten", "value": "yes" });{% endif %}
+
+      var displayStart = $.grep(aoData, function(o) { return o.name === "iDisplayStart"; })[0];
+      if (displayStart && {{ iTotalRecords }} > 0 && displayStart.value >= {{ iTotalRecords }}) {
+        displayStart.value = 0;
+        this.fnSettings()._iDisplayStart = 0;
+      }
       $.getJSON(sSource, aoData, fnCallback)
         .fail(failed)
     },


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Always navigate to first page when page number is out of range in tree view.


## How to test

* Upload a component.
* Navigate to tree-view and to a folder where there are over 100 files.
* Click on page number and change it to last/ any.
* Now in sub menu click any top folder where file count is lesser.
* Tool should auto select page one. 
