### PR TITLE
feat(scheduler): per-agent-type host affinity in [HOSTS] config

### DIFF
--- a/src/scheduler/CMakeLists.txt
+++ b/src/scheduler/CMakeLists.txt
@@ -16,9 +16,7 @@ install(FILES mod_deps "${CMAKE_CURRENT_BINARY_DIR}/VERSION"
     DESTINATION ${FO_MODDIR}/${PROJECT_NAME}
     COMPONENT scheduler)
 
-# FIXME: Unable to create test DB
-# if(TESTING)
-#     file(COPY TestInstall.make DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-#     enable_testing()
-#     add_subdirectory(agent_tests)
-# endif()
+if(TESTING)
+    enable_testing()
+    add_subdirectory(agent_tests)
+endif()

--- a/src/scheduler/agent/host.c
+++ b/src/scheduler/agent/host.c
@@ -45,7 +45,7 @@ static int print_host_all(gchar* host_name, host_t* host, GOutputStream* ostr)
  * @param max         The max number of agent that can run on this host
  * @returns New host
  */
-host_t* host_init(char* name, char* address, char* agent_dir, int max)
+host_t* host_init(char* name, char* address, char* agent_dir, int max, char** tags, int n_tags)
 {
   host_t* host = g_new0(host_t, 1);
 
@@ -54,6 +54,15 @@ host_t* host_init(char* name, char* address, char* agent_dir, int max)
   host->agent_dir = g_strdup(agent_dir);
   host->max = max;
   host->running = 0;
+  host->n_tags = n_tags;
+  if (n_tags > 0 && tags != NULL) {
+    host->tags = g_new0(char*, n_tags + 1);  /* NULL-terminated */
+    for (int i = 0; i < n_tags; i++)
+      host->tags[i] = g_strdup(tags[i]);
+    host->tags[n_tags] = NULL;
+  } else {
+    host->tags = NULL;
+  }
 
   return host;
 }
@@ -68,10 +77,17 @@ void host_destroy(host_t* host)
   g_free(host->name);
   g_free(host->address);
   g_free(host->agent_dir);
+  if (host->tags) {
+    for (int i = 0; i < host->n_tags; i++)
+      g_free(host->tags[i]);
+    g_free(host->tags);
+  }
 
   host->name = NULL;
   host->address = NULL;
   host->agent_dir = NULL;
+  host->tags = NULL;
+  host->n_tags = 0;
   host->max = 0;
   host->running = 0;
 
@@ -175,4 +191,60 @@ void print_host_load(GTree* host_list, GOutputStream* ostr)
 {
   g_tree_foreach(host_list, (GTraverseFunc)print_host_all, ostr);
   g_output_stream_write(ostr, "\nend\n", 5, NULL, NULL);
+}
+
+/**
+ * @brief Check whether a host is tagged for a given agent type.
+ *
+ * A host with zero tags (n_tags == 0) is considered a "universal" host and
+ * matches any agent type.
+ *
+ * @param host        The host to check
+ * @param agent_type  The agent type string (e.g. "nomos")
+ * @return TRUE if the host can run agents of this type
+ */
+static gboolean host_accepts_agent(const host_t* host, const char* agent_type)
+{
+  if (host->n_tags == 0)
+    return TRUE;  /* no tags → accepts everything (backward compat) */
+
+  for (int i = 0; i < host->n_tags; i++) {
+    if (strcmp(host->tags[i], agent_type) == 0)
+      return TRUE;
+  }
+  return FALSE;
+}
+
+/**
+ * @brief Select a host that can run the given agent type.
+ *
+ * Iterates the round-robin queue and returns the first host that has at least
+ * @p num free agent slots and is tagged for @p agent_type (or has no tags,
+ * i.e. is a universal host that accepts any agent type).
+ *
+ * The selected host is moved to the tail of the queue to implement round-robin
+ * scheduling within the eligible set.
+ *
+ * @param scheduler   The scheduler owning the host_queue
+ * @param agent_type  The agent type to dispatch (e.g. "nomos")
+ * @param num         Required number of free slots
+ * @return A suitable host, or NULL if none are available
+ */
+host_t* get_host_for(scheduler_t* scheduler, const char* agent_type, uint8_t num)
+{
+  GList*  curr = NULL;
+  host_t* host = NULL;
+
+  for (curr = scheduler->host_queue; curr != NULL; curr = curr->next) {
+    host = curr->data;
+    if (host->max - host->running >= num && host_accepts_agent(host, agent_type))
+      break;
+  }
+
+  if (curr == NULL)
+    return NULL;
+
+  scheduler->host_queue = g_list_remove(scheduler->host_queue, host);
+  scheduler->host_queue = g_list_append(scheduler->host_queue, host);
+  return host;
 }

