### PR TITLE
fix(reportImport): add setLicenseCandidate for custom text licenses

### DIFF
--- a/src/reportImport/agent/SpdxThreeImportSource.php
+++ b/src/reportImport/agent/SpdxThreeImportSource.php
@@ -246,22 +246,26 @@ class SpdxThreeImportSource implements ImportSource
       $rawLicenseId = $licenseIdLiteral->getValue();
       $licenseId = $this->stripLicenseRefPrefix($rawLicenseId);
 
+      $isCustomText = false;
       if ($license->isA('spdx:expandedlicensing_CustomLicense') &&
         (strlen($licenseId) > 33 &&
           substr($licenseId, -33, 1) === "-" &&
           ctype_alnum(substr($licenseId, -32))
         )) {
         $licenseId = substr($licenseId, 0, -33);
-        $item = new ReportImportDataItem($licenseId);
-        $item->setCustomText($licenseTextLiteral->getValue());
-      } else {
-        $item = new ReportImportDataItem($licenseId);
-        $item->setLicenseCandidate($licenseNameLiteral->getValue(),
-          $licenseTextLiteral->getValue(),
-          strpos($rawLicenseId, LicenseRef::SPDXREF_PREFIX),
-          ($seeAlsoLiteral != null) ? $seeAlsoLiteral->getValue() : ""
-        );
+        $isCustomText = true;
       }
+
+      $item = new ReportImportDataItem($licenseId);
+      if ($isCustomText) {
+        $item->setCustomText($licenseTextLiteral->getValue());
+      }
+      $item->setLicenseCandidate($licenseNameLiteral->getValue(),
+        $licenseTextLiteral->getValue(),
+        strpos($rawLicenseId, LicenseRef::SPDXREF_PREFIX),
+        ($seeAlsoLiteral != null) ? $seeAlsoLiteral->getValue() : ""
+      );
+
       return [$item];
     }
     return [];

--- a/src/reportImport/agent/SpdxThreeImportSource.php
+++ b/src/reportImport/agent/SpdxThreeImportSource.php
@@ -254,6 +254,7 @@ class SpdxThreeImportSource implements ImportSource
         $licenseId = substr($licenseId, 0, -33);
         $item = new ReportImportDataItem($licenseId);
         $item->setCustomText($licenseTextLiteral->getValue());
