### PR TITLE
fix(lib): fix undefined array key warnings in JobDao::hasActionPermissionsOnJob()

### DIFF
--- a/src/lib/php/Dao/JobDao.php
+++ b/src/lib/php/Dao/JobDao.php
@@ -67,25 +67,23 @@ class JobDao
     return $result;
   }
 
-  public function hasActionPermissionsOnJob($jobId, $userId, $groupId)
+  public function hasActionPermissionsOnJob($jobId, $userId, $groupId): bool
   {
-    $result = array();
     $stmt = __METHOD__;
     $this->dbManager->prepare($stmt,
-      "SELECT *
+      "SELECT 1
        FROM job
          LEFT JOIN group_user_member gm
            ON gm.user_fk = job_user_fk
        WHERE job_pk = $1
          AND (job_user_fk = $2
-              OR gm.group_fk = $3)");
+              OR gm.group_fk = $3)
+       LIMIT 1");
 
     $res = $this->dbManager->execute($stmt, array($jobId, $userId, $groupId));
-    while ($row = $this->dbManager->fetchArray($res)) {
-      $result[$row['jq_pk']] = $row['end_bits'];
-    }
+    $hasPermission = $this->dbManager->fetchArray($res) !== false;
     $this->dbManager->freeResult($res);
 
-    return $result;
+    return $hasPermission;
   }
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Fixes undefined array key warnings in `JobDao::hasActionPermissionsOnJob()`. The method queries the `job` table but the result loop accessed `$row['jq_pk']` and `$row['end_bits']`, which are columns from `jobqueue` — not present in the `job` result set. This is a copy-paste artifact from the neighbouring `getAllJobStatus()` methods.

Both callers (`JobController.php:197` and `showjobs.php:120`) use the return value as a boolean, so the array-building loop was replaced with a simple existence check.

Closes #3381

### Changes

- `SELECT *` → `SELECT 1` (no unnecessary data transfer)
- Added `LIMIT 1` to stop at first matching row
- Removed access to undefined `jq_pk`/`end_bits` columns
- Method now explicitly returns `bool` instead of an array

## How to test

1. As a job owner, delete a job via `DELETE /api/v2/jobs/{id}` — should return 200
2. As a user in the same group as the job owner, delete the job — should return 200
3. As an unrelated user, attempt to delete the job — should be denied with 403
4. Check PHP error log: no "undefined array key" warnings should appear for `jq_pk` or `end_bits`