### PR TITLE
feat(deploy): add kubernetes deployment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,22 @@ Avoid using version-specific internal paths such as:
 ```
 
 These directories may not be persisted as expected when containers are recreated. Always rely on the directory structure defined by the Postgres image.
+
+## Kubernetes
+
+An example Kubernetes deployment is available in `deploy/kubernetes`.
+It provisions a single FOSSology application pod, an in-cluster PostgreSQL
+database, and persistent volumes for the repository and database data.
+
+Deploy it with:
+
+```sh
+kubectl apply -k deploy/kubernetes
+```
+
+The guide in `deploy/kubernetes/README.md` covers customization points such as
+credentials, storage classes, and exposing the web UI with port-forwarding or
+an ingress controller.
  
 ## Vagrant
 

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -1,0 +1,81 @@
+<!--
+SPDX-FileCopyrightText: © 2026 FOSSology contributors
+
+SPDX-License-Identifier: GPL-2.0-only
+-->
+# Kubernetes Deployment
+
+This directory contains a small Kubernetes baseline for running FOSSology with
+an in-cluster PostgreSQL database and persistent storage for both PostgreSQL
+data and the FOSSology repository.
+
+The example is intentionally conservative:
+
+- It uses the published `fossology/fossology` container image.
+- It runs FOSSology as a single replica so the scheduler and web UI share the
+  same repository volume.
+- It exposes the web UI with a `ClusterIP` service so clusters can choose
+  port-forwarding, an ingress controller, or a platform-specific load balancer.
+
+## Included resources
+
+- `namespace.yaml`: dedicated namespace for the deployment.
+- `configmap.yaml`: non-sensitive database configuration.
+- `secret.yaml`: example credentials for PostgreSQL and FOSSology.
+- `postgres-pvc.yaml`: persistent volume claim for PostgreSQL data.
+- `postgres-deployment.yaml`: PostgreSQL deployment.
+- `postgres-service.yaml`: PostgreSQL service for the application.
+- `repository-pvc.yaml`: persistent volume claim for the FOSSology repository.
+- `fossology-deployment.yaml`: FOSSology application deployment.
+- `fossology-service.yaml`: internal web service.
+- `kustomization.yaml`: lets you deploy the full stack with one command.
+
+## Deploy
+
+Review and update the default credentials in `secret.yaml` before deploying.
+
+```sh
+kubectl apply -k deploy/kubernetes
+kubectl -n fossology rollout status deployment/postgres
+kubectl -n fossology rollout status deployment/fossology
+```
+
+To access the web UI locally:
+
+```sh
+kubectl -n fossology port-forward service/fossology-web 8081:80
+```
+
+Then open `http://127.0.0.1:8081/repo`.
+
+Default login:
+
+- Username: `fossy`
+- Password: `fossy`
+
+## Customization
+
+- Change storage requests in `postgres-pvc.yaml` and `repository-pvc.yaml`.
+- Set a `storageClassName` in the PVCs if your cluster does not provide a
+  default storage class.
+- Replace `fossology/fossology:latest` with a pinned release tag in
+  `fossology-deployment.yaml` for reproducible environments.
+- Add an ingress or load balancer if you want external cluster access.
+- Use an external PostgreSQL service if your cluster already provides one.
+
+## Operational notes
+
+- The deployment uses one FOSSology replica because the scheduler and web UI
+  share a filesystem repository. Scaling this deployment horizontally requires
+  shared storage with an access mode that fits your cluster and workload.
+- The bundled PostgreSQL deployment is a convenient starting point for
+  development and evaluation. For production, a managed or separately operated
+  PostgreSQL instance is usually the better fit.
+- The health probes target `/repo/api/v1/health`, which matches the existing
+  container healthcheck used in Docker Compose.
+
+## Remove
+
+```sh
+kubectl delete -k deploy/kubernetes
+```

--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: © 2026 FOSSology contributors
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fossology-config
+data:
+  FOSSOLOGY_DB_HOST: postgres
+  FOSSOLOGY_DB_NAME: fossology
+  FOSSOLOGY_DB_USER: fossy
+  POSTGRES_DB: fossology
+  POSTGRES_USER: fossy

