### PR TITLE
feat(bulk): add functionality to delete a wrong bulk scan from history

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -840,6 +840,113 @@ INSERT INTO clearing_decision (
   }
 
   /**
+   * Check if user can delete a kotoba entry
+   * @param string $reportinfo
+   * @param int $userId
+   * @param int $groupId
+   * @return bool
+   */
+  public function canUserDeleteKotobaEntry($reportinfo, $userId, $groupId)
+  {
+    $stmt = __METHOD__;
+    $sql = "SELECT user_fk, group_fk FROM clearing_event WHERE type_fk = " . ClearingEventTypes::KOTOBA . "
+            AND reportinfo = $1 AND group_fk = $2 LIMIT 1";
+    $this->dbManager->prepare($stmt, $sql);
+    $res = $this->dbManager->execute($stmt, array($reportinfo, $groupId));
+    $row = $this->dbManager->fetchArray($res);
+    $this->dbManager->freeResult($res);
+    if (!$row) {
+      return false;
+    }
+    return $row['user_fk'] == $userId || $row['group_fk'] == $groupId;
+  }
+
+  /**
+   * Delete a kotoba history entry and all related data
+   * @param string $reportinfo
+   * @param int $groupId
+   * @throws \Exception
+   */
+  public function deleteKotobaEntry($reportinfo, $groupId)
+  {
+    if (empty($reportinfo)) {
+      throw new \InvalidArgumentException('Invalid reportinfo provided');
+    }
+    $this->dbManager->begin();
+    try {
+      $clearingEventIds = array();
+      $jobIds = array();
+      $stmt = __METHOD__ . ".get_kotoba_events";
+      $sql  = "SELECT clearing_event_pk, job_fk FROM clearing_event WHERE type_fk = " . ClearingEventTypes::KOTOBA . "
+               AND reportinfo = $1 AND group_fk = $2";
+      $this->dbManager->prepare($stmt, $sql);
+      $res  = $this->dbManager->execute($stmt, array($reportinfo, $groupId));
+      while ($row = $this->dbManager->fetchArray($res)) {
+        $clearingEventIds[] = $row['clearing_event_pk'];
+        if (!empty($row['job_fk'])) {
+          $jobIds[] = $row['job_fk'];
+        }
+      }
+      $this->dbManager->freeResult($res);
+
+      if (empty($clearingEventIds)) {
+        $this->dbManager->commit();
+        return;
+      }
+
+      $eventIdArray = '{' . implode(',', $clearingEventIds) . '}';
+
+      $stmt = __METHOD__ . ".delete_kotoba_highlights";
+      $sql  = "DELETE FROM highlight_kotoba WHERE clearing_event_fk = ANY($1)";
+      $this->dbManager->prepare($stmt, $sql);
+      $this->dbManager->execute($stmt, array($eventIdArray));
+
+      $affectedDecisionIds = array();
+      $stmt = __METHOD__ . ".find_affected_decisions";
+      $sql  = "SELECT DISTINCT clearing_decision_fk FROM clearing_decision_event WHERE clearing_event_fk = ANY($1)";
+      $this->dbManager->prepare($stmt, $sql);
+      $res = $this->dbManager->execute($stmt, array($eventIdArray));
+      while ($row = $this->dbManager->fetchArray($res)) {
+        $affectedDecisionIds[] = $row['clearing_decision_fk'];
+      }
+      $this->dbManager->freeResult($res);
+
+      $stmt = __METHOD__ . ".delete_decision_events";
+      $sql  = "DELETE FROM clearing_decision_event WHERE clearing_event_fk = ANY($1)";
+      $this->dbManager->prepare($stmt, $sql);
+      $this->dbManager->execute($stmt, array($eventIdArray));
+
+      $stmt = __METHOD__ . ".delete_clearing_events";
+      $sql  = "DELETE FROM clearing_event WHERE clearing_event_pk = ANY($1)";
+      $this->dbManager->prepare($stmt, $sql);
+      $this->dbManager->execute($stmt, array($eventIdArray));
+
+      if (!empty($affectedDecisionIds)) {
+        $decisionArray = '{' . implode(',', $affectedDecisionIds) . '}';
+        $stmt = __METHOD__ . ".reset_decisions_to_wip";
+        $sql  = "UPDATE clearing_decision SET decision_type = 0 WHERE clearing_decision_pk = ANY($1)";
+        $this->dbManager->prepare($stmt, $sql);
+        $this->dbManager->execute($stmt, array($decisionArray));
+      }
+
+      if (!empty($jobIds)) {
+        $jobIdArray = '{' . implode(',', array_unique($jobIds)) . '}';
+        $stmt = __METHOD__ . ".delete_deciderjob_entries";
+        $sql  = "DELETE FROM jobqueue WHERE jq_type = 'deciderjob' AND jq_job_fk = ANY($1)";
+        $this->dbManager->prepare($stmt, $sql);
+        $this->dbManager->execute($stmt, array($jobIdArray));
+      }
+
+      $this->dbManager->commit();
+      $this->logger->debug("Successfully deleted kotoba entry '$reportinfo': " . count($clearingEventIds) . " clearing events removed, " . count($affectedDecisionIds) . " decisions reset to WIP");
+    } catch (\Exception $e) {
+      $this->dbManager->rollback();
+      $this->logger->error("Failed to delete kotoba entry '$reportinfo': " . $e->getMessage());
+      throw $e;
+    }
+  }
+
+  /**
    * @param ItemTreeBounds $itemTreeBounds
    * @param int $groupId
    * @return array mapping 'shortname'=>'count'
@@ -877,6 +984,120 @@ INSERT INTO clearing_decision (
     $this->dbManager->freeResult($res);
 
     return $multiplicity;
+  }
+
+  /**
+   * Check if user can delete the bulk entry
+   * @param int $bulkId
+   * @param int $userId
+   * @param int $groupId
+   * @return bool
+   */
+  public function canUserDeleteBulkEntry($bulkId, $userId, $groupId)
+  {
+    $stmt = __METHOD__;
+    $sql = "SELECT user_fk, group_fk FROM license_ref_bulk WHERE lrb_pk = $1";
+    $this->dbManager->prepare($stmt, $sql);
+    $res = $this->dbManager->execute($stmt, array($bulkId));
+    $row = $this->dbManager->fetchArray($res);
+    $this->dbManager->freeResult($res);
+    if (!$row) {
+      return false;
+    }
+
+    return $row['user_fk'] == $userId || $row['group_fk'] == $groupId;
+  }
+
+  /**
+   * Delete a bulk history entry and all related data
+   * @param int $bulkId
+   * @param int $groupId
+   * @throws \Exception
+   */
+  public function deleteBulkEntry($bulkId, $groupId)
+  {
+    if (empty($bulkId) || !is_numeric($bulkId)) {
+      throw new \InvalidArgumentException('Invalid bulk ID provided');
+    }
+    $this->dbManager->begin();
+    try {
+      $clearingEventIds = array();
+      $affectedDecisionIds = array();
+      $stmt = __METHOD__ . ".get_clearing_events";
+      $sql  = "SELECT clearing_event_fk FROM highlight_bulk WHERE lrb_fk = $1";
+      $this->dbManager->prepare($stmt, $sql);
+      $res  = $this->dbManager->execute($stmt, array($bulkId));
+      while ($row = $this->dbManager->fetchArray($res)) {
+        $clearingEventIds[] = $row['clearing_event_fk'];
+      }
+      $this->dbManager->freeResult($res);
+
+      if (!empty($clearingEventIds)) {
+        $eventIdArray = '{' . implode(',', $clearingEventIds) . '}';
+        $stmt = __METHOD__ . ".find_affected_decisions";
+        $sql  = "SELECT DISTINCT clearing_decision_fk FROM clearing_decision_event WHERE clearing_event_fk = ANY($1)";
+        $this->dbManager->prepare($stmt, $sql);
+        $res = $this->dbManager->execute($stmt, array($eventIdArray));
+        while ($row = $this->dbManager->fetchArray($res)) {
+          $affectedDecisionIds[] = $row['clearing_decision_fk'];
+        }
+        $this->dbManager->freeResult($res);
+
+        $stmt = __METHOD__ . ".delete_decision_events";
+        $sql  = "DELETE FROM clearing_decision_event WHERE clearing_event_fk = ANY($1)";
+        $this->dbManager->prepare($stmt, $sql);
+        $this->dbManager->execute($stmt, array($eventIdArray));
+
+        $stmt = __METHOD__ . ".delete_clearing_events";
+        $sql  = "DELETE FROM clearing_event WHERE clearing_event_pk = ANY($1)";
+        $this->dbManager->prepare($stmt, $sql);
+        $this->dbManager->execute($stmt, array($eventIdArray));
+        if (!empty($affectedDecisionIds)) {
+          $decisionArray = '{' . implode(',', $affectedDecisionIds) . '}';
+          $stmt = __METHOD__ . ".reset_decisions_to_wip";
+          $sql  = "UPDATE clearing_decision SET decision_type = 0 WHERE clearing_decision_pk = ANY($1)";
+          $this->dbManager->prepare($stmt, $sql);
+          $this->dbManager->execute($stmt, array($decisionArray));
+        }
+      }
+
+      $stmt = __METHOD__ . ".delete_highlights";
+      $sql  = "DELETE FROM highlight_bulk WHERE lrb_fk = $1";
+      $this->dbManager->prepare($stmt, $sql);
+      $this->dbManager->execute($stmt, array($bulkId));
+
+      $stmt = __METHOD__ . ".find_job_for_bulk";
+      $sql  = "SELECT jq_job_fk FROM jobqueue WHERE jq_type = 'monkbulk' AND jq_args = $1 LIMIT 1";
+      $this->dbManager->prepare($stmt, $sql);
+      $res  = $this->dbManager->execute($stmt, array((string)$bulkId));
+      $row = $this->dbManager->fetchArray($res);
+      $this->dbManager->freeResult($res);
+      $jobId = $row ? $row['jq_job_fk'] : null;
+
+      if (!empty($jobId)) {
+        $stmt = __METHOD__ . ".delete_deciderjob_entries";
+        $sql  = "DELETE FROM jobqueue WHERE jq_type = 'deciderjob' AND jq_job_fk = $1";
+        $this->dbManager->prepare($stmt, $sql);
+        $this->dbManager->execute($stmt, array($jobId));
+      }
+
+      $stmt = __METHOD__ . ".delete_monkbulk_entries";
+      $sql  = "DELETE FROM jobqueue WHERE jq_type = 'monkbulk' AND jq_args = $1";
+      $this->dbManager->prepare($stmt, $sql);
+      $this->dbManager->execute($stmt, array((string)$bulkId));
+
+      $stmt = __METHOD__ . ".delete_bulk";
+      $sql  = "DELETE FROM license_ref_bulk WHERE lrb_pk = $1 AND group_fk = $2";
+      $this->dbManager->prepare($stmt, $sql);
+      $this->dbManager->execute($stmt, array($bulkId, $groupId));
+
+      $this->dbManager->commit();
+      $this->logger->debug("Successfully deleted bulk entry $bulkId: " . count($clearingEventIds) . " clearing events removed, " . count($affectedDecisionIds) . " decisions reset to WIP");
+    } catch (\Exception $e) {
+      $this->dbManager->rollback();
+      $this->logger->error("Failed to delete bulk entry $bulkId: " . $e->getMessage());
+      throw $e;
+    }
   }
 
   /**

--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -26,6 +26,12 @@ use Monolog\Logger;
 
 class ClearingDao
 {
+  /**
+   * Deletion window (in seconds) within which a bulk/kotoba history entry
+   * can be deleted after it was created.
+   */
+  const DELETION_WINDOW_SECONDS = 3600;
+
   /** @var DbManager */
   private $dbManager;
   /** @var Logger */
