### PR TITLE
feat(db): composite index on upload_package

### DIFF
--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -2831,6 +2831,8 @@
 
   $Schema["INDEX"]["upload_events"]["upload_events_upload_fk_event_ts_event_type_idx"] = "CREATE INDEX upload_events_upload_fk_event_ts_event_type_idx ON upload_events USING btree (upload_fk, event_ts DESC, event_type);";
 
+  $Schema["INDEX"]["upload_packages"]["upload_packages_package_fk_upload_fk_idx"] = "CREATE INDEX upload_packages_package_fk_upload_fk_idx ON upload_packages USING btree (package_fk, upload_fk);";
+
   $Schema["INDEX"]["copyright_event"]["copyright_event_upload_fk_index"] = "CREATE INDEX copyright_event_upload_fk_index ON copyright_event USING btree (upload_fk);";
   $Schema["INDEX"]["copyright_event"]["copyright_event_uploadtree_fk_index"] = "CREATE INDEX copyright_event_uploadtree_fk_index ON copyright_event USING btree (uploadtree_fk);";
   $Schema["INDEX"]["copyright_event"]["copyright_event_copyright_fk_index"] = "CREATE INDEX copyright_event_copyright_fk_index ON copyright_event USING btree (copyright_fk);";


### PR DESCRIPTION
Add a CREATE INDEX entry to `core-schema.dat` to create a non‑unique B‑Tree index on (package_fk, upload_fk) for upload_packages. 

**Purpose**
Improves join/filter performance for queries that look up packages by package then upload.

Simple queries benefit also directly, looking at the maximum costs PSQL expects, see live tests below. If the table has only a few entries it will still use a Sequential Scan (in case it'll be cheaper). As the `upload_packages` table is usually small, maintaining the index produces no overhead.

See also: https://www.postgresql.org/docs/13/planner-optimizer.html

_"...The possible plans are determined by the available indexes on each relation. There is always the possibility of performing a sequential scan..."_
 
 
**Verification / Examples**

Currently:

```
EXPLAIN SELECT * FROM public.upload_packages WHERE package_fk = 13 AND upload_fk = 3769;
                          QUERY PLAN
---------------------------------------------------------------
 Seq Scan on upload_packages  (cost=0.00..6.91 rows=1 width=8)
   Filter: ((package_fk = 13) AND (upload_fk = 3769))
(2 rows)

EXPLAIN SELECT * FROM public.upload_packages WHERE package_fk = 13;
                           QUERY PLAN
----------------------------------------------------------------
 Seq Scan on upload_packages  (cost=0.00..6.09 rows=44 width=8)
   Filter: (package_fk = 13)
(2 rows)
```

WITH index (the queries are improved by over 50% here, with "simple" selects):
```

EXPLAIN SELECT * FROM public.upload_packages WHERE package_fk = 13 AND upload_fk = 3769;
                                                     QUERY PLAN
---------------------------------------------------------------------------------------------------------------------
 Index Only Scan using upload_packages_package_fk_upload_fk_idx on upload_packages  (cost=0.15..2.17 rows=1 width=8)
   Index Cond: ((package_fk = 13) AND (upload_fk = 3769))
(2 rows)

EXPLAIN SELECT * FROM public.upload_packages WHERE package_fk = 13;
                                                      QUERY PLAN
----------------------------------------------------------------------------------------------------------------------
 Index Only Scan using upload_packages_package_fk_upload_fk_idx on upload_packages  (cost=0.15..2.87 rows=44 width=8)
   Index Cond: (package_fk = 13)
(2 rows)
```