### PR TITLE
perf(admin): optimize folder size dashboard clearing duration batch 

### DIFF
--- a/src/lib/php/Dao/UploadDao.php
+++ b/src/lib/php/Dao/UploadDao.php
@@ -312,7 +312,7 @@ class UploadDao
    */
   public function getAssigneeDate(int $uploadId): ?string
   {
-    $sql = "SELECT event_ts FROM upload_events WHERE upload_fk = $1 " .
+    $sql = "SELECT MIN(event_ts) as event_ts FROM upload_events WHERE upload_fk = $1 " .
       "AND event_type = " . UploadEvents::ASSIGNEE_EVENT;
     $row = $this->dbManager->getSingleRow($sql, [$uploadId], __METHOD__);
     if (empty($row) || empty($row["event_ts"])) {
@@ -329,7 +329,7 @@ class UploadDao
    */
   public function getClosedDate(int $uploadId): ?string
   {
-    $sql = "SELECT event_ts FROM upload_events WHERE upload_fk = $1 " .
+    $sql = "SELECT MAX(event_ts) as event_ts FROM upload_events WHERE upload_fk = $1 " .
       "AND event_type = " . UploadEvents::UPLOAD_CLOSED_EVENT;
     $row = $this->dbManager->getSingleRow($sql, [$uploadId], __METHOD__);
     if (empty($row) || empty($row["event_ts"])) {
@@ -344,24 +344,64 @@ class UploadDao
    * @return array with duration and durationSort when upload was closed
    *                   or rejected.
    */
-  public function getClearingDuration(int $uploadId): ?array
+  public function getClearingDuration(int $uploadId): array
   {
-    $duration = "NA";
-    $assignDate = $this->getAssigneeDate($uploadId);
-    $closingDate = $this->getClosedDate($uploadId);
-    $durationSort = 0;
-    if ($assignDate != null && $closingDate != null) {
-      try {
-        $closingDate = new DateTime($closingDate);
-        $assignDate = new DateTime($assignDate);
-        if ($assignDate < $closingDate) {
-          $duration = HumanDuration($closingDate->diff($assignDate));
-          $durationSort = $closingDate->getTimestamp() - $assignDate->getTimestamp();
-        }
-      } catch (Exception $_) {
-      }
+    $batch = $this->getClearingDurationsBatch(array($uploadId));
+    return $batch[$uploadId] ?? ['NA', 0];
+  }
+
+  /**
+   * Get clearing durations for a list of uploads.
+   * @param int[] $uploadIds
+   * @return array Map of upload_pk => array(duration, durationSort)
+   */
+  public function getClearingDurationsBatch(array $uploadIds): array
+  {
+    if (empty($uploadIds)) {
+      return array();
     }
-    return array($duration, $durationSort);
+
+    $uploadIds = array_unique(array_filter($uploadIds));
+    if (empty($uploadIds)) {
+      return array();
+    }
+
+    $results = array();
+    foreach ($uploadIds as $id) {
+      $results[(int)$id] = array("NA", 0);
+    }
+
+    $uploadIdsStr = '{' . implode(',', array_map('intval', $uploadIds)) . '}';
+
+    $sql = "SELECT upload_fk, " .
+           "MIN(CASE WHEN event_type = $2 THEN event_ts END) as assignee_ts, " .
+           "MAX(CASE WHEN event_type = $3 THEN event_ts END) as closed_ts " .
+           "FROM upload_events " .
+           "WHERE upload_fk = ANY($1::int[]) AND event_type IN ($2, $3) " .
+           "GROUP BY upload_fk";
+
+    $rows = $this->dbManager->getRows($sql, array($uploadIdsStr, UploadEvents::ASSIGNEE_EVENT, UploadEvents::UPLOAD_CLOSED_EVENT), __METHOD__);
+
+    foreach ($rows as $row) {
+      $id = (int)$row['upload_fk'];
+      $duration = "NA";
+      $durationSort = 0;
+
+      if (!empty($row['assignee_ts']) && !empty($row['closed_ts'])) {
+        try {
+          $assignDate = new DateTime($row['assignee_ts']);
+          $closingDate = new DateTime($row['closed_ts']);
+          if ($assignDate < $closingDate) {
+            $duration = HumanDuration($closingDate->diff($assignDate));
+            $durationSort = $closingDate->getTimestamp() - $assignDate->getTimestamp();
+          }
+        } catch (\Exception $_) {
+        }
+      }
+      $results[$id] = array($duration, $durationSort);
+    }
+
+    return $results;
   }
   /**
    * \brief Get the uploadtree table name for this upload_pk

--- a/src/www/ui/admin-folder-size.php
+++ b/src/www/ui/admin-folder-size.php
@@ -49,13 +49,17 @@ class size_dashboard extends FO_Plugin
     $row = $this->dbManager->getSingleRow($folderSizesql,array($folderId),$statementName);
     $folderSize = HumanSize($row['sum']);
 
-    $statementName = __METHOD__."GetEachUploadSize";
     $dispSql = "SELECT DISTINCT ON (upload.upload_pk) upload_pk, upload_filename, pfile_size, " .
       "to_char(upload_ts, 'YYYY-MM-DD HH24:MI:SS') AS upload_ts, status_fk FROM pfile " . $sql . " ORDER BY upload.upload_pk";
-    $results = $this->dbManager->getRows($dispSql, [$folderId], $statementName);
+    $statementNameDisp = __METHOD__ . "GetEachUploadSize";
+    $results = $this->dbManager->getRows($dispSql, [$folderId], $statementNameDisp);
+
+    $uploadIds = array_column($results, 'upload_pk');
+    $durationBatch = $this->uploadDao->getClearingDurationsBatch($uploadIds);
+
     $var = '';
     foreach ($results as $result) {
-      $clearingDuration = $this->uploadDao->getClearingDuration($result["upload_pk"]);
+      $clearingDuration = $durationBatch[$result["upload_pk"]] ?? ['NA', 0];
       $var .= "<tr><td align='left'>" . $result['upload_pk'] .
         "</td><td align='left'>" . $result['upload_filename'] .
         "</td><td align='left' data-order='{$result['pfile_size']}'>" .
@@ -75,19 +79,22 @@ class size_dashboard extends FO_Plugin
   private function generateExportData($folderId, $format)
   {
     $results = $this->dbManager->getRows(
-      "SELECT DISTINCT ON (upload.upload_pk) upload_pk, upload_filename, pfile_size, to_char(upload_ts, 'YYYY-MM-DD HH24:MI:SS') AS upload_ts " .
+      "SELECT DISTINCT ON (upload.upload_pk) upload_pk, upload_filename, pfile_size, to_char(upload_ts, 'YYYY-MM-DD HH24:MI:SS') AS upload_ts, status_fk " .
       "FROM pfile " .
       "INNER JOIN upload ON upload.pfile_fk=pfile.pfile_pk " .
       "INNER JOIN foldercontents ON upload.upload_pk=foldercontents.child_id " .
-      "INNER JOIN upload_clearing ON upload.upload_pk=upload_clearing.upload_fk ".
+      "INNER JOIN upload_clearing ON upload.upload_pk=upload_clearing.upload_fk " .
       "WHERE parent_fk=$1 ORDER BY upload.upload_pk",
       [$folderId],
-      __METHOD__."ExportData"
+      __METHOD__ . "ExportData"
     );
+
+    $uploadIds = array_column($results, 'upload_pk');
+    $durationBatch = $this->uploadDao->getClearingDurationsBatch($uploadIds);
 
     $data = [];
     foreach ($results as $row) {
-      $clearingDuration = $this->uploadDao->getClearingDuration($row["upload_pk"]);
+      $clearingDuration = $durationBatch[$row["upload_pk"]] ?? ['NA', 0];
       $data[] = [
         'uploadid' => $row['upload_pk'],
         'name' => $row['upload_filename'],


### PR DESCRIPTION
Description:
While checking the code responsible for "Folder and upload dashboard", I noticed that the system was fetching clearing durations one by one for every single upload in the list.
I’ve optimized this by adding a way to fetch these durations in a single batch, so that the database is not called for every upload.

<img width="774" height="184" alt="image" src="https://github.com/user-attachments/assets/ee0c9db7-1dd9-4dea-b948-d00a5685f47e" />

Changes:
Optimized Dashboard Loading: Updated the Folder dashboard to fetch all upload "clearing durations" in one go rather than one by one.

<img width="755" height="149" alt="image" src="https://github.com/user-attachments/assets/15084ccc-16a0-4939-b503-c79ed9339898" />

Improved Data Exports: Applied the same optimization to the CSV and JSON export features so they generate instantly.
<img width="808" height="99" alt="image" src="https://github.com/user-attachments/assets/7f3dcd8a-ea37-43fb-b3d9-1fcd2aa44e2f" />

New Batch Logic: Added a getClearingDurationsBatch() method to the library to handle multiple duration requests efficiently.
<img width="668" height="105" alt="image" src="https://github.com/user-attachments/assets/6d386a63-455f-4143-9174-ce54888aa4ee" />

Fixed Export Bug: Corrected a minor issue where the "Status" column in exported CSV/JSON files was sometimes showing inaccurate data.
<img width="766" height="74" alt="image" src="https://github.com/user-attachments/assets/eca64c0c-d864-4abd-a9fd-1924f282c165" />

Works perfectly after the new changes:

<img width="1915" height="975" alt="image" src="https://github.com/user-attachments/assets/253bea50-87c3-4d9b-99b6-b14776ff72b5" />


How to test
Go to Admin -> Dashboards -> Folder/Upload Proportions.
Select a folder that contains several uploads.
The page should load correctly (and faster if the folder is large).
Also, Click on the CSV or JSON export buttons at the top; verify that the downloaded file contains the correct durations and statuses.

