### PR TITLE
fix(test): replace deprecated assertRegExp in test_common_menu.php

### DIFF
--- a/src/lib/php/tests/test_common_menu.php
+++ b/src/lib/php/tests/test_common_menu.php
@@ -12,6 +12,7 @@
 namespace Fossology\Tests;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\Version as PHPUnitVersion;
 
 require_once dirname(__FILE__) . '/../common-menu.php';
 require_once dirname(__FILE__) . '/../common-parm.php';
@@ -96,12 +97,20 @@ class CommonMenuTest extends TestCase
     // Assert that menu_to_1html() generates correct output
     $result = menu_to_1html($MenuList);
     $pattern = "/TestMenu/";
-    $this->assertRegExp($pattern, $result);
+    if (intval(explode('.', PHPUnitVersion::id())[0]) >= 9) {
+      $this->assertMatchesRegularExpression($pattern, $result);
+    } else {
+      $this->assertRegExp($pattern, $result);
+    }
 
     $parm = "";
     $result = menu_to_1list($MenuList, $parm, "", "");
     // Assert that menu_to_1list() generates correct output
-    $this->assertRegExp($pattern, $result);
+    if (intval(explode('.', PHPUnitVersion::id())[0]) >= 9) {
+      $this->assertMatchesRegularExpression($pattern, $result);
+    } else {
+      $this->assertRegExp($pattern, $result);
+    }
   }
 
   /**


### PR DESCRIPTION
## What this fixes

`assertRegExp` was deprecated in PHPUnit 9 and removed in PHPUnit 10.
`test_common_menu.php` was still using the old method, causing test warnings
(and failures on newer PHPUnit). Replaced with `assertMatchesRegularExpression`.

## Files changed

- `src/lib/php/tests/test_common_menu.php` — 2 occurrences replaced

## What was NOT changed

`LicenseStdCommentDaoTest.php` and `cliTest.php` also call `assertRegExp` but
they already wrap it in a PHPUnit version check (`>= 9`), so they are
intentionally backwards-compatible and left as-is.


---
