### PR TITLE
fix(ui): pause/unpause job from Scheduler Administration

### DIFF
--- a/src/www/ui/async/AjaxAdminScheduler.php
+++ b/src/www/ui/async/AjaxAdminScheduler.php
@@ -80,6 +80,20 @@ class AjaxAdminScheduler extends DefaultPlugin
   }
 
   /**
+   * @brief Convert simple array to associative array for Twig macro
+   * @param array $simpleArray Simple array like [259, 260]
+   * @return array Associative array like [259 => 259, 260 => 260]
+   */
+  private function convertToAssociative($simpleArray)
+  {
+    $result = [];
+    foreach ($simpleArray as $item) {
+      $result[$item] = $item;
+    }
+    return $result;
+  }
+
+  /**
    * @brief get the job list for the specified operation
    * @param string $type operation type
    * @return array job list of option elements
@@ -92,16 +106,16 @@ class AjaxAdminScheduler extends DefaultPlugin
 
     $job_array = array();
     if ('status' == $type || 'verbose' == $type || 'priority' == $type) {
-      $job_array = GetRunnableJobList();
+      $job_array = $this->convertToAssociative(GetRunnableJobList());
       if ('priority' != $type) {
         $job_array[0] = "scheduler";
       }
     }
     if ('pause' == $type) {
-      $job_array = GetJobList("Started");
+      $job_array = $this->convertToAssociative(GetRunnableJobList());
     }
     if ('restart' == $type) {
-      $job_array = GetJobList("Paused");
+      $job_array = $this->convertToAssociative(GetRunnableJobList());
     }
     return $job_array;
   }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description
Fixes the issue where users were unable to pause/unpause a job from the Scheduler Administration UI. The form was submitting `job_id='0'` instead of the actual job ID, causing the job to continue running. This occurred because the Twig macro expects an associative array (`job_id => job_id`).

It's linked to issue: #1460 

### Changes
- Added `convertToAssociative()` to convert job list from indexed array to associative array (`job_id => job_id`)

## Screenshots
### Before

https://github.com/user-attachments/assets/df9d8651-0a28-45ba-83c9-b62e32f771f2


### After

https://github.com/user-attachments/assets/7dfaca4f-9760-4986-8bbe-b676a2403a1d

