### PR TITLE
feat(test): extend ci to test php 8.2 with phpunit 11.5 / fixed tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -120,6 +120,10 @@ jobs:
       matrix:
         config:
           - {
+            php: "8.2",
+            phpunit: "^11.5.55",
+          }
+          - {
             php: "8.1",
             phpunit: "^10.0.12",
           }
@@ -181,15 +185,24 @@ jobs:
           ./utils/prepare-test -afty
           composer install --working-dir=src
           mkdir coverage
+      - name: Determine PHPUnit config based on PHP version
+        run: |
+          if [ "${{ matrix.config.php }}" = "8.2" ]; then
+            echo "MIGRATED_CONFIG=src/phpunit.82.xml" >> $GITHUB_ENV
+            echo "Using src/phpunit.82.xml for PHP 8.2"
+          else
+            echo "MIGRATED_CONFIG=src/phpunit.xml" >> $GITHUB_ENV
+            echo "Using src/phpunit.xml for PHP ${{ matrix.config.php }}"
+          fi
       - name: PHPUnit test suit
         env:
           PGHOST: 127.0.0.1
           PGPORT: 5432
         run: |
-          phpunit -csrc/phpunit.xml --testsuite="Fossology PhpUnit Test Suite" --colors=always --coverage-clover ./coverage/unit-clover.xml
+          phpunit -c ${MIGRATED_CONFIG} --testsuite="Fossology PhpUnit Test Suite" --colors=always --coverage-clover ./coverage/unit-clover.xml
       - name: PHPUnit agent test suit
         env:
           PGHOST: 127.0.0.1
           PGPORT: 5432
         run: |
-          phpunit -csrc/phpunit.xml --testsuite="Fossology PhpUnit Agent Test Suite" --colors=always --coverage-clover ./coverage/agent-clover.xml
+          phpunit -c ${MIGRATED_CONFIG} --testsuite="Fossology PhpUnit Agent Test Suite" --colors=always --coverage-clover ./coverage/agent-clover.xml

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get update
           echo PATH="/usr/lib/ccache/:$PATH" >> $GITHUB_ENV
           echo COMPOSER_HOME="$HOME/.composer/" >> $GITHUB_ENV
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: Setup PHP 7.4
@@ -45,6 +45,13 @@ jobs:
           extensions: gettext, mbstring, json, xml, pgsql, curl, uuid, posix, sqlite3
       - name: Composer check on PHP 8.1
         run: composer validate --no-check-all --working-dir=src --strict
+      - name: Setup PHP 8.2
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: gettext, mbstring, json, xml, pgsql, curl, uuid, posix, sqlite3
+      - name: Composer check on PHP 8.2
+        run: composer validate --no-check-all --working-dir=src --strict
 
   code-analysis:
     runs-on: ubuntu-22.04
@@ -55,7 +62,7 @@ jobs:
           sudo apt-get install -y cppcheck
           echo PATH="/usr/lib/ccache/:$PATH" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: Static Code Analysis
@@ -69,7 +76,7 @@ jobs:
         with:
           php-version: '8.1'
           extensions: gettext, mbstring, gd, json, xml, zip, pgsql, curl, uuid, posix, sqlite3
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: PHP Codesniffer
@@ -88,7 +95,7 @@ jobs:
           php-version: '8.1'
           extensions: gettext, mbstring, gd, json, xml, zip, pgsql, curl, uuid, posix, sqlite3, dom
           tools: sebastian/phpcpd:6.0.3
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 50
       - name: Copy/Paste detector
@@ -101,7 +108,7 @@ jobs:
   openapi-lint:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup default rules
         run: |
           echo '{"extends": ["spectral:oas"]}' > .spectral.json
@@ -113,7 +120,7 @@ jobs:
   REUSE-Compliance-Check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v5
 
@@ -121,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/src/lib/php/Application/CustomTextImportTest.php
+++ b/src/lib/php/Application/CustomTextImportTest.php
@@ -320,7 +320,7 @@ class CustomTextImportTest extends \PHPUnit\Framework\TestCase
     $this->assertSame($expected, $result);
   }
 
