### PR TITLE
fix(cp2foss): check wget_agent failure using jq_end_bits bitmask

### DIFF
--- a/src/cli/cp2foss.php
+++ b/src/cli/cp2foss.php
@@ -357,6 +357,15 @@ function UploadOne($FolderPath, $UploadArchive, $UploadName, $UploadDescription,
       $row = $dbManager->getSingleRow($SQL, array($UploadPk), __METHOD__.".UploadOne");
       if (empty($row)) {
         $working = false;
+        if ($jobqueuepk > 0) {
+          $SQL = "SELECT jq_end_bits FROM jobqueue WHERE jq_pk = $1";
+          $status = $dbManager->getSingleRow($SQL, array($jobqueuepk), __METHOD__);
+
+          if (!empty($status) && ($status['jq_end_bits'] & 0x2)) {
+            fwrite(STDERR, "ERROR: Failed to download component (URL invalid or HTTP error)\n");
+            return 1;
+          }
+        }
       }
 
     }


### PR DESCRIPTION
Fixes the issue: This PR is the aftermath of the discussion in previous unmerged PR #3442 

### Overall Changes

- Added logic to fetch `jq_end_bits` from the `jobqueue` table after job execution
- Correctly interpret bitmask using bitwise operation (`& 0x2`) to detect failure state
- Print a clear error message to STDERR when a download failure occurs
- Added validation check for `jobqueuepk` before querying the database
- Ensured correct exit behavior on failure (`return 1`)

## How to test

1. Run `cp2foss` with a valid URL → verify normal execution (no error message)
2. Run `cp2foss` with an invalid URL or unreachable resource → verify:
   - Error message is printed:
     ```
     ERROR: Failed to download component (URL invalid or HTTP error)
     ```
   - Script exits with status code `1`
3. Verify that successful cases (where `jq_end_bits = 0x1`) are not incorrectly treated as failures

### Related Issue

- Closes #503 