### PR TITLE
Fix #3002: Allow clearing upload descriptions and comments

### DIFF
--- a/src/www/ui/admin-upload-edit.php
+++ b/src/www/ui/admin-upload-edit.php
@@ -46,11 +46,11 @@ class upload_properties extends FO_Plugin
    **/
   public function UpdateUploadProperties($uploadId, $newName, $newDesc)
   {
-    if (empty($newName) and empty($newDesc)) {
+    if ($newName === null && $newDesc === null) {
       return 2;
     }
 
-    if (!empty($newName)) {
+    if ($newName !== null) {
       /*
        * Use pfile_fk to select the correct entry in the upload tree, artifacts
        * (e.g. directories of the upload do not have pfiles).
@@ -74,7 +74,7 @@ class upload_properties extends FO_Plugin
         __METHOD__ . '.updateUpload.name');
     }
 
-    if (! empty($newDesc)) {
+    if ($newDesc !== null) {
       $trimNewDesc = trim($newDesc);
       $this->dbManager->getSingleRow("UPDATE upload SET upload_desc=$2 WHERE upload_pk=$1",
         array($uploadId, $trimNewDesc), __METHOD__ . '.updateUpload.desc');

--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -726,16 +726,14 @@ class UploadController extends RestController
     // Handle update of name
     if (
       $isJsonRequest &&
-      array_key_exists(self::FILTER_NAME, $bodyContent) &&
-      strlen(trim($bodyContent[self::FILTER_NAME])) > 0
+      array_key_exists(self::FILTER_NAME, $bodyContent)
     ) {
       $newName = trim($bodyContent[self::FILTER_NAME]);
     }
     // Handle update of description
     if (
       $isJsonRequest &&
-      array_key_exists("uploadDescription", $bodyContent) &&
-      strlen(trim($bodyContent["uploadDescription"])) > 0
+      array_key_exists("uploadDescription", $bodyContent)
     ) {
       $newDescription = trim($bodyContent["uploadDescription"]);
     }

--- a/src/www/ui/async/AjaxBrowse.php
+++ b/src/www/ui/async/AjaxBrowse.php
@@ -88,7 +88,7 @@ class AjaxBrowse extends DefaultPlugin
     } else if (! empty($uploadId) && ! empty($direction)) {
       $uploadBrowseProxy = new UploadBrowseProxy($groupId, $this->userPerm, $this->dbManager);
       $uploadBrowseProxy->moveUploadToInfinity($uploadId, $direction == 'top');
-    } else if (!empty($uploadId) && !empty($commentText) && !empty($statusId)) {
+    } else if (!empty($uploadId) && !is_null($commentText) && !empty($statusId)) {
       $uploadBrowseProxy = new UploadBrowseProxy($groupId, $this->userPerm, $this->dbManager);
       $uploadBrowseProxy->setStatusAndComment($uploadId, $statusId, $commentText);
     } else {


### PR DESCRIPTION
This PR resolves [Issue #3002](https://github.com/fossology/fossology/issues/3002) which prevented users from clearing the "Upload Description" and "Comment" fields in the WebUI and via REST API.

### Changes:
- **`src/www/ui/admin-upload-edit.php`**: Updated `UpdateUploadProperties` to allow empty strings for name and description by checking for `null` instead of `empty()`.
- - **`src/www/ui/async/AjaxBrowse.php`**: Updated AJAX handler to accept empty `commentText` when updating status.
- - **`src/www/ui/api/Controllers/UploadController.php`**: Removed `strlen` checks in the REST API controller to allow clearing fields via API.
These changes ensure that clearing a text field in the UI correctly persists an empty string to the database rather than being ignored by the backend.