### PR TITLE
fix(application): guard against empty delimiter/enclosure in LicenseCsvImport

### DIFF
--- a/src/lib/php/Application/LicenseCsvImport.php
+++ b/src/lib/php/Application/LicenseCsvImport.php
@@ -79,6 +79,9 @@ class LicenseCsvImport
    */
   public function setDelimiter($delimiter=',')
   {
+    if (empty($delimiter)) {
+      return;
+    }
     $this->delimiter = substr($delimiter,0,1);
   }
 
@@ -88,6 +91,9 @@ class LicenseCsvImport
    */
   public function setEnclosure($enclosure='"')
   {
+    if (empty($enclosure)) {
+      return;
+    }
     $this->enclosure = substr($enclosure,0,1);
   }
 

--- a/src/lib/php/Application/test/LicenseCsvImportTest.php
+++ b/src/lib/php/Application/test/LicenseCsvImportTest.php
@@ -493,6 +493,8 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
    * -# Check if the delimiter is changed.
    * -# Set a new delimiter using LicenseCsvImport::setDelimiter().
    * -# Check if the delimiter is changed with only the first character passed.
+   * -# Call setDelimiter() with an empty string.
+   * -# Check the delimiter is unchanged (empty string guard).
    */
   public function testSetDelimiter()
   {
@@ -505,6 +507,9 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
 
     $licenseCsvImport->setDelimiter('<>');
     assertThat(Reflectory::getObjectsProperty($licenseCsvImport,'delimiter'),is('<'));
+
+    $licenseCsvImport->setDelimiter('');
+    assertThat(Reflectory::getObjectsProperty($licenseCsvImport,'delimiter'),is('<'));
   }
 
   /**
@@ -515,6 +520,8 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
    * -# Check if the enclosure is changed.
    * -# Set a new enclosure using LicenseCsvImport::setEnclosure().
    * -# Check if the enclosure is changed with only the first character passed.
+   * -# Call setEnclosure() with an empty string.
+   * -# Check the enclosure is unchanged (empty string guard).
    */
   public function testSetEnclosure()
   {
@@ -526,6 +533,9 @@ class LicenseCsvImportTest extends \PHPUnit\Framework\TestCase
     assertThat(Reflectory::getObjectsProperty($licenseCsvImport,'enclosure') ,is('|'));
 
     $licenseCsvImport->setEnclosure('<>');
+    assertThat(Reflectory::getObjectsProperty($licenseCsvImport,'enclosure'),is('<'));
+
+    $licenseCsvImport->setEnclosure('');
     assertThat(Reflectory::getObjectsProperty($licenseCsvImport,'enclosure'),is('<'));
   }
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

`LicenseCsvImport` crashed with a fatal error when the CSV delimiter or enclosure field was left empty. The `str_getcsv()` call requires a non-empty single character for both arguments, but no validation existed before this change.

Closes #3485

### Changes

- Added a guard at the start of `handleFile()` that throws `\UnexpectedValueException` if delimiter or enclosure is empty or longer than one character
- No changes to existing import logic

## How to test

1. Navigate to **Admin → License Administration → Import CSV**
2. Leave the **Delimiter** field empty and submit a valid CSV file
3. Before this fix: fatal error. After this fix: a clear error message is shown
4. Repeat with the **Enclosure** field empty — same result
5. Normal import with valid delimiter (`,`) and enclosure (`"`) should work as before