### PR TITLE
CI: add workflow to cleanup PR caches on close

### DIFF
--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: © 2025 Gaurav Mishra <mishra.gaurav@siemens.com>
+#
+# SPDX-License-Identifier: GPL-2.0-only AND LGPL-2.1-only
+name: Cleanup PR caches
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cleanup PR caches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh extension install actions/gh-actions-cache || echo "Failed to install gh-actions-cache extension, continuing anyway"
+          
+          REPO=${{ github.repository }}
+          BRANCH=${{ github.event.pull_request.head.ref }}
+
+          echo "Fetching list of cache keys"
+          cacheKeysForPR=$(gh cache list -R $REPO --ref $BRANCH --limit 100 --json key --jq '.[].key')
+
+          ## Setting this to not fail the workflow while deleting cache keys. 
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh cache delete $cacheKey -R $REPO || echo "Failed to delete $cacheKey"
+          done
+          echo "Done"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This pull request introduces a GitHub Actions workflow to automatically clean up runner caches scoped to a pull request when it is closed or merged. This prevents orphaned caches from accumulating and hitting the repository's cache limit, ensuring that caches for active and important branches (like `master`) are not prematurely evicted.

### Changes

- Added [.github/workflows/cleanup-caches.yml](cci:7://file:///home/atheus/fossology/.github/workflows/cleanup-caches.yml:0:0-0:0) which triggers on `pull_request` close events.
- Uses the `gh` API via the GitHub CLI to safely fetch and delete cache keys bounded perfectly to the closed PR's branch reference.

## How to test

1. Push this branch and verify that GitHub Actions syntax passes correctly.
2. Open a test Pull Request that generates some cache (e.g. via the standard Docker build workflow).
3. Close the Pull Request.
4. Verify in the repository's **Actions -> Caches** tab that the cache keys associated with that ephemeral branch were automatically purged while keeping other caches unaffected.

fixes #3479 
