### PR TITLE
fix(nomos): improve dual license detection for BSD+MIT (#2677)

### DIFF
--- a/src/nomos/agent/generator/STRINGS.in
+++ b/src/nomos/agent/generator/STRINGS.in
@@ -1715,6 +1715,10 @@
 %KEY% "licen[cs]"
 %STR% "spdx-license-identifier[-_:\+\.\(\)[:alnum:][:blank:]]+[[:blank:]]OR[[:blank:]]"
 #
+%ENTRY% _LT_DUAL_LICENSE_51
+%KEY% "bsd"
+%STR% "bsd =FEW= mit"
+#
 %ENTRY% _LT_SUBSEQUENT_VERSION
 %KEY% "licen[cs]"
 %STR% "under the terms of either =SOME= license =FEW= or =FEW= (subsequent|later|new) version =FEW= license"

--- a/src/nomos/agent/parse.c
+++ b/src/nomos/agent/parse.c
@@ -6698,11 +6698,16 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
   else if (HASTEXT(_LT_DUAL_LICENSE_49, REG_EXTENDED)) {
     MEDINTEREST(lDebug ? "Dual-license(49)" : "Dual-license");
   }
+<<<<<<< Updated upstream
   else if (INFILE(_LT_DUAL_LICENSE_50)) {
   MEDINTEREST(lDebug ? "Dual-license(50)" : "Dual-license");
   }
   else if (INFILE(_LT_DUAL_LICENSE_51)) {
   MEDINTEREST(lDebug ? "Dual-license(BSD+MIT)" : "Dual-license");
+=======
+  else if (INFILE(_LT_DUAL_LICENSE_51)) {
+    MEDINTEREST(lDebug ? "Dual-license(BSD+MIT)" : "Dual-license");
+>>>>>>> Stashed changes
   }
   cleanLicenceBuffer();
   /*


### PR DESCRIPTION
Fixes #2677

Added new rule in STRINGS.in to detect dual BSD+MIT license patterns.
Added condition in parse.c for _LT_DUAL_LICENSE_51.

This improves detection for files like Modernizr v2.8.3
which are distributed under BSD and MIT dual license.

Tested locally with sample text.