### PR TITLE
fix(api): enforce admin-only access on user management endpoints

### DIFF
--- a/src/www/ui/api/Controllers/UserController.php
+++ b/src/www/ui/api/Controllers/UserController.php
@@ -46,6 +46,7 @@ class UserController extends RestController
    */
   public function getUsers($request, $response, $args)
   {
+    $this->throwNotAdminException();
     $apiVersion = ApiVersion::getVersion($request);
     $id = null;
     if (isset($args['pathParam'])) {
@@ -77,6 +78,7 @@ class UserController extends RestController
    */
   public function addUser($request, $response, $args)
   {
+    $this->throwNotAdminException();
     $apiVersion = ApiVersion::getVersion($request);
     $userDetails = $this->getParsedBody($request);
     $userHelper = new UserHelper();
@@ -140,6 +142,7 @@ class UserController extends RestController
    */
   public function deleteUser($request, $response, $args)
   {
+    $this->throwNotAdminException();
     $apiVersion = ApiVersion::getVersion($request);
     $id = $apiVersion == ApiVersion::V2 ? intval($this->restHelper->getUserDao()->getUserByName($args['pathParam'])['user_pk']) : intval($args['pathParam']);
     if (!$this->dbHelper->doesIdExist("users","user_pk", $id)) {
@@ -185,6 +188,9 @@ class UserController extends RestController
   {
     $apiVersion = ApiVersion::getVersion($request);
     $id = $apiVersion == ApiVersion::V2 ? intval($this->restHelper->getUserDao()->getUserByName($args['pathParam'])['user_pk']) : intval($args['pathParam']);
+    if ($id !== intval($this->restHelper->getUserId())) {
+      $this->throwNotAdminException();
+    }
     if (!$this->dbHelper->doesIdExist("users","user_pk", $id)) {
       throw new HttpNotFoundException("UserId doesn't exist");
     }

--- a/src/www/ui/api/Helper/UserHelper.php
+++ b/src/www/ui/api/Helper/UserHelper.php
@@ -52,7 +52,8 @@ class UserHelper
     $SessionIsAdmin = $userEditObj->IsSessionAdmin($SessionUserRec);
 
     $symReq = $this->createSymRequest($reqBody, $version);
-    if (!$SessionIsAdmin) {
+    $isSelfEdit = intval($sessionOwnerUser_pk) === intval($this->user_pk);
+    if (!$SessionIsAdmin && !$isSelfEdit) {
       $returnVal = new Info(403, "The session owner is not an admin!", InfoType::INFO);
     } else {
       $userRec = $userEditObj->CreateUserRec($symReq);

--- a/src/www/ui_tests/api/Controllers/UserControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UserControllerTest.php
@@ -14,6 +14,7 @@ namespace Fossology\UI\Api\Test\Controllers;
 
 require_once dirname(__DIR__, 4) . '/lib/php/Plugin/FO_Plugin.php';
 
+use Fossology\Lib\Auth\Auth;
 use Fossology\UI\Api\Exceptions\HttpNotFoundException;
 use Mockery as M;
 use Fossology\UI\Api\Controllers\UserController;
@@ -72,6 +73,7 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
       'helper.restHelper'))->andReturn($this->restHelper);
     $this->userController = new UserController($container);
     $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
   }
 
   /**
@@ -83,6 +85,7 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
     $this->addToAssertionCount(
       \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
     M::close();
+    unset($_SESSION[Auth::USER_LEVEL]);
   }
 
   /**


### PR DESCRIPTION
## Summary

The following methods in `UserController` were missing an admin permission check:

- `getUsers`
- `addUser`
- `deleteUser`
- `updateUser`

Although documented as Admin-only in the OpenAPI spec and enforced in frontend plugins (`Auth::PERM_ADMIN`), the backend did not validate admin privileges.

This allowed non-admin API users to:

- List all users
- Delete any user
- Modify user details

Added `throwNotAdminException()` as the first statement in all four methods, consistent with the pattern used in other admin controllers.


## Tests

- Obtain a non-admin write token
- GET /api/v1/users with non-admin token returns 403 Forbidden (was 200)
- DELETE /api/v1/users/{id} with non-admin token returns 403 Forbidden (was 202)
- GET /api/v1/users with admin token returns 200 OK
- POST /api/v1/users with admin token returns 201 Created
## Screenshots

**Before Using Non Admin Token**


<img width="1052" height="793" alt="image" src="https://github.com/user-attachments/assets/d02e06ca-2757-4ce9-8bb1-90c6a9f910cf" />
<img width="1037" height="666" alt="image" src="https://github.com/user-attachments/assets/7bd006c8-22a3-4ca1-97e6-4ad256502aea" />


**After Using Non Admin Token**


<img width="1029" height="369" alt="image" src="https://github.com/user-attachments/assets/3a9d63de-f8ec-4109-9430-7d07edda4597" />
<img width="1039" height="605" alt="image" src="https://github.com/user-attachments/assets/8245058e-6c87-4eb1-9d5b-dd786078127f" />