### PR TITLE
fix(folders): Fix silent empty result when listing uploads with PERM_WRITE

### DIFF
--- a/src/lib/php/common-folders.php
+++ b/src/lib/php/common-folders.php
@@ -419,7 +419,7 @@ function FolderListUploadsRecurse($ParentFolder=-1, $FolderPath = '',
   if (empty($ParentFolder)) {
     return array();
   }
-  if ($perm != Auth::PERM_READ && $perm = Auth::PERM_WRITE) {
+  if ($perm != Auth::PERM_READ && $perm != Auth::PERM_WRITE) {
     return array();
   }
   if ($ParentFolder == "-1") {


### PR DESCRIPTION
## What's the bug

`FolderListUploadsRecurse()` has a typo on the permission guard — a single `=` instead of `!=`:

```php
// before
if ($perm != Auth::PERM_READ && $perm = Auth::PERM_WRITE) {

// after
if ($perm != Auth::PERM_READ && $perm != Auth::PERM_WRITE) {
```

The assignment `$perm = Auth::PERM_WRITE` always evaluates to truthy, so every call with `PERM_WRITE` hits the early `return array()` and gives back an empty upload list. Two callers are affected: `fossjobs.php` and `admin-tag-manage.php`.

## Fix

One character: `=` → `!=`. The guard now correctly passes through both `PERM_READ` and `PERM_WRITE` and only bails on invalid values.

## CI checks (run locally)

| Check | Result |
|---|---|
| syntax-check (`syntaxtest.sh`) | ✅ pass |
| code-analysis (`cppcheck`) | ✅ no new errors (pre-existing macro errors unchanged) |
| lint-commits | ✅ pass |
| php-unit | ✅ pass |
| cmake build | ✅ pass (PHP-only change, no C/C++ impact) |