### PR TITLE
fix(ununpack): prevent floating point exception in IsInflatedFile 

### DIFF
--- a/src/ununpack/agent/utils.c
+++ b/src/ununpack/agent/utils.c
@@ -58,9 +58,16 @@ int IsInflatedFile(char *FileName, int InflateSize)
          e.g. for the file ./10g.tar.bz.dir/10g.tar, partent file is ./10g.tar.bz
        */
       FileNameParent[strlen(FileNameParent) - 4] = '\0';
-      stat(FileNameParent, &stParent);
-      stat(FileName, &st);
-      if(S_ISREG(stParent.st_mode) && (st.st_size/stParent.st_size > InflateSize))
+
+      /* Ensure parent and child files exist and can be stated */
+      if (stat(FileNameParent, &stParent) != 0 || stat(FileName, &st) != 0)
+      {
+        return 0;
+      }
+
+      /* Guard against division by zero */
+      if(S_ISREG(stParent.st_mode) && stParent.st_size > 0 && 
+         (st.st_size/stParent.st_size > InflateSize))
       {
         result = 1;
       }


### PR DESCRIPTION
### Description
This pull request fixes a Signal 8 (Floating Point Exception) crash in the `ununpack` agent. The crash was caused by a division-by-zero error in the `IsInflatedFile` function, which occurred when processing archives with 0-byte parent files.

### Changes

- **Added Division-by-Zero Guard**: Updated `IsInflatedFile` in `utils.c` to ensure the parent file size is greater than 0 before performing division.
- **Added Return Checks for `stat()`**: The code now verifies that `stat()` calls are successful before using file metadata. If a file is missing or inaccessible, the function returns safely instead of using garbage data and crashing.

### How to test
I have verified this fix through both automated script testing and manual UI testing:
1.  **Reproduction Script**: 
    I wrote a standalone C script (`test_issue_2684.c`) that manually creates a 0-byte file structure to trigger the bug.
    *   **Before fix**: The original logic triggers a `Floating point exception`.
    *   **After fix**: The new logic handles the situation safely without crashing.
    
[test_issue_2684.c](https://github.com/user-attachments/files/26886776/test_issue_2684.c)

2.  **FOSSology UI Testing**:
    *   **Uploaded a test archive** containing a 0-byte file component.
    *   Observed that the `ununpack` job now moves to "Completed" status instead of crashing mid-process.
   
- **Before Fix :** 

<img width="1855" height="1079" alt="Screenshot from 2026-04-19 22-51-45" src="https://github.com/user-attachments/assets/0d6c896f-5e25-4944-97fc-b5e8549036c3" />

<img width="1855" height="1079" alt="Screenshot from 2026-04-19 22-51-54" src="https://github.com/user-attachments/assets/115efb74-f3a9-414f-9abf-42c358d0eba2" />

- **After Fix :**

<img width="1855" height="1079" alt="Screenshot from 2026-04-19 23-50-19" src="https://github.com/user-attachments/assets/6794b174-0535-4bce-a5f4-e8a019b5605a" />

<img width="1855" height="1079" alt="Screenshot from 2026-04-19 23-50-40" src="https://github.com/user-attachments/assets/eb67ae63-78a9-4c86-b1ab-d886297a4119" />


Closes #2684 