### PR TITLE
fix(cyclonedx): include license text in SBOM export when available

### DIFF
--- a/src/cyclonedx/agent/cyclonedx.php
+++ b/src/cyclonedx/agent/cyclonedx.php
@@ -222,8 +222,13 @@ class CycloneDXAgent extends Agent
           ->setTextPrinted(true)
           ->setListedLicense(true);
       }
+      $licensedata = array();
       $licensedata['id'] = $mainLicObj->getSpdxId();
       $licensedata['url'] = $mainLicObj->getUrl();
+      if (!empty($mainLicObj->getText())) {
+          $licensedata['textContent'] = base64_encode($mainLicObj->getText());
+          $licensedata['textContentType'] = 'text/plain';
+      }
       $mainLicenses[] = $this->reportGenerator->createLicense($licensedata);
     }
 


### PR DESCRIPTION
Fixes #3451

CycloneDX SBOM export currently omits license text even when it is available
via LicenseDao::getLicenseById()->getText().

This change passes the license text to BomReportGenerator::createLicense()
when available, encoding it in base64 and emitting it through the CycloneDX
`license.text` field as supported by the specification.