### PR TITLE
perf(clearing): optimize directory decision marking by batch-fetching

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -829,7 +829,7 @@ INSERT INTO clearing_decision (
     $uploadTreeProxy = new UploadTreeProxy($itemTreeBounds->getUploadId(), $options, $itemTreeBounds->getUploadTreeTableName());
     if (!$removeDecision) {
       $sql = $uploadTreeProxy->asCTE() .
-        ' SELECT uploadtree_pk FROM UploadTreeView;';
+        ' SELECT uploadtree_pk, upload_fk, lft, rgt FROM UploadTreeView;';
       $itemRows = $this->dbManager->getRows($sql, $params,
         __METHOD__ . ".getRevelantItems");
       $uploadTreeTableName = $itemTreeBounds->getUploadTreeTableName();
@@ -837,8 +837,9 @@ INSERT INTO clearing_decision (
       $clearingDecisionEventProcessor = $GLOBALS['container']->get(
         'businessrules.clearing_decision_processor');
       foreach ($itemRows as $itemRow) {
-        $itemBounds = $this->uploadDao->getItemTreeBounds(
-          $itemRow['uploadtree_pk'], $uploadTreeTableName);
+        $itemBounds = new ItemTreeBounds(
+          $itemRow['uploadtree_pk'], $uploadTreeTableName,
+          $itemRow['upload_fk'], $itemRow['lft'], $itemRow['rgt']);
         $clearingDecisionEventProcessor->makeDecisionFromLastEvents(
           $itemBounds, $userId, $groupId, $decisionMark, DecisionScopes::ITEM);
       }


### PR DESCRIPTION
Description:
This PR fixes a performance issue: When you mark a whole folder with a decision (like setting a folder as "Irrelevant"), as of now if a folder has hundreds of files, the system sends hundreds of separate requests to the database to find the "tree bounds" for each file. This makes the process very slow for large uploads.

<img width="704" height="375" alt="image" src="https://github.com/user-attachments/assets/81e19058-8475-46ba-8b57-cc9d17cf24c6" />


Changes:
Updated the main query in ClearingDao to fetch all the tree info (lft, rgt, upload_fk) for all files in one go.
Changed the loop so it uses this pre-fetched data instead of asking the database again for every single file.

<img width="694" height="408" alt="image" src="https://github.com/user-attachments/assets/59544807-afd6-4ed6-b562-2fdfc6db7d93" />

How to test:
Upload a package with many files (e.g., 500+ files in one folder).
Go to the folder view and mark the entire folder as "Irrelevant" or "Concluded".
The process should finish much quicker than before, and the decisions should be applied correctly to all files in that folder.
You can also check the background logs; you will see only one main query instead of a long list of repeated "SELECT * FROM uploadtree" queries.