### PR TITLE
fix(browser): reset action dropdown after back navigation (#3586)

### DIFF
--- a/src/www/ui/scripts/browse.js
+++ b/src/www/ui/scripts/browse.js
@@ -20,6 +20,10 @@ var staSel = null;
 $(document).ready(function () {
   assigneeSelected = ($.cookie("assigneeSelected") || 0);
   $('#assigneeSelector').val(assigneeSelected);
+  $(window).on('pageshow', function () {
+    $('select.goto-active-option').prop('selectedIndex', 0);
+  });
+
   table = createBrowseTable();
   $('#insert_browsetbl_filter').append($('#browsetbl_filter'));
   $("input[type='search']").addClass("form-control-sm");
@@ -32,13 +36,16 @@ $(document).ready(function () {
         var source=table.cell(this).data();
         openCommentModal(source[0],source[1],source[2]);
     } );
-    $('select.goto-active-option').change(function() {
+    $('select.goto-active-option')
+    .off('change')
+    .on('change', function() {
       const url = $(this).val();
       const optionText = $(this).find("option:selected").text();
-      let userResponse = true
+      let userResponse = true;
       if (optionText === "Delete") {
-        userResponse = confirm("Are you sure you want to delete this upload ?")
-      } 
+        userResponse = confirm("Are you sure you want to delete this upload ?");
+      }
+      this.selectedIndex = 0;
       if(url && userResponse) {
         window.location = url;
       }


### PR DESCRIPTION
## Summary
- Fixes issue #3586 where file/folder action dropdown on Browse page keeps previous selection after navigating back.
- Ensures returning via browser Back/Forward resets `goto-active-option` to default using `pageshow`.
- Resets dropdown selection after action handling so selecting the same option again triggers navigation without needing an intermediate selection.

## Problem
After selecting a file action and returning to Browse via browser Back, the previously selected action stayed selected, so choosing the same action again did not redirect unless another option was selected first.

## Fix


- Added a `pageshow` listener to reset all `select.goto-active-option` dropdowns when the page is shown again (including browser back/forward cache restore).
- In the existing dropdown `change` handler, after reading the selected value and handling Delete confirmation, explicitly reset the current dropdown:
  - `this.selectedIndex = 0`
- Prevent duplicate event bindings by unbinding existing handlers before attaching new ones

This keeps the default state after each action and guarantees that selecting the same option again is treated as a valid new action.

## Result
- Returning to Browse with browser Back no longer leaves stale action selections.
- Selecting the same action again works immediately (no extra intermediate selection needed).
- Existing behavior for action routing and Delete confirmation remains intact.
- Overall Browse action flow is predictable and repeatable for users performing multiple operations on the same row.