### PR TITLE
Enhance CycloneDX export with scanner evidence and SPDX expressionsCy…

### DIFF
--- a/src/cyclonedx/agent/cyclonedx.php
+++ b/src/cyclonedx/agent/cyclonedx.php
@@ -33,6 +33,7 @@ use Fossology\Lib\Report\ReportUtils;
 
 include_once(__DIR__ . "/version.php");
 include_once(__DIR__ . "/reportgenerator.php");
+include_once(__DIR__ . "/../../spdx/agent/spdxutils.php");
 
 /**
  * @class cyclonedxAgent
@@ -105,20 +106,20 @@ class CycloneDXAgent extends Agent
   {
     // deduce the agent name from the command line arguments
     $args = getopt("", array(
-      self::OUTPUT_FORMAT_KEY.'::',
-      self::UPLOADS_ADD_KEY.'::'
+      self::OUTPUT_FORMAT_KEY . '::',
+      self::UPLOADS_ADD_KEY . '::'
     ));
     $agentName = "";
     if (array_key_exists(self::OUTPUT_FORMAT_KEY, $args)) {
       $agentName = trim($args[self::OUTPUT_FORMAT_KEY]);
     }
     if (empty($agentName)) {
-        $agentName = self::DEFAULT_OUTPUT_FORMAT;
+      $agentName = self::DEFAULT_OUTPUT_FORMAT;
     }
     if (array_key_exists(self::UPLOADS_ADD_KEY, $args)) {
       $uploadsString = $args[self::UPLOADS_ADD_KEY];
       if (!empty($uploadsString)) {
-          $this->additionalUploads = explode(',', $uploadsString);
+        $this->additionalUploads = explode(',', $uploadsString);
       }
     }
 
@@ -159,10 +160,10 @@ class CycloneDXAgent extends Agent
     if (count($this->additionalUploads) > 0) {
       $fileName = $fileBase . "multifile" . "_" . strtoupper($this->outputFormat);
     } else {
-      $fileName = $fileBase. strtoupper($this->outputFormat)."_".$this->packageName;
+      $fileName = $fileBase . strtoupper($this->outputFormat) . "_" . $this->packageName;
     }
 
-    return $fileName .".json" ;
+    return $fileName . ".json";
   }
 
   /**
@@ -175,7 +176,7 @@ class CycloneDXAgent extends Agent
     $upload = $this->uploadDao->getUpload($uploadId);
     $this->packageName = $upload->getFilename();
 
-    $fileBase = $SysConf['FOSSOLOGY']['path']."/report/";
+    $fileBase = $SysConf['FOSSOLOGY']['path'] . "/report/";
 
     $this->uri = $this->getUri($fileBase);
   }
@@ -193,8 +194,12 @@ class CycloneDXAgent extends Agent
     $this->heartbeat(0);
 
     $filesWithLicenses = $this->reportutils
-      ->getFilesWithLicensesFromClearings($itemTreeBounds, $this->groupId,
-        $this, $this->licensesInDocument);
+      ->getFilesWithLicensesFromClearings(
+        $itemTreeBounds,
+        $this->groupId,
+        $this,
+        $this->licensesInDocument
+      );
     $this->heartbeat(0);
 
     $this->reportutils->addClearingStatus($filesWithLicenses, $itemTreeBounds, $this->groupId);
@@ -236,7 +241,7 @@ class CycloneDXAgent extends Agent
       $serializedhash[] = $this->reportGenerator->createHash('SHA-256', $hashes['sha256']);
     }
 
-    $maincomponentData = array (
+    $maincomponentData = array(
       'bomref' => strval($uploadId),
       'type' => 'library',
       'name' => $upload->getFilename(),
@@ -247,7 +252,7 @@ class CycloneDXAgent extends Agent
     );
     $maincomponent = $this->reportGenerator->createComponent($maincomponentData);
 
-    $bomdata = array (
+    $bomdata = array(
       'tool-version' => $SysConf['BUILD']['VERSION'],
       'maincomponent' => $maincomponent,
       'components' => $components
@@ -291,23 +296,34 @@ class CycloneDXAgent extends Agent
       $licensesfound = [];
 
       if (!empty($licenses->getConcludedLicenses())) {
+        $concludedLicensesString = [];
         foreach ($licenses->getConcludedLicenses() as $licenseId) {
           if (array_key_exists($licenseId, $this->licensesInDocument)) {
+            $shortName = $this->licensesInDocument[$licenseId]->getLicenseObj()->getShortName();
+            if (\Fossology\Lib\Util\StringOperation::stringStartsWith($shortName, \Fossology\Lib\Data\LicenseRef::SPDXREF_PREFIX)) {
+              $concludedLicensesString[] = $shortName;
+            } else {
+              $concludedLicensesString[] = $this->licensesInDocument[$licenseId]->getLicenseObj()->getSpdxId();
+            }
+          }
+        }
+        $expression = \Fossology\Spdx\SpdxUtils::implodeLicenses(
+            \Fossology\Spdx\SpdxUtils::removeEmptyLicenses($concludedLicensesString)
+        );
+        if (!empty($expression)) {
             $licensedata = array(
-              "id"   => $this->licensesInDocument[$licenseId]->getLicenseObj()->getSpdxId(),
-              "name" => $this->licensesInDocument[$licenseId]->getLicenseObj()->getFullName(),
-              "url"  => $this->licensesInDocument[$licenseId]->getLicenseObj()->getUrl()
+              "expression" => $expression
             );
             $licensesfound[] = $this->reportGenerator->createLicense($licensedata);
-          }
         }
       } else {
         foreach ($licenses->getScanners() as $licenseId) {
           if (array_key_exists($licenseId, $this->licensesInDocument)) {
             $licensedata = array(
-              "id"   => $this->licensesInDocument[$licenseId]->getLicenseObj()->getSpdxId(),
+              "id" => $this->licensesInDocument[$licenseId]->getLicenseObj()->getSpdxId(),
               "name" => $this->licensesInDocument[$licenseId]->getLicenseObj()->getFullName(),
-              "url"  => $this->licensesInDocument[$licenseId]->getLicenseObj()->getUrl()
+              "url" => $this->licensesInDocument[$licenseId]->getLicenseObj()->getUrl(),
+              "evidences" => $licenses->getScannerEvidences($licenseId)
             );
             $licensesfound[] = $this->reportGenerator->createLicense($licensedata);
           }
@@ -315,7 +331,7 @@ class CycloneDXAgent extends Agent
       }
       if (!empty($fileName)) {
         $componentdata = array(
-          'bomref' => $uploadId .'-'. $fileId,
+          'bomref' => $uploadId . '-' . $fileId,
           'type' => 'file',
           'name' => $fileName,
           'hashes' => $serializedhash,
@@ -347,7 +363,7 @@ class CycloneDXAgent extends Agent
     $contents = json_encode($packageNodes, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
     // To ensure the file is valid, replace any non-printable characters with a question mark.
     // 'Non-printable' is ASCII < 0x20 (excluding \r, \n and tab) and 0x7F - 0x9F.
-    $contents = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/u','?',$contents);
+    $contents = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/u', '?', $contents);
     file_put_contents($this->uri, $contents);
     $this->updateReportTable($uploadId, $this->jobId, $this->uri);
   }

--- a/src/cyclonedx/agent/reportgenerator.php
+++ b/src/cyclonedx/agent/reportgenerator.php
@@ -59,10 +59,10 @@ class BomReportGenerator
   {
     return [
       'bomFormat' => 'CycloneDX',
-      '$schema' => 'http://cyclonedx.org/schema/bom-1.4.schema.json',
-      'specVersion' => '1.4',
+      '$schema' => 'https://cyclonedx.org/schema/bom-1.7.schema.json',
+      'specVersion' => '1.7',
       'version' => 1.0,
-      'serialNumber' => 'urn:uuid:'. uuid_create(UUID_TYPE_TIME),
+      'serialNumber' => 'urn:uuid:' . uuid_create(UUID_TYPE_TIME),
       'metadata' => [
         'timestamp' => date('c'),
         'tools' => [
@@ -138,29 +138,58 @@ class BomReportGenerator
   {
     $license = [];
 
-    // Check license ID is a LicenseRef
-    if (array_key_exists('id', $licenseData) && !empty($licenseData['id']) &&
-      stripos($licenseData['id'], LicenseRef::SPDXREF_PREFIX) === 0) {
+    // Check for explicit expression
+    if (array_key_exists('expression', $licenseData) && !empty($licenseData['expression'])) {
+      $license['expression'] = $licenseData['expression'];
+    } else if (
+      array_key_exists('id', $licenseData) && !empty($licenseData['id']) &&
+      stripos($licenseData['id'], LicenseRef::SPDXREF_PREFIX) === 0
+    ) {
       $license['expression'] = $licenseData['id'];
-      return $license;
+    } else {
+      if (array_key_exists('id', $licenseData) && !empty($licenseData['id'])) {
+        $license['license']['id'] = $licenseData['id'];
+      } else if (array_key_exists('name', $licenseData) && !empty($licenseData['name'])) {
+        $license['license']['name'] = $licenseData['name'];
+      }
+
+      if (array_key_exists('url', $licenseData) && !empty($licenseData['url'])) {
+        $license['license']['url'] = $licenseData['url'];
+      }
+
+      if (array_key_exists('textContent', $licenseData) && !empty($licenseData['textContent'])) {
+        $license['license']['text'] = [
+          'content' => $licenseData['textContent'],
+          'contentType' => $licenseData['textContentType'],
+          'encoding' => 'base64'
+        ];
+      }
     }
 
-    if (array_key_exists('id', $licenseData) && !empty($licenseData['id'])) {
-      $license['license']['id'] = $licenseData['id'];
-    } else if (array_key_exists('name', $licenseData) && !empty($licenseData['name'])) {
-      $license['license']['name'] = $licenseData['name'];
-    }
+    if (array_key_exists('evidences', $licenseData) && !empty($licenseData['evidences'])) {
+      $license['evidence']['licenses'] = [];
+      foreach ($licenseData['evidences'] as $ev) {
+        $evidenceLicense = [];
+        if (array_key_exists('id', $licenseData) && !empty($licenseData['id']) && stripos($licenseData['id'], LicenseRef::SPDXREF_PREFIX) !== 0) {
+          $evidenceLicense['id'] = $licenseData['id'];
+        } else if (array_key_exists('name', $licenseData) && !empty($licenseData['name'])) {
+          $evidenceLicense['name'] = $licenseData['name'];
+        } else if (array_key_exists('id', $licenseData) && !empty($licenseData['id'])) {
+          $evidenceLicense['name'] = $licenseData['id'];
+        }
 
-    if (array_key_exists('url', $licenseData) && !empty($licenseData['url'])) {
-      $license['license']['url'] = $licenseData['url'];
-    }
+        $source = [
+          'name' => $ev['scanner']
+        ];
+        if (isset($ev['confidence']) && $ev['confidence'] !== null) {
+          $source['confidence'] = $ev['confidence'];
+        }
 
-    if (array_key_exists('textContent', $licenseData) && !empty($licenseData['textContent'])) {
-      $license['license']['text'] = [
-        'content' => $licenseData['textContent'],
-        'contentType' => $licenseData['textContentType'],
-        'encoding' => 'base64'
-      ];
+        $license['evidence']['licenses'][] = [
+          'license' => $evidenceLicense,
+          'source' => $source
+        ];
+      }
     }
 
     return $license;

--- a/src/lib/php/Data/Report/FileNode.php
+++ b/src/lib/php/Data/Report/FileNode.php
@@ -42,6 +42,12 @@ class FileNode
   private $copyrights = [];
 
   /**
+   * @var array $scannerEvidences
+   * Scanner evidence (rf_pk + md5(text) => [['scanner' => 'agent_name', 'confidence' => percentage]])
+   */
+  private $scannerEvidences = [];
+
+  /**
    * Add comment to file.
    *
    * @param string|null $comment
@@ -148,6 +154,26 @@ class FileNode
   }
 
   /**
+   * Add scanner evidence finding to file.
+   *
+   * @param string $scannerId
+   * @param string $scannerName
+   * @param float|null $confidence
+   * @return FileNode
+   */
+  public function addScannerEvidence(string $scannerId, string $scannerName, ?float $confidence): FileNode
+  {
+    if (!isset($this->scannerEvidences[$scannerId])) {
+      $this->scannerEvidences[$scannerId] = [];
+    }
+    $this->scannerEvidences[$scannerId][] = [
+      'scanner' => $scannerName,
+      'confidence' => $confidence
+    ];
+    return $this;
+  }
+
+  /**
    * @return string[]
    */
   public function getComments(): array