@@ -49,6 +55,23 @@ class ClearingDao
     $this->licenseRefCache = array();
     global $container;
     $this->copyrightDao = $container->get('dao.copyright');
+  }
+
+  /**
+   * Check whether the given creation date is still within the deletion window.
+   * @param string|null $dateAdded date_added column value (timestamptz) or null
+   * @return bool
+   */
+  private function isWithinDeletionWindow($dateAdded)
+  {
+    if ($dateAdded === null || $dateAdded === '') {
+      return true;
+    }
+    $created = strtotime($dateAdded);
+    if ($created === false) {
+      return true;
+    }
+    return (time() - $created) <= self::DELETION_WINDOW_SECONDS;
   }
 
   private function getRelevantDecisionsCte(ItemTreeBounds $itemTreeBounds, $groupId, $onlyCurrent, &$statementName, &$params, $condition="")
@@ -680,12 +703,22 @@ INSERT INTO clearing_decision (
               SELECT DISTINCT ON(lrb_pk) lrb_pk, ce_pk, tried, true AS matched FROM alltried WHERE uploadtree_fk = $2
               UNION ALL
               SELECT DISTINCT ON(lrb_pk) lrb_pk, ce_pk, tried, false AS matched FROM alltried WHERE uploadtree_fk != $2 OR uploadtree_fk IS NULL
-            ) AS result ORDER BY lrb_pk, matched DESC)
-            SELECT a.lrb_pk, lr.rf_text AS text, lrf.rf_shortname, lsb.removing, a.tried, a.ce_pk, a.matched
+            ) AS result ORDER BY lrb_pk, matched DESC),
+            bulk_dates AS (
+            SELECT lrb.lrb_pk, MIN(ce.date_added) AS date_added
+            FROM license_ref_bulk lrb
+              INNER JOIN highlight_bulk h ON h.lrb_fk = lrb.lrb_pk
+              INNER JOIN clearing_event ce ON ce.clearing_event_pk = h.clearing_event_fk
+              INNER JOIN $uploadTreeTableName ut ON ut.uploadtree_pk = ce.uploadtree_fk
+            WHERE lrb.group_fk = $4 AND ut.upload_fk = $1
+            GROUP BY lrb.lrb_pk)
+            SELECT a.lrb_pk, lr.rf_text AS text, lrf.rf_shortname, lsb.removing, a.tried, a.ce_pk, a.matched,
+                   EXTRACT(EPOCH FROM bd.date_added)::bigint AS date_added
             FROM aggregated_tried a
               INNER JOIN license_set_bulk lsb ON lsb.lrb_fk = a.lrb_pk
               INNER JOIN license_ref lrf ON lsb.rf_fk = lrf.rf_pk
               INNER JOIN license_ref_bulk lr ON lr.lrb_pk = a.lrb_pk