--- a/deploy/kubernetes/fossology-deployment.yaml
+++ b/deploy/kubernetes/fossology-deployment.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: © 2026 FOSSology contributors
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fossology
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: app
+    spec:
+      containers:
+        - name: fossology
+          image: fossology/fossology:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+              name: http
+          envFrom:
+            - configMapRef:
+                name: fossology-config
+            - secretRef:
+                name: fossology-secrets
+          startupProbe:
+            httpGet:
+              path: /repo/api/v1/health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /repo/api/v1/health
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /repo/api/v1/health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          volumeMounts:
+            - name: repository
+              mountPath: /srv/fossology/repository
+      volumes:
+        - name: repository
+          persistentVolumeClaim:
+            claimName: fossology-repository

--- a/deploy/kubernetes/fossology-service.yaml
+++ b/deploy/kubernetes/fossology-service.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: © 2026 FOSSology contributors
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: fossology-web
+spec:
+  selector:
+    app.kubernetes.io/component: app
+  ports:
+    - port: 80
+      targetPort: http
+      name: http

--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: © 2026 FOSSology contributors
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: fossology
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - secret.yaml
+  - postgres-pvc.yaml
+  - postgres-deployment.yaml
+  - postgres-service.yaml
+  - repository-pvc.yaml
+  - fossology-deployment.yaml
+  - fossology-service.yaml
+labels:
+  - pairs:
+      app.kubernetes.io/name: fossology

--- a/deploy/kubernetes/namespace.yaml
+++ b/deploy/kubernetes/namespace.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: © 2026 FOSSology contributors
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fossology

--- a/deploy/kubernetes/postgres-deployment.yaml
+++ b/deploy/kubernetes/postgres-deployment.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: © 2026 FOSSology contributors
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5432
+              name: postgres
+          envFrom:
+            - configMapRef:
+                name: fossology-config
+            - secretRef:
+                name: fossology-secrets
+          env:
+            - name: POSTGRES_INITDB_ARGS
+              value: -E SQL_ASCII
+          readinessProbe:
+            tcpSocket:
+              port: postgres
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: postgres
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: postgres-data

--- a/deploy/kubernetes/postgres-pvc.yaml
+++ b/deploy/kubernetes/postgres-pvc.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: © 2026 FOSSology contributors
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/deploy/kubernetes/postgres-service.yaml
+++ b/deploy/kubernetes/postgres-service.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: © 2026 FOSSology contributors
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app.kubernetes.io/component: postgres
+  ports:
+    - port: 5432
+      targetPort: postgres
+      name: postgres

--- a/deploy/kubernetes/repository-pvc.yaml
+++ b/deploy/kubernetes/repository-pvc.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: © 2026 FOSSology contributors
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fossology-repository
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/deploy/kubernetes/secret.yaml
+++ b/deploy/kubernetes/secret.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: © 2026 FOSSology contributors
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fossology-secrets
+type: Opaque
+stringData:
+  FOSSOLOGY_DB_PASSWORD: fossy
+  POSTGRES_PASSWORD: fossy


### PR DESCRIPTION
## Description

Add a Kubernetes deployment example for FOSSology that mirrors the existing container deployment story and gives contributors a starting point for running the stack on a cluster.

### Changes

- add a `deploy/kubernetes` kustomization with namespace, config, secret, PVCs, PostgreSQL deployment/service, and FOSSology deployment/service
- document how to deploy, port-forward, customize storage, and adapt the setup for production
- link the new Kubernetes deployment guide from the root README

## How to test

1. Run `kubectl kustomize deploy/kubernetes` and verify the manifests render successfully.
2. Apply the manifests with `kubectl apply -k deploy/kubernetes` on a test cluster.
3. Wait for `deployment/postgres` and `deployment/fossology` to become ready in the `fossology` namespace.
4. Port-forward `service/fossology-web` and open `/repo` in a browser.
5. Update the example secret and PVC settings as needed for the target cluster.