### PR TITLE
feat(copyrightHist): add functionility to group select items using Sh…

### DIFF
--- a/src/copyright/ui/template/histTable.js.twig
+++ b/src/copyright/ui/template/histTable.js.twig
@@ -92,9 +92,40 @@ function createTable{{ table.type }}() {
 
   createTableBase{{ table.type }}(false);
 
+  let lastCheckedRow = null;
   $('#selectDelete{{ table.type }}').change(function () {
-    $('.deleteBySelect{{ table.type }}').prop('checked', $(this).prop("checked"));
+    const isChecked = $(this).prop('checked');
+    $('.deleteBySelect{{ table.type }}').prop('checked', isChecked);
+    lastCheckedRow = null; // Reset on select all
   });
+
+  $(document).on('click', '.deleteBySelect{{ table.type }}', function (event) {
+    const $checkboxes = $('table tbody tr .deleteBySelect{{ table.type }}');
+    const currentRow = $checkboxes.index(this);
+    const isChecked = $(this).prop('checked');
+    if (event.shiftKey && lastCheckedRow !== null) {
+      const start = Math.min(lastCheckedRow, currentRow);
+      const end   = Math.max(lastCheckedRow, currentRow);
+      $checkboxes.slice(start, end + 1).prop('checked', isChecked);
+    }
+    lastCheckedRow = currentRow;
+    syncFromSelectAll{{ table.type }}();
+  });
+
+  function syncFromSelectAll{{ table.type }}() {
+    const $checkboxes = $('table tbody tr .deleteBySelect{{ table.type }}');
+    const total   = $checkboxes.length;
+    const checked = $checkboxes.filter(':checked').length;
+    const $selectAll = $('#selectDelete{{ table.type }}');
+
+    if (checked === 0) {
+      $selectAll.prop('checked', false).prop('indeterminate', false);
+    } else if (checked === total) {
+      $selectAll.prop('checked', true).prop('indeterminate', false);
+    } else {
+      $selectAll.prop('checked', false).prop('indeterminate', true); // Shows dash –
+    }
+  }
 
   $('#deleteSelected{{ table.type }}').click(function () {
     $("input:checkbox[class=deleteBySelect{{ table.type }}]:checked").each(function () {


### PR DESCRIPTION
…ift key

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Extend the select all functionality to detect grouped select using shift key from keyboard.

### Changes

Identify the min and max current rows using math and calculate the distance to select rest.

## How to test

* Go to copyright hist page.
* For activated copyrights table select any one copyright row in the middle of the table.
* Now press shift and select n numbered row.
* All the rows in between shall get selected.

Note: the functionality is not implemented for selection of <td> to avoid duplicate selection of single row.
