### PR TITLE
docs(nomos): update Notes to reflect current build and integration

### DIFF
--- a/src/nomos/agent/Notes
+++ b/src/nomos/agent/Notes
@@ -9,25 +9,18 @@ To Whom it May Concern:
 What This Is and How to Work It
 -------------------------------
 
-This directory in the FOSSology source tree
-(agents/nomos) contains work for a new license analysis agent. This
-code originated from a standalone license-scanning tool called Nomos.
-
-At this point in time, the code is not integrated with the rest of FOSSology. 
-It uses it's own non-standard Makefile to build a single standalone 
-executable.
-
-To try it out...
-
-   % make
-   % ./nomos <file_to_be_scanned>
-
-The file to be scanned should be a regular file (binary or text). In
-particular, it should not be an archive. No unpacking is done; the file
-is scanned as is.
-
+This directory in the FOSSology source tree (`agents/nomos`) contains the source code for the `nomos` license analysis agent. It scans files for known license text patterns using pattern matching whose results are recorded and later used for license analysis and reporting. The file to be scanned should be a regular file (binary or text). In particular, it should not be an archive. No unpacking is done; the file is scanned as is.
 There are currently no command-line options.
 
+`nomos` initially started as a standalone license scanning tool whose code was later imported into the project. It is now a fully integrated agent within the analysis pipeline into the FOSSology agent framework and is no longer a standalone tool and is invoked by the scheduler, not run manually.
+
+`nomos` is now built using the FOSSology CMake build system and compiled as a part of the main project build process unlike preceding versions which used a custom Makefile. The build configuration is defined in src/nomos/CMakeLists.txt
+
+## PostgreSQL Dependency
+To build the `nomos` agent, PostgreSQL development headers must be installed as it interacts with the FOSSology database. Attempting to build `nomos` without PostgreSQL development libraries might cause the build to fail. Hence ensure the PostgreSQL development package (`libpq-dev`) is available on your system.
+
+## Environment Dependency
+`nomos` is designed to run within the FOSSology agent framework and expects the FOSSology runtime environment and relies on configuration provided through `fossology.conf`. Manual execution of the binary is primarily useful for development or debugging.
 
 Note About the Source Code and Impending Changes
 ------------------------------------------------
@@ -109,4 +102,3 @@ Changes made from my nomos_experimental version
 -----------------------------------------------
 
 Remove all code #ifdef'd by USE_MMAP 
-


### PR DESCRIPTION
## Summary

This PR updates the developer notes for `nomos` to reflect the current
architecture and build system within FOSSology. The current notes describe
an earlier stage where `nomos` existed as a standalone tool built with a
custom Makefile. However, it is now integrated into the FOSSology agent
framework and built through the CMake build system.

## Details

- Clarified that `nomos` was originally developed as a standalone license
  scanning tool and later integrated into FOSSology.
- Updated documentation to reflect that `nomos` is built using the FOSSology
  CMake build system.
- Removed outdated references to building `nomos` using a standalone Makefile.
- Added clarification about dependency on PostgreSQL client headers during
  compilation.
- Added note explaining reliance on the FOSSology runtime configuration
  (`fossology.conf`).
- Preserved the original historical contextual development notes.

# Testing

 - Verified the documentation in `src/nomos/agent/Notes` reflects the current
   integration of `nomos` within FOSSology.
 - Confirmed outdated standalone build instructions referencing a custom
   Makefile are removed.
 - Ensured the updated notes reference the current CMake based build system.
 - Confirmed that historical development notes remain preserved.

### Related Issue

- Closes #2795

Notes

   - This change updates documentation only.
   - No functional or behavioral changes were made to the `nomos` agent.
   - No changes were made to the build system or runtime behavior.