### PR TITLE
perf(search): reduce database query overhead on search page

### DIFF
--- a/src/lib/php/Dao/UploadDao.php
+++ b/src/lib/php/Dao/UploadDao.php
@@ -11,6 +11,7 @@ namespace Fossology\Lib\Dao;
 use Fossology\Lib\Data\Tree\Item;
 use Fossology\Lib\Data\Tree\ItemTreeBounds;
 use Fossology\Lib\Data\Upload\Upload;
+use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Data\Upload\UploadEvents;
 use Fossology\Lib\Data\UploadStatus;
 use Fossology\Lib\Db\DbManager;
@@ -136,6 +137,30 @@ class UploadDao
     $stmt = __METHOD__;
     $queryResult = $this->dbManager->getRows("SELECT * FROM upload where pfile_fk IS NOT NULL",
         array(), $stmt);
+
+    $results = array();
+    foreach ($queryResult as $row) {
+      $results[] = Upload::createFromTable($row);
+    }
+
+    return $results;
+  }
+
+  /**
+   * Get all uploads accessible by a group.
+   * @param int $groupId Group id
+   * @return Upload[] Array of Upload objects
+   */
+  public function getAccessibleUploads($groupId)
+  {
+    $stmt = __METHOD__;
+    $permNone = Auth::PERM_NONE;
+    $sql = "SELECT u.* FROM upload u
+            LEFT JOIN perm_upload p ON p.upload_fk = u.upload_pk AND p.group_fk = $1
+            WHERE u.pfile_fk IS NOT NULL
+            AND (p.perm > $permNone OR u.public_perm > $permNone)";
+
+    $queryResult = $this->dbManager->getRows($sql, array($groupId), $stmt);
 
     $results = array();
     foreach ($queryResult as $row) {

--- a/src/www/ui/search.php
+++ b/src/www/ui/search.php
@@ -43,15 +43,15 @@ class search extends FO_Plugin
 
   function loadUploads()
   {
-    $allUploadsPre = $this->uploadDao->getActiveUploadsArray();
-    $filteredUploadsList = array();
+    if (Auth::isAdmin()) {
+      return $this->uploadDao->getActiveUploadsArray();
+    }
 
-    return array_filter($allUploadsPre, function($uploadObj){
-      if ($this->uploadDao->isAccessible($uploadObj->getId(), Auth::getGroupId())) {
-        return true;
-      }
-      return false;
-    });
+    if (Auth::getUserId() === 0) {
+      return array();
+    }
+
+    return $this->uploadDao->getAccessibleUploads(Auth::getGroupId());
   }
 
   /**


### PR DESCRIPTION
Description:
This pull request makes the search page load much faster by changing how it checks for user permissions. Instead of asking the database about every single upload one by one, it now gets all the information in one single step.

This is what was happening previously:
<img width="630" height="492" alt="image" src="https://github.com/user-attachments/assets/f2dbf42e-1318-4f12-a3e7-4aa9c02b9c8c" />

Changes
Updated search.php: I removed the old code that used a loop to check permissions for every upload. This was causing a lot of extra work for the database.
Improved UploadDao.php: I added a new function called getAccessibleUploads. It uses a single SQL query with a "JOIN" to find all the uploads a user is allowed to see.

<img width="784" height="564" alt="image" src="https://github.com/user-attachments/assets/66c567f9-af46-418d-a8d0-c7a6f80bbe0c" />

Admin Optimization: If you are logged in as an administrator, the code now skips the extra permission checks and shows all uploads immediately to save time.
Reduced Database Load: This change moves the filtering logic from the PHP code to the database itself, which is much more efficient.
How to test
Log in to Fossology as a normal user.
Go to the Search page from the main menu.
Open the Upload dropdown list. You should only see uploads that belong to your group or ones that are marked as public.
Log in as an Admin and go to the same page. You should be able to see every upload in the system.
If your database has many uploads, you will see that the Search page now opens significantly faster than it did before.