### PR TITLE
perf(dao): optimize job filtering using hash-map

### DIFF
--- a/src/lib/php/Dao/ShowJobsDao.php
+++ b/src/lib/php/Dao/ShowJobsDao.php
@@ -141,10 +141,11 @@ class ShowJobsDao
     $this->dbManager->freeResult($result);
 
     $accessibleUploads = $this->uploadDao->filterAccessibleUploads(array_unique($uploadIds), Auth::getGroupId());
+    $accessibleMap = array_flip($accessibleUploads);
 
     foreach ($rows as $row) {
       if (!empty($row['job_upload_fk'])) {
-        if (!in_array(intval($row['job_upload_fk']), $accessibleUploads)) {
+        if (!isset($accessibleMap[intval($row['job_upload_fk'])])) {
           continue;
         }
       }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The current code uses `in_array()` inside a loop, which is fine for small data but it's not very efficient for large datasets since it has to scan the whole list every single time. 

In this PR, I have updated the logic to use a hash-map approach. This moves the performance from a nested O(N*M) search to a much simpler O(N+M) lookup.

### Changes

- **`ShowJobsDao.php`**: I've added `array_flip()` to convert the accessible uploads list into a hash-map. Then, I replaced the iterative `in_array()` check with a direct `isset()` check inside the loop. This ensures that the permission filtering happens in constant time (O(1)) for each job record.

## How to test

1. Go to the dashboard and click on **My Recent Jobs**.
2. Check and make sure that all the jobs you expect to see are still showing up correctly.
3. If you have an account with a lot of job history, you should notice that the page is loading more smoothly now.
