### PR TITLE
fix(scancode): replace tmpnam with mkstemp to fix warning

### DIFF
--- a/src/scancode/agent/scancode_utils.cc
+++ b/src/scancode/agent/scancode_utils.cc
@@ -85,8 +85,24 @@ bool processUploadId(const State &state, int uploadId,
 
   bool errors = false;
 
-  string fileLocation = tmpnam(nullptr);
-  string outputFile = tmpnam(nullptr);
+  char fileLocationTpl[] = "/tmp/scancode_input_XXXXXX";
+  int fdInput = mkstemp(fileLocationTpl);
+  if (fdInput == -1) {
+    LOG_ERROR("Failed to create temporary input file.\n");
+    return false;
+  }
+  close(fdInput);
+  string fileLocation(fileLocationTpl);
+
+  char outputFileTpl[] = "/tmp/scancode_output_XXXXXX";
+  int fdOutput = mkstemp(outputFileTpl);
+  if (fdOutput == -1) {
+    LOG_ERROR("Failed to create temporary output file.\n");
+    unlink(fileLocationTpl);
+    return false;
+  }
+  close(fdOutput);
+  string outputFile(outputFileTpl);
 
   size_t pFileCount = fileIds.size();
   for (size_t it = 0; it < pFileCount; ++it) {
@@ -105,7 +121,7 @@ bool processUploadId(const State &state, int uploadId,
 
   std::ifstream opfile(outputFile);
   if (!opfile) {
-    std::cerr << "Error opening the JSON file.\n";
+    LOG_ERROR("Error opening the JSON file.\n");
     return false;
   }
 
@@ -147,6 +163,9 @@ bool processUploadId(const State &state, int uploadId,
   }
   if (unlink(outputFile.c_str()) != 0) {
     LOG_FATAL("Unable to delete file %s \n", outputFile.c_str());
+  }
+  if (unlink(fileLocation.c_str()) != 0) {
+    LOG_FATAL("Unable to delete file %s \n", fileLocation.c_str());
   }
 
   return !errors;


### PR DESCRIPTION
## Description
The linker warned that `tmpnam` is dangerous due to a TOCTOU (time-of-check to time-of-use) race condition another process could create a file between the name being generated and the file being opened.

### Changes

1. Replaced both `tmpnam(nullptr)` calls in `processUploadId()` with `mkstemp()`, which atomically creates the file and returns a file descriptor, eliminating the race condition.
2. Added error handling for temp file creation failures.
3. Added cleanup `unlink` for the input temp file `fileLocation`, which was previously leaked  only the output file was being deleted.

## How to test
1. Build should happen without this warning:
<img width="1219" height="80" alt="image" src="https://github.com/user-attachments/assets/a7f00a91-5590-497b-ab02-437955bce0b2" />

2. Upload a component and run scancode to test License and Copyright. It should work.
