### PR TITLE
fix(ununpack): Ununpack handling encrypted and raw files

### DIFF
--- a/src/adj2nest/agent/adj2nest.c
+++ b/src/adj2nest/agent/adj2nest.c
@@ -115,34 +115,38 @@ void	WalkTree	(long Index, long Depth)
 {
   long LeftSet;
   PGresult* pgResult;
+  int i;
 
-  if (agent_verbose)
+  /* Traverse sibling chain iteratively to avoid stack overflow on directories
+     with a large number of files
+  */
+  for (;;)
     {
-    int i;
-    for(i=0; i<Depth; i++) printf(" ");
-    LOG_VERBOSE("%ld\n",Tree[Index].UploadtreePk);
-    }
+    if (agent_verbose)
+      {
+      for(i=0; i<Depth; i++) printf(" ");
+      LOG_VERBOSE("%ld\n",Tree[Index].UploadtreePk);
+      }
 
-  LeftSet = SetNum;
-  SetNum++;
-
-  if (Tree[Index].Child > -1)
-    {
-    WalkTree(Tree[Index].Child,Depth+1);
+    LeftSet = SetNum;
     SetNum++;
-    }
 
-  snprintf(SQL,sizeof(SQL),"UPDATE %s SET lft='%ld', rgt='%ld' WHERE uploadtree_pk='%ld'",
+    if (Tree[Index].Child > -1)
+      {
+      WalkTree(Tree[Index].Child,Depth+1);
+      SetNum++;
+      }
+
+    snprintf(SQL,sizeof(SQL),"UPDATE %s SET lft='%ld', rgt='%ld' WHERE uploadtree_pk='%ld'",
 	uploadtree_tablename,LeftSet,SetNum,Tree[Index].UploadtreePk);
-  pgResult = PQexec(pgConn, SQL);
-  fo_checkPQcommand(pgConn, pgResult, SQL, __FILE__, __LINE__);
-  PQclear(pgResult);
-  fo_scheduler_heart(1);
+    pgResult = PQexec(pgConn, SQL);
+    fo_checkPQcommand(pgConn, pgResult, SQL, __FILE__, __LINE__);
+    PQclear(pgResult);
+    fo_scheduler_heart(1);
 
-  if (Tree[Index].Sibling > -1)
-    {
+    if (Tree[Index].Sibling < 0) break;
     SetNum++;
-    WalkTree(Tree[Index].Sibling,Depth+1);
+    Index = Tree[Index].Sibling;
     }
 
 } /* WalkTree() */

--- a/src/ununpack/agent/traverse.c
+++ b/src/ununpack/agent/traverse.c
@@ -221,6 +221,11 @@ void	TraverseChild	(int Index, ContainerInfo *CI, char *NewDir)
       LOG_ERROR("pfile %s Command %s failed on: %s, Password required.",
         Pfile_Pk, CMD[CI->PI.Cmd].Cmd, CI->Source);
     }
