### PR TITLE
Fix NULL pointer dereference in SMTP configuration handling

### DIFF
--- a/src/scheduler/agent/database.c
+++ b/src/scheduler/agent/database.c
@@ -1154,8 +1154,10 @@ char* get_email_command(scheduler_t* scheduler, char* user_email)
       g_string_append_printf(client_cmd, " -S mta=\"");
     }
     /* use smtps only if port is not 25 or SMTPStartTls is provided */
-    if((g_strcmp0((char *)g_hash_table_lookup(smtpvariables, "SMTPPort"), "25") !=  0) 
-        || g_strcmp0((char *)g_hash_table_lookup(smtpvariables, "SMTPStartTls"), "1") == 0)
+    char *smtpPort = (char *)g_hash_table_lookup(smtpvariables, "SMTPPort");
+    char *smtpStartTls = (char *)g_hash_table_lookup(smtpvariables, "SMTPStartTls");
+    if((smtpPort && g_strcmp0(smtpPort, "25") != 0) 
+        || (smtpStartTls && g_strcmp0(smtpStartTls, "1") == 0))
     {
       g_string_append_printf(client_cmd, "smtps://");
     }
@@ -1174,8 +1176,11 @@ char* get_email_command(scheduler_t* scheduler, char* user_email)
         g_string_append_uri_escaped(client_cmd, temp_smtpvariable, NULL, TRUE);
       }
       g_string_append_printf(client_cmd, "@");
-      g_string_append_printf(client_cmd, "%s:%s\"", (char *)g_hash_table_lookup(smtpvariables, "SMTPHostName"),
-          (char *)g_hash_table_lookup(smtpvariables, "SMTPPort"));
+      char *smtpHostName = (char *)g_hash_table_lookup(smtpvariables, "SMTPHostName");
+      char *smtpPort2 = (char *)g_hash_table_lookup(smtpvariables, "SMTPPort");
+      g_string_append_printf(client_cmd, "%s:%s\"", 
+          smtpHostName ? smtpHostName : "",
+          smtpPort2 ? smtpPort2 : "");
     }
     temp_smtpvariable = NULL;
     final_command = g_strdup_printf(EMAIL_BUILD_CMD, scheduler->email_command,


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

SPDX-License-Identifier: GPL-2.0-only

-->
## Description

This PR resolves potential NULL pointer dereference crashes in `src/scheduler/agent/database.c` when retrieving SMTP configuration from the hash table. 

This wouldcrash when:

SMTPHostName key missing from smtpvariables hash table
SMTPPort key missing from smtpvariables hash table

Crash Reason: g_hash_table_lookup() returns NULL, and g_string_append_printf() with %s format cannot handle NULL pointers - causes segmentation fault.

### Changes

* **Memory Safety:** Implemented NULL checks for `g_hash_table_lookup` calls related to `SMTPPort`, `SMTPStartTls`, and `SMTPHostName`.
* **Logic Improvements:** Refactored nested lookups into local variables to improve readability and ensure `g_strcmp0` is only called on non-NULL pointers.
* **Graceful Degradation:** Used ternary operators to provide empty string defaults in `g_string_append_printf` to prevent crashes while maintaining command string structure.

## How to test

1.  **Environment Setup:** Ensure Fossology is built and the scheduler agent is running.
2.  **Triggering the Bug:** Manually remove or comment out `SMTPHostName` or `SMTPPort` from your configuration database/hash table.
3.  **Execution:** Run a task that triggers an email notification or an SMTP-related agent action.
4.  **Expected Result:** The agent should now handle the missing keys gracefully (by skipping the logic or using empty strings) instead of triggering a Segmentation Fault (SIGSEGV).

---
Fixes #3384 