### PR TITLE
fix(cp2foss): detect wget_agent failure and report download error

### DIFF
--- a/src/cli/cp2foss.php
+++ b/src/cli/cp2foss.php
@@ -357,6 +357,15 @@ function UploadOne($FolderPath, $UploadArchive, $UploadName, $UploadDescription,
       $row = $dbManager->getSingleRow($SQL, array($UploadPk), __METHOD__.".UploadOne");
       if (empty($row)) {
         $working = false;
+        if ($jobqueuepk > 0) {
+          $SQL = "SELECT jq_end_bits FROM jobqueue WHERE jq_pk = $1";
+          $status = $dbManager->getSingleRow($SQL, array($jobqueuepk), __METHOD__);
+
+          if (!empty($status) && $status['jq_end_bits'] != 0) {
+            fwrite(STDERR, "ERROR: Failed to download component (URL invalid or HTTP error)\n");
+            return 1;
+          }
+        }
       }
 
     }


### PR DESCRIPTION
## Summary

This PR improves error reporting in cp2foss when a wget_agent job fails to download a component (for example due to HTTP 404 or network error). Previously, cp2foss would exit silently after the synchronous wait loop even if the download failed. This change checks the job status and reports a clear error message to the user.

## Details

- Added logic in UploadOne() to check the wget_agent job status (`jq_end_bits`) after the synchronous wait loop completes.
- If the wget_agent job finished with a non-zero status, cp2foss now prints a clear error message to STDERR.
- Added a defensive check to ensure `jobqueuepk` is valid before querying the jobqueue table.
- Script exits with status code `1` when a download failure occurs.
- No changes were made to job scheduling or existing agent workflow.

# Testing

 - Verified logic flow of synchronous execution in `UploadOne()`.
 - Confirmed that previously the loop exited without checking wget_agent failure status.
 - Verified that the added logic reads `jq_end_bits` and reports failure correctly.
 - Confirmed that successful execution path remains unchanged.

### Related Issue

- Closes #503

Notes

   - This change only adds error reporting after wget_agent execution.
   - No database schema changes included.
   - No changes to existing agent scheduling or processing logic.