+        $item->setLicenseCandidate($licenseNameLiteral->getValue(), $licenseTextLiteral->getValue(), strpos($rawLicenseId, LicenseRef::SPDXREF_PREFIX), ($seeAlsoLiteral != null) ? $seeAlsoLiteral->getValue() : "");
       } else {
         $item = new ReportImportDataItem($licenseId);
         $item->setLicenseCandidate($licenseNameLiteral->getValue(),

--- a/src/reportImport/agent/SpdxTwoImportSource.php
+++ b/src/reportImport/agent/SpdxTwoImportSource.php
@@ -293,6 +293,7 @@ class SpdxTwoImportSource implements ImportSource
         $licenseId = substr($licenseId, 0, -33);
         $item = new ReportImportDataItem($licenseId);
         $item->setCustomText($licenseTextLiteral->getValue());
+        $item->setLicenseCandidate($licenseNameLiteral->getValue(), $licenseTextLiteral->getValue(), strpos($rawLicenseId, LicenseRef::SPDXREF_PREFIX), ($seeAlsoLiteral != null) ? $seeAlsoLiteral->getValue() : "");
       } else {
         $item = new ReportImportDataItem($licenseId);
         $item->setLicenseCandidate($licenseNameLiteral->getValue(),

--- a/src/reportImport/agent/SpdxTwoImportSource.php
+++ b/src/reportImport/agent/SpdxTwoImportSource.php
@@ -285,22 +285,26 @@ class SpdxTwoImportSource implements ImportSource
       $rawLicenseId = $licenseIdLiteral->getValue();
       $licenseId = $this->stripLicenseRefPrefix($rawLicenseId);
 
+      $isCustomText = false;
       if ($license->isA('spdx:ExtractedLicensingInfo') &&
         (strlen($licenseId) > 33 &&
           substr($licenseId, -33, 1) === "-" &&
           ctype_alnum(substr($licenseId, -32))
         )) {
         $licenseId = substr($licenseId, 0, -33);
-        $item = new ReportImportDataItem($licenseId);
-        $item->setCustomText($licenseTextLiteral->getValue());
-      } else {
-        $item = new ReportImportDataItem($licenseId);
-        $item->setLicenseCandidate($licenseNameLiteral->getValue(),
-          $licenseTextLiteral->getValue(),
-          strpos($rawLicenseId, LicenseRef::SPDXREF_PREFIX),
-          ($seeAlsoLiteral != null) ? $seeAlsoLiteral->getValue() : ""
-        );
+        $isCustomText = true;
       }
+
+      $item = new ReportImportDataItem($licenseId);
+      if ($isCustomText) {
+        $item->setCustomText($licenseTextLiteral->getValue());
+      }
+      $item->setLicenseCandidate($licenseNameLiteral->getValue(),
+        $licenseTextLiteral->getValue(),
+        strpos($rawLicenseId, LicenseRef::SPDXREF_PREFIX),
+        ($seeAlsoLiteral != null) ? $seeAlsoLiteral->getValue() : ""
+      );
+
       return [$item];
     }
     return [];


### PR DESCRIPTION
### Description
This PR fixes issue #3025 where SPDX report imports silently drop license findings when the license has custom text (hash-suffixed ExtractedLicensingInfo) and doesn't already exist in the database.

Right now, if you import an SPDX report that contains something like LicenseRef-Permission-Notice-b79dfa8d57b6aef14cf0aa1e0a5519fa, and your FOSSology instance doesn't have Permission-Notice in its database, the finding just disappears. No error, no warning in the job log — it's silently ignored. This can lead to missing clearing decisions, which is a real problem for projects like OSSelot that rely on importing SPDX reports across different FOSSology instances.

The root cause is in handleLicenseInfo() — the custom-text code branch calls setCustomText() but never calls setLicenseCandidate(). Since the downstream ReportImportSink only creates new licenses when isSetLicenseCandidate() returns true, these findings get skipped entirely.

### Changes

- **SpdxTwoImportSource.php:** Added setLicenseCandidate() call in the custom-text branch (the ExtractedLicensingInfo with 32-char hash suffix path). This ensures unknown licenses with custom text are registered as candidates so the Sink can create them in the database.

- **SpdxThreeImportSource.php:** Applied the same one-line fix for SPDX 3 imports (expandedlicensing_CustomLicense path) to keep both importers consistent.

### How to test
**Reproduce the bug (before the fix):**

1. Upload any small file (e.g., a simple test.c) to FOSSology without running any agents
2. Create a minimal SPDX 2 RDF file that references a made-up license with custom text — something like LicenseRef-MyTestLicense-<32 hex characters> as an ExtractedLicensingInfo with extractedText
3. Import the RDF via Upload → Import Report
4. Browse to the file and check the license table — it will be empty
<img width="1723" height="1001" alt="Screenshot from 2026-04-13 17-34-55" src="https://github.com/user-attachments/assets/1e5132b7-a6c2-4b3a-b3e8-fd0697c0100e" />

**Verify the fix (after the fix):**

1. Apply the changes from this PR
2. Repeat the same import steps
3. Browse to the file — the license now appears in the table with source reportimport
4. Click on the license name to verify the custom text is preserved in the License Info popup
<img width="1848" height="1070" alt="Screenshot from 2026-04-15 10-13-50" src="https://github.com/user-attachments/assets/8d6a4518-7610-40f4-8170-e1979c42c069" />

You can also reproduce this with the exact scenario from the original issue: download the [busybox SPDX2 RDF from OSSelot](https://raw.githubusercontent.com/Open-Source-Compliance/package-analysis/refs/heads/main/analysed-packages/busybox/version-1.36.1/busybox-1.36.1.spdx.rdf.xml), upload busybox-1.36.1, import the RDF, and navigate to editors/ed.c — the Permission-Notice finding should now appear.
 
Closes #3025 


