### PR TITLE
chore(ci): skip commit lint check for dependabot

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -132,6 +132,7 @@ jobs:
           fi
 
       - name: Run Commit Lint
+        if: github.actor != 'dependabot[bot]'
         uses: wagoid/commitlint-github-action@v6
         with:
           configFile: ./commitlint.config.mjs


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Commit lint check is for rigid rules on the commit messages pushed. Dependabot on the other hand is designed to put all the information necessary in the body of the commit.

Now, We can play around with a bit of prefix and things with dependabot but there are no configurations to restrict the commit type or size. Hence, We need to skip the commit lint for dependabot. 

### Changes

Added a if check on commit lint stage, if the actor is `dependabot[bot]` action will skip.