@@ -193,5 +219,14 @@ class FileNode
   public function getCopyrights(): array
   {
     return $this->copyrights;
+  }
+
+  /**
+   * @param string $scannerId
+   * @return array
+   */
+  public function getScannerEvidences(string $scannerId): array
+  {
+    return $this->scannerEvidences[$scannerId] ?? [];
   }
 }

--- a/src/lib/php/Report/ReportUtils.php
+++ b/src/lib/php/Report/ReportUtils.php
@@ -78,12 +78,16 @@ class ReportUtils
    */
   public function addClearingStatus(&$filesWithLicenses, ItemTreeBounds $itemTreeBounds, $groupId)
   {
-    $alreadyClearedUploadTreeView = new UploadTreeProxy($itemTreeBounds->getUploadId(),
-        array(UploadTreeProxy::OPT_SKIP_THESE => UploadTreeProxy::OPT_SKIP_ALREADY_CLEARED,
-              UploadTreeProxy::OPT_ITEM_FILTER => "AND (lft BETWEEN ".$itemTreeBounds->getLeft()." AND ".$itemTreeBounds->getRight().")",
-              UploadTreeProxy::OPT_GROUP_ID => $groupId),
-        $itemTreeBounds->getUploadTreeTableName(),
-        'already_cleared_uploadtree' . $itemTreeBounds->getUploadId());
+    $alreadyClearedUploadTreeView = new UploadTreeProxy(
+      $itemTreeBounds->getUploadId(),
+      array(
+        UploadTreeProxy::OPT_SKIP_THESE => UploadTreeProxy::OPT_SKIP_ALREADY_CLEARED,
+        UploadTreeProxy::OPT_ITEM_FILTER => "AND (lft BETWEEN " . $itemTreeBounds->getLeft() . " AND " . $itemTreeBounds->getRight() . ")",
+        UploadTreeProxy::OPT_GROUP_ID => $groupId
+      ),
+      $itemTreeBounds->getUploadTreeTableName(),
+      'already_cleared_uploadtree' . $itemTreeBounds->getUploadId()
+    );
 
     $alreadyClearedUploadTreeView->materialize();
     $filesThatShouldStillBeCleared = $alreadyClearedUploadTreeView->getNonArtifactDescendants($itemTreeBounds);
@@ -120,24 +124,26 @@ class ReportUtils
       return [];
     }
     $tableName = $itemTreeBounds->getUploadTreeTableName();
