### PR TITLE
fix(ui): ensure testReplacement processes all selected copyright rows

### DIFF
--- a/src/copyright/ui/CopyrightView.php
+++ b/src/copyright/ui/CopyrightView.php
@@ -85,6 +85,12 @@ class CopyrightView extends Xpview
     $(document).ready(function() {
       tableCopyright =  createTablestatement();
       tableScancode =  createTablescancode_statement();
+      $('#testReplacementstatement').click(function() {
+        testReplacement(tableCopyright, 'statement');
+      });
+      $('#testReplacementscancode_statement').click(function() {
+        testReplacement(tableScancode, 'scancode_statement');
+      });
       $('#CopyrightViewTabs').tabs({
         active: ($.cookie(copyrightTabViewCookie) || 0),
         activate: function(e, ui){

--- a/src/copyright/ui/copyright-hist.php
+++ b/src/copyright/ui/copyright-hist.php
@@ -115,6 +115,9 @@ class CopyrightHistogram extends HistogramBase
       $('#testReplacementstatement').click(function() {
         testReplacement(tableCopyright, 'statement');
       });
+      $('#testReplacementscancode_statement').click(function() {
+        testReplacement(tableScancode, 'scancode_statement');
+      });
       $('#copyrightFindingsTabs').tabs({
         active: ($.cookie(copyrightTabCookie) || 0),
         activate: function(e, ui){

--- a/src/copyright/ui/template/copyrighthist_scripts.html.twig
+++ b/src/copyright/ui/template/copyrighthist_scripts.html.twig
@@ -57,18 +57,35 @@
     }
     var idPrefix = '#testVal' + type;
 
-    var firstRow = checkBoxes.first();
-    var testVal = table.api().row($(firstRow).parent().parent()[0]).data()[1];
-    testVal = $("<textarea/>").html(testVal).text();  // Decode HTML &lt; &gt;
     var regex = advanceSearchToRegex($('#advSearchText' + type).val());
-    var finalVal = toVal;
-    if (!/^\s*$/.test(regex)) {
-      finalVal = testVal.replace(new RegExp(regex, "gi"), toVal);
-    }
+    var fromValues = [];
+    var toValues = [];
 
-    $(idPrefix + 'From').text(testVal);
-    $(idPrefix + 'To').text(finalVal);
-    $(idPrefix).show();
+    checkBoxes.each(function() {
+      var testVal = table.api().row($(this).parent().parent()[0]).data()[1];
+      testVal = $("<textarea/>").html(testVal).text();  // Decode HTML &lt; &gt;
+      var finalVal = toVal;
+      if (!/^\s*$/.test(regex)) {
+        if (testVal.search(new RegExp(regex, "gi")) !== -1) {
+          finalVal = testVal.replace(new RegExp(regex, "gi"), toVal);
+          fromValues.push(testVal);
+          toValues.push(finalVal);
+        }
+      } else {
+        fromValues.push(testVal);
+        toValues.push(finalVal);
+      }
+    });
+
+    var testTable = $(idPrefix);
+    testTable.find('tr:not(:first)').remove();
+    
+    for (var i = 0; i < fromValues.length; i++) {
+      var newRow = '<tr><td>' + fromValues[i].replace(/</g, '&lt;').replace(/>/g, '&gt;') + '</td><td>' + toValues[i].replace(/</g, '&lt;').replace(/>/g, '&gt;') + '</td></tr>';
+      testTable.append(newRow);
+    }
+    
+    testTable.show();
   }
 
   function createReplacementText(type) {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

The `Test Replacement` feature was not displaying the expected results in **Scanner Findings → FOSSology Findings**, and the button was not functioning in **ScanCode Findings** within the **Copyright Browser**. Additionally, the **Test Replacement** feature was not working in the **View Copyright/URL/Email Analysis** page.  

The issue occurred because the replacement logic only processed the first selected row, did not properly filter matching entries, and required missing event handlers in some tabs. The functionality has been fixed so that test replacement now processes all selected rows, correctly filters matching entries, and works consistently across all relevant pages and tabs.

## Changes

- Updated `src/copyright/ui/template/copyrighthist_scripts.html.twig` to iterate through all selected rows, filter only matching entries, display results as table rows, and escape HTML for security.  
- Added missing ScanCode Test Replacement event handler in `src/copyright/ui/copyright-hist.php`.  
- Added Test Replacement event handlers for both FOSSology and ScanCode tabs in `src/copyright/ui/CopyrightView.php`.  

## Scrrenshots
### Before

https://github.com/user-attachments/assets/cd001be3-7e73-4e59-8510-28d513fb6cab

### After

https://github.com/user-attachments/assets/89944113-4e81-4ada-9acf-002dd0056593

CC: @shaheemazmalmmd @Kaushl2208 
