### PR TITLE
fix(spdx): propagate custom license text to package-level concluded l…

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -900,6 +900,38 @@ INSERT INTO clearing_decision (
   }
 
   /**
+   * Fetch custom license texts (reportinfo) for main licenses of an upload.
+   *
+   * @param int $uploadId
+   * @param int $groupId
+   * @return array<int,string> license_id => reportinfo text
+   */
+  public function getMainLicenseReportInfos($uploadId, $groupId)
+  {
+    $uploadTreeTableName = $this->uploadDao->getUploadtreeTableName($uploadId);
+    $statementName = __METHOD__;
+    $sql = "SELECT DISTINCT ON (ce.rf_fk)
+              ce.rf_fk AS license_id,
+              ce.reportinfo
+            FROM $uploadTreeTableName ut
+            INNER JOIN clearing_event ce ON ce.uploadtree_fk = ut.uploadtree_pk
+            WHERE ut.upload_fk = \$1
+              AND ce.group_fk = \$2
+              AND NOT ce.removed
+              AND ce.reportinfo IS NOT NULL
+              AND ce.reportinfo <> ''
+            ORDER BY ce.rf_fk, ce.date_added DESC, ce.clearing_event_pk DESC";
+    $this->dbManager->prepare($statementName, $sql);
+    $result = $this->dbManager->execute($statementName, array($uploadId, $groupId));
+    $reportInfos = array();
+    while ($row = $this->dbManager->fetchArray($result)) {
+      $reportInfos[intval($row['license_id'])] = $row['reportinfo'];
+    }
+    $this->dbManager->freeResult($result);
+    return $reportInfos;
+  }
+
+  /**
    * @param $uploadId
    * @param int $groupId
    * @param int $licenseId

--- a/src/spdx/agent/spdx.php
+++ b/src/spdx/agent/spdx.php
@@ -379,6 +379,7 @@ class SpdxAgent extends Agent
     $fileNodes = $this->generateFileNodes($filesWithLicenses, $upload->getTreeTableName(), $uploadId);
 
     $mainLicenseIds = $this->clearingDao->getMainLicenseIds($uploadId, $this->groupId);
+    $customMainLicenseTexts = $this->clearingDao->getMainLicenseReportInfos($uploadId, $this->groupId);
     $mainLicenses = array();
     foreach ($mainLicenseIds as $licId) {
       $reportedLicenseId = $this->licenseMap->getProjectedId($licId);
@@ -389,16 +390,37 @@ class SpdxAgent extends Agent
         );
         continue; // Skip this license and continue with the next one
       }
-      $reportLicId = $mainLicense->getId() . "-" . md5($mainLicense->getText());
-      $mainLicenses[] = $reportLicId;
-      if (!array_key_exists($reportLicId, $this->licensesInDocument)) {
-        $listedLicense = stripos($mainLicense->getSpdxId(),
-            LicenseRef::SPDXREF_PREFIX) !== 0;
+      $customText = $customMainLicenseTexts[$licId] ?? null;
+      if (!empty($customText)) {
+        $reportLicId = $mainLicense->getId() . "-" . md5($customText);
+        $prefix = $stateOsselot ? LicenseRef::SPDXREF_PREFIX : LicenseRef::SPDXREF_PREFIX_FOSSOLOGY;
+        $customShortName = $prefix . $mainLicense->getShortName() . "-" . md5($customText);
+        $customLicense = new License(
+          $mainLicense->getId(),
+          $customShortName,
+          $mainLicense->getFullName(),
+          $mainLicense->getRisk(),
+          $customText,
+          $mainLicense->getUrl(),
+          $mainLicense->getDetectorType(),
+          ''
+        );
         $this->licensesInDocument[$reportLicId] = (new SpdxLicenseInfo())
-          ->setLicenseObj($mainLicense)
-          ->setCustomText(false)
-          ->setListedLicense($listedLicense);
+          ->setLicenseObj($customLicense)
+          ->setCustomText(true)
+          ->setListedLicense(false);
+      } else {
+        $reportLicId = $mainLicense->getId() . "-" . md5($mainLicense->getText());
+        if (!array_key_exists($reportLicId, $this->licensesInDocument)) {
+          $listedLicense = stripos($mainLicense->getSpdxId(),
+              LicenseRef::SPDXREF_PREFIX) !== 0;
+          $this->licensesInDocument[$reportLicId] = (new SpdxLicenseInfo())
+            ->setLicenseObj($mainLicense)
+            ->setCustomText(false)
+            ->setListedLicense($listedLicense);
+        }
       }
+      $mainLicenses[] = $reportLicId;
     }
     $mainLicenseString = [];
     if ($this->outputFormat == "spdx2tv" ||


### PR DESCRIPTION
## Description

When a license with custom text (reportinfo) is set as the main license of an upload, the package-level `PackageLicenseConcluded` and `PackageLicenseDeclared` fields in SPDX exports showed the generic SPDX identifier (e.g. `BSD-2-Clause`) instead of the correct `LicenseRef-fossology-<license>-<hash>` identifier, causing inconsistency with the file-level license entries.

### Root cause
`renderPackage()` in `spdx.php` always used `md5($mainLicense->getText())` (the standard license text hash) when building the package-level license entry, ignoring any custom reportinfo text set by the user.

### Fix
- Added `getMainLicenseReportInfos()` to `ClearingDao.php` — fetches the latest custom reportinfo text per license for the upload.
- Updated `renderPackage()` in `spdx.php` — when custom text exists for a main license, builds the `LicenseRef-fossology-*` identifier using `md5($customText)`, matching the file-level behavior exactly.

## How to test

1. Upload a file with a detectable license (e.g. BSD-2-Clause)  
2. Run nomos scan  
3. Clear the license and mark it as main license (star it)  
4. Add custom text in the Report Info field  
5. Export SPDX2 TV report  
6. Verify `PackageLicenseConcluded` and `PackageLicenseDeclared` reference the `LicenseRef-fossology-*` identifier and `ExtractedText` contains the custom text

## Screenshots

**Package-level license now references the correct LicenseRef identifier:**

<img width="1075" height="420" alt="image" src="https://github.com/user-attachments/assets/e90037a8-4218-41b0-add5-9c704b23a0ad" />

**Custom text correctly included in ExtractedText:**

<img width="989" height="219" alt="image" src="https://github.com/user-attachments/assets/ad52f40a-75e4-405f-a57e-e4938da1a8e3" />

Closes #3106 