### PR TITLE
feat(upload): allow users to delete their own uploads

### DIFF
--- a/src/delagent/ui/Page/AdminUploadDelete.php
+++ b/src/delagent/ui/Page/AdminUploadDelete.php
@@ -39,7 +39,7 @@ class AdminUploadDelete extends DefaultPlugin
     parent::__construct(self::NAME, array(
         self::TITLE => _("Delete Uploaded File"),
         self::MENU_LIST => "Organize::Uploads::Delete Uploaded File",
-        self::PERMISSION => Auth::PERM_ADMIN,
+        self::PERMISSION => Auth::PERM_WRITE,
         self::REQUIRES_LOGIN => true
     ));
 

--- a/src/delagent/ui/delete-file-browse.php
+++ b/src/delagent/ui/delete-file-browse.php
@@ -38,7 +38,7 @@ class BrowseUploadDelete extends DefaultPlugin
   {
     parent::__construct(self::NAME, array(
         self::TITLE => _("Delete Uploaded File"),
-        self::PERMISSION => Auth::PERM_ADMIN,
+        self::PERMISSION => Auth::PERM_WRITE,
         self::REQUIRES_LOGIN => true
     ));
 


### PR DESCRIPTION
Recommended PR description:
Issue: #1943

Changed delete flow permission from admin to write for eligible users.
Kept backend authorization via TryToDelete as final gate.
Filtered delete options to only editable uploads.
Added controller test coverage for success and permission-denied paths.
DCO signoff included.
<img width="1351" height="713" alt="image" src="https://github.com/user-attachments/assets/c7a1c18d-256a-4c70-b832-ac80527d0af3" />
