### PR TITLE
fix(test): add setUp/tearDown to initialize MenuList

### DIFF
--- a/src/lib/php/tests/test_common_menu.php
+++ b/src/lib/php/tests/test_common_menu.php
@@ -23,6 +23,15 @@ require_once dirname(__FILE__) . '/../common-parm.php';
 class CommonMenuTest extends TestCase
 {
   /**
+   * Set up before each test
+   */
+  protected function setUp() : void
+  {
+    global $MenuList;
+    $MenuList = array();
+  }
+
+  /**
    * Test for MenuPage() function
    */
   public function testMenuPage()
@@ -109,6 +118,7 @@ class CommonMenuTest extends TestCase
    */
   protected function tearDown(): void
   {
-    // Additional teardown code, if needed
+    global $MenuList;
+    $MenuList = array();
   }
 }


### PR DESCRIPTION
This PR adds proper setUp() and tearDown() methods to the PHPUnit test for common-menu.php.

Changes:
- Added setUp() method to initialize global $MenuList array before each test
- Added tearDown() method to clean up $MenuList after each test

This fixes the test to work properly with the CMake build system as mentioned in issue #2084.

Fixes #2084