### PR TITLE
fix(security): escape shell args in getRepoPathOfPfile() to prevent command injection

### DIFF
--- a/src/lib/php/Dao/TreeDao.php
+++ b/src/lib/php/Dao/TreeDao.php
@@ -124,15 +124,18 @@ class TreeDao
 
   public function getRepoPathOfPfile($pfileId, $repo="files")
   {
+    if (!is_string($repo)) {
+      return null;
+    }
     $pfileRow = $this->dbManager->getSingleRow('SELECT * FROM pfile WHERE pfile_pk=$1',array($pfileId));
     global $LIBEXECDIR;
     if (empty($pfileRow['pfile_sha1'])) {
       return null;
     }
     $hash = $pfileRow['pfile_sha1'] . "." . $pfileRow['pfile_md5'] . "." . $pfileRow['pfile_size'];
-    $path = '';
-    exec("$LIBEXECDIR/reppath $repo $hash", $path);
-    return($path[0]);
+    $path = array();
+    exec(escapeshellcmd($LIBEXECDIR . "/reppath") . " " . escapeshellarg($repo) . " " . escapeshellarg($hash), $path);
+    return(isset($path[0]) ? $path[0] : null);
   }
 
   /**

--- a/src/lib/php/Dao/test/TreeDaoTest.php
+++ b/src/lib/php/Dao/test/TreeDaoTest.php
@@ -304,6 +304,8 @@ class TreeDaoTest extends \PHPUnit\Framework\TestCase
 
     assertThat($this->treeDao->getFullPath(12, "uploadtree", 7),      equalTo('subExample.tar/subExample/innerFile'));
     assertThat($this->treeDao->getFullPath(12, "uploadtree", 7,true), equalTo(               'subExample/innerFile'));
+  }
+
   public function testGetRepoPathOfPfile()
   {
     $this->testDb->createPlainTables(array('pfile'));

--- a/src/lib/php/Dao/test/TreeDaoTest.php
+++ b/src/lib/php/Dao/test/TreeDaoTest.php
@@ -304,5 +304,16 @@ class TreeDaoTest extends \PHPUnit\Framework\TestCase
 
     assertThat($this->treeDao->getFullPath(12, "uploadtree", 7),      equalTo('subExample.tar/subExample/innerFile'));
     assertThat($this->treeDao->getFullPath(12, "uploadtree", 7,true), equalTo(               'subExample/innerFile'));
+  public function testGetRepoPathOfPfile()
+  {
+    $this->testDb->createPlainTables(array('pfile'));
+    $this->dbManager->queryOnce('INSERT INTO pfile (pfile_pk, pfile_md5, pfile_sha1, pfile_sha256, pfile_size) VALUES (1, \'md5\', \'sha1\', \'sha256\', 100)');
+
+    $path = $this->treeDao->getRepoPathOfPfile(1, array('invalid'));
+    $this->assertNull($path);
+
+    $this->dbManager->queryOnce('INSERT INTO pfile (pfile_pk, pfile_md5, pfile_sha1, pfile_sha256, pfile_size) VALUES (2, \'md5\', \'\', \'sha256\', 100)');
+    $path = $this->treeDao->getRepoPathOfPfile(2);
+    $this->assertNull($path);
   }
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description
This pull request addresses a security vulnerability in the `getRepoPathOfPfile` method where shell arguments were being interpolated directly into an `exec()` call without proper escaping.

### Changes
- Wrapped the `$repo` and `$hash` arguments in `escapeshellarg()` to prevent shell metacharacter injection.
- Wrapped the base command path in `escapeshellcmd()` for defense-in-depth.
- Added an `is_string($repo)` guard clause to ensure input validity before shell execution.
- Added a new unit test `testGetRepoPathOfPfile` in `TreeDaoTest.php` to verify the new validation logic and error handling.

## How to test
1. Run the updated unit test suite for TreeDao:
```bash
# From the src directory
./vendor/bin/phpunit lib/php/Dao/test/TreeDaoTest.php
```
2. Verify that the testGetRepoPathOfPfile test case passes, ensuring that invalid (non-string) $repo values and empty hashes are handled safely.
3. Perform a manual code audit of the exec() call in src/lib/php/Dao/TreeDao.php to confirm arguments are correctly passed through escapeshellarg().