+              LEFT JOIN bulk_dates bd ON bd.lrb_pk = a.lrb_pk
             ORDER BY a.lrb_pk";
 
     $this->dbManager->prepare($stmt, $sql);
@@ -701,6 +734,7 @@ INSERT INTO clearing_decision (
             "text" => $row['text'],
             "matched" => $this->dbManager->booleanFromDb($row['matched']),
             "tried" => $this->dbManager->booleanFromDb($row['tried']),
+            "dateAdded" => $row['date_added'],
             "removedLicenses" => array(),
             "addedLicenses" => array());
       }
@@ -802,12 +836,21 @@ INSERT INTO clearing_decision (
               SELECT DISTINCT ON(cp_fk) cp_fk, ce_pk, tried, true AS matched FROM alltried WHERE uploadtree_fk = $2
               UNION ALL
               SELECT DISTINCT ON(cp_fk) cp_fk, ce_pk, tried, false AS matched FROM alltried WHERE uploadtree_fk != $2 OR uploadtree_fk IS NULL
-            ) AS result ORDER BY cp_fk, matched DESC)
-            SELECT a.cp_fk, cp.text, lrf.rf_shortname, cplm.removing, a.tried, a.ce_pk, a.matched
+            ) AS result ORDER BY cp_fk, matched DESC),
+            phrase_dates AS (
+            SELECT h.cp_fk, MIN(ce.date_added) AS date_added
+            FROM clearing_event ce
+              INNER JOIN highlight_kotoba h ON h.clearing_event_fk = ce.clearing_event_pk
+              INNER JOIN $uploadTreeTableName ut ON ut.uploadtree_pk = ce.uploadtree_fk
+            WHERE ce.type_fk = $kotobaType AND ce.group_fk = $5 AND ut.upload_fk = $1
+            GROUP BY h.cp_fk)
+            SELECT a.cp_fk, cp.text, lrf.rf_shortname, cplm.removing, a.tried, a.ce_pk, a.matched,
+                   EXTRACT(EPOCH FROM pd.date_added)::bigint AS date_added
             FROM aggregated_tried a
               INNER JOIN custom_phrase cp ON cp.cp_pk = a.cp_fk
               INNER JOIN custom_phrase_license_map cplm ON cplm.cp_fk = a.cp_fk
               INNER JOIN license_ref lrf ON cplm.rf_fk = lrf.rf_pk
+              LEFT JOIN phrase_dates pd ON pd.cp_fk = a.cp_fk
             ORDER BY a.cp_fk";
 
     $this->dbManager->prepare($stmt, $sql);
@@ -824,6 +867,7 @@ INSERT INTO clearing_decision (
             "text" => $row['text'],
             "matched" => $this->dbManager->booleanFromDb($row['matched']),
             "tried" => $this->dbManager->booleanFromDb($row['tried']),
+            "dateAdded" => $row['date_added'],
             "removedLicenses" => array(),
             "addedLicenses" => array());
       }
