### PR TITLE
fix(fossinit): add license by ojo to update the license text

### DIFF
--- a/install/fossinit.php
+++ b/install/fossinit.php
@@ -600,7 +600,8 @@ function initLicenseRefTable($Verbose)
       $sql = "UPDATE license_ref SET ";
       if (($rf_flag_check == 1 && $rf_flag == 1) &&
           ($rf_text_check != $rf_text && !empty($rf_text) &&
-          !(stristr($rf_text, 'License by Nomos')))) {
+          !(stristr($rf_text, 'License by Nomos')) &&
+          !(stristr($rf_text, 'License by OJO')))) {
         $params[] = $rf_text;
         $position = "$" . count($params);
         $sql .= "rf_text=$position,rf_md5=md5($position),rf_flag=1,";


### PR DESCRIPTION
closes #2085 

## Description

Add 'License by ojo' in the condition for update.

## How to test

* Upload a source with spdx - license -identifier : licenseName
* make sure that the license name is not there in fossology database.
* Now scanner ojo creates the license with text "License by OJO"
* Now add this new license in licenseref.json file with text.
* Do post install. license text of license by ojo shall get updated.
