### PR TITLE
perf(reuser): optimize copyright reuse by eliminating queries inside a loop

### DIFF
--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -219,7 +219,7 @@ class CopyrightDao
     }
 
     $sql = "SELECT DISTINCT ON(copyright_pk, UT.uploadtree_pk)
-copyright_pk, UT.uploadtree_pk as uploadtree_pk,
+copyright_pk, UT.uploadtree_pk as uploadtree_pk, UT.upload_fk, UT.lft, UT.rgt,
 (CASE WHEN (CE.content IS NULL OR CE.content = '') THEN C.content ELSE CE.content END) AS content,
 (CASE WHEN (CE.hash IS NULL OR CE.hash = '') THEN C.hash ELSE CE.hash END) AS hash,
 C.agent_fk as agent_fk

--- a/src/reuser/agent/ReuserAgent.php
+++ b/src/reuser/agent/ReuserAgent.php
@@ -234,8 +234,9 @@ class ReuserAgent extends Agent
             $content = "";
           }
           $hash = $copyright['hash'];
-          $item = $this->uploadDao->getItemTreeBounds(intval($copyright['uploadtree_pk']),
-                    $uploadTreeTableName);
+          $item = new ItemTreeBounds(
+                    intval($copyright['uploadtree_pk']), $uploadTreeTableName,
+                    $copyright['upload_fk'], $copyright['lft'], $copyright['rgt']);
           $this->copyrightDao->updateTable($item, $hash, $content,
             $this->userId, 'copyright', $action);
           $this->heartbeat(1);


### PR DESCRIPTION
Description:
While using the reuser agent on large uploads, I noticed it gets very slow when copying over a lot of copyrights. This happens because the agent was stopping to ask the database for the same location information every time for every single copyright it found.

<img width="598" height="152" alt="image" src="https://github.com/user-attachments/assets/75add5eb-ee37-4ca1-b0b2-9947adf11d21" />


Changes:
Updated the copyright fetching query to grab the folder position data (like the lft and rgt values) all at once at the start.
Modified the reuser agent so it uses this pre-fetched info directly instead of making a fresh database call for each copyright.

<img width="880" height="146" alt="image" src="https://github.com/user-attachments/assets/402fbcb3-4a3c-41e7-8014-c0d736f3a769" />



How to test:
Run a reuser job on an upload that has a high number of copyrights (e.g., a few thousand).
The job should finish faster than it did before.
Check the "copyrights" tab to make sure all findings are still being copied over correctly.