### PR TITLE
fix(schema-export): remove  and add current path fix libschema pg_con…

### DIFF
--- a/src/cli/schema-export.php
+++ b/src/cli/schema-export.php
@@ -21,12 +21,17 @@
  * dummy options in order to catch invalid options.
  */
 
- /* TODO: Once $MODDIR logic is fixed replace $dir with $MODDIR and remove below code */
-$dir = getcwd();
-if ($dir === false) {
-  return "Unable to determine working directory";
+if (!empty($MODDIR)) {
+  $dir = $MODDIR;
+} else {
+  /* Fallback: derive base dir from cwd (for environments where fo_wrapper did not bootstrap) */
+  $dir = getcwd();
+  if ($dir === false) {
+    print "ERROR: Unable to determine working directory and \$MODDIR is not set.\n";
+    exit(1);
+  }
+  $dir = dirname($dir);
 }
-$dir = dirname($dir);
 
 require_once("$dir/lib/php/libschema.php");
 

--- a/src/cli/schema-export.php
+++ b/src/cli/schema-export.php
@@ -20,6 +20,16 @@
 /* Note: php 5 getopt() ignores options not specified in the function call, so add
  * dummy options in order to catch invalid options.
  */
+
+ /* TODO: Once $MODDIR logic is fixed replace $dir with $MODDIR and remove below code */
+$dir = getcwd();
+if ($dir === false) {
+  return "Unable to determine working directory";
+}
+$dir = dirname($dir);
+
+require_once("$dir/lib/php/libschema.php");
+
 $AllPossibleOpts = "abc:d:ef:ghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
 /* defaults */
@@ -29,7 +39,7 @@ $UpdateLiceneseRef = false;
 $showUsage = false;
 
 /* default location of core-schema.dat.  This file is checked into svn */
-$SchemaFilePath = "$MODDIR/www/ui/core-schema.dat";
+$SchemaFilePath = "$dir/www/ui/core-schema.dat";
 
 /* command-line options */
 $Options = getopt($AllPossibleOpts);

--- a/src/lib/php/libschema.php
+++ b/src/lib/php/libschema.php
@@ -80,20 +80,12 @@ class fo_libschema
     if ($driver !== null && $driver instanceof Driver && $driver->isConnected()) {
       return;
     }
-
     global $PG_CONN;
     if (!empty($PG_CONN)) {
       $pgDriver = new Postgres($PG_CONN);
       $this->dbman->setDriver($pgDriver);
       return;
     }
-
-    if (!empty($GLOBALS['PG_CONN'])) {
-      $pgDriver = new Postgres($GLOBALS['PG_CONN']);
-      $this->dbman->setDriver($pgDriver);
-      return;
-    }
-
     throw new \Exception(
       "No database connection available: \$PG_CONN is not set and no driver " .
       "was injected into \$dbManager before calling this function."
@@ -589,7 +581,10 @@ class fo_libschema
       $viewowner = pg_parameter_status($PG_CONN, 'session_authorization');
     }
     if (empty($viewowner)) {
-      $viewowner = 'fossology';
+      throw new \Exception(
+        "Unable to load schema views: could not determine the view owner. " .
+        "Ensure \$SysConf['DBCONF']['user'] is set or a valid \$PG_CONN is available."
+      );
     }
     $this->addViews($viewowner);
     $this->addSequences($referencedSequencesInTableColumns);

--- a/src/lib/php/libschema.php
+++ b/src/lib/php/libschema.php
@@ -69,6 +69,36 @@ class fo_libschema
     $this->dbman->setDriver($dbDriver);
   }
 
