### PR TITLE
fix(api): Remove debug echo and fix wrong parameter in CopyrightController

### DIFF
--- a/src/www/ui/api/Controllers/CopyrightController.php
+++ b/src/www/ui/api/Controllers/CopyrightController.php
@@ -934,12 +934,10 @@ class CopyrightController extends RestController
     $userId = $this->restHelper->getUserId();
     $cpTable = $this->copyrightHist->getTableName($dataType);
 
-    echo $uploadTreeId;
-
     $this->uploadAccessible($uploadPk);
     $this->isItemExists($uploadPk, $uploadTreeId);
 
-    $uploadTreeTableName = $uploadDao->getUploadTreeTableName($uploadTreeId);
+    $uploadTreeTableName = $uploadDao->getUploadTreeTableName($uploadPk);
     if (self::TYPE_COPYRIGHT_USERFINDINGS == $cxType) {
       $tableName = $cpTable."_decision";
       $decisions = $this->copyrightDao->getDecisionsFromHash($tableName, $copyrightHash,
@@ -977,7 +975,7 @@ class CopyrightController extends RestController
     $this->uploadAccessible($uploadPk);
     $this->isItemExists($uploadPk, $uploadTreeId);
 
-    $uploadTreeTableName = $this->restHelper->getUploadDao()->getuploadTreeTableName($uploadTreeId);
+    $uploadTreeTableName = $this->restHelper->getUploadDao()->getuploadTreeTableName($uploadPk);
     if (self::TYPE_COPYRIGHT_USERFINDINGS == $cxType) {
       $tableName = $cpTable."_decision";
       $decisions = $this->copyrightDao->getDecisionsFromHash($tableName, $copyrightHash,
@@ -1018,7 +1016,7 @@ class CopyrightController extends RestController
     $this->uploadAccessible($uploadPk);
     $this->isItemExists($uploadPk, $uploadTreeId);
 
-    $uploadTreeTableName = $this->restHelper->getUploadDao()->getuploadTreeTableName($uploadTreeId);
+    $uploadTreeTableName = $this->restHelper->getUploadDao()->getuploadTreeTableName($uploadPk);
     if (self::TYPE_COPYRIGHT_USERFINDINGS == $cxType) {
       $tableName = $cpTable."_decision";
       $decisions = $this->copyrightDao->getDecisionsFromHash($tableName, $copyrightHash,


### PR DESCRIPTION
## Summary

Fixes two bugs in `CopyrightController.php` that affect all copyright-related DELETE, RESTORE, and UPDATE REST API endpoints.

Closes #3358

---

## Bug 1 — Debug `echo` left in production (`deleteFileCX`, line 937)

A leftover debug statement `echo $uploadTreeId;` was writing the raw upload tree ID directly into the HTTP response body **before** the JSON response, corrupting it for all copyright DELETE endpoints.

**Before (broken response):**
```
12345{"code":200,"message":"Successfully removed copyright.","type":"INFO"}
```

**After (correct response):**
```json
{"code":200,"message":"Successfully removed copyright.","type":"INFO"}
```

**Fix:** Removed the `echo $uploadTreeId;` line.

---

## Bug 2 — Wrong parameter passed to `getUploadTreeTableName()` (lines 942, 980, 1021)

Three methods (`deleteFileCX`, `restoreFileCx`, `updateFileCx`) were calling `getUploadTreeTableName()` with `$uploadTreeId` (item ID) instead of `$uploadPk` (upload ID). This function requires the **upload primary key** to determine the correct upload tree table.

The correct usage already exists in the same file in `getFileCX()` (line 876):
```php
// Correct — getFileCX (line 876)
$uploadTreeTableName = $this->restHelper->getUploadDao()->getuploadTreeTableName($uploadPk);

//  Was wrong in deleteFileCX / restoreFileCx / updateFileCx
$uploadTreeTableName = $uploadDao->getUploadTreeTableName($uploadTreeId); // wrong!
```

**Fix:** Changed `$uploadTreeId` → `$uploadPk` in all three affected methods.

---

## Files Changed

- `src/www/ui/api/Controllers/CopyrightController.php`
  - Removed debug `echo` (line 937)
  - Fixed `getUploadTreeTableName($uploadTreeId)` → `getUploadTreeTableName($uploadPk)` in `deleteFileCX()`
  - Fixed `getuploadTreeTableName($uploadTreeId)` → `getuploadTreeTableName($uploadPk)` in `restoreFileCx()`
  - Fixed `getuploadTreeTableName($uploadTreeId)` → `getuploadTreeTableName($uploadPk)` in `updateFileCx()`

---

## How to Test

1. Set up FOSSology with a scanned upload containing copyright entries
2. Call any copyright DELETE endpoint:
   ```
   DELETE /api/v1/uploads/{uploadId}/item/{itemId}/copyrights/{hash}
   ```
3. **Before fix:** Response body contains raw integer prepended to JSON (invalid JSON)
4. **After fix:** Response is clean, valid JSON

