### PR TITLE
feat(ui): bulk text export json/csv with filter

### DIFF
--- a/src/lib/php/Application/BulkTextExport.php
+++ b/src/lib/php/Application/BulkTextExport.php
@@ -1,0 +1,239 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Kaushlendra Pratap <kaushlendra-pratap.singh@siemens.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\Lib\Application;
+
+use Fossology\Lib\Db\DbManager;
+
+/**
+ * @file
+ * @brief Helper class to export license reference bulk data as CSV or JSON from the DB
+ */
+
+/**
+ * @class BulkTextExport
+ * @brief Helper class to export license reference bulk data as CSV or JSON from the DB
+ */
+class BulkTextExport
+{
+  /** @var DbManager $dbManager
+   * DB manager in use */
+  protected $dbManager;
+  /** @var string $delimiter
+   * Delimiter for CSV */
+  protected $delimiter = ',';
+  /** @var string $enclosure
+   * Enclosure for CSV strings */
+  protected $enclosure = '"';
+
+  /**
+   * Constructor
+   * @param DbManager $dbManager DB manager to use.
+   */
+  public function __construct(DbManager $dbManager)
+  {
+    $this->dbManager = $dbManager;
+  }
+
+  /**
+   * @brief Update the delimiter
+   * @param string $delimiter New delimiter to use.
+   */
+  public function setDelimiter($delimiter=',')
+  {
+    if (!is_string($delimiter) || strlen($delimiter) !== 1) {
+      throw new \InvalidArgumentException("CSV delimiter must be a non-empty single-byte character.");
+    }
+    if ($delimiter === $this->enclosure) {
+      throw new \InvalidArgumentException("CSV delimiter and enclosure must be different characters.");
+    }
+    $this->delimiter = $delimiter;
+  }
+
+  /**
+   * @brief Update the enclosure
+   * @param string $enclosure New enclosure to use.
+   */
+  public function setEnclosure($enclosure='"')
+  {
+    if (!is_string($enclosure) || strlen($enclosure) !== 1) {
+      throw new \InvalidArgumentException("CSV enclosure must be a non-empty single-byte character.");
+    }
+    if ($enclosure === $this->delimiter) {
+      throw new \InvalidArgumentException("CSV delimiter and enclosure must be different characters.");
+    }
+    $this->enclosure = $enclosure;
+  }
+
+  /**
+   * @brief Export license reference bulk data from the DB as CSV or JSON
+   * @param int $user_pk Filter by user ID, set 0 to export all
+   * @param int $group_pk Filter by group ID, set 0 to export all
+   * @param bool $generateJson Whether to generate JSON format instead of CSV
+   * @return string CSV or JSON content
+   */
+  public function exportBulkText($user_pk=0, $group_pk=0, $generateJson=false)
+  {
+    $whereClause = "";
+    $params = array();
+
+    if ($user_pk > 0) {
+      $whereClause = "WHERE lrb.user_fk = $1";
+      $params[] = $user_pk;
+    } elseif ($group_pk > 0) {
+      $whereClause = "WHERE lrb.group_fk = $1";
+      $params[] = $group_pk;
+    }
+
+    $sql = "SELECT DISTINCT
+              lrb.rf_text,
+              lr.rf_shortname,
+              lsb.removing,
+              lsb.comment,
+              lsb.acknowledgement,
+              lr.rf_active
+            FROM license_ref_bulk lrb
+            LEFT JOIN license_set_bulk lsb ON lsb.lrb_fk = lrb.lrb_pk
+            LEFT JOIN license_ref lr ON lr.rf_pk = lsb.rf_fk
+            $whereClause
+            ORDER BY lrb.rf_text, lr.rf_shortname";
+
+    $result = $this->dbManager->getRows($sql, $params);
+
+    if ($generateJson) {
+      return $this->createJson($result);
+    } else {
+      return $this->createCsvContent($result);
+    }
+  }
+
+  /**
+   * @brief Group flat DB rows by bulk text, splitting licenses into add/remove buckets
+   * @param array $result Database result array
+   * @return array Associative array keyed by rf_text with grouped export fields
+   */
+  private function groupResultsByText($result)
+  {
+    $grouped = array();
+    foreach ($result as $row) {
+      $text = $row['rf_text'] ?: '';
+      if (!isset($grouped[$text])) {
+        $grouped[$text] = array(
+          'licenses_to_add'    => array(),
+          'licenses_to_remove' => array(),
+          'comments'           => array(),
+          'acknowledgements'   => array(),
+          'is_active_values'   => array()
+        );
+      }
+      if (!empty($row['rf_shortname'])) {
+        if ($row['removing'] === 't' || $row['removing'] === true) {
+          $grouped[$text]['licenses_to_remove'][] = $row['rf_shortname'];
+        } else {
+          $grouped[$text]['licenses_to_add'][] = $row['rf_shortname'];
+        }
+      }
+
+      if (!empty($row['comment'])) {
+        $grouped[$text]['comments'][] = $row['comment'];
+      }
+
+      if (!empty($row['acknowledgement'])) {
+        $grouped[$text]['acknowledgements'][] = $row['acknowledgement'];
+      }
+
+      if ($row['rf_active'] !== null) {
+        $isActive = ($row['rf_active'] === 't' || $row['rf_active'] === true ||
+          $row['rf_active'] === 1 || $row['rf_active'] === '1');
+        $grouped[$text]['is_active_values'][] = $isActive;
+      }
+    }
+
+    foreach ($grouped as $text => $values) {
+      $grouped[$text]['licenses_to_add'] = array_values(array_unique($values['licenses_to_add']));
+      $grouped[$text]['licenses_to_remove'] = array_values(array_unique($values['licenses_to_remove']));
+      $grouped[$text]['comments'] = array_values(array_unique($values['comments']));
+      $grouped[$text]['acknowledgements'] = array_values(array_unique($values['acknowledgements']));
+
+      if (empty($values['is_active_values'])) {
+        $grouped[$text]['is_active'] = null;
+      } else {
+        $grouped[$text]['is_active'] = !in_array(false, $values['is_active_values'], true);
+      }
+
+      unset($grouped[$text]['is_active_values']);
+    }
+
+    return $grouped;
+  }
+
+  /**
+   * @brief Create CSV content from result array
+   * @param array $result Database result array
+   * @return string CSV content
+   */
+  private function createCsvContent($result)
+  {
+    $headers = array('text', 'licenses_to_add', 'licenses_to_remove', 'comments', 'acknowledgements', 'is_active');
+    $out = fopen('php://output', 'w');
+    ob_start();
+    fputs($out, $bom =( chr(0xEF) . chr(0xBB) . chr(0xBF) ));
+    fputcsv($out, $headers, $this->delimiter, $this->enclosure);
+
+    foreach ($this->groupResultsByText($result) as $text => $licenses) {
+      $csvRow = array(
+        $this->normalizeNewlinesForCsv($text),
+        implode('|', array_map(array($this, 'normalizeNewlinesForCsv'), $licenses['licenses_to_add'])),
+        implode('|', array_map(array($this, 'normalizeNewlinesForCsv'), $licenses['licenses_to_remove'])),
+        implode('|', array_map(array($this, 'normalizeNewlinesForCsv'), $licenses['comments'])),
+        implode('|', array_map(array($this, 'normalizeNewlinesForCsv'), $licenses['acknowledgements'])),
+        $licenses['is_active'] === null ? '' : ($licenses['is_active'] ? 'true' : 'false')
+      );
+      fputcsv($out, $csvRow, $this->delimiter, $this->enclosure);
+    }
+
+    $content = ob_get_contents();
+    ob_end_clean();
+    return $content;
+  }
+
+  /**
+   * @brief Convert CR/LF variants to literal \n for line-safe CSV rows.
+   * @param string|null $value Value to normalize.
+   * @return string
+   */
+  private function normalizeNewlinesForCsv($value)
+  {
+    if ($value === null) {
+      return '';
+    }
+    return str_replace(array("\r\n", "\r", "\n"), '\\n', (string)$value);
+  }
+
+  /**
+   * @brief Create JSON content from result array
+   * @param array $result Database result array
+   * @return string JSON content
+   */
+  private function createJson($result)
+  {
+    $data = array();
+
+    foreach ($this->groupResultsByText($result) as $text => $licenses) {
+      $data[] = array(
+        'text'               => $text,
+        'licenses_to_add'    => $licenses['licenses_to_add'],
+        'licenses_to_remove' => $licenses['licenses_to_remove'],
+        'comments'           => $licenses['comments'],
+        'acknowledgements'   => $licenses['acknowledgements'],
+        'is_active'          => $licenses['is_active']
+      );
+    }
+
+    return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+  }
+}