-    $stmt = __METHOD__ .'.scanner_findings';
+    $stmt = __METHOD__ . '.scanner_findings';
     $sql = "SELECT DISTINCT uploadtree_pk,rf_fk FROM $tableName ut, license_file
       WHERE ut.pfile_fk=license_file.pfile_fk AND rf_fk IS NOT NULL AND agent_fk=any($1)";
-    $param = array('{'.implode(',',$scannerIds).'}');
+    $param = array('{' . implode(',', $scannerIds) . '}');
     if ($tableName == 'uploadtree_a') {
       $param[] = $uploadId;
-      $sql .= " AND upload_fk=$".count($param);
+      $sql .= " AND upload_fk=$" . count($param);
       $stmt .= $tableName;
     }
-    $sql .=  " GROUP BY uploadtree_pk,rf_fk";
+    $sql .= " GROUP BY uploadtree_pk,rf_fk";
     $rows = $this->dbManager->getRows($sql, $param, $stmt);
     foreach ($rows as $row) {
       $reportedLicenseId = $this->licenseMap->getProjectedId($row['rf_fk']);
       $foundLicense = $this->licenseDao->getLicenseById($reportedLicenseId);
       if ($foundLicense !== null && $foundLicense->getShortName() != 'Void') {
-        $reportLicId =  "$reportedLicenseId-" . md5($foundLicense->getText());
+        $reportLicId = "$reportedLicenseId-" . md5($foundLicense->getText());
         $listedLicense = !StringOperation::stringStartsWith(
-          $foundLicense->getSpdxId(), LicenseRef::SPDXREF_PREFIX);
+          $foundLicense->getSpdxId(),
+          LicenseRef::SPDXREF_PREFIX
+        );
 
         if (!array_key_exists($row['uploadtree_pk'], $filesWithLicenses)) {
           $filesWithLicenses[$row['uploadtree_pk']] = new FileNode();
@@ -169,8 +175,10 @@ class ReportUtils
     /** @var CopyrightDao $copyrightDao */
     $copyrightDao = $this->container->get('dao.copyright');
     /** @var ScanJobProxy $scanJobProxy */
-    $scanJobProxy = new ScanJobProxy($this->container->get('dao.agent'),
-      $uploadId);
+    $scanJobProxy = new ScanJobProxy(
+      $this->container->get('dao.agent'),
+      $uploadId
+    );
 
     $scanJobProxy->createAgentStatus($agentName);
     $selectedScanners = $scanJobProxy->getLatestSuccessfulAgentIds();
@@ -182,22 +190,22 @@ class ReportUtils
       $latestAgentId[] = $selectedScanners[$agentName[1]];
     }
     $ids = implode(',', $latestAgentId);
-    $extrawhere = ' agent_fk IN ('.$ids.')';
+    $extrawhere = ' agent_fk IN (' . $ids . ')';
 
     $uploadtreeTable = $this->uploadDao->getUploadtreeTableName($uploadId);
-    $allScannerEntries = $copyrightDao->getScannerEntries('copyright', $uploadtreeTable, $uploadId, $type='statement', $extrawhere);
-    $allEditedEntries = $copyrightDao->getEditedEntries('copyright_decision', $uploadtreeTable, $uploadId, $decisionType=null);
+    $allScannerEntries = $copyrightDao->getScannerEntries('copyright', $uploadtreeTable, $uploadId, $type = 'statement', $extrawhere);
+    $allEditedEntries = $copyrightDao->getEditedEntries('copyright_decision', $uploadtreeTable, $uploadId, $decisionType = null);
     foreach ($allScannerEntries as $finding) {
       if (!array_key_exists($finding['uploadtree_pk'], $filesWithLicenses)) {
         $filesWithLicenses[$finding['uploadtree_pk']] = new FileNode();
       }
-      $filesWithLicenses[$finding['uploadtree_pk']]->addCopyright(\convertToUTF8($finding['content'],false));
+      $filesWithLicenses[$finding['uploadtree_pk']]->addCopyright(\convertToUTF8($finding['content'], false));
     }
     foreach ($allEditedEntries as $finding) {
       if (!array_key_exists($finding['uploadtree_pk'], $filesWithLicenses)) {
         $filesWithLicenses[$finding['uploadtree_pk']] = new FileNode();
       }
-      $filesWithLicenses[$finding['uploadtree_pk']]->addCopyright(\convertToUTF8($finding['textfinding'],false));
+      $filesWithLicenses[$finding['uploadtree_pk']]->addCopyright(\convertToUTF8($finding['textfinding'], false));
     }
   }
 
