### PR TITLE
fix(buckets): prevent NULL dereference when parsing scheduler input

### DIFF
--- a/src/buckets/agent/buckets.c
+++ b/src/buckets/agent/buckets.c
@@ -236,12 +236,19 @@ int main(int argc, char **argv)
       {
         if (strcmp(token, "bppk") == 0)
         {
-          bucketpool_pk = atoi(strtok_r(NULL, Delims, &saveptr));
+          char *val = strtok_r(NULL, Delims, &saveptr);
+          if (val)
+            bucketpool_pk = atoi(val);
+          else
+            LOG_ERROR("Malformed scheduler input: missing value for bppk");
         }
-        else
-        if (strcmp(token, "upk") == 0)
+        else if (strcmp(token, "upk") == 0)
         {
-          uploadtree.upload_fk = atoi(strtok_r(NULL, Delims, &saveptr));
+          char *val = strtok_r(NULL, Delims, &saveptr);
+          if (val)
+            uploadtree.upload_fk = atoi(val);
+          else
+            LOG_ERROR("Malformed scheduler input: missing value for upk");
         }
         token = strtok_r(NULL, Delims, &saveptr);
       }


### PR DESCRIPTION
The buckets agent parses scheduler input using strtok_r and atoi.

If malformed input is received (missing value after bppk= or upk=),
strtok_r may return NULL, which is then passed to atoi(). This results
in undefined behavior, which may cause a crash.

This patch adds validation before converting tokens to integers to
prevent NULL dereference and improve robustness.