### PR TITLE
fix(ui): schedule agent button not working in view file information page

### DIFF
--- a/src/www/ui/ui-view-info.php
+++ b/src/www/ui/ui-view-info.php
@@ -355,6 +355,7 @@ class ui_view_info extends FO_Plugin
       $vars['packageAgentStatus'] = 1;
       $vars['trackback_uri'] = Traceback_uri() .
       "?mod=schedule_agent&upload=$Upload&agent=agent_pkgagent";
+      $vars['activeScript'] = ActiveHTTPscript("Schedule");
       return ($vars);
     }
     $sql = "SELECT mimetype_name
@@ -592,7 +593,7 @@ class ui_view_info extends FO_Plugin
     $this->vars['micromenu'] = Dir2Browse("browse", $itemId, null, $showBox = 0, "View-Meta");
 
     $this->vars += $this->ShowTagInfo($uploadId, $itemId);
-    $this->vars += $this->ShowPackageinfo($uploadId, $itemId, 1);
+    $this->vars += $this->ShowPackageInfo($uploadId, $itemId, 1);
     $this->vars += $this->ShowMetaView($uploadId, $itemId);
     $this->vars += $this->ShowSightings($uploadId, $itemId);
     $this->vars += $this->ShowView($uploadId, $itemId);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix the issue where the **Schedule Agent** button did not work in the **Browser → Info → View File Information** flow.  
The problem occurred because the template `ui-view-info.html.twig` expected an `activeScript` variable containing the JavaScript required for the `Schedule_Get` function, but this variable was not being provided by `ui-view-info.php`.

As a result, the **Schedule Agent** button could not trigger the AJAX request to schedule the agent.

This PR ensures the required JavaScript is correctly passed to the template and fixes a method name inconsistency [showPackageInfo()](https://github.com/fossology/fossology/blob/b868067cb3e4283de9cb7a354c1f167f1585415a/src/www/ui/ui-view-info.php#L285) method is being called as [showPackageinfo()](https://github.com/fossology/fossology/blob/b868067cb3e4283de9cb7a354c1f167f1585415a/src/www/ui/ui-view-info.php#L595) in **ui-view-info.php** even though php is case insensitive for function call the change properly follows the writing style.

---

## Changes

- Added the missing `activeScript` variable in the `ShowPackageInfo()` method:

  ```php
  $vars['activeScript'] = ActiveHTTPscript("Schedule");

- Change the inconsistent call to showPackageInfo().

## Screenshots
### Before

https://github.com/user-attachments/assets/404f799a-9256-4a21-89aa-011cd1ff0d82

### After

https://github.com/user-attachments/assets/50934f56-8d26-419a-82d8-850946c2f962




