### PR TITLE
fix(scheduler): portable mailx version check for MTA support

### DIFF
--- a/src/scheduler/agent/database.c
+++ b/src/scheduler/agent/database.c
@@ -1036,12 +1036,17 @@ void database_job_priority(scheduler_t* scheduler, job_t* job, int priority)
  *
  * \return 1 if mta is supported, 0 if not
  */
+/**
+ * @brief Find s-nail version to check if mta is supported 
+ *
+ * \return 1 if mta is supported, 0 if not
+ */
 int check_mta_support()
 {
-  char cmd[] = "dpkg -s s-nail | grep -i 'Version' | awk '{print$2}' | cut -c -4";
-  char version_str[128];
+  char cmd[] = "mailx -V 2>&1 | grep -i 'v' | awk '{print$2}' | cut -c -4";
+  char version_str[128] = {0};
   char buf[128];
-  float version_float;
+  float version_float = 0.0;
   FILE *fp;
 
   fp = popen(cmd, "r");
@@ -1050,11 +1055,16 @@ int check_mta_support()
     WARNING("Unable to run the command '%s'.\n", cmd);
     return 0;
   }
-  while(fgets(buf, sizeof(buf), fp) != NULL)
+  if(fgets(buf, sizeof(buf), fp) != NULL)
   {
-    strcpy(version_str,buf);
+    strncpy(version_str, buf, sizeof(version_str) - 1);
   }
   pclose(fp);
+
+  if (version_str[0] == '\0') {
+    return 0;
+  }
+
   sscanf(version_str, "%f", &version_float);
 
   if(version_float - 14.8 > 0.0001)


### PR DESCRIPTION
Currently, the FOSSology scheduler uses a distribution-specific  command to check for MTA support in the mail client. This approach is brittle as it:
1. Fails on non-Debian distributions (CentOS, Fedora, etc.).
2. Fails in environments where  might be installed but not managed by  (e.g., custom Docker builds, manual installs).
3. Causes SMTP job completion notifications to fail silently on modern systems where  is the required successor to the deprecated .

This PR replaces the  check with a direct call to , which is a more portable way to identify  and its version.

## Changes
- Modified :
    - Replaced  with mailx: illegal option -- V
Usage: mailx [-dEiInv] [-s subject] [-c cc-addr] [-b bcc-addr] [-F] to-addr ...
       mailx [-dEHiInNv] [-F] -f [name]
       mailx [-dEHiInNv] [-F] [-u user]
       mailx [-d] -e [-f name]
       mailx -H.
    - Updated the parsing logic to extract the version number from the command output.
    - Added basic error handling for empty version strings.

Closes #3374.