### PR TITLE
Implement secure user creation and group management via REST API #1578

### DIFF
--- a/src/lib/php/Dao/UserDao.php
+++ b/src/lib/php/Dao/UserDao.php
@@ -104,6 +104,27 @@ class UserDao
   }
 
   /**
+   * @param int $userId
+   * @return array List of groups with permissions in format [['id'=>int, 'name'=>string, 'perm'=>int], ...]
+   */
+  public function getUserGroupsWithPerm($userId)
+  {
+    $sql = "SELECT group_pk, group_name, group_perm FROM groups, group_user_member WHERE group_pk=group_fk AND user_fk=$1";
+    $this->dbManager->prepare($stmt=__METHOD__, $sql);
+    $res = $this->dbManager->execute($stmt,array($userId));
+    $groups = array();
+    while ($row = $this->dbManager->fetchArray($res)) {
+      $groups[] = array(
+        'id' => intval($row['group_pk']),
+        'name' => $row['group_name'],
+        'perm' => intval($row['group_perm'])
+      );
+    }
+    $this->dbManager->freeResult($res);
+    return $groups;
+  }
+
+  /**
    * @brief get array of groups that this user has admin access to
    * @param int $userId
    * @return array in the format {group_pk=>group_name, group_pk=>group_name, ...}

--- a/src/www/ui/api/Controllers/UserController.php
+++ b/src/www/ui/api/Controllers/UserController.php
@@ -127,6 +127,43 @@ class UserController extends RestController
       throw new HttpInternalServerErrorException($ErrMsg);
     }
 
+    if (isset($userDetails['groups']) && is_array($userDetails['groups'])) {
+      $userDao = $this->restHelper->getUserDao();
+      $newUser = $userDao->getUserByName($userDetails['name']);
+      if ($newUser) {
+        $newUserId = $newUser['user_pk'];
+        $currentUserId = $this->restHelper->getUserId();
+        foreach ($userDetails['groups'] as $group) {
+          if (!isset($group['id'])) {
+            continue;
+          }
+          $groupId = intval($group['id']);
+          $perm = intval($group['perm'] ?? 0);
+
+          // Security check 2 & 4: Validate group exists and caller has access
+          if (!$this->dbHelper->doesIdExist("groups", "group_pk", $groupId)) {
+            continue;
+          }
+
+          // If not system admin, check if caller is group admin/advisor
+          // Note: addUser is currently system-admin only due to throwNotAdminException()
+          if (!Auth::isAdmin() && !$userDao->isAdvisorOrAdmin($currentUserId, $groupId)) {
+            continue;
+          }
+
+          // Security check 3: Validate perm values [0, 1, 2]
+          if (!in_array($perm, [\Fossology\Lib\Dao\UserDao::USER, \Fossology\Lib\Dao\UserDao::ADMIN, \Fossology\Lib\Dao\UserDao::ADVISOR])) {
+            $perm = \Fossology\Lib\Dao\UserDao::USER;
+          }
+
+          // Avoid duplicate membership (add_user already adds them to their private group)
+          if ($groupId != $newUser['group_fk']) {
+            $userDao->addGroupMembership($groupId, $newUserId, $perm);
+          }
+        }
+      }
+    }
+
     $returnVal = new Info(201, "User created successfully", InfoType::INFO);
     return $response->withJson($returnVal->getArray(), $returnVal->getCode());
   }

--- a/src/www/ui/api/Helper/DbHelper.php
+++ b/src/www/ui/api/Helper/DbHelper.php
@@ -269,15 +269,18 @@ FROM $tableName WHERE $idRowName = $1", [$id],
     }
     $currentUser = Auth::getUserId();
     $userIsAdmin = Auth::isAdmin();
+    global $container;
+    $userDao = $container->get('helper.restHelper')->getUserDao();
     foreach ($result as $row) {
       $user = null;
       if ($userIsAdmin ||
         ($row["user_pk"] == $currentUser)) {
-        $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
+        $groups = $userDao->getUserGroupsWithPerm($row["user_pk"]);
+        $user = new User($row["user_pk"], $row["name"] ?? $row["user_name"], $row["user_desc"],
           $row["user_email"], $row["user_perm"], $row["root_folder_fk"],
-          $row["email_notify"], $row["user_agent_list"], $row["group_fk"], $row["default_bucketpool_fk"]);
+          $row["email_notify"], $row["user_agent_list"], $row["group_fk"], $row["default_bucketpool_fk"], $groups);
       } else {
-        $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
+        $user = new User($row["user_pk"], $row["name"] ?? $row["user_name"], $row["user_desc"],
           null, null, null, null, null, null);
       }
       $users[] = $user;

--- a/src/www/ui/api/Models/User.php
+++ b/src/www/ui/api/Models/User.php
@@ -74,6 +74,11 @@ class User
    * Default bucket pool of the user
    */
   private $defaultBucketPool;
