### PR TITLE
fix(cli): prevent crashes in fo_nomos_license_list when scanner results are missing

### DIFF
--- a/src/cli/fo_nomos_license_list.php
+++ b/src/cli/fo_nomos_license_list.php
@@ -141,10 +141,12 @@ function GetLicenseList($uploadtree_pk, $upload_pk, $showContainer, $excluding, 
 
   /* get last nomos agent_pk that has data for this upload */
   $AgentRec = AgentARSList("nomos_ars", $upload_pk, 1);
-  if ($AgentRec === false) {
-    echo _("No data available\n");
+
+  if (empty($AgentRec) || !isset($AgentRec[0]["agent_fk"])) {
+    echo _("No nomos scan results available\n");
     return;
   }
+
   $agent_pk = $AgentRec[0]["agent_fk"];
 
   $uploadtreeTablename = getUploadtreeTableName($upload_pk);
@@ -206,6 +208,12 @@ function GetCopyrightList($uploadtree_pk, $upload_pk, $exclude, $ignore)
   $scanJobProxy = new ScanJobProxy($GLOBALS['container']->get('dao.agent'), $upload_pk);
   $scanJobProxy->createAgentStatus([$agentName]);
   $selectedScanners = $scanJobProxy->getLatestSuccessfulAgentIds();
+
+  if (!isset($selectedScanners[$agentName])) {
+    echo _("No copyright scan results available\n");
+    return;
+  }
+
   $latestAgentId = $selectedScanners[$agentName];
   $agentFilter = ' AND C.agent_fk='.$latestAgentId;
   $uploadtreeTablename = getUploadtreeTableName($upload_pk);


### PR DESCRIPTION
### Summary

`fo_nomos_license_list` assumes that scanner results always exist for the given upload. When scanner results are missing, the CLI throws PHP warnings or generates invalid SQL queries.

This patch adds defensive checks to handle these situations gracefully.

### Changes

* Added validation when retrieving **Nomos agent results**.
* Added validation when retrieving **Copyright agent results**.
* If scanner results are missing, the CLI now prints a user-friendly message instead of crashing.

### Example behaviour

Before:

```
PHP Warning: Undefined array key 0
Trying to access array offset on value of type null
```

After:

```
No nomos scan results available
```

### Testing

Tested locally using the FOSSology Docker setup:

* Ran `fo_nomos_license_list` with missing Nomos results.
* Ran `fo_nomos_license_list --type copyright` without copyright scanner data.

Both commands now fail gracefully without warnings or SQL errors.
