### PR TITLE
fix(ui): sanitize tag outputs to prevent stored XSS

### DIFF
--- a/src/www/ui/ui-tags.php
+++ b/src/www/ui/ui-tags.php
@@ -326,7 +326,7 @@ class ui_tag extends FO_Plugin
       $text3 = _("Tag Date");
       $VE .= "<tr><th>$text1</th><th>$text2</th><th>$text3</th><th></th></tr>\n";
       while ($row = pg_fetch_assoc($result)) {
-        $VE .= "<tr><td align='center'>" . $row['tag'] . "</td><td align='center'>" . $row['tag_desc'] . "</td><td align='center'>" . substr($row['tag_file_date'],0,19) . "</td>";
+        $VE .= "<tr><td align='center'>" . htmlspecialchars($row['tag'], ENT_QUOTES, 'UTF-8') . "</td><td align='center'>" . htmlspecialchars($row['tag_desc'], ENT_QUOTES, 'UTF-8') . "</td><td align='center'>" . substr($row['tag_file_date'],0,19) . "</td>";
         if ($this->uploadDao->isEditable($Upload, Auth::getGroupId())) {
           $VE .= "<td align='center'><a href='" . Traceback_uri() . "?mod=tag&action=edit&upload=$Upload&item=$Uploadtree_pk&tag_file_pk=" . $row['tag_file_pk'] . "'>View/Edit</a>|<a href='" . Traceback_uri() . "?mod=tag&action=delete&upload=$Upload&item=$Uploadtree_pk&tag_file_pk=" . $row['tag_file_pk'] . "'>Delete</a></td></tr>\n";
         } else {
@@ -520,11 +520,11 @@ class ui_tag extends FO_Plugin
     $VEd.= "<form name='form' method='POST' action='" . Traceback_uri() ."?mod=tag&upload=$Upload&item=$Item'>\n";
     $VEd .= "<p>";
     $text = _("Tag");
-    $VEd .= "$text: <input type='text' id='tag_name' name='tag_name' autocomplete='off' onclick='Tags_Get(\"". Traceback_uri() . "?mod=tag_get&uploadtree_pk=$Item\")' value=\"$tag\"/> ";
+    $VEd .= "$text: <input type='text' id='tag_name' name='tag_name' autocomplete='off' onclick='Tags_Get(\"" . Traceback_uri() . "?mod=tag_get&uploadtree_pk=$Item\")' value=\"" . htmlspecialchars($tag, ENT_QUOTES, 'UTF-8') . "\"/> ";
     $text = _("Tag description:");
-    $VEd .= "<p>$text <input type='text' name='tag_desc' value=\"$tag_desc\"/></p>";
+    $VEd .= "<p>$text <input type='text' name='tag_desc' value=\"" . htmlspecialchars($tag_desc, ENT_QUOTES, 'UTF-8') . "\"/></p>";
     $VEd .= _("<p>Notes:</p>");
-    $VEd .= "<p><textarea rows='10' cols='80' name='tag_notes'>$tag_notes</textarea></p>";
+    $VEd .= "<p><textarea rows='10' cols='80' name='tag_notes'>" . htmlspecialchars($tag_notes, ENT_QUOTES, 'UTF-8') . "</textarea></p>";
 
     if (Isdir($ufile_mode)) {
       $VEd .= "<p><input type='hidden' name='tag_dir' value='1'/></p>";
@@ -577,7 +577,7 @@ class ui_tag extends FO_Plugin
       $VD .= "<form name='form' method='POST' action='" . Traceback_uri() ."?mod=tag&upload=$Upload&item=$Item'>\n";
       $VD .= "<select multiple size='10' name='tag_file_pk[]'>\n";
       while ($row = pg_fetch_assoc($result)) {
-        $VD .= "<option value='" . $row['tag_file_pk'] . "'>" . "-" . $row['tag'] . "</option>\n";
+        $VD .= "<option value='" . $row['tag_file_pk'] . "'>" . "-" . htmlspecialchars($row['tag'], ENT_QUOTES, 'UTF-8') . "</option>\n";
       }
       $VD .= "</select>\n";
       if (Iscontainer($ufile_mode)) {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © Fossology contributors

SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Fix Stored Cross-Site Scripting (XSS) vulnerability in Tag Management (`src/www/ui/ui-tags.php`). User-controlled inputs (`tag`, `tag_desc`, `tag_notes`) were rendered in HTML without output encoding, allowing an attacker to inject malicious scripts that execute in other users' browsers.

### Changes

All user-controlled values are now sanitized with `htmlspecialchars($value, ENT_QUOTES, 'UTF-8')` before rendering in HTML:

- `ShowExistTags()` : `tag` and `tag_desc` in the Current Tags table
- `ShowEditTagPage()` : `tag`, `tag_desc`, and `tag_notes` in form input/textarea values
- `ShowDeleteTagPage()` : `tag` in select option text

## How to test

1. Navigate to any upload tree item
2. Select **Browse-Pfile::Tag** to open the Tagging page
3. Enter `<script>alert("XSS")</script>` or `<img src=x onerror=alert(1)>` as a Tag name
4. Click **Create**
5. Verify the script does **not** execute and the tag name is displayed as plain text

Closes #3575
