### PR TITLE
Fix: Command injection vulnerability in getRepoPathOfPfile() by escaping shell arguments

### DIFF
--- a/src/lib/php/Dao/TreeDao.php
+++ b/src/lib/php/Dao/TreeDao.php
@@ -131,7 +131,11 @@ class TreeDao
     }
     $hash = $pfileRow['pfile_sha1'] . "." . $pfileRow['pfile_md5'] . "." . $pfileRow['pfile_size'];
     $path = '';
-    exec("$LIBEXECDIR/reppath $repo $hash", $path);
+    // Escape shell arguments to prevent command injection
+    $safeRepo = escapeshellarg($repo);
+    $safeHash = escapeshellarg($hash);
+    $safeExec = escapeshellcmd("$LIBEXECDIR/reppath");
+    exec("$safeExec $safeRepo $safeHash", $path);
     return($path[0]);
   }
 


### PR DESCRIPTION
#3577 
PR Description:
This PR fixes a command injection vulnerability in [TreeDao.php](vscode-file://vscode-app/c:/Users/shiva/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (method getRepoPathOfPfile).

The $repo and $hash variables are now properly escaped using escapeshellarg() and escapeshellcmd() before being passed to exec().
This prevents attackers from injecting arbitrary shell commands via manipulated database entries.
The fix preserves all existing functionality and ensures secure command execution.

### Validation

**Before fix:**
1. Inserted `abc123; touch /tmp/hacked` as pfile_sha1.
2. Triggered getRepoPathOfPfile().
3. `/tmp/hacked` was created (vulnerability present).

**After fix:**
1. Repeated the above steps.
2. `/tmp/hacked` was NOT created (vulnerability fixed)
<img width="750" height="44" alt="image" src="https://github.com/user-attachments/assets/d4f61620-628c-4460-8b59-b0a4b63758a4" />


Command used:
ls /tmp/hacked