### PR TITLE
docs: update email notification setup for modern Debian/Ubuntu

### DIFF
--- a/docs/email-notification-setup.md
+++ b/docs/email-notification-setup.md
@@ -54,8 +54,8 @@ set from="your-email@example.com"
 
 ## Summary
 
- Package          Status       Recommended 
-|--------------|--------------|-------------|
- heirloom-mailx   Deprecated    No          
- bsd-mailx        Supported     Yes         
- mailutils        Supported     Yes         
+| Package         | Status      | Recommended |
+|-----------------|------------|-------------|
+| heirloom-mailx  | Deprecated | No          |
+| bsd-mailx       | Supported  | Yes         |
+| mailutils       | Supported  | Yes         |      


### PR DESCRIPTION
### Summary

Updated email notification setup documentation to support modern Debian/Ubuntu systems.

### Changes

* Replaced deprecated `heirloom-mailx` with `bsd-mailx` and `mailutils`
* Added installation instructions for both alternatives
* Documented compatibility notes and differences
* Fixed markdown formatting

### Related Issue

Fixes #3374
