### PR TITLE
fix(reuser): check if same pfile have different decisions

### DIFF
--- a/src/reuser/agent/ReuserAgent.php
+++ b/src/reuser/agent/ReuserAgent.php
@@ -380,6 +380,13 @@ class ReuserAgent extends Agent
       $fileId = $clearingDecision->getPfileId();
       if (!array_key_exists($fileId, $clearingDecisionByFileId)) {
         $clearingDecisionByFileId[$fileId] = $clearingDecision;
+      } else {
+        $existingType = $clearingDecisionByFileId[$fileId]->getType();
+        $newType = $clearingDecision->getType();
+        if ($this->getDecisionTypePriority($newType) > $this->getDecisionTypePriority($existingType)) {
+          print "INFO :: Detected conflicting decisions for the same pfile. Applying the stronger decision.\n";
+          $clearingDecisionByFileId[$fileId] = $clearingDecision;
+        }
       }
     }
     return $clearingDecisionByFileId;
@@ -437,5 +444,27 @@ class ReuserAgent extends Agent
     }
 
     return $mapped;
+  }
+
+  /**
+   * @brief Get priority for a decision type during reuse
+   *
+   * When the same pfile has different decisions at different locations,
+   * higher priority decisions take precedence for reuse.
+   *
+   * @param int $decisionType One of DecisionTypes constants
+   * @return int Priority value (higher = stronger)
+   */
+  private function getDecisionTypePriority($decisionType)
+  {
+    $priority = array(
+      DecisionTypes::WIP => 0,
+      DecisionTypes::TO_BE_DISCUSSED => 1,
+      DecisionTypes::IRRELEVANT => 2,
+      DecisionTypes::NON_FUNCTIONAL => 3,
+      DecisionTypes::DO_NOT_USE => 4,
+      DecisionTypes::IDENTIFIED => 5,
+    );
+    return array_key_exists($decisionType, $priority) ? $priority[$decisionType] : 0;
   }
 }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Irrelevant decisions are getting added in case of the same pfile and different clearing decisions.

### Changes

Add check for the conflicts if conflicts exists the add a stronger decision (identified) instead of irrelevant 

## How to test

* Upload a package which contains same file in multiple locations of the same package.
* Mark these files with different decisions (few with identified and few with irrelevant). 
* Now upload a next version of it. and check there should not be irrelevant decisions.
