### PR TITLE
fix(pkgagent): wrong Binary field, unsafe strcpy, NULL-before-free, and HTML double-encoding in package info

### DIFF
--- a/src/pkgagent/agent/pkgagent.c
+++ b/src/pkgagent/agent/pkgagent.c
@@ -399,10 +399,14 @@ int ProcessUpload (long upload_pk)
         if (RecordMetadataDEB(dpi) != 0) continue;
       }
       /* free memory */
-      int i;
-      for(i=0; i< dpi->dep_size;i++)
-        free(dpi->depends[i]);
-      free(dpi->depends);
+      if (dpi->depends) {
+        int i;
+        for(i=0; i< dpi->dep_size;i++)
+          free(dpi->depends[i]);
+        free(dpi->depends);
+        dpi->depends = NULL;
+        dpi->dep_size = 0;
+      }
     }
     else if (!strcasecmp(mimetype, "application/x-debian-source")){
       dpi->pFileFk = atoi(PQgetvalue(result, i, 0));
@@ -418,10 +422,14 @@ int ProcessUpload (long upload_pk)
         RecordMetadataDEB(dpi);
       }
       /* free memory */
-      int i;
-      for(i=0; i< dpi->dep_size;i++)
-        free(dpi->depends[i]);
-      free(dpi->depends);
+      if (dpi->depends) {
+        int i;
+        for(i=0; i< dpi->dep_size;i++)
+          free(dpi->depends[i]);
+        free(dpi->depends);
+        dpi->depends = NULL;
+        dpi->dep_size = 0;
+      }
     } else {
       printf("LOG: Not RPM and DEBIAN package!\n");
     }
@@ -522,7 +530,8 @@ void ReadHeaderInfo(Header header, struct rpmpkginfo *pi)
     for (j=0; j<(int)data_size;j++){
       const char * temp = rpmtdNextString(&req);
       pi->requires[j] = malloc(MAXCMD);
-      strcpy(pi->requires[j],temp);
+      strncpy(pi->requires[j], temp, MAXCMD - 1);
+      pi->requires[j][MAXCMD - 1] = '\0';
     }
     pi->req_size = data_size;
     rpmtdFreeData(&req);
@@ -842,7 +851,8 @@ int GetMetadataDebBinary (long upload_pk, struct debpkginfo *pi)
         for (i=0; i<size; i++){
           pi->depends[i] = calloc(length, sizeof(char));
           if (depends) {
-            strcpy(pi->depends[i], depends);
+            strncpy(pi->depends[i], depends, length - 1);
+            pi->depends[i][length - 1] = '\0';
             depends = strtok(NULL, ",");
           }
         }
@@ -960,7 +970,7 @@ int GetMetadataDebSource (char *repFile, struct debpkginfo *pi)
     if (!strcasecmp(field, "Source")) {
       EscapeString(value, pi->source, sizeof(pi->source));
     }
-    if (!strcasecmp(field, "Source")) {
+    if (!strcasecmp(field, "Binary")) {
       EscapeString(value, pi->pkgName, sizeof(pi->pkgName));
     }
     if (!strcasecmp(field, "Architecture")) {
@@ -1008,7 +1018,8 @@ int GetMetadataDebSource (char *repFile, struct debpkginfo *pi)
         for (i=0; i<size; i++){
           pi->depends[i] = calloc(length, sizeof(char));
           if (depends) {
-            strcpy(pi->depends[i], depends);
+            strncpy(pi->depends[i], depends, length - 1);
+            pi->depends[i][length - 1] = '\0';
             depends = strtok(NULL, ",");
           }
         }

--- a/src/pkgagent/agent_tests/Unit/testGetMetadataDebSource.c
+++ b/src/pkgagent/agent_tests/Unit/testGetMetadataDebSource.c
@@ -24,6 +24,10 @@ extern char *DBConfFile;
 void test_GetMetadataDebSource()
 {
   char *repFile = "./testdata/fossology_1.4.1.dsc";
+  const char *expectedBinary = "fossology, fossology-common, fossology-web, "
+      "fossology-web-single, fossology-scheduler, "
+      "fossology-scheduler-single, fossology-db, fossology-agents, "
+      "fossology-agents-single, fossology-dev";
   struct debpkginfo *pi;
   //char *DBConfFile = NULL;  /* use default Db.conf */
   char *ErrorBuf;
@@ -37,7 +41,8 @@ void test_GetMetadataDebSource()
   //printf("GetMetadataDebSource Result is:%d\n", Result);
 
   //printf("GetMetadataDebSource Result is:%s\n", pi->version);
-  CU_ASSERT_STRING_EQUAL(pi->pkgName, "fossology");
+  CU_ASSERT_STRING_EQUAL(pi->pkgName, expectedBinary);
+  CU_ASSERT_STRING_EQUAL(pi->source, "fossology");
   CU_ASSERT_STRING_EQUAL(pi->pkgArch, "any");
   CU_ASSERT_STRING_EQUAL(pi->version, "1.4.1");
   CU_ASSERT_STRING_EQUAL(pi->maintainer, "Matt Taggart <taggart@debian.org>");
@@ -93,4 +98,3 @@ CU_TestInfo testcases_GetMetadataDebSource[] = {
     {"Testing the function GetMetadataDebSource with wrong testfile", test_GetMetadataDebSource_wrong_testfile},
     CU_TEST_INFO_NULL
 };
-

--- a/src/www/ui/template/ui-view-info.html.twig
+++ b/src/www/ui/template/ui-view-info.html.twig
@@ -58,7 +58,7 @@
           <tr>
             <td align="right">{{ entry.count|e }}</td>
             <td>{{ entry.type|e }}</td>
-            <td class="pkg-value" data-encoded="{{ entry.value|e }}"></td>
+            <td>{{ entry.value|e }}</td>
           </tr>
         {% endfor %}
         {% for require in packageRequires %}
@@ -230,14 +230,4 @@
 {% endblock %}
 {% block foot %}
   {{ parent() }}
-  <script type="text/javascript">
-    document.addEventListener('DOMContentLoaded', function() {
-      document.querySelectorAll('.pkg-value').forEach(el => {
-        const encoded = el.getAttribute('data-encoded');
-        const txt = document.createElement('textarea');
-        txt.innerHTML = encoded;
-        el.textContent = txt.value;
-      });
-    });
-  </script>
 {% endblock %}

--- a/src/www/ui/ui-view-info.php
+++ b/src/www/ui/ui-view-info.php
@@ -394,7 +394,7 @@ class ui_view_info extends FO_Plugin
           $entry = [];
           $entry['count'] = $Count;
           $entry['type'] = _($key);
-          $entry['value'] = htmlspecialchars($R["$value"], ENT_QUOTES|ENT_HTML5, 'UTF-8');
+          $entry['value'] = $R["$value"] ?? '';
           $Count++;
           $vars['packageEntries'][] = $entry;
         }
@@ -407,7 +407,7 @@ class ui_view_info extends FO_Plugin
           $entry = [];
           $entry['count'] = $Count;
           $entry['type'] = _("Requires");
-          $entry['value'] = htmlspecialchars($R["req_value"], ENT_QUOTES|ENT_HTML5, 'UTF-8');
+          $entry['value'] = $R["req_value"] ?? '';
           $Count++;
           $vars['packageRequires'][] = $entry;
         }
@@ -430,7 +430,7 @@ class ui_view_info extends FO_Plugin
           $entry = [];
           $entry['count'] = $Count;
           $entry['type'] = _($key);
-          $entry['value'] = htmlspecialchars($R["$value"], ENT_QUOTES|ENT_HTML5, 'UTF-8');
+          $entry['value'] = $R["$value"] ?? '';
           $Count++;
           $vars['packageEntries'][] = $entry;
         }
