### PR TITLE
fix(uploadFile): fix cast expression error on a empty database

### DIFF
--- a/src/lib/php/common-agents.php
+++ b/src/lib/php/common-agents.php
@@ -232,7 +232,7 @@ function GetAgentKey($agentName, $agentDesc)
 
   if (pg_num_rows($result) == 0) {
     /* no match, so add an agent rec */
-    $sql = "INSERT INTO agent (agent_name,agent_desc,agent_enabled) VALUES ('$agentName',E'$agentDesc',1)";
+    $sql = "INSERT INTO agent (agent_name,agent_desc,agent_enabled) VALUES ('$agentName',E'$agentDesc',true)";
     $result = pg_query($PG_CONN, $sql);
     DBCheckResult($result, $sql, __FILE__, __LINE__);
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

As part of testing for release #3592 , Cleaned up the database. While uploading a first file i have observed that there is a error and no agent runs except from ununpack and adj2nest. 

<img width="1527" height="365" alt="image" src="https://github.com/user-attachments/assets/6b7de81a-57cf-4909-8d55-bb5f76990372" />


### Changes

Replaced with true. 

## How to test

* Drop fossology database.
* upload a new package.
* fossology shall work as usual.
