### PR TITLE
Edit short name in license administration #1969

### DIFF
--- a/src/www/ui/admin-license-file.php
+++ b/src/www/ui/admin-license-file.php
@@ -421,8 +421,8 @@ class admin_license_file extends FO_Plugin
       $spdxId = LicenseRef::replaceSpaces($spdxId);
     }
 
-    if (empty($shortname)) {
-      $text = _("ERROR: The license shortname is empty. License not added.");
+    if ($this->isShortnameBlocked($rfId, $shortname, $text)) {
+      $text = _("ERROR: Shortname already exists. License not updated.");
       return "<b>$text</b><p>";
     }
 

--- a/src/www/ui/template/admin_license_file.js.twig
+++ b/src/www/ui/template/admin_license_file.js.twig
@@ -97,15 +97,16 @@ function createLicenseTable() {
   }
 
   function renderEdit(data) {
-    var rf_pk = data[0];
-    var marydone = data[1];
-    var rf_shortname = data[2];
+  var rf_pk = data[0];
+  var marydone = data[1];
+  var rf_shortname = data[2];
 
-    return "<a href=\"{{ tracebackURI }}?mod=admin_license&rf_pk=" + rf_pk +
-           "&req_marydone=" + marydone + "&req_shortname=" + rf_shortname + "\" >" +
-           "<img border=0 src=\"{{ tracebackURI }}images/button_edit.png\">" +
-           "</a>";
-  }
+  return '<a href="{{ tracebackURI }}?mod=admin_license&rf_pk=' + rf_pk +
+         '&req_marydone=' + marydone +
+         '&req_shortname=' + encodeURIComponent(rf_shortname) + '">' +
+         '<img border="0" src="{{ tracebackURI }}images/button_edit.png">' +
+         '</a>';
+}
 
   function renderLink(url) {
     return "<a href=\"" + url + "\">" + url + "</a>";


### PR DESCRIPTION
This PR allows editing of the short name in License Administration.

- Removed restriction preventing modification of shortname
- Added validation to prevent duplicate shortnames
- Ensured existing functionality remains unaffected

Fixes #1969
<img width="721" height="266" alt="Screenshot 2026-03-24 204120" src="https://github.com/user-attachments/assets/260da06e-c311-4523-ac68-765782a4d8f0" />
<img width="653" height="112" alt="Screenshot 2026-03-24 204147" src="https://github.com/user-attachments/assets/6f5387a9-732d-4196-9bc6-94d783dc8ab5" />