-  public function parseBooleanProvider(): array
+  public static function parseBooleanProvider(): array
   {
     return [
       ['true',   true],

--- a/src/lib/php/Report/ClearedGetterCommon.php
+++ b/src/lib/php/Report/ClearedGetterCommon.php
@@ -116,19 +116,19 @@ abstract class ClearedGetterCommon
   {
     $uniqueArray = array();
     foreach ($findings as $item) {
-      $contentKey = $item['content'];
+      $contentKey = array_key_exists('content', $item) ? $item['content'] : '';
       if (!isset($uniqueArray[$contentKey])) {
         $uniqueArray[$contentKey] = array(
-          "licenseId" => $item["licenseId"],
-          "content" => $item["content"],
-          "text" => $item["text"],
+          "licenseId" => array_key_exists('licenseId', $item) ? $item['licenseId'] : '',
+          "content" => $contentKey,
+          "text" => array_key_exists('text', $item) ? $item['text'] : '',
           "files" => array(),
           "hash" => array(),
-          "comments" => $item["comments"]
+          "comments" => array_key_exists('comments', $item) ? $item['comments'] : ''
           );
       }
-      $uniqueArray[$contentKey]['files'] = array_merge($uniqueArray[$contentKey]['files'], $item['files']);
-      $uniqueArray[$contentKey]['hash'] = array_merge($uniqueArray[$contentKey]['hash'], $item['hash']);
+      $uniqueArray[$contentKey]['files'] = array_merge($uniqueArray[$contentKey]['files'], (array)($item['files'] ?? array()));
+      $uniqueArray[$contentKey]['hash'] = array_merge($uniqueArray[$contentKey]['hash'], (array)($item['hash'] ?? array()));
     }
     return array_values($uniqueArray);
   }
@@ -169,10 +169,10 @@ abstract class ClearedGetterCommon
 
       if ($agentCall == "license") {
         $this->groupBy = "text";
-        $groupBy = md5($statement[$this->groupBy].$statement["content"]);
+        $groupBy = md5($text . $content);
       } else {
         $this->groupBy = "content";
-        $groupBy = $statement[$this->groupBy];
+        $groupBy = $content;
       }
 
       if (empty($comments) && array_key_exists($groupBy, $statements)) {

--- a/src/monk/agent_tests/Functional/schedulerTest.php
+++ b/src/monk/agent_tests/Functional/schedulerTest.php
@@ -5,6 +5,8 @@
  SPDX-License-Identifier: GPL-2.0-only
 */
 
+namespace Fossology\Monk\Test;
+
 use Fossology\Lib\Dao\ClearingDao;
 use Fossology\Lib\Dao\HighlightDao;
 use Fossology\Lib\Dao\LicenseDao;
@@ -19,7 +21,7 @@ use Fossology\Lib\Test\TestInstaller;
 use Fossology\Lib\Test\TestPgDb;
 use Monolog\Logger;
 
-class MonkScheduledTest extends \PHPUnit\Framework\TestCase
+class SchedulerTest extends \PHPUnit\Framework\TestCase
 {
   /** @var TestPgDb */
   private $testDb;

--- a/src/nomos/agent_tests/testdata/NomosTestfiles/AGPL/JsonMapper.php
+++ b/src/nomos/agent_tests/testdata/NomosTestfiles/AGPL/JsonMapper.php
@@ -106,7 +106,7 @@ class JsonMapper
         continue;
       }
 
-      if ($type{0} != '\\') {
+      if ($type[0] != '\\') {
         //create a full qualified namespace
         if ($strNs != '') {
           $type = '\\' . $strNs . '\\' . $type;
@@ -130,7 +130,7 @@ class JsonMapper
       }
 
       if ($array !== null) {
-        if ($subtype{0} != '\\') {
+        if ($subtype[0] != '\\') {
           //create a full qualified namespace
           if ($strNs != '') {
             $subtype = $strNs . '\\' . $subtype;

--- a/src/ojo/agent_tests/Functional/schedulerTest.php
+++ b/src/ojo/agent_tests/Functional/schedulerTest.php
@@ -9,6 +9,9 @@
  * @file
  * @brief Functional test cases for ojo agent using scheduler
  */
+
+namespace Fossology\Ojo\Test;
+
 require_once "SchedulerTestRunnerCli.php";
 require_once "SchedulerTestRunnerScheduler.php";
 
@@ -23,10 +26,10 @@ use Fossology\Ojo\Test\SchedulerTestRunnerCli;
 use Fossology\Ojo\Test\SchedulerTestRunnerScheduler;
 
 /**
- * @class OjoScheduledTest
+ * @class SchedulerTest
  * @brief Functional test cases for ojo agent using scheduler
  */
-class OjoScheduledTest extends \PHPUnit\Framework\TestCase
+class SchedulerTest extends \PHPUnit\Framework\TestCase
 {
 
   /**
@@ -217,7 +220,7 @@ class OjoScheduledTest extends \PHPUnit\Framework\TestCase
    * @return number -1 if right is small, 1 is left is small or 0 if both are
    *         equal
    */
-  private function compareMatches($left, $right)
+  public static function compareMatches($left, $right)
   {
     $leftFile = basename($left["file"]);
     $rightFile = basename($right["file"]);
@@ -250,7 +253,7 @@ class OjoScheduledTest extends \PHPUnit\Framework\TestCase
    * @param array $right Right match
    * @return number strcmp of left filename and right filename
    */
-  private function compareMatchesFiles($left, $right)
+  public static function compareMatchesFiles($left, $right)
   {
     return strcmp($left["file"], $right["file"]);
   }
@@ -366,12 +369,12 @@ class OjoScheduledTest extends \PHPUnit\Framework\TestCase
     $jsonFromOutput = json_decode($output, true);
 
     // Sort the data to reduce differences
-    usort($jsonFromFile, array('OjoScheduledTest', 'compareMatchesFiles'));
-    usort($jsonFromOutput, array('OjoScheduledTest', 'compareMatchesFiles'));
+    usort($jsonFromFile, array(self::class, 'compareMatchesFiles'));
+    usort($jsonFromOutput, array(self::class, 'compareMatchesFiles'));
 
     // Find the difference
     $jsonDiff = array_udiff($jsonFromFile, $jsonFromOutput,
-      array('OjoScheduledTest', 'compareMatches'));
+      array(self::class, 'compareMatches'));
 
     $outputDiff = "JSON does not match regression test file.\n";
     $outputDiff .= "Following are the results not in regression test file.\n";

--- a/src/phpunit.82.xml
+++ b/src/phpunit.82.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- SPDX-FileCopyrightText: © Fossology contributors
+
+     SPDX-License-Identifier: GPL-2.0-only
+-->
+<phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  bootstrap="./phpunit-bootstrap.php"
+  colors="true" backupGlobals="true"
+  beStrictAboutTestsThatDoNotTestAnything="false"
+  failOnWarning="false" stopOnFailure="false"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+  cacheDirectory=".phpunit.cache">
+  <coverage>
+    <report>
+      <clover outputFile="../clover.xml"/>
+    </report>
+  </coverage>
+  <php>
+    <env name="SYSCONFDIR" value="src/lib/php/tests/sysconfigDirTest"/>
+  </php>
+  <logging/>
+  <testsuites>
+    <testsuite name="Fossology PhpUnit Test Suite">
+      <directory suffix="Test.php">lib/php</directory>
+      <file>www/ui_tests/startUpTest.php</file>
+      <directory suffix="Test.php">www/ui_tests/api</directory>
+      <file>cli/tests/test_fo_copyright_list.php</file>
+    </testsuite>
+    <testsuite name="Fossology PhpUnit Agent Test Suite">
+      <directory suffix="Test.php">copyright/agent_tests/Functional</directory>
+      <directory suffix="Test.php">decider/agent_tests</directory>
+      <directory suffix="Test.php">deciderjob/agent_tests/Functional</directory>
+      <directory suffix="Test.php">monk/agent_tests/Functional</directory>
+      <directory suffix="Test.php">ojo/agent_tests/Functional</directory>
+      <directory suffix="Test.php">reuser/agent_tests/Functional</directory>
+      <directory suffix="Test.php">spdx/agent_tests</directory>
+      <directory suffix="Test.php">clixml/agent_tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+  </source>
+</phpunit>


### PR DESCRIPTION
**1) Add PHP 8.2 to build-test matrix**

Add PHPUnit matrix entries for 8.2–8.4

Createa a new XML configuration `phpunit.82.xml` to make it PHP 8.2+ and phpunit 10+ compatible. As it is valid for newer versions as well, maybe a different naming?
 
 
**2) Fix tests for PHP 8.2**

Found during test runs, see https://github.com/fossology/fossology/actions/runs/22360035039/job/64710537659

- src/nomos/agent_tests/testdata/NomosTestfiles/AGPL/JsonMapper.php

Cannot parse /home/runner/work/fossology/fossology/src/nomos/agent_tests/testdata/NomosTestfiles/AGPL/JsonMapper.php: Syntax error, unexpected '{' on line 109

- src/nomos/agent_tests/testdata/NomosTestfiles/AGPL/JsonMapper.php

Message:  Cannot parse /home/runner/work/fossology/fossology/src/nomos/agent_tests/testdata/NomosTestfiles/AGPL/JsonMapper.php: Syntax error, unexpected '{' on line 109
Location: phar:///usr/local/bin/phpunit/nikic-php-parser/PhpParser/ParserAbstract.php:319

![test_run](https://github.com/user-attachments/assets/f1902495-7427-4ba7-905a-3b496a8ec357)

Issue for discussion: #3285