### PR TITLE
perf(uploadpage): optimize upload page and reuser query performance

### DIFF
--- a/src/lib/php/Dao/FolderDao.php
+++ b/src/lib/php/Dao/FolderDao.php
@@ -168,15 +168,74 @@ class FolderDao
 
     $userGroupMap = $this->userDao->getUserGroupMap(Auth::getUserId());
 
-    $results = array();
+    // Collect all rows first
+    $rows = array();
     while ($row = $this->dbManager->fetchArray($res)) {
-      $countUploads = $this->countFolderUploads(intval($row['folder_pk']), $userGroupMap);
+      $rows[] = $row;
+    }
+    $this->dbManager->freeResult($res);
+
+    $folderIds = [];
+    foreach ($rows as $r) {
+      $folderIds[] = intval($r['folder_pk']);
+    }
+    // Batch-fetch upload counts for ALL folders in one query
+    $allCounts = $this->countFolderUploadsBatch($folderIds, $userGroupMap);
+
+    $results = array();
+    foreach ($rows as $row) {
+      $folderId = intval($row['folder_pk']);
+      $countUploads = isset($allCounts[$folderId]) ? $allCounts[$folderId] : array();
 
       $results[] = array(
         self::FOLDER_KEY => new Folder(
-          intval($row['folder_pk']), $row['folder_name'], $row['folder_desc'], intval($row['folder_perm'])),
+          $folderId, $row['folder_name'], $row['folder_desc'], intval($row['folder_perm'])),
         self::DEPTH_KEY => $row['depth'],
         self::REUSE_KEY => $countUploads
+      );
+    }
+    return $results;
+  }
+
+  /**
+   * @param int[] $folderIds
+   * @param string[] $userGroupMap map groupId=>groupName
+   * @return array map folderPk => array(groupName => array('group_id'=>...,'count'=>...,'group_name'=>...))
+   */
+  public function countFolderUploadsBatch($folderIds, $userGroupMap)
+  {
+    if (empty($folderIds)) {
+      return array();
+    }
+
+    $trustGroupIds = array_keys($userGroupMap);
+    $trustedGroups = '{' . implode(',', $trustGroupIds) . '}';
+    $folderIdList = '{' . implode(',', array_map('intval', $folderIds)) . '}';
+
+    $statementName = __METHOD__;
+    $this->dbManager->prepare($statementName, "
+      SELECT fc.parent_fk AS folder_pk, uc.group_fk AS group_id, count(*) AS cnt
+      FROM foldercontents fc
+      INNER JOIN upload u ON u.upload_pk = fc.child_id
+      INNER JOIN upload_clearing uc ON u.upload_pk = uc.upload_fk AND uc.group_fk = ANY($1)
+      WHERE fc.parent_fk = ANY($2)
+        AND fc.foldercontents_mode = " . self::MODE_UPLOAD . "
+        AND (u.upload_mode = 100 OR u.upload_mode = 104)
+      GROUP BY fc.parent_fk, uc.group_fk
+    ");
+    $res = $this->dbManager->execute($statementName, array($trustedGroups, $folderIdList));
+
+    $results = array();
+    while ($row = $this->dbManager->fetchArray($res)) {
+      $folderId = intval($row['folder_pk']);
+      $groupName = $userGroupMap[$row['group_id']];
+      if (!isset($results[$folderId])) {
+        $results[$folderId] = array();
+      }
+      $results[$folderId][$groupName] = array(
+        'group_id' => $row['group_id'],
+        'count' => $row['cnt'],
+        'group_name' => $groupName
       );
     }
     $this->dbManager->freeResult($res);
@@ -253,6 +312,33 @@ WHERE fc.parent_fk = $1 AND fc.foldercontents_mode = " . self::MODE_UPLOAD . ";"
     foreach ($this->getFolderChildUploads($parentId, $trustGroupId) as $row) {
       $results[] = UploadProgress::createFromTable($row);
     }
+    return $results;
+  }
+
+  /**
+   * @brief Get all uploads accessible to a group in a single query
+   * @param int $trustGroupId
+   * @return UploadProgress[]
+   */
+  public function getAllUploadsForGroup($trustGroupId)
+  {
+    $statementName = __METHOD__;
+    $this->dbManager->prepare($statementName, "
+      SELECT u.upload_pk, u.upload_filename, u.upload_desc,
+        u.uploadtree_tablename, u.upload_ts,
+        uc.group_fk, uc.assignee, uc.status_fk, uc.status_comment
+      FROM upload u
+      INNER JOIN upload_clearing uc ON uc.upload_fk = u.upload_pk AND uc.group_fk = $1
+      WHERE u.upload_mode IN (100, 104)
+        AND u.pfile_fk IS NOT NULL
+      ORDER BY u.upload_filename
+    ");
+    $res = $this->dbManager->execute($statementName, array($trustGroupId));
+    $results = array();
+    while ($row = $this->dbManager->fetchArray($res)) {
+      $results[] = UploadProgress::createFromTable($row);
+    }
+    $this->dbManager->freeResult($res);
     return $results;
   }
 

--- a/src/reuser/ui/reuser-plugin.php
+++ b/src/reuser/ui/reuser-plugin.php
@@ -69,24 +69,22 @@ class ReuserPlugin extends DefaultPlugin
   }
 
   /**
-   * @brief Get all uploads accessible to curent user
-   *
-   * Gets all folders accessible by current user and iterate them. Find every
-   * upload with in that folder and add data from prepareFolderUploads().
+   * @brief Get all uploads accessible to current user
    * @return array Key as upload id
    */
   function getAllUploads()
   {
-    $allFolder = $this->folderDao->getAllFolderIds();
-    $result = [];
-
-    foreach ($allFolder as $folderId) {
-      foreach ($this->prepareFolderUploads($folderId) as $key => $value) {
-        $result[strstr($key, ',', true) ?: $key] = $value;
-      }
+    $trustGroupId = Auth::getGroupId();
+    $folderUploads = $this->folderDao->getAllUploadsForGroup($trustGroupId);
+    $uploadsById = array();
+    foreach ($folderUploads as $uploadProgress) {
+      $key = $uploadProgress->getId();
+      $display = $uploadProgress->getFilename() . _(" from ")
+            . Convert2BrowserTime(date("Y-m-d H:i:s", $uploadProgress->getTimestamp()))
+            . ' (' . $uploadProgress->getStatusString() . ')';
+      $uploadsById[$key] = $display;
     }
-
-    return $result;
+    return $uploadsById;
   }
 
   /**


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

perf(uploadpage): optimize upload page and reuser query performance

## Changes
**FolderDao.php**
- Added `countFolderUploadsBatch()` to fetch upload counts for all folders in a single query instead of one query per folder.
- Updated `getFolderStructure` to use the batch method.
- Added `getAllUploadsForGroup()` to fetch all accessible uploads in one query.

**reuser-plugin.php**
- Rewrote `getAllUploads` to use `getAllUploadsForGroup()` instead of iterating every folder individually.

CC: @shaheemazmalmmd @Kaushl2208 

Closes #3408 
