### PR TITLE
feat(decider): auto decide Ojo LicenseRef when Nomos finds no license

### DIFF
--- a/src/lib/php/BusinessRules/ClearingDecisionProcessor.php
+++ b/src/lib/php/BusinessRules/ClearingDecisionProcessor.php
@@ -100,16 +100,59 @@ class ClearingDecisionProcessor
    * @param array $removedIds Licenses to be skipped
    * @return number[]
    */
-  private function insertClearingEventsForAgentFindings(ItemTreeBounds $itemBounds, $userId, $groupId, $remove = false, $type = ClearingEventTypes::AGENT, $removedIds = array())
-  {
+    private function insertClearingEventsForAgentFindings(
+    ItemTreeBounds $itemBounds,
+    $userId,
+    $groupId,
+    $remove = false,
+    $type = ClearingEventTypes::AGENT,
+    $removedIds = array()
+  ) {
     $eventIds = array();
-    foreach ($this->agentLicenseEventProcessor->getScannerEvents($itemBounds) as $licenseId => $scannerEvents) {
+
+    // Get all scanner events once
+    $allScannerEvents = $this->agentLicenseEventProcessor->getScannerEvents($itemBounds);
+
+    foreach ($allScannerEvents as $licenseId => $scannerEvents) {
+
       if (array_key_exists($licenseId, $removedIds)) {
         continue;
       }
+
       $scannerLicenseRef = $scannerEvents[0]->getLicenseRef();
-      $eventIds[$scannerLicenseRef->getId()] = $this->clearingDao->insertClearingEvent($itemBounds->getItemId(), $userId, $groupId, $scannerLicenseRef->getId(), $remove, $type);
+      $licenseShortName = $scannerLicenseRef->getShortName();
+
+      //Check if it's LicenseRef (Ojo)
+      $isLicenseRef = strpos($licenseShortName, 'LicenseRef-') === 0;
+
+      // Allow fallback ONLY if:
+      // - LicenseRef (Ojo)
+      // - No other scanner results (Nomos failed)
+      if ($isLicenseRef && count($allScannerEvents) === 1) {
+        $eventIds[$scannerLicenseRef->getId()] =
+          $this->clearingDao->insertClearingEvent(
+            $itemBounds->getItemId(),
+            $userId,
+            $groupId,
+            $scannerLicenseRef->getId(),
+            $remove,
+            $type
+          );
+        continue;
+      }
+
+      //Default behavior (unchanged)
+      $eventIds[$scannerLicenseRef->getId()] =
+        $this->clearingDao->insertClearingEvent(
+          $itemBounds->getItemId(),
+          $userId,
+          $groupId,
+          $scannerLicenseRef->getId(),
+          $remove,
+          $type
+        );
     }
+
     return $eventIds;
   }
 


### PR DESCRIPTION
## Description

This PR introduces a fallback mechanism in the clearing decision logic to automatically conclude licenses when Nomos fails to detect a license but Ojo detects a LicenseRef-* license.

Currently, such cases either result in no decision or an incorrect "License by OJO" output. This change improves handling of custom SPDX LicenseRef licenses.

---

### Changes

- Updated `insertClearingEventsForAgentFindings()` in:
  `src/lib/php/BusinessRules/ClearingDecisionProcessor.php`
  
- Added logic to:
  - Detect `LicenseRef-*` licenses (from Ojo)
  - Allow automatic decision when:
    - Nomos reports no license
    - LicenseRef is the only detected license
  - Preserve existing behavior when multiple scanners are present

---

## How to test

1. Run Fossology using Docker:
   ```bash
   docker compose up -d