### PR TITLE
Improve folder access check performance using CTE-based lookup

### DIFF
--- a/src/lib/php/Dao/FolderDao.php
+++ b/src/lib/php/Dao/FolderDao.php
@@ -436,16 +436,11 @@ WHERE fc.parent_fk = $1 AND fc.foldercontents_mode = " . self::MODE_UPLOAD . " A
    */
   public function isFolderAccessible($folderId, $userId = null)
   {
-    $allUserFolders = array();
     if ($userId == null) {
       $userId = Auth::getUserId();
     }
     $rootFolder = $this->getRootFolder($userId)->getId();
-    GetFolderArray($rootFolder, $allUserFolders);
-    if (in_array($folderId, array_keys($allUserFolders))) {
-      return true;
-    }
-    return false;
+    return $this->isInFolderTree($rootFolder, $folderId);
   }
 
   /**


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
Browsing folders using the folder query parameter is slow on systems with a large number of folders.
The delay is caused by `FolderDao::isFolderAccessible()` recursively traversing the entire folder tree in `GetFolderArray()`, which resulted in a large number of database queries per request.

### Changes
Refactored `isFolderAccessible()` to use the existing CTE-based folder tree lookup via `isInFolderTree()`.

CC: @shaheemazmalmmd @Kaushl2208 
