### PR TITLE
fix(cyclonedx): revert  URL to http:// to fix schema validation

### DIFF
--- a/src/cyclonedx/agent/reportgenerator.php
+++ b/src/cyclonedx/agent/reportgenerator.php
@@ -59,7 +59,7 @@ class BomReportGenerator
   {
     return [
       'bomFormat' => 'CycloneDX',
-      '$schema' => 'https://cyclonedx.org/schema/bom-1.4.schema.json',
+      '$schema' => 'http://cyclonedx.org/schema/bom-1.4.schema.json',
       'specVersion' => '1.4',
       'version' => 1.0,
       'serialNumber' => 'urn:uuid:'. uuid_create(UUID_TYPE_TIME),


### PR DESCRIPTION
## Summary

Issue #3352  noted that the schema URL should correspond to the live endpoint. PR #3354  changed it from `http://` to `https://` for that reason. However, the CycloneDX 1.4 JSON schema defines an enum constraint that only allows:

`http://cyclonedx.org/schema/bom-1.4.schema.json` as the valid value for the `$schema` field.

Using `https://` causes the generated BOM to fail validation against its own declared schema, confirmed with cyclonedx-cli:

<img width="535" height="104" alt="image" src="https://github.com/user-attachments/assets/6c9cf8eb-ffa3-4ddd-8baf-0c21ecf791db" />
<img width="884" height="96" alt="image" src="https://github.com/user-attachments/assets/b38b782d-9df2-4375-98a0-e29071f5e012" />

The schema field is a schema identifier, not a fetchable URL. Its value must therefore match the enum defined by the CycloneDX specification.

## Fix

Revert schema to `http://cyclonedx.org/schema/bom-1.4.schema.json` to comply with the CycloneDX 1.4 schema enum.

## Tests

Validated with cyclonedx-cli using a BOM generated by FOSSology.
<img width="890" height="183" alt="image" src="https://github.com/user-attachments/assets/d11a864e-91e3-47bf-ab70-48382c767d89" />



## Ref

* Fixes regression introduced by #3354 
* Related issue: #3352 

cc @shaheemazmalmmd @JanAltenberg @its-sushant 