### PR TITLE
fix(reportimport): patch easyrdf for PHP 8.4 compatibility

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -92,6 +92,12 @@
         "license"
     ],
     "scripts": {
+        "post-install-cmd": [
+            "patch -d vendor/easyrdf/easyrdf -N -p1 < patches/easyrdf-php84-xml-parser-fix.patch || true"
+        ],
+        "post-update-cmd": [
+            "patch -d vendor/easyrdf/easyrdf -N -p1 < patches/easyrdf-php84-xml-parser-fix.patch || true"
+        ],
         "phpcs": "phpcs --standard=fossy-ruleset.xml -p",
         "phpcbf": "phpcbf --standard=fossy-ruleset.xml -p"
     }

--- a/src/patches/easyrdf-php84-xml-parser-fix.patch
+++ b/src/patches/easyrdf-php84-xml-parser-fix.patch
@@ -1,0 +1,18 @@
+--- a/lib/Parser/RdfXml.php
++++ b/lib/Parser/RdfXml.php
+@@ -87,11 +87,11 @@
+     /** @ignore */
+     protected function initXMLParser()
+     {
+         if (!isset($this->xmlParser)) {
+             $parser = xml_parser_create_ns('UTF-8', '');
+             xml_parser_set_option($parser, XML_OPTION_SKIP_WHITE, 0);
+             xml_parser_set_option($parser, XML_OPTION_CASE_FOLDING, 0);
++            xml_set_object($parser, $this);
+             xml_set_element_handler($parser, 'startElementHandler', 'endElementHandler');
+             xml_set_character_data_handler($parser, 'cdataHandler');
+             xml_set_start_namespace_decl_handler($parser, 'newNamespaceHandler');
+-            xml_set_object($parser, $this);
+             $this->xmlParser = $parser;
+         }
+     }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

    SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fix `reportImport` agent crashing on PHP 8.4 with a `ValueError` in `easyrdf/easyrdf` v1.1.1. PHP 8.4 requires `xml_set_object()` to be called **before** `xml_set_element_handler()` when using string method names, but the library calls it after.

### Changes

- Added `src/patches/easyrdf-php84-xml-parser-fix.patch` that moves the `xml_set_object()` call before the XML handler registrations in `lib/Parser/RdfXml.php`. This mirrors the upstream fix from [easyrdf/easyrdf PR #414](https://github.com/easyrdf/easyrdf/pull/414).
- Updated `src/composer.json` with `post-install-cmd` and `post-update-cmd` scripts to automatically apply the patch after `composer install` or `composer update`.

## How to test

1. Run `composer install` in the `src/` directory — the patch should apply automatically.
2. Trigger a `reportImport` job on a system running PHP 8.4 (e.g., Debian Trixie with PHP 8.4.16).
3. Verify the job completes without the `xml_set_element_handler()` `ValueError`.

Closes #3584

