### PR TITLE
fix(api): support analysisFile in one-shot uploads

### DIFF
--- a/src/www/ui/api/Controllers/OneShotController.php
+++ b/src/www/ui/api/Controllers/OneShotController.php
@@ -18,6 +18,7 @@ use Fossology\Lib\View\HighlightProcessor;
 use Fossology\UI\Api\Models\OneShot;
 use Fossology\UI\Api\Helper\ResponseHelper;
 use Fossology\UI\Api\Exceptions\HttpBadRequestException;
+use Fossology\UI\Api\Exceptions\HttpPayloadTooLargeException;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -27,6 +28,7 @@ use Psr\Http\Message\ServerRequestInterface;
 class OneShotController extends RestController
 {
   const FILE_INPUT_NAME = 'fileInput';
+  const ALT_FILE_INPUT_NAME = 'analysisFile';
 
   /** @var HighlightProcessor */
   private $highlightProcessor;
@@ -52,14 +54,7 @@ class OneShotController extends RestController
    */
   public function runOneShotNomos($request, $response, $args)
   {
-    $symReq = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
-    $uploadedFile = $symReq->files->get($this::FILE_INPUT_NAME, null);
-    if (is_null($uploadedFile)) {
-      throw new HttpBadRequestException("No file uploaded");
-    }
-    if ($uploadedFile->getError() !== UPLOAD_ERR_OK) {
-      throw new HttpBadRequestException("Error uploading file");
-    }
+    $uploadedFile = $this->getUploadedFileOrThrow();
     list($licenses, $highlightInfoKeywords, $highlightInfoLicenses) = $this->restHelper->getPlugin('agent_nomos_once')->
       AnalyzeFile($uploadedFile->getPathname(), true);
 
@@ -96,14 +91,7 @@ class OneShotController extends RestController
    */
   public function runOneShotMonk($request, $response, $args)
   {
-    $symReq = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
-    $uploadedFile = $symReq->files->get($this::FILE_INPUT_NAME, null);
-    if (is_null($uploadedFile)) {
-      throw new HttpBadRequestException("No file uploaded");
-    }
-    if ($uploadedFile->getError() !== UPLOAD_ERR_OK) {
-      throw new HttpBadRequestException("Error uploading file");
-    }
+    $uploadedFile = $this->getUploadedFileOrThrow();
 
     list($licenseIds, $highlights) = $this->restHelper->getPlugin('oneshot-monk')->
       scanMonk($uploadedFile->getPathname());
@@ -127,18 +115,56 @@ class OneShotController extends RestController
    */
   public function runOneShotCEU($request, $response, $args)
   {
-    $symReq = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
-    $uploadedFile = $symReq->files->get($this::FILE_INPUT_NAME, null);
-    if (is_null($uploadedFile)) {
-      throw new HttpBadRequestException("No file uploaded");
-    }
-    if ($uploadedFile->getError() !== UPLOAD_ERR_OK) {
-      throw new HttpBadRequestException("Error uploading file");
-    }
+    $uploadedFile = $this->getUploadedFileOrThrow();
     list($copyrights, $highlights) = $this->restHelper->getPlugin('agent_copyright_once')->
       AnalyzeOne(true, $uploadedFile->getPathname());
     $this->highlightProcessor->sortHighlights($highlights);
     $returnVal = new OneShot($copyrights, $highlights);
     return $response->withJson($returnVal->getArray('copyrights'), 200);
+  }
+
+  /**
+   * Get uploaded file from accepted form field names.
+   *
+   * @return \Symfony\Component\HttpFoundation\File\UploadedFile
+   * @throws HttpBadRequestException
+   * @throws HttpPayloadTooLargeException
+   */
+  private function getUploadedFileOrThrow()
+  {
+    $symReq = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
+    $uploadedFile = $symReq->files->get($this::FILE_INPUT_NAME, null);
+    if (is_null($uploadedFile)) {
+      $uploadedFile = $symReq->files->get($this::ALT_FILE_INPUT_NAME, null);
+    }
+    if (is_null($uploadedFile)) {
+      throw new HttpBadRequestException("No file uploaded");
+    }
+
+    $uploadError = $uploadedFile->getError();
+    if ($uploadError === UPLOAD_ERR_OK) {
+      return $uploadedFile;
+    }
+
+    if ($uploadError === UPLOAD_ERR_INI_SIZE || $uploadError === UPLOAD_ERR_FORM_SIZE) {
+      throw new HttpPayloadTooLargeException("Uploaded file is too large");
+    }
+    if ($uploadError === UPLOAD_ERR_PARTIAL) {
+      throw new HttpBadRequestException("File was only partially uploaded");
+    }
+    if ($uploadError === UPLOAD_ERR_NO_FILE) {
+      throw new HttpBadRequestException("No file uploaded");
+    }
+    if ($uploadError === UPLOAD_ERR_NO_TMP_DIR) {
+      throw new HttpBadRequestException("Temporary upload directory is missing");
+    }
+    if ($uploadError === UPLOAD_ERR_CANT_WRITE) {
+      throw new HttpBadRequestException("Failed to write uploaded file to disk");
+    }
+    if ($uploadError === UPLOAD_ERR_EXTENSION) {
+      throw new HttpBadRequestException("File upload stopped by server extension");
+    }
+
+    throw new HttpBadRequestException("Error uploading file");
   }
 }

--- a/src/www/ui/api/Exceptions/HttpPayloadTooLargeException.php
+++ b/src/www/ui/api/Exceptions/HttpPayloadTooLargeException.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Divyam Agrawal
+ SPDX-FileContributor: Divyam Agrawal <ludicrouslytrue@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+ */
+
+namespace Fossology\UI\Api\Exceptions;
+
+use Throwable;
+
+/**
+ * Exception for HTTP 413 Payload Too Large errors.
+ */
+class HttpPayloadTooLargeException extends HttpErrorException
+{
+  public function __construct(string $message, ?Throwable $previous = null)
+  {
+    parent::__construct($message, 413, $previous);
+  }
+}


### PR DESCRIPTION
Improves one-shot REST upload compatibility for the web UI migration and makes upload error responses more explicit in preparation 

### Changes

- Updated `OneShotController` to accept both multipart file keys:
  - `analysisFile` (new web UI field)
  - `fileInput` (existing field, preserved for backward compatibility)
- Refactored repeated upload parsing/validation into a shared helper method.
- Added `HttpPayloadTooLargeException` (HTTP `413`) for oversized uploads.
- Added explicit handling for PHP upload error codes:
  - `UPLOAD_ERR_INI_SIZE` / `UPLOAD_ERR_FORM_SIZE` -> `413 Uploaded file is too large`
  - `UPLOAD_ERR_NO_FILE` -> `400 No file uploaded`
  - other upload errors -> clear `400` messages

## How to test

1. Generate a token:
   ```
   $expire = (Get-Date).AddDays(7).ToString("yyyy-MM-dd")
   $tokenName = "oneshot-" + [DateTimeOffset]::Now.ToUnixTimeSeconds()
   $body = @{ username="fossy"; password="fossy"; tokenName=$tokenName; tokenScope="write"; tokenExpire=$expire } | ConvertTo-Json
   $auth = (Invoke-RestMethod -Method Post -Uri "http://localhost:8081/repo/api/v2/tokens" -ContentType "application/json" -Body $body).Authorization
   ```

2. Create a test file:
   ```
   "MIT License sample text" | Set-Content .\oneshot-test.txt
   ```

3. Verify new field (`analysisFile`) works:
   ```
   curl.exe -i -X POST "http://localhost:8081/repo/api/v2/uploads/oneshot/nomos" -H "Authorization: $auth" -F "analysisFile=@oneshot-test.txt"
   ```
   Expected: `HTTP/1.1 200 OK`

4. Verify existing field (`fileInput`) still works:
   ```
   curl.exe -i -X POST "http://localhost:8081/repo/api/v2/uploads/oneshot/nomos" -H "Authorization: $auth" -F "fileInput=@oneshot-test.txt"
   ```
   Expected: `HTTP/1.1 200 OK`

5. Verify missing file behavior:
   ```
   curl.exe -i -X POST "http://localhost:8081/repo/api/v2/uploads/oneshot/nomos" -H "Authorization: $auth"
   ```
   Expected: `HTTP/1.1 400 Bad Request` with `No file uploaded`

<img width="1282" height="405" alt="image" src="https://github.com/user-attachments/assets/7dc32e07-ce0e-474b-b77e-0b333322d7e9" />
`analysisFile` call -> `200`

<img width="1286" height="401" alt="image" src="https://github.com/user-attachments/assets/225ac36c-9b3d-4c78-8c79-2e90c3bd573a" />
`fileInput` call -> `200`

<img width="1299" height="470" alt="image" src="https://github.com/user-attachments/assets/8ca704c0-2ffd-479c-a12f-84fcd7e8c4d0" />
no-file call -> `400` with message


## Manual Web UI validation

- Opened `http://localhost:8081/repo/?mod=agent_nomos_once`
- Uploaded `oneshot-test.txt`
- Clicked **Analyze**
- Result rendered successfully with detected license (`MIT`) and no server error

<img width="1675" height="1014" alt="image" src="https://github.com/user-attachments/assets/e8a3e6ef-2289-4463-bc24-3da0454db628" />

