### PR TITLE
fix(api): return 400 for negative folderId in POST /uploads

### DIFF
--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -483,8 +483,7 @@ class UploadController extends RestController
       throw new HttpBadRequestException(
         "Require location object if uploadType != file");
     }
-    if (empty($folderId) ||
-        !is_numeric($folderId) && $folderId > 0) {
+    if (!is_numeric($folderId) || intval($folderId) < 1) {
       throw new HttpBadRequestException("folderId must be a positive integer!");
     }
 

--- a/src/www/ui_tests/api/Controllers/UploadControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadControllerTest.php
@@ -966,6 +966,76 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
    * @runInSeparateProcess
    * @preserveGlobalState disabled
    * @test
+   * -# Test for UploadController::postUpload() with negative folderId V1
+   * -# Check if response status is 400
+   */
+  public function testPostUploadNegativeFolderIdV1()
+  {
+    $this->testPostUploadNegativeFolderId(ApiVersion::V1);
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test for UploadController::postUpload() with negative folderId V2
+   * -# Check if response status is 400
+   */
+  public function testPostUploadNegativeFolderIdV2()
+  {
+    $this->testPostUploadNegativeFolderId(ApiVersion::V2);
+  }
+
+  /**
+   * @param int $version Version to test
+   * @return void
+   */
+  private function testPostUploadNegativeFolderId(int $version)
+  {
+    $folderId = -1;
+    $uploadDescription = "Test Upload";
+
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-type', 'application/json');
+    if ($version == ApiVersion::V2) {
+      $body = $this->streamFactory->createStream(json_encode([
+        "location" => "vcsData",
+        "folderId" => $folderId,
+        "uploadDescription" => $uploadDescription,
+        "ignoreScm" => "true",
+        "scanOptions" => "scanOptions",
+        "uploadType" => "vcs"
+      ]));
+    } else {
+      $body = $this->streamFactory->createStream(json_encode([
+        "location" => "vcsData",
+        "scanOptions" => "scanOptions"
+      ]));
+      $requestHeaders->setHeader('folderId', $folderId);
+      $requestHeaders->setHeader('uploadDescription', $uploadDescription);
+      $requestHeaders->setHeader('ignoreScm', 'true');
+      $requestHeaders->setHeader('Content-Type', 'application/json');
+      $requestHeaders->setHeader('uploadType', 'vcs');
+    }
+    $request = new Request("POST", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+    if ($version == ApiVersion::V2) {
+      $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,
+        ApiVersion::V2);
+    }
+
+    $uploadHelper = M::mock('overload:Fossology\UI\Api\Helper\UploadHelper');
+
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->uploadController->postUpload($request, new ResponseHelper(),
+      []);
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
    * -# Test for UploadController::postUpload() with internal error with V1 parameters
    * -# Check if response status is 500 with error messages set
    */


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

`POST /api/v2/uploads` returned **404 Not Found** when `folderId` was a negative integer. Negative values are invalid input and should be rejected early with **400 Bad Request**.

The validation condition `empty($folderId) || !is_numeric($folderId) && $folderId > 0` failed to catch negatives: `empty(-1)` is `false` and `-1` is numeric, so the value fell through to the folder-existence lookup and returned a misleading 404.

Closes #3385

### Changes

- Replaced the flawed validation condition with `!is_numeric($folderId) || intval($folderId) < 1`
- Added `testPostUploadNegativeFolderIdV1` and `testPostUploadNegativeFolderIdV2` unit tests

## How to test

```bash
# Get a token
TOKEN=$(curl -s -X POST http://localhost/repo/api/v1/tokens \
  -H "Content-Type: application/json" \
  -d '{"username":"fossy","password":"fossy","token_scope":"write","token_name":"test","token_expire":"YYYY-MM-DD"}' \
  | jq -r '.Authorization' | sed 's/Bearer //')

# Should return 400 (was 404 before)
curl -s -X POST http://localhost/repo/api/v2/uploads \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"folderId":-1,"uploadType":"vcs","location":{"vcsType":"git","vcsUrl":"https://github.com/example/repo","vcsName":"test","vcsBranch":"main"}}'
# Expected: {"code":400,"message":"folderId must be a positive integer!","type":"ERROR"}

# Valid folderId should still work
curl -s -X POST http://localhost/repo/api/v2/uploads \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"folderId":1,"uploadType":"vcs","location":{"vcsType":"git","vcsUrl":"https://github.com/example/repo","vcsName":"test","vcsBranch":"main"}}'
# Expected: 201
```