### PR TITLE
fix(ui): allow clearing upload name and description

### DIFF
--- a/src/www/ui/admin-upload-edit.php
+++ b/src/www/ui/admin-upload-edit.php
@@ -46,11 +46,11 @@ class upload_properties extends FO_Plugin
    **/
   public function UpdateUploadProperties($uploadId, $newName, $newDesc)
   {
-    if (empty($newName) and empty($newDesc)) {
+    if ($newName === null && $newDesc === null) {
       return 2;
     }
 
-    if (!empty($newName)) {
+    if ($newName !== null) {
       /*
        * Use pfile_fk to select the correct entry in the upload tree, artifacts
        * (e.g. directories of the upload do not have pfiles).
@@ -74,7 +74,7 @@ class upload_properties extends FO_Plugin
         __METHOD__ . '.updateUpload.name');
     }
 
-    if (! empty($newDesc)) {
+    if ($newDesc !== null) {
       $trimNewDesc = trim($newDesc);
       $this->dbManager->getSingleRow("UPDATE upload SET upload_desc=$2 WHERE upload_pk=$1",
         array($uploadId, $trimNewDesc), __METHOD__ . '.updateUpload.desc');

--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -734,8 +734,7 @@ class UploadController extends RestController
     // Handle update of description
     if (
       $isJsonRequest &&
-      array_key_exists("uploadDescription", $bodyContent) &&
-      strlen(trim($bodyContent["uploadDescription"])) > 0
+      array_key_exists("uploadDescription", $bodyContent)
     ) {
       $newDescription = trim($bodyContent["uploadDescription"]);
     }


### PR DESCRIPTION
## Description

Clearing the upload name or description does not currently work. If a user deletes the text and saves, the previous value remains unchanged.

The issue occurs because the validation logic uses `empty()` to check whether parameters were provided. In PHP, `empty("")` evaluates to `true`, so an empty string is treated the same as `null`. This causes the update logic to interpret `""` as "no input", preventing fields from being cleared.

However, the function documentation specifies that `null` means the field should not be modified. Therefore `""` should be accepted as a valid value to explicitly clear the field.

This change replaces `empty()` checks with strict null comparisons and removes an API validation that blocked empty descriptions.

## Changes

**src/www/ui/admin-upload-edit.php**
- Replace `empty()` checks with `=== null` in `UpdateUploadProperties()` so empty strings are accepted

**src/www/ui/api/Controllers/UploadController.php**
- Remove `strlen(trim(...)) > 0` validation that prevented empty descriptions from being processed via API

## Resulting behavior

- `null` → field remains unchanged
- `""` → field is cleared
- `"text"` → field is updated

## How to test

1. Go to **Organize → Uploads → Edit Properties**
2. Clear the description field and save → Description should be removed
3. Enter a new description and save → Description should update correctly
4. Leave the field unchanged and save → Existing value should remain unchanged
