### PR TITLE
docs(contributing): fix end user documentation wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 We welcome contributions in several forms, e.g.
 
-- Improve end user documenting on the [Wiki](https://github.com/fossology/fossology/wiki)
+- Improve end user documentation on the [Wiki](https://github.com/fossology/fossology/wiki)
 
 - Testing
 


### PR DESCRIPTION
 <!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix awkward wording in `CONTRIBUTING.md` by changing "end user documenting" to "end user documentation".

## Testing

Not run; documentation-only change.

### Changes

- Updated one sentence in `CONTRIBUTING.md` to use the grammatically correct phrase "end user documentation".

## How to test

1. Open `CONTRIBUTING.md`.
2. Confirm the contribution list says "Improve end user documentation on the Wiki".
3. Confirm no functional code was changed.
