### PR TITLE
perf(nomos): optimize hash table lookups in nomos_utils.c

### DIFF
--- a/src/nomos/agent/nomos_utils.c
+++ b/src/nomos/agent/nomos_utils.c
@@ -104,7 +104,7 @@ FUNCTION long add2license_ref(char *licenseName)
 }
 
 /**
- \brief calculate the hash of an rf_shortname
+ \brief calculate the hash of an rf_shortname using FNV-1a hash algorithm
  rf_shortname is the key
 
  @param pcroot Root pointer
@@ -114,15 +114,16 @@ FUNCTION long add2license_ref(char *licenseName)
  */
 FUNCTION long lrcache_hash(cacheroot_t *pcroot, char *rf_shortname)
 {
-  long hashval = 0;
-  int len, i;
-
-  /* use the first sizeof(long) bytes for the hash value */
-  len = (strlen(rf_shortname) < sizeof(long)) ? strlen(rf_shortname) : sizeof(long);
-  for (i = 0; i < len; i++)
-    hashval += rf_shortname[i] << 8 * i;
-  hashval = hashval % pcroot->maxnodes;
-  return hashval;
+  unsigned long hashval = 2166136261UL; // FNV offset basis
+  unsigned char *p = (unsigned char *)rf_shortname;
+  
+  while (*p) {
+    hashval ^= (unsigned long)*p++;
+    hashval *= 16777619UL; // FNV prime
+  }
+  
+  // Ensure hash fits within table bounds using power-of-2 masking
+  return (long)(hashval & (pcroot->maxnodes - 1));
 }
 
 /**
@@ -169,6 +170,9 @@ FUNCTION void lrcache_free(cacheroot_t *pcroot)
     {
       free(pcnode->rf_shortname);
     }
+    pcnode->rf_shortname = NULL;
+    pcnode->len = 0;
+    pcnode->rf_pk = 0;
     pcnode++;
   }
   free(pcroot->nodes);
@@ -202,6 +206,7 @@ FUNCTION int lrcache_add(cacheroot_t *pcroot, long rf_pk, char *rf_shortname)
     if (!pcnode->rf_pk)
     {
       pcnode->rf_shortname = strdup(rf_shortname);
+      pcnode->len = strlen(rf_shortname);
       pcnode->rf_pk = rf_pk;
       break;
     }
@@ -227,6 +232,7 @@ FUNCTION long lrcache_lookup(cacheroot_t *pcroot, char *rf_shortname)
   long hashval = 0;
   int i;
   int noden;
+  size_t key_len = strlen(rf_shortname);
 
   hashval = lrcache_hash(pcroot, rf_shortname);
 
@@ -238,7 +244,10 @@ FUNCTION long lrcache_lookup(cacheroot_t *pcroot, char *rf_shortname)
     pcnode = pcroot->nodes + noden;
     if (!pcnode->rf_pk)
       return 0;
-    if (strcmp(pcnode->rf_shortname, rf_shortname) == 0)
+    
+    // Quick length check before expensive string comparison
+    if (pcnode->len == key_len &&
+        strcmp(pcnode->rf_shortname, rf_shortname) == 0)
     {
       return pcnode->rf_pk;
     }

--- a/src/nomos/agent/nomos_utils.h
+++ b/src/nomos/agent/nomos_utils.h
@@ -31,6 +31,7 @@ extern gboolean* printcomma;       ///< True to print comma while printing JSON 
 struct cachenode
 {
     char *rf_shortname;     ///< License shortname
+    size_t len;             ///< Length of rf_shortname string
     long rf_pk;             ///< License id from database
 };
 typedef struct cachenode cachenode_t;
@@ -58,9 +59,9 @@ long add2license_ref(char *licenseName);
 long updateLicenseFile(long rfPk);
 int updateLicenseHighlighting(cacheroot_t *pcroot);
 int initLicRefCache(cacheroot_t *pcroot);
-long lrcache_hash(cacheroot_t *pcroot, char *rf_shortname);
+long lrcache_hash(cacheroot_t *pcroot, char *rf_shortname) __attribute__((always_inline));
 int lrcache_add(cacheroot_t *pcroot, long rf_pk, char *rf_shortname);
-long lrcache_lookup(cacheroot_t *pcroot, char *rf_shortname);
+long lrcache_lookup(cacheroot_t *pcroot, char *rf_shortname) __attribute__((always_inline));
 void lrcache_free(cacheroot_t *pcroot);
 void initializeCurScan(struct curScan* cur);
 void addLicence(GArray* theMatches, char* licenceName );


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Improve hash table lookup performance in `nomos_utils.c`.

The existing hash function used only a few bytes of the key, which could lead to poor hash distribution and increased collisions. This change introduces the FNV-1a hash algorithm and optimizes lookup operations to reduce unnecessary string comparisons.

## Changes

- Replace the existing hash function with the FNV-1a algorithm for better distribution.
- Store the length of `rf_shortname` in the cache node to avoid repeated `strlen()` calls.
- Add a quick length check before performing `strcmp()` during lookups.
- Mark critical lookup functions for inlining.
- Use bit masking for hash indexing when the table size is a power of two.

## How to test

1. Build Fossology normally.
2. Run the Nomos agent on a sample repository or test dataset.
3. Verify that license detection results remain unchanged.
4. Confirm that the application runs without errors and cache lookups function correctly.

Closing issue: #3461