### PR TITLE
fix(schema): add missing copyright_ars table to core-schema.dat

### DIFF
--- a/src/clixml/agent_tests/Functional/schedulerTest.php
+++ b/src/clixml/agent_tests/Functional/schedulerTest.php
@@ -68,7 +68,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
   {
     $this->testDb->createPlainTables(array(),true);
     $this->testDb->createInheritedTables();
-    $this->dbManager->queryOnce("CREATE TABLE copyright_ars () INHERITS (ars_master)");
+    $this->dbManager->queryOnce("CREATE TABLE IF NOT EXISTS copyright_ars () INHERITS (ars_master)");
 
     $this->testDb->createSequences(array('agent_agent_pk_seq','pfile_pfile_pk_seq','upload_upload_pk_seq','nomos_ars_ars_pk_seq','license_file_fl_pk_seq','license_ref_rf_pk_seq','license_ref_bulk_lrb_pk_seq','clearing_decision_clearing_decision_pk_seq','clearing_event_clearing_event_pk_seq'));
     $this->testDb->createConstraints(array('agent_pkey','pfile_pkey','upload_pkey_idx','FileLicense_pkey','clearing_event_pkey'));

--- a/src/copyright/agent_tests/Functional/schedulerTest.php
+++ b/src/copyright/agent_tests/Functional/schedulerTest.php
@@ -162,7 +162,7 @@ class schedulerTest extends \PHPUnit\Framework\TestCase
     $this->testDb->createSequences(array('agent_agent_pk_seq','upload_upload_pk_seq','pfile_pfile_pk_seq','users_user_pk_seq','nomos_ars_ars_pk_seq'));
     $this->testDb->createConstraints(array('agent_pkey','upload_pkey_idx','pfile_pkey','user_pkey'));
     $this->testDb->alterTables(array('agent','pfile','upload','ars_master','users'));
-    $this->testDb->createInheritedTables(array('uploadtree_a'));
+    $this->testDb->createInheritedTables(array('uploadtree_a', 'copyright_ars'));
 
     $this->testDb->insertData(array('upload','pfile','uploadtree_a','bucketpool','mimetype','users'), false);
   }

--- a/src/spdx/agent_tests/Functional/schedulerTest.php
+++ b/src/spdx/agent_tests/Functional/schedulerTest.php
@@ -110,7 +110,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
   {
     $this->testDb->createPlainTables(array(),true);
     $this->testDb->createInheritedTables();
-    $this->dbManager->queryOnce("CREATE TABLE copyright_ars () INHERITS (ars_master)");
+    $this->dbManager->queryOnce("CREATE TABLE IF NOT EXISTS copyright_ars () INHERITS (ars_master)");
 
     $this->testDb->createSequences(array('agent_agent_pk_seq','pfile_pfile_pk_seq','upload_upload_pk_seq',
       'nomos_ars_ars_pk_seq','license_file_fl_pk_seq','license_ref_rf_pk_seq',

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -2875,5 +2875,6 @@
   $Schema["INHERITS"]["ununpack_ars"] = "ars_master";
   $Schema["INHERITS"]["nomos_ars"] = "ars_master";
   $Schema["INHERITS"]["monk_ars"] = "ars_master";
+  $Schema["INHERITS"]["copyright_ars"] = "ars_master";
   $Schema["INHERITS"]["spasht_ars"] = "ars_master";
   $Schema["INHERITS"]["license_candidate"] = "license_ref";


### PR DESCRIPTION
## Description

The `copyright_ars` table was missing from the `INHERITS` section of `core-schema.dat`, causing a white page when running **Copyright/Email/URL scans** on fresh Docker installations.

All other agent result tables (`nomos_ars`, `monk_ars`, `reuser_ars`, `ununpack_ars`, etc.) were correctly defined, but `copyright_ars` was absent.

This change adds `copyright_ars` to the schema `INHERITS` block so it is automatically created during installation, alongside other agent result tables.

---

## Changes

- Added `copyright_ars` to the `INHERITS` section of `core-schema.dat`
- Ensures table is created automatically on fresh installations
- Fixes the white page issue on Copyright/Email/URL scans

---

## How to test

1. Perform a fresh Docker installation of Fossology.

2. Enter the database container:

```bash
docker exec -it fossology-db psql -U fossy fossology
````

3. Verify that the `copyright_ars` table does **not** exist before the fix:

```sql
\d copyright_ars
```

Expected output:

```
Did not find any relation named "copyright_ars".
```

4. Apply the schema change by adding the inheritance entry in:

```
src/www/ui/core-schema.dat
```

Add the line:

```php
$Schema["INHERITS"]["copyright_ars"] = "ars_master";
```

5. Restart Fossology services:

```bash
docker compose restart
```

6. Recheck the table in PostgreSQL:

```sql
\d copyright_ars
```

7. Confirm that the table now exists and inherits from `ars_master`.

8. Run a **Copyright/Email/URL scan** from the Fossology UI and verify that the scan completes successfully without the white page.

---

Fixes #3218 