@@ -835,6 +879,136 @@ INSERT INTO clearing_decision (
 
     $this->dbManager->freeResult($res);
     return $phrases;
+  }
+
+  /**
+   * Check if user can delete a kotoba entry
+   * @param int $cpFk custom_phrase primary key
+   * @param int $userId
+   * @param int $groupId
+   * @return bool
+   */
+  public function canUserDeleteKotobaEntry($cpFk, $userId, $groupId)
+  {
+    $stmt = __METHOD__;
+    $kotobaType = ClearingEventTypes::KOTOBA;
+    $sql = "SELECT ce.user_fk, ce.group_fk, MIN(ce.date_added) AS date_added
+            FROM clearing_event ce
+            INNER JOIN highlight_kotoba hk ON hk.clearing_event_fk = ce.clearing_event_pk
+            WHERE ce.type_fk = $3 AND hk.cp_fk = $1 AND ce.group_fk = $2
+            GROUP BY ce.user_fk, ce.group_fk LIMIT 1";
+    $this->dbManager->prepare($stmt, $sql);
+    $res = $this->dbManager->execute($stmt, array($cpFk, $groupId, $kotobaType));
+    $row = $this->dbManager->fetchArray($res);
+    $this->dbManager->freeResult($res);
+    if (!$row) {
+      return false;
+    }
+    if (!$this->isWithinDeletionWindow($row['date_added'])) {
+      return false;
+    }
+    return $row['user_fk'] == $userId || $row['group_fk'] == $groupId;
+  }
+
+  /**
+   * Delete a kotoba history entry and all related data
+   * @param int $cpFk custom_phrase primary key
+   * @param int $groupId
+   * @throws \Exception
+   */
+  public function deleteKotobaEntry($cpFk, $groupId)
+  {
+    if (empty($cpFk) || !is_numeric($cpFk)) {
+      throw new \InvalidArgumentException('Invalid custom phrase ID provided');
+    }
+    $this->dbManager->begin();
+    try {
+      $clearingEventIds = array();
+      $jobIds = array();
+      $kotobaType = ClearingEventTypes::KOTOBA;
+
+      $stmt = __METHOD__ . ".get_kotoba_creation_date";
+      $sql  = "SELECT MIN(ce.date_added) AS date_added
+               FROM clearing_event ce
+                 INNER JOIN highlight_kotoba hk ON hk.clearing_event_fk = ce.clearing_event_pk
+               WHERE ce.type_fk = $3 AND hk.cp_fk = $1 AND ce.group_fk = $2";
+      $this->dbManager->prepare($stmt, $sql);
+      $res = $this->dbManager->execute($stmt, array($cpFk, $groupId, $kotobaType));
+      $dateRow = $this->dbManager->fetchArray($res);
+      $this->dbManager->freeResult($res);
+      if ($dateRow && !$this->isWithinDeletionWindow($dateRow['date_added'])) {
+        throw new \RuntimeException('This entry can only be deleted within one hour of creation');
+      }
+
+      $stmt = __METHOD__ . ".get_kotoba_events";
+      $sql  = "SELECT ce.clearing_event_pk, ce.job_fk FROM clearing_event ce
+               INNER JOIN highlight_kotoba hk ON hk.clearing_event_fk = ce.clearing_event_pk
+               WHERE ce.type_fk = $3 AND hk.cp_fk = $1 AND ce.group_fk = $2";
+      $this->dbManager->prepare($stmt, $sql);
+      $res  = $this->dbManager->execute($stmt, array($cpFk, $groupId, $kotobaType));
+      while ($row = $this->dbManager->fetchArray($res)) {
+        $clearingEventIds[] = $row['clearing_event_pk'];
+        if (!empty($row['job_fk'])) {
+          $jobIds[] = $row['job_fk'];
+        }
+      }
+      $this->dbManager->freeResult($res);
+
+      if (empty($clearingEventIds)) {
+        $this->dbManager->commit();
+        return;
+      }
+
+      $eventIdArray = '{' . implode(',', $clearingEventIds) . '}';
+
+      $stmt = __METHOD__ . ".delete_kotoba_highlights";
+      $sql  = "DELETE FROM highlight_kotoba WHERE clearing_event_fk = ANY($1)";
+      $this->dbManager->prepare($stmt, $sql);
+      $this->dbManager->execute($stmt, array($eventIdArray));
+
+      $affectedDecisionIds = array();
+      $stmt = __METHOD__ . ".find_affected_decisions";
+      $sql  = "SELECT DISTINCT clearing_decision_fk FROM clearing_decision_event WHERE clearing_event_fk = ANY($1)";
+      $this->dbManager->prepare($stmt, $sql);
+      $res = $this->dbManager->execute($stmt, array($eventIdArray));
+      while ($row = $this->dbManager->fetchArray($res)) {
+        $affectedDecisionIds[] = $row['clearing_decision_fk'];
+      }
+      $this->dbManager->freeResult($res);
+
+      $stmt = __METHOD__ . ".delete_decision_events";
+      $sql  = "DELETE FROM clearing_decision_event WHERE clearing_event_fk = ANY($1)";
+      $this->dbManager->prepare($stmt, $sql);
+      $this->dbManager->execute($stmt, array($eventIdArray));
+
+      $stmt = __METHOD__ . ".delete_clearing_events";
+      $sql  = "DELETE FROM clearing_event WHERE clearing_event_pk = ANY($1)";
+      $this->dbManager->prepare($stmt, $sql);
+      $this->dbManager->execute($stmt, array($eventIdArray));
+
+      if (!empty($affectedDecisionIds)) {
+        $decisionArray = '{' . implode(',', $affectedDecisionIds) . '}';
+        $stmt = __METHOD__ . ".reset_decisions_to_wip";
+        $sql  = "UPDATE clearing_decision SET decision_type = 0 WHERE clearing_decision_pk = ANY($1)";
+        $this->dbManager->prepare($stmt, $sql);
+        $this->dbManager->execute($stmt, array($decisionArray));
+      }
+
+      if (!empty($jobIds)) {
+        $jobIdArray = '{' . implode(',', array_unique($jobIds)) . '}';
+        $stmt = __METHOD__ . ".delete_deciderjob_entries";
+        $sql  = "DELETE FROM jobqueue WHERE jq_type = 'deciderjob' AND jq_job_fk = ANY($1)";
+        $this->dbManager->prepare($stmt, $sql);
+        $this->dbManager->execute($stmt, array($jobIdArray));
+      }
+
+      $this->dbManager->commit();
+      $this->logger->debug("Successfully deleted kotoba entry cp_fk=$cpFk: " . count($clearingEventIds) . " clearing events removed, " . count($affectedDecisionIds) . " decisions reset to WIP");
+    } catch (\Exception $e) {
+      $this->dbManager->rollback();
+      $this->logger->error("Failed to delete kotoba entry cp_fk=$cpFk: " . $e->getMessage());
+      throw $e;
+    }
   }
 
   /**
@@ -875,6 +1049,146 @@ INSERT INTO clearing_decision (
     $this->dbManager->freeResult($res);
 
     return $multiplicity;
+  }
+
+  /**
+   * Check if user can delete the bulk entry
+   * @param int $bulkId
+   * @param int $userId
+   * @param int $groupId
+   * @return bool
+   */
+  public function canUserDeleteBulkEntry($bulkId, $userId, $groupId)
+  {
+    $stmt = __METHOD__;
+    $sql = "SELECT lrb.user_fk, lrb.group_fk, MIN(ce.date_added) AS date_added
+            FROM license_ref_bulk lrb
+              LEFT JOIN highlight_bulk h ON h.lrb_fk = lrb.lrb_pk
+              LEFT JOIN clearing_event ce ON ce.clearing_event_pk = h.clearing_event_fk
+            WHERE lrb.lrb_pk = $1
+            GROUP BY lrb.user_fk, lrb.group_fk";
+    $this->dbManager->prepare($stmt, $sql);
+    $res = $this->dbManager->execute($stmt, array($bulkId));
+    $row = $this->dbManager->fetchArray($res);
+    $this->dbManager->freeResult($res);
+    if (!$row) {
+      return false;
+    }
+    if (!$this->isWithinDeletionWindow($row['date_added'])) {
+      return false;
+    }
+
+    return $row['user_fk'] == $userId || $row['group_fk'] == $groupId;
+  }
+
+  /**
+   * Delete a bulk history entry and all related data
+   * @param int $bulkId
+   * @param int $groupId
+   * @throws \Exception
+   */
+  public function deleteBulkEntry($bulkId, $groupId)
+  {
+    if (empty($bulkId) || !is_numeric($bulkId)) {
+      throw new \InvalidArgumentException('Invalid bulk ID provided');
+    }
+    $this->dbManager->begin();
+    try {
+      $bulkCreationDate = null;
+      $stmt = __METHOD__ . ".get_bulk_creation_date";
+      $sql  = "SELECT MIN(ce.date_added) AS date_added
+               FROM license_ref_bulk lrb
+                 INNER JOIN highlight_bulk h ON h.lrb_fk = lrb.lrb_pk
+                 INNER JOIN clearing_event ce ON ce.clearing_event_pk = h.clearing_event_fk
+               WHERE lrb.lrb_pk = $1 AND lrb.group_fk = $2";
+      $this->dbManager->prepare($stmt, $sql);
+      $res = $this->dbManager->execute($stmt, array($bulkId, $groupId));
+      $dateRow = $this->dbManager->fetchArray($res);
+      $this->dbManager->freeResult($res);
+      if ($dateRow) {
+        $bulkCreationDate = $dateRow['date_added'];
+      }
+      if (!$this->isWithinDeletionWindow($bulkCreationDate)) {
+        throw new \RuntimeException('This entry can only be deleted within one hour of creation');
+      }
+
+      $clearingEventIds = array();
+      $affectedDecisionIds = array();
+      $stmt = __METHOD__ . ".get_clearing_events";
+      $sql  = "SELECT clearing_event_fk FROM highlight_bulk WHERE lrb_fk = $1";
+      $this->dbManager->prepare($stmt, $sql);
+      $res  = $this->dbManager->execute($stmt, array($bulkId));
+      while ($row = $this->dbManager->fetchArray($res)) {
+        $clearingEventIds[] = $row['clearing_event_fk'];
+      }
+      $this->dbManager->freeResult($res);
+
+      if (!empty($clearingEventIds)) {
+        $eventIdArray = '{' . implode(',', $clearingEventIds) . '}';
+        $stmt = __METHOD__ . ".find_affected_decisions";
+        $sql  = "SELECT DISTINCT clearing_decision_fk FROM clearing_decision_event WHERE clearing_event_fk = ANY($1)";
+        $this->dbManager->prepare($stmt, $sql);
+        $res = $this->dbManager->execute($stmt, array($eventIdArray));
+        while ($row = $this->dbManager->fetchArray($res)) {
+          $affectedDecisionIds[] = $row['clearing_decision_fk'];
+        }
+        $this->dbManager->freeResult($res);
+
+        $stmt = __METHOD__ . ".delete_decision_events";
+        $sql  = "DELETE FROM clearing_decision_event WHERE clearing_event_fk = ANY($1)";
+        $this->dbManager->prepare($stmt, $sql);
+        $this->dbManager->execute($stmt, array($eventIdArray));
+
+        $stmt = __METHOD__ . ".delete_clearing_events";
+        $sql  = "DELETE FROM clearing_event WHERE clearing_event_pk = ANY($1)";
+        $this->dbManager->prepare($stmt, $sql);
+        $this->dbManager->execute($stmt, array($eventIdArray));
+        if (!empty($affectedDecisionIds)) {
+          $decisionArray = '{' . implode(',', $affectedDecisionIds) . '}';
+          $stmt = __METHOD__ . ".reset_decisions_to_wip";
+          $sql  = "UPDATE clearing_decision SET decision_type = 0 WHERE clearing_decision_pk = ANY($1)";
+          $this->dbManager->prepare($stmt, $sql);
+          $this->dbManager->execute($stmt, array($decisionArray));
+        }
+      }
+
+      $stmt = __METHOD__ . ".delete_highlights";
+      $sql  = "DELETE FROM highlight_bulk WHERE lrb_fk = $1";
+      $this->dbManager->prepare($stmt, $sql);
+      $this->dbManager->execute($stmt, array($bulkId));
+
+      $stmt = __METHOD__ . ".find_job_for_bulk";
+      $sql  = "SELECT jq_job_fk FROM jobqueue WHERE jq_type = 'monkbulk' AND jq_args = $1 LIMIT 1";
+      $this->dbManager->prepare($stmt, $sql);
+      $res  = $this->dbManager->execute($stmt, array((string)$bulkId));
+      $row = $this->dbManager->fetchArray($res);
+      $this->dbManager->freeResult($res);
+      $jobId = $row ? $row['jq_job_fk'] : null;
+
+      if (!empty($jobId)) {
+        $stmt = __METHOD__ . ".delete_deciderjob_entries";
+        $sql  = "DELETE FROM jobqueue WHERE jq_type = 'deciderjob' AND jq_job_fk = $1";
+        $this->dbManager->prepare($stmt, $sql);
+        $this->dbManager->execute($stmt, array($jobId));
+      }
+
+      $stmt = __METHOD__ . ".delete_monkbulk_entries";
+      $sql  = "DELETE FROM jobqueue WHERE jq_type = 'monkbulk' AND jq_args = $1";
+      $this->dbManager->prepare($stmt, $sql);
+      $this->dbManager->execute($stmt, array((string)$bulkId));
+
+      $stmt = __METHOD__ . ".delete_bulk";
+      $sql  = "DELETE FROM license_ref_bulk WHERE lrb_pk = $1 AND group_fk = $2";
+      $this->dbManager->prepare($stmt, $sql);
+      $this->dbManager->execute($stmt, array($bulkId, $groupId));
+
+      $this->dbManager->commit();
+      $this->logger->debug("Successfully deleted bulk entry $bulkId: " . count($clearingEventIds) . " clearing events removed, " . count($affectedDecisionIds) . " decisions reset to WIP");
+    } catch (\Exception $e) {
+      $this->dbManager->rollback();
+      $this->logger->error("Failed to delete bulk entry $bulkId: " . $e->getMessage());
+      throw $e;
+    }
   }
 
   /**

--- a/src/monk/agent/kotoba.c
+++ b/src/monk/agent/kotoba.c
@@ -205,11 +205,9 @@ int phrase_onAllMatches(MonkState* state, const File* file, const GArray* matche
       if (clearingEventId <= 0)
         continue;
 
-      if (k == 0) {
-        if (!saveKotobaHighlights(state, file, matches, clearingEventId, phrase->cpId)) {
-          fo_dbManager_rollback(state->dbManager);
-          return 0;
-        }
+      if (!saveKotobaHighlights(state, file, matches, clearingEventId, phrase->cpId)) {
+        fo_dbManager_rollback(state->dbManager);
+        return 0;
       }
     }
   }

--- a/src/www/ui/async/AjaxBulkHistory.php
+++ b/src/www/ui/async/AjaxBulkHistory.php
@@ -15,6 +15,7 @@ use Fossology\Lib\Plugin\DefaultPlugin;
 use Fossology\Lib\Auth\Auth;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Session\Session;
 
 class AjaxBulkHistory extends DefaultPlugin
@@ -28,7 +29,7 @@ class AjaxBulkHistory extends DefaultPlugin
   function __construct()
   {
     parent::__construct(self::NAME, array(
-        self::PERMISSION => Auth::PERM_READ
+        self::PERMISSION => Auth::PERM_WRITE
     ));
 
     $this->uploadDao = $this->getObject('dao.upload');
@@ -41,6 +42,10 @@ class AjaxBulkHistory extends DefaultPlugin
    */
   protected function handle(Request $request)
   {
+    $action = $request->get('do');
+    if ($action === 'deleteBulk') {
+      return $this->deleteBulkEntry($request);
+    }
     $uploadId = intval($request->get('upload'));
     if (empty($uploadId)) {
       return;
@@ -59,6 +64,31 @@ class AjaxBulkHistory extends DefaultPlugin
     $groupId = $session->get(Auth::GROUP_ID);
     $bulkHistory = $this->clearingDao->getBulkHistory($itemTreeBounds, $groupId, $onlyTried);
     return $this->render("bulk-history.html.twig",$this->mergeWithDefault(array('bulkHistory'=>$bulkHistory)));
+  }
+  /**
+   * Delete a bulk history entry
+   * @param Request $request
+   * @return Response
+   */
+  protected function deleteBulkEntry(Request $request)
+  {
+    $bulkId = intval($request->get('bulkId'));
+    if (empty($bulkId)) {
+      return new Response('Invalid bulk ID', Response::HTTP_BAD_REQUEST);
+    }
+    /** @var Session */
+    $session = $this->getObject('session');
+    $groupId = $session->get(Auth::GROUP_ID);
+    $userId = $session->get(Auth::USER_ID);
+    if (!$this->clearingDao->canUserDeleteBulkEntry($bulkId, $userId, $groupId)) {
+      return new Response('Permission denied', Response::HTTP_FORBIDDEN);
+    }
+    try {
+      $this->clearingDao->deleteBulkEntry($bulkId, $groupId);
+      return new JsonResponse(['status' => 'success'], Response::HTTP_OK);
+    } catch (\Exception $e) {
+      return new JsonResponse(['status' => 'error', 'message' => 'Deletion failed: ' . $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+    }
   }
 }
 

--- a/src/www/ui/async/AjaxKotobaHistory.php
+++ b/src/www/ui/async/AjaxKotobaHistory.php
@@ -15,6 +15,7 @@ use Fossology\Lib\Plugin\DefaultPlugin;
 use Fossology\Lib\Auth\Auth;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Session\Session;
 
 class AjaxKotobaHistory extends DefaultPlugin
@@ -28,7 +29,7 @@ class AjaxKotobaHistory extends DefaultPlugin
   function __construct()
   {
     parent::__construct(self::NAME, array(
-        self::PERMISSION => Auth::PERM_READ
+        self::PERMISSION => Auth::PERM_WRITE
     ));
 
     $this->uploadDao = $this->getObject('dao.upload');
@@ -41,6 +42,10 @@ class AjaxKotobaHistory extends DefaultPlugin
    */
   protected function handle(Request $request)
   {
+    $action = $request->get('do');
+    if ($action === 'deleteKotoba') {
+      return $this->deleteKotobaEntry($request);
+    }
     $uploadId = intval($request->get('upload'));
     if (empty($uploadId)) {
       return new Response('Missing upload parameter', Response::HTTP_BAD_REQUEST);
@@ -59,6 +64,32 @@ class AjaxKotobaHistory extends DefaultPlugin
     $groupId = $session->get(Auth::GROUP_ID);
     $kotobaHistory = $this->clearingDao->getKotobaHistory($itemTreeBounds, $groupId, $onlyTried);
     return $this->render("kotoba-history.html.twig",$this->mergeWithDefault(array('kotobaHistory'=>$kotobaHistory)));
+  }
+
+  /**
+   * Delete a kotoba history entry
+   * @param Request $request
+   * @return Response
+   */
+  protected function deleteKotobaEntry(Request $request)
+  {
+    $reportinfo = $request->get('reportinfo');
+    if (empty($reportinfo)) {
+      return new Response('Invalid reportinfo', Response::HTTP_BAD_REQUEST);
+    }
+    /** @var Session */
+    $session = $this->getObject('session');
+    $groupId = $session->get(Auth::GROUP_ID);
+    $userId = $session->get(Auth::USER_ID);
+    if (!$this->clearingDao->canUserDeleteKotobaEntry($reportinfo, $userId, $groupId)) {
+      return new Response('Permission denied', Response::HTTP_FORBIDDEN);
+    }
+    try {
+      $this->clearingDao->deleteKotobaEntry($reportinfo, $groupId);
+      return new JsonResponse(['status' => 'success'], Response::HTTP_OK);
+    } catch (\Exception $e) {
+      return new JsonResponse(['status' => 'error', 'message' => 'Deletion failed: ' . $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+    }
   }
 }
 

--- a/src/www/ui/async/AjaxKotobaHistory.php
+++ b/src/www/ui/async/AjaxKotobaHistory.php
@@ -15,6 +15,7 @@ use Fossology\Lib\Plugin\DefaultPlugin;
 use Fossology\Lib\Auth\Auth;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Session\Session;
 
 class AjaxKotobaHistory extends DefaultPlugin
@@ -28,7 +29,7 @@ class AjaxKotobaHistory extends DefaultPlugin
   function __construct()
   {
     parent::__construct(self::NAME, array(
-        self::PERMISSION => Auth::PERM_READ
+        self::PERMISSION => Auth::PERM_WRITE
     ));
 
     $this->uploadDao = $this->getObject('dao.upload');
@@ -41,6 +42,10 @@ class AjaxKotobaHistory extends DefaultPlugin
    */
   protected function handle(Request $request)
   {
+    $action = $request->get('do');
+    if ($action === 'deleteKotoba') {
+      return $this->deleteKotobaEntry($request);
+    }
     $uploadId = intval($request->get('upload'));
     if (empty($uploadId)) {
       return new Response('Missing upload parameter', Response::HTTP_BAD_REQUEST);
@@ -59,6 +64,32 @@ class AjaxKotobaHistory extends DefaultPlugin
     $groupId = $session->get(Auth::GROUP_ID);
     $kotobaHistory = $this->clearingDao->getKotobaHistory($itemTreeBounds, $groupId, $onlyTried);
     return $this->render("kotoba-history.html.twig",$this->mergeWithDefault(array('kotobaHistory'=>$kotobaHistory)));
+  }
+
+  /**
+   * Delete a kotoba history entry
+   * @param Request $request
+   * @return Response
+   */
+  protected function deleteKotobaEntry(Request $request)
+  {
+    $cpFk = intval($request->get('cpFk'));
+    if (empty($cpFk)) {
+      return new Response('Invalid phrase ID', Response::HTTP_BAD_REQUEST);
+    }
+    /** @var Session */
+    $session = $this->getObject('session');
+    $groupId = $session->get(Auth::GROUP_ID);
+    $userId = $session->get(Auth::USER_ID);
+    if (!$this->clearingDao->canUserDeleteKotobaEntry($cpFk, $userId, $groupId)) {
+      return new Response('Permission denied', Response::HTTP_FORBIDDEN);
+    }
+    try {
+      $this->clearingDao->deleteKotobaEntry($cpFk, $groupId);
+      return new JsonResponse(['status' => 'success'], Response::HTTP_OK);
+    } catch (\Exception $e) {
+      return new JsonResponse(['status' => 'error', 'message' => 'Deletion failed: ' . $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+    }
   }
 }
 

--- a/src/www/ui/css/fossology.css
+++ b/src/www/ui/css/fossology.css
@@ -205,6 +205,12 @@ img.delete {
   background-image: url('../images/icons/close_16.png');
 }
 
+img.delete.delete-disabled {
+  cursor: default;
+  filter: grayscale(100%);
+  opacity: 0.5;
+}
+
 img.added {
   background-image: url('../images/icons/added_16.png');
 }

--- a/src/www/ui/template/browse.html.twig
+++ b/src/www/ui/template/browse.html.twig
@@ -95,6 +95,7 @@
   <script type="text/javascript">
     {% set bulkHistoryOptions = '&all=1' %}
     {% include 'bulk-history.js.twig' %}
+    {% include 'kotoba-history.js.twig' %}
   </script>
   <script type="text/javascript">
     {% include 'browse_license-lic_hist.js.twig' %}

--- a/src/www/ui/template/browse_license.html.twig
+++ b/src/www/ui/template/browse_license.html.twig
@@ -41,5 +41,6 @@
   <script type="text/javascript">
     {% set bulkHistoryOptions = '&all=1' %}
     {% include 'bulk-history.js.twig' %}
+    {% include 'kotoba-history.js.twig' %}
   </script>
 {% endblock %}

--- a/src/www/ui/template/bulk-history.html.twig
+++ b/src/www/ui/template/bulk-history.html.twig
@@ -4,12 +4,18 @@
 #}
 <table class="dataTable" border="1" cellpadding="5px" id="bulkHistoryTable" name="bulkHistoryTable">
   <tr>
+    <th>{{ 'Action'| trans }}</th>
     <th>{{ 'License'| trans }}</th>
     <th>{{ 'Text'| trans }}</th>
   </tr>
   {% if bulkHistory %}
   {% for row in bulkHistory %}
     <tr class="{{ cycle(['odd','even'], loop.index0) }}{% if row.matched %} match{% endif %}{% if not row.tried %} inactive{% endif %}">
+      <td>
+        <a href="javascript:;" onclick="deleteBulkEntry({{ row.bulkId }});" title="{{ 'Delete this bulk scan entry'| trans }}">
+          <img class="delete" src="images/space_16.png" alt="{{ 'Delete'| trans }}"/>
+        </a>
+      </td>
       <td>
           <table>
             {% if row.addedLicenses is not empty %}
@@ -39,6 +45,7 @@
   {% endfor %}
   {% else %}
     <tr class="even">
+      <td>&lt;no entries&gt;</td>
       <td>&lt;no entries&gt;</td>
       <td>&lt;no entries&gt;</td>
     </tr>

--- a/src/www/ui/template/bulk-history.html.twig
+++ b/src/www/ui/template/bulk-history.html.twig
@@ -4,12 +4,25 @@
 #}
 <table class="dataTable" border="1" cellpadding="5px" id="bulkHistoryTable" name="bulkHistoryTable">
   <tr>
+    <th>{{ 'Action'| trans }}</th>
     <th>{{ 'License'| trans }}</th>
     <th>{{ 'Text'| trans }}</th>
   </tr>
   {% if bulkHistory %}
+  {% set nowEpoch = "now"|date("U") %}
   {% for row in bulkHistory %}
     <tr class="{{ cycle(['odd','even'], loop.index0) }}{% if row.matched %} match{% endif %}{% if not row.tried %} inactive{% endif %}">
+      <td>
+        {% set expired = row.dateAdded is not null and (nowEpoch - row.dateAdded) > 3600 %}
+        {% if expired %}
+          <img class="delete delete-disabled" src="images/space_16.png" alt="{{ 'Delete'| trans }}"
+               title="{{ 'You can only delete entries within one hour of creation.'| trans }}"/>
+        {% else %}
+        <a href="javascript:;" onclick="deleteBulkEntry({{ row.bulkId }}{% if row.dateAdded is not null %}, {{ row.dateAdded }}{% endif %});" title="{{ 'Delete this bulk scan entry'| trans }}">
+          <img class="delete" src="images/space_16.png" alt="{{ 'Delete'| trans }}"/>
+        </a>
+        {% endif %}
+      </td>
       <td>
           <table>
             {% if row.addedLicenses is not empty %}
@@ -39,6 +52,7 @@
   {% endfor %}
   {% else %}
     <tr class="even">
+      <td>&lt;no entries&gt;</td>
       <td>&lt;no entries&gt;</td>
       <td>&lt;no entries&gt;</td>
     </tr>

--- a/src/www/ui/template/bulk-history.js.twig
+++ b/src/www/ui/template/bulk-history.js.twig
@@ -11,3 +11,42 @@ function refreshBulkHistory(callbacksuccess) {
     }
   });
 }
+
+function deleteBulkEntry(bulkId) {
+  if (!confirm('{{ "Are you sure you want to delete this bulk scan entry ?\n\nDeleting it will permanently remove it from bulk history and undo all decisions previously applied using this phrase."| trans|e('js') }}')) {
+    return;
+  }
+  
+  $.ajax({
+    url: "{{ baseuri }}?mod=bulk-history",
+    type: "POST",
+    data: {
+      do: "deleteBulk",
+      bulkId: bulkId
+    },
+    success: function(response) {
+      try {
+        var data = typeof response === 'string' ? JSON.parse(response) : response;
+        if (data.status === 'success') {
+          $('#decTypeSet').addClass('border-danger');
+          
+          refreshBulkHistory(function() {
+            if (typeof createClearingTable === 'function') {
+              var clearingTable = createClearingTable();
+              if (clearingTable && typeof clearingTable.fnDraw === 'function') {
+                clearingTable.fnDraw(false);
+              }
+            }
+          });
+        } else {
+          alert('{{ "Error deleting bulk entry: "| trans|e('js') }}' + (data.message || 'Unknown error'));
+        }
+      } catch (e) {
+        alert('{{ "Error deleting bulk entry: "| trans|e('js') }}' + 'Invalid response: ' + response);
+      }
+    },
+    error: function(xhr, status, error) {
+      alert('{{ "Error deleting bulk entry: "| trans|e('js') }}' + error);
+    }
+  });
+}

--- a/src/www/ui/template/bulk-history.js.twig
+++ b/src/www/ui/template/bulk-history.js.twig
@@ -11,3 +11,56 @@ function refreshBulkHistory(callbacksuccess) {
     }
   });
 }
+
+var deletionWindowSeconds = 3600;
+
+function isDeletionExpired(dateAdded) {
+  if (!dateAdded) {
+    return false;
+  }
+  var now = Math.floor(Date.now() / 1000);
+  return (now - dateAdded) > deletionWindowSeconds;
+}
+
+function deleteBulkEntry(bulkId, dateAdded) {
+  if (isDeletionExpired(dateAdded)) {
+    alert('{{ "You can only delete entries within one hour of creation."| trans|e('js') }}');
+    return;
+  }
+  if (!confirm('{{ "Are you sure you want to delete this bulk scan entry ?\n\nDeleting it will permanently remove it from bulk history and undo all decisions previously applied using this phrase.\n\nYou can only delete this entry within one hour of its creation."| trans|e('js') }}')) {
+    return;
+  }
+  
+  $.ajax({
+    url: "{{ baseuri }}?mod=bulk-history",
+    type: "POST",
+    data: {
+      do: "deleteBulk",
+      bulkId: bulkId
+    },
+    success: function(response) {
+      try {
+        var data = typeof response === 'string' ? JSON.parse(response) : response;
+        if (data.status === 'success') {
+          $('#decTypeSet').addClass('border-danger');
+          
+          refreshBulkHistory(function() {
+            if (typeof createClearingTable === 'function') {
+              var clearingTable = createClearingTable();
+              if (clearingTable && typeof clearingTable.fnDraw === 'function') {
+                clearingTable.fnDraw(false);
+              }
+            }
+          });
+        } else {
+          alert('{{ "Error deleting bulk entry: "| trans|e('js') }}' + (data.message || 'Unknown error'));
+        }
+      } catch (e) {
+        alert('{{ "Error deleting bulk entry: "| trans|e('js') }}' + 'Invalid response: ' + response);
+      }
+    },
+    error: function(xhr, status, error) {
+      alert('{{ "Error deleting bulk entry: "| trans|e('js') }}' + error);
+    }
+  });
+}

--- a/src/www/ui/template/kotoba-history.html.twig
+++ b/src/www/ui/template/kotoba-history.html.twig
@@ -5,12 +5,18 @@
 #}
 <table class="dataTable" border="1" cellpadding="5px" id="kotobaHistoryTable" name="kotobaHistoryTable">
   <tr>
+    <th>{{ 'Action'| trans }}</th>
     <th>{{ 'License'| trans }}</th>
     <th>{{ 'Text'| trans }}</th>
   </tr>
   {% if kotobaHistory %}
   {% for row in kotobaHistory %}
     <tr class="{{ cycle(['odd','even'], loop.index0) }}{% if row.matched %} match{% endif %}{% if not row.tried %} inactive{% endif %}">
+      <td>
+        <a href="javascript:;" onclick="deleteKotobaEntry('{{ row.text|e('js') }}');" title="{{ 'Delete this kotoba scan entry'| trans }}">
+          <img class="delete" src="images/space_16.png" alt="{{ 'Delete'| trans }}"/>
+        </a>
+      </td>
       <td>
           <table>
             {% if row.addedLicenses is not empty %}
@@ -34,6 +40,7 @@
   {% endfor %}
   {% else %}
     <tr class="even">
+      <td>&lt;no entries&gt;</td>
       <td>&lt;no entries&gt;</td>
       <td>&lt;no entries&gt;</td>
     </tr>

--- a/src/www/ui/template/kotoba-history.html.twig
+++ b/src/www/ui/template/kotoba-history.html.twig
@@ -5,12 +5,25 @@
 #}
 <table class="dataTable" border="1" cellpadding="5px" id="kotobaHistoryTable" name="kotobaHistoryTable">
   <tr>
+    <th>{{ 'Action'| trans }}</th>
     <th>{{ 'License'| trans }}</th>
     <th>{{ 'Text'| trans }}</th>
   </tr>
   {% if kotobaHistory %}
+  {% set nowEpoch = "now"|date("U") %}
   {% for row in kotobaHistory %}
     <tr class="{{ cycle(['odd','even'], loop.index0) }}{% if row.matched %} match{% endif %}{% if not row.tried %} inactive{% endif %}">
+      <td>
+        {% set expired = row.dateAdded is not null and (nowEpoch - row.dateAdded) > 3600 %}
+        {% if expired %}
+          <img class="delete delete-disabled" src="images/space_16.png" alt="{{ 'Delete'| trans }}"
+               title="{{ 'You can only delete entries within one hour of creation.'| trans }}"/>
+        {% else %}
+        <a href="javascript:;" onclick="deleteKotobaEntry({{ row.phraseId }}{% if row.dateAdded is not null %}, {{ row.dateAdded }}{% endif %});" title="{{ 'Delete this kotoba scan entry'| trans }}">
+          <img class="delete" src="images/space_16.png" alt="{{ 'Delete'| trans }}"/>
+        </a>
+        {% endif %}
+      </td>
       <td>
           <table>
             {% if row.addedLicenses is not empty %}
@@ -40,6 +53,7 @@
   {% endfor %}
   {% else %}
     <tr class="even">
+      <td>&lt;no entries&gt;</td>
       <td>&lt;no entries&gt;</td>
       <td>&lt;no entries&gt;</td>
     </tr>

--- a/src/www/ui/template/kotoba-history.js.twig
+++ b/src/www/ui/template/kotoba-history.js.twig
@@ -13,3 +13,42 @@ function refreshKotobaHistory(callbacksuccess) {
   });
 }
 