+  /**
+   * Ensure a driver is set on the DbManager before any query is executed.
+   * @throws \Exception if no connection is available
+   */
+  private function ensureDriver()
+  {
+    // If dbman already has a working driver, nothing to do
+    $driver = $this->dbman->getDriver();
+    if ($driver !== null && $driver instanceof Driver && $driver->isConnected()) {
+      return;
+    }
+
+    global $PG_CONN;
+    if (!empty($PG_CONN)) {
+      $pgDriver = new Postgres($PG_CONN);
+      $this->dbman->setDriver($pgDriver);
+      return;
+    }
+
+    if (!empty($GLOBALS['PG_CONN'])) {
+      $pgDriver = new Postgres($GLOBALS['PG_CONN']);
+      $this->dbman->setDriver($pgDriver);
+      return;
+    }
+
+    throw new \Exception(
+      "No database connection available: \$PG_CONN is not set and no driver " .
+      "was injected into \$dbManager before calling this function."
+    );
+  }
 
   /**
    * Apply or echo the SQL statement based on the debugging status.
@@ -77,6 +107,7 @@ class fo_libschema
    */
   function applyOrEchoOnce($sql, $stmt = '')
   {
+    $this->ensureDriver();
     if ($this->debug) {
       print ("$sql\n");
     } else {
@@ -98,46 +129,26 @@ class fo_libschema
     global $PG_CONN;
 
     // first check to make sure we don't already have the plpgsql language installed
-    $sql_statement = "select lanname from pg_language where lanname = 'plpgsql'";
-
-    $result = pg_query($PG_CONN, $sql_statement);
-    if (!$result) {
-      throw new Exception("Could not check the database for plpgsql language");
-    }
-
-    $plpgsql_already_installed = false;
-    if ( pg_fetch_row($result) ) {
-      $plpgsql_already_installed = true;
-    }
+    $result = $this->dbman->getSingleRow(
+      "SELECT lanname FROM pg_language WHERE lanname = 'plpgsql'",
+      array(),
+      __METHOD__ . '.checkPlpgsql'
+    );
 
     // then create language plpgsql if not already created
-    if ($plpgsql_already_installed == false) {
-      $sql_statement = "CREATE LANGUAGE plpgsql";
-      $result = pg_query($PG_CONN, $sql_statement);
-      if (!$result) {
-        throw new Exception("Could not create plpgsql language in the database");
-      }
+    if (empty($result)) {
+      $this->dbman->queryOnce("CREATE LANGUAGE plpgsql", __METHOD__ . '.createPlpgsql');
     }
 
-    $sql_statement = "select extname from pg_extension where extname = 'uuid-ossp'";
-
-    $result = pg_query($PG_CONN, $sql_statement);
-    if (!$result) {
-      throw new Exception("Could not check the database for uuid-ossp extension");
-    }
-
-    $uuid_already_installed = false;
-    if ( pg_fetch_row($result) ) {
-      $uuid_already_installed = true;
-    }
+    $result = $this->dbman->getSingleRow(
+      "SELECT extname FROM pg_extension WHERE extname = 'uuid-ossp'",
+      array(),
+      __METHOD__ . '.checkUuid'
+    );
 
     // then create extension uuid-ossp if not already created
-    if ( $uuid_already_installed == false ) {
-      $sql_statement = 'CREATE EXTENSION "uuid-ossp";';
-      $result = pg_query($PG_CONN, $sql_statement);
-      if (!$result) {
-        throw new Exception("Could not create uuid-ossp extension in the database");
-      }
+    if (empty($result)) {
+      $this->dbman->queryOnce('CREATE EXTENSION "uuid-ossp"', __METHOD__ . '.createUuid');
     }
 
     $this->debug = $debug;
@@ -295,6 +306,19 @@ class fo_libschema
       } elseif (!array_key_exists($table, $this->currSchema['TABLE'])) {
         $newTable = true;
       }
+      /* Drop any leftover _old columns from previous incomplete migrations. */
+      $this->applyOrEchoOnce(
+        "DO \$cleanup\$ DECLARE r RECORD; BEGIN
+           FOR r IN
+             SELECT column_name FROM information_schema.columns
+             WHERE table_name = '$table' AND column_name LIKE '%_old'
+           LOOP
+             EXECUTE 'ALTER TABLE \"$table\" DROP COLUMN IF EXISTS \"' || r.column_name || '\"';
+           END LOOP;
+         END \$cleanup\$;",
+        $stmt = __METHOD__ . ".$table.purge_old_cols"
+      );
+
       foreach ($columns as $column => $modification) {
         if (!$newTable && !array_key_exists($column, $this->currSchema['TABLE'][$table])) {
           $colNewTable = true;
@@ -554,11 +578,20 @@ class fo_libschema
    **/
   function getCurrSchema()
   {
-    global $SysConf;
+    $this->ensureDriver();
+    global $SysConf, $PG_CONN;
     $this->currSchema = array();
     $this->addInheritedRelations();
     $referencedSequencesInTableColumns = $this->addTables();
-    $this->addViews($viewowner = $SysConf['DBCONF']['user']);
+    if (!empty($SysConf['DBCONF']['user'])) {
+      $viewowner = $SysConf['DBCONF']['user'];
+    } elseif (!empty($PG_CONN)) {
+      $viewowner = pg_parameter_status($PG_CONN, 'session_authorization');
+    }
+    if (empty($viewowner)) {
+      $viewowner = 'fossology';
+    }
+    $this->addViews($viewowner);
     $this->addSequences($referencedSequencesInTableColumns);
     $this->addConstraints();
     $this->addIndexes();
@@ -953,7 +986,7 @@ class fo_libschema
   }
 
   /**
-   * \brief Export the schema of the connected ($PG_CONN) database to a
+   * \brief Export the schema of the connected database to a
    *        file in the format readable by GetSchema().
    *
    * @param string $filename Path to the file to store the schema in.
@@ -962,15 +995,6 @@ class fo_libschema
    **/
   function exportSchema($filename = NULL)
   {
-    global $PG_CONN;
-
-    /* set driver */
-    $dbDriver = $this->dbman->getDriver();
-    if (empty($dbDriver)) {
-      $pgDrive = new Postgres($PG_CONN);
-      $this->dbman->setDriver($pgDrive);
-    }
-
     if (empty($filename)) {
       $filename = 'php://stdout';
     }
@@ -1088,8 +1112,22 @@ if (empty($dbManager) || !($dbManager instanceof DbManager)) {
   $logger = new Logger(__FILE__);
   $logger->pushHandler(new ErrorLogHandler(ErrorLogHandler::OPERATING_SYSTEM, $logLevel));
   $dbManager = new ModernDbManager($logger);
-  $pgDriver = new Postgres($GLOBALS['PG_CONN']);
-  $dbManager->setDriver($pgDriver);
+}
+global $PG_CONN;
+if (empty($PG_CONN)) {
+  $sysconfdir = getenv('SYSCONFDIR');
+  if (empty($sysconfdir)) {
+    $sysconfdir = "/usr/local/etc/fossology";
+  }
+  $foConf = $sysconfdir . "/fossology.conf";
+  if (file_exists($foConf)) {
+    require_once(__DIR__ . "/common-db.php");
+    $PG_CONN = DBconnect($sysconfdir);
+    $GLOBALS['PG_CONN'] = $PG_CONN;
+    if (!isset($GLOBALS['SysConf']) && isset($SysConf)) {
+      $GLOBALS['SysConf'] = $SysConf;
+    }
+  }
 }
 /* simulate the old functions*/
 $libschema = new fo_libschema($dbManager);
@@ -1116,7 +1154,7 @@ function GetSchema()
 }
 
 /**
- * \brief Export the schema of the connected ($PG_CONN) database to a
+ * \brief Export the schema of the connected database to a
  *        file in the format readable by GetSchema().
  * @param string $filename path to the file to store the schema in.
  * @return false=success, on error return string with error message.


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Update the core-schema.dat to match the output of schema-export tool.

### Changes

1. `src/www/ui/core-schema.dat`: Update the schema with `src/cli/schema-export`
2. Fix issues in schema-export.php
3. Fix issues in libschema.php 

## How to test

1. Dump the output of following SQL
```sql
SELECT
  table_name AS table, ordinal_position AS ordinal, column_name,
  udt_name AS type, character_maximum_length AS modifier,
  CASE is_nullable WHEN 'YES' THEN false WHEN 'NO' THEN true END AS notnull,
  column_default AS default,
  col_description(table_name::regclass, ordinal_position) AS description
FROM information_schema.columns
WHERE table_schema = 'public'
ORDER BY ordinal_position;
```
4. Install the branch and run `fo-postinstall`.
5. Dump the output of the SQL again.
    1. If no schema change was done recently, the ordinal number of the columns should not change.