### PR TITLE
fix(cyclonedx): use HTTPS schema URL for BOM 1.4

### DIFF
--- a/src/cyclonedx/agent/reportgenerator.php
+++ b/src/cyclonedx/agent/reportgenerator.php
@@ -59,7 +59,7 @@ class BomReportGenerator
   {
     return [
       'bomFormat' => 'CycloneDX',
-      '$schema' => 'http://cyclonedx.org/schema/bom-1.4.schema.json',
+      '$schema' => 'https://cyclonedx.org/schema/bom-1.4.schema.json',
       'specVersion' => '1.4',
       'version' => 1.0,
       'serialNumber' => 'urn:uuid:'. uuid_create(UUID_TYPE_TIME),


### PR DESCRIPTION
Updates the CycloneDX $schema URL from HTTP to HTTPS to align with the official schema endpoint. This is a non-breaking change affecting only the exported BOM metadata.

Closes #3352