### PR TITLE
fix(fossdash): skip empty cleanfile entries

### DIFF
--- a/install/fossdash/fossdash-publish.py.in
+++ b/install/fossdash/fossdash-publish.py.in
@@ -302,10 +302,13 @@ def cleanOldReportedFile(connection):
     # TODO: require BUG FIX
     with open(fossdash_cleanfile_path,"r") as file_ptr:
         for file_name in file_ptr:
+            file_name = file_name.strip()
+            if not file_name:
+                continue
+
             print("cleaning old reported file : ", file_name)
-            delete_cmd = "rm -rf "+file_name
-            delete_cmd_output = subprocess.Popen(delete_cmd,shell=True)
-              
+            subprocess.run(["rm", "-rf", file_name])
+            
 def updateNewInstanceNameInAllFiles(new_instance_name):
 
     print("updating all reported files with new instance UUID : ", new_instance_name)


### PR DESCRIPTION
## Description

The PR fixes the cleanup of files by removing trailing newline characters and uses safe subprocess execution instead of shell-based command invocation.

### Changes

- Fixes incorrect cleanup of old reported files caused by trailing newline characters
- Avoids shell injection risk during file deletion.
