### PR TITLE
Include license text in CycloneDX SBOM export when available

### DIFF
--- a/src/cyclonedx/agent/cyclonedx.php
+++ b/src/cyclonedx/agent/cyclonedx.php
@@ -222,10 +222,17 @@ class CycloneDXAgent extends Agent
           ->setTextPrinted(true)
           ->setListedLicense(true);
       }
-      $licensedata['id'] = $mainLicObj->getSpdxId();
-      $licensedata['url'] = $mainLicObj->getUrl();
-      $mainLicenses[] = $this->reportGenerator->createLicense($licensedata);
+      $licensedata = [
+      'id'  => $mainLicObj->getSpdxId(),
+      'url' => $mainLicObj->getUrl()
+    ];
+
+    if (!empty($mainLicObj->getText())) {
+      $licensedata['textContent'] = base64_encode($mainLicObj->getText());
+      $licensedata['textContentType'] = 'text/plain';
     }
+
+    $mainLicenses[] = $this->reportGenerator->createLicense($licensedata);
 
     $hashes = $this->uploadDao->getUploadHashes($uploadId);
     $serializedhash = array();


### PR DESCRIPTION
Fixes #3451

CycloneDX SBOM export currently omits **license text** even when it is available via **LicenseDao::getLicenseById()->getText()**.

This PR includes the **license text** in the generated SBOM when available by passing the text content to **BomReportGenerator::createLicense()**.

The text is **base64 encoded** and emitted using the CycloneDX **`license.text`** field as supported by the specification.