+function deleteKotobaEntry(reportinfo) {
+  if (!confirm('{{ "Are you sure you want to delete this kotoba scan entry ?\n\nDeleting it will permanently remove it from kotoba history and undo all decisions previously applied using this phrase."| trans|e('js') }}')) {
+    return;
+  }
+  
+  $.ajax({
+    url: "{{ baseuri }}?mod=kotoba-history",
+    type: "POST",
+    data: {
+      do: "deleteKotoba",
+      reportinfo: reportinfo
+    },
+    success: function(response) {
+      try {
+        var data = typeof response === 'string' ? JSON.parse(response) : response;
+        if (data.status === 'success') {
+          $('#decTypeSet').addClass('border-danger');
+          
+          refreshKotobaHistory(function() {
+            if (typeof createClearingTable === 'function') {
+              var clearingTable = createClearingTable();
+              if (clearingTable && typeof clearingTable.fnDraw === 'function') {
+                clearingTable.fnDraw(false);
+              }
+            }
+          });
+        } else {
+          alert('{{ "Error deleting kotoba entry: "| trans|e('js') }}' + (data.message || 'Unknown error'));
+        }
+      } catch (e) {
+        alert('{{ "Error deleting kotoba entry: "| trans|e('js') }}' + 'Invalid response: ' + response);
+      }
+    },
+    error: function(xhr, status, error) {
+      alert('{{ "Error deleting kotoba entry: "| trans|e('js') }}' + error);
+    }
+  });
+}
+

