### PR TITLE
fix(report): exclude irrelevant files from SPDX and ReadmeOSS reports

### DIFF
--- a/src/lib/php/Report/LicenseClearedGetter.php
+++ b/src/lib/php/Report/LicenseClearedGetter.php
@@ -24,6 +24,8 @@ class LicenseClearedGetter extends ClearedGetterCommon
   private $onlyComments = false;
   /** @var Boolean */
   private $onlyAcknowledgements = false;
+  /** @var Boolean */
+  private $excludeIrrelevant = true;
   /** @var ClearingDao */
   private $clearingDao;
   /** @var LicenseDao */
@@ -54,7 +56,7 @@ class LicenseClearedGetter extends ClearedGetterCommon
     $licenseMap = new LicenseMap($dbManager, $groupId, LicenseMap::REPORT);
     $ungroupedStatements = array();
     foreach ($clearingDecisions as $clearingDecision) {
-      if ($clearingDecision->getType() == DecisionTypes::IRRELEVANT) {
+      if ($this->excludeIrrelevant && $clearingDecision->getType() == DecisionTypes::IRRELEVANT) {
         continue;
       }
       /** @var ClearingDecision $clearingDecision */
@@ -188,6 +190,14 @@ class LicenseClearedGetter extends ClearedGetterCommon
   {
     $this->onlyComments = false;
     $this->onlyAcknowledgements = $displayOnlyAcknowledgements;
+  }
+
+  /**
+   * @param boolean $excludeIrrelevant Whether to exclude irrelevant files
+   */
+  public function setExcludeIrrelevant($excludeIrrelevant)
+  {
+    $this->excludeIrrelevant = $excludeIrrelevant;
   }
 
   /**

--- a/src/lib/php/Report/ReportUtils.php
+++ b/src/lib/php/Report/ReportUtils.php
@@ -207,10 +207,12 @@ class ReportUtils
    * @param int $groupId
    * @param Agent $agentObj
    * @param SpdxLicenseInfo[] &$licensesInDocument
+   * @param bool $excludeIrrelevant Whether to exclude irrelevant files (default: true)
    * @return FileNode[] Mapping item->FileNode
    */
   public function getFilesWithLicensesFromClearings(
-    ItemTreeBounds $itemTreeBounds, $groupId, $agentObj, &$licensesInDocument)
+    ItemTreeBounds $itemTreeBounds, $groupId, $agentObj, &$licensesInDocument,
+    $excludeIrrelevant = true)
   {
     if ($this->licenseMap === null) {
       $this->licenseMap = new LicenseMap($this->dbManager, $groupId, LicenseMap::REPORT, true);
@@ -225,7 +227,7 @@ class ReportUtils
       if (($clearingsProceeded&2047)==0) {
         $agentObj->heartbeat(0);
       }
-      if ($clearingDecision->getType() == DecisionTypes::IRRELEVANT) {
+      if ($excludeIrrelevant && $clearingDecision->getType() == DecisionTypes::IRRELEVANT) {
         continue;
       }
 

--- a/src/lib/php/Report/tests/LicenseClearedGetterTest.php
+++ b/src/lib/php/Report/tests/LicenseClearedGetterTest.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Contributors to FOSSology
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\Lib\Report;
+
+use Fossology\Lib\Dao\ClearingDao;
+use Fossology\Lib\Dao\LicenseDao;
+use Fossology\Lib\Dao\AgentDao;
+use Fossology\Lib\Dao\TreeDao;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Data\ClearingDecision;
+use Fossology\Lib\Data\DecisionTypes;
+use Fossology\Lib\Data\Tree\ItemTreeBounds;
+use Fossology\Lib\Db\DbManager;
+use Mockery as M;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @class LicenseClearedGetterTest
+ * @brief Tests for LicenseClearedGetter
+ */
+class LicenseClearedGetterTest extends TestCase
+{
+  /** @var LicenseClearedGetter */
+  private $licenseClearedGetter;
+
+  protected function setUp(): void
+  {
+    global $container;
+    $container = M::mock('ContainerBuilder');
+
+    $this->clearingDao = M::mock(ClearingDao::class);
+    $this->licenseDao = M::mock(LicenseDao::class);
+    $this->agentDao = M::mock(AgentDao::class);
+    $this->treeDao = M::mock(TreeDao::class);
+    $this->uploadDao = M::mock(UploadDao::class);
+    $this->dbManager = M::mock(DbManager::class);
+
+    $container->shouldReceive('get')->with('dao.clearing')->andReturn($this->clearingDao);
+    $container->shouldReceive('get')->with('dao.license')->andReturn($this->licenseDao);
+    $container->shouldReceive('get')->with('dao.agent')->andReturn($this->agentDao);
+    $container->shouldReceive('get')->with('dao.tree')->andReturn($this->treeDao);
+    $container->shouldReceive('get')->with('dao.upload')->andReturn($this->uploadDao);
+    $container->shouldReceive('get')->with('db.manager')->andReturn($this->dbManager);
+
+    $this->licenseClearedGetter = new LicenseClearedGetter();
+  }
+
+  protected function tearDown(): void
+  {
+    M::close();
+  }
+
+  /**
+   * @brief Test that setExcludeIrrelevant sets the property correctly
+   */
+  public function testSetExcludeIrrelevant()
+  {
+    // By default, excludeIrrelevant should be true
+    $reflection = new \ReflectionClass($this->licenseClearedGetter);
+    $property = $reflection->getProperty('excludeIrrelevant');
+    $property->setAccessible(true);
+
+    $this->assertTrue($property->getValue($this->licenseClearedGetter));
+
+    // Set to false
+    $this->licenseClearedGetter->setExcludeIrrelevant(false);
+    $this->assertFalse($property->getValue($this->licenseClearedGetter));
+
+    // Set back to true
+    $this->licenseClearedGetter->setExcludeIrrelevant(true);
+    $this->assertTrue($property->getValue($this->licenseClearedGetter));
+  }
+}

--- a/src/lib/php/Report/tests/ReportUtilsExcludeIrrelevantTest.php
+++ b/src/lib/php/Report/tests/ReportUtilsExcludeIrrelevantTest.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Contributors to FOSSology
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\Lib\Report;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @class ReportUtilsExcludeIrrelevantTest
+ * @brief Tests for ReportUtils excludeIrrelevant parameter
+ */
+class ReportUtilsExcludeIrrelevantTest extends TestCase
+{
+  /**
+   * @brief Test that getFilesWithLicensesFromClearings accepts excludeIrrelevant parameter
+   */
+  public function testMethodSignatureIncludesExcludeIrrelevant()
+  {
+    $reflection = new \ReflectionMethod(ReportUtils::class, 'getFilesWithLicensesFromClearings');
+    $parameters = $reflection->getParameters();
+
+    // Should have 5 parameters now
+    $this->assertCount(5, $parameters);
+
+    // The last parameter should be excludeIrrelevant with default true
+    $lastParam = $parameters[4];
+    $this->assertEquals('excludeIrrelevant', $lastParam->getName());
+    $this->assertTrue($lastParam->isDefaultValueAvailable());
+    $this->assertTrue($lastParam->getDefaultValue());
+  }
+}

--- a/src/spdx/agent/spdx.php
+++ b/src/spdx/agent/spdx.php
@@ -883,8 +883,11 @@ class SpdxAgent extends Agent
     $getCommentState = $this->dbManager->getSingleRow($sql, array($uploadId), __METHOD__.'.SPDX_license_comment');
     if (!empty($getCommentState['ri_spdx_selection'])) {
       $getCommentStateSingle = explode(',', $getCommentState['ri_spdx_selection']);
-      if ($getCommentStateSingle[$key] === "checked") {
+      if (isset($getCommentStateSingle[$key]) && $getCommentStateSingle[$key] === "checked") {
         return true;
+      }
+      if (isset($getCommentStateSingle[$key])) {
+        return false;
       }
     }
     return false;


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Files marked as **Irrelevant** by the clearing workflow were not being excluded from SPDX and ReadmeOSS report output, even though the Unified (DOCX) and CLIXML agents already excluded them via `LicenseClearedGetter`.

This fix makes SPDX and ReadmeOSS consistent with the rest of the report agents.

Closes #2853

### Changes

- **`LicenseClearedGetter`**: add explicit `$excludeIrrelevant` flag (default `true`) so the always-on exclusion is intentional and testable via `setExcludeIrrelevant()`
- **`ReportUtils::getFilesWithLicensesFromClearings`**: add `$excludeIrrelevant` parameter (default `true`) that is passed through to `LicenseClearedGetter`
- **`spdx.php`**: fix `getSPDXReportConf()` to guard against undefined array index when `ri_spdx_selection` has fewer entries than expected
- Add unit tests for `LicenseClearedGetter::setExcludeIrrelevant()` and `ReportUtils` parameter signature

## How to test

1. Upload a package and scan it
2. Mark one or more files as **Irrelevant** via the clearing workflow
3. Generate an SPDX report — the irrelevant files should not appear in the output
4. Generate a ReadmeOSS report — same result
5. Verify that Unified (DOCX) report behaviour is unchanged
6. Run unit tests: `php vendor/bin/phpunit --no-coverage src/lib/php/Report/tests/`