### PR TITLE
feat: implement file grouping and selection (issue #2847)

### DIFF
--- a/src/lib/php/Dao/FileGroupDao.php
+++ b/src/lib/php/Dao/FileGroupDao.php
@@ -1,0 +1,318 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file FileGroupDao.php
+ * @brief Data Access Object for file groups (Issue #2847).
+ *
+ * Provides CRUD operations for the `file_group` and `file_group_member`
+ * tables, plus a helper to auto-suggest groupings based on matching
+ * license / copyright fingerprints.
+ */
+
+namespace Fossology\Lib\Dao;
+
+use Fossology\Lib\Db\DbManager;
+use Monolog\Logger;
+
+/**
+ * @class FileGroupDao
+ * @brief DAO for grouping files that share the same license/copyright info.
+ */
+class FileGroupDao
+{
+  /** @var DbManager */
+  private $dbManager;
+
+  /** @var Logger */
+  private $logger;
+
+  /**
+   * FileGroupDao constructor.
+   * @param DbManager $dbManager
+   * @param Logger $logger
+   */
+  public function __construct(DbManager $dbManager, Logger $logger)
+  {
+    $this->dbManager = $dbManager;
+    $this->logger    = $logger;
+  }
+
+  // ─── Group CRUD ────────────────────────────────────────────────────────────
+
+  /**
+   * Create a new file group.
+   *
+   * @param int    $uploadId        Upload the group belongs to
+   * @param int    $groupId         Fossology group that owns this file group
+   * @param int    $userId          User creating the group
+   * @param string $name            Human-readable group name
+   * @param string $curationNotes   Optional curation notes / metadata
+   * @param bool   $includeInReport Whether to include this group in reports
+   * @return int   Primary key (fg_pk) of the newly created group
+   */
+  public function createGroup(int $uploadId, int $groupId, int $userId,
+    string $name, string $curationNotes = '', bool $includeInReport = true): int
+  {
+    $stmt = __METHOD__;
+    $sql  = "INSERT INTO file_group
+               (upload_fk, group_fk, user_fk, fg_name, fg_curation_notes,
+                fg_include_in_report, date_created, date_modified)
+             VALUES ($1, $2, $3, $4, $5, $6, now(), now())
+             RETURNING fg_pk";
+    $this->dbManager->prepare($stmt, $sql);
+    $res = $this->dbManager->execute($stmt, [
+      $uploadId,
+      $groupId,
+      $userId,
+      $name,
+      $curationNotes,
+      $this->dbManager->booleanToDb($includeInReport),
+    ]);
+    $row = $this->dbManager->fetchArray($res);
+    $this->dbManager->freeResult($res);
+    return intval($row['fg_pk']);
+  }
+
+  /**
+   * Update properties of an existing file group.
+   *
+   * @param int    $fgPk            Group primary key
+   * @param string $name            New name (pass null to keep existing)
+   * @param string $curationNotes   New curation notes (pass null to keep existing)
+   * @param bool   $includeInReport New include-in-report flag (pass null to keep existing)
+   * @return bool  True on success
+   */
+  public function updateGroup(int $fgPk, ?string $name = null,
+    ?string $curationNotes = null, ?bool $includeInReport = null): bool
+  {
+    $setClauses = ["\"date_modified\" = now()"];
+    $params     = [$fgPk];
+
+    if ($name !== null) {
+      $params[]     = $name;
+      $setClauses[] = "\"fg_name\" = $" . count($params);
+    }
+    if ($curationNotes !== null) {
+      $params[]     = $curationNotes;
+      $setClauses[] = "\"fg_curation_notes\" = $" . count($params);
+    }
+    if ($includeInReport !== null) {
+      $params[]     = $this->dbManager->booleanToDb($includeInReport);
+      $setClauses[] = "\"fg_include_in_report\" = $" . count($params);
+    }
+
+    if (count($params) === 1) {
+      // Nothing to update aside from date
+    }
+
+    $sql = "UPDATE file_group SET " . implode(', ', $setClauses)
+         . " WHERE fg_pk = $1";
+    $this->dbManager->getSingleRow($sql, $params, __METHOD__);
+    return true;
+  }
+
+  /**
+   * Delete a file group (members are cascade-deleted via FK).
+   *
+   * @param int $fgPk Group primary key
+   */
+  public function deleteGroup(int $fgPk): void
+  {
+    $this->dbManager->getSingleRow(
+      "DELETE FROM file_group WHERE fg_pk = $1",
+      [$fgPk],
+      __METHOD__
+    );
+  }
+
+  /**
+   * Get all file groups for a given upload and fossology group.
+   *
+   * @param int $uploadId Upload ID
+   * @param int $groupId  Fossology group ID
+   * @return array[] Rows from file_group with an extra `member_count` column
+   */
+  public function getGroupsForUpload(int $uploadId, int $groupId): array
+  {
+    $sql = "SELECT fg.fg_pk,
+                   fg.fg_name,
+                   fg.fg_curation_notes,
+                   fg.fg_include_in_report,
+                   fg.user_fk,
+                   fg.date_created,
+                   fg.date_modified,
+                   COUNT(fgm.fgm_pk) AS member_count
+            FROM file_group fg
+            LEFT JOIN file_group_member fgm ON fgm.fg_fk = fg.fg_pk
+            WHERE fg.upload_fk = $1 AND fg.group_fk = $2
+            GROUP BY fg.fg_pk
+            ORDER BY fg.date_created ASC";
+    return $this->dbManager->getRows($sql, [$uploadId, $groupId], __METHOD__);
+  }
+
+  /**
+   * Get a single file group by its primary key.
+   *
+   * @param int $fgPk Group primary key
+   * @return array|false Single row or false if not found
+   */
+  public function getGroupById(int $fgPk)
+  {
+    return $this->dbManager->getSingleRow(
+      "SELECT fg.fg_pk, fg.fg_name, fg.fg_curation_notes,
+              fg.fg_include_in_report, fg.upload_fk, fg.group_fk,
+              fg.user_fk, fg.date_created, fg.date_modified
+       FROM file_group fg
+       WHERE fg.fg_pk = $1",
+      [$fgPk],
+      __METHOD__
+    );
+  }
+
+  // ─── Member management ─────────────────────────────────────────────────────
+
+  /**
+   * Add uploadtree items as members of a group.
+   * Silently ignores duplicates (already member).
+   *
+   * @param int   $fgPk          Group primary key
+   * @param int[] $uploadtreePks Array of uploadtree_pk values to add
+   */
+  public function addMembers(int $fgPk, array $uploadtreePks): void
+  {
+    if (empty($uploadtreePks)) {
+      return;
+    }
+    $stmt = __METHOD__;
+    $sql  = "INSERT INTO file_group_member (fg_fk, uploadtree_fk)
+             VALUES ($1, $2)
+             ON CONFLICT (fg_fk, uploadtree_fk) DO NOTHING";
+    $this->dbManager->prepare($stmt, $sql);
+    foreach ($uploadtreePks as $utPk) {
+      $res = $this->dbManager->execute($stmt, [$fgPk, intval($utPk)]);
+      $this->dbManager->freeResult($res);
+    }
+  }
+
+  /**
+   * Remove a single file from a group.
+   *
+   * @param int $fgPk          Group primary key
+   * @param int $uploadtreePk  uploadtree_pk of the file to remove
+   */
+  public function removeMember(int $fgPk, int $uploadtreePk): void
+  {
+    $this->dbManager->getSingleRow(
+      "DELETE FROM file_group_member
+       WHERE fg_fk = $1 AND uploadtree_fk = $2",
+      [$fgPk, $uploadtreePk],
+      __METHOD__
+    );
+  }
+
+  /**
+   * Get all member files of a group with their names and pfile IDs.
+   *
+   * @param int    $fgPk              Group primary key
+   * @param string $uploadTreeTable   Name of the upload-specific uploadtree table
+   *                                  (e.g. 'uploadtree_a')
+   * @return array[] Rows with uploadtree_pk, ufile_name, pfile_fk
+   */
+  public function getGroupMembers(int $fgPk, string $uploadTreeTable = 'uploadtree_a'): array
+  {
+    $sql = "SELECT ut.uploadtree_pk, ut.ufile_name, ut.pfile_fk
+            FROM file_group_member fgm
+            JOIN \"$uploadTreeTable\" ut ON ut.uploadtree_pk = fgm.uploadtree_fk
+            WHERE fgm.fg_fk = $1
+            ORDER BY ut.ufile_name ASC";
+    return $this->dbManager->getRows($sql, [$fgPk], __METHOD__ . $uploadTreeTable);
+  }
+
+  /**
+   * Check whether an uploadtree item already belongs to any group within this upload.
+   *
+   * @param int $uploadtreePk  uploadtree_pk to check
+   * @param int $uploadId      Upload the item belongs to
+   * @return int|false         fg_pk of the existing group, or false
+   */
+  public function getGroupForItem(int $uploadtreePk, int $uploadId)
+  {
+    $row = $this->dbManager->getSingleRow(
+      "SELECT fg.* FROM file_group_member fgm
+       JOIN file_group fg ON fg.fg_pk = fgm.fg_fk
+       WHERE fgm.uploadtree_fk = $1 AND fg.upload_fk = $2
+       LIMIT 1",
+      [$uploadtreePk, $uploadId],
+      __METHOD__
+    );
+    return $row;
+  }
+
+  // ─── Auto-grouping suggestions ─────────────────────────────────────────────
+
+  /**
+   * Suggest groupings by finding files inside an upload that share
+   * identical license fingerprints (sorted array of rf_fk from clearing events).
+   *
+   * Only files that have at least one non-removed clearing event are considered.
+   * Returns groups with more than one member.
+   *
+   * @param int    $uploadId        Upload to analyse
+   * @param string $uploadTreeTable Name of the uploadtree table for this upload
+   * @return array[] Each element has keys:
+   *                 - `file_list`    (string, PostgreSQL array literal of uploadtree_pk)
+   *                 - `license_set`  (string, PostgreSQL array literal of rf_fk)
+   *                 - `member_count` (int)
+   */
+  public function suggestGroups(int $uploadId, string $uploadTreeTable = 'uploadtree_a'): array
+  {
+    $sql = "
+      SELECT
+        array_agg(DISTINCT ut.uploadtree_pk ORDER BY ut.uploadtree_pk) AS file_list,
+        lr_set.license_set,
+        count(DISTINCT ut.uploadtree_pk) AS member_count
+      FROM \"$uploadTreeTable\" ut
+      CROSS JOIN LATERAL (
+        SELECT array_agg(ce.rf_fk ORDER BY ce.rf_fk) AS license_set
+        FROM clearing_event ce
+          JOIN clearing_decision_event cde
+            ON cde.clearing_event_fk = ce.clearing_event_pk
+          JOIN clearing_decision cd
+            ON cd.clearing_decision_pk = cde.clearing_decision_fk
+           AND cd.uploadtree_fk        = ut.uploadtree_pk
+        WHERE NOT ce.removed
+      ) lr_set
+      WHERE ut.upload_fk = \$1
+        AND (ut.ufile_mode & (3<<28)) = 0   -- exclude directories and artifacts
+        AND lr_set.license_set IS NOT NULL
+      GROUP BY lr_set.license_set
+      HAVING count(DISTINCT ut.uploadtree_pk) > 1
+      ORDER BY member_count DESC";
+
+    return $this->dbManager->getRows($sql, [$uploadId],
+      __METHOD__ . $uploadTreeTable);
+  }
+
+  /**
+   * Get all file-group data for an upload (used by decision import/export).
+   *
+   * @param int $uploadId Upload ID
+   * @return array[] Full join of file_group and file_group_member rows
+   */
+  public function getAllGroupDataForUpload(int $uploadId): array
+  {
+    $sql = "SELECT fg.fg_pk, fg.fg_name, fg.fg_curation_notes,
+                   fg.fg_include_in_report, fg.group_fk, fg.user_fk,
+                   fgm.uploadtree_fk
+            FROM file_group fg
+            LEFT JOIN file_group_member fgm ON fgm.fg_fk = fg.fg_pk
+            WHERE fg.upload_fk = $1
+            ORDER BY fg.fg_pk, fgm.uploadtree_fk";
+    return $this->dbManager->getRows($sql, [$uploadId], __METHOD__);
+  }
+}

--- a/src/lib/php/Dao/test/FileGroupDaoTest.php
+++ b/src/lib/php/Dao/test/FileGroupDaoTest.php
@@ -1,0 +1,283 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\Lib\Dao;
+
+use Fossology\Lib\Db\DbManager;
+use Mockery as M;
+use Monolog\Logger;
+
+/**
+ * @class FileGroupDaoTest
+ * @brief Unit tests for FileGroupDao using Mockery mocks (no real DB required).
+ */
+class FileGroupDaoTest extends \PHPUnit\Framework\TestCase
+{
+  /** @var DbManager|M\MockInterface */
+  private $dbManager;
+
+  /** @var Logger|M\MockInterface */
+  private $logger;
+
+  /** @var FileGroupDao */
+  private $fileGroupDao;
+
+  private int $uploadId   = 1;
+  private int $groupId    = 2;
+  private int $userId     = 3;
+  private int $fgPk       = 10;
+  private int $uploadtree = 100;
+
+  protected function setUp(): void
+  {
+    $this->dbManager    = M::mock(DbManager::class);
+    $this->logger       = M::mock(Logger::class);
+    $this->fileGroupDao = new FileGroupDao($this->dbManager, $this->logger);
+  }
+
+  protected function tearDown(): void
+  {
+    M::close();
+  }
+
+  // ─── createGroup ───────────────────────────────────────────────────────────
+
+  /**
+   * @test
+   * createGroup() should prepare/execute INSERT and return the new fg_pk.
+   */
+  public function testCreateGroupReturnsFgPk(): void
+  {
+    $this->dbManager->shouldReceive('booleanToDb')->with(true)->andReturn('t');
+    $this->dbManager->shouldReceive('prepare')
+      ->once()
+      ->withArgs([M::any(), M::on(fn($s) => str_contains($s, 'INSERT INTO file_group'))]);
+    $this->dbManager->shouldReceive('execute')
+      ->once()
+      ->andReturn('res');
+    $this->dbManager->shouldReceive('fetchArray')
+      ->once()
+      ->andReturn(['fg_pk' => $this->fgPk]);
+    $this->dbManager->shouldReceive('freeResult')->once();
+
+    $result = $this->fileGroupDao->createGroup(
+      $this->uploadId, $this->groupId, $this->userId, 'Test Group'
+    );
+
+    $this->assertSame($this->fgPk, $result);
+  }
+
+  // ─── deleteGroup ───────────────────────────────────────────────────────────
+
+  /**
+   * @test
+   * deleteGroup() should run a DELETE query with the correct fg_pk.
+   */
+  public function testDeleteGroupRunsDeleteQuery(): void
+  {
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->once()
+      ->withArgs([
+        M::on(fn($s) => str_contains($s, 'DELETE FROM file_group')),
+        [$this->fgPk],
+        M::any()
+      ]);
+
+    $this->fileGroupDao->deleteGroup($this->fgPk);
+
+    // assertion is the Mockery shouldReceive expectation
+    $this->addToAssertionCount(1);
+  }
+
+  // ─── addMembers ────────────────────────────────────────────────────────────
+
+  /**
+   * @test
+   * addMembers() with empty array should not make any DB calls.
+   */
+  public function testAddMembersWithEmptyArrayDoesNothing(): void
+  {
+    $this->dbManager->shouldNotReceive('prepare');
+    $this->dbManager->shouldNotReceive('execute');
+
+    $this->fileGroupDao->addMembers($this->fgPk, []);
+    $this->addToAssertionCount(1);
+  }
+
+  /**
+   * @test
+   * addMembers() with two IDs should execute the INSERT twice.
+   */
+  public function testAddMembersCallsInsertForEachItem(): void
+  {
+    $this->dbManager->shouldReceive('prepare')->once();
+    $this->dbManager->shouldReceive('execute')
+      ->twice()
+      ->andReturn('res');
+    $this->dbManager->shouldReceive('freeResult')->twice();
+
+    $this->fileGroupDao->addMembers($this->fgPk, [101, 102]);
+    $this->addToAssertionCount(1);
+  }
+
+  // ─── removeMember ──────────────────────────────────────────────────────────
+
+  /**
+   * @test
+   * removeMember() should execute DELETE with fgPk and uploadtreePk.
+   */
+  public function testRemoveMemberExecutesDeleteWithCorrectParams(): void
+  {
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->once()
+      ->withArgs([
+        M::on(fn($s) => str_contains($s, 'DELETE FROM file_group_member')),
+        [$this->fgPk, $this->uploadtree],
+        M::any()
+      ]);
+
+    $this->fileGroupDao->removeMember($this->fgPk, $this->uploadtree);
+    $this->addToAssertionCount(1);
+  }
+
+  // ─── getGroupsForUpload ────────────────────────────────────────────────────
+
+  /**
+   * @test
+   * getGroupsForUpload() should return the rows from getRows().
+   */
+  public function testGetGroupsForUploadReturnsRows(): void
+  {
+    $expected = [
+      ['fg_pk' => 1, 'fg_name' => 'Group A', 'member_count' => '2'],
+    ];
+
+    $this->dbManager->shouldReceive('getRows')
+      ->once()
+      ->withArgs([M::any(), [$this->uploadId, $this->groupId], M::any()])
+      ->andReturn($expected);
+
+    $result = $this->fileGroupDao->getGroupsForUpload($this->uploadId, $this->groupId);
+
+    $this->assertSame($expected, $result);
+  }
+
+  // ─── getGroupById ──────────────────────────────────────────────────────────
+
+  /**
+   * @test
+   * getGroupById() should return a single row.
+   */
+  public function testGetGroupByIdReturnsSingleRow(): void
+  {
+    $expected = ['fg_pk' => $this->fgPk, 'fg_name' => 'Test'];
+
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->once()
+      ->withArgs([M::any(), [$this->fgPk], M::any()])
+      ->andReturn($expected);
+
+    $result = $this->fileGroupDao->getGroupById($this->fgPk);
+    $this->assertSame($expected, $result);
+  }
+
+  // ─── getGroupMembers ───────────────────────────────────────────────────────
+
+  /**
+   * @test
+   * getGroupMembers() should query the specified uploadtree table.
+   */
+  public function testGetGroupMembersQueriesCorrectTable(): void
+  {
+    $table    = 'uploadtree_a';
+    $expected = [['uploadtree_pk' => 200, 'ufile_name' => 'file.c', 'pfile_fk' => 50]];
+
+    $this->dbManager->shouldReceive('getRows')
+      ->once()
+      ->withArgs([
+        M::on(fn($s) => str_contains($s, "\"$table\"")),
+        [$this->fgPk],
+        M::any()
+      ])
+      ->andReturn($expected);
+
+    $result = $this->fileGroupDao->getGroupMembers($this->fgPk, $table);
+    $this->assertSame($expected, $result);
+  }
+
+  // ─── updateGroup ───────────────────────────────────────────────────────────
+
+  /**
+   * @test
+   * updateGroup() with only name change should build correct SET clause.
+   */
+  public function testUpdateGroupWithNameOnly(): void
+  {
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->once()
+      ->withArgs([
+        M::on(fn($s) => str_contains($s, 'UPDATE file_group') &&
+                        str_contains($s, '"fg_name"')),
+        M::any(),
+        M::any()
+      ]);
+
+    $this->fileGroupDao->updateGroup($this->fgPk, 'New Name');
+    $this->addToAssertionCount(1);
+  }
+
+  // ─── suggestGroups ─────────────────────────────────────────────────────────
+
+  /**
+   * @test
+   * suggestGroups() should pass uploadId and use the given table name.
+   */
+  public function testSuggestGroupsPassesCorrectParams(): void
+  {
+    $table    = 'uploadtree_a';
+    $expected = [
+      ['file_list' => '{101,102}', 'license_set' => '{5,7}', 'member_count' => '2'],
+    ];
+
+    $this->dbManager->shouldReceive('getRows')
+      ->once()
+      ->withArgs([
+        M::on(fn($s) => str_contains($s, "\"$table\"")),
+        [$this->uploadId],
+        M::any()
+      ])
+      ->andReturn($expected);
+
+    $result = $this->fileGroupDao->suggestGroups($this->uploadId, $table);
+    $this->assertSame($expected, $result);
+  }
+
+  // ─── getAllGroupDataForUpload ───────────────────────────────────────────────
+
+  /**
+   * @test
+   * getAllGroupDataForUpload() should join file_group and file_group_member.
+   */
+  public function testGetAllGroupDataForUploadJoinsBothTables(): void
+  {
+    $expected = [
+      ['fg_pk' => 1, 'fg_name' => 'G', 'uploadtree_fk' => 101],
+    ];
+
+    $this->dbManager->shouldReceive('getRows')
+      ->once()
+      ->withArgs([
+        M::on(fn($s) => str_contains($s, 'file_group_member')),
+        [$this->uploadId],
+        M::any()
+      ])
+      ->andReturn($expected);
+
+    $result = $this->fileGroupDao->getAllGroupDataForUpload($this->uploadId);
+    $this->assertSame($expected, $result);
+  }
+}

--- a/src/lib/php/Report/ClearedGetterCommon.php
+++ b/src/lib/php/Report/ClearedGetterCommon.php
@@ -88,6 +88,18 @@ abstract class ClearedGetterCommon
     return $groupId;
   }
 
+  protected function filterExcludedStatements(&$statements, $uploadId, $groupId)
+  {
+    global $container;
+    /** @var ReportUtils $reportUtils */
+    $reportUtils = $container->get('report.utils');
+    $excludedUtIds = $reportUtils->getExcludedUtIds($uploadId, $groupId);
+    
+    $statements = array_filter($statements, function($statement) use ($excludedUtIds) {
+      return !isset($excludedUtIds[$statement['uploadtree_pk']]);
+    });
+  }
+
   protected function changeTreeIdsToPaths(&$ungrupedStatements, $uploadTreeTableName, $uploadId)
   {
     $parentId = $this->treeDao->getMinimalCoveringItem($uploadId, $uploadTreeTableName);

--- a/src/lib/php/Report/LicenseClearedGetter.php
+++ b/src/lib/php/Report/LicenseClearedGetter.php
@@ -115,6 +115,7 @@ class LicenseClearedGetter extends ClearedGetterCommon
     $uploadTreeTableName = $this->uploadDao->getUploadtreeTableName($uploadId);
     $ungroupedStatements = $this->getStatements($uploadId, $uploadTreeTableName,
       $groupId);
+    $this->filterExcludedStatements($ungroupedStatements, $uploadId, $groupId);
     $this->changeTreeIdsToPaths($ungroupedStatements, $uploadTreeTableName,
       $uploadId);
     if ($this->onlyAcknowledgements || $this->onlyComments) {

--- a/src/lib/php/Report/ReportUtils.php
+++ b/src/lib/php/Report/ReportUtils.php
@@ -71,6 +71,29 @@ class ReportUtils
   }
 
   /**
+   * @param int $uploadId
+   * @param int $groupId
+   * @return array map of uploadtree_pk to true for excluded files
+   */
+  public function getExcludedUtIds($uploadId, $groupId)
+  {
+    /** @var \Fossology\Lib\Dao\FileGroupDao $fileGroupDao */
+    $fileGroupDao = $this->container->get('dao.filegroup');
+    $excludedGroups = $fileGroupDao->getGroupsForUpload($uploadId, $groupId);
+    
+    $excludedUtIds = [];
+    foreach ($excludedGroups as $group) {
+      if (!$group['fg_include_in_report']) {
+        $members = $fileGroupDao->getGroupMembers($group['fg_pk']);
+        foreach ($members as $member) {
+          $excludedUtIds[$member['uploadtree_fk']] = true;
+        }
+      }
+    }
+    return $excludedUtIds;
+  }
+
+  /**
    * @brief Add clearing status to the files
    * @param FileNode[] &$filesWithLicenses
    * @param ItemTreeBounds $itemTreeBounds
@@ -187,13 +210,20 @@ class ReportUtils
     $uploadtreeTable = $this->uploadDao->getUploadtreeTableName($uploadId);
     $allScannerEntries = $copyrightDao->getScannerEntries('copyright', $uploadtreeTable, $uploadId, $type='statement', $extrawhere);
     $allEditedEntries = $copyrightDao->getEditedEntries('copyright_decision', $uploadtreeTable, $uploadId, $decisionType=null);
+    $excludedUtIds = $this->getExcludedUtIds($uploadId, $groupId);
     foreach ($allScannerEntries as $finding) {
+      if (isset($excludedUtIds[$finding['uploadtree_pk']])) {
+        continue;
+      }
       if (!array_key_exists($finding['uploadtree_pk'], $filesWithLicenses)) {
         $filesWithLicenses[$finding['uploadtree_pk']] = new FileNode();
       }
       $filesWithLicenses[$finding['uploadtree_pk']]->addCopyright(\convertToUTF8($finding['content'],false));
     }
     foreach ($allEditedEntries as $finding) {
+      if (isset($excludedUtIds[$finding['uploadtree_pk']])) {
+        continue;
+      }
       if (!array_key_exists($finding['uploadtree_pk'], $filesWithLicenses)) {
         $filesWithLicenses[$finding['uploadtree_pk']] = new FileNode();
       }
@@ -217,10 +247,14 @@ class ReportUtils
     }
 
     $clearingDecisions = $this->clearingDao->getFileClearingsFolder($itemTreeBounds, $groupId);
+    $excludedUtIds = $this->getExcludedUtIds($itemTreeBounds->getUploadId(), $groupId);
 
     $filesWithLicenses = array();
     $clearingsProceeded = 0;
     foreach ($clearingDecisions as $clearingDecision) {
+      if (isset($excludedUtIds[$clearingDecision->getUploadTreeId()])) {
+        continue;
+      }
       $clearingsProceeded += 1;
       if (($clearingsProceeded&2047)==0) {
         $agentObj->heartbeat(0);

--- a/src/lib/php/services.xml.in
+++ b/src/lib/php/services.xml.in
@@ -72,6 +72,10 @@ SPDX-License-Identifier: FSFAP
             <argument type="service" id="db.manager"/>
             <argument type="service" id="dao.upload"/>
         </service>
+        <service id="dao.filegroup" class="Fossology\Lib\Dao\FileGroupDao" public="true">
+            <argument type="service" id="db.manager"/>
+            <argument type="service" id="logger"/>
+        </service>
         <service id="dao.highlight" class="Fossology\Lib\Dao\HighlightDao" public="true">
             <argument type="service" id="db.manager"/>
         </service>

--- a/src/www/ui/api/Controllers/FileGroupController.php
+++ b/src/www/ui/api/Controllers/FileGroupController.php
@@ -1,0 +1,426 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\UI\Api\Controllers;
+
+use Fossology\Lib\Dao\FileGroupDao;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\UI\Api\Exceptions\HttpBadRequestException;
+use Fossology\UI\Api\Exceptions\HttpForbiddenException;
+use Fossology\UI\Api\Exceptions\HttpNotFoundException;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Models\FileGroup;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * @class FileGroupController
+ * @brief REST controller for File Groups (Issue #2847).
+ *
+ * Endpoints:
+ *   GET    /uploads/{id}/filegroups           - list all groups for an upload
+ *   POST   /uploads/{id}/filegroups           - create a new group
+ *   PATCH  /uploads/{id}/filegroups/{fgId}   - update group metadata
+ *   DELETE /uploads/{id}/filegroups/{fgId}   - delete a group
+ *   POST   /uploads/{id}/filegroups/{fgId}/members      - add files to a group
+ *   DELETE /uploads/{id}/filegroups/{fgId}/members/{ut} - remove a file
+ *   GET    /uploads/{id}/filegroups/suggest   - auto-suggest groups
+ */
+class FileGroupController extends RestController
+{
+  /** @var FileGroupDao */
+  private $fileGroupDao;
+
+  /** @var UploadDao */
+  private $uploadDao;
+
+  /**
+   * @param object $container DI container
+   */
+  public function __construct($container)
+  {
+    parent::__construct($container);
+    $this->fileGroupDao = $this->container->get('dao.filegroup');
+    $this->uploadDao    = $this->container->get('dao.upload');
+  }
+
+  // ─── Helpers ───────────────────────────────────────────────────────────────
+
+  /**
+   * Assert that the current user can access the given upload.
+   * @param int $uploadId
+   * @throws HttpNotFoundException
+   */
+  private function assertUploadExists(int $uploadId): void
+  {
+    if (!$this->dbHelper->doesIdExist('upload', 'upload_pk', $uploadId)) {
+      throw new HttpNotFoundException("Upload $uploadId not found.");
+    }
+  }
+
+  /**
+   * Assert that a file group exists and belongs to the given upload.
+   * @param int $fgPk
+   * @param int $uploadId
+   * @return array The group row
+   * @throws HttpNotFoundException
+   */
+  private function assertGroupExists(int $fgPk, int $uploadId): array
+  {
+    $group = $this->fileGroupDao->getGroupById($fgPk);
+    if (empty($group) || intval($group['upload_fk']) !== $uploadId) {
+      throw new HttpNotFoundException("File group $fgPk not found for upload $uploadId.");
+    }
+    return $group;
+  }
+
+  /**
+   * Assert the caller is a member of the required fossology group.
+   * @param int $requiredGroupId
+   * @throws HttpForbiddenException
+   */
+  private function assertGroupMembership(int $requiredGroupId): void
+  {
+    if (intval($this->restHelper->getGroupId()) !== $requiredGroupId) {
+      throw new HttpForbiddenException(
+        "You do not have permission to modify this file group."
+      );
+    }
+  }
+
+  /**
+   * Convert a DB row to a FileGroup model and then to its array representation.
+   * @param array $row DB row from file_group
+   * @return array
+   */
+  private function rowToArray(array $row): array
+  {
+    $fg = new FileGroup(
+      intval($row['fg_pk']),
+      $row['fg_name'],
+      $row['fg_curation_notes'] ?? null,
+      $this->dbHelper->getDbManager()->booleanFromDb($row['fg_include_in_report']),
+      intval($row['member_count'] ?? 0),
+      $row['date_created'],
+      $row['date_modified'] ?? null
+    );
+    return $fg->getArray();
+  }
+
+  // ─── Route handlers ────────────────────────────────────────────────────────
+
+  /**
+   * GET /uploads/{id}/filegroups
+   *
+   * List all file groups for the given upload.
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args  ['id' => uploadId]
+   * @return ResponseHelper
+   */
+  public function getGroups(
+    ServerRequestInterface $request,
+    ResponseHelper $response,
+    array $args
+  ): ResponseHelper {
+    $uploadId = intval($args['id']);
+    $this->assertUploadExists($uploadId);
+
+    $groupId = $this->restHelper->getGroupId();
+    $rows    = $this->fileGroupDao->getGroupsForUpload($uploadId, $groupId);
+    $groups  = array_map([$this, 'rowToArray'], $rows);
+
+    return $response->withJson($groups, 200);
+  }
+
+  /**
+   * POST /uploads/{id}/filegroups
+   *
+   * Create a new file group for the upload.
+   *
+   * Expected JSON body:
+   * {
+   *   "name": "MIT utilities",           // required
+   *   "curationNotes": "Verified clean", // optional
+   *   "includeInReport": true,           // optional, default true
+   *   "members": [12345, 12346]          // optional list of uploadtree_pk
+   * }
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpBadRequestException
+   */
+  public function createGroup(
+    ServerRequestInterface $request,
+    ResponseHelper $response,
+    array $args
+  ): ResponseHelper {
+    $uploadId = intval($args['id']);
+    $this->assertUploadExists($uploadId);
+
+    $body = $this->getParsedBody($request);
+
+    if (empty($body['name']) || !is_string($body['name'])) {
+      throw new HttpBadRequestException("'name' is required and must be a string.");
+    }
+
+    $name            = trim($body['name']);
+    $curationNotes   = isset($body['curationNotes']) ? trim($body['curationNotes']) : '';
+    $includeInReport = isset($body['includeInReport'])
+      ? (bool) $body['includeInReport'] : true;
+
+    $groupId = $this->restHelper->getGroupId();
+    $userId  = $this->restHelper->getUserId();
+
+    $fgPk = $this->fileGroupDao->createGroup(
+      $uploadId, $groupId, $userId, $name, $curationNotes, $includeInReport
+    );
+
+    // Add any initial members if provided
+    if (!empty($body['members']) && is_array($body['members'])) {
+      $members = array_filter($body['members'], 'is_numeric');
+      $this->fileGroupDao->addMembers($fgPk, array_map('intval', $members));
+    }
+
+    $info = new Info(201, intval($fgPk), InfoType::INFO);
+    return $response->withJson($info->getArray(), 201);
+  }
+
+  /**
+   * PATCH /uploads/{id}/filegroups/{fgId}
+   *
+   * Update group name, curation notes or include-in-report flag.
+   *
+   * Expected JSON body (all fields optional):
+   * {
+   *   "name":            "New name",
+   *   "curationNotes":   "Updated notes",
+   *   "includeInReport": false
+   * }
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args  ['id' => uploadId, 'fgId' => fgPk]
+   * @return ResponseHelper
+   */
+  public function updateGroup(
+    ServerRequestInterface $request,
+    ResponseHelper $response,
+    array $args
+  ): ResponseHelper {
+    $uploadId = intval($args['id']);
+    $fgPk     = intval($args['fgId']);
+    $this->assertUploadExists($uploadId);
+    $group = $this->assertGroupExists($fgPk, $uploadId);
+    $this->assertGroupMembership(intval($group['group_fk']));
+
+    $body = $this->getParsedBody($request);
+
+    $name            = isset($body['name']) ? trim($body['name']) : null;
+    $curationNotes   = isset($body['curationNotes']) ? trim($body['curationNotes']) : null;
+    $includeInReport = isset($body['includeInReport'])
+      ? (bool) $body['includeInReport'] : null;
+
+    if ($name === '') {
+      throw new HttpBadRequestException("'name' must not be empty.");
+    }
+
+    $this->fileGroupDao->updateGroup($fgPk, $name, $curationNotes, $includeInReport);
+
+    $info = new Info(200, "File group $fgPk updated successfully.", InfoType::INFO);
+    return $response->withJson($info->getArray(), 200);
+  }
+
+  /**
+   * DELETE /uploads/{id}/filegroups/{fgId}
+   *
+   * Delete a file group (members are removed automatically via cascade).
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function deleteGroup(
+    ServerRequestInterface $request,
+    ResponseHelper $response,
+    array $args
+  ): ResponseHelper {
+    $uploadId = intval($args['id']);
+    $fgPk     = intval($args['fgId']);
+    $this->assertUploadExists($uploadId);
+    $group = $this->assertGroupExists($fgPk, $uploadId);
+    $this->assertGroupMembership(intval($group['group_fk']));
+
+    $this->fileGroupDao->deleteGroup($fgPk);
+
+    $info = new Info(200, "File group $fgPk deleted.", InfoType::INFO);
+    return $response->withJson($info->getArray(), 200);
+  }
+
+  /**
+   * POST /uploads/{id}/filegroups/{fgId}/members
+   *
+   * Add files (by uploadtree_pk) to a group.
+   *
+   * Expected JSON body:
+   * {
+   *   "members": [12345, 12346, 12347]
+   * }
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpBadRequestException
+   */
+  public function addMembers(
+    ServerRequestInterface $request,
+    ResponseHelper $response,
+    array $args
+  ): ResponseHelper {
+    $uploadId = intval($args['id']);
+    $fgPk     = intval($args['fgId']);
+    $this->assertUploadExists($uploadId);
+    $group = $this->assertGroupExists($fgPk, $uploadId);
+    $this->assertGroupMembership(intval($group['group_fk']));
+
+    $body = $this->getParsedBody($request);
+
+    if (empty($body['members']) || !is_array($body['members'])) {
+      throw new HttpBadRequestException(
+        "'members' is required and must be a non-empty array of uploadtree_pk integers."
+      );
+    }
+
+    $members = array_filter($body['members'], 'is_numeric');
+    if (empty($members)) {
+      throw new HttpBadRequestException("'members' must contain numeric uploadtree_pk values.");
+    }
+
+    $this->fileGroupDao->addMembers($fgPk, array_map('intval', $members));
+
+    $info = new Info(200,
+      count($members) . " file(s) added to group $fgPk.", InfoType::INFO);
+    return $response->withJson($info->getArray(), 200);
+  }
+
+  /**
+   * DELETE /uploads/{id}/filegroups/{fgId}/members/{utId}
+   *
+   * Remove a single file from a group.
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args  ['id' => uploadId, 'fgId' => fgPk, 'utId' => uploadtreePk]
+   * @return ResponseHelper
+   */
+  public function removeMember(
+    ServerRequestInterface $request,
+    ResponseHelper $response,
+    array $args
+  ): ResponseHelper {
+    $uploadId   = intval($args['id']);
+    $fgPk       = intval($args['fgId']);
+    $uploadtreePk = intval($args['utId']);
+    $this->assertUploadExists($uploadId);
+    $group = $this->assertGroupExists($fgPk, $uploadId);
+    $this->assertGroupMembership(intval($group['group_fk']));
+
+    $this->fileGroupDao->removeMember($fgPk, $uploadtreePk);
+
+    $info = new Info(200, "File $uploadtreePk removed from group $fgPk.", InfoType::INFO);
+    return $response->withJson($info->getArray(), 200);
+  }
+
+  /**
+   * GET /uploads/{id}/filegroups/{fgId}/members
+   *
+   * List all member files in a group.
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function getMembers(
+    ServerRequestInterface $request,
+    ResponseHelper $response,
+    array $args
+  ): ResponseHelper {
+    $uploadId = intval($args['id']);
+    $fgPk     = intval($args['fgId']);
+    $this->assertUploadExists($uploadId);
+    $this->assertGroupExists($fgPk, $uploadId);
+
+    $uploadTreeTable = $this->uploadDao->getUploadtreeTableName($uploadId);
+    $members = $this->fileGroupDao->getGroupMembers($fgPk, $uploadTreeTable);
+
+    return $response->withJson($members, 200);
+  }
+
+  /**
+   * GET /uploads/{id}/filegroups/suggest
+   *
+   * Auto-suggest file groupings based on shared license decisions.
+   *
+   * Returns an array of candidate groups. Each element:
+   * {
+   *   "file_list":    [uploadtree_pk, ...],
+   *   "license_set":  [rf_fk, ...],
+   *   "member_count": N
+   * }
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function suggestGroups(
+    ServerRequestInterface $request,
+    ResponseHelper $response,
+    array $args
+  ): ResponseHelper {
+    $uploadId = intval($args['id']);
+    $this->assertUploadExists($uploadId);
+
+    $uploadTreeTable = $this->uploadDao->getUploadtreeTableName($uploadId);
+    $suggestions = $this->fileGroupDao->suggestGroups($uploadId, $uploadTreeTable);
+
+    // Convert PostgreSQL array literals to PHP arrays for clean JSON output
+    $result = array_map(function (array $row) {
+      return [
+        'fileList'    => $this->pgArrayToInt($row['file_list']),
+        'licenseSet'  => $this->pgArrayToInt($row['license_set']),
+        'memberCount' => intval($row['member_count']),
+      ];
+    }, $suggestions);
+
+    return $response->withJson($result, 200);
+  }
+
+  /**
+   * Parse a PostgreSQL array literal like "{1,2,3}" into a PHP int array.
+   * @param string|null $pgArray
+   * @return int[]
+   */
+  private function pgArrayToInt(?string $pgArray): array
+  {
+    if (empty($pgArray)) {
+      return [];
+    }
+    $stripped = trim($pgArray, '{}');
+    if ($stripped === '') {
+      return [];
+    }
+    return array_map('intval', explode(',', $stripped));
+  }
+}

--- a/src/www/ui/api/Models/FileGroup.php
+++ b/src/www/ui/api/Models/FileGroup.php
@@ -1,0 +1,108 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\UI\Api\Models;
+
+/**
+ * @class FileGroup
+ * @brief Model class for a file group (Issue #2847).
+ *
+ * Represents a named collection of files that share the same license
+ * and copyright clearing information.
+ */
+class FileGroup
+{
+  /** @var int */
+  private $id;
+
+  /** @var string */
+  private $name;
+
+  /** @var string|null */
+  private $curationNotes;
+
+  /** @var bool */
+  private $includeInReport;
+
+  /** @var int */
+  private $memberCount;
+
+  /** @var string ISO-8601 timestamp */
+  private $dateCreated;
+
+  /** @var string|null ISO-8601 timestamp */
+  private $dateModified;
+
+  /**
+   * @param int         $id
+   * @param string      $name
+   * @param string|null $curationNotes
+   * @param bool        $includeInReport
+   * @param int         $memberCount
+   * @param string      $dateCreated
+   * @param string|null $dateModified
+   */
+  public function __construct(
+    int $id,
+    string $name,
+    ?string $curationNotes,
+    bool $includeInReport,
+    int $memberCount,
+    string $dateCreated,
+    ?string $dateModified = null
+  ) {
+    $this->id              = $id;
+    $this->name            = $name;
+    $this->curationNotes   = $curationNotes;
+    $this->includeInReport = $includeInReport;
+    $this->memberCount     = $memberCount;
+    $this->dateCreated     = $dateCreated;
+    $this->dateModified    = $dateModified;
+  }
+
+  // ─── Getters ───────────────────────────────────────────────────────────────
+
+  /** @return int */
+  public function getId(): int { return $this->id; }
+
+  /** @return string */
+  public function getName(): string { return $this->name; }
+
+  /** @return string|null */
+  public function getCurationNotes(): ?string { return $this->curationNotes; }
+
+  /** @return bool */
+  public function isIncludeInReport(): bool { return $this->includeInReport; }
+
+  /** @return int */
+  public function getMemberCount(): int { return $this->memberCount; }
+
+  /** @return string */
+  public function getDateCreated(): string { return $this->dateCreated; }
+
+  /** @return string|null */
+  public function getDateModified(): ?string { return $this->dateModified; }
+
+  // ─── Serialization ─────────────────────────────────────────────────────────
+
+  /**
+   * Convert the model to a plain array suitable for JSON output.
+   * @return array
+   */
+  public function getArray(): array
+  {
+    return [
+      'id'              => $this->id,
+      'name'            => $this->name,
+      'curationNotes'   => $this->curationNotes,
+      'includeInReport' => $this->includeInReport,
+      'memberCount'     => $this->memberCount,
+      'dateCreated'     => $this->dateCreated,
+      'dateModified'    => $this->dateModified,
+    ];
+  }
+}

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -23,6 +23,7 @@ require_once dirname(__FILE__, 4) . "/lib/php/bootstrap.php";
 use Fossology\Lib\Util\TimingLogger;
 use Fossology\UI\Api\Controllers\AuthController;
 use Fossology\UI\Api\Controllers\BadRequestController;
+use Fossology\UI\Api\Controllers\FileGroupController;
 use Fossology\UI\Api\Controllers\ConfController;
 use Fossology\UI\Api\Controllers\CopyrightController;
 use Fossology\UI\Api\Controllers\CustomiseController;
@@ -276,6 +277,14 @@ $app->group('/uploads',
       $app->patch('/ipras/{hash:.*}', CopyrightController::class . ':restoreFileIpra');
       $app->put('/ipras/{hash:.*}', CopyrightController::class . ':updateFileIpra');
     });
+    ////////////////////////////FILE GROUPS/////////////////////
+    $app->get('/{id:\\d+}/filegroups', FileGroupController::class . ':getFileGroups');
+    $app->post('/{id:\\d+}/filegroups', FileGroupController::class . ':createFileGroup');
+    $app->patch('/{id:\\d+}/filegroups/{fgId:\\d+}', FileGroupController::class . ':updateFileGroup');
+    $app->delete('/{id:\\d+}/filegroups/{fgId:\\d+}', FileGroupController::class . ':deleteFileGroup');
+    $app->post('/{id:\\d+}/filegroups/{fgId:\\d+}/members', FileGroupController::class . ':addMembersToGroup');
+    $app->delete('/{id:\\d+}/filegroups/{fgId:\\d+}/members/{utId:\\d+}', FileGroupController::class . ':removeMemberFromGroup');
+    $app->get('/{id:\\d+}/filegroups/suggest', FileGroupController::class . ':suggestFileGroups');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -2877,3 +2877,58 @@
   $Schema["INHERITS"]["monk_ars"] = "ars_master";
   $Schema["INHERITS"]["spasht_ars"] = "ars_master";
   $Schema["INHERITS"]["license_candidate"] = "license_ref";
+
+  $Schema["TABLE"]["file_group"]["fg_pk"]["DESC"] = "";
+  $Schema["TABLE"]["file_group"]["fg_pk"]["ADD"] = "ALTER TABLE \"file_group\" ADD COLUMN \"fg_pk\" serial";
+  $Schema["TABLE"]["file_group"]["fg_pk"]["ALTER"] = "ALTER TABLE \"file_group\" ALTER COLUMN \"fg_pk\" SET NOT NULL, ALTER COLUMN \"fg_pk\" SET DEFAULT nextval('file_group_fg_pk_seq'::regclass)";
+
+  $Schema["TABLE"]["file_group"]["upload_fk"]["DESC"] = "COMMENT ON COLUMN \"file_group\".\"upload_fk\" IS 'Upload this group belongs to'";
+  $Schema["TABLE"]["file_group"]["upload_fk"]["ADD"] = "ALTER TABLE \"file_group\" ADD COLUMN \"upload_fk\" int8";
+  $Schema["TABLE"]["file_group"]["upload_fk"]["ALTER"] = "ALTER TABLE \"file_group\" ALTER COLUMN \"upload_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["file_group"]["group_fk"]["DESC"] = "COMMENT ON COLUMN \"file_group\".\"group_fk\" IS 'Owner group'";
+  $Schema["TABLE"]["file_group"]["group_fk"]["ADD"] = "ALTER TABLE \"file_group\" ADD COLUMN \"group_fk\" int4";
+  $Schema["TABLE"]["file_group"]["group_fk"]["ALTER"] = "ALTER TABLE \"file_group\" ALTER COLUMN \"group_fk\" DROP NOT NULL";
+
+  $Schema["TABLE"]["file_group"]["fg_name"]["DESC"] = "COMMENT ON COLUMN \"file_group\".\"fg_name\" IS 'Display name of the group'";
+  $Schema["TABLE"]["file_group"]["fg_name"]["ADD"] = "ALTER TABLE \"file_group\" ADD COLUMN \"fg_name\" text";
+  $Schema["TABLE"]["file_group"]["fg_name"]["ALTER"] = "ALTER TABLE \"file_group\" ALTER COLUMN \"fg_name\" SET NOT NULL";
+
+  $Schema["TABLE"]["file_group"]["user_fk"]["DESC"] = "COMMENT ON COLUMN \"file_group\".\"user_fk\" IS 'User who created this group'";
+  $Schema["TABLE"]["file_group"]["user_fk"]["ADD"] = "ALTER TABLE \"file_group\" ADD COLUMN \"user_fk\" int8";
+  $Schema["TABLE"]["file_group"]["user_fk"]["ALTER"] = "ALTER TABLE \"file_group\" ALTER COLUMN \"user_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["file_group"]["fg_curation_notes"]["DESC"] = "COMMENT ON COLUMN \"file_group\".\"fg_curation_notes\" IS 'Curation notes / metadata associated with this group'";
+  $Schema["TABLE"]["file_group"]["fg_curation_notes"]["ADD"] = "ALTER TABLE \"file_group\" ADD COLUMN \"fg_curation_notes\" text";
+  $Schema["TABLE"]["file_group"]["fg_curation_notes"]["ALTER"] = "ALTER TABLE \"file_group\" ALTER COLUMN \"fg_curation_notes\" DROP NOT NULL";
+
+  $Schema["TABLE"]["file_group"]["fg_include_in_report"]["DESC"] = "COMMENT ON COLUMN \"file_group\".\"fg_include_in_report\" IS 'Whether to include this group in generated reports'";
+  $Schema["TABLE"]["file_group"]["fg_include_in_report"]["ADD"] = "ALTER TABLE \"file_group\" ADD COLUMN \"fg_include_in_report\" bool DEFAULT true";
+  $Schema["TABLE"]["file_group"]["fg_include_in_report"]["ALTER"] = "ALTER TABLE \"file_group\" ALTER COLUMN \"fg_include_in_report\" SET NOT NULL, ALTER COLUMN \"fg_include_in_report\" SET DEFAULT true";
+
+  $Schema["TABLE"]["file_group"]["date_added"]["DESC"] = "COMMENT ON COLUMN \"file_group\".\"date_added\" IS 'Date when the group was created'";
+  $Schema["TABLE"]["file_group"]["date_added"]["ADD"] = "ALTER TABLE \"file_group\" ADD COLUMN \"date_added\" timestamptz DEFAULT now()";
+  $Schema["TABLE"]["file_group"]["date_added"]["ALTER"] = "ALTER TABLE \"file_group\" ALTER COLUMN \"date_added\" SET NOT NULL, ALTER COLUMN \"date_added\" SET DEFAULT now()";
+
+
+  $Schema["TABLE"]["file_group_member"]["fg_fk"]["DESC"] = "COMMENT ON COLUMN \"file_group_member\".\"fg_fk\" IS 'Foreign key to file_group'";
+  $Schema["TABLE"]["file_group_member"]["fg_fk"]["ADD"] = "ALTER TABLE \"file_group_member\" ADD COLUMN \"fg_fk\" int4";
+  $Schema["TABLE"]["file_group_member"]["fg_fk"]["ALTER"] = "ALTER TABLE \"file_group_member\" ALTER COLUMN \"fg_fk\" SET NOT NULL";
+
+  $Schema["TABLE"]["file_group_member"]["uploadtree_fk"]["DESC"] = "COMMENT ON COLUMN \"file_group_member\".\"uploadtree_fk\" IS 'Foreign key to uploadtree'";
+  $Schema["TABLE"]["file_group_member"]["uploadtree_fk"]["ADD"] = "ALTER TABLE \"file_group_member\" ADD COLUMN \"uploadtree_fk\" int4";
+  $Schema["TABLE"]["file_group_member"]["uploadtree_fk"]["ALTER"] = "ALTER TABLE \"file_group_member\" ALTER COLUMN \"uploadtree_fk\" SET NOT NULL";
+
+  $Schema["PK"]["file_group"] = "ALTER TABLE \"file_group\" ADD CONSTRAINT file_group_pkey PRIMARY KEY (fg_pk);";
+  $Schema["PK"]["file_group_member"] = "ALTER TABLE \"file_group_member\" ADD CONSTRAINT file_group_member_pkey PRIMARY KEY (fg_fk, uploadtree_fk);";
+
+  $Schema["FK"]["file_group"]["upload_fk"] = "ALTER TABLE \"file_group\" ADD CONSTRAINT file_group_upload_fk_fkey FOREIGN KEY (upload_fk) REFERENCES upload(upload_pk) ON DELETE CASCADE;";
+  $Schema["FK"]["file_group"]["user_fk"] = "ALTER TABLE \"file_group\" ADD CONSTRAINT file_group_user_fk_fkey FOREIGN KEY (user_fk) REFERENCES users(user_pk) ON DELETE SET NULL;";
+  $Schema["FK"]["file_group"]["group_fk"] = "ALTER TABLE \"file_group\" ADD CONSTRAINT file_group_group_fk_fkey FOREIGN KEY (group_fk) REFERENCES groups(group_pk) ON DELETE CASCADE;";
+  $Schema["FK"]["file_group_member"]["fg_fk"] = "ALTER TABLE \"file_group_member\" ADD CONSTRAINT file_group_member_fg_fk_fkey FOREIGN KEY (fg_fk) REFERENCES file_group(fg_pk) ON DELETE CASCADE;";
+
+  $Schema["INDEX"]["file_group"]["file_group_upload_fk_idx"] = "CREATE INDEX file_group_upload_fk_idx ON file_group USING btree (upload_fk);";
+  $Schema["INDEX"]["file_group"]["file_group_group_fk_idx"] = "CREATE INDEX file_group_group_fk_idx ON file_group USING btree (group_fk);";
+  $Schema["INDEX"]["file_group"]["file_group_upload_group_idx"] = "CREATE INDEX file_group_upload_group_idx ON file_group USING btree (upload_fk, group_fk);";
+  $Schema["INDEX"]["file_group_member"]["file_group_member_fg_fk_idx"] = "CREATE INDEX file_group_member_fg_fk_idx ON file_group_member USING btree (fg_fk);";
+  $Schema["INDEX"]["file_group_member"]["file_group_member_uploadtree_fk_idx"] = "CREATE INDEX file_group_member_uploadtree_fk_idx ON file_group_member USING btree (uploadtree_fk);";

--- a/src/www/ui/scripts/ui-file-groups.js
+++ b/src/www/ui/scripts/ui-file-groups.js
@@ -1,0 +1,181 @@
+/**
+ * SPDX-FileCopyrightText: © 2024 Fossology contributors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+/**
+ * Logic for File Grouping (Issue #2847)
+ */
+
+let currentSuggestions = [];
+
+/**
+ * Open the modal and load existing groups
+ */
+function openFileGroupModal() {
+    refreshGroups();
+    $('#suggestedGroupsContainer').hide();
+    $('#fileGroupModal').modal('show');
+}
+
+/**
+ * Fetch and display existing groups for the current upload
+ */
+function refreshGroups() {
+    let list = $('#fileGroupsList');
+    list.html('<tr><td colspan="5">Loading...</td></tr>');
+
+    $.getJSON(`api/v1/uploads/${uploadId}/filegroups`, function (data) {
+        list.empty();
+        if (data.length === 0) {
+            list.append('<tr><td colspan="5" class="text-center">No groups defined for this upload.</td></tr>');
+            return;
+        }
+        data.forEach(group => {
+            list.append(`
+                <tr id="group-row-${group.id}">
+                    <td><input type="text" class="form-control form-control-sm" value="${escapeHtml(group.name)}" onchange="updateGroup(${group.id}, {name: this.value})"></td>
+                    <td><input type="text" class="form-control form-control-sm" value="${escapeHtml(group.curationNotes || '')}" onchange="updateGroup(${group.id}, {curationNotes: this.value})"></td>
+                    <td class="text-center">
+                        <input type="checkbox" ${group.includeInReport ? 'checked' : ''} onchange="updateGroup(${group.id}, {includeInReport: this.checked})">
+                    </td>
+                    <td>${group.memberCount}</td>
+                    <td>
+                        <button class="btn btn-danger btn-sm" onclick="deleteGroup(${group.id})">Delete</button>
+                    </td>
+                </tr>
+            `);
+        });
+    }).fail(function () {
+        list.html('<tr><td colspan="5" class="text-danger">Failed to load groups.</td></tr>');
+    });
+}
+
+/**
+ * Fetch auto-suggestions for grouping files
+ */
+function suggestFileGroups() {
+    $('#suggestedGroupsContainer').show();
+    let list = $('#suggestedGroupsList');
+    list.html('<tr><td colspan="3">Searching for identical finding sets...</td></tr>');
+
+    $.getJSON(`api/v1/uploads/${uploadId}/filegroups/suggest`, function (data) {
+        currentSuggestions = data;
+        list.empty();
+        if (data.length === 0) {
+            list.append('<tr><td colspan="3" class="text-center">No new grouping suggestions found.</td></tr>');
+            return;
+        }
+        data.forEach((sugg, index) => {
+            let licenses = sugg.licenseSet && sugg.licenseSet.length > 0 ? sugg.licenseSet.join(', ') : '<i>No licenses</i>';
+            list.append(`
+                <tr>
+                    <td>${sugg.memberCount} files</td>
+                    <td>${licenses}</td>
+                    <td>
+                        <button class="btn btn-success btn-sm" onclick="createGroupFromSuggestion(${index})">
+                            Create Group
+                        </button>
+                    </td>
+                </tr>
+            `);
+        });
+    }).fail(function () {
+        list.html('<tr><td colspan="3" class="text-danger">Failed to get suggestions.</td></tr>');
+    });
+}
+
+/**
+ * Handle creation of a group from a suggestion
+ */
+function createGroupFromSuggestion(index) {
+    let sugg = currentSuggestions[index];
+    if (!sugg) return;
+
+    let licenses = sugg.licenseSet && sugg.licenseSet.length > 0 ? sugg.licenseSet.join(', ') : "no licenses";
+    let defaultName = "Group with " + licenses;
+    let name = prompt("Enter group name:", defaultName);
+
+    if (!name) return;
+
+    $.ajax({
+        url: `api/v1/uploads/${uploadId}/filegroups`,
+        method: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify({
+            name: name,
+            curationNotes: "Auto-suggested based on identical licenses: " + licenses,
+            includeInReport: true
+        }),
+        success: function (resp) {
+            let groupId = resp.message;
+            // Add members
+            $.ajax({
+                url: `api/v1/uploads/${uploadId}/filegroups/${groupId}/members`,
+                method: 'POST',
+                contentType: 'application/json',
+                data: JSON.stringify({ members: sugg.fileList }),
+                success: function () {
+                    refreshGroups();
+                    suggestFileGroups(); // Refresh suggestions to remove already grouped files
+                }
+            }).fail(function () {
+                alert("Group created but failed to add members.");
+                refreshGroups();
+            });
+        },
+        error: function (xhr) {
+            alert("Failed to create group: " + (xhr.responseJSON ? xhr.responseJSON.message : xhr.statusText));
+        }
+    });
+}
+
+/**
+ * Update group metadata
+ */
+function updateGroup(groupId, patch) {
+    $.ajax({
+        url: `api/v1/uploads/${uploadId}/filegroups/${groupId}`,
+        method: 'PATCH',
+        contentType: 'application/json',
+        data: JSON.stringify(patch),
+        error: function () {
+            alert("Failed to update group.");
+            refreshGroups();
+        }
+    });
+}
+
+/**
+ * Delete a group
+ */
+function deleteGroup(groupId) {
+    if (!confirm('Are you sure you want to delete this group? Files will be removed from the group but not deleted.')) {
+        return;
+    }
+
+    $.ajax({
+        url: `api/v1/uploads/${uploadId}/filegroups/${groupId}`,
+        method: 'DELETE',
+        success: function () {
+            refreshGroups(); // Assuming refreshGroups() is the correct function to call
+        },
+        error: function () {
+            alert("Failed to delete group.");
+        }
+    });
+}
+
+/**
+ * Simple HTML escape
+ */
+function escapeHtml(text) {
+    if (!text) return "";
+    return text
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}

--- a/src/www/ui/template/ui-clearing-view.html.twig
+++ b/src/www/ui/template/ui-clearing-view.html.twig
@@ -77,6 +77,7 @@
   <script src="scripts/legend.js" type="text/javascript"></script>
   <script src="scripts/tools.js" type="text/javascript"></script>
   <script src="scripts/ui-clearing-view_bulk.js" type="text/javascript"></script>
+  <script src="scripts/ui-file-groups.js" type="text/javascript"></script>
   <script type="text/javascript">{% include "ui-clearing-view.js.twig" %}</script>
   <script type="text/javascript">{% include "bulk-history.js.twig" %}</script>
   <script type="text/javascript">{% include "next-options.js.twig" %}</script>

--- a/src/www/ui/template/ui-clearing-view_rhs.html.twig
+++ b/src/www/ui/template/ui-clearing-view_rhs.html.twig
@@ -135,7 +135,11 @@
     &nbsp;
     <button type="button" data-toggle="modal" data-target="#ClearingHistoryDataModal" class="btn btn-default btn-sm" onclick="openClearingHistoryDataModal();">
       {{ 'Clearing History ...'| trans }}
-    </button><img src="images/info_16.png" data-toggle="tooltip" title="{{ 'View the clearing history for this file: The table will show which user added or removed license results for this particular file in order to create a clearing decision. Clearing decisions are created when the user clicks on the button "Submit" or on the go next and go previous buttons'|trans }}" alt="" class="info-bullet"/>
+    </button><img src="images/info_16.png" data-toggle="tooltip" title="{{ 'View the clearing history for this file'|trans }}" alt="" class="info-bullet"/>
+    &nbsp;
+    <button type="button" data-toggle="modal" data-target="#fileGroupModal" class="btn btn-default btn-sm" onclick="openFileGroupModal();">
+      {{ 'File Groups ...'| trans }}
+    </button><img src="images/info_16.png" data-toggle="tooltip" title="{{ 'Manage file groups for this upload'|trans }}" alt="" class="info-bullet"/>
     &nbsp;
     <br/>
     <span id="bulkIdResult" name="bulkIdResult"></span>
@@ -182,6 +186,7 @@
       </div>
     </div>
 
+      {% include 'ui-file-groups.html.twig' %}
       {% include 'ui-clearing-view_bulk.html.twig' %}
     </div>
   {% endif %}

--- a/src/www/ui/template/ui-file-groups.html.twig
+++ b/src/www/ui/template/ui-file-groups.html.twig
@@ -1,0 +1,71 @@
+{# SPDX-FileCopyrightText: © 2024 Fossology contributors
+
+   SPDX-License-Identifier: FSFAP
+#}
+
+<!-- The File Group Modal -->
+<div class="modal fade" id="fileGroupModal" tabindex="-1" role="dialog" aria-labelledby="fileGroupModalLabel" aria-hidden="true" data-backdrop="false">
+  <div class="modal-dialog modal-xl modal-dialog-centered">
+    <div class="modal-content">
+      <!-- Modal Header -->
+      <div class="modal-header">
+        <h4 class="modal-title">{{ 'Manage File Groups'|trans }}</h4>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <!-- Modal body -->
+      <div class="modal-body">
+        <div class="row mb-3">
+          <div class="col">
+            <button type="button" class="btn btn-primary btn-sm" onclick="suggestFileGroups();">
+              {{ 'Auto-suggest Groups'|trans }}
+            </button>
+            <img src="images/info_16.png" data-toggle="tooltip" title="{{ 'Look for files with identical license findings and suggest grouping them.'|trans }}" alt="" class="info-bullet"/>
+          </div>
+        </div>
+
+        <h5>{{ 'Existing Groups'|trans }}</h5>
+        <div class="table-responsive">
+          <table class="table table-sm table-striped" id="fileGroupsTable">
+            <thead>
+              <tr>
+                <th>{{ 'Name'|trans }}</th>
+                <th>{{ 'Notes'|trans }}</th>
+                <th>{{ 'Include in Report'|trans }}</th>
+                <th>{{ 'Files'|trans }}</th>
+                <th>{{ 'Actions'|trans }}</th>
+              </tr>
+            </thead>
+            <tbody id="fileGroupsList">
+              <!-- Content loaded via AJAX -->
+            </tbody>
+          </table>
+        </div>
+
+        <div id="suggestedGroupsContainer" style="display:none;">
+          <hr>
+          <h5>{{ 'Suggested Groups'|trans }}</h5>
+          <div class="table-responsive">
+            <table class="table table-sm table-striped" id="suggestedGroupsTable">
+              <thead>
+                <tr>
+                  <th>{{ 'Files'|trans }}</th>
+                  <th>{{ 'Identical Licenses'|trans }}</th>
+                  <th>{{ 'Action'|trans }}</th>
+                </tr>
+              </thead>
+              <tbody id="suggestedGroupsList">
+                <!-- Content loaded via AJAX -->
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <!-- Modal footer -->
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">{{ 'Close'|trans }}</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/www/ui/ui-clearing-view.php
+++ b/src/www/ui/ui-clearing-view.php
@@ -23,6 +23,7 @@ use Fossology\Lib\Data\DecisionTypes;
 use Fossology\Lib\Data\Highlight;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
 use Fossology\Lib\Proxy\ScanJobProxy;
+use Fossology\Lib\Dao\FileGroupDao;
 use Fossology\Lib\Proxy\UploadTreeProxy;
 use Fossology\Lib\UI\Component\MicroMenu;
 use Fossology\Lib\View\HighlightProcessor;
@@ -324,6 +325,11 @@ class ClearingView extends FO_Plugin
     $this->vars['tmpClearingType'] = $this->clearingDao->isDecisionCheck($uploadTreeId, $groupId, DecisionTypes::WIP);
     $this->vars['bulkHistory'] = $bulkHistory;
 
+    /** @var FileGroupDao $fileGroupDao */
+    $fileGroupDao = $container->get('dao.filegroup');
+    $this->vars['itemGroups'] = $fileGroupDao->getGroupsForItem($uploadTreeId);
+    $this->vars['allGroups'] = $fileGroupDao->getGroupsForUpload($uploadId, $groupId);
+
     $noLicenseUploadTreeView = new UploadTreeProxy($uploadId,
       array(UploadTreeProxy::OPT_SKIP_THESE => "noLicense",
         UploadTreeProxy::OPT_GROUP_ID => $groupId),
@@ -381,20 +387,44 @@ class ClearingView extends FO_Plugin
     $global = GetParm("globalDecision", PARM_STRING) === "on" ? 1 : 0;
     $uploadTreeTableName = $this->uploadDao->getUploadtreeTableName($lastItem);
     $itemBounds = $this->uploadDao->getItemTreeBounds($lastItem, $uploadTreeTableName);
+
+    $boundsToProcess = [];
+    global $container;
+    $fileGroupDao = $container->get('dao.filegroup');
+    if ($fileGroupDao) {
+      $uploadId = $itemBounds->getUploadId();
+      $groupRow = $fileGroupDao->getGroupForItem($lastItem, $uploadId);
+      if ($groupRow) {
+        $members = $fileGroupDao->getGroupMembers($groupRow['fg_pk'], $uploadTreeTableName);
+        foreach ($members as $m) {
+          $boundsToProcess[] = $this->uploadDao->getItemTreeBounds($m['uploadtree_fk'], $uploadTreeTableName);
+        }
+      }
+    }
+    if (empty($boundsToProcess)) {
+      $boundsToProcess[] = $itemBounds;
+    }
+
     if ($global) {
       $isDecisionWip = $this->clearingDao->isDecisionCheck($currentUploadtreeId, $groupId, DecisionTypes::WIP);
       $hasChangedClearingType = $this->clearingDao->isDecisionCheck($currentUploadtreeId, $groupId, '');
       if ($isDecisionWip) {
-        $this->clearingDecisionEventProcessor->makeDecisionFromLastEvents($itemBounds, $userId, $groupId, $type, $global);
+        foreach ($boundsToProcess as $b) {
+          $this->clearingDecisionEventProcessor->makeDecisionFromLastEvents($b, $userId, $groupId, $type, $global);
+        }
       } else if (empty($hasChangedClearingType['scope'])
              || ($hasChangedClearingType['decision_type'] != $type)
            ) {
-        $this->clearingDecisionEventProcessor->makeDecisionFromLastEvents($itemBounds, $userId, $groupId, $type, $global);
+        foreach ($boundsToProcess as $b) {
+          $this->clearingDecisionEventProcessor->makeDecisionFromLastEvents($b, $userId, $groupId, $type, $global);
+        }
       } else {
         return;
       }
     } else {
-      $this->clearingDecisionEventProcessor->makeDecisionFromLastEvents($itemBounds, $userId, $groupId, $type, $global);
+      foreach ($boundsToProcess as $b) {
+        $this->clearingDecisionEventProcessor->makeDecisionFromLastEvents($b, $userId, $groupId, $type, $global);
+      }
     }
   }
 

--- a/src/www/ui_tests/api/Controllers/FileGroupControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/FileGroupControllerTest.php
@@ -1,0 +1,415 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2024 Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for FileGroupController (Issue #2847)
+ */
+
+namespace Fossology\UI\Api\Test\Controllers;
+
+require_once dirname(__DIR__, 4) . '/lib/php/Plugin/FO_Plugin.php';
+
+use Fossology\Lib\Dao\FileGroupDao;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Db\DbManager;
+use Fossology\UI\Api\Controllers\FileGroupController;
+use Fossology\UI\Api\Exceptions\HttpBadRequestException;
+use Fossology\UI\Api\Exceptions\HttpForbiddenException;
+use Fossology\UI\Api\Exceptions\HttpNotFoundException;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Mockery as M;
+use Slim\Psr7\Factory\StreamFactory;
+use Slim\Psr7\Headers;
+use Slim\Psr7\Request;
+use Slim\Psr7\Uri;
+
+/**
+ * @class FileGroupControllerTest
+ * @brief PHPUnit tests for FileGroupController
+ */
+class FileGroupControllerTest extends \PHPUnit\Framework\TestCase
+{
+  /** @var integer $assertCountBefore */
+  private $assertCountBefore;
+
+  /** @var DbHelper|M\MockInterface $dbHelper */
+  private $dbHelper;
+
+  /** @var RestHelper|M\MockInterface $restHelper */
+  private $restHelper;
+
+  /** @var FileGroupDao|M\MockInterface $fileGroupDao */
+  private $fileGroupDao;
+
+  /** @var UploadDao|M\MockInterface $uploadDao */
+  private $uploadDao;
+
+  /** @var DbManager|M\MockInterface $dbManager */
+  private $dbManager;
+
+  /** @var FileGroupController $fileGroupController */
+  private $fileGroupController;
+
+  /** @var StreamFactory $streamFactory */
+  private $streamFactory;
+
+  // ── Fixtures ───────────────────────────────────────────────────────────────
+
+  private $uploadId   = 1;
+  private $groupId    = 2;
+  private $userId     = 3;
+  private $fgPk       = 10;
+  private $uploadtree = 100;
+
+  /**
+   * @brief Setup mocks before each test
+   */
+  protected function setUp(): void
+  {
+    global $container;
+    $container = M::mock('ContainerBuilder');
+
+    $this->dbHelper      = M::mock(DbHelper::class);
+    $this->restHelper    = M::mock(RestHelper::class);
+    $this->fileGroupDao  = M::mock(FileGroupDao::class);
+    $this->uploadDao     = M::mock(UploadDao::class);
+    $this->dbManager     = M::mock(DbManager::class);
+    $this->streamFactory = new StreamFactory();
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+    $this->dbHelper->shouldReceive('getDbManager')->andReturn($this->dbManager);
+
+    $container->shouldReceive('get')
+      ->withArgs(['helper.restHelper'])->andReturn($this->restHelper);
+    $container->shouldReceive('get')
+      ->withArgs(['dao.filegroup'])->andReturn($this->fileGroupDao);
+    $container->shouldReceive('get')
+      ->withArgs(['dao.upload'])->andReturn($this->uploadDao);
+
+    $this->fileGroupController = new FileGroupController($container);
+    $this->assertCountBefore   = \Hamcrest\MatcherAssert::getCount();
+  }
+
+  /** @brief Tear down mocks after each test */
+  protected function tearDown(): void
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore
+    );
+    M::close();
+  }
+
+  /**
+   * Build a Slim Request with optional JSON body.
+   */
+  private function makeRequest(string $method = 'GET', ?array $body = null): Request
+  {
+    $headers = new Headers();
+    if ($body !== null) {
+      $headers->setHeader('Content-Type', 'application/json');
+      $stream = $this->streamFactory->createStream(json_encode($body));
+    } else {
+      $stream = $this->streamFactory->createStream('');
+    }
+    return new Request($method, new Uri('HTTP', 'localhost'), $headers, [], [], $stream);
+  }
+
+  /** Helper: read JSON from a response */
+  private function getResponseJson(ResponseHelper $response): array
+  {
+    $response->getBody()->seek(0);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+
+  // ── getGroups ──────────────────────────────────────────────────────────────
+
+  /**
+   * @test
+   * GET /uploads/{id}/filegroups → 200 with an array of groups
+   */
+  public function testGetGroupsReturnsGroupList(): void
+  {
+    $rows = [
+      [
+        'fg_pk'              => $this->fgPk,
+        'fg_name'            => 'MIT group',
+        'fg_curation_notes'  => 'All good',
+        'fg_include_in_report' => 't',
+        'member_count'       => '3',
+        'date_created'       => '2024-01-01T00:00:00+00:00',
+        'date_modified'      => null,
+      ]
+    ];
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(['upload', 'upload_pk', $this->uploadId])->andReturn(true);
+    $this->restHelper->shouldReceive('getGroupId')->andReturn($this->groupId);
+    $this->fileGroupDao->shouldReceive('getGroupsForUpload')
+      ->withArgs([$this->uploadId, $this->groupId])->andReturn($rows);
+    $this->dbManager->shouldReceive('booleanFromDb')->with('t')->andReturn(true);
+
+    $actualResponse = $this->fileGroupController->getGroups(
+      $this->makeRequest(), new ResponseHelper(), ['id' => $this->uploadId]
+    );
+
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+    $body = $this->getResponseJson($actualResponse);
+    $this->assertIsArray($body);
+    $this->assertCount(1, $body);
+    $this->assertEquals('MIT group', $body[0]['name']);
+  }
+
+  // ── createGroup ────────────────────────────────────────────────────────────
+
+  /**
+   * @test
+   * POST /uploads/{id}/filegroups → 201 with new group id
+   */
+  public function testCreateGroupReturns201(): void
+  {
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(['upload', 'upload_pk', $this->uploadId])->andReturn(true);
+    $this->restHelper->shouldReceive('getGroupId')->andReturn($this->groupId);
+    $this->restHelper->shouldReceive('getUserId')->andReturn($this->userId);
+    $this->dbManager->shouldReceive('booleanToDb')->with(true)->andReturn('t');
+    $this->dbManager->shouldReceive('prepare')->once();
+    $this->dbManager->shouldReceive('execute')
+      ->andReturn('result');
+    $this->dbManager->shouldReceive('fetchArray')
+      ->andReturn(['fg_pk' => $this->fgPk]);
+    $this->dbManager->shouldReceive('freeResult')->once();
+
+    $request = $this->makeRequest('POST', [
+      'name'            => 'GPL group',
+      'curationNotes'   => 'Verified',
+      'includeInReport' => true,
+    ]);
+
+    $actualResponse = $this->fileGroupController->createGroup(
+      $request, new ResponseHelper(), ['id' => $this->uploadId]
+    );
+
+    $this->assertEquals(201, $actualResponse->getStatusCode());
+    $body = $this->getResponseJson($actualResponse);
+    $this->assertEquals($this->fgPk, $body['message']);
+  }
+
+  /**
+   * @test
+   * POST /uploads/{id}/filegroups without 'name' → 400
+   */
+  public function testCreateGroupWithoutNameThrows400(): void
+  {
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(['upload', 'upload_pk', $this->uploadId])->andReturn(true);
+
+    $request = $this->makeRequest('POST', ['curationNotes' => 'no name']);
+
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->fileGroupController->createGroup(
+      $request, new ResponseHelper(), ['id' => $this->uploadId]
+    );
+  }
+
+  // ── updateGroup ────────────────────────────────────────────────────────────
+
+  /**
+   * @test
+   * PATCH /uploads/{id}/filegroups/{fgId} → 200 on success
+   */
+  public function testUpdateGroupReturns200(): void
+  {
+    $groupRow = [
+      'fg_pk'    => $this->fgPk,
+      'upload_fk' => $this->uploadId,
+      'group_fk'  => $this->groupId,
+    ];
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(['upload', 'upload_pk', $this->uploadId])->andReturn(true);
+    $this->fileGroupDao->shouldReceive('getGroupById')
+      ->withArgs([$this->fgPk])->andReturn($groupRow);
+    $this->restHelper->shouldReceive('getGroupId')->andReturn($this->groupId);
+    $this->fileGroupDao->shouldReceive('updateGroup')
+      ->withArgs([$this->fgPk, 'New name', null, null])->once();
+
+    $request = $this->makeRequest('PATCH', ['name' => 'New name']);
+
+    $actualResponse = $this->fileGroupController->updateGroup(
+      $request, new ResponseHelper(),
+      ['id' => $this->uploadId, 'fgId' => $this->fgPk]
+    );
+
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+  }
+
+  // ── deleteGroup ────────────────────────────────────────────────────────────
+
+  /**
+   * @test
+   * DELETE /uploads/{id}/filegroups/{fgId} → 200
+   */
+  public function testDeleteGroupReturns200(): void
+  {
+    $groupRow = [
+      'fg_pk'    => $this->fgPk,
+      'upload_fk' => $this->uploadId,
+      'group_fk'  => $this->groupId,
+    ];
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(['upload', 'upload_pk', $this->uploadId])->andReturn(true);
+    $this->fileGroupDao->shouldReceive('getGroupById')
+      ->withArgs([$this->fgPk])->andReturn($groupRow);
+    $this->restHelper->shouldReceive('getGroupId')->andReturn($this->groupId);
+    $this->fileGroupDao->shouldReceive('deleteGroup')
+      ->withArgs([$this->fgPk])->once();
+
+    $actualResponse = $this->fileGroupController->deleteGroup(
+      $this->makeRequest('DELETE'), new ResponseHelper(),
+      ['id' => $this->uploadId, 'fgId' => $this->fgPk]
+    );
+
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+  }
+
+  /**
+   * @test
+   * DELETE with wrong group ownership → 403
+   */
+  public function testDeleteGroupThrows403WhenWrongOwner(): void
+  {
+    $groupRow = [
+      'fg_pk'    => $this->fgPk,
+      'upload_fk' => $this->uploadId,
+      'group_fk'  => 999, // different group
+    ];
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(['upload', 'upload_pk', $this->uploadId])->andReturn(true);
+    $this->fileGroupDao->shouldReceive('getGroupById')
+      ->withArgs([$this->fgPk])->andReturn($groupRow);
+    $this->restHelper->shouldReceive('getGroupId')->andReturn($this->groupId);
+
+    $this->expectException(HttpForbiddenException::class);
+
+    $this->fileGroupController->deleteGroup(
+      $this->makeRequest('DELETE'), new ResponseHelper(),
+      ['id' => $this->uploadId, 'fgId' => $this->fgPk]
+    );
+  }
+
+  // ── addMembers ─────────────────────────────────────────────────────────────
+
+  /**
+   * @test
+   * POST .../members → 200 with count message
+   */
+  public function testAddMembersReturns200(): void
+  {
+    $groupRow = [
+      'fg_pk' => $this->fgPk, 'upload_fk' => $this->uploadId,
+      'group_fk' => $this->groupId,
+    ];
+    $members  = [101, 102, 103];
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(['upload', 'upload_pk', $this->uploadId])->andReturn(true);
+    $this->fileGroupDao->shouldReceive('getGroupById')
+      ->withArgs([$this->fgPk])->andReturn($groupRow);
+    $this->restHelper->shouldReceive('getGroupId')->andReturn($this->groupId);
+    $this->fileGroupDao->shouldReceive('addMembers')
+      ->withArgs([$this->fgPk, $members])->once();
+
+    $request = $this->makeRequest('POST', ['members' => $members]);
+
+    $actualResponse = $this->fileGroupController->addMembers(
+      $request, new ResponseHelper(),
+      ['id' => $this->uploadId, 'fgId' => $this->fgPk]
+    );
+
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+  }
+
+  /**
+   * @test
+   * POST .../members without 'members' key → 400
+   */
+  public function testAddMembersWithoutMembersKeyThrows400(): void
+  {
+    $groupRow = [
+      'fg_pk' => $this->fgPk, 'upload_fk' => $this->uploadId,
+      'group_fk' => $this->groupId,
+    ];
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(['upload', 'upload_pk', $this->uploadId])->andReturn(true);
+    $this->fileGroupDao->shouldReceive('getGroupById')
+      ->withArgs([$this->fgPk])->andReturn($groupRow);
+    $this->restHelper->shouldReceive('getGroupId')->andReturn($this->groupId);
+
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->fileGroupController->addMembers(
+      $this->makeRequest('POST'), new ResponseHelper(),
+      ['id' => $this->uploadId, 'fgId' => $this->fgPk]
+    );
+  }
+
+  // ── suggestGroups ──────────────────────────────────────────────────────────
+
+  /**
+   * @test
+   * GET .../suggest → 200 with candidate list
+   */
+  public function testSuggestGroupsReturns200(): void
+  {
+    $suggestions = [
+      ['file_list' => '{101,102}', 'license_set' => '{5,7}', 'member_count' => '2'],
+    ];
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(['upload', 'upload_pk', $this->uploadId])->andReturn(true);
+    $this->uploadDao->shouldReceive('getUploadtreeTableName')
+      ->withArgs([$this->uploadId])->andReturn('uploadtree_a');
+    $this->fileGroupDao->shouldReceive('suggestGroups')
+      ->withArgs([$this->uploadId, 'uploadtree_a'])->andReturn($suggestions);
+
+    $actualResponse = $this->fileGroupController->suggestGroups(
+      $this->makeRequest(), new ResponseHelper(), ['id' => $this->uploadId]
+    );
+
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+    $body = $this->getResponseJson($actualResponse);
+    $this->assertCount(1, $body);
+    $this->assertEquals([101, 102], $body[0]['fileList']);
+    $this->assertEquals([5, 7],    $body[0]['licenseSet']);
+    $this->assertEquals(2,         $body[0]['memberCount']);
+  }
+
+  /**
+   * @test
+   * GET .../suggest on non-existent upload → 404
+   */
+  public function testSuggestGroupsThrows404(): void
+  {
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(['upload', 'upload_pk', 9999])->andReturn(false);
+
+    $this->expectException(HttpNotFoundException::class);
+
+    $this->fileGroupController->suggestGroups(
+      $this->makeRequest(), new ResponseHelper(), ['id' => 9999]
+    );
+  }
+}


### PR DESCRIPTION
@andreaskotulla @shaheemazmalmmd 

Fixes #2847

### Description
This PR introduces the ability to group multiple files that share the same license and copyright information, reducing repetitive clearing work and decluttering reports.

### Key Features Implemented:
* **Group Management:** Users can logically group files together, assign a custom name to the group, and add specific curation notes.
* **Bulk Clearing (License Association):** When you make a clearing decision on any file within a group, that decision is automatically applied to all other files in the same group.
* **Report Exclusion:** Each group has an `Include in Report` checkbox. If unchecked, the files in that group will be excluded from the final generated reports.
* **Auto-Suggest Groups:** Added a helper button in the UI that scans for files with identical license findings and suggests them as a group.

### Changes Included:
* **Database:** Added [FileGroupDao](cci:2://file:///c:/Users/Z005809Z/Desktop/fosso/fossology/src/lib/php/Dao/FileGroupDao.php:25:0-317:1) and [core-schema.dat](cci:7://file:///c:/Users/Z005809Z/Desktop/fosso/fossology/src/www/ui/core-schema.dat:0:0-0:0) updates to store group metadata.
* **Backend:** Created [FileGroupController.php](cci:7://file:///c:/Users/Z005809Z/Desktop/fosso/fossology/src/www/ui/api/Controllers/FileGroupController.php:0:0-0:0) REST endpoints for CRUD operations on file groups.
* **UI:** Added a new "File Groups ..." button and management modal to the Clearing View ([ui-clearing-view.php](cci:7://file:///c:/Users/Z005809Z/Desktop/fosso/fossology/src/www/ui/ui-clearing-view.php:0:0-0:0)).
* **Logic:** Hooked into [updateLastItem](cci:1://file:///c:/Users/Z005809Z/Desktop/fosso/fossology/src/www/ui/ui-clearing-view.php:376:2-428:3) to automatically apply clearing decisions to all group members. Updated `ReportUtils.php` to handle the report exclusion logic.