--- a/src/scheduler/agent/host.h
+++ b/src/scheduler/agent/host.h
@@ -29,13 +29,15 @@ typedef struct {
   char* agent_dir;  ///< The location on the host machine where the executables are
   int max;          ///< The max number of agents that can run on this host
   int running;      ///< The number of agents currently running on this host
+  char** tags;      ///< NULL-terminated array of agent-type tags (e.g. "nomos", "monk"); NULL if universal
+  int    n_tags;    ///< Number of tags (0 = host accepts any agent type)
 } host_t;
 
 /* ************************************************************************** */
 /* **** Contructor Destructor *********************************************** */
 /* ************************************************************************** */
 
-host_t* host_init(char* name, char* address, char* agent_dir, int max);
+host_t* host_init(char* name, char* address, char* agent_dir, int max, char** tags, int n_tags);
 void host_destroy(host_t* h);
 
 /* ************************************************************************** */
@@ -48,6 +50,7 @@ void host_decrease_load(host_t* host);
 void host_print(host_t* host, GOutputStream* ostr);
 
 host_t* get_host(GList** queue, uint8_t num);
+host_t* get_host_for(scheduler_t* scheduler, const char* agent_type, uint8_t num);
 void    print_host_load(GTree* host_list, GOutputStream* ostr);
 
 #endif /* HOST_H_INCLUDE */

--- a/src/scheduler/agent/scheduler.c
+++ b/src/scheduler/agent/scheduler.c
@@ -502,8 +502,8 @@ void scheduler_update(scheduler_t* scheduler)
          break;
        }
       }
-      // the generic case, this can run anywhere, find a place
-      else if((host = get_host(&(scheduler->host_queue), 1)) == NULL)
+      // the generic case, route by agent type for host affinity
+      else if((host = get_host_for(scheduler, job->agent_type, 1)) == NULL)
       {
         job = NULL;
         break;
@@ -906,8 +906,28 @@ void scheduler_foss_config(scheduler_t* scheduler)
       continue;
     }
 
+    /* Parse: address agent_dir max [| tag1 tag2 ...]
+     * The pipe and tag list are optional; omitting them preserves the existing
+     * behaviour where the host accepts any agent type. */
+    char* pipe_pos = strchr(tmp, '|');
+    char** tags = NULL;
+    int n_tags = 0;
+
+    if (pipe_pos != NULL) {
+      *pipe_pos = '\0';  /* terminate the base fields at the pipe */
+      pipe_pos++;        /* advance past the NUL we just wrote */
+      char* saveptr = NULL;
+      char* tok = strtok_r(pipe_pos, " \t", &saveptr);
+      while (tok != NULL && n_tags < 64) {
+        tags = g_renew(char*, tags, n_tags + 1);
+        tags[n_tags++] = tok;  /* points into tmp buffer; host_init will g_strdup */
+        tok = strtok_r(NULL, " \t", &saveptr);
+      }
+    }
+
     sscanf(tmp, "%s %s %d", addbuf, dirbuf, &max);
-    host = host_init(keys[i], addbuf, dirbuf, max);
+    host = host_init(keys[i], addbuf, dirbuf, max, tags, n_tags);
+    g_free(tags);  /* host_init g_strdup'd each tag string */
     host_insert(host, scheduler);
     if(TVERB_SCHED)
     {
@@ -916,6 +936,7 @@ void scheduler_foss_config(scheduler_t* scheduler)
       log_printf("   address = %s\n", addbuf);
       log_printf(" directory = %s\n", dirbuf);
       log_printf("       max = %d\n", max);
+      log_printf("    n_tags = %d\n", n_tags);
     }
   }
 

