### PR TITLE
fix(api): remove stray debug echo from deleteFileCX and correct limit error messages

### DIFF
--- a/src/www/ui/api/Controllers/CopyrightController.php
+++ b/src/www/ui/api/Controllers/CopyrightController.php
@@ -850,7 +850,7 @@ class CopyrightController extends RestController
       $limit = filter_var($limit, FILTER_VALIDATE_INT);
       if ($limit < 1) {
         throw new HttpBadRequestException(
-          "limit should be positive integer > 1");
+          "limit should be a positive integer >= 1");
       }
     } else {
       $limit = self::COPYRIGHT_FETCH_LIMIT;
@@ -933,8 +933,6 @@ class CopyrightController extends RestController
     $copyrightHash = $args['hash'];
     $userId = $this->restHelper->getUserId();
     $cpTable = $this->copyrightHist->getTableName($dataType);
-
-    echo $uploadTreeId;
 
     $this->uploadAccessible($uploadPk);
     $this->isItemExists($uploadPk, $uploadTreeId);

--- a/src/www/ui/api/Controllers/LicenseController.php
+++ b/src/www/ui/api/Controllers/LicenseController.php
@@ -169,7 +169,7 @@ class LicenseController extends RestController
       $limit = filter_var($limit, FILTER_VALIDATE_INT);
       if ($limit < 1) {
         throw new HttpBadRequestException(
-          "limit should be positive integer > 1");
+          "limit should be a positive integer >= 1");
       }
     } else {
       $limit = self::LICENSE_FETCH_LIMIT;

--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -235,7 +235,7 @@ class UploadController extends RestController
       $limit = filter_var($limit, FILTER_VALIDATE_INT);
       if ($limit < 1) {
         throw new HttpBadRequestException(
-          "limit should be positive integer > 1");
+          "limit should be a positive integer >= 1");
       }
     } else {
       $limit = self::UPLOAD_FETCH_LIMIT;


### PR DESCRIPTION
Found two small bugs while reading through the API controllers.

**Debug echo left in production**
`deleteFileCX()` has `echo $uploadTreeId;` sitting right before the JSON response. This leaks the item ID as raw text into the response body, which breaks JSON parsing on the client. Affects all the DELETE endpoints for copyrights, emails, urls, authors, ecc, keywords, ipra — scanner variants too.

**Wrong error message for `limit`**
The check is `if ($limit < 1)` so `limit=1` is fine, but the error says `"> 1"` which makes it look like 1 is rejected. Changed it to `>= 1`. Same issue in three controllers — `LicenseController` and `UploadController` had the same copy-paste. `UploadTreeController` already said it right.

Closes #3433

Signed-off-by: Mandar Joshi <mandarjoshi1045@gmail.com>