### PR TITLE
perf(core): batch isAccessible permission checks

### DIFF
--- a/src/lib/php/Dao/SearchHelperDao.php
+++ b/src/lib/php/Dao/SearchHelperDao.php
@@ -242,8 +242,17 @@ class SearchHelperDao
     $stmt = __METHOD__ . "_paginated";
     $rows = $this->dbManager->getRows($PaginatedSQL, [], $stmt);
     if (!empty($rows)) {
+      $uploadIds = array();
       foreach ($rows as $row) {
-        if (!$uploadDao->isAccessible($row['upload_fk'], $groupID)) {
+        if (!empty($row['upload_fk'])) {
+          $uploadIds[] = $row['upload_fk'];
+        }
+      }
+      $accessibleUploads = $uploadDao->filterAccessibleUploads(array_unique($uploadIds), $groupID);
+      $accessibleMap = array_flip($accessibleUploads);
+
+      foreach ($rows as $row) {
+        if (empty($row['upload_fk']) || !isset($accessibleMap[$row['upload_fk']])) {
           continue;
         }
         $totalUploadtreeRecs[] = $row;

--- a/src/lib/php/common-folders.php
+++ b/src/lib/php/common-folders.php
@@ -371,16 +371,29 @@ function FolderListUploads_perm($ParentFolder, $perm)
 	ORDER BY upload_filename,upload_pk;";
   $result = pg_query($PG_CONN, $sql);
   DBCheckResult($result, $sql, __FILE__, __LINE__);
+
+  $fetchedRows = array();
+  $uploadIds = array();
   while ($R = pg_fetch_assoc($result)) {
     if (empty($R['upload_pk'])) {
       continue;
     }
-    if ($perm == Auth::PERM_READ &&
-      ! $uploadDao->isAccessible($R['upload_pk'], $groupId)) {
+    $fetchedRows[] = $R;
+    $uploadIds[] = $R['upload_pk'];
+  }
+  pg_free_result($result);
+
+  $accessibleMap = array();
+  if ($perm == Auth::PERM_READ && !empty($uploadIds)) {
+    $accessibleUploads = $uploadDao->filterAccessibleUploads(array_unique($uploadIds), $groupId);
+    $accessibleMap = array_flip($accessibleUploads);
+  }
+
+  foreach ($fetchedRows as $R) {
+    if ($perm == Auth::PERM_READ && !isset($accessibleMap[$R['upload_pk']])) {
       continue;
     }
-    if ($perm == Auth::PERM_WRITE &&
-      ! $uploadDao->isEditable($R['upload_pk'], $groupId)) {
+    if ($perm == Auth::PERM_WRITE && ! $uploadDao->isEditable($R['upload_pk'], $groupId)) {
       continue;
     }
 
@@ -391,7 +404,6 @@ function FolderListUploads_perm($ParentFolder, $perm)
     $New['name'] = $R['upload_filename'];
     $List[] = $New;
   }
-  pg_free_result($result);
   return($List);
 } // FolderListUploads_perm()
 
@@ -443,16 +455,29 @@ function FolderListUploadsRecurse($ParentFolder=-1, $FolderPath = '',
     ORDER BY uploadtree.ufile_name,upload.upload_desc";
   $result = pg_query($PG_CONN, $sql);
   DBCheckResult($result, $sql, __FILE__, __LINE__);
+
+  $fetchedRows = array();
+  $uploadIds = array();
   while ($R = pg_fetch_assoc($result)) {
     if (empty($R['upload_pk'])) {
       continue;
     }
-    if ($perm == Auth::PERM_READ &&
-      ! $uploadDao->isAccessible($R['upload_pk'], $groupId)) {
+    $fetchedRows[] = $R;
+    $uploadIds[] = $R['upload_pk'];
+  }
+  pg_free_result($result);
+
+  $accessibleMap = array();
+  if ($perm == Auth::PERM_READ && !empty($uploadIds)) {
+    $accessibleUploads = $uploadDao->filterAccessibleUploads(array_unique($uploadIds), $groupId);
+    $accessibleMap = array_flip($accessibleUploads);
+  }
+
+  foreach ($fetchedRows as $R) {
+    if ($perm == Auth::PERM_READ && !isset($accessibleMap[$R['upload_pk']])) {
       continue;
     }
-    if ($perm == Auth::PERM_WRITE &&
-      ! $uploadDao->isEditable($R['upload_pk'], $groupId)) {
+    if ($perm == Auth::PERM_WRITE && ! $uploadDao->isEditable($R['upload_pk'], $groupId)) {
       continue;
     }
 
@@ -463,7 +488,6 @@ function FolderListUploadsRecurse($ParentFolder=-1, $FolderPath = '',
     $New['folder'] = $FolderPath . "/" . $R['folder_name'];
     $List[] = $New;
   }
-  pg_free_result($result);
 
   /* Get list of subfolders and recurse */
   /* mode 1<<0 = folder_pk */

--- a/src/www/ui/api/Controllers/FileSearchController.php
+++ b/src/www/ui/api/Controllers/FileSearchController.php
@@ -197,10 +197,8 @@ class FileSearchController extends RestController
     if (empty($uploads)) {
       return [];
     }
-    return array_filter($uploads, function ($upload) {
-      return $this->restHelper->getUploadDao()->isAccessible($upload,
-        $this->restHelper->getGroupId());
-    });
+    return $this->restHelper->getUploadDao()->filterAccessibleUploads($uploads,
+      $this->restHelper->getGroupId());
   }
 
   /**

--- a/src/www/ui/async/AjaxBrowse.php
+++ b/src/www/ui/async/AjaxBrowse.php
@@ -122,14 +122,27 @@ class AjaxBrowse extends DefaultPlugin
 
     $output = array();
     $rowCounter = 0;
+
+    $fetchedRows = array();
+    $uploadIds = array();
     while ($row = $this->dbManager->fetchArray($result)) {
-      if (empty($row['upload_pk']) || !$this->uploadDao->isAccessible($row['upload_pk'],Auth::getGroupId())) {
+      $fetchedRows[] = $row;
+      if (!empty($row['upload_pk'])) {
+        $uploadIds[] = $row['upload_pk'];
+      }
+    }
+    $this->dbManager->freeResult($result);
+
+    $accessibleUploads = $this->uploadDao->filterAccessibleUploads(array_unique($uploadIds), Auth::getGroupId());
+    $accessibleMap = array_flip($accessibleUploads);
+
+    foreach ($fetchedRows as $row) {
+      if (empty($row['upload_pk']) || !isset($accessibleMap[$row['upload_pk']])) {
         continue;
       }
       $rowCounter++;
       $output[] = $this->showRow($row, $request, $uri, $menuPfile, $menuPfileNoCompare, $statusTypesAvailable, $users, $rowCounter);
     }
-    $this->dbManager->freeResult($result);
     return new JsonResponse(array(
               'sEcho' => intval($request->get('sEcho')),
               'aaData' => $output,


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

In this PR I found 5 other instances across 4 files where `isAccessible` is being called inside a loop (since it causes the N+1 database query problem) and have updated those files to use the `filterAccessibleUploads` batching method. Now it will load much faster, especially when users are exploring large folders or doing global searches.

### Changes

- **`FileSearchController.php`**: I removed the `array_filter` loop and directly passed the array to `filterAccessibleUploads`.
- **`SearchHelperDao.php` & `AjaxBrowse.php`**: I updated the `while` loops. Now they first collect all the IDs in an array, run one single batch query, and use `isset` with a mapper (`array_flip`) to filter the results cleanly.
- **`common-folders.php`**: I applied the same batching logic for the `Auth::PERM_READ` checks. I also made sure that the `Auth::PERM_WRITE` checks still use the old `isEditable()` line-by-line check, so nothing breaks for folder owners.

## How to test

1. Login to the UI and go to the **Browse** menu. Try to navigate inside a folder that has hundreds of files. It should load much faster without lagging the DB.
2. Go to the **Search** menu and search for a common file. It should process the search results properly.
3. Finally, please verify that you are only able to see the files and folders that your specific user group has permission to see.

