### PR TITLE
fix(libfossrepo): use strlen(Ext) instead of strlen(Type) when tracking extension length in fo_RepMkPathTmp

### DIFF
--- a/src/lib/c/libfossrepo.c
+++ b/src/lib/c/libfossrepo.c
@@ -333,7 +333,7 @@ char* fo_RepMkPathTmp(const char* Type, char* Filename, char* Ext, int Which)
   {
     strcat(Path, ".");
     strcat(Path, Ext);
-    Len += strlen(Type) + 1;
+    Len += strlen(Ext) + 1;
   }
   return (Path);
 } /* fo_RepMkPathTmp() */


### PR DESCRIPTION
Fixes a small length-tracking typo in `fo_RepMkPathTmp()` in `src/lib/c/libfossrepo.c`.

When an extension is appended, the code was adding `strlen(Type)` instead of `strlen(Ext)`. That leaves `Len` out of sync with the actual path being built.

This patch switches that update to `strlen(Ext)` so the running length stays correct.