### PR TITLE
fix(copyright): correct navigation for files with copyright/email/url

### DIFF
--- a/src/lib/php/Proxy/UploadTreeProxy.php
+++ b/src/lib/php/Proxy/UploadTreeProxy.php
@@ -337,8 +337,8 @@ ORDER BY cd.clearing_decision_pk DESC LIMIT 1";
         return " $conditionQueryHasLicense
             AND NOT EXISTS (SELECT 1 FROM ($decisionQuery) AS latest_decision WHERE latest_decision.decision_type IN (".DecisionTypes::IRRELEVANT.",".DecisionTypes::IDENTIFIED.",".DecisionTypes::DO_NOT_USE.",".DecisionTypes::NON_FUNCTIONAL."))";
       case "noCopyright":
-        return "EXISTS (SELECT copyright_pk FROM copyright cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null )".
-              " OR EXISTS (SELECT 1 FROM copyright_decision AS cd WHERE ut.pfile_fk = cd.pfile_fk)";
+        return "(EXISTS (SELECT copyright_pk FROM copyright cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null )".
+              " OR EXISTS (SELECT 1 FROM copyright_decision AS cd WHERE ut.pfile_fk = cd.pfile_fk))";
       case "noIpra":
         return "EXISTS (SELECT ipra_pk FROM ipra cp WHERE cp.pfile_fk=ut.pfile_fk and cp.hash is not null )".
               " OR EXISTS (SELECT 1 FROM ipra_decision AS cd WHERE ut.pfile_fk = cd.pfile_fk)";


### PR DESCRIPTION

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
Navigation for **"Go through all files with copyright/email/url"** was not moving to the next file because of an SQL operator precedence issue in `UploadTreeProxy.php`.

The generated query did not group the copyright conditions, so `AND` was evaluated before `OR`.   As a result, the current file still matched the first condition and was returned again.

### Changes
- Added parentheses in `getAgentFilter()` to fix SQL precedence
- Navigation now correctly moves to the next matching file

## Screenshots
### Before

https://github.com/user-attachments/assets/376912d7-d42f-42e2-8450-bfd7097b752f

### After

https://github.com/user-attachments/assets/dcf8268f-1433-4472-8951-ae4384c1d9f5