--- a/src/lib/php/Application/test/BulkTextExportTest.php
+++ b/src/lib/php/Application/test/BulkTextExportTest.php
@@ -1,0 +1,103 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\Lib\Application;
+
+use Fossology\Lib\Db\DbManager;
+use Mockery as M;
+
+/**
+ * @class BulkTextExportTest
+ * @brief Test for class BulkTextExport
+ */
+class BulkTextExportTest extends \PHPUnit\Framework\TestCase
+{
+  /** @var int */
+  private $assertCountBefore;
+
+  /**
+   * @brief One time setup for test
+   * @see PHPUnit::Framework::TestCase::setUp()
+   */
+  protected function setUp() : void
+  {
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+  }
+
+  /**
+   * @brief Close mockery
+   * @see PHPUnit::Framework::TestCase::tearDown()
+   */
+  protected function tearDown() : void
+  {
+    $this->addToAssertionCount(\Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  /**
+   * @test
+    * -# Export CSV with a comma and newline in text.
+    * -# Verify newlines are flattened to literal \n so each CSV record stays on one physical line.
+   */
+  public function testExportBulkTextCsvEscapesDelimiterAndNewlineInText()
+  {
+    $dbManager = M::mock(DbManager::class);
+    $dbManager->shouldReceive('getRows')->once()->withAnyArgs()->andReturn(array(
+      array(
+        'rf_text' => "hello, world\nsecond line",
+        'rf_shortname' => 'MIT',
+        'removing' => 'f',
+        'comment' => null,
+        'acknowledgement' => null,
+        'rf_active' => 't'
+      )
+    ));
+
+    $bulkTextExport = new BulkTextExport($dbManager);
+    $csv = $bulkTextExport->exportBulkText();
+
+    $handle = fopen('php://temp', 'r+');
+    fwrite($handle, $csv);
+    rewind($handle);
+
+    $rows = array();
+    while (($row = fgetcsv($handle, 0, ',', '"')) !== false) {
+      $rows[] = $row;
+    }
+    fclose($handle);
+
+    $this->assertCount(2, $rows);
+    $this->assertSame("\xEF\xBB\xBFtext", $rows[0][0]);
+    $this->assertSame('hello, world\\nsecond line', $rows[1][0]);
+    $this->assertSame('MIT', $rows[1][1]);
+    $this->assertSame(2, substr_count($csv, "\n"));
+  }
+
+  /**
+   * @test
+   */
+  public function testSetDelimiterRejectsEmptyValue()
+  {
+    $dbManager = M::mock(DbManager::class);
+    $bulkTextExport = new BulkTextExport($dbManager);
+
+    $this->expectException(\InvalidArgumentException::class);
+    $bulkTextExport->setDelimiter('');
+  }
+
+  /**
+   * @test
+   */
+  public function testSetEnclosureRejectsSameValueAsDelimiter()
+  {
+    $dbManager = M::mock(DbManager::class);
+    $bulkTextExport = new BulkTextExport($dbManager);
+
+    $this->expectException(\InvalidArgumentException::class);
+    $bulkTextExport->setEnclosure(',');
+  }
+}

--- a/src/lib/php/Dao/UserDao.php
+++ b/src/lib/php/Dao/UserDao.php
@@ -63,6 +63,30 @@ class UserDao
   }
 
   /**
+   * Get active users of a group as user_pk => user_name.
+   *
+   * @param int|null $groupId
+   * @return array
+   */
+  public function getUsersByGroup($groupId=null)
+  {
+    if (empty($groupId)) {
+      $groupId = Auth::getGroupId();
+    }
+    $userChoices = array();
+    $statementN = __METHOD__;
+    $sql = "SELECT user_pk, user_name FROM users LEFT JOIN group_user_member AS gum ON users.user_pk = gum.user_fk"
+            . " WHERE gum.group_fk = $1 AND users.user_status='active'";
+    $this->dbManager->prepare($statementN, $sql);
+    $res = $this->dbManager->execute($statementN, array($groupId));
+    while ($rw = $this->dbManager->fetchArray($res)) {
+      $userChoices[$rw['user_pk']] = $rw['user_name'];
+    }
+    $this->dbManager->freeResult($res);
+    return $userChoices;
+  }
+
+  /**
    * @brief get array of groups that this user has admin access to
    * @param int $userId
    * @return array in the format {group_pk=>group_name, group_pk=>group_name, ...}

--- a/src/www/ui/api/Controllers/LicenseController.php
+++ b/src/www/ui/api/Controllers/LicenseController.php
@@ -12,6 +12,7 @@
 
 namespace Fossology\UI\Api\Controllers;
 
+use Fossology\Lib\Application\BulkTextExport;
 use Fossology\Lib\Application\LicenseCsvExport;
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\LicenseAcknowledgementDao;
@@ -914,6 +915,104 @@ class LicenseController extends RestController
       ->withHeader('Pragma', 'no-cache')
       ->withHeader('Cache-Control', 'no-cache, must-revalidate, maxage=1, post-check=0, pre-check=0')
       ->withHeader('Expires', 'Expires: Thu, 19 Nov 1981 08:52:00 GMT');
+    $sf = new StreamFactory();
+    return $newResponse->withBody(
+      $content ? $sf->createStream($content) : $sf->createStream('')
+    );
+  }
+
+  /**
+   * Export bulk text scan data to CSV or JSON.
+   *
+   * Query params:
+   * - format: optional export format, csv|json (default json)
+   * - filter: optional filter type, all|user|group (default all)
+   * - userId: required when filter=user
+   * - groupId: required when filter=group
+   * - delimiter: optional CSV delimiter (default ,)
+   * - enclosure: optional CSV enclosure (default ")
+   *
+   * @param Request $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpErrorException
+   */
+  public function exportBulkText($request, $response, $args)
+  {
+    $this->throwNotAdminException();
+    $query = $request->getQueryParams();
+
+    $format = 'json';
+    if (array_key_exists('format', $query) && !empty($query['format'])) {
+      $format = strtolower($query['format']);
+    }
+    if (!in_array($format, array('csv', 'json'))) {
+      throw new HttpBadRequestException("Invalid format. Use 'csv' or 'json'.");
+    }
+
+    $filter = 'all';
+    if (array_key_exists('filter', $query) && !empty($query['filter'])) {
+      $filter = strtolower($query['filter']);
+    }
+    if (!in_array($filter, array('all', 'user', 'group'))) {
+      throw new HttpBadRequestException("Invalid filter. Use 'all', 'user', or 'group'.");
+    }
+
+    $userPk = 0;
+    $groupPk = 0;
+    if ($filter === 'user') {
+      if (!array_key_exists('userId', $query)) {
+        throw new HttpBadRequestException("userId is required when filter=user.");
+      }
+      $userPk = intval($query['userId']);
+      if ($userPk <= 0) {
+        throw new HttpBadRequestException("Invalid userId.");
+      }
+    } elseif ($filter === 'group') {
+      if (!array_key_exists('groupId', $query)) {
+        throw new HttpBadRequestException("groupId is required when filter=group.");
+      }
+      $groupPk = intval($query['groupId']);
+      if ($groupPk <= 0) {
+        throw new HttpBadRequestException("Invalid groupId.");
+      }
+    }
+
+    $dbManager = $this->dbHelper->getDbManager();
+    $bulkTextExport = new BulkTextExport($dbManager);
+
+    $isJson = ($format === 'json');
+    if (!$isJson) {
+      $delimiter = ',';
+      if (array_key_exists('delimiter', $query) && !empty($query['delimiter'])) {
+        $delimiter = $query['delimiter'];
+      }
+
+      $enclosure = '"';
+      if (array_key_exists('enclosure', $query) && !empty($query['enclosure'])) {
+        $enclosure = $query['enclosure'];
+      }
+
+      try {
+        $bulkTextExport->setDelimiter($delimiter);
+        $bulkTextExport->setEnclosure($enclosure);
+      } catch (\InvalidArgumentException $e) {
+        throw new HttpBadRequestException($e->getMessage());
+      }
+    }
+
+    $content = $bulkTextExport->exportBulkText($userPk, $groupPk, $isJson);
+    $fileName = "fossology-bulk-text-export-" . date("YMj-Gis");
+    $extension = $isJson ? 'json' : 'csv';
+    $contentType = $isJson ? 'application/json; charset=UTF-8' : 'text/csv; charset=UTF-8';
+
+    $newResponse = $response->withHeader('Content-type', $contentType)
+      ->withHeader('Content-Disposition', 'attachment; filename=' . $fileName . '.' . $extension)
+      ->withHeader('Pragma', 'no-cache')
+      ->withHeader('Cache-Control', 'no-cache, must-revalidate, maxage=1, post-check=0, pre-check=0')
+      ->withHeader('Expires', 'Expires: Thu, 19 Nov 1981 08:52:00 GMT');
+
     $sf = new StreamFactory();
     return $newResponse->withBody(
       $content ? $sf->createStream($content) : $sf->createStream('')

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -4693,6 +4693,83 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+
+  /license/bulk-text/export:
+    get:
+      operationId: exportBulkText
+      tags:
+        - License
+        - Admin
+      summary: Export bulk scan text as CSV or JSON
+      description: >
+        Export bulk scan text entries from license_ref_bulk.
+        Defaults are format=json and filter=all.
+      parameters:
+        - name: format
+          in: query
+          required: false
+          description: Output format.
+          schema:
+            type: string
+            enum:
+              - csv
+              - json
+            default: json
+        - name: filter
+          in: query
+          required: false
+          description: Filter mode for export.
+          schema:
+            type: string
+            enum:
+              - all
+              - user
+              - group
+            default: all
+        - name: userId
+          in: query
+          required: false
+          description: User ID, required when filter=user.
+          schema:
+            type: integer
+            minimum: 1
+        - name: groupId
+          in: query
+          required: false
+          description: Group ID, required when filter=group.
+          schema:
+            type: integer
+            minimum: 1
+        - name: delimiter
+          in: query
+          required: false
+          description: CSV delimiter character (used only when format=csv).
+          schema:
+            type: string
+            default: ','
+        - name: enclosure
+          in: query
+          required: false
+          description: CSV enclosure character (used only when format=csv).
+          schema:
+            type: string
+            default: '"'
+      responses:
+        '200':
+          description: Successfully exported
+          content:
+            text/csv:
+            application/json:
+        '400':
+          description: Validation error in query parameters
+          content:
+            application/json:
+        '403':
+          description: Route is not accessible
+          content:
+            application/json:
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /license/{shortname}:
     parameters:
       - name: shortname

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -165,7 +165,7 @@ if ($dbConnected) {
 }
 
 // Regex for matching a valid path parameter
-$pattern = "[\\w\\d\\-\\.@_]+}";
+$pattern = "[\\w\\d\\-\\.@_]+";
 
 //////////////////////////OPTIONS/////////////////////
 $app->options('/{routes:.+}', AuthController::class . ':optionsVerification');
@@ -284,10 +284,10 @@ $app->group('/uploads',
 $app->group('/users',
   function (\Slim\Routing\RouteCollectorProxy $app) use ($pattern) {
     $app->get('/self', UserController::class . ':getCurrentUser');
-    $app->get("[/{pathParam:$pattern]", UserController::class . ':getUsers');
-    $app->put("/{pathParam:$pattern", UserController::class . ':updateUser');
+    $app->get("[/{pathParam:$pattern}]", UserController::class . ':getUsers');
+    $app->put("/{pathParam:$pattern}", UserController::class . ':updateUser');
     $app->post('', UserController::class . ':addUser');
-    $app->delete("/{pathParam:$pattern", UserController::class . ':deleteUser');
+    $app->delete("/{pathParam:$pattern}", UserController::class . ':deleteUser');
     $app->post('/tokens', UserController::class . ':createRestApiToken');
     $app->get('/tokens/{type:\\w+}', UserController::class . ':getTokens');
     $app->any('/{params:.*}', BadRequestController::class);
@@ -312,12 +312,12 @@ $app->group('/groups',
   function (\Slim\Routing\RouteCollectorProxy $app) use ($pattern) {
     $app->get('', GroupController::class . ':getGroups');
     $app->post('', GroupController::class . ':createGroup');
-    $app->post("/{pathParam:$pattern/user/{userPathParam:$pattern", GroupController::class . ':addMember');
-    $app->delete("/{pathParam:$pattern", GroupController::class . ':deleteGroup');
-    $app->delete("/{pathParam:$pattern/user/{userPathParam:$pattern", GroupController::class . ':deleteGroupMember');
+    $app->post("/{pathParam:$pattern}/user/{userPathParam:$pattern}", GroupController::class . ':addMember');
+    $app->delete("/{pathParam:$pattern}", GroupController::class . ':deleteGroup');
+    $app->delete("/{pathParam:$pattern}/user/{userPathParam:$pattern}", GroupController::class . ':deleteGroupMember');
     $app->get('/deletable', GroupController::class . ':getDeletableGroups');
-    $app->get("/{pathParam:$pattern/members", GroupController::class . ':getGroupMembers');
-    $app->put("/{pathParam:$pattern/user/{userPathParam:$pattern", GroupController::class . ':changeUserPermission');
+    $app->get("/{pathParam:$pattern}/members", GroupController::class . ':getGroupMembers');
+    $app->put("/{pathParam:$pattern}/user/{userPathParam:$pattern}", GroupController::class . ':changeUserPermission');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 
@@ -411,6 +411,7 @@ $app->group('/license',
     $app->get('/export-csv', LicenseController::class . ':exportAdminLicenseToCSV');
     $app->post('/import-json', LicenseController::class . ':handleImportLicense');
     $app->get('/export-json', LicenseController::class . ':exportAdminLicenseToJSON');
+    $app->get('/bulk-text/export', LicenseController::class . ':exportBulkText');
     $app->post('', LicenseController::class . ':createLicense');
     $app->put('/verify/{shortname:.+}', LicenseController::class . ':verifyLicense');
     $app->put('/merge/{shortname:.+}', LicenseController::class . ':mergeLicense');

--- a/src/www/ui/page/AdminBulkTextExport.php
+++ b/src/www/ui/page/AdminBulkTextExport.php
@@ -1,0 +1,126 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Kaushlendra Pratap <kaushlendra-pratap.singh@siemens.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\UI\Page;
+
+use Fossology\Lib\Application\BulkTextExport;
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\UserDao;
+use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\Plugin\DefaultPlugin;
+use Fossology\Lib\Util\DownloadUtil;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * \brief Export bulk text license data as CSV or JSON
+ */
+class AdminBulkTextExport extends DefaultPlugin
+{
+  const NAME = "admin_bulk_text_export";
+
+  /** @var DbManager */
+  private $dbManager;
+
+  /** @var UserDao */
+  private $userDao;
+
+  function __construct()
+  {
+    parent::__construct(self::NAME, array(
+      self::TITLE => "Admin Bulk Text Export",
+      self::MENU_LIST => "Admin::Bulk::Bulk Text Export",
+      self::REQUIRES_LOGIN => true,
+      self::PERMISSION => Auth::PERM_ADMIN
+    ));
+    $this->dbManager = $this->getObject('db.manager');
+    $this->userDao = $this->getObject('dao.user');
+  }
+
+  /**
+   * @param Request $request
+   * @return Response
+   */
+  protected function handle(Request $request)
+  {
+    if ($request->get('export', false)) {
+      return $this->handleExport($request);
+    }
+
+    $vars = $this->getFormVars();
+    return $this->render('admin_bulk_text_export.html.twig', $this->mergeWithDefault($vars));
+  }
+
+  /**
+   * Get variables for the form
+   * @return array
+   */
+  private function getFormVars()
+  {
+    $userId = Auth::getUserId();
+    $groupMap = $this->userDao->getAdminGroupMap($userId, $_SESSION[Auth::USER_LEVEL]);
+    $vars = array(
+      'users' => $this->userDao->getUsersByGroup(),
+      'groups' => $groupMap
+    );
+    return $vars;
+  }
+
+  /**
+   * Handle the export action
+   * @param Request $request
+   * @return Response
+   */
+  private function handleExport(Request $request)
+  {
+    $exportFormat = $request->get('export_format', 'csv');
+    $filterType = $request->get('filter_type', 'all');
+    $user_pk = intval($request->get('selected_user', 0));
+    $group_pk = intval($request->get('selected_group', 0));
+    $delimiter = $request->get('delimiter', ',');
+    $enclosure = $request->get('enclosure', '"');
+
+    if (!in_array($exportFormat, array('csv', 'json'))) {
+      $exportFormat = 'csv';
+    }
+
+    if ($exportFormat === 'json') {
+      $fileName = "fossology-bulk-text-export-" . date("YMj-Gis") . '.json';
+      $contentType = 'application/json';
+      $generateJson = true;
+    } else {
+      $fileName = "fossology-bulk-text-export-" . date("YMj-Gis") . '.csv';
+      $contentType = 'text/csv';
+      $generateJson = false;
+    }
+
+    $filterUserPk = 0;
+    $filterGroupPk = 0;
+
+    if ($filterType === 'user' && $user_pk > 0) {
+      $filterUserPk = $user_pk;
+    } elseif ($filterType === 'group' && $group_pk > 0) {
+      $filterGroupPk = $group_pk;
+    }
+
+    $bulkTextExporter = new BulkTextExport($this->dbManager);
+    if (!$generateJson) {
+      try {
+        $bulkTextExporter->setDelimiter($delimiter);
+        $bulkTextExporter->setEnclosure($enclosure);
+      } catch (\InvalidArgumentException $e) {
+        return new Response($e->getMessage(), 400, array('Content-Type' => 'text/plain; charset=UTF-8'));
+      }
+    }
+
+    $content = $bulkTextExporter->exportBulkText($filterUserPk, $filterGroupPk, $generateJson);
+
+    return DownloadUtil::getDownloadResponse($content, $fileName, $contentType);
+  }
+}
+
+register_plugin(new AdminBulkTextExport());

--- a/src/www/ui/template/admin_bulk_text_export.html.twig
+++ b/src/www/ui/template/admin_bulk_text_export.html.twig
@@ -1,0 +1,180 @@
+{# SPDX-FileCopyrightText: © 2026 Kaushlendra Pratap <kaushlendra-pratap.singh@siemens.com>
+
+   SPDX-License-Identifier: FSFAP
+#}
+{% extends "include/base.html.twig" %}
+
+{% block styles %}
+  {{ parent() }}
+  <style>
+    .radio-group {
+      margin-top: 10px;
+    }
+    .radio-group input[type="radio"] {
+      margin-right: 5px;
+    }
+    .select-field {
+      width: 40%;
+    }
+    .csv-select {
+      width: 150px;
+      display: inline-block;
+      margin-left: 10px;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <p>
+    {{ 'Use this tool to export bulk scan text data in CSV or JSON format, filtered by user or group.' | trans }}
+  </p>
+
+  <form id="bulkTextExportForm" method="POST">
+    <input type="hidden" name="export" value="1">
+
+    <ol>
+      <li>
+        <div class="form-group">
+          <label>{{ 'Export Format' | trans }}:</label>
+          <div class="radio-group">
+            <input type="radio" id="exportFormatCsv" name="export_format" value="csv" checked="checked"/>
+            <label for="exportFormatCsv" class="d-inline">{{ 'CSV (Comma-Separated Values)' | trans }}</label>
+            <img src="images/info_16.png" data-toggle="tooltip" title="{{'Standard spreadsheet format'|trans}}" alt="" class="info-bullet"/>
+          </div>
+          <div class="radio-group">
+            <input type="radio" id="exportFormatJson" name="export_format" value="json"/>
+            <label for="exportFormatJson" class="d-inline">{{ 'JSON (JavaScript Object Notation)' | trans }}</label>
+            <img src="images/info_16.png" data-toggle="tooltip" title="{{'Structured data format for APIs'|trans}}" alt="" class="info-bullet"/>
+          </div>
+        </div>
+      </li>
+
+      <li>
+        <div class="form-group">
+          <label>{{ 'Filter By' | trans }}:</label>
+          <div class="radio-group">
+            <input type="radio" id="filterTypeAll" name="filter_type" value="all" checked="checked"/>
+            <label for="filterTypeAll" class="d-inline">{{ 'All (No Filter)' | trans }}</label>
+            <img src="images/info_16.png" data-toggle="tooltip" title="{{'Export all bulk text entries'|trans}}" alt="" class="info-bullet"/>
+          </div>
+          <div class="radio-group">
+            <input type="radio" id="filterTypeUser" name="filter_type" value="user"/>
+            <label for="filterTypeUser" class="d-inline">{{ 'By User' | trans }}</label>
+            <img src="images/info_16.png" data-toggle="tooltip" title="{{'Filter by specific user'|trans}}" alt="" class="info-bullet"/>
+          </div>
+          <div class="radio-group">
+            <input type="radio" id="filterTypeGroup" name="filter_type" value="group"/>
+            <label for="filterTypeGroup" class="d-inline">{{ 'By Group' | trans }}</label>
+            <img src="images/info_16.png" data-toggle="tooltip" title="{{'Filter by specific group'|trans}}" alt="" class="info-bullet"/>
+          </div>
+        </div>
+      </li>
+
+      <li id="userSelectionRow" style="display: none;">
+        <div class="form-group">
+          <label for="selectedUser">{{ 'Select User' | trans }}:</label>
+          <select id="selectedUser" name="selected_user" class="form-control select-field">
+            <option value="0">{{ 'Select a user...' | trans }}</option>
+            {% for user_pk, user_name in users %}
+              <option value="{{ user_pk }}">{{ user_name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </li>
+
+      <li id="groupSelectionRow" style="display: none;">
+        <div class="form-group">
+          <label for="selectedGroup">{{ 'Select Group' | trans }}:</label>
+          <select id="selectedGroup" name="selected_group" class="form-control select-field">
+            <option value="0">{{ 'Select a group...' | trans }}</option>
+            {% for group_pk, group_name in groups %}
+              <option value="{{ group_pk }}">{{ group_name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </li>
+
+      <li id="csvOptionsRow">
+        <div class="form-group">
+          <label>{{ 'CSV Options' | trans }}:</label>
+          <div class="radio-group">
+            <label for="csvDelimiter">{{ 'Field Delimiter' | trans }}:</label>
+            <select id="csvDelimiter" name="delimiter" class="form-control csv-select">
+              <option value=",">{{ 'Comma (,)' | trans }}</option>
+              <option value=";">{{ 'Semicolon (;)' | trans }}</option>
+              <option value="|">{{ 'Pipe (|)' | trans }}</option>
+              <option value="	">{{ 'Tab' | trans }}</option>
+            </select>
+            <img src="images/info_16.png" data-toggle="tooltip" title="{{'Character that separates columns'|trans}}" alt="" class="info-bullet"/>
+          </div>
+          <div class="radio-group">
+            <label for="csvEnclosure">{{ 'Text Enclosure' | trans }}:</label>
+            <select id="csvEnclosure" name="enclosure" class="form-control csv-select">
+              <option value="&quot;">{{ 'Double Quote (&quot;)' | trans }}</option>
+              <option value="'">{{ 'Single Quote (\')' | trans }}</option>
+            </select>
+            <img src="images/info_16.png" data-toggle="tooltip" title="{{'Character for wrapping fields with special characters'|trans}}" alt="" class="info-bullet"/>
+          </div>
+        </div>
+      </li>
+    </ol>
+
+    <p>
+      <input type="submit" class="btn btn-primary btn-sm" value="{{ 'Export' | trans }}"/>
+    </p>
+  </form>
+{% endblock %}
+
+{% block foot %}
+  {{ parent() }}
+  <script type="text/javascript">
+    $(document).ready(function() {
+      $('[data-toggle="tooltip"]').tooltip();
+
+      function updateFilterOptions() {
+        var filterType = $('input[name="filter_type"]:checked').val();
+        if (filterType === 'user') {
+          $('#userSelectionRow').show();
+          $('#groupSelectionRow').hide();
+        } else if (filterType === 'group') {
+          $('#userSelectionRow').hide();
+          $('#groupSelectionRow').show();
+        } else {
+          $('#userSelectionRow').hide();
+          $('#groupSelectionRow').hide();
+        }
+      }
+
+      function updateCsvOptions() {
+        var exportFormat = $('input[name="export_format"]:checked').val();
+        if (exportFormat === 'csv') {
+          $('#csvOptionsRow').show();
+        } else {
+          $('#csvOptionsRow').hide();
+        }
+      }
+
+      $('input[name="filter_type"]').on('change', updateFilterOptions);
+      $('input[name="export_format"]').on('change', updateCsvOptions);
+
+      $('#bulkTextExportForm').on('submit', function(e) {
+        var filterType = $('input[name="filter_type"]:checked').val();
+
+        if (filterType === 'user' && $('#selectedUser').val() === '0') {
+          e.preventDefault();
+          alert('{{ "Please select a user for filtering" | trans }}');
+          return false;
+        }
+
+        if (filterType === 'group' && $('#selectedGroup').val() === '0') {
+          e.preventDefault();
+          alert('{{ "Please select a group for filtering" | trans }}');
+          return false;
+        }
+      });
+
+      updateFilterOptions();
+      updateCsvOptions();
+    });
+  </script>
+{% endblock %}

--- a/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
@@ -1655,6 +1655,125 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
 
   }
 
+  /**
+   * @test
+   * -# Test for LicenseController::exportBulkText() default behavior.
+   * -# Verify default format=json and filter=all returns downloadable JSON.
+   * @return void
+   * @throws \Fossology\UI\Api\Exceptions\HttpErrorException
+   */
+  public function testExportBulkTextDefaultJsonAll()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->dbManager->shouldReceive('getRows')->withAnyArgs()->andReturn([]);
+
+    $request = $this->getRequestWithQueryParams('GET', []);
+    $actualResponse = $this->licenseController->exportBulkText($request,
+      new ResponseHelper(), []);
+
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+    $this->assertStringContainsString('application/json',
+      $actualResponse->getHeaderLine('Content-type'));
+    $this->assertStringContainsString('.json',
+      $actualResponse->getHeaderLine('Content-Disposition'));
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::exportBulkText() CSV with user filter.
+   * -# Verify csv content type and file extension.
+   * @return void
+   * @throws \Fossology\UI\Api\Exceptions\HttpErrorException
+   */
+  public function testExportBulkTextCsvByUser()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->dbManager->shouldReceive('getRows')->withAnyArgs()->andReturn([]);
+
+    $request = $this->getRequestWithQueryParams('GET', [
+      'format' => 'csv',
+      'filter' => 'user',
+      'userId' => 4,
+      'delimiter' => ';',
+      'enclosure' => '"'
+    ]);
+    $actualResponse = $this->licenseController->exportBulkText($request,
+      new ResponseHelper(), []);
+
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+    $this->assertStringContainsString('text/csv',
+      $actualResponse->getHeaderLine('Content-type'));
+    $this->assertStringContainsString('.csv',
+      $actualResponse->getHeaderLine('Content-Disposition'));
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::exportBulkText() invalid format.
+   * -# Verify HttpBadRequestException is thrown.
+   * @return void
+   * @throws \Fossology\UI\Api\Exceptions\HttpErrorException
+   */
+  public function testExportBulkTextInvalidFormat()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $request = $this->getRequestWithQueryParams('GET', ['format' => 'xml']);
+
+    $this->expectException(HttpBadRequestException::class);
+    $this->licenseController->exportBulkText($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::exportBulkText() missing userId.
+   * -# Verify HttpBadRequestException is thrown for filter=user.
+   * @return void
+   * @throws \Fossology\UI\Api\Exceptions\HttpErrorException
+   */
+  public function testExportBulkTextFilterUserWithoutUserId()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $request = $this->getRequestWithQueryParams('GET', ['filter' => 'user']);
+
+    $this->expectException(HttpBadRequestException::class);
+    $this->licenseController->exportBulkText($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::exportBulkText() invalid groupId.
+   * -# Verify HttpBadRequestException is thrown for non-positive group id.
+   * @return void
+   * @throws \Fossology\UI\Api\Exceptions\HttpErrorException
+   */
+  public function testExportBulkTextFilterGroupInvalidGroupId()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $request = $this->getRequestWithQueryParams('GET', [
+      'filter' => 'group',
+      'groupId' => 0
+    ]);
+
+    $this->expectException(HttpBadRequestException::class);
+    $this->licenseController->exportBulkText($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::exportBulkText() with non-admin user.
+   * -# Verify HttpForbiddenException is thrown.
+   * @return void
+   * @throws \Fossology\UI\Api\Exceptions\HttpErrorException
+   */
+  public function testExportBulkTextNotAdmin()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $request = $this->getRequestWithQueryParams('GET', []);
+
+    $this->expectException(HttpForbiddenException::class);
+    $this->licenseController->exportBulkText($request, new ResponseHelper(), []);
+  }
+
   /**\
    * @test
    * @return Request
@@ -1678,6 +1797,19 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
 
     $request = new Request($method, new Uri("HTTP", "localhost"),
       $requestHeaders, [], [], $body);
+    return $request;
+  }
+
+  /**
+   * @param string $method
+   * @param array $queryParams
+   * @return M\MockInterface
+   */
+  private function getRequestWithQueryParams($method, $queryParams)
+  {
+    $request = M::mock('Psr\\Http\\Message\\ServerRequestInterface');
+    $request->shouldReceive('getQueryParams')->andReturn($queryParams);
+    $request->shouldReceive('getMethod')->andReturn($method);
     return $request;
   }
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Feature to Export monkbulk text in either JSON/CSV Format. With filters required --> by group, by users or all. 

### Changes

1. `src/lib/php/Application/BulkTextExport.php` : The Process file which handles the extraction of text and converting it into required format from user.
2. `src/www/ui/page/AdminBulkTextExport.php` : Controller routing the user request to the process and dao functions.
3. `src/www/ui/template/admin_bulk_text_export.html.twig` : Twig Template for Admin --> Bulk --> Bulk Text Export
4. Create API endpoint `license/bulk-text/export` to extend api support
5. Write test cases to test new api endpoint
6. Fix the pattern in `index.php`, Following the issue of `}` closing pretty late. Could be optimized

## How to test

1. Go to `Admin --> Bulk --> Bulk Text Export`
2. Select the Export Format, Select the filter
3. Click on  Export to download the files in the required format.
4. Also test through theapi endpoint.


