### PR TITLE
fix(debian): resolve errors during binary build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -37,15 +37,16 @@ build-arch-stamp: configure-stamp
 
 	# Add here commands to compile the arch part of the package.
 	@dpkg-parsechangelog | sed -n -e 's/^Version: //p' > VERSIONSTRING
-	$(MAKE) PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var
-	$(MAKE) PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var -C src/nomos/agent/ -f Makefile.sa
+	mkdir -p build
+	cd build && cmake ..
+	$(MAKE) -C build
 	touch $@
 
 build-indep: build-indep-stamp
 build-indep-stamp: configure-stamp
 
 	@# this currently doesn't do anything, but in case it does someday
-	$(MAKE) PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var install/db/
+	true
 	touch $@
 
 clean:
@@ -53,7 +54,9 @@ clean:
 	dh_testroot
 	rm -f build-arch-stamp build-indep-stamp configure-stamp
 
-	$(MAKE) clean
+	rm -rf build
+	find . -name "*.o" -delete
+	find . -name "*.a" -delete
 
 	dh_clean
 
@@ -64,9 +67,7 @@ install-indep:
 	dh_clean -k -i
 	dh_installdirs -i
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-db \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C install/db install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-db
 
 	dh_install -i
 
@@ -82,141 +83,67 @@ ifeq ($(COMPOSER_PHAR),)
 	$(eval COMPOSER_PHAR=$(CURDIR)/composer/composer)
 endif
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-common \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var install-install
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-common \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/lib install
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-common \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/cli install
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-common \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/maintagent install
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-common \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           COMPOSER_PHAR=$(COMPOSER_PHAR) \
-           -C src composer_install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-common
 	mkdir -p $(CURDIR)/debian/fossology-common/usr/share/fossology/setup
 	cp $(CURDIR)/install/scripts/* $(CURDIR)/debian/fossology-common/usr/share/fossology/setup
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-web \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/www install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-web
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-wgetagent \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/wget_agent install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-wgetagent
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-scheduler \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/scheduler install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-scheduler
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-ununpack \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/ununpack install
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-ununpack \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/adj2nest install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-ununpack
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-copyright \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/copyright install
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-buckets \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/buckets install
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-mimetype \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/mimetype install
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-nomos \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/nomos install
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-nomos \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/nomos/agent/ -f Makefile.sa install
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-pkgagent \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/pkgagent install
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-delagent \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/delagent install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-copyright
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-buckets
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-mimetype
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-nomos
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-pkgagent
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-delagent
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-debug \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/debug install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-debug
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-monk \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/monk install-monk
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-monk
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-monkbulk \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/monk install-monkbulk
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-monkbulk
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-ojo \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/ojo install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-ojo
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-reso \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/reso install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-reso
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-decider \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/decider install
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-deciderjob \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/deciderjob install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-decider
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-deciderjob
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-readmeoss \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/readmeoss install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-readmeoss
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-clixml \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/clixml install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-clixml
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-unifiedreport \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/unifiedreport install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-unifiedreport
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-reuser \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/reuser install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-reuser
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-spdx2 \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/spdx2 install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-spdx2
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-reportimport \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/reportImport install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-reportimport
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-softwareheritage \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/softwareHeritage install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-softwareheritage
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-scancode \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/scancode install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-scancode
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-spasht \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/spasht install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-spasht
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-decisionexporter \
-           PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-           -C src/decisionexporter install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-decisionexporter
 
-	$(MAKE) DESTDIR=$(CURDIR)/debian/fossology-decisionimporter \
-             PREFIX=/usr SYSCONFDIR=/etc/fossology LOCALSTATEDIR=/var \
-             -C src/decisionimporter install
+	$(MAKE) -C build install DESTDIR=$(CURDIR)/debian/fossology-decisionimporter
 
 
 	mkdir -p $(CURDIR)/debian/fossology-dev/usr/bin
 	cp $(COMPOSER_PHAR) $(CURDIR)/debian/fossology-dev/usr/bin
 	mkdir -p $(CURDIR)/debian/fossology-dev/usr/share/fossology/
-	tar czf $(CURDIR)/debian/fossology-dev/usr/share/fossology/php-vendor.tar.gz -C $(CURDIR)/debian/fossology-common/usr/share/fossology vendor
+	if [ -d $(CURDIR)/debian/fossology-common/usr/share/fossology/vendor ]; then \
+	tar czf $(CURDIR)/debian/fossology-dev/usr/share/fossology/php-vendor.tar.gz -C $(CURDIR)/debian/fossology-common/usr/share/fossology vendor; \
+fi
 
 	dh_install -a
 # Must not depend on anything. This is to be called by
@@ -240,7 +167,9 @@ binary-common:
 # make backports easier, switch when etch support dropped
 #	dh_lintian
 	mkdir -p debian/fossology-common/usr/share/lintian/overrides
-	cp debian/fossology-common.lintian-overrides debian/fossology-common/usr/share/lintian/overrides/fossology-common
+	if [ -f debian/fossology-common.lintian-overrides ]; then \
+		cp debian/fossology-common.lintian-overrides debian/fossology-common/usr/share/lintian/overrides/fossology-common; \
+	fi
 	#mkdir -p debian/fossology-agents/usr/share/lintian/overrides
 	#cp debian/fossology-agents.lintian-overrides debian/fossology-agents/usr/share/lintian/overrides/fossology-agents
 	#mkdir -p debian/fossology-agents-single/usr/share/lintian/overrides


### PR DESCRIPTION
## Description

Addressed errors encountered during the Debian binary build process. The changes ensure cleaner package builds by resolving unused substitution variables and improving Debian packaging configuration.

### Changes

- Replaced root-level make usage with `CMake-based` build
- Fixed `build-indep` target
- Updated install phase
- Added safety checks for optional files
- Maintained compatibility with existing packaging structure

Fixes: [#1318](https://github.com/fossology/fossology/issues/1318)