+    else if (strstr(CMD[CI->PI.Cmd].Magic, "/pdf") && IsPdfEncrypted(CI->Source))
+    {
+      LOG_WARNING("pfile %s Command Failed on PDF file '%s' it is encrypted/password-protected",
+        Pfile_Pk, CI->Source);
+    }
     else
     {
       LOG_ERROR("pfile %s Command %s failed on: %s",
@@ -391,7 +396,18 @@ int	Traverse	(char *Filename, char *Basename,
     }
 
     if (CI.Source[strlen(CI.Source)-1] != '/') strcat(CI.Source,"/");
+    errno = 0;
     DLhead = MakeDirList(CI.Source);
+    if (DLhead == NULL && errno != 0)
+    {
+      /* Directory could not be opened even after chmod attempt — log and skip.
+         Do not register it as a container with children since none can be found. */
+      LOG_WARNING("pfile %s Cannot read directory \"%s\": %s -- skipping.",
+                  Pfile_Pk, CI.Source, strerror(errno));
+      CI.HasChild = 0;
+      IsContainer  = 0;
+      goto TraverseEnd;
+    }
     /* process inode in the directory (only if unique) */
     if (DisplayContainerInfo(&CI,PI->Cmd))
     {

--- a/src/ununpack/agent/traverse.c
+++ b/src/ununpack/agent/traverse.c
@@ -221,6 +221,11 @@ void	TraverseChild	(int Index, ContainerInfo *CI, char *NewDir)
       LOG_ERROR("pfile %s Command %s failed on: %s, Password required.",
         Pfile_Pk, CMD[CI->PI.Cmd].Cmd, CI->Source);
     }
+    else if (strstr(CMD[CI->PI.Cmd].Magic, "/pdf") && IsPdfEncrypted(CI->Source))
+    {
+      LOG_WARNING("pfile %s Command Failed on PDF file '%s' it is encrypted/password-protected",
+        Pfile_Pk, CI->Source);
+    }
     else
     {
       LOG_ERROR("pfile %s Command %s failed on: %s",
@@ -391,7 +396,24 @@ int	Traverse	(char *Filename, char *Basename,
     }
 
     if (CI.Source[strlen(CI.Source)-1] != '/') strcat(CI.Source,"/");
+    errno = 0;
     DLhead = MakeDirList(CI.Source);
+    if (DLhead == NULL && errno != 0)
+    {
+      /* Directory could not be opened even after chmod attempt — log and skip.
+         Do not register it as a container with children since none can be found. */
+      LOG_WARNING("pfile %s Cannot read directory \"%s\": %s -- skipping.",
+                  Pfile_Pk, CI.Source, strerror(errno));
+      CI.HasChild = 0;
+      IsContainer  = 0;
+      goto TraverseEnd;
+    }
+    if (DLhead == NULL)
+    {
+      /* Directory is accessible but empty — do not mark as container with children. */
+      CI.HasChild = 0;
+      IsContainer = 0;
+    }
     /* process inode in the directory (only if unique) */
     if (DisplayContainerInfo(&CI,PI->Cmd))
     {
@@ -406,7 +428,7 @@ int	Traverse	(char *Filename, char *Basename,
         CI.PI.uploadtree_pk = TmpPk;
       }
     }
-    if (PI->Cmd && ListOutFile)
+    if (PI->Cmd && ListOutFile && CI.HasChild)
     {
       fputs("</item>\n",ListOutFile);
     }
@@ -565,9 +587,14 @@ int	Traverse	(char *Filename, char *Basename,
       }
       if (WIFEXITED(rc)) rc = WEXITSTATUS(rc);
       else rc=-1;
-      if (rc != 0) LOG_ERROR("Unable to run command '%s'",Cmd)
-      /* add it to the list of files */
-      RecurseOk = DisplayContainerInfo(&CImeta,PI->Cmd);
+      if (rc != 0)
+      {
+        LOG_ERROR("Unable to run command '%s'",Cmd)
+      }
+      else
+      {
+        RecurseOk = DisplayContainerInfo(&CImeta,PI->Cmd);
+      }
       if (UnlinkAll) unlink(CImeta.Source);
     }
 

--- a/src/ununpack/agent/ununpack.h
+++ b/src/ununpack/agent/ununpack.h
@@ -190,6 +190,7 @@ void Usage (char *Name, char *Version);
 void deleteTmpFiles(char *dir);
 void SQLNoticeProcessor(void *arg, const char *message);
 int ShouldExclude(char *Filename, const char *ExcludePatterns);
+int IsPdfEncrypted(char *Filename);
 
 
 /* traverse.c */

--- a/src/ununpack/agent/utils.c
+++ b/src/ununpack/agent/utils.c
@@ -807,7 +807,7 @@ void OctetType(char *Filename, char *TypeBuf)
   rc2 = RunCommand("7z","t -y -pjunk",Filename,">/dev/null 2>&1",NULL,NULL);
   if(rc2!=0)
   {
-    rc3 = RunCommand("7z","t -y -pjunk",Filename,"|grep 'Wrong password' >/dev/null 2>&1",NULL,NULL);
+    rc3 = RunCommand("7z","t -y -pjunk",Filename," 2>&1 | grep 'Wrong password' >/dev/null",NULL,NULL);
     if(rc3==0)
     {
       LOG_ERROR("'%s' cannot be unpacked, password required.",Filename);
@@ -946,6 +946,19 @@ int	FindCmd	(char *Filename)
   }
   return(Match);
 } /* FindCmd() */
+
+/**
+ * @brief Check if a PDF file is encrypted/password-protected.
+ *  if the detection command cannot be run, so the caller falls
+ * back to the normal error path.
+ * @param Filename Absolute path to the PDF file
+ * @returns 1 if the PDF is encrypted, 0 otherwise
+ */
+int IsPdfEncrypted(char *Filename)
+{
+  return RunCommand("pdftotext", "", Filename,
+      "/dev/null 2>&1 | grep -qi 'password'", NULL, NULL) == 0;
+} /* IsPdfEncrypted() */
 
 /***************************************************************************/
 /***************************************************************************/

--- a/src/ununpack/agent/utils.c
+++ b/src/ununpack/agent/utils.c
@@ -800,7 +800,7 @@ void OctetType(char *Filename, char *TypeBuf)
   rc2 = RunCommand("7z","t -y -pjunk",Filename,">/dev/null 2>&1",NULL,NULL);
   if(rc2!=0)
   {
-    rc3 = RunCommand("7z","t -y -pjunk",Filename,"|grep 'Wrong password' >/dev/null 2>&1",NULL,NULL);
+    rc3 = RunCommand("7z","t -y -pjunk",Filename," 2>&1 | grep 'Wrong password' >/dev/null",NULL,NULL);
     if(rc3==0)
     {
       LOG_ERROR("'%s' cannot be unpacked, password required.",Filename);
@@ -939,6 +939,19 @@ int	FindCmd	(char *Filename)
   }
   return(Match);
 } /* FindCmd() */
+
+/**
+ * @brief Check if a PDF file is encrypted/password-protected.
+ *  if the detection command cannot be run, so the caller falls
+ * back to the normal error path.
+ * @param Filename Absolute path to the PDF file
+ * @returns 1 if the PDF is encrypted, 0 otherwise
+ */
+int IsPdfEncrypted(char *Filename)
+{
+  return RunCommand("pdftotext", "", Filename,
+      "/dev/null 2>&1 | grep -qi 'password'", NULL, NULL) == 0;
+} /* IsPdfEncrypted() */
 
 /***************************************************************************/
 /***************************************************************************/


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
Ununpack throws an archive error, when a 7z file was passed. It also sometimes fails, when there is a pdf with password protected group. Needed to handle that gently. 
Also sometimes, a dir registered as a container doesnt contain child, handling that gracefully is also important.
Adj2nest was throwing `segmentation-fault` with multiple siblings with childs. Logic needed to be changed.

### Changes

1. IsPdfEncrypted --> function added just like a 7z based iteration, to check if the pdf is encrypted and then can be logged.
2. Check if a dir cant be opened, it should not be registered as a container and Has no child.
3. Handles `7z` errors gracefully.
4. Replaced the sibling recursive logic to a loop --> Loop -> Process ->Move

Tested ununpack with: [HWLOC](https://www.open-mpi.org/software/hwloc/v2.9/downloads/hwloc-2.9.3.tar.bz2) and [libzip](https://libzip.org/download/libzip-1.5.1.tar.xz)

Finishes successfully with no error thrown.

Fixes: #3082 #1504 

CC: @shaheemazmalmmd @GMishx 