+  /**
+   * @var array $groups
+   * Groups the user belongs to
+   */
+  private $groups;
 
   /**
    * User constructor.
@@ -87,9 +92,10 @@ class User
    * @param boolean $emailNotification
    * @param object $agents
    * @param integer $defaultBucketPool
+   * @param array $groups
    */
   public function __construct($id, $name, $description, $email, $accessLevel, $root_folder_id, $emailNotification,
-                              $agents, $default_group_fk=null, $defaultBucketPool=null)
+                              $agents, $default_group_fk=null, $defaultBucketPool=null, $groups=array())
   {
     $this->id = intval($id);
     $this->name = $name;
@@ -122,6 +128,7 @@ class User
     } else {
       $this->defaultBucketPool = null;
     }
+    $this->groups = $groups;
   }
 
   ////// Getters //////
@@ -244,6 +251,9 @@ class User
     }
     if ($this->defaultBucketPool !== null) {
       $returnUser["defaultBucketpool"] = $this->defaultBucketPool;
+    }
+    if ($this->groups !== null && !empty($this->groups)) {
+      $returnUser["groups"] = $this->groups;
     }
     return $returnUser;
   }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -5856,6 +5856,19 @@ components:
           description: Default bucket pool id
           type: integer
           nullable: true
+        groups:
+          type: array
+          description: List of groups to assign the user to
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+                description: ID of the group
+              perm:
+                type: integer
+                enum: [0, 1, 2]
+                description: Permission level in the group (0=User, 1=Admin, 2=Advisor)
       required:
         - id
     Analysis:

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -5676,6 +5676,19 @@ components:
           description: Default bucket pool id
           type: integer
           nullable: true
+        groups:
+          type: array
+          description: List of groups to assign the user to
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+                description: ID of the group
+              perm:
+                type: integer
+                enum: [0, 1, 2]
+                description: Permission level in the group (0=User, 1=Admin, 2=Advisor)
       required:
         - id
     Analysis:

--- a/src/www/ui_tests/api/Controllers/UserControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UserControllerTest.php
@@ -119,7 +119,7 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
         continue;
       }
       $user = new User($userId, "user$userId", "User $userId",
-        "user$userId@example.com", $accessLevel, 2, 4, "");
+        "user$userId@example.com", $accessLevel, 2, 4, "", null, null, [['id' => 1, 'name' => 'fossy', 'perm' => 1]]);
       $userArray[] = $user;
     }
     return $userArray;
