### PR TITLE
fix(ui): preserve SPDX id on no-op candidate edits

### DIFF
--- a/src/www/ui/page/AdviceLicense.php
+++ b/src/www/ui/page/AdviceLicense.php
@@ -147,8 +147,6 @@ class AdviceLicense extends DefaultPlugin
    */
   private function saveInput(Request $request, $oldRow, $userId)
   {
-    $spdxLicenses = new SpdxLicenses();
-
     $spdxId = $request->get('spdx_id');
     $shortname = $request->get('shortname');
     $fullname = $request->get('fullname');
@@ -178,22 +176,32 @@ class AdviceLicense extends DefaultPlugin
       $oldRow['rf_pk'] = $licenseDao->insertUploadLicense($shortname, $rfText, Auth::getGroupId(), $userId);
     }
 
-    if (! empty($spdxId) &&
-      strstr(strtolower($spdxId), strtolower(LicenseRef::SPDXREF_PREFIX)) === false) {
-      if (! $spdxLicenses->validate($spdxId)) {
-        $spdxId = LicenseRef::convertToSpdxId($spdxId, null);
-      }
-    } elseif (empty($spdxId)) {
-      $spdxId = null;
-    }
-    if (! empty($spdxId)) {
-      $spdxId = LicenseRef::replaceSpaces($spdxId);
-    }
+    $spdxId = $this->normalizeSpdxId($spdxId, $oldRow['rf_spdx_id'] ?? null);
 
     $licenseDao->updateCandidate($oldRow['rf_pk'], $shortname, $fullname,
       $rfText, $url, $note, $lastmodified, $userIdmodified, !empty($marydone),
       $riskLvl, $spdxId);
     return $this->getDataRow(Auth::getGroupId(), $oldRow['rf_pk']);
+  }
+
+  private function normalizeSpdxId($submittedSpdxId, $existingSpdxId)
+  {
+    if (empty($submittedSpdxId)) {
+      return null;
+    }
+
+    if (! empty($existingSpdxId) && $submittedSpdxId === $existingSpdxId) {
+      return $existingSpdxId;
+    }
+
+    if (strstr(strtolower($submittedSpdxId), strtolower(LicenseRef::SPDXREF_PREFIX)) === false) {
+      $spdxLicenses = new SpdxLicenses();
+      if (! $spdxLicenses->validate($submittedSpdxId)) {
+        $submittedSpdxId = LicenseRef::convertToSpdxId($submittedSpdxId, null);
+      }
+    }
+
+    return LicenseRef::replaceSpaces($submittedSpdxId);
   }
 }
 

--- a/src/www/ui_tests/api/Controllers/AdviceLicenseTest.php
+++ b/src/www/ui_tests/api/Controllers/AdviceLicenseTest.php
@@ -1,0 +1,118 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\UI\Page
+{
+  function register_plugin($plugin)
+  {
+    return null;
+  }
+}
+
+namespace Fossology\UI\Api\Test\Controllers
+{
+  use Fossology\Lib\Data\LicenseRef;
+  use Fossology\Lib\Test\Reflectory;
+  use Fossology\UI\Page\AdviceLicense;
+
+  $GLOBALS['SysConf'] = [
+    'DIRECTORIES' => [
+      'LOGDIR' => sys_get_temp_dir(),
+    ],
+  ];
+  $GLOBALS['container'] = new class
+  {
+    public function get($name)
+    {
+      return new \stdClass();
+    }
+  };
+
+  require_once dirname(__DIR__, 3) . '/ui/page/AdviceLicense.php';
+
+  /**
+   * @class AdviceLicenseTest
+   * @brief Tests for candidate-license SPDX-id handling.
+   */
+  class AdviceLicenseTest extends \PHPUnit\Framework\TestCase
+  {
+    protected function setUp() : void
+    {
+      global $container;
+      global $SysConf;
+
+      $SysConf = [
+        'DIRECTORIES' => [
+          'LOGDIR' => sys_get_temp_dir(),
+        ],
+      ];
+
+      $container = new class
+      {
+        public function get($name)
+        {
+          return new \stdClass();
+        }
+      };
+    }
+
+    /**
+     * @test
+     * -# Save a candidate with the same stored and submitted SPDX id.
+     * -# Check that an invalid existing id is not rewritten.
+     */
+    public function testNormalizeSpdxIdKeepsUnchangedExistingId()
+    {
+      $adviceLicense = new AdviceLicense();
+
+      $spdxId = Reflectory::invokeObjectsMethodnameWith(
+        $adviceLicense,
+        'normalizeSpdxId',
+        ['Existing Bad SPDX', 'Existing Bad SPDX']
+      );
+
+      $this->assertSame('Existing Bad SPDX', $spdxId);
+    }
+
+    /**
+     * @test
+     * -# Save a candidate with a newly entered invalid SPDX id.
+     * -# Check that the new value is still converted to a LicenseRef id.
+     */
+    public function testNormalizeSpdxIdConvertsNewInvalidId()
+    {
+      $adviceLicense = new AdviceLicense();
+
+      $spdxId = Reflectory::invokeObjectsMethodnameWith(
+        $adviceLicense,
+        'normalizeSpdxId',
+        ['legacy custom id', 'ExistingBadSpdx']
+      );
+
+      $this->assertSame(LicenseRef::convertToSpdxId('legacy custom id', null),
+        $spdxId);
+    }
+
+    /**
+     * @test
+     * -# Save a candidate with an empty SPDX id.
+     * -# Check that the stored value is cleared.
+     */
+    public function testNormalizeSpdxIdClearsEmptyId()
+    {
+      $adviceLicense = new AdviceLicense();
+
+      $spdxId = Reflectory::invokeObjectsMethodnameWith(
+        $adviceLicense,
+        'normalizeSpdxId',
+        ['', 'ExistingBadSpdx']
+      );
+
+      $this->assertNull($spdxId);
+    }
+  }
+}


### PR DESCRIPTION
## Description

Fix candidate license editing so a no-op save keeps the existing SPDX id instead of rewriting it to a `LicenseRef-fossology-*` value.

Issue context from #3583:

- the issue was reported after editing a candidate license from `Organize > Licenses`
- in the discussion, it was clarified that the desired behavior is to keep the stored SPDX id unchanged on a no-op save
- the existing `LicenseRef-fossology-` conversion is still useful for genuinely new invalid SPDX ids, so this PR keeps that behavior for new edits and only skips the rewrite when the submitted value already matches the stored one

### Changes

- extract SPDX normalization in `AdviceLicense` into a small helper
- preserve the existing SPDX id when the submitted value matches the stored value exactly
- keep normalizing newly entered invalid SPDX ids into `LicenseRef` form
- add regression tests covering both the no-op save case and the still-normalized invalid-input case

## How to test

1. Open `Organize > Licenses` and edit a candidate license with an existing SPDX id.
2. Click save without changing the SPDX id.
3. Verify that the stored SPDX id remains unchanged.
4. Edit the same license again with a brand-new invalid SPDX id.
5. Verify that the new invalid value is still normalized to a `LicenseRef-fossology-*` identifier.
6. Run `php -d session.save_path=/tmp ./vendor/bin/phpunit --bootstrap ./phpunit-bootstrap.php www/ui_tests/api/Controllers/AdviceLicenseTest.php` from `src/`.
<img width="1920" height="1200" alt="Screenshot from 2026-04-21 21-43-40" src="https://github.com/user-attachments/assets/90e851e8-dd4b-4228-be23-bcef18157cd6" />

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/642903e7-f637-41a6-818e-79cac143413e" />


Closes #3583