### PR TITLE
fix(nomos): detect GPL-2.0 as "published by FSF" license variant

### DIFF
--- a/src/nomos/agent/generator/STRINGS.in
+++ b/src/nomos/agent/generator/STRINGS.in
@@ -2944,6 +2944,10 @@
 %KEY% "\<under\>"
 %STR% "released under version 2 of the (gnu )?gpl"
 #
+%ENTRY% _LT_GPL_V2_as_published
+%KEY% "licen[cs]"
+%STR% "gnu general public license as published by the free software foundation; either version 2 of the license, or \(at your option\) any later version"
+#
 %ENTRY% _LT_GPL_V3_ref
 %KEY% "licen[cs]"
 %STR% "licen[cs]ed under (the )?((general p|p)ublic|general purpose) licen[cs]e (version |v)3"

--- a/src/nomos/agent/parse.c
+++ b/src/nomos/agent/parse.c
@@ -1415,7 +1415,7 @@ char *parseLicenses(char *filetext, int size, scanres_t *scp,
         lmem[_mGPL] = 1;
       }
     }
-    else if ((INFILE(_LT_GPL_V2) || INFILE(_LT_GPL_V2_ref) || INFILE(_LT_GPL_V2_ref1) || INFILE(_LT_GPL_V2_ref2)) && !HASTEXT(_LT_GPL_EXCEPT_0, REG_EXTENDED)) {
+    else if ((INFILE(_LT_GPL_V2) || INFILE(_LT_GPL_V2_ref) || INFILE(_LT_GPL_V2_ref1) || INFILE(_LT_GPL_V2_ref2) || INFILE(_LT_GPL_V2_as_published)) && !HASTEXT(_LT_GPL_EXCEPT_0, REG_EXTENDED)) {
       if (INFILE(_PHR_GPL2_OR_LATER_1) && !HASTEXT(_LT_IGNORE_CLAUSE, REG_EXTENDED))
       {
         INTERESTING(lDebug ? "PHR(GPL2_OR_LATER#2)" : "GPL-2.0-or-later");


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Fix GPL-2.0 license detection in Nomos for variants using "as published by the Free Software Foundation".
Closes: #2021 

### Changes

- Added new regex pattern to detect GPL-2.0 license text using "as published by the Free Software Foundation" in `STRINGS.in`
- Added the condition check in `parce.c`

## Screenshots
### Before
<img width="1353" height="682" alt="Screenshot 2026-03-28 185237" src="https://github.com/user-attachments/assets/e36e407b-dddc-469b-8ac6-6710f1354a9c" />
<img width="1883" height="612" alt="Screenshot 2026-03-28 185217" src="https://github.com/user-attachments/assets/942a529e-7abb-4a7a-9b7a-b644d742fb93" />

### After
<img width="1354" height="673" alt="Screenshot 2026-03-28 191239" src="https://github.com/user-attachments/assets/8e4ae6ce-c11f-4c85-8a8f-f4fa3f6988d0" />

<img width="1891" height="620" alt="Screenshot 2026-03-28 183900" src="https://github.com/user-attachments/assets/452f0649-208a-4401-b0ea-a3f987aa42c4" />
