### PR TITLE
perf(dao): optimize upload permission batch check and job filter

### DIFF
--- a/src/lib/php/Dao/ShowJobsDao.php
+++ b/src/lib/php/Dao/ShowJobsDao.php
@@ -143,10 +143,11 @@ class ShowJobsDao
     $this->dbManager->freeResult($result);
 
     $accessibleUploads = $this->uploadDao->filterAccessibleUploads(array_unique($uploadIds), Auth::getGroupId());
+    $accessibleUploadIdsMap = array_flip($accessibleUploads);
 
     foreach ($rows as $row) {
       if (!empty($row['job_upload_fk'])) {
-        if (!in_array(intval($row['job_upload_fk']), $accessibleUploads)) {
+        if (!isset($accessibleUploadIdsMap[intval($row['job_upload_fk'])])) {
           continue;
         }
       }

--- a/src/lib/php/Dao/UploadPermissionDao.php
+++ b/src/lib/php/Dao/UploadPermissionDao.php
@@ -41,6 +41,7 @@ class UploadPermissionDao
     return !empty($uploadPub);
   }
 
+
   public function isEditable($uploadId, $groupId)
   {
     if ($_SESSION[Auth::USER_LEVEL] == PLUGIN_DB_ADMIN) {
@@ -138,40 +139,25 @@ class UploadPermissionDao
       return array();
     }
 
-    $accessible = array();
-    $placeholders = implode(',', array_map('intval', $uploadIds));
-
-    // Group-level permissions
-    $sql = "SELECT upload_fk FROM perm_upload WHERE upload_fk IN ($placeholders)
-          AND group_fk = $1
-          AND perm > $2";
-    $stmt = __METHOD__ . '.batch_group_perm';
-    $this->dbManager->prepare($stmt, $sql);
-    $result = $this->dbManager->execute($stmt, array($groupId, Auth::PERM_NONE));
-    while ($row = $this->dbManager->fetchArray($result)) {
-      $accessible[] = intval($row['upload_fk']);
-    }
-    $this->dbManager->freeResult($result);
-
-    // Public permissions — check uploads not already cleared
-    $remaining = array_diff($uploadIds, $accessible);
-    if (!empty($remaining)
-      && isset($_SESSION)
-      && array_key_exists(Auth::USER_LEVEL, $_SESSION)
-      && $_SESSION[Auth::USER_LEVEL] !== Auth::PERM_NONE) {
-
-      $remaining = implode(',', array_map('intval', $remaining));
-      $sql = "SELECT upload_pk FROM upload WHERE upload_pk IN ($remaining)
-              AND public_perm > $1";
-      $stmt = __METHOD__ . '.batch_public_perm';
-      $this->dbManager->prepare($stmt, $sql);
-      $result = $this->dbManager->execute($stmt, array(Auth::PERM_NONE));
-      while ($row = $this->dbManager->fetchArray($result)) {
-        $accessible[] = intval($row['upload_pk']);
-      }
-      $this->dbManager->freeResult($result);
+    $uploadIds = array_unique(array_filter($uploadIds));
+    if (empty($uploadIds)) {
+      return array();
     }
 
-    return $accessible;
+    $uploadIdsStr = '{' . implode(',', array_map('intval', $uploadIds)) . '}';
+
+    $publicAccessAllowed = isset($_SESSION) &&
+        array_key_exists(Auth::USER_LEVEL, $_SESSION) &&
+        $_SESSION[Auth::USER_LEVEL] !== Auth::PERM_NONE;
+
+    $publicFilter = $publicAccessAllowed ? "public_perm > $2" : "FALSE";
+
+    $sql = "SELECT upload_pk FROM upload " .
+           "WHERE upload_pk = ANY($1::int[]) AND ($publicFilter " .
+           "OR EXISTS(SELECT 1 FROM perm_upload WHERE upload_fk = upload_pk AND group_fk = $3 AND perm > $4))";
+
+    $rows = $this->dbManager->getRows($sql, array($uploadIdsStr, Auth::PERM_NONE, $groupId, Auth::PERM_NONE), __METHOD__);
+
+    return array_column($rows, 'upload_pk');
   }
 }


### PR DESCRIPTION
Description:
This PR improves the performance of the "My Recent Jobs" dashboard. While exploring the code, I noticed that the logic for checking upload permissions inside the job list was doing extra work, which made the page lag a bit for the users with a large number of recent jobs.

<img width="553" height="336" alt="image" src="https://github.com/user-attachments/assets/eae3cf56-afd7-4cb0-bce9-e71c1d795dc0" />


Changes:
Batch Permission Checks: Updated UploadPermissionDao to verify permissions for all jobs in the list at once, rather than one by one. This reduces the continuous communication with the database.
Faster Filtering: Changed the way we filter the job list in ShowJobsDao. By using a simple mapping technique instead of repeatedly searching through arrays, the code can now find and display accessible jobs almost instantly.

<img width="718" height="434" alt="image" src="https://github.com/user-attachments/assets/74392be3-3348-4220-9b4d-da2410d35beb" />

The new Permission Query:
<img width="684" height="219" alt="image" src="https://github.com/user-attachments/assets/5399996b-d213-4691-97ac-1a97bede6db8" />


How to test
Log in to fossology with a user who has several recent jobs.
Go to the "My Recent Jobs" section on the dashboard.
Verify that the list loads correctly and only displays jobs for uploads you have permission to view.
If you have a large history, you should notice the page loads more smoothly than it did before.