### PR TITLE
fix(nomos): prevent command buffer overflow in mySystem

### DIFF
--- a/src/nomos/agent/util.c
+++ b/src/nomos/agent/util.c
@@ -32,7 +32,7 @@ static char grepzone[10485760]; /* 10M for now, adjust if needed */
 static va_list ap;
 static char utilbuf[myBUFSIZ];
 static struct mm_cache mmap_data[MM_CACHESIZE];
-static char cmdBuf[512];
+static char cmdBuf[PATH_MAX * 2 + 256];
 
 
 #ifdef MEMORY_TRACING
@@ -1298,14 +1298,20 @@ void appendFile(char *pathname, char *str)
  * \brief Run a system command
  * \param fmt The command to run along with parameters
  * \note The function will log errors if and error occurs
- * \return The return code from the command.
+ * \return The return code from the command or -1 if the command was truncated.
  */
-int mySystem(const char *fmt, ...)
-{
+int mySystem(const char *fmt, ...) {
   int ret;
+  int len;
   va_start(ap, fmt);
-  (void) vsprintf(cmdBuf, fmt, ap);
+  len = vsnprintf(cmdBuf, sizeof(cmdBuf), fmt, ap);
   va_end(ap);
+
+  if(len < 0 || (size_t)len >= sizeof(cmdBuf)) {
+    LOG_ERROR("mySystem: command truncated (%d bytes needed, buffer is %zu bytes)",
+              len, sizeof(cmdBuf));
+    return -1;
+  }
 
 #if defined(PROC_TRACE) || defined(UNPACK_DEBUG)
   traceFunc("== mySystem('%s')\n", cmdBuf);


### PR DESCRIPTION

## Description

An overflow could occur when formatting shell commands with long file paths, potentially leading to memory corruption and arbitrary code execution.

### Changes

- Increased the size of the static command buffer (`cmdBuf`) to safely accommodate long file paths and command strings.
- Replaced unsafe `vsprintf` with `vsnprintf` for secure formatting, adding bounds checking to prevent buffer overflow.
- Added error handling to log and return an error if the command is truncated due to buffer limits.