### PR TITLE
docs(cyclonedx): clarify specVersion baseline and schema behavior

### DIFF
--- a/src/cyclonedx/agent/cyclonedx.php
+++ b/src/cyclonedx/agent/cyclonedx.php
@@ -10,7 +10,7 @@
  * @file
  * @brief CycloneDX report generation
  *
- * Generates reports according to CycloneDX standards.
+ * Generates CycloneDX SBOM reports compliant with CycloneDX specification v1.4.
  */
 
 /**
@@ -35,8 +35,8 @@ include_once(__DIR__ . "/version.php");
 include_once(__DIR__ . "/reportgenerator.php");
 
 /**
- * @class cyclonedxAgent
- * @brief cyclonedxAgent agent generates SBOM in cyclonedx format
+ * @class CycloneDXAgent
+ * @brief Generates an SBOM in CycloneDX format
  */
 class CycloneDXAgent extends Agent
 {

--- a/src/cyclonedx/cyclonedx.conf
+++ b/src/cyclonedx/cyclonedx.conf
@@ -3,6 +3,13 @@
 ; SPDX-License-Identifier: FSFAP
 
 ; scheduler configure file for this agent
+;
+; CycloneDX SBOM generation details:
+; - Generates CycloneDX JSON reports compliant with specification v1.4.
+; - The JSON schema URL corresponds to the specVersion defined in the agent.
+; - Upgrading to a newer CycloneDX specification (e.g., 1.7) requires
+;   corresponding updates in the report generator implementation.
+;
 [default]
 
 ; name: The name of the agent from the agent table


### PR DESCRIPTION
This PR improves documentation clarity around the CycloneDX agent:

- Clarifies that current reports follow CycloneDX spec v1.4.
- Documents that the schema URL is derived from the specVersion used by the report generator.
- Adds notes about official CycloneDX schema and upgrade implications (e.g., 1.7).

No functional changes.