### PR TITLE
fix(cyclonedx): store main license info using license key instead of overwriting licensesInDocument

### DIFF
--- a/src/cyclonedx/agent/cyclonedx.php
+++ b/src/cyclonedx/agent/cyclonedx.php
@@ -215,13 +215,6 @@ class CycloneDXAgent extends Agent
       $reportedLicenseId = $this->licenseMap->getProjectedId($licId);
       $mainLicObj = $this->licenseDao->getLicenseById($reportedLicenseId, $this->groupId);
       $licId = $mainLicObj->getId() . "-" . md5($mainLicObj->getText());
-      if (!array_key_exists($licId, $this->licensesInDocument)) {
-        $this->licensesInDocument = (new SpdxLicenseInfo())
-          ->setLicenseObj($mainLicObj)
-          ->setCustomText(false)
-          ->setTextPrinted(true)
-          ->setListedLicense(true);
-      }
       $licensedata['id'] = $mainLicObj->getSpdxId();
       $licensedata['url'] = $mainLicObj->getUrl();
       $mainLicenses[] = $this->reportGenerator->createLicense($licensedata);


### PR DESCRIPTION
Fixes #3435

`licensesInDocument` is declared as an array of `SpdxLicenseInfo`, but in the main license loop the array was overwritten with a single object. This change stores the license info using the computed `$licId` as key, preserving the array structure and avoiding potential issues when multiple main licenses are processed.

<img width="1141" height="69" alt="Screenshot 2026-03-13 012904" src="https://github.com/user-attachments/assets/4407b126-d39d-41b7-ae10-45b272b62cdf" />

CLI reproduction showing that replacing the licensesInDocument array with a SpdxLicenseInfo object causes array_key_exists() to fail on the next iteration.
