### PR TITLE
chore(vagrant): upgrade base box from focal to jammy

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,7 +63,7 @@ sudo systemctl daemon-reload
 SCRIPT
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "ubuntu/jammy64"
   config.vm.post_up_message = $post_up_message
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ".", "/fossology"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Ubuntu 20.04 (Focal) reached end of standard support in April 2025. This PR updates the Vagrant base box to Ubuntu 22.04 (Jammy) to match the local development environment with the CI runner (`ubuntu-22.04`) and the Dockerfile (`debian:bookworm-slim`).

### Changes

- Updated `config.vm.box` from `ubuntu/focal64` to `ubuntu/jammy64` in [Vagrantfile](cci:7://file:///home/atheus/fossology/Vagrantfile:0:0-0:0) (line 66)

## How to test

1. Verify [utils/fo-installdeps](cci:7://file:///home/atheus/fossology/utils/fo-installdeps:0:0-0:0) supports Ubuntu 22.04 it uses a `Debian,Ubuntu,Tuxedo` case match, so it is adaptable.
2. Verify the CI matrix runs on `ubuntu-22.04` all 9 workflow entries in [build-test.yml](cci:7://file:///home/atheus/fossology/.github/workflows/build-test.yml:0:0-0:0) and [static-checks.yml](cci:7://file:///home/atheus/fossology/.github/workflows/static-checks.yml:0:0-0:0) confirm this .
3. Optionally, run `vagrant up` with VirtualBox installed to confirm the provisioning script completes successfully on Jammy.

Fixes #3390 
