### PR TITLE
fix(nomos): eliminate buffer overflow vulnerabilities

### DIFF
--- a/src/nomos/agent/nomos.c
+++ b/src/nomos/agent/nomos.c
@@ -105,7 +105,8 @@ void arsNomos(cacheroot_t* cacheroot, bool ignoreFilesWithMimeType) {
     for (i = 0; i < numrows; i++)
     {
       initializeCurScan(&cur);
-      strcpy(cur.pFile, PQgetvalue(result, i, 1));
+      strncpy(cur.pFile, PQgetvalue(result, i, 1), sizeof(cur.pFile) - 1);
+      cur.pFile[sizeof(cur.pFile) - 1] = '\0';
       cur.pFileFk = atoi(PQgetvalue(result, i, 0));
       repFile = fo_RepMkPath("files", cur.pFile);
       if (!repFile)
@@ -157,7 +158,7 @@ void list_dir (const char * dir_name, int process_count, int *distribute_count, 
   {
     /* get the file path, form the file path /dir_name/file_name,
        e.g. dir_name is '/tmp' file_name is 'test_file_1.txt', form one path '/tmp/test_file_1.txt' */
-    sprintf( filename_buf , "%s/%s",dir_name, dirent_handler->d_name);
+    snprintf(filename_buf, sizeof(filename_buf), "%s/%s", dir_name, dirent_handler->d_name);
 
     if (stat(filename_buf, &stat_buf) == -1) // if can access the current file, return
     {
@@ -291,7 +292,7 @@ int main(int argc, char **argv)
 
   COMMIT_HASH = fo_sysconfig("nomos", "COMMIT_HASH");
   VERSION = fo_sysconfig("nomos", "VERSION");
-  sprintf(agent_rev, "%s.%s", VERSION, COMMIT_HASH);
+  snprintf(agent_rev, sizeof(agent_rev), "%s.%s", VERSION, COMMIT_HASH);
 
   gl.agentPk = fo_GetAgentKey(gl.pgConn, basename(argv[0]), 0, agent_rev, agent_desc);
 
@@ -435,7 +436,8 @@ int main(int argc, char **argv)
         {
           LOG_FATAL("failed to open %s, %s\n", file_template, strerror(errno));
         }
-        strcpy(pTempFileName[i], file_template); // store temp file names
+        strncpy(pTempFileName[i], file_template, sizeof(pTempFileName[i]) - 1);
+        pTempFileName[i][sizeof(pTempFileName[i]) - 1] = '\0'; // store temp file names
       }
 
       /* walk through the specified directory to get all the file(file path) and

--- a/src/nomos/agent/util.c
+++ b/src/nomos/agent/util.c
@@ -182,7 +182,7 @@ char *newReloTarget(char *basename)
 #endif /* PROC_TRACE */
 
   for (i = 0; i < MAX_RENAME; i++) {
-    (void) sprintf(newpath, "%s_%s-renamed.%03d", basename, gl.progName, i);
+    (void) snprintf(newpath, sizeof(newpath), "%s_%s-renamed.%03d", basename, gl.progName, i);
     if (access(newpath, F_OK) && errno == ENOENT) {
       break;
     }
@@ -243,7 +243,8 @@ char *memAllocTagged(int size, char *name)
 #endif /* DEBUG > 3 || MEM_ACCT */
   memcache[memlast].mmPtr = ptr;
   memcache[memlast].size = size;
-  (void) strcpy(memcache[memlast].label, name);
+  strncpy(memcache[memlast].label, name, sizeof(memcache[memlast].label) - 1);
+  memcache[memlast].label[sizeof(memcache[memlast].label) - 1] = '\0';
 #ifdef MEM_ACCT
   printf("memAllocTagged(%d, \"%s\") == %p [entry %04d]\n", size, name, ptr,
       memlast);
@@ -575,7 +576,7 @@ char *wordCount(char *textp)
         break;
     }
   }
-  (void) sprintf(wcbuf, "%d lines", lines);
+  (void) snprintf(wcbuf, sizeof(wcbuf), "%d lines", lines);
   /*
    * Save these values for use elsewhere, too.
    */
@@ -671,7 +672,7 @@ char *getInstances(char *textp, int size, int nBefore, int nAfter, char *regex,
   if (recordOffsets) {
     if (p->bList) free(p->bList);
     p->bList = (list_t *)memAlloc(sizeof(list_t), MTAG_LIST);
-    (void) sprintf(utilbuf, "\"%c%c%c%c%c%c%c%c%c%c\" match-list",
+    (void) snprintf(utilbuf, sizeof(utilbuf), "\"%c%c%c%c%c%c%c%c%c%c\" match-list",
         *regex, *(regex+1), *(regex+2), *(regex+3), *(regex+4),
         *(regex+5), *(regex+6), *(regex+7), *(regex+8), *(regex+9));
 #ifdef PHRASE_DEBUG
@@ -729,7 +730,7 @@ char *getInstances(char *textp, int size, int nBefore, int nAfter, char *regex,
     printf("... found Match #%d\n", p->nMatch);
 #endif /* PHRASE_DEBUG */
     if (recordOffsets) {
-      (void) sprintf(utilbuf, "buf%05d", p->nMatch);
+      (void) snprintf(utilbuf, sizeof(utilbuf), "buf%05d", p->nMatch);
       bp = listGetItem(p->bList, utilbuf);
     }
     start = findBol(curptr + cur.regm.rm_so, textp);
@@ -870,9 +871,13 @@ char *getInstances(char *textp, int size, int nBefore, int nAfter, char *regex,
     }
     cp = bufmark = ibuf+buflen-1; /* where the NULL is _now_ */
     buflen += newDataLen;  /* new end-of-data ptr */
-    bufmark += sprintf(bufmark, "%s", start);
+    int remaining = bufmax - (bufmark - ibuf);
+    int written = snprintf(bufmark, remaining, "%s", start);
+    bufmark += (written >= remaining) ? remaining - 1 : written;
     if (notDone) {
-      bufmark += sprintf(bufmark, "%s\n", sep);
+      remaining = bufmax - (bufmark - ibuf);
+      written = snprintf(bufmark, remaining, "%s\n", sep);
+      bufmark += (written >= remaining) ? remaining - 1 : written;
     }
     /*
      * Some files use ^M as a line-terminator, so we need to convert those
@@ -935,7 +940,7 @@ void memStats(char *s)
 
   if (first) {
     first = 0;
-    sprintf(mbuf, "grep VmRSS /proc/%d/status", getpid());
+    snprintf(mbuf, sizeof(mbuf), "grep VmRSS /proc/%d/status", getpid());
   }
   if (s && *s) {
     int i;
@@ -963,7 +968,7 @@ void makeSymlink(char *path)
   traceFunc("== makeSymlink(%s)\n", path);
 #endif /* PROC_TRACE || UNPACK_DEBUG */
 
-  (void) sprintf(cmdBuf, ".%s", strrchr(path, '/'));
+  (void) snprintf(cmdBuf, sizeof(cmdBuf), ".%s", strrchr(path, '/'));
   if (symlink(path, cmdBuf) < 0) {
     perror(cmdBuf);
     LOG_FATAL("Failed: symlink(%s, %s)", path, cmdBuf)
@@ -1015,7 +1020,7 @@ void printRegexMatch(int n, int cached)
     printf("Match [%d:%d]\n", save_so, save_eo);
 #endif /* DEBUG */
     textp = mmapFile(debugStr);
-    (void) sprintf(misc, "=#%03d", n);
+    (void) snprintf(misc, sizeof(misc), "=#%03d", n);
     if (strGrep(misc, textp, REG_EXTENDED)) {
 #ifdef DEBUG
       printf("Patt: %s\nMatch: %d:%d\n", misc,
@@ -1034,7 +1039,8 @@ void printRegexMatch(int n, int cached)
       (void) strncpy(misc, x, cp - x); /* CDB - Fix */
       misc[cp-x] = NULL_CHAR;
     } else {
-      (void) strcpy(misc, "?");
+      strncpy(misc, "?", sizeof(misc) - 1);
+      misc[sizeof(misc) - 1] = '\0';
     }
     munmapFile(textp);
     if (match) {
@@ -1129,7 +1135,8 @@ char *mmapFile(char *pathname) /* read-only for now */
     Bail(14);
   }
 
-  (void) strcpy(mmp->label, pathname);
+  strncpy(mmp->label, pathname, sizeof(mmp->label) - 1);
+  mmp->label[sizeof(mmp->label) - 1] = '\0';
   if (cur.stbuf.st_size)
   {
     mmp->size = cur.stbuf.st_size + 1;
@@ -1364,7 +1371,7 @@ int isFILE(char *pathname)
 int addEntry(char *pathname, int forceFlag, const char *fmt, ...)
 {
   va_start(ap, fmt);
-  vsprintf(utilbuf, fmt, ap);
+  vsnprintf(utilbuf, sizeof(utilbuf), fmt, ap);
   va_end(ap);
 
 #ifdef  PROC_TRACE
@@ -1401,8 +1408,10 @@ void Msg(const char *fmt, ...)
 void Assert(int fatalFlag, const char *fmt, ...)
 {
   va_start(ap, fmt);
-  (void) sprintf(utilbuf, "ASSERT: ");
-  (void) vsprintf(utilbuf+strlen(utilbuf), fmt, ap);
+  (void) snprintf(utilbuf, sizeof(utilbuf), "ASSERT: ");
+  int offset = strlen(utilbuf);
+  int remaining_len = sizeof(utilbuf) - offset;
+  (void) vsnprintf(utilbuf + offset, remaining_len, fmt, ap);
   va_end(ap);
 
 #ifdef  PROC_TRACE

--- a/src/nomos/agent/util.c
+++ b/src/nomos/agent/util.c
@@ -182,7 +182,7 @@ char *newReloTarget(char *basename)
 #endif /* PROC_TRACE */
 
   for (i = 0; i < MAX_RENAME; i++) {
-    (void) sprintf(newpath, "%s_%s-renamed.%03d", basename, gl.progName, i);
+    (void) snprintf(newpath, sizeof(newpath), "%s_%s-renamed.%03d", basename, gl.progName, i);
     if (access(newpath, F_OK) && errno == ENOENT) {
       break;
     }
@@ -243,7 +243,8 @@ char *memAllocTagged(int size, char *name)
 #endif /* DEBUG > 3 || MEM_ACCT */
   memcache[memlast].mmPtr = ptr;
   memcache[memlast].size = size;
-  (void) strcpy(memcache[memlast].label, name);
+  strncpy(memcache[memlast].label, name, sizeof(memcache[memlast].label) - 1);
+  memcache[memlast].label[sizeof(memcache[memlast].label) - 1] = '\0';
 #ifdef MEM_ACCT
   printf("memAllocTagged(%d, \"%s\") == %p [entry %04d]\n", size, name, ptr,
       memlast);
@@ -575,7 +576,7 @@ char *wordCount(char *textp)
         break;
     }
   }
-  (void) sprintf(wcbuf, "%d lines", lines);
+  (void) snprintf(wcbuf, sizeof(wcbuf), "%d lines", lines);
   /*
    * Save these values for use elsewhere, too.
    */
@@ -603,7 +604,8 @@ char *copyString(char *s, char *label)
 #ifdef DEBUG
   printf("+CS: %d @ %p\n", len, cp);
 #endif /* DEBUG */
-  (void) strcpy(cp, s);
+  strncpy(cp, s, len - 1);
+  cp[len - 1] = '\0';
   return(cp);
 }
 
@@ -671,7 +673,7 @@ char *getInstances(char *textp, int size, int nBefore, int nAfter, char *regex,
   if (recordOffsets) {
     if (p->bList) free(p->bList);
     p->bList = (list_t *)memAlloc(sizeof(list_t), MTAG_LIST);
-    (void) sprintf(utilbuf, "\"%c%c%c%c%c%c%c%c%c%c\" match-list",
+    (void) snprintf(utilbuf, sizeof(utilbuf), "\"%c%c%c%c%c%c%c%c%c%c\" match-list",
         *regex, *(regex+1), *(regex+2), *(regex+3), *(regex+4),
         *(regex+5), *(regex+6), *(regex+7), *(regex+8), *(regex+9));
 #ifdef PHRASE_DEBUG
@@ -729,7 +731,7 @@ char *getInstances(char *textp, int size, int nBefore, int nAfter, char *regex,
     printf("... found Match #%d\n", p->nMatch);
 #endif /* PHRASE_DEBUG */
     if (recordOffsets) {
-      (void) sprintf(utilbuf, "buf%05d", p->nMatch);
+      (void) snprintf(utilbuf, sizeof(utilbuf), "buf%05d", p->nMatch);
       bp = listGetItem(p->bList, utilbuf);
     }
     start = findBol(curptr + cur.regm.rm_so, textp);
@@ -870,9 +872,11 @@ char *getInstances(char *textp, int size, int nBefore, int nAfter, char *regex,
     }
     cp = bufmark = ibuf+buflen-1; /* where the NULL is _now_ */
     buflen += newDataLen;  /* new end-of-data ptr */
-    bufmark += sprintf(bufmark, "%s", start);
+    int remaining = bufmax - (bufmark - ibuf);
+    bufmark += snprintf(bufmark, remaining, "%s", start);
     if (notDone) {
-      bufmark += sprintf(bufmark, "%s\n", sep);
+      remaining = bufmax - (bufmark - ibuf);
+      bufmark += snprintf(bufmark, remaining, "%s\n", sep);
     }
     /*
      * Some files use ^M as a line-terminator, so we need to convert those
@@ -935,7 +939,7 @@ void memStats(char *s)
 
   if (first) {
     first = 0;
-    sprintf(mbuf, "grep VmRSS /proc/%d/status", getpid());
+    snprintf(mbuf, sizeof(mbuf), "grep VmRSS /proc/%d/status", getpid());
   }
   if (s && *s) {
     int i;
@@ -963,7 +967,7 @@ void makeSymlink(char *path)
   traceFunc("== makeSymlink(%s)\n", path);
 #endif /* PROC_TRACE || UNPACK_DEBUG */
 
-  (void) sprintf(cmdBuf, ".%s", strrchr(path, '/'));
+  (void) snprintf(cmdBuf, sizeof(cmdBuf), ".%s", strrchr(path, '/'));
   if (symlink(path, cmdBuf) < 0) {
     perror(cmdBuf);
     LOG_FATAL("Failed: symlink(%s, %s)", path, cmdBuf)
@@ -1015,7 +1019,7 @@ void printRegexMatch(int n, int cached)
     printf("Match [%d:%d]\n", save_so, save_eo);
 #endif /* DEBUG */
     textp = mmapFile(debugStr);
-    (void) sprintf(misc, "=#%03d", n);
+    (void) snprintf(misc, sizeof(misc), "=#%03d", n);
     if (strGrep(misc, textp, REG_EXTENDED)) {
 #ifdef DEBUG
       printf("Patt: %s\nMatch: %d:%d\n", misc,
@@ -1034,7 +1038,8 @@ void printRegexMatch(int n, int cached)
       (void) strncpy(misc, x, cp - x); /* CDB - Fix */
       misc[cp-x] = NULL_CHAR;
     } else {
-      (void) strcpy(misc, "?");
+      strncpy(misc, "?", sizeof(misc) - 1);
+      misc[sizeof(misc) - 1] = '\0';
     }
     munmapFile(textp);
     if (match) {
@@ -1129,7 +1134,8 @@ char *mmapFile(char *pathname) /* read-only for now */
     Bail(14);
   }
 
-  (void) strcpy(mmp->label, pathname);
+  strncpy(mmp->label, pathname, sizeof(mmp->label) - 1);
+  mmp->label[sizeof(mmp->label) - 1] = '\0';
   if (cur.stbuf.st_size)
   {
     mmp->size = cur.stbuf.st_size + 1;
@@ -1364,7 +1370,7 @@ int isFILE(char *pathname)
 int addEntry(char *pathname, int forceFlag, const char *fmt, ...)
 {
   va_start(ap, fmt);
-  vsprintf(utilbuf, fmt, ap);
+  vsnprintf(utilbuf, sizeof(utilbuf), fmt, ap);
   va_end(ap);
 
 #ifdef  PROC_TRACE
@@ -1401,8 +1407,10 @@ void Msg(const char *fmt, ...)
 void Assert(int fatalFlag, const char *fmt, ...)
 {
   va_start(ap, fmt);
-  (void) sprintf(utilbuf, "ASSERT: ");
-  (void) vsprintf(utilbuf+strlen(utilbuf), fmt, ap);
+  (void) snprintf(utilbuf, sizeof(utilbuf), "ASSERT: ");
+  int offset = strlen(utilbuf);
+  int remaining_len = sizeof(utilbuf) - offset;
+  (void) vsnprintf(utilbuf + offset, remaining_len, fmt, ap);
   va_end(ap);
 
 #ifdef  PROC_TRACE


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

   SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This PR addresses critical memory corruption and buffer overflow vulnerabilities identified in the Nomos Agent C codebase. Over 20 unbounded string operations have been replaced with their safe, bounded equivalents to guarantee robust internal text manipulation and mitigate potential RCE/DoS risks. 

Fixes #3582 

### Changes

- **Audited string operations:** Conducted a sweep of `nomos.c` and `util.c` to identify uses of `strcpy`, `sprintf`, and `vsprintf`.
- **Enforced Bounded Functions:** Upgraded unsafe usages to `strncpy`, `snprintf`, and `vsnprintf` tightly coupled to buffer `sizeof()` boundaries limiters mapping to static array schemas. Properly ensured strings remain NULL-terminated.
- **Dynamic Offset Bounds Checking:** Overhauled `getInstances` logic within `util.c` where dynamic `bufmark` offsets were extensively used. Added safety size calculations (`remaining = bufmax - (bufmark - ibuf);`) ahead of writing appended characters to secure memory bounds during reallocation sequences.

## How to test

1. Check out this branch locally: `git fetch origin pull/<PR_ID>/head:test-nomos-security && git checkout test-nomos-security`
2. Navigate to the agent source directory: `cd src/nomos/agent/`
3. Compile the Nomos agent by running: `make` or the standard project compilation procedure.
4. Verify that the compile completes successfully without regressions by running the standard unit and functional tests for the Nomos agent.
5. Alternatively, run the agent continuously over extremely large scan workloads to ensure the dynamic buffer pointers accurately operate within bounds.
