### PR TITLE
fix(wget): send periodic heartbeats during long-running wget operations

### DIFF
--- a/src/wget_agent/agent/CMakeLists.txt
+++ b/src/wget_agent/agent/CMakeLists.txt
@@ -32,13 +32,13 @@ foreach(FO_WGET_TARGET wget_agent wget_agent_exec wget_agent_cov)
     )
     if(${FO_WGET_TARGET} STREQUAL "wget_agent_exec")
         target_link_libraries(${FO_WGET_TARGET}
-            PRIVATE fossology wget_agent gcrypt checksum)
+            PRIVATE fossology wget_agent gcrypt checksum pthread)
         set_target_properties(${FO_WGET_TARGET}
             PROPERTIES OUTPUT_NAME wget_agent)
         set(WGET_XSRC "main.c")
     else()
         target_link_libraries(${FO_WGET_TARGET}
-            PRIVATE fossology gcrypt checksum)
+            PRIVATE fossology gcrypt checksum pthread)
         set(WGET_XSRC "")
     endif()
     target_sources(${FO_WGET_TARGET}

--- a/src/wget_agent/agent/wget_agent.c
+++ b/src/wget_agent/agent/wget_agent.c
@@ -16,6 +16,9 @@
 #define ASPRINTF_MEM_ERROR_LOG LOG_FATAL("Not enough memory for asprintf before line %d", __LINE__)
 
 #include "wget_agent.h"
+#include <pthread.h>
+#include <signal.h>
+#include <time.h>
 
 char SQL[STRMAX];
 
@@ -29,6 +32,63 @@ char *GlobalProxy[6];         ///< Proxy from fossology.conf
 char GlobalHttpProxy[STRMAX]; ///< HTTP proxy command to use
 int GlobalImportGold=1;       ///< Set to 0 to not store file in gold repository
 gid_t ForceGroup=-1;          ///< Set to group id to be used for download files
+
+/* Heartbeat monitoring variables */
+static volatile sig_atomic_t heartbeat_active = 0;
+static pthread_t heartbeat_thread;
+static pthread_mutex_t heartbeat_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+/**
+ * \brief Heartbeat monitoring thread function
+ * \param arg Unused parameter
+ * \return NULL
+ */
+static void* heartbeat_monitor(void* arg)
+{
+  (void)arg;  /* Suppress unused parameter warning */
+  
+  while(heartbeat_active)
+  {
+    sleep(30);  /* Send heartbeat every 30 seconds */
+    if (heartbeat_active)
+    {
+      fo_scheduler_heart(0);  /* Send heartbeat without incrementing item count */
+    }
+  }
+  return NULL;
+}
+
+/**
+ * \brief Start heartbeat monitoring
+ */
+static void start_heartbeat_monitoring()
+{
+  pthread_mutex_lock(&heartbeat_mutex);
+  if (!heartbeat_active)
+  {
+    heartbeat_active = 1;
+    if (pthread_create(&heartbeat_thread, NULL, heartbeat_monitor, NULL) != 0)
+    {
+      LOG_ERROR("Failed to create heartbeat monitoring thread");
+      heartbeat_active = 0;
+    }
+  }
+  pthread_mutex_unlock(&heartbeat_mutex);
+}
+
+/**
+ * \brief Stop heartbeat monitoring
+ */
+static void stop_heartbeat_monitoring()
+{
+  pthread_mutex_lock(&heartbeat_mutex);
+  if (heartbeat_active)
+  {
+    heartbeat_active = 0;
+    pthread_join(heartbeat_thread, NULL);
+  }
+  pthread_mutex_unlock(&heartbeat_mutex);
+}
 
 /**
  * \brief Given a filename, is it a file?
@@ -425,7 +485,11 @@ int GetURL(char *TempFile, char *URL, char *TempFileDir)
      'http://a.org/file' -l 1 -R index.html*  2>&1"
    */
   LOG_VERBOSE0("CMD: %s", cmd);
+  
+  /* Start heartbeat monitoring for the long-running wget operation */
+  start_heartbeat_monitoring();
   rc = system(cmd);
+  stop_heartbeat_monitoring();
 
   if (WIFEXITED(rc) && (WEXITSTATUS(rc) != 0))
   {
@@ -499,7 +563,10 @@ int GetURL(char *TempFile, char *URL, char *TempFileDir)
 
       free(tmpfile_path);
 
+      /* Start heartbeat monitoring for the potentially long-running tar/mv operation */
+      start_heartbeat_monitoring();
       rc_system = system(cmd);
+      stop_heartbeat_monitoring();
       if (rc_system != 0)
       {
         systemError(__LINE__, rc_system, cmd)
@@ -612,7 +679,11 @@ int GetVersionControl()
     free(tmp_file_directory);
     return ASPRINTF_MEM_ERROR;
   }
+  
+  /* Start heartbeat monitoring for the long-running version control operation */
+  start_heartbeat_monitoring();
   rc = system(command);
+  stop_heartbeat_monitoring();
   free(command);
 
   if (resethome) // rollback
@@ -653,7 +724,11 @@ int GetVersionControl()
     return ASPRINTF_MEM_ERROR;
   }
   free(tmp_file_directory);
+  
+  /* Start heartbeat monitoring for the potentially long-running tar operation */
+  start_heartbeat_monitoring();
   rc = system(command);
+  stop_heartbeat_monitoring();
   if (rc != 0)
   {
     systemError(__LINE__, rc, command)

--- a/src/wget_agent/wget_agent.conf
+++ b/src/wget_agent/wget_agent.conf
@@ -21,5 +21,4 @@ max = -1
 ; Directives:
 ;     NOKILL: do not kill the agent if it isn't sending status updates
 ;     LOCAL:  only run the agent on the same computer as the scheduler
-special[] = NOKILL
 special[] = 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

The wget agent previously relied on the `NOKILL` special tag to prevent the scheduler from terminating it during long downloads. This PR removes the `NOKILL` workaround and introduces periodic heartbeats so the scheduler can detect that the agent is still active during long-running operations. 

closes: #64 
## Changes

1. Added the following functions:

   - `heartbeat_monitor()` – Background thread that sends scheduler heartbeats every 30 seconds.
   - `start_heartbeat_monitoring()` – Safely starts the monitoring thread before long-running operations.
   - `stop_heartbeat_monitoring()` – Stops the monitoring thread after the operation completes.

2. Added heartbeat monitoring around long-running operations such as:
   - wget downloads
   - tar/mv operations
   - tar operations in **GetVersionControl**

3. Updated `CMakeLists.txt` to link the agent with the `pthread` library.

4. Removed the `NOKILL` special option from `wget_agent.conf`.

## How To Test
1. Tested the download of CentOS iso file ~14 GB
``` bash
https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-latest-x86_64-dvd1.iso
```
<img width="1298" height="600" alt="Screenshot 2026-03-08 221124" src="https://github.com/user-attachments/assets/af013651-360c-4262-b799-6a23886cb268" />

The wget agent runs correctly even for long-running downloads.

2. Tested the download 500mb.bin ~500mb

```bash
https://mirror.nforce.com/pub/speedtests/500mb.bin
```

CC: @shaheemazmalmmd 
