### PR TITLE
fix(clearing): preserve clearing decision when adding comment

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -457,29 +457,34 @@ INSERT INTO clearing_decision (
     $params = array($uploadTreeId, $licenseId, $groupId);
     $row = $this->dbManager->getSingleRow($statementGetOldata, $params, $statementName);
 
+    $changeTo = StringOperation::replaceUnicodeControlChar($changeTo, false);
+
     if (!$row) {  //The license was not added as user decision yet -> we promote it here
       $type = ClearingEventTypes::USER;
       $row['type_fk'] = $type;
       $row['comment'] = "";
       $row['reportinfo'] = "";
       $row['acknowledgement'] = "";
-    }
-
-    $changeTo = StringOperation::replaceUnicodeControlChar($changeTo, false);
-    if ($what == 'reportinfo') {
-      $reportInfo = $changeTo;
-      $comment = $row['comment'];
-      $acknowledgement = $row['acknowledgement'];
-    } elseif ($what == 'comment') {
-      $reportInfo = $row['reportinfo'];
-      $comment = $changeTo;
-      $acknowledgement = $row['acknowledgement'];
+      if ($what == 'reportinfo') {
+        $row['reportinfo'] = $changeTo;
+      } elseif ($what == 'comment') {
+        $row['comment'] = $changeTo;
+      } else {
+        $row['acknowledgement'] = $changeTo;
+      }
+      $this->insertClearingEvent($uploadTreeId, $userId, $groupId, $licenseId, false, $row['type_fk'], $row['reportinfo'], $row['comment'], $row['acknowledgement']);
     } else {
-      $reportInfo = $row['reportinfo'];
-      $comment = $row['comment'];
-      $acknowledgement = $changeTo;
+      $updateStatement = __METHOD__ . '.update';
+      $updateParams = array($changeTo, $row['clearing_event_pk']);
+      if ($what == 'reportinfo') {
+        $this->dbManager->prepare($updateStatement, "UPDATE clearing_event SET reportinfo = $1 WHERE clearing_event_pk = $2");
+      } elseif ($what == 'comment') {
+        $this->dbManager->prepare($updateStatement, "UPDATE clearing_event SET comment = $1 WHERE clearing_event_pk = $2");
+      } else {
+        $this->dbManager->prepare($updateStatement, "UPDATE clearing_event SET acknowledgement = $1 WHERE clearing_event_pk = $2");
+      }
+      $this->dbManager->execute($updateStatement, $updateParams);
     }
-    $this->insertClearingEvent($uploadTreeId, $userId, $groupId, $licenseId, false, $row['type_fk'], $reportInfo, $comment, $acknowledgement);
 
     $this->dbManager->commit();
 

--- a/src/www/ui/ajax-clearing-view.php
+++ b/src/www/ui/ajax-clearing-view.php
@@ -239,6 +239,13 @@ class AjaxClearingView extends FO_Plugin
         }
         return $this->createPlainResponse("success");
 
+      case "checkWipStatus":
+        $uploadTreeId = GetParm("uploadTreeId", PARM_INTEGER);
+        $uploadId = GetParm("upload", PARM_INTEGER);
+        $groupId = $this->restHelper->getGroupId();
+        $isWip = $this->clearingDao->isDecisionCheck($uploadTreeId, $groupId, DecisionTypes::WIP);
+        return new JsonResponse(array('isWip' => $isWip));
+
       case "showClearingHistory":
         return new JsonResponse($this->doClearingHistory($groupId, $uploadId, $uploadTreeId));
 

--- a/src/www/ui/scripts/change-license-common.js
+++ b/src/www/ui/scripts/change-license-common.js
@@ -413,7 +413,19 @@ function closeAckInputModal(){
 
 function doOnSuccess(textModal) {
   textModal.modal('hide');
-  $('#decTypeSet').addClass('border-danger');
+  $.ajax({
+    url: '?mod=conclude-license&do=checkWipStatus',
+    method: 'POST',
+    data: {
+      uploadTreeId: $('#lastItem').val(),
+      upload: $('#upload').val()
+    },
+    success: function(response) {
+      if(response.isWip) {
+        $('#decTypeSet').addClass('border-danger');
+      }
+    }
+  });
   oTable = $('#licenseDecisionsTable').dataTable(selectedLicensesTableConfig).makeEditable(editableConfiguration);
   oTable.fnDraw(false);
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Adding or editing comments, acknowledgements, or license text on an already confirmed clearing decision was incorrectly resetting the decision status from **confirmed (green)** to **WIP (red)**.

This happened because [updateClearingEvent()](https://github.com/fossology/fossology/blob/2b78463c0fe30f0f9e6020d9a441afc9d0fc6548/src/lib/php/Dao/ClearingDao.php#L451) created a **new clearing event** even when an event for the same decision already existed. Creating a new event triggered [markDecisionAsWip()](https://github.com/fossology/fossology/blob/2b78463c0fe30f0f9e6020d9a441afc9d0fc6548/src/lib/php/Dao/ClearingDao.php#L603), which invalidated the previously confirmed clearing decision. As a result, users were forced to resubmit the decision and an unnecessary extra entry was added to the clearing history.

The fix updates the existing clearing event in place when only metadata is modified, so the clearing decision remains confirmed and no redundant history entries are created.

Closes: #2059 

## Changes

- Modify  [updateClearingEvent()](https://github.com/fossology/fossology/blob/2b78463c0fe30f0f9e6020d9a441afc9d0fc6548/src/lib/php/Dao/ClearingDao.php#L451) to **update existing clearing events** instead of inserting new ones for metadata-only changes.
- This removes creation of duplicate clearing history entries caused by metadata updates.

## Screenshots
### Before  

https://github.com/user-attachments/assets/9c7cf310-df1d-4aef-a13d-1aa5bc180f8b

<img width="1423" height="466" alt="image" src="https://github.com/user-attachments/assets/e262d259-a00e-4aa3-a0dc-fc46e9de53e3" />

<img width="828" height="331" alt="image" src="https://github.com/user-attachments/assets/8b58950f-95b7-4bef-9d60-c456984dea61" />

### After


https://github.com/user-attachments/assets/a64beeb6-0e49-4062-950d-de60e4670991

<img width="1399" height="410" alt="image" src="https://github.com/user-attachments/assets/a72ab807-3db5-4d42-bbfd-781728e2ec09" />

<img width="803" height="273" alt="image" src="https://github.com/user-attachments/assets/4bd3ae97-a466-47e4-a805-5e4a3e06cf43" />

@shaheemazmalmmd @Kaushl2208 
