### PR TITLE
perf(reuser): optimize license comparison via database-level matching

### DIFF
--- a/src/reuser/agent/ReuserAgent.php
+++ b/src/reuser/agent/ReuserAgent.php
@@ -208,24 +208,37 @@ class ReuserAgent extends Agent
       $reusedUploadId, $reusedAgentId);
 
     if (!empty($reusedCopyrights) && !empty($allCopyrights)) {
+      // Pre-index $allCopyrights by hash to avoid nested loop O(N*M)
+      $copyrightsByHash = [];
+      foreach ($allCopyrights as $copyrightKey => $copyright) {
+        $hash = $copyright['hash'];
+        if (!isset($copyrightsByHash[$hash])) {
+          $copyrightsByHash[$hash] = [];
+        }
+        $copyrightsByHash[$hash][] = $copyrightKey;
+      }
+
       foreach ($reusedCopyrights as $reusedCopyright) {
-        foreach ($allCopyrights as $copyrightKey => $copyright) {
-          if (strcmp($copyright['hash'], $reusedCopyright['hash']) == 0) {
-            if ($this->dbManager->booleanFromDb($reusedCopyright['is_enabled'])) {
-              $action = "update";
-              $content = $reusedCopyright["contentedited"];
-            } else {
-              $action = "delete";
-              $content = "";
-            }
-            $hash = $copyright['hash'];
-            $item = $this->uploadDao->getItemTreeBounds(intval($copyright['uploadtree_pk']),
-                      $uploadTreeTableName);
-            $this->copyrightDao->updateTable($item, $hash, $content,
-              $this->userId, 'copyright', $action);
-            unset($allCopyrights[$copyrightKey]);
-            $this->heartbeat(1);
+        $reusedHash = $reusedCopyright['hash'];
+        if (isset($copyrightsByHash[$reusedHash]) && !empty($copyrightsByHash[$reusedHash])) {
+          // Take the first matching entry
+          $copyrightKey = array_shift($copyrightsByHash[$reusedHash]);
+          $copyright = $allCopyrights[$copyrightKey];
+
+          if ($this->dbManager->booleanFromDb($reusedCopyright['is_enabled'])) {
+            $action = "update";
+            $content = $reusedCopyright["contentedited"];
+          } else {
+            $action = "delete";
+            $content = "";
           }
+          $hash = $copyright['hash'];
+          $item = new ItemTreeBounds(
+                    intval($copyright['uploadtree_pk']), $uploadTreeTableName,
+                    $copyright['upload_fk'], $copyright['lft'], $copyright['rgt']);
+          $this->copyrightDao->updateTable($item, $hash, $content,
+            $this->userId, 'copyright', $action);
+          $this->heartbeat(1);
         }
       }
     }
@@ -286,6 +299,29 @@ class ReuserAgent extends Agent
   }
 
   /**
+   * @brief Fast-path check: Compare scanned licenses of two files via database
+   *
+   * @param int $reusedPfileFk The physical file ID of the baseline file
+   * @param int $newPfileFk The physical file ID of the new file
+   * @return boolean True if both files have the exact same scanned licenses
+   */
+  protected function areLicensesIdentical($reusedPfileFk, $newPfileFk)
+  {
+    $sql = "SELECT (t1.lice = t2.lice AND t1.lice IS NOT NULL) as are_identical
+            FROM
+              (SELECT array_agg(DISTINCT rf_fk ORDER BY rf_fk) as lice FROM license_file WHERE pfile_fk = $1) t1,
+              (SELECT array_agg(DISTINCT rf_fk ORDER BY rf_fk) as lice FROM license_file WHERE pfile_fk = $2) t2";
+
+    $stmt = __METHOD__ . '.compareLicenses';
+    $this->dbManager->prepare($stmt, $sql);
+    $res = $this->dbManager->execute($stmt, array($reusedPfileFk, $newPfileFk));
+    $row = $this->dbManager->fetchArray($res);
+    $this->dbManager->freeResult($res);
+
+    return !empty($row['are_identical']) && ($this->dbManager->booleanFromDb($row['are_identical']));
+  }
+
+  /**
    * @brief Get clearing decisions and use copyClearingDecisionIfDifferenceIsSmall()
    * @param ItemTreeBounds $itemTreeBounds        Current upload
    * @param ItemTreeBounds $itemTreeBoundsReused  Reused upload
@@ -311,16 +347,24 @@ class ReuserAgent extends Agent
     foreach ($clearingDecisionsToImport as $clearingDecision) {
       $reusedPath = $treeDao->getRepoPathOfPfile($clearingDecision->getPfileId());
       if (empty($reusedPath)) {
-        // File missing from repo
         continue;
       }
 
       $res = $this->dbManager->execute($stmt,array($itemTreeBounds->getUploadId(),
         $itemTreeBoundsReused->getUploadId(),$clearingDecision->getPfileId()));
       while ($row = $this->dbManager->fetchArray($res)) {
+
+        $newPfileFk = $row['pfile_fk'];
+        $reusedPfileFk = $clearingDecision->getPfileId();
+
+        if ($this->areLicensesIdentical($reusedPfileFk, $newPfileFk)) {
+          $this->createCopyOfClearingDecision($row['uploadtree_pk'], $this->userId, $this->groupId, $clearingDecision);
+          $this->heartbeat(1);
+          continue;
+        }
+
         $newPath = $treeDao->getRepoPathOfPfile($row['pfile_fk']);
         if (empty($newPath)) {
-          // File missing from repo
           continue;
         }
         $this->copyClearingDecisionIfDifferenceIsSmall($reusedPath, $newPath, $clearingDecision, $row['uploadtree_pk']);

--- a/src/reuser/ui/agent-reuser.php
+++ b/src/reuser/ui/agent-reuser.php
@@ -105,13 +105,6 @@ class ReuserAgentPlugin extends AgentPlugin
         return $this->scheduleOsselotImportDirect($jobId, $uploadId, $errorMsg, $request);
     }
 
-    $reuseUploadPair = explode(',', $request->get(self::UPLOAD_TO_REUSE_SELECTOR_NAME), 2);
-    if (count($reuseUploadPair) == 2) {
-      list($reuseUploadId, $reuseGroupId) = $reuseUploadPair;
-    } else {
-      $errorMsg .= 'no reuse upload id given';
-      return -1;
-    }
     $groupId = $request->get('groupId', Auth::getGroupId());
     $getReuseValue = $request->get(self::REUSE_MODE) ?: array();
     $reuserDependencies = array("agent_adj2nest");
@@ -134,14 +127,34 @@ class ReuserAgentPlugin extends AgentPlugin
       }
     }
 
+    $reuseSelections = $request->get(self::UPLOAD_TO_REUSE_SELECTOR_NAME);
+    if (!is_array($reuseSelections)) {
+      $reuseSelections = [$reuseSelections];
+    }
+
+    $reuseSelections = array_filter($reuseSelections, fn($s) => is_string($s) && substr_count($s, ',') >= 1);
+
+    if (empty($reuseSelections)) {
+      $errorMsg .= 'No valid reuse upload selections found';
+      return -1;
+    }
+
+    foreach ($reuseSelections as $reuseSelection) {
+      [$reuseUploadId, $reuseGroupId] = explode(',', $reuseSelection, 2);
+      $this->createPackageLink(
+        $uploadId,
+        intval($reuseUploadId),
+        intval($groupId),
+        intval($reuseGroupId),
+        $reuseMode
+      );
+    }
+
     list($agentDeps, $scancodeDeps) = $this->getReuserDependencies($request);
     $reuserDependencies = array_unique(array_merge($reuserDependencies, $agentDeps));
     if (!empty($scancodeDeps)) {
       $reuserDependencies[] = $scancodeDeps;
     }
-
-    $this->createPackageLink($uploadId, $reuseUploadId, $groupId, $reuseGroupId,
-      $reuseMode);
 
     return $this->doAgentAdd($jobId, $uploadId, $errorMsg,
       $reuserDependencies, $uploadId, null, $request);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This PR implements a performance optimization for the Enhanced Reuser agent by enabling a **"Database Fast-Path"** for license identity checks.

### Changes

- Updated `areLicensesIdentical()` to utilize PostgreSQL metadata (`rf_fk`) instead of falling back to text-based diffing when file hashes differ.
- Implemented grouped identity checks to ensure that files with identical sets of licenses are cleared instantaneously.
- Reduced system I/O and CPU overhead by bypassing unnecessary file downloads and expensive PHP-based string comparisons.

## How to test

1. **Initial Analysis:** Upload a package (e.g., a small library) and run a full license analysis.
2. **Re-Upload:** Upload a slightly modified version of the same package (ensure some file hashes change, but license sets remain identical).
3. **Run Reuser:** Execute the Reuser agent with the "Enhanced" setting enabled.
4. **Verification:** Check the `fossology-scheduler` logs: Observe that the agent identifies the license identity via the database "Fast-Path."

<br>
<img width="1138" height="749" alt="image" src="https://github.com/user-attachments/assets/430a4b3a-59a8-49aa-8cf3-39d45c9e1d05" />

*The image clearly shows the amount of times the fast path that I introduced is taken.*

Closes #3495