@@ -443,7 +443,7 @@ class ui_view_info extends FO_Plugin
           $entry = [];
           $entry['count'] = $Count;
           $entry['type'] = _("Depends");
-          $entry['value'] = htmlspecialchars($R["req_value"], ENT_QUOTES|ENT_HTML5, 'UTF-8');
+          $entry['value'] = $R["req_value"] ?? '';
           $Count++;
           $vars['packageRequires'][] = $entry;
         }
@@ -465,7 +465,7 @@ class ui_view_info extends FO_Plugin
           $entry = [];
           $entry['count'] = $Count;
           $entry['type'] = _($key);
-          $entry['value'] = htmlspecialchars($R["$value"], ENT_QUOTES|ENT_HTML5, 'UTF-8');
+          $entry['value'] = $R["$value"] ?? '';
           $Count++;
           $vars['packageEntries'][] = $entry;
         }
@@ -478,7 +478,7 @@ class ui_view_info extends FO_Plugin
           $entry = [];
           $entry['count'] = $Count;
           $entry['type'] = _("Build-Depends");
-          $entry['value'] = htmlspecialchars($R["req_value"], ENT_QUOTES|ENT_HTML5, 'UTF-8');
+          $entry['value'] = $R["req_value"] ?? '';
           $Count++;
           $vars['packageRequires'][] = $entry;
         }


### PR DESCRIPTION
Fixes #1704

## What was wrong?

When you upload an RPM or Debian package and open its **Info page**, special characters like `&`, `<`, `>` in the package description or maintainer field were showing up as raw HTML codes (`&amp;`, `&lt;`, `&gt;`) instead of the actual characters. This was confusing and made the page look broken.

Also, for Debian source packages (`.dsc` files), the **Binary** column in the package info table was always empty or wrong — it was accidentally reading the source name twice instead of reading the binary package name.

---

## What was fixed?

**4 bugs fixed across 3 files:**

### 1. Wrong column value for Debian source packages (`pkgagent.c`)
There was a copy-paste mistake in the code — the same field (`Source`) was being read twice. The second read should have been reading the `Binary` field. Fixed by correcting the field name.

### 2. Special characters showing as `&amp;` / `&lt;` in the browser (`ui-view-info.php` + `ui-view-info.html.twig`)
The package data was being HTML-escaped **twice** — once in PHP and once again in the template. That's like encoding a message twice: the result is garbage. Fixed by removing the PHP encoding and letting the template do it once (the correct way).

The JavaScript workaround that was added earlier to patch around this double-encoding is also removed — it's no longer needed.

### 3. Unsafe string copy without length check (`pkgagent.c`)
In 3 places, the code was copying strings into fixed-size memory buffers without checking the length. If a string was too long, it could overwrite memory beyond the buffer. Fixed by using the safe version of the copy function that respects the buffer size.

### 4. Crash risk when a package has no dependencies (`pkgagent.c`)
After processing a package, the code was trying to free memory that was never allocated — this happens when a package has no `Depends` or `Build-Depends` field. Fixed by checking that the memory was actually allocated before trying to free it.

---

## How to test

1. Upload any RPM package → open its Info page → check that the description, vendor, and packager fields show real characters (not `&amp;`, `&lt;`, etc.)
2. Upload a Debian `.deb` file → check that the maintainer email like `Jane Doe <jane@example.com>` displays correctly
3. Upload a Debian source `.dsc` file → check that the **Binary** column shows the correct binary package name
4. Run pkgagent tests: `ctest -R pkgagent`