### PR TITLE
Fix: Handle empty/null delimiter in LicenseCsvImport

### DIFF
--- a/src/lib/php/Application/LicenseCsvImport.php
+++ b/src/lib/php/Application/LicenseCsvImport.php
@@ -77,10 +77,14 @@ class LicenseCsvImport
    * @brief Update the delimiter
    * @param string $delimiter New delimiter to use.
    */
-  public function setDelimiter($delimiter=',')
-  {
-    $this->delimiter = substr($delimiter,0,1);
-  }
+  public function setDelimiter($delimiter = ',')
+{
+    if (!is_string($delimiter) || trim($delimiter) === '') {
+        $this->delimiter = ',';
+    } else {
+        $this->delimiter = $delimiter[0];
+    }
+}
 
   /**
    * @brief Update the enclosure


### PR DESCRIPTION
## Description

This PR fixes an issue where `substr()` was used on user-provided delimiter input without validation.  
When an empty string or null value is passed, `substr()` returns `false` instead of a valid string, leading to unexpected behavior in CSV parsing.

---

### Changes

- Added validation for empty, null, and non-string delimiter inputs
- Introduced default fallback delimiter `','` for invalid inputs
- Replaced `substr()` with safer string indexing (`$delimiter[0]`)
- Ensured consistent string output for delimiter handling

---

## How to test

1. Run FOSSology locally using Docker:
   ```bash
   docker compose up