### PR TITLE
fix(ununpack): prevent gcrypt handle leak in checksum error paths

### DIFF
--- a/src/ununpack/agent/checksum.c
+++ b/src/ununpack/agent/checksum.c
@@ -197,6 +197,7 @@ Cksum *	SumComputeBuff	(CksumFile *CF)
   {
     LOG_ERROR("GCRY Error: %s/%s\n", gcry_strsource(checksumError),
         gcry_strerror(checksumError));
+    gcry_md_close(checksumhandler);
     return(NULL);
   }
 
@@ -205,12 +206,14 @@ Cksum *	SumComputeBuff	(CksumFile *CF)
   {
     LOG_ERROR("GCRY Error: %s/%s\n", gcry_strsource(checksumError),
         gcry_strerror(checksumError));
+    gcry_md_close(checksumhandler);
     return(NULL);
   }
 
   Sum = (Cksum *)calloc(1,sizeof(Cksum));
   if (!Sum)
   {
+    gcry_md_close(checksumhandler);
     return(NULL);
   }
   Sum->DataLen = CF->MmapSize;


### PR DESCRIPTION

## Description

Previously, three error paths returned `NULL` without `calling gcry_md_close(checksumhandler),` which caused the allocated gcrypt handle to leak.

### Changes

-Added `gcry_md_close(checksumhandler)` before `return(NULL)` when `gcry_md_enable()` fails for MD5.
-Added `gcry_md_close(checksumhandler)` before `return(NULL)` when `gcry_md_enable()` fails for SHA1.
-Added `gcry_md_close(checksumhandler)` before `return(NULL)` when `calloc()` fails during checksum structure allocation.


