### PR TITLE
Fix(fossdash): Strip filenames before safe clean up

### DIFF
--- a/install/fossdash/fossdash-publish.py.in
+++ b/install/fossdash/fossdash-publish.py.in
@@ -304,7 +304,7 @@ def cleanOldReportedFile(connection):
         for file_name in file_ptr:
             file_name = file_name.strip()
             if not file_name:
-               continue
+                continue
             print("cleaning old reported file : ", file_name)
             subprocess.run(["rm", "-rf", file_name])
             


### PR DESCRIPTION
## Description

The PR fixes the cleanup of files by removing trailing newline characters and uses safe subprocess execution instead of shell-based command invocation.

### Changes

- Fixes incorrect cleanup of old reported files caused by trailing newline characters
- Avoids shell injection risk during file deletion.

