### PR TITLE
fix(cyclonedx): determine correct mimetype per file instead of hardcoded text/plain

### DIFF
--- a/src/cyclonedx/agent/cyclonedx.php
+++ b/src/cyclonedx/agent/cyclonedx.php
@@ -314,12 +314,13 @@ class CycloneDXAgent extends Agent
         }
       }
       if (!empty($fileName)) {
+        $mimeType = $this->getFileMimeType($fileId, $treeTableName);
         $componentdata = array(
           'bomref' => $uploadId .'-'. $fileId,
           'type' => 'file',
           'name' => $fileName,
           'hashes' => $serializedhash,
-          'mimeType' => 'text/plain',
+          'mimeType' => $mimeType,
           'copyright' => implode("\n", $licenses->getCopyrights()),
           'licenses' => $licensesfound
         );
@@ -377,6 +378,24 @@ class CycloneDXAgent extends Agent
 
     $row = $this->dbManager->getSingleRow($sql, [$uploadId], __METHOD__);
     return $row['mimetype_name'];
+  }
+
+  /**
+   * @brief Get the mime type of a file
+   * @param int $fileId File ID
+   * @param string $treeTableName Tree table name
+   * @return string Mime type of the file
+   */
+  protected function getFileMimeType($fileId, $treeTableName)
+  {
+    $sql = "SELECT m.mimetype_name
+      FROM $treeTableName ut
+      JOIN pfile pf ON ut.pfile_fk = pf.pfile_pk
+      LEFT JOIN mimetype m ON pf.pfile_mimetypefk = m.mimetype_pk
+      WHERE ut.uploadtree_pk = $1";
+
+    $row = $this->dbManager->getSingleRow($sql, [$fileId], __METHOD__);
+    return $row['mimetype_name'] ?? 'application/octet-stream';
   }
 }
 


### PR DESCRIPTION


<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->


## Description

The MIME type in the CycloneDX report is currently hardcoded to `text/plain`.  
This PR updates the implementation to retrieve the correct MIME type for each file from the database.

## Changes Made

- Added `getFileMimeType()`  method that queries the database to determine the actual MIME type for each file.

- Updated `generateFileComponents()` method, replaced the hardcoded `text/plain` value with a dynamic call to:
```php
$this->getFileMimeType($fileId, $treeTableName);
```
CC: @shaheemazmalmmd @Kaushl2208 