### PR TITLE
fix(reuser): support multiple upload reuse selections

### DIFF
--- a/src/reuser/agent_tests/Functional/schedulerTest.php
+++ b/src/reuser/agent_tests/Functional/schedulerTest.php
@@ -28,6 +28,7 @@ use Fossology\Lib\Dao\UploadPermissionDao;
 use Fossology\Lib\Data\Clearing\ClearingEvent;
 use Fossology\Lib\Data\Clearing\ClearingEventTypes;
 use Fossology\Lib\Data\Clearing\ClearingLicense;
+use Fossology\Reuser\ReuserAgentPlugin;
 use Fossology\Lib\Data\ClearingDecision;
 use Fossology\Lib\Data\DecisionScopes;
 use Fossology\Lib\Data\DecisionTypes;
@@ -616,5 +617,150 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
     $mainLicenseSingle = array_values($mainLicense);
     $this->assertEquals($mainLicenseIdForReuseSingle, $mainLicenseSingle);
     $this->rmRepo();
+  }
+
+  /**
+   * @brief Test multiple reuse selections validation logic
+   * @test
+   * -# Test the validation logic for multiple reuse selections
+   * -# Verify proper handling of array format
+   */
+  public function testReuserMultipleReuseSelectionsValidation()
+  {
+    // Test array format (multiple selections)
+    $reuseSelections = ['2,1', '4,1'];
+    // Simulate the validation logic from scheduleAgent
+    $createdLinks = 0;
+    foreach ($reuseSelections as $reuseSelection) {
+      if (empty($reuseSelection) || !is_string($reuseSelection)) {
+        $this->fail("Invalid reuse selection found - empty or non-string value");
+      }
+
+      $reuseUploadPair = explode(',', $reuseSelection, 2);
+      if (count($reuseUploadPair) !== 2) {
+        $this->fail("Invalid reuse selection format: '$reuseSelection' (expected format: 'uploadId,groupId')");
+      }
+
+      [$reuseUploadId, $reuseGroupId] = $reuseUploadPair;
+      $this->assertIsNumeric($reuseUploadId, "Upload ID should be numeric");
+      $this->assertIsNumeric($reuseGroupId, "Group ID should be numeric");
+      $createdLinks++;
+    }
+
+    $this->assertEquals(2, $createdLinks, 'Should process 2 reuse selections');
+  }
+
+  /**
+   * @brief Test single reuse selection validation logic (backward compatibility)
+   * @test
+   * -# Test the validation logic for single reuse selection
+   * -# Verify proper handling of scalar format
+   */
+  public function testReuserSingleReuseSelectionValidation()
+  {
+    // Test scalar format (single selection)
+    $reuseSelections = '2,1';
+    // Simulate the validation logic from scheduleAgent
+    if (!is_array($reuseSelections)) {
+      $reuseSelections = [$reuseSelections];
+    }
+
+    $createdLinks = 0;
+    foreach ($reuseSelections as $reuseSelection) {
+      if (empty($reuseSelection) || !is_string($reuseSelection)) {
+        $this->fail("Invalid reuse selection found - empty or non-string value");
+      }
+
+      $reuseUploadPair = explode(',', $reuseSelection, 2);
+      if (count($reuseUploadPair) !== 2) {
+        $this->fail("Invalid reuse selection format: '$reuseSelection' (expected format: 'uploadId,groupId')");
+      }
+
+      [$reuseUploadId, $reuseGroupId] = $reuseUploadPair;
+      $this->assertIsNumeric($reuseUploadId, "Upload ID should be numeric");
+      $this->assertIsNumeric($reuseGroupId, "Group ID should be numeric");
+      $createdLinks++;
+    }
+
+    $this->assertEquals(1, $createdLinks, 'Should process 1 reuse selection');
+  }
+
+  /**
+   * @brief Test invalid reuse selection format throws exception
+   * @test
+   * -# Test reuser with invalid reuse selection format
+   * -# Verify exception is thrown for invalid data
+   */
+  public function testReuserInvalidReuseSelectionFormat()
+  {
+    $invalidSelection = "invalid_format";
+    // Simulate the validation logic from scheduleAgent
+    $reuseUploadPair = explode(',', $invalidSelection, 2);
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage("Reuser: Invalid reuse selection format: '$invalidSelection' (expected format: 'uploadId,groupId')");
+
+    if (count($reuseUploadPair) !== 2) {
+      throw new \InvalidArgumentException("Reuser: Invalid reuse selection format: '$invalidSelection' (expected format: 'uploadId,groupId')");
+    }
+  }
+
+  /**
+   * @brief Test empty reuse selection throws exception
+   * @test
+   * -# Test reuser with empty reuse selection
+   * -# Verify exception is thrown for empty data
+   */
+  public function testReuserEmptyReuseSelection()
+  {
+    $emptySelection = "";
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage("Reuser: Invalid reuse selection found - empty or non-string value");
+
+    if (empty($emptySelection) || !is_string($emptySelection)) {
+      throw new \InvalidArgumentException("Reuser: Invalid reuse selection found - empty or non-string value");
+    }
+  }
+
+  /**
+   * @brief Test non-string reuse selection throws exception
+   * @test
+   * -# Test reuser with non-string reuse selection
+   * -# Verify exception is thrown for non-string data
+   */
+  public function testReuserNonStringReuseSelection()
+  {
+    $nonStringSelection = 123;
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage("Reuser: Invalid reuse selection found - empty or non-string value");
+
+    if (empty($nonStringSelection) || !is_string($nonStringSelection)) {
+      throw new \InvalidArgumentException("Reuser: Invalid reuse selection found - empty or non-string value");
+    }
+  }
+
+  /**
+   * @brief Test malformed reuse selection strings
+   * @test
+   * -# Test reuser with malformed strings
+   * -# Verify exception is thrown for malformed data
+   */
+  public function testReuserMalformedReuseSelection()
+  {
+    // Test various malformed formats
+    $malformedCases = [
+      '123,',    // Missing group ID
+      ',456',    // Missing upload ID
+      '123,456,789', // Too many parts
+      '123'      // Missing comma separator
+    ];
+
+    foreach ($malformedCases as $malformedValue) {
+      $reuseUploadPair = explode(',', $malformedValue, 2);
+      if (count($reuseUploadPair) !== 2) {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Reuser: Invalid reuse selection format: '$malformedValue' (expected format: 'uploadId,groupId')");
+        throw new \InvalidArgumentException("Reuser: Invalid reuse selection format: '$malformedValue' (expected format: 'uploadId,groupId')");
+      }
+    }
   }
 }

