### PR TITLE
fix(pkAgent): dependency's of the packages where missed due to strtok

### DIFF
--- a/src/pkgagent/agent/pkgagent.c
+++ b/src/pkgagent/agent/pkgagent.c
@@ -818,13 +818,15 @@ int GetMetadataDebBinary (long upload_pk, struct debpkginfo *pi)
     }
     if (!strcasecmp(field, "Depends")) {
       char *depends = NULL;
-      char tempvalue[MAXCMD];
+      char countcopy[MAXCMD];
+      char splitcopy[MAXCMD];
       int size,i;
       size_t length = MAXLENGTH;
       size = 0;
       if (value[0] != '\0'){
-        strncpy(tempvalue, value, sizeof(tempvalue));
-        depends = strtok(value, ",");
+        strncpy(countcopy, value, sizeof(countcopy)-1);
+        countcopy[sizeof(countcopy)-1] = '\0';
+        depends = strtok(countcopy, ",");
         while (depends && (depends[0] != '\0')) {
           if (strlen(depends) >= length)
             length = strlen(depends) + 1;
@@ -833,12 +835,16 @@ int GetMetadataDebBinary (long upload_pk, struct debpkginfo *pi)
         }
         if (Verbose) { printf("SIZE:%d\n", size);}
 
+        strncpy(splitcopy, value, sizeof(splitcopy)-1);
+        splitcopy[sizeof(splitcopy)-1] = '\0';
         pi->depends = calloc(size, sizeof(char *));
-        pi->depends[0] = calloc(length, sizeof(char));
-        strcpy(pi->depends[0],strtok(tempvalue,","));
-        for (i=1;i<size;i++){
+        depends = strtok(splitcopy, ",");
+        for (i=0; i<size; i++){
           pi->depends[i] = calloc(length, sizeof(char));
-          strcpy(pi->depends[i],strtok(NULL, ","));
+          if (depends) {
+            strcpy(pi->depends[i], depends);
+            depends = strtok(NULL, ",");
+          }
         }
         pi->dep_size = size;
       }
@@ -978,13 +984,15 @@ int GetMetadataDebSource (char *repFile, struct debpkginfo *pi)
     }
     if (!strcasecmp(field, "Build-Depends")) {
       char *depends = NULL;
-      char tempvalue[MAXCMD];
+      char countcopy[MAXCMD];
+      char splitcopy[MAXCMD];
       int size,i;
       size = 0;
       size_t length = MAXLENGTH;
       if (value[0] != '\0'){
-        strncpy(tempvalue, value, sizeof(tempvalue));
-        depends = strtok(value, ",");
+        strncpy(countcopy, value, sizeof(countcopy)-1);
+        countcopy[sizeof(countcopy)-1] = '\0';
+        depends = strtok(countcopy, ",");
         while (depends && (depends[0] != '\0')) {
           if (strlen(depends) >= length)
             length = strlen(depends) + 1;
@@ -993,12 +1001,16 @@ int GetMetadataDebSource (char *repFile, struct debpkginfo *pi)
         }
         if (Verbose) { printf("SIZE:%d\n", size);}
 
+        strncpy(splitcopy, value, sizeof(splitcopy)-1);
+        splitcopy[sizeof(splitcopy)-1] = '\0';
         pi->depends = calloc(size, sizeof(char *));
-        pi->depends[0] = calloc(length, sizeof(char));
-        strcpy(pi->depends[0],strtok(tempvalue,","));
-        for (i=1;i<size;i++){
+        depends = strtok(splitcopy, ",");
+        for (i=0; i<size; i++){
           pi->depends[i] = calloc(length, sizeof(char));
-          strcpy(pi->depends[i],strtok(NULL, ","));
+          if (depends) {
+            strcpy(pi->depends[i], depends);
+            depends = strtok(NULL, ",");
+          }
         }
         pi->dep_size = size;
       }

--- a/src/www/ui/template/ui-view-info.html.twig
+++ b/src/www/ui/template/ui-view-info.html.twig
@@ -65,7 +65,7 @@
           <tr>
             <td align="right">{{ require.count|e }}</td>
             <td>{{ require.type|e }}</td>
-            <td><a href="{{ require.value|e }}" class="pkg-value" data-encoded="{{ require.value|e }}"></a></td>
+            <td>{{ require.value|e }}</td>
           </tr>
         {% endfor %}
       </table>

--- a/src/www/ui/ui-view-info.php
+++ b/src/www/ui/ui-view-info.php
@@ -407,7 +407,7 @@ class ui_view_info extends FO_Plugin
           $entry = [];
           $entry['count'] = $Count;
           $entry['type'] = _("Requires");
-          $entry['value'] = htmlspecialchars($R["$value"], ENT_QUOTES|ENT_HTML5, 'UTF-8');
+          $entry['value'] = htmlspecialchars($R["req_value"], ENT_QUOTES|ENT_HTML5, 'UTF-8');
           $Count++;
           $vars['packageRequires'][] = $entry;
         }
@@ -443,7 +443,7 @@ class ui_view_info extends FO_Plugin
           $entry = [];
           $entry['count'] = $Count;
           $entry['type'] = _("Depends");
-          $entry['value'] = htmlspecialchars($R["$value"], ENT_QUOTES|ENT_HTML5, 'UTF-8');
+          $entry['value'] = htmlspecialchars($R["req_value"], ENT_QUOTES|ENT_HTML5, 'UTF-8');
           $Count++;
           $vars['packageRequires'][] = $entry;
         }
@@ -479,7 +479,7 @@ class ui_view_info extends FO_Plugin
           $entry = [];
           $entry['count'] = $Count;
           $entry['type'] = _("Build-Depends");
-          $entry['value'] = htmlspecialchars($R["$value"], ENT_QUOTES|ENT_HTML5, 'UTF-8');
+          $entry['value'] = htmlspecialchars($R["req_value"], ENT_QUOTES|ENT_HTML5, 'UTF-8');
           $Count++;
           $vars['packageRequires'][] = $entry;
         }
@@ -491,7 +491,6 @@ class ui_view_info extends FO_Plugin
     }
     return $vars;
   } // ShowPackageInfo()
-
 
   /**
    * \brief Display the tag info data associated with the file.


### PR DESCRIPTION
## How to test

* Upload a .deb package to fossology
* Make sure to select mimetype and package analysis.
* Once the scans are finished go to info page.
* Under package Info you should be able to see all the information of the package along with dependencies.

**Before Fix**

<img width="1833" height="946" alt="image" src="https://github.com/user-attachments/assets/3e3465af-b131-4351-9e0d-561bd69381d7" />

**After FIx**

<img width="1377" height="915" alt="image" src="https://github.com/user-attachments/assets/55b7a274-0d88-480c-ae2c-89dc9954eb63" />