--- a/src/www/ui/template/kotoba-history.js.twig
+++ b/src/www/ui/template/kotoba-history.js.twig
@@ -13,3 +13,56 @@ function refreshKotobaHistory(callbacksuccess) {
   });
 }
 
+var kotobaDeletionWindowSeconds = 3600;
+
+function isKotobaDeletionExpired(dateAdded) {
+  if (!dateAdded) {
+    return false;
+  }
+  var now = Math.floor(Date.now() / 1000);
+  return (now - dateAdded) > kotobaDeletionWindowSeconds;
+}
+
+function deleteKotobaEntry(phraseId, dateAdded) {
+  if (isKotobaDeletionExpired(dateAdded)) {
+    alert('{{ "You can only delete entries within one hour of creation."| trans|e('js') }}');
+    return;
+  }
+  if (!confirm('{{ "Are you sure you want to delete this kotoba scan entry ?\n\nDeleting it will permanently remove it from kotoba history and undo all decisions previously applied using this phrase.\n\nYou can only delete this entry within one hour of its creation."| trans|e('js') }}')) {
+    return;
+  }
+  
+  $.ajax({
+    url: "{{ baseuri }}?mod=kotoba-history",
+    type: "POST",
+    data: {
+      do: "deleteKotoba",
+      cpFk: phraseId
+    },
+    success: function(response) {
+      try {
+        var data = typeof response === 'string' ? JSON.parse(response) : response;
+        if (data.status === 'success') {
+          $('#decTypeSet').addClass('border-danger');
+          
+          refreshKotobaHistory(function() {
+            if (typeof createClearingTable === 'function') {
+              var clearingTable = createClearingTable();
+              if (clearingTable && typeof clearingTable.fnDraw === 'function') {
+                clearingTable.fnDraw(false);
+              }
+            }
+          });
+        } else {
+          alert('{{ "Error deleting kotoba entry: "| trans|e('js') }}' + (data.message || 'Unknown error'));
+        }
+      } catch (e) {
+        alert('{{ "Error deleting kotoba entry: "| trans|e('js') }}' + 'Invalid response: ' + response);
+      }
+    },
+    error: function(xhr, status, error) {
+      alert('{{ "Error deleting kotoba entry: "| trans|e('js') }}' + error);
+    }
+  });
+}
+

