### PR TITLE
fix(softwareHeritage): handle missing X-RateLimit-Reset and prevent negative sleep()

### DIFF
--- a/src/softwareHeritage/agent/softwareHeritageAgent.php
+++ b/src/softwareHeritage/agent/softwareHeritageAgent.php
@@ -129,8 +129,10 @@ class softwareHeritageAgent extends Agent
       print "INFO :Software Heritage X-RateLimit-Limit reached. Next slot unlocks in ".gmdate("H:i:s", $timeToReset)."\n";
       if ($timeToReset > $maxTime) {
         sleep($maxTime);
-      } else {
+      } elseif ($timeToReset > 0) {
         sleep($timeToReset);
+      } else {
+        sleep(min($maxTime, 60));
       }
       $this->processEachPfileForSWH($pfileDetail, $agentId, $maxTime);
     } else {
@@ -158,10 +160,19 @@ class softwareHeritageAgent extends Agent
       $cookedResult = array();
       if ($statusCode == SoftwareHeritageDao::SWH_STATUS_OK) {
         $responseContent = json_decode($response->getBody()->getContents(),true);
-        $cookedResult = $responseContent["facts"][0]["licenses"];
+        if (isset($responseContent["facts"]) && !empty($responseContent["facts"]) &&
+            isset($responseContent["facts"][0]["licenses"])) {
+          $cookedResult = $responseContent["facts"][0]["licenses"];
+        } else {
+          $cookedResult = array();
+        }
       } else if ($statusCode == SoftwareHeritageDao::SWH_RATELIMIT_EXCEED) {
         $responseContent = $response->getHeaders();
-        $cookedResult = $responseContent["X-RateLimit-Reset"][0];
+        if (isset($responseContent["X-RateLimit-Reset"][0])) {
+          $cookedResult = $responseContent["X-RateLimit-Reset"][0];
+        } else {
+          $cookedResult = time() + $this->configuration['maxtime'];
+        }
       } else if ($statusCode == SoftwareHeritageDao::SWH_NOT_FOUND) {
         $response = $this->guzzleClient->get($URIToGetContent);
         $responseContent = json_decode($response->getBody(),true);


### PR DESCRIPTION

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

While running the SoftwareHeritage analysis on an upload, the agent crashed with the following error:
``` 
PHP Fatal error: Uncaught ValueError: sleep(): Argument #1 ($seconds) must be greater than or equal to 0
```
The issue occurs in `processEachPfileForSWH()` where `$timeToReset` is calculated using the value returned from `getSoftwareHeritageLicense()`.

In `getSoftwareHeritageLicense()`, the code assumes that the `X-RateLimit-Reset` header is always present when the API returns a rate limit response:

```php
$cookedResult = $responseContent["X-RateLimit-Reset"][0];
```

However, if the header is missing, `$currentResult` becomes `NULL`. This leads to:
```php
$timeToReset = $currentResult - time();
```
which results in a negative value being passed to `sleep()`.
In PHP 8+, passing a negative value to sleep() throws a **ValueError**, causing the agent to terminate.

This change ensures the agent handles missing headers safely and prevents negative values from being passed to `sleep().`

### Screenshot
<img width="1912" height="205" alt="Screenshot 2026-03-06 160657" src="https://github.com/user-attachments/assets/985398d3-5a1a-433f-9763-461c4f132282" />

### Changes

- Added validation for the X-RateLimit-Reset header before accessing it.
- Added a safeguard to ensure $timeToReset is never negative before calling sleep().
- Prevents the SoftwareHeritage agent from crashing when the API response does not include the expected rate limit header.

CC: @shaheemazmalmmd 