### PR TITLE
fix(api): fix null dereference and error concat in scheduleBulkScan

### DIFF
--- a/src/www/ui/api/Controllers/UploadTreeController.php
+++ b/src/www/ui/api/Controllers/UploadTreeController.php
@@ -785,14 +785,16 @@ class UploadTreeController extends RestController
           if ($existingLicense == null) {
             $isValid = false;
             $errors[] = "License with short name " . $license['licenseShortName'] . " does not exist";
-          } else if ($license['licenseAction'] != null && !in_array($license['licenseAction'], ["ADD", "REMOVE"])) {
-            $isValid = false;
-            $errors[] = "License action should be either ADD or REMOVE";
+          } else {
+            $licenseAction = $license['licenseAction'] ?? null;
+            if ($licenseAction !== null && !in_array($licenseAction, ["ADD", "REMOVE"])) {
+              $isValid = false;
+              $errors[] = "License action should be either ADD or REMOVE";
+            }
+            $license['licenseId'] = $existingLicense->getId();
+            $license['reportinfo'] = $license['licenseText'] ?? '';
+            $license['action'] = $licenseAction === 'REMOVE' ? 'Remove' : 'Add';
           }
-
-          $license['licenseId'] = $existingLicense->getId();
-          $license['reportinfo'] = $license['licenseText'];
-          $license['action'] = $license['licenseAction'] == 'REMOVE' ? 'Remove' : 'Add';
         }
       }
     }
@@ -800,7 +802,7 @@ class UploadTreeController extends RestController
     $errorMess = "";
     if (!$isValid) {
       foreach ($errors as $error) {
-        $errorMess = $error . "\n";
+        $errorMess .= $error . "\n";
       }
       throw new HttpBadRequestException($errorMess);
     }


### PR DESCRIPTION
## Summary

This PR fixes two issues in `UploadTreeController::scheduleBulkScan()` related to license validation and error handling.

Fixes #3369 

### Bug 1 — Null dereference (500 instead of validation error)

When an invalid `licenseShortName` is passed in `bulkActions`, `getLicenseByShortName()` returns `null`. The code previously called `->getId()` on that null value, causing a PHP Fatal Error and returning HTTP 500 instead of a proper validation response.

Fix:

* Moved `$license['licenseId']`, `$license['reportinfo']`, and `$license['action']` assignments inside the `else` block.
* Property access now occurs only when the license is non-null, preventing null dereference.

### Bug 2 — Silent error overwrite (only last error returned)

During error accumulation, `=` was used instead of `.=`. As a result, each new error overwrote the previous one, and only the last invalid license was reported.

Fix:

* Changed `$errorMess = $error` to `$errorMess .= $error` so all validation errors are accumulated and returned.

## Changes

* `src/www/ui/api/Controllers/UploadTreeController.php`

  * Guard against null dereference by moving license property assignments inside `else`
  * Fix error accumulation by replacing `=` with `.=`

## Test Results 

**Before fix** 
<img width="1047" height="671" alt="image" src="https://github.com/user-attachments/assets/d435fc25-7b95-4401-9ab5-ece82e93dea2" />
<img width="1043" height="659" alt="image" src="https://github.com/user-attachments/assets/c55daeb1-2a58-4bac-bcfb-70b9ffd7b6ca" />

**After fix**
* Invalid license - returns 400 (no 500 crash)
<img width="1086" height="791" alt="image" src="https://github.com/user-attachments/assets/9292a65e-b5e2-4d9e-9fbe-e894205705bf" />
* Two invalid licenses - both errors reported
<img width="1088" height="767" alt="image" src="https://github.com/user-attachments/assets/daf9a8f4-b43c-4e39-923c-213767b938df" />
* Valid license - returns 201 (no regression)
<img width="1089" height="762" alt="image" src="https://github.com/user-attachments/assets/1a51ed5e-b210-4d87-86a3-42b9d838e4ca" />