### PR TITLE
fix(copyright): edge case with no copyright statement jumps before declutter

### DIFF
--- a/src/decider/agent/DeciderAgent.php
+++ b/src/decider/agent/DeciderAgent.php
@@ -636,6 +636,11 @@ class DeciderAgent extends Agent
     $allCopyrights = $this->copyrightDao->getScannerEntries('copyright',
       $uploadTreeTableName, $uploadId, null, $extrawhere);
 
+    if (empty($allCopyrights)) {
+      echo "No copyrights found for upload $uploadId. Skipping false positive deactivation.\n";
+      return;
+    }
+
     $copyrightJSON = json_encode($allCopyrights);
     $tmpFile = tmpfile();
     $tmpFilePath = stream_get_meta_data($tmpFile)['uri'];


### PR DESCRIPTION
## Description

In case of components with no copyright data, or failure of copyright agent, False Positive and Declutter script should also not fail.

### Changes

Add a basic empty check to make sure, there is always the right copyright content available before sending to the copyrightDeclutterScript.

## How to test

1. Upload a component (with copyright data)
2. Select copyright, Select Declutter and False Positive (Check if everything is working fine)
3. Upload a component with (no copyright info) or pause copyright agent. Check that decider should not fail and there is no error or warning in the logs.
