### PR TITLE
fix(scheduler): safely handle NULL folder_pk during email replacement

### DIFF
--- a/src/scheduler/agent/database.c
+++ b/src/scheduler/agent/database.c
@@ -213,7 +213,8 @@ static gboolean email_replace(const GMatchInfo* match, GString* ret,
     {
       rows = g_ptr_array_new();
       GString *foldername = g_string_new(PQgetvalue(db_result, 0, 0));
-      guint folder_pk = atoi(PQget(db_result, 0, "folder_pk"));
+      char *folderPkStr = PQget(db_result, 0, "folder_pk");
+      guint folder_pk = (folderPkStr != NULL) ? (guint)atoi(folderPkStr) : 0;
       g_ptr_array_add(rows, foldername);
       SafePQclear(db_result);
       g_free(sql);
@@ -229,7 +230,8 @@ static gboolean email_replace(const GMatchInfo* match, GString* ret,
       while(PQresultStatus(db_result) == PGRES_TUPLES_OK && PQntuples(db_result) == 1)
       {
         GString *foldername = g_string_new(PQgetvalue(db_result, 0, 0));
-        guint folder_pk = atoi(PQget(db_result, 0, "folder_pk"));
+        char *folderPkStr = PQget(db_result, 0, "folder_pk");
+        guint folder_pk = (folderPkStr != NULL) ? atoi(folderPkStr) : 0;
         g_ptr_array_add(rows, foldername);
         SafePQclear(db_result);
         g_free(sql);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This PR addresses the unsafe integer conversion identified in issue #3429.



### Changes

1. Added validation to ensure the result of PQget() is not NULL before passing it to atoi().
2.  Implemented a safe fallback to 0 for folder_pk if the database returns a null value.
 
3. Updated the $UPLOADFOLDERNAME replacement logic in src/scheduler/agent/database.c to handle both the initial folder lookup and the recursive parent-folder traversal loop safely.

- ## How to test
1.Compilation Check: Run make and sudo make install in the repository root to ensure the syntax in src/scheduler/agent/database.c is correct and the scheduler builds without errors.

2.Manual Code Audit: Verified that folderPkStr is checked for NULL before every atoi() call in the $UPLOADFOLDERNAME block.

3.Logic Verification: Verified that the while loop still correctly terminates and uses the fallback value 0 for the parent_folder_name query if a primary key is missing, preventing a segmentation fault.




Fixes #3429
