### PR TITLE
fix(unpack): use MAP_FAILED for mmap failure check in CopyFile

### DIFF
--- a/src/ununpack/agent/utils.c
+++ b/src/ununpack/agent/utils.c
@@ -477,7 +477,7 @@ int	CopyFile	(char *Src, char *Dst)
 
   /* load the source file */
   Mmap = mmap(0,LenIn,PROT_READ,MAP_PRIVATE,Fin,0);
-  if (Mmap == NULL)
+  if (Mmap == MAP_FAILED)
   {
     LOG_FATAL("pfile %s Unable to process file.",Pfile_Pk);
     LOG_WARNING("pfile %s Mmap failed during copy.",Pfile_Pk);


### PR DESCRIPTION
## Description

A failed `mmap()` call was never detected due to the incorrect `NULL` comparison. This allowed execution to continue with an invalid pointer, which could later trigger a segmentation fault during the `write()` loop around.

### Changes

-Replaced `NULL` check with `MAP_FAILED` in `CopyFile()`.

