### PR TITLE
perf(bulkreuser): optimize bulk reuse scanning to eliminate duplicate scans

### DIFF
--- a/src/decider/agent/BulkReuser.php
+++ b/src/decider/agent/BulkReuser.php
@@ -36,11 +36,11 @@ class BulkReuser
 
   /**
    * @fn rerunBulkAndDeciderOnUpload($uploadId, $groupId, $userId, $bulkId, $dependency)
-   * @brief Rerun Monk bulk and decider on a given upload
-   * @param int   $uploadId   Upload on which the agents have to run
+   * @brief Rerun Monk bulk and decider on a given upload (handles grouped entries by processing latest ID)
+   * @param int   $uploadId   Upload on which agents have to run
    * @param int   $groupId    Group which is running the agents
    * @param int   $userId     User who is running the agents
-   * @param int   $bulkId     Previous bulk for reuse
+   * @param int   $bulkId     Bulk ID to process (for grouped entries, uses latest ID from group)
    * @param array $dependency Dependency on agent (Not in use)
    * @throws Exception If agent cannot be added, throw exception with message as HTML
    * @return int Id of the new job

--- a/src/decider/agent/DeciderAgent.php
+++ b/src/decider/agent/DeciderAgent.php
@@ -186,15 +186,18 @@ class DeciderAgent extends Agent
     }
     if (array_key_exists("r", $args) && (($this->activeRules&self::RULES_BULK_REUSE)== self::RULES_BULK_REUSE)) {
       $bulkReuser = new BulkReuser();
-      $bulkIds = $this->clearingDao->getPreviousBulkIds($uploadId, $this->groupId, $this->userId);
-      if (count($bulkIds) == 0) {
+      // Get bulk IDs grouped by both text content AND license IDs, ordered by scheduling date
+      $bulkGroups = $this->clearingDao->getBulkIdsGroupedByTextAndLicenses($uploadId, $this->groupId, $this->userId);
+      if (count($bulkGroups) == 0) {
         return true;
       }
       $jqId=0;
       $minTime="4";
       $maxTime="60";
-      foreach ($bulkIds as $bulkId) {
-        $jqId = $bulkReuser->rerunBulkAndDeciderOnUpload($uploadId, $this->groupId, $this->userId, $bulkId, $jqId);
+      foreach ($bulkGroups as $group) {
+        $bulkIds = $group['bulk_ids'];
+        // Use latest bulk ID from group - ensures most recent/corrected scan is processed
+        $jqId = $bulkReuser->rerunBulkAndDeciderOnUpload($uploadId, $this->groupId, $this->userId, $group['latest_bulk_id'], $jqId);
         $this->heartbeat(1);
         if (!empty($jqId)) {
           $jqIdRow = $this->showJobsDao->getDataForASingleJob($jqId);

--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -1017,6 +1017,67 @@ INSERT INTO clearing_decision (
   }
 
   /**
+   * Get bulk IDs grouped by both text content AND license IDs, ordered by chronological (oldest first)
+   * Only combines entries when both text and license IDs are identical
+   * Returns latest bulk ID for each group (highest lrb_pk) to ensure most recent activity is processed
+   * Uses MAX(j.job_queued) to capture latest activity time including user corrections
+   * Groups display in chronological order: earliest scheduled appears first, latest scheduled appears last
+   * @param int $uploadId
+   * @param int $groupId
+   * @param int $userId
+   * @return array Array of groups, each containing bulk IDs with identical text AND licenses
+   */
+  public function getBulkIdsGroupedByTextAndLicenses($uploadId, $groupId, $userId)
+  {
+    $stmt = __METHOD__;
+    // Group by both text hash AND license IDs, ordered by job scheduling date
+    $sql = "SELECT DISTINCT lrb.lrb_pk, lrb.rf_text,
+                   md5(regexp_replace(regexp_replace(lrb.rf_text, E'\\s+', ' ', 'g'), '^\\s+|\\s+$', '', 'g')) as text_hash,
+                   array_agg(DISTINCT lsb.rf_fk ORDER BY lsb.rf_fk) as license_ids,
+                   MAX(j.job_queued) as job_queued
+            FROM license_ref_bulk lrb
+            JOIN license_set_bulk lsb ON lrb.lrb_pk = lsb.lrb_fk
+            JOIN jobqueue jq ON jq.jq_args LIKE '%' || lrb.lrb_pk || '%'
+            JOIN job j ON jq.jq_job_fk = j.job_pk
+            WHERE lrb.lrb_pk IN (
+              SELECT DISTINCT unnest(string_to_array(jq_args, '\n'))::bigint as bulk_id
+              FROM upload_reuse, jobqueue, job
+              WHERE upload_fk=$1 AND group_fk=$2
+               AND EXISTS(SELECT * FROM group_user_member gum WHERE gum.group_fk=upload_reuse.group_fk AND gum.user_fk=$3)
+               AND jq_type=$4 AND jq_job_fk=job_pk
+               AND job_upload_fk=reused_upload_fk AND job_group_fk=reused_group_fk
+            )
+            GROUP BY lrb.lrb_pk, lrb.rf_text
+            ORDER BY MAX(j.job_queued) ASC";
+    $this->dbManager->prepare($stmt, $sql);
+    $res = $this->dbManager->execute($stmt, array($uploadId, $groupId, $userId, 'monkbulk'));
+    $groups = array();
+    while ($row = $this->dbManager->fetchArray($res)) {
+      $textHash = $row['text_hash'];
+      // Create combined hash of text + license IDs for precise grouping
+      $licenseIds = is_array($row['license_ids']) ? $row['license_ids'] : array();
+      $licenseHash = md5(implode(',', $licenseIds));
+      $combinedHash = $textHash . '_' . $licenseHash;
+      if (!isset($groups[$combinedHash])) {
+        $groups[$combinedHash] = array(
+          'rf_text' => $row['rf_text'],
+          'license_ids' => $row['license_ids'],
+          'bulk_ids' => array(),
+          'latest_bulk_id' => $row['lrb_pk'],
+          'job_queued' => $row['job_queued']
+        );
+      }
+      // Keep track of latest bulk ID for this group
+      if ($row['lrb_pk'] > $groups[$combinedHash]['latest_bulk_id']) {
+        $groups[$combinedHash]['latest_bulk_id'] = $row['lrb_pk'];
+      }
+      $groups[$combinedHash]['bulk_ids'][] = $row['lrb_pk'];
+    }
+    $this->dbManager->freeResult($res);
+    return array_values($groups);
+  }
+
+  /**
    * @param int $uploadTreeId
    * @return int count
    */


### PR DESCRIPTION


<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description
 
Optimizes bulk reuse scanning by implementing a text, license-based grouping mechanism that eliminates duplicate scans for identical content. The solution groups bulk entries by normalized text + license hash, validates license consistency, and combines matching entries.
 
## Changes
 
- Added `getBulkIdsGroupedByTextAndLicenses(`) in `ClearingDao` to group bulk entries by text content and license IDs, process them chronologically by job_queued, and return groups with identical content.
- Optimized `DeciderAgent.processUploadId()` to use grouped data, process only one entry per group, and maintain chronological order.

## Screenshots

### Before
https://github.com/user-attachments/assets/e696118e-c531-46eb-8820-900819d9fc7e

CC: @shaheemazmalmmd 