### PR TITLE
fix(adj2nest): validate PGresult before processing upload rows

### DIFF
--- a/src/adj2nest/agent/adj2nest.c
+++ b/src/adj2nest/agent/adj2nest.c
@@ -70,6 +70,7 @@
 #include <ctype.h>
 #include <signal.h>
 #include <libgen.h>
+#include <libpq-fe.h>
 
 #include "libfossology.h"
 
@@ -345,6 +346,11 @@ void    ListUploads     ()
   snprintf(SQL,sizeof(SQL), "SELECT upload_pk,upload_desc,upload_filename FROM upload ORDER BY upload_pk");
   pgResult = PQexec(pgConn, SQL);
   fo_checkPQresult(pgConn, pgResult, SQL, __FILE__, __LINE__);
+
+  if (PQresultStatus(pgResult) != PGRES_TUPLES_OK) {
+    PQclear(pgResult);
+    return;
+  }
 
   /* list each value */
   MaxRow = PQntuples(pgResult);


### PR DESCRIPTION
## Description

Improvement in error handling by validating `PostgreSQL` query result before processing upload rows.

### Changes

- Added `PQresultStatus(pgResult) != PGRES_TUPLES_OK `validation after `PQexec()`.
- Cleared `pgResult` using `PQclear()` when the query result is invalid.
- Added an early `return` to avoid calling `PQntuples()` on an invalid result.