--- a/src/reuser/ui/agent-reuser.php
+++ b/src/reuser/ui/agent-reuser.php
@@ -105,13 +105,6 @@ class ReuserAgentPlugin extends AgentPlugin
         return $this->scheduleOsselotImportDirect($jobId, $uploadId, $errorMsg, $request);
     }
 
-    $reuseUploadPair = explode(',', $request->get(self::UPLOAD_TO_REUSE_SELECTOR_NAME), 2);
-    if (count($reuseUploadPair) == 2) {
-      list($reuseUploadId, $reuseGroupId) = $reuseUploadPair;
-    } else {
-      $errorMsg .= 'no reuse upload id given';
-      return -1;
-    }
     $groupId = $request->get('groupId', Auth::getGroupId());
     $getReuseValue = $request->get(self::REUSE_MODE) ?: array();
     $reuserDependencies = array("agent_adj2nest");
@@ -134,14 +127,43 @@ class ReuserAgentPlugin extends AgentPlugin
       }
     }
 
+    $reuseSelections = $request->get(self::UPLOAD_TO_REUSE_SELECTOR_NAME);
+    if (!is_array($reuseSelections)) {
+      $reuseSelections = [$reuseSelections];
+    }
+
+    $createdLinks = 0;
+    foreach ($reuseSelections as $reuseSelection) {
+      if (empty($reuseSelection) || !is_string($reuseSelection)) {
+        throw new \InvalidArgumentException("Reuser: Invalid reuse selection found - empty or non-string value");
+      }
+
+      $reuseUploadPair = explode(',', $reuseSelection, 2);
+      if (count($reuseUploadPair) !== 2) {
+        throw new \InvalidArgumentException("Reuser: Invalid reuse selection format: '$reuseSelection' (expected format: 'uploadId,groupId')");
+      }
+
+      [$reuseUploadId, $reuseGroupId] = $reuseUploadPair;
+      $this->createPackageLink(
+        $uploadId,
+        intval($reuseUploadId),
+        intval($groupId),
+        intval($reuseGroupId),
+        $reuseMode
+      );
+      $createdLinks++;
+    }
+
+    if ($createdLinks === 0) {
+      $errorMsg .= 'No valid reuse upload selections found';
+      return -1;
+    }
+
     list($agentDeps, $scancodeDeps) = $this->getReuserDependencies($request);
     $reuserDependencies = array_unique(array_merge($reuserDependencies, $agentDeps));
     if (!empty($scancodeDeps)) {
       $reuserDependencies[] = $scancodeDeps;
     }
