### PR TITLE
fix(copyright/oneshot): escape shell arguments to prevent command injection

### DIFF
--- a/src/copyright/ui/oneshot.php
+++ b/src/copyright/ui/oneshot.php
@@ -59,7 +59,9 @@ class agent_copyright_once extends FO_Plugin
       return _("unable to change working directory to $copyright_dir\n");
     }
     //$Sys = "./copyright -C $tempFileName -c $SYSCONFDIR";
-    $Sys = "./copyright -c $SYSCONFDIR $tempFileName";
+    $escapedSysConfDir = escapeshellarg($SYSCONFDIR);
+    $escapedTempFile = escapeshellarg($tempFileName);
+    $Sys = "./copyright -c $escapedSysConfDir $escapedTempFile";
 
     $inputFile = popen($Sys, "r");
     $colors = array();


### PR DESCRIPTION
## Description

The PR replaces direct use of `SYSCONFDIR` and temp file path in `popen` command with `escapeshellarg()`. This secures the shell invocation against injection attacks.

### Changes
-Used `escapeshellarg()`  this prevents shell metacharacters in input paths from being interpreted as commands.


