### PR TITLE
fix(upload): allow clearing upload description and name fields

### DIFF
--- a/src/www/ui/admin-upload-edit.php
+++ b/src/www/ui/admin-upload-edit.php
@@ -44,40 +44,41 @@ class upload_properties extends FO_Plugin
    *
    * @return int 1 if the upload record is updated, 0 if not, 2 if no inputs
    **/
-  public function UpdateUploadProperties($uploadId, $newName, $newDesc)
+  public function UpdateUploadProperties($uploadId, $newName, $newDesc) 
   {
-    if (empty($newName) and empty($newDesc)) {
+    if ($newName === null && $newDesc === null) {
       return 2;
     }
 
-    if (!empty($newName)) {
-      /*
-       * Use pfile_fk to select the correct entry in the upload tree, artifacts
-       * (e.g. directories of the upload do not have pfiles).
-       */
+    if ($newName !== null) {
       $row = $this->dbManager->getSingleRow(
-        "SELECT pfile_fk FROM upload WHERE upload_pk=$1",array($uploadId),__METHOD__.'.getPfileId');
+        "SELECT pfile_fk FROM upload WHERE upload_pk=$1", array($uploadId), __METHOD__ . '.getPfileId'
+      );
       if (empty($row)) {
         return 0;
       }
       $pfileFk = $row['pfile_fk'];
       $trimNewName = trim($newName);
 
-      /* Always keep uploadtree.ufile_name and upload.upload_filename in sync */
       $this->dbManager->getSingleRow(
         "UPDATE uploadtree SET ufile_name=$3 WHERE upload_fk=$1 AND pfile_fk=$2",
         array($uploadId, $pfileFk, $trimNewName),
-        __METHOD__ . '.updateItem');
+        __METHOD__ . '.updateItem'
+      );
       $this->dbManager->getSingleRow(
         "UPDATE upload SET upload_filename=$3 WHERE upload_pk=$1 AND pfile_fk=$2",
         array($uploadId, $pfileFk, $trimNewName),
-        __METHOD__ . '.updateUpload.name');
+        __METHOD__ . '.updateUpload.name'
+      );
     }
 
-    if (! empty($newDesc)) {
+    if ($newDesc !== null) {
       $trimNewDesc = trim($newDesc);
-      $this->dbManager->getSingleRow("UPDATE upload SET upload_desc=$2 WHERE upload_pk=$1",
-        array($uploadId, $trimNewDesc), __METHOD__ . '.updateUpload.desc');
+      $this->dbManager->getSingleRow(
+        "UPDATE upload SET upload_desc=$2 WHERE upload_pk=$1",
+        array($uploadId, $trimNewDesc),
+        __METHOD__ . '.updateUpload.desc'
+      );
     }
     return 1;
   }


### PR DESCRIPTION
## Description

This PR fixes an issue where users were unable to clear the upload description and upload name fields.

Previously, the backend used `empty()` checks, which ignored empty string (`""`) values. As a result, when users cleared these fields, the previous values were retained instead of being removed.

This fix replaces `empty()` checks with `null` checks to ensure empty strings are treated as valid inputs and properly saved.

Fixes #3002


### Changes

- Replaced `empty()` checks with `null` checks in `UpdateUploadProperties()` function
- Allowed empty string (`""`) values to be saved to the database
- Enabled proper clearing of:
  - Upload description
  - Upload name


## How to test

1. Run Fossology locally
2. Navigate to **Organize → Uploads**
3. Select an upload and click **Edit Properties**
4. Add a description → Click Save (should be saved correctly)
5. Clear the description (remove all text) → Click Save

### Expected Result:
- The description field should be empty after saving

6. Repeat the same steps for upload name

### Expected Result:
- The upload name should be updated or cleared correctly