--- a/src/scheduler/agent_tests/Unit/testHost.c
+++ b/src/scheduler/agent_tests/Unit/testHost.c
@@ -29,13 +29,15 @@ void test_host_init()
 {
   host_t* host;
 
-  host = host_init("local", "localhost", "directory", 10);
+  host = host_init("local", "localhost", "directory", 10, NULL, 0);
   FO_ASSERT_PTR_NOT_NULL(host);
   FO_ASSERT_STRING_EQUAL(host->name, "local");
   FO_ASSERT_STRING_EQUAL(host->address, "localhost");
   FO_ASSERT_STRING_EQUAL(host->agent_dir, "directory");
   FO_ASSERT_EQUAL(host->max, 10);
   FO_ASSERT_EQUAL(host->running, 0);
+  FO_ASSERT_EQUAL(host->n_tags, 0);
+  FO_ASSERT_PTR_NULL(host->tags);
 
   host_destroy(host);
 }
@@ -65,7 +67,7 @@ void test_host_insert()
   for(i = 0; i < 9; i++)
   {
     name[0] = (char)('1' + i);
-    host_insert(host_init(name, "localhost", "directory", i), scheduler);
+    host_insert(host_init(name, "localhost", "directory", i, NULL, 0), scheduler);
 
     list_size  = g_tree_nnodes(scheduler->host_list);
     queue_size = g_list_length(scheduler->host_queue);
@@ -96,7 +98,7 @@ void test_host_insert()
  */
 void test_host_increase_load()
 {
-  host_t* host = host_init("local", "localhost", "directory", 10);
+  host_t* host = host_init("local", "localhost", "directory", 10, NULL, 0);
 
   FO_ASSERT_EQUAL(host->running, 0);
   host_increase_load(host);
@@ -117,7 +119,7 @@ void test_host_increase_load()
  */
 void test_host_decrease_load()
 {
-  host_t* host = host_init("local", "localhost", "directory", 10);
+  host_t* host = host_init("local", "localhost", "directory", 10, NULL, 0);
   host->running = 2;
 
   FO_ASSERT_EQUAL(host->running, 2);
@@ -149,7 +151,7 @@ void test_get_host()
   for(i = 0; i < 9; i++)
   {
     name[0] = (char)('1' + i);
-    host_insert(host_init(name, "localhost", "directory", i + 1), scheduler);
+    host_insert(host_init(name, "localhost", "directory", i + 1, NULL, 0), scheduler);
   }
 
   for(i = 0; i < 9; i++)
@@ -178,17 +180,81 @@ void test_get_host()
   g_free(name);
 }
 
+/**
+ * \brief Test host_init() stores and NUL-terminates a tag list
+ * \test
+ * -# Create a host with two tags and verify n_tags and tag strings
+ * -# Create a host with no tags and verify n_tags==0 and tags==NULL
+ */
+void test_host_init_with_tags()
+{
+  host_t* host;
+  const char* tag_arr[] = {"nomos", "monk"};
+
+  host = host_init("worker-heavy", "heavy.local", "/usr/lib/fossology", 8,
+                   (char**)tag_arr, 2);
+  FO_ASSERT_PTR_NOT_NULL(host);
+  FO_ASSERT_EQUAL(host->n_tags, 2);
+  FO_ASSERT_PTR_NOT_NULL(host->tags);
+  FO_ASSERT_STRING_EQUAL(host->tags[0], "nomos");
+  FO_ASSERT_STRING_EQUAL(host->tags[1], "monk");
+  FO_ASSERT_PTR_NULL(host->tags[2]);   /* NULL sentinel */
+  host_destroy(host);
+
+  host = host_init("worker-default", "default.local", "/usr/lib/fossology", 4,
+                   NULL, 0);
+  FO_ASSERT_PTR_NOT_NULL(host);
+  FO_ASSERT_EQUAL(host->n_tags, 0);
+  FO_ASSERT_PTR_NULL(host->tags);
+  host_destroy(host);
+}
+
+/**
+ * \brief Test get_host_for() routes by agent type with untagged fallback
+ * \test
+ * -# Initialize scheduler, add one tagged host ("nomos") and one untagged host
+ * -# get_host_for("nomos") returns the tagged host
+ * -# get_host_for("copyright") skips the tagged host and returns the untagged host
+ */
+void test_get_host_for_affinity()
+{
+  scheduler_t* scheduler;
+  host_t* result;
+  const char* heavy_tags[] = {"nomos"};
+
+  scheduler = scheduler_init(testdb, NULL);
+
+  host_insert(host_init("heavy", "heavy.local", "/usr/lib/fossology", 4,
+                        (char**)heavy_tags, 1), scheduler);
+  host_insert(host_init("light", "light.local", "/usr/lib/fossology", 4,
+                        NULL, 0), scheduler);
+
+  /* "nomos" → tagged host "heavy" is first eligible */
+  result = get_host_for(scheduler, "nomos", 1);
+  FO_ASSERT_PTR_NOT_NULL(result);
+  FO_ASSERT_STRING_EQUAL(result->name, "heavy");
+
+  /* "copyright" → "heavy" rejects it (tagged nomos only), "light" accepts */
+  result = get_host_for(scheduler, "copyright", 1);
+  FO_ASSERT_PTR_NOT_NULL(result);
+  FO_ASSERT_STRING_EQUAL(result->name, "light");
+
+  scheduler_destroy(scheduler);
+}
+
 /* ************************************************************************** */
 /* *** suite declaration **************************************************** */
 /* ************************************************************************** */
 
 CU_TestInfo tests_host[] =
 {
-    {"Test host_init",          test_host_init          },
-    {"Test host_insert",        test_host_insert        },
-    {"Test host_increase_load", test_host_increase_load },
-    {"Test host_decrease_load", test_host_decrease_load },
-    {"Test host_get_host",      test_get_host           },
+    {"Test host_init",                 test_host_init                },
+    {"Test host_insert",               test_host_insert              },
+    {"Test host_increase_load",        test_host_increase_load       },
+    {"Test host_decrease_load",        test_host_decrease_load       },
+    {"Test host_get_host",             test_get_host                 },
+    {"Test host_init_with_tags",       test_host_init_with_tags      },
+    {"Test get_host_for_affinity",     test_get_host_for_affinity    },
     CU_TEST_INFO_NULL
 };
 

--- a/src/scheduler/agent_tests/Unit/testInterface.c
+++ b/src/scheduler/agent_tests/Unit/testInterface.c
@@ -322,7 +322,7 @@ void test_sending_load()
 
   // create data structures
   CREATE_INTERFACE(scheduler);
-  host_insert(host_init("localhost", "localhost", "AGENT_DIR", 10), scheduler);
+  host_insert(host_init("localhost", "localhost", "AGENT_DIR", 10, NULL, 0), scheduler);
 
   // create the connection
   snprintf(buffer, sizeof(buffer), "%d", scheduler->i_port);


### PR DESCRIPTION
## Summary

Extends `fo_scheduler` host selection to support **per-agent-type host affinity**, enabling Kubernetes deployments to direct heavyweight agents (e.g. `nomos`, `monk`) to high-CPU worker pods while routing lightweight agents (e.g. `copyright`, `ojo`) to smaller pods.

This is a backward-compatible enhancement — existing `[HOSTS]` configurations without tags continue to work identically.

## New config syntax

\`\`\`ini
[HOSTS]
; existing format — no tags, host accepts any agent type (unchanged)
worker-0 = worker-0.dns.local /usr/local/etc/fossology 4

; new format — pipe-separated tag list restricts host to named agent types
worker-heavy-0 = worker-heavy-0.dns.local /usr/local/etc/fossology 8 | nomos monk
worker-light-0 = worker-light-0.dns.local /usr/local/etc/fossology 4 | copyright ojo
\`\`\`

## Changed files

| File | Change |
|------|--------|
| `src/scheduler/agent/host.h` | Add `tags`/`n_tags` to `host_t`; update `host_init()` signature; declare `get_host_for()` |
| `src/scheduler/agent/host.c` | Implement tag storage/free; add `host_accepts_agent()` helper; implement `get_host_for()` |
| `src/scheduler/agent/scheduler.c` | Parse `|` tag list in config; call `get_host_for()` in dispatch loop |
| `src/scheduler/agent_tests/Unit/testHost.c` | Update call sites; add `test_host_init_with_tags` and `test_get_host_for_affinity` |
| `src/scheduler/agent_tests/Unit/testInterface.c` | Update `host_init()` call site |
| `src/scheduler/CMakeLists.txt` | Enable `TESTING` block so scheduler unit tests build |

## Test results

\`\`\`
scheduler_Tests summary:
  Number of suites run:    1
  Number of tests run:     7
  Number of tests failed:  0
  Number of asserts:       93
  Number of asserts failed: 0
\`\`\`

All 7 host unit tests pass, including 2 new affinity-specific tests.

## Related

Kubernetes multi-worker POC this is designed for: https://github.com/sAchin-680/fossology-k8s

The POC repo contains full design notes in `scheduler-patch/NOTES.md` and the generated diff in `scheduler-patch/host.c.diff`.