### PR TITLE
fix(api): return 400 for negative folderId in POST /uploads

### DIFF
--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -484,7 +484,8 @@ class UploadController extends RestController
         "Require location object if uploadType != file");
     }
     if (empty($folderId) ||
-        !is_numeric($folderId) && $folderId > 0) {
+        !is_numeric($folderId) ||
+        intval($folderId) <= 0) {
       throw new HttpBadRequestException("folderId must be a positive integer!");
     }
 

--- a/src/www/ui_tests/api/Controllers/UploadControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadControllerTest.php
@@ -817,7 +817,48 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     $this->assertEquals($this->getResponseJson($expectedResponse),
       $this->getResponseJson($actualResponse));
   }
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test for UploadController::postUpload() with negative folderId (V2)
+   * -# Negative folderId is invalid input and should return 400
+   */
+  public function testPostUploadNegativeFolderIdV2()
+  {
+    $folderId = -1;
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
 
+    $body = $this->streamFactory->createStream(json_encode([
+      "location" => "vcsData",
+      "folderId" => $folderId,
+      "uploadDescription" => "Test Upload",
+      "ignoreScm" => "true",
+      "scanOptions" => "scanOptions",
+      "uploadType" => "vcs"
+    ]));
+
+    $request = new Request(
+      "POST",
+      new Uri("HTTP", "localhost"),
+      $requestHeaders,
+      [],
+      [],
+      $body
+    );
+
+    $request = $request->withAttribute(
+      ApiVersion::ATTRIBUTE_NAME,
+      ApiVersion::V2
+    );
+
+    M::mock('overload:Fossology\UI\Api\Helper\UploadHelper');
+
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->uploadController->postUpload($request, new ResponseHelper(), []);
+  }
   /**
    * @runInSeparateProcess
    * @preserveGlobalState disabled


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

`POST /api/v2/uploads` returned **HTTP `404` Not Found** when `folderId` was a **negative integer** (e.g., `-1`).  
A negative `folderId` is invalid input and should be rejected as a **validation error** with **HTTP `400` Bad Request**.

## Root cause

The validation condition in `UploadController::postUpload()` used:

```php
!is_numeric($folderId) && $folderId > 0

```

Due to operator precedence, negative numeric values (e.g., -1) were not rejected by validation and the request reached the folder existence check, which returned 404.

## Changes

- Fix folderId validation in UploadController::postUpload() to reject non-numeric values and any value <= 0.
- Add a regression test for API V2 negative folderId.

## Files changed

- `src/www/ui/api/Controllers/UploadController.php`
- `src/www/ui_tests/api/Controllers/UploadControllerTest.php`

## How to test

1. Run unit test:
    - `UploadControllerTest::testPostUploadNegativeFolderIdV2()` (PHPUnit)

2. Manual test (API V2):
     - Send a request with a negative folderId:
     
      ```bash
       curl -i -X POST "http://localhost:8081/repo/api/v2/uploads" \
           -H "Authorization: Bearer <token>" \
           -H "Content-Type: application/json" \
           -d '{"folderId":-1,"uploadType":"vcs","location":{"vcsType":"git","vcsUrl":"https://github.com/example/repo.git"}}'
      ```

Expected:

   - HTTP 400 Bad Request
   - Message: folderId must be a positive integer!

Fixes #3385