### PR TITLE
fix(ui): allow clearing upload description and browse comment

### DIFF
--- a/src/www/ui/admin-upload-edit.php
+++ b/src/www/ui/admin-upload-edit.php
@@ -74,11 +74,9 @@ class upload_properties extends FO_Plugin
         __METHOD__ . '.updateUpload.name');
     }
 
-    if (! empty($newDesc)) {
-      $trimNewDesc = trim($newDesc);
-      $this->dbManager->getSingleRow("UPDATE upload SET upload_desc=$2 WHERE upload_pk=$1",
-        array($uploadId, $trimNewDesc), __METHOD__ . '.updateUpload.desc');
-    }
+    $trimNewDesc = trim($newDesc);
+    $this->dbManager->getSingleRow("UPDATE upload SET upload_desc=$2 WHERE upload_pk=$1",
+      array($uploadId, $trimNewDesc), __METHOD__ . '.updateUpload.desc');
     return 1;
   }
 

--- a/src/www/ui/async/AjaxBrowse.php
+++ b/src/www/ui/async/AjaxBrowse.php
@@ -88,7 +88,7 @@ class AjaxBrowse extends DefaultPlugin
     } else if (! empty($uploadId) && ! empty($direction)) {
       $uploadBrowseProxy = new UploadBrowseProxy($groupId, $this->userPerm, $this->dbManager);
       $uploadBrowseProxy->moveUploadToInfinity($uploadId, $direction == 'top');
-    } else if (!empty($uploadId) && !empty($commentText) && !empty($statusId)) {
+    } else if (!empty($uploadId) && !is_null($commentText) && !empty($statusId)) {
       $uploadBrowseProxy = new UploadBrowseProxy($groupId, $this->userPerm, $this->dbManager);
       $uploadBrowseProxy->setStatusAndComment($uploadId, $statusId, $commentText);
     } else {


### PR DESCRIPTION
## Description

Fixes #3002

Users could not clear the upload description (Edit Properties) or the browse status comment — the fields would silently retain the previous text.

### Root cause

Both code paths used PHP's `empty()` to check whether the user supplied a value. Since `empty("")` is `true`, an empty string was treated as *no input*, and the database update was skipped.

### Changes

| File | Before | After |
|------|--------|-------|
| `src/www/ui/admin-upload-edit.php` | `if (! empty($newDesc))` guarded the UPDATE | Guard removed; the description column is always updated with the submitted value. The existing early-return (`empty($newName) and empty($newDesc)` → return 2) still prevents spurious writes on non-POST page loads. |
| `src/www/ui/async/AjaxBrowse.php` | `!empty($commentText)` in the condition chain | Changed to `!is_null($commentText)`. Symfony's `Request::get()` returns `null` when the parameter is absent, so this correctly distinguishes *missing* from *empty*. |

### How to test

1. **Upload description** — Go to *Organize → Uploads → Edit Properties*, select an upload with a description, clear the text, click *Edit*. The description should now be empty.
2. **Browse comment** — Go to the *Browse* tab, double-click the Comment cell of an upload, clear the text, click *OK*. The comment should now be empty.