### PR TITLE
feat: implement real-time dashboard sync for audit decisions

### DIFF
--- a/src/www/ui/api/AuditController.php
+++ b/src/www/ui/api/AuditController.php
@@ -1,0 +1,21 @@
+<?php
+namespace Fossology\UI\Api\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class AuditController extends RestController
+{
+    public function post(Request $request)
+    {
+        $uploadId = $request->get('uploadId');
+        $result = $this->getObject('dao.audit')->saveDecision($request);
+
+        if ($result) {
+            // Real-time sync trigger
+            $this->getObject('dao.dashboard')->refreshUploadStats($uploadId);
+            return new JsonResponse(['status' => 'success', 'message' => 'Decision synced'], 200);
+        }
+        return new JsonResponse(['status' => 'error', 'message' => 'Failed to save decision'], 400);
+    }
+}

--- a/src/www/ui/api/Models/DashboardDao.php
+++ b/src/www/ui/api/Models/DashboardDao.php
@@ -1,0 +1,11 @@
+<?php
+namespace Fossology\UI\Api\Models;
+
+class DashboardDao extends RestModel
+{
+    public function refreshUploadStats($uploadId)
+    {
+        $sql = "SELECT refresh_dashboard_stats($1)";
+        return $this->dbManager->getSingleRow($sql, array($uploadId));
+    }
+}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

**Description**

This pull request introduces real-time synchronization between the Audit API and the Dashboard statistics.
Previously, when a clearing expert saved an audit decision, the dashboard "Total Pending" statistics did not update immediately and required manual refresh or container restart.

This change ensures that whenever a decision is successfully saved, the dashboard statistics for the corresponding upload are refreshed automatically.

Closes #3460

**Changes**
-Added a post-save trigger in AuditController.php after saveDecision() execution.
-Implemented refreshUploadStats() in DashboardDao.php.
<img width="1920" height="1080" alt="Screenshot (527)" src="https://github.com/user-attachments/assets/033be0ed-5198-463c-bfd0-c499a1f44b5e" />
The new method calls the PostgreSQL function refresh_dashboard_stats($uploadId) to update dashboard statistics.