@@ -210,8 +218,11 @@ class ReportUtils
    * @return FileNode[] Mapping item->FileNode
    */
   public function getFilesWithLicensesFromClearings(
-    ItemTreeBounds $itemTreeBounds, $groupId, $agentObj, &$licensesInDocument)
-  {
+    ItemTreeBounds $itemTreeBounds,
+    $groupId,
+    $agentObj,
+    &$licensesInDocument
+  ) {
     if ($this->licenseMap === null) {
       $this->licenseMap = new LicenseMap($this->dbManager, $groupId, LicenseMap::REPORT, true);
     }
@@ -222,7 +233,7 @@ class ReportUtils
     $clearingsProceeded = 0;
     foreach ($clearingDecisions as $clearingDecision) {
       $clearingsProceeded += 1;
-      if (($clearingsProceeded&2047)==0) {
+      if (($clearingsProceeded & 2047) == 0) {
         $agentObj->heartbeat(0);
       }
       if ($clearingDecision->getType() == DecisionTypes::IRRELEVANT) {
@@ -235,8 +246,12 @@ class ReportUtils
           continue;
         }
 
-        if (!array_key_exists($clearingDecision->getUploadTreeId(),
-          $filesWithLicenses)) {
+        if (
+          !array_key_exists(
+            $clearingDecision->getUploadTreeId(),
+            $filesWithLicenses
+          )
+        ) {
           $filesWithLicenses[$clearingDecision->getUploadTreeId()] = new FileNode();
         }
 
@@ -250,7 +265,7 @@ class ReportUtils
         $concludedLicense = $this->licenseDao->getLicenseById($reportedLicenseId, $groupId);
         if ($concludedLicense === null) {
           error_log(
-              "ReportUtils: warning: clearing-license {$reportedLicenseId} not found; skipping event."
+            "ReportUtils: warning: clearing-license {$reportedLicenseId} not found; skipping event."
           );
           continue;
         }
@@ -264,11 +279,16 @@ class ReportUtils
           $filesWithLicenses[$clearingDecision->getUploadTreeId()]
             ->addConcludedLicense($reportLicId);
           if (!array_key_exists($reportLicId, $licensesInDocument)) {
-            $licenseObj = new License($concludedLicense->getId(),
-              $reportedLicenseShortname, $concludedLicense->getFullName(),
-              $concludedLicense->getRisk(), $customLicenseText,
-              $concludedLicense->getUrl(), $concludedLicense->getDetectorType(),
-              $concludedLicense->getSpdxId());
+            $licenseObj = new License(
+              $concludedLicense->getId(),
+              $reportedLicenseShortname,
+              $concludedLicense->getFullName(),
+              $concludedLicense->getRisk(),
+              $customLicenseText,
+              $concludedLicense->getUrl(),
+              $concludedLicense->getDetectorType(),
+              $concludedLicense->getSpdxId()
+            );
             $licensesInDocument[$reportLicId] = (new SpdxLicenseInfo())
               ->setLicenseObj($licenseObj)
               ->setCustomText(true)
@@ -282,7 +302,9 @@ class ReportUtils
           if (!array_key_exists($reportLicId, $licensesInDocument)) {
             $licenseObj = $this->licenseDao->getLicenseById($reportedLicenseId, $groupId);
             $listedLicense = !StringOperation::stringStartsWith(
-              $licenseObj->getSpdxId(), LicenseRef::SPDXREF_PREFIX);
+              $licenseObj->getSpdxId(),
+              LicenseRef::SPDXREF_PREFIX
+            );
             $licensesInDocument[$reportLicId] = (new SpdxLicenseInfo())
               ->setLicenseObj($licenseObj)
               ->setCustomText(false)
@@ -308,17 +330,25 @@ class ReportUtils
   public function updateOrInsertReportgenEntry($upload_fk, $job_fk, $filepath)
   {
     $sqlCheck = "SELECT 1 FROM reportgen WHERE upload_fk = $1 AND filepath = $2";
-    $row = $this->dbManager->getSingleRow($sqlCheck, [$upload_fk, $filepath],
-      __METHOD__.'.checkReportgenEntry');
+    $row = $this->dbManager->getSingleRow(
+      $sqlCheck,
+      [$upload_fk, $filepath],
+      __METHOD__ . '.checkReportgenEntry'
+    );
 
     if (!empty($row)) {
       $sqlUpdate = "UPDATE reportgen SET job_fk = $1 WHERE upload_fk = $2 AND filepath = $3";
-      $this->dbManager->getSingleRow($sqlUpdate, [$job_fk, $upload_fk, $filepath],
-        __METHOD__.'.updateReportgen');
+      $this->dbManager->getSingleRow(
+        $sqlUpdate,
+        [$job_fk, $upload_fk, $filepath],
+        __METHOD__ . '.updateReportgen'
+      );
     } else {
-      $this->dbManager->insertTableRow('reportgen',
+      $this->dbManager->insertTableRow(
+        'reportgen',
         ['upload_fk' => $upload_fk, 'job_fk' => $job_fk, 'filepath' => $filepath],
-        __METHOD__);
+        __METHOD__
+      );
     }
   }
 }

--- a/src/www/ui/ui-view-info.php
+++ b/src/www/ui/ui-view-info.php
@@ -244,7 +244,7 @@ class ui_view_info extends FO_Plugin
     $sql = "select * from upload where upload_pk=$1";
     $row = $this->dbManager->getSingleRow(
       $sql,
-      array($row['upload_fk']),
+      array($Upload),
       __METHOD__ . "getUploadOrigin"
     );
     if ($row) {
@@ -403,7 +403,7 @@ class ui_view_info extends FO_Plugin
         $this->dbManager->prepare(__METHOD__ . "getPkg_rpm_req", $sql);
         $result = $this->dbManager->execute(__METHOD__ . "getPkg_rpm_req", array($Require));
 
-        while ($R = pg_fetch_assoc($result) and ! empty($R['req_pk'])) {
+        while (($R = pg_fetch_assoc($result)) && ! empty($R['req_pk'])) {
           $entry = [];
           $entry['count'] = $Count;
           $entry['type'] = _("Requires");
@@ -439,7 +439,7 @@ class ui_view_info extends FO_Plugin
         $this->dbManager->prepare(__METHOD__ . "getPkg_rpm_req", $sql);
         $result = $this->dbManager->execute(__METHOD__ . "getPkg_rpm_req", array($Require));
 
-        while ($R = pg_fetch_assoc($result) and ! empty($R['req_pk'])) {
+        while (($R = pg_fetch_assoc($result)) && ! empty($R['req_pk'])) {
           $entry = [];
           $entry['count'] = $Count;
           $entry['type'] = _("Depends");
@@ -449,7 +449,6 @@ class ui_view_info extends FO_Plugin
         }
         $this->dbManager->freeResult($result);
       }
-      $V .= "</table>\n";
     } elseif ($MIMETYPE == "application/x-debian-source") {
       $vars['packageType'] = _("Debian Source Package\n");
 
@@ -475,7 +474,7 @@ class ui_view_info extends FO_Plugin
         $this->dbManager->prepare(__METHOD__ . "getPkg_rpm_req", $sql);
         $result = $this->dbManager->execute(__METHOD__ . "getPkg_rpm_req", array($Require));
 
-        while ($R = pg_fetch_assoc($result) and ! empty($R['req_pk'])) {
+        while (($R = pg_fetch_assoc($result)) && ! empty($R['req_pk'])) {
           $entry = [];
           $entry['count'] = $Count;
           $entry['type'] = _("Build-Depends");


### PR DESCRIPTION
Enhance CycloneDX export with Scanner Evidence and SPDX Expressions

This PR improves CycloneDX SBOM compliance by adding two critical features:

License Evidence: Extracted scanner metadata (agent_name and detection confidence rf_match_pct) from the database and mapped it to the CycloneDX evidence schema.
SPDX Expressions: Integrated with 

SpdxUtils
 to emit formal boolean expressions (e.g., MIT AND Apache-2.0) for files with multiple concluded licenses, adhering to modern SBOM standards.
This change improves transparency and automated processing of FOSSology-generated SBOMs.