### PR TITLE
fix(db): add primary key constraints for obligation_map tables

### DIFF
--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -2578,6 +2578,8 @@
   $Schema["CONSTRAINT"]["copyright_decision_pkey"] = "ALTER TABLE \"copyright_decision\" ADD CONSTRAINT \"copyright_decision_pkey\" PRIMARY KEY (\"copyright_decision_pk\");";
   $Schema["CONSTRAINT"]["copyright_decision_pfile_fk_fkey"] = "ALTER TABLE \"copyright_decision\" ADD CONSTRAINT \"copyright_decision_pfile_fk_fkey\" FOREIGN KEY (\"pfile_fk\") REFERENCES \"pfile\" (\"pfile_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["copyright_decision_pfile_hash_ukey"] = "ALTER TABLE \"copyright_decision\" ADD CONSTRAINT \"copyright_decision_pfile_hash_ukey\" UNIQUE (\"pfile_fk\",\"hash\");";
+  $Schema["CONSTRAINT"]["obligation_map_pkey"] = "ALTER TABLE \"obligation_map\" ADD CONSTRAINT \"obligation_map_pkey\" PRIMARY KEY (\"om_pk\");";
+  $Schema["CONSTRAINT"]["obligation_candidate_map_pkey"] = "ALTER TABLE \"obligation_candidate_map\" ADD CONSTRAINT \"obligation_candidate_map_pkey\" PRIMARY KEY (\"om_pk\");";
   $Schema["CONSTRAINT"]["copyright_spasht_pkey"] = "ALTER TABLE \"copyright_spasht\" ADD CONSTRAINT \"copyright_spasht_pkey\" PRIMARY KEY (\"copyright_spasht_pk\");";
   $Schema["CONSTRAINT"]["copyright_spasht_pfile_fk_fkey"] = "ALTER TABLE \"copyright_spasht\" ADD CONSTRAINT \"copyright_spasht_pfile_fk_fkey\" FOREIGN KEY (\"pfile_fk\") REFERENCES \"pfile\" (\"pfile_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";
   $Schema["CONSTRAINT"]["copyright_spasht_agent_fk_fkey"] = "ALTER TABLE \"copyright_spasht\" ADD CONSTRAINT \"copyright_spasht_agent_fk_fkey\" FOREIGN KEY (\"agent_fk\") REFERENCES \"agent\" (\"agent_pk\") ON UPDATE NO ACTION ON DELETE CASCADE;";


### PR DESCRIPTION
Add explicit primary-key constraints for the obligation mapping tables to enforce data integrity and make the intent explicit in the schema file > Enforces uniqueness and NOT NULL on om_p

Inserted two ALTER TABLE PRIMARY KEY entries into the $Schema["CONSTRAINT"] block in `core-schema.dat`

**Why?** 
See: https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-PRIMARY-KEYS

*"Adding a primary key will automatically create a unique B-tree index on the column or group of columns listed in the primary key, and will force the column(s) to be marked NOT NULL."*

So i would propose it is best practise as well to have it for those and to be consistent to PSQL default behaviour.

```
\d+ obligation_candidate_map;
 -> om_pk is a primary key and should therefore automatically receive an index.
 => ALTER TABLE public.obligation_candidate_map ADD CONSTRAINT obligation_candidate_map_pkey PRIMARY KEY (om_pk);

\d+ obligation_map;

-> om_pk is a primary key and should therefore automatically receive an index.
=> ALTER TABLE public.obligation_map ADD CONSTRAINT obligation_map_pkey PRIMARY KEY (om_pk);
```

This was noticed during database reindexing; there are a few tables that don't have an index. Creating an index isn't practical for all of them. But these two from my point of view.

The $Schema["CONSTRAINT"] block is not strictly alphabetically ordered. If you want a different position (or reorder the complete block), please let me know.