--- a/src/www/ui/template/ui-clearing-view.html.twig
+++ b/src/www/ui/template/ui-clearing-view.html.twig
@@ -79,5 +79,6 @@
   <script src="scripts/ui-clearing-view_bulk.js" type="text/javascript"></script>
   <script type="text/javascript">{% include "ui-clearing-view.js.twig" %}</script>
   <script type="text/javascript">{% include "bulk-history.js.twig" %}</script>
+  <script type="text/javascript">{% include "kotoba-history.js.twig" %}</script>
   <script type="text/javascript">{% include "next-options.js.twig" %}</script>
 {% endblock %}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Adds functionality to delete an incorrect bulk scan entry from the bulk history.

A new **"Action"** column with a delete option has been introduced. When the user clicks delete, a confirmation dialog is shown to clearly communicate the impact of the action. Upon confirmation:

- The selected bulk scan is removed from bulk history  
- All associated scanner findings (licenses) are deleted  
- Related clearing decisions are reset to **WIP**, aligning with existing behavior when licenses are manually removed from scanner findings  

### Tables Involved

- `license_ref_bulk` – Main bulk entry  
- `highlight_bulk` – Maps bulk entries to clearing events  
- `clearing_event` – Scanner findings  
- `clearing_decision_event` – Junction table (events ↔ decisions)  
- `clearing_decision` – Decision records (reset to WIP)  
- `jobqueue` – Background jobs (cleanup required for `monkbulk`)  

> Note: Cleanup in `jobqueue` is required because `Bulkreuser.php` relies on this table for bulk IDs.  

closes: #2062 

## Changes

- **ClearingDao.php**
  - Added `canUserDeleteBulkEntry()` for permission validation (user/group ownership)
  - Added `deleteBulkEntry()` implementing transactional deletion logic

- **AjaxBulkHistory.php**
  - Updated permission from **READ → WRITE**
  - Added handler for `deleteBulk` action with proper authorization and JSON response

- **bulk-history.html.twig**
  - Added "Action" column with delete button

- **bulk-history.js.twig**
  - Implemented `deleteBulkEntry(bulkId)`:
    - Confirmation dialog
    - AJAX request to backend
    - Refresh of bulk history and clearing tables on success

## Screenshots

https://github.com/user-attachments/assets/318c204b-9bbd-49a1-9a1d-5bba3a24e83d

cc: @shaheemazmalmmd 
