### PR TITLE
refactor(cli): implement version parameter support in mkpod and remove legacy SVN logic

### DIFF
--- a/src/cli/mkpod
+++ b/src/cli/mkpod
@@ -6,20 +6,20 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 # simple script to generate man pages from pod sources
-# TODO: process version parameter.... need to be able to pass one in.
 #
 usage='mkpod <input-file>, input file should be a pod file.'
 
 infile=$1
 version=$2
+
 if [[ -z $infile ]]
 then
 	echo $usage
+	exit 1
 fi
 
 if [[ -z $version ]]
 then
-	echo "Setting version to 0.dev"
 	version='0.dev'
 fi
 

--- a/utils/mkpod
+++ b/utils/mkpod
@@ -7,40 +7,24 @@
 # 
 #
 # simple script to generate man pages from pod sources
-# TODO: process version parameter.... need to be able to pass one in.
 #
 usage='mkpod <input-file>, input file should be a pod file.'
 
 infile=$1
+version=$2
 if [[ -z $infile ]]
 then
 	echo $usage
+	exit 1
 fi
 
-# Check if SVN is available.  If not, then abort.
-which svn >/dev/null 2>&1
-if [ $? != 0 ] ; then
-  echo "No SubVersion available."
-  exit 1
+if [[ -z $version ]]
+then
+	version='0.dev'
 fi
-which svnversion >/dev/null 2>&1
-if [ $? != 0 ] ; then
-  echo "No svnversion available."
-  exit 1
-fi
-
 name=${infile%.pod}
 # Man format (*roff)
-#version is the svn version use svn info to get it, can only specify
-# release in the pod2man translator.
-version="`svn info | grep '^Revision:' | awk '{print $2}'`"
-#echo "\$version is:$version"
-if [ "$version" == "" ]
-then
-	echo "Setting version to 1.x(unknown)"
-	version='1.x(unknown)'
-fi
-pod2man --center="$name" --release="Version: $version" "$infile" > "$name.1"
+pod2man --center="$name" --release="Version $version" "$infile" > "$name.1"
 
 # HTML
 pod2html --infile=$infile --outfile=$name.html


### PR DESCRIPTION
## Summary

This PR resolves the following TODO present in both:

- `utils/mkpod`
- `src/cli/mkpod`

```bash
# TODO: process version parameter.... need to be able to pass one in.
```

Previously, the scripts did not properly support passing a version parameter explicitly and, in the case of `utils/mkpod`, relied on legacy SVN-based version extraction.

---

## 1. Process Version Parameter

Both scripts now accept an optional second argument:

```bash
mkpod <input-file> <version>
```

If no version is provided, the scripts default to:

```bash
Version 0. dev
```

This directly addresses the TODO comment about allowing a version parameter to be passed.

---

## 2. Remove Legacy SVN Dependency (`utils/mkpod`)

The following obsolete logic was removed:

- `which svn`
- `which svnversion`
- `svn info` based revision extraction
- Fallback to `1.x(unknown)`

Since the project is Git-based and version can now be supplied explicitly, SVN-based extraction is no longer required.

This improves portability and removes unnecessary external dependency.

---

## 3. Standardize Behavior Across Both Scripts

Both:

- `utils/mkpod`
- `src/cli/mkpod`

now:

- Accept version parameter  
- Default to `0.dev`  
- Exit with status `1` if input file is missing  
- Use consistent `--release="Version $version"` formatting  

Updating both ensures consistent CLI behavior and prevents divergence between duplicate tooling.

---

## Local Testing Performed

The scripts were tested locally using a sample `.pod` file.

### Without version parameter

```bash
./utils/mkpod test.pod
grep TH test.1
```

Output:

```bash
.TH TEST 1 <date> "Version 0.dev" test
```

### With version parameter

```bash
./utils/mkpod test.pod 5.7.1
grep TH test.1
```

Output:

```bash
.TH TEST 1 <date> "Version 5.7.1" test
```

### Verified for `src/cli` version as well

Screenshots of terminal verification are attached.

<img width="1034" height="216" alt="image" src="https://github.com/user-attachments/assets/acf067e2-bec3-476f-9a7f-a53dc134b44c" />
