### PR TITLE
fix(php): correct logic errors and resource handling in common utiliy files

### DIFF
--- a/src/lib/php/common-agents.php
+++ b/src/lib/php/common-agents.php
@@ -233,7 +233,7 @@ function GetAgentKey($agentName, $agentDesc)
   if (pg_num_rows($result) == 0) {
     /* no match, so add an agent rec */
     $sql = "INSERT INTO agent (agent_name,agent_desc,agent_enabled) VALUES ('$agentName',E'$agentDesc',1)";
-    $result = pg_query($PG_CONN, $sqlselect);
+    $result = pg_query($PG_CONN, $sql);
     DBCheckResult($result, $sql, __FILE__, __LINE__);
 
     /* get inserted agent_pk */

--- a/src/lib/php/common-cache.php
+++ b/src/lib/php/common-cache.php
@@ -56,7 +56,7 @@ function ReportCacheGet($CacheKey)
     DBCheckResult($result, $sql, __FILE__, __LINE__);
     $row = pg_fetch_assoc($result);
     pg_free_result($result);
-    if (! empty($row['cache_on']) && ($result['cache_on'] == 'N')) {
+    if (! empty($row['cache_on']) && ($row['cache_on'] == 'N')) {
       $UserCacheStat = 2;
       return; /* cache is off for this user */
     }

--- a/src/lib/php/common-cli.php
+++ b/src/lib/php/common-cli.php
@@ -68,7 +68,7 @@ function cli_logger($handle, $message, $mode='a')
   $wrote = fwrite ($FR, $message);
   fflush($FR);
   fclose($FR);
-  if ($wrote == -1) {
+  if ($wrote === false) {
     $text = _("ERROR: could not write message to");
     return "$text $handle\n";
   }

--- a/src/lib/php/common-compare.php
+++ b/src/lib/php/common-compare.php
@@ -316,7 +316,7 @@ function FuzzyName(&$Children)
     $NoNumbName = preg_replace('/([0-9]|\.|-|_)/', "", $NoExtName);
     $NoNumbNameext = preg_replace('/([0-9]|\.|-|_)/', "", $Child['ufile_name']);
     $Child['fuzzyname'] = $NoNumbName;
-    $Child['fuzzynameext'] = $NoNumbName;
+    $Child['fuzzynameext'] = $NoNumbNameext;
   }
 
   return;

--- a/src/lib/php/common-db.php
+++ b/src/lib/php/common-db.php
@@ -131,6 +131,7 @@ function DB2KeyValArray($Table, $KeyCol, $ValCol, $Where="")
   while ($row = pg_fetch_assoc($result)) {
     $ResArray[$row[$KeyCol]] = $row[$ValCol];
   }
+  pg_free_result($result);
   return $ResArray;
 }
 
@@ -169,6 +170,7 @@ function DB2ValArray($Table, $ValCol, $Uniq=false, $Where="")
     $ResArray[$i] = $row[$ValCol];
     ++ $i;
   }
+  pg_free_result($result);
   return $ResArray;
 }
 

--- a/src/lib/php/common-folders.php
+++ b/src/lib/php/common-folders.php
@@ -435,7 +435,7 @@ function FolderListUploadsRecurse($ParentFolder=-1, $FolderPath = '',
   if (empty($ParentFolder)) {
     return array();
   }
-  if ($perm != Auth::PERM_READ && $perm = Auth::PERM_WRITE) {
+  if ($perm != Auth::PERM_READ && $perm != Auth::PERM_WRITE) {
     return array();
   }
   if ($ParentFolder == "-1") {

--- a/src/lib/php/common-menu.php
+++ b/src/lib/php/common-menu.php
@@ -162,7 +162,6 @@ function menu_cmp($a, $b)
   if ($a->Order < $b->Order) {
     return (1);
   }
-  $rc = strcmp($a->Name, $b->Name);
   return (strcmp($a->Name, $b->Name));
 } // menu_cmp()
 


### PR DESCRIPTION


<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description
This PR fixes multiple logic and resource handling issues found in the PHP utility files under `src/lib/php`. These issues include incorrect variable usage, improper error checking, missing resource cleanup, and redundant conditions that could lead to incorrect behavior.

### Changes
- `common-agents.php` Execute `$sql` instead of `$sqlselect` so that a new agent record is created correctly.
- `common-cache.php` Use `$row['cache_on']` instead of `$result['cache_on']` when checking the cache status.
- `common-cli.php` Update `fwrite()` failure check to `$wrote === false` since `fwrite()` returns number of bytes written or `false` on failure. But currently it checks for `-1`.
- `common-compare.php` Correct assignment to `$Child['fuzzynameext'] = $NoNumbNameext`.
- `common-db.php` Add missing `pg_free_result()` calls in `DB2KeyValArray()` and `DB2ValArray()` to properly release PostgreSQL query result resources.
- `common-folder.php` Fix permission check logic by adding the missing `!` in `$perm != Auth::PERM_WRITE`.
- `common-menu.php` Remove redundant condition to simplify the logic.

CC: @shaheemazmalmmd @Kaushl2208 