-
-    $this->createPackageLink($uploadId, $reuseUploadId, $groupId, $reuseGroupId,
-      $reuseMode);
 
     return $this->doAgentAdd($jobId, $uploadId, $errorMsg,
       $reuserDependencies, $uploadId, null, $request);

--- a/src/reuser/ui/template/agent_reuser.html.twig
+++ b/src/reuser/ui/template/agent_reuser.html.twig
@@ -67,7 +67,7 @@
       </label><br/>
       
       <label for="{{ uploadToReuseSelectorName }}">{{ 'Upload to reuse'|trans }}:</label><br/>
-      {{ macro.select(uploadToReuseSelectorName, folderUploads, uploadToReuseSelectorName, reuseUploadId, 'style="min-width:420px;"', 5) }}
+      {{ macro.select(uploadToReuseSelectorName ~ '[]', folderUploads, uploadToReuseSelectorName, reuseUploadId, 'style="min-width:420px;"', 5) }}
     </div>
 
     {% if osselotAvailable %}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->


## Description

When selecting multiple uploads in the UI, only one upload was processed for reuse. This occurred because the UI was sending only a single value to the backend, as `uploadToReuseSelectorName` was not defined as an array.

Closes: #1271 

### Changes

- `agent_reuser.html.twig`: Changed `uploadToReuseSelectorName` to an array to support multiple selections.
- `agent-reuser.php`: Added logic to handle multiple uploads.

## Screenshots

### Context
- In `zlib-1.3.1.tar.gz` i have cleared licenses for `zlib-1.3.1.tar.gz/zlib-1.3.1.tar/zlib-1.3.1/contrib/ada`
- In `zlib-1.2.12.tar.gz`  i have cleared licenses for `zlib-1.3.1.tar.gz/zlib-1.3.1.tar/zlib-1.3.1/contrib/dotzlib/DotZib`
### Before

https://github.com/user-attachments/assets/1ba4e189-bd19-4159-987c-e44cbfddbc4d

Only reused decison from one upload file. ie. `zlib-1.3.1.tar.gz`

<img width="1039" height="146" alt="Screenshot 2026-03-21 131516" src="https://github.com/user-attachments/assets/c696952d-51ba-4892-ae46-056721aae22e" />


### After

https://github.com/user-attachments/assets/c9c014a4-0841-4000-8acf-9ec14975ac0b

Used decisons form both uploads i.e.  `zlib-1.3.1.tar.gz` and  `zlib-1.2.13.tar.gz`

<img width="1055" height="175" alt="Screenshot 2026-03-21 132120" src="https://github.com/user-attachments/assets/034535b5-a8de-459e-8cc4-a2be30de70f5" />

## How to test
- Select multiple uploads for reuse and verify that multiple items are processed in jobs.
- Execute the following query:
 ```sql
 SELECT * FROM upload_reuse WHERE upload_fk = <upload_id>;
```
### Uploads used
```bash
wget https://zlib.net/fossils/zlib-1.2.13.tar.gz
wget https://zlib.net/fossils/zlib-1.2.8.tar.gz
wget https://zlib.net/fossils/zlib-1.3.1.tar.gz
```