@@ -392,5 +392,122 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
       $actualResponse->getStatusCode());
     $this->assertEquals($this->getResponseJson($expectedResponse),
       $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test UserController::addUser() for version 1
+   * -# Check if response status is 201
+   */
+  public function testAddUserV1()
+  {
+    $this->testAddUser(ApiVersion::V1);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::addUser() for version 2
+   * -# Check if response status is 201
+   */
+  public function testAddUserV2()
+  {
+    $this->testAddUser();
+  }
+
+  /**
+   * @param $version to test
+   * @return void
+   */
+  private function testAddUser($version = ApiVersion::V2)
+  {
+    $request = M::mock(Request::class);
+    $request->shouldReceive('getAttribute')->andReturn($version);
+    $request->shouldReceive('getHeaderLine')->with('Content-Type')->andReturn('application/json');
+    $userDetails = [
+      'name' => 'newuser',
+      'description' => 'test user',
+      'email' => 'test@example.com',
+      'accessLevel' => 'read_only',
+      'rootFolderId' => 1,
+      'emailNotification' => true,
+      'defaultVisibility' => 'public'
+    ];
+    $userDetails[$version == ApiVersion::V2 ? 'userPass' : 'user_pass'] = 'Password123!';
+
+    $stream = M::mock(\Psr\Http\Message\StreamInterface::class);
+    $stream->shouldReceive('getContents')->andReturn(json_encode($userDetails));
+    $request->shouldReceive('getBody')->andReturn($stream);
+
+    global $container;
+    $userAddPlugin = M::mock('user_add');
+    $userAddPlugin->shouldReceive('add')->with(M::type(\Symfony\Component\HttpFoundation\Request::class))
+      ->andReturn('');
+
+    $this->restHelper->shouldReceive('getPlugin')->with('user_add')->andReturn($userAddPlugin);
+
+    $info = new Info(201, "User created successfully", InfoType::INFO);
+    $expectedResponse = (new ResponseHelper())->withJson($info->getArray(), $info->getCode());
+
+    $actualResponse = $this->userController->addUser($request, new ResponseHelper(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(), $actualResponse->getStatusCode());
+  }
+
+  /**
+   * @test
+   * -# Test UserController::addUser() with groups for version 2
+   * -# Check if response status is 201 and group membership is added
+   */
+  public function testAddUserWithGroupsV2()
+  {
+    $version = ApiVersion::V2;
+    $request = M::mock(Request::class);
+    $request->shouldReceive('getAttribute')->andReturn($version);
+    $request->shouldReceive('getHeaderLine')->with('Content-Type')->andReturn('application/json');
+
+    $userDetails = [
+      'name' => 'newuser',
+      'userPass' => 'Password123!',
+      'description' => 'test user',
+      'email' => 'test@example.com',
+      'accessLevel' => 'read_only',
+      'rootFolderId' => 1,
+      'emailNotification' => true,
+      'defaultVisibility' => 'public',
+      'groups' => [
+        ['id' => 10, 'perm' => 1],
+        ['id' => 11, 'perm' => 0]
+      ]
+    ];
+
+    $stream = M::mock(\Psr\Http\Message\StreamInterface::class);
+    $stream->shouldReceive('getContents')->andReturn(json_encode($userDetails));
+    $request->shouldReceive('getBody')->andReturn($stream);
+
+    global $container;
+    $userAddPlugin = M::mock('user_add');
+    $userAddPlugin->shouldReceive('add')->andReturn('');
+    $this->restHelper->shouldReceive('getPlugin')->with('user_add')->andReturn($userAddPlugin);
+
+    $newUser = ['user_pk' => 100, 'name' => 'newuser', 'group_fk' => 100]; // own group is 100
+    $this->userDao->shouldReceive('getUserByName')->with('newuser')->andReturn($newUser);
+    $this->restHelper->shouldReceive('getUserId')->andReturn(1); // caller is admin (id 1)
+
+    // Setup group validation mocks
+    $this->dbHelper->shouldReceive('doesIdExist')->with('groups', 'group_pk', 10)->andReturn(true);
+    $this->dbHelper->shouldReceive('doesIdExist')->with('groups', 'group_pk', 11)->andReturn(true);
+
+    // Callers access check
+    // Note: addUser is system-admin only in Controller, and we mock session in setUp.
+    // However the code also checks isAdvisorOrAdmin if not system admin.
+    // In our test Auth::isAdmin() is true (set in setUp).
+
+    $this->userDao->shouldReceive('addGroupMembership')->with(10, 100, 1)->once();
+    $this->userDao->shouldReceive('addGroupMembership')->with(11, 100, 0)->once();
+
+    $info = new Info(201, "User created successfully", InfoType::INFO);
+    $expectedResponse = (new ResponseHelper())->withJson($info->getArray(), $info->getCode());
+
+    $actualResponse = $this->userController->addUser($request, new ResponseHelper(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(), $actualResponse->getStatusCode());
   }
 }


### PR DESCRIPTION
- Added `groups` parameter to `addUser` API for secure group assignment.
- - Updated `User` model and `DbHelper` to include group memberships in GET responses.
- - Implemented robust security checks (admin authorization, group validation, permission limits).
- - Added comprehensive automated tests in `UserControllerTest.php`.
- - Updated OpenAPI documentation (v1 and v2).