### PR TITLE
perf(reuser): eliminating redundant database calls in reuseMainLicense function

### DIFF
--- a/src/reuser/agent/ReuserAgent.php
+++ b/src/reuser/agent/ReuserAgent.php
@@ -150,8 +150,9 @@ class ReuserAgent extends Agent
   {
     $mainLicenseIds = $this->clearingDao->getMainLicenseIds($reusedUploadId, $reusedGroupId);
     if (!empty($mainLicenseIds)) {
+      $existingMainLicenseIds = $this->clearingDao->getMainLicenseIds($uploadId, $groupId);
       foreach ($mainLicenseIds as $mainLicenseId) {
-        if (in_array($mainLicenseId, $this->clearingDao->getMainLicenseIds($uploadId, $groupId))) {
+        if (in_array($mainLicenseId, $existingMainLicenseIds)) {
           continue;
         } else {
           $this->clearingDao->makeMainLicense($uploadId, $groupId, $mainLicenseId);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors
     SPDX-License-Identifier: GPL-2.0-only
-->

## Description
This PR optimizes the [reuseMainLicense](cci:1://file:///c:/Users/ayush/fossology/src/reuser/agent/ReuserAgent.php:138:2-162:3) function by reducing the number of redundant database hits. 

Previously, if a package had multiple main licenses, the system would re-fetch the target upload's list from the database multiple times. Now, it fetches that list **once** before the loop starts, which is much more efficient.

Fixes #3520

### Changes
- **ReuserAgent.php**: Refactored [reuseMainLicense](cci:1://file:///c:/Users/ayush/fossology/src/reuser/agent/ReuserAgent.php:138:2-162:3) to use a single database call for existing licenses.
<img width="553" height="436" alt="image" src="https://github.com/user-attachments/assets/fb76623a-61b3-4690-b9b6-2cf2cbce011b" />


## How to test
1. Take an existing upload that is dual-licensed (e.g., has two labels marked as "Main License").
2. Upload a newer version of the same package.
3. Run the Reuser using the dual-licensed upload as the reference.
4. Confirm that both licenses are correctly promoted in the new upload and that the process finishes smoothly.
