### PR TITLE
fix(ui): detect application/vnd.debian.binary-package for Debian packages

### DIFF
--- a/src/pkgagent/agent/pkgagent.c
+++ b/src/pkgagent/agent/pkgagent.c
@@ -166,6 +166,7 @@ int ProcessUpload (long upload_pk)
   PGresult *result;
   int mimetypepk = 0;
   int debmimetypepk = 0;
+  int debmodernmimetypepk = 0;
   int debsrcmimetypepk = 0;
   int numrows;
   int i;
@@ -259,6 +260,45 @@ int ProcessUpload (long upload_pk)
       return (-1);
     }
   }
+  snprintf(sqlbuf, sizeof(sqlbuf), "SELECT mimetype_pk FROM mimetype WHERE mimetype_name = 'application/vnd.debian.binary-package' LIMIT 1;");
+  result = PQexec(db_conn, sqlbuf);
+  if (fo_checkPQresult(db_conn, result, sqlbuf, __FILE__, __LINE__))
+  {
+    free(pi);
+    free(dpi);
+    exit(-1);
+  }
+  debmodernmimetypepk = atoi(PQgetvalue(result, 0, 0));
+  PQclear(result);
+  if ( debmodernmimetypepk == 0 )
+  {
+    snprintf(sqlbuf, sizeof(sqlbuf), "INSERT INTO mimetype (mimetype_name) VALUES ('application/vnd.debian.binary-package');");
+    result = PQexec(db_conn, sqlbuf);
+    if (fo_checkPQcommand(db_conn, result, sqlbuf, __FILE__, __LINE__))
+    {
+      printf("ERROR: unable to insert modern debian mimetype %s\n", sqlbuf);
+      free(pi);
+      free(dpi);
+      exit(-1);
+    }
+    snprintf(sqlbuf, sizeof(sqlbuf), "SELECT mimetype_pk FROM mimetype WHERE mimetype_name = 'application/vnd.debian.binary-package' LIMIT 1;");
+    result = PQexec(db_conn, sqlbuf);
+    if (fo_checkPQresult(db_conn, result, sqlbuf, __FILE__, __LINE__))
+    {
+      free(pi);
+      free(dpi);
+      exit(-1);
+    }
+    debmodernmimetypepk = atoi(PQgetvalue(result, 0, 0));
+    PQclear(result);
+    if ( debmodernmimetypepk == 0 )
+    {
+      LOG_ERROR("pkgagent modern debian mimetype not installed!");
+      free(pi);
+      free(dpi);
+      return (-1);
+    }
+  }
   snprintf(sqlbuf, sizeof(sqlbuf), "SELECT mimetype_pk FROM mimetype WHERE mimetype_name = 'application/x-debian-source' LIMIT 1;");
   result = PQexec(db_conn, sqlbuf);
   if (fo_checkPQresult(db_conn, result, sqlbuf, __FILE__, __LINE__))
@@ -308,7 +348,7 @@ int ProcessUpload (long upload_pk)
   if (NULL == uploadtree_tablename) uploadtree_tablename = strdup("uploadtree_a");
   /*  retrieve the records to process */
   snprintf(sqlbuf, sizeof(sqlbuf),
-      "SELECT pfile_pk as pfile_pk, pfile_sha1 || '.' || pfile_md5 || '.' || pfile_size AS pfilename, mimetype_name as mimetype from pfile, mimetype, (SELECT distinct(pfile_fk) as PF from %s where upload_fk='%ld') as SS where PF=pfile_pk and (pfile_mimetypefk='%d' or pfile_mimetypefk='%d' OR pfile_mimetypefk='%d') and mimetype_pk=pfile_mimetypefk and (not exists (SELECT 1 from pkg_rpm where pkg_rpm.pfile_fk = pfile_pk)) and (not exists (SELECT 1 from pkg_deb where pkg_deb.pfile_fk = pfile_pk))", uploadtree_tablename, upload_pk, mimetypepk, debmimetypepk, debsrcmimetypepk);
+      "SELECT pfile_pk as pfile_pk, pfile_sha1 || '.' || pfile_md5 || '.' || pfile_size AS pfilename, mimetype_name as mimetype from pfile, mimetype, (SELECT distinct(pfile_fk) as PF from %s where upload_fk='%ld') as SS where PF=pfile_pk and (pfile_mimetypefk='%d' or pfile_mimetypefk='%d' OR pfile_mimetypefk='%d' OR pfile_mimetypefk='%d') and mimetype_pk=pfile_mimetypefk and (not exists (SELECT 1 from pkg_rpm where pkg_rpm.pfile_fk = pfile_pk)) and (not exists (SELECT 1 from pkg_deb where pkg_deb.pfile_fk = pfile_pk))", uploadtree_tablename, upload_pk, mimetypepk, debmimetypepk, debsrcmimetypepk, debmodernmimetypepk);
   result = PQexec(db_conn, sqlbuf);
   if (fo_checkPQresult(db_conn, result, sqlbuf, __FILE__, __LINE__))
   {
@@ -350,7 +390,8 @@ int ProcessUpload (long upload_pk)
         free(pi->requires[i]);
       free(pi->requires);
     }
-    else if (!strcasecmp(mimetype, "application/x-debian-package")){
+    else if (!strcasecmp(mimetype, "application/x-debian-package") ||
+             !strcasecmp(mimetype, "application/vnd.debian.binary-package")){
       dpi->pFileFk = atoi(PQgetvalue(result, i, 0));
       strncpy(dpi->pFile, PQgetvalue(result, i, 1), sizeof(dpi->pFile)-1);
       dpi->pFile[sizeof(dpi->pFile)-1] = '\0';

--- a/src/pkgagent/agent_tests/Unit/testGetMetadataDebBinary.c
+++ b/src/pkgagent/agent_tests/Unit/testGetMetadataDebBinary.c
@@ -70,6 +70,16 @@ long prepare_Database(PGconn *db_conn, struct debpkginfo *pi)
     return (-1);
   }
   PQclear(result);
+  memset(SQL,'\0',MAXSQL);
+  snprintf(SQL,MAXSQL,"INSERT INTO mimetype (mimetype_name) VALUES ('application/vnd.debian.binary-package');");
+  result =  PQexec(db_conn, SQL);
+  if (fo_checkPQcommand(db_conn, result, SQL, __FILE__ ,__LINE__))
+  {
+    printf("Perpare modern debian mimetype information ERROR!\n");
+    PQclear(result);
+    return (-1);
+  }
+  PQclear(result);
 
   /* insert pfile: fossology-web_1.4.1_all.deb */
   memset(SQL,'\0',MAXSQL);

--- a/src/www/ui/ui-view-info.php
+++ b/src/www/ui/ui-view-info.php
@@ -413,7 +413,8 @@ class ui_view_info extends FO_Plugin
         }
         $this->dbManager->freeResult($result);
       }
-    } elseif ($MIMETYPE == "application/x-debian-package") {
+    } elseif ($MIMETYPE == "application/x-debian-package" ||
+              $MIMETYPE == "application/vnd.debian.binary-package") {
       $vars['packageType'] = _("Debian Binary Package\n");
 
       $sql = "SELECT *


### PR DESCRIPTION

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add support for the modern Debian MIME type `application/vnd.debian.binary-package` in pkgagent.

Previously, pkgagent only recognized the legacy MIME type `application/x-debian-package`. As modern systems often detect `.deb` files as `application/vnd.debian.binary-package`, these files were ignored during scanning, resulting in **0 items scanned** and missing package metadata.

This change ensures `pkgagent` can detect and process `.deb` files identified with the modern MIME type while maintaining compatibility with the legacy one.

## Changes

- Added support for MIME type `application/vnd.debian.binary-package`.
- Ensured the MIME type exists in the `mimetype` table and retrieved its PK.
- Updated pkgagent query to include the modern Debian MIME type.
- Enabled pkgagent to process `.deb` files detected with either legacy or modern MIME types.

## Screenshots
### Before 

https://github.com/user-attachments/assets/fe9bbaab-9c35-47b1-bf5a-fd6e330af75a


### After

https://github.com/user-attachments/assets/2c76bf27-f7f9-4f42-90ae-9d0fe0262a63


## How to test
- Download a file which contains `application/vnd.debain.binary-package`.
```bash
wget http://deb.debian.org/debian/pool/main/s/sl/sl_5.02-1+b1_amd64.deb
```
- Upload and schedule for package analysis.
- Check Browser -> info for the file

CC: @shaheemazmalmmd 