### PR TITLE
feat(bulk): extend include license text functionality

### DIFF
--- a/src/lib/php/Application/BulkTextExport.php
+++ b/src/lib/php/Application/BulkTextExport.php
@@ -76,7 +76,7 @@ class BulkTextExport
    * @param bool $generateJson Whether to generate JSON format instead of CSV
    * @return string CSV or JSON content
    */
-  public function exportBulkText($user_pk=0, $group_pk=0, $generateJson=false)
+  public function exportBulkText($user_pk=0, $group_pk=0, $generateJson=false, $includeLicenseText=false)
   {
     $whereClause = "";
     $params = array();
@@ -89,13 +89,15 @@ class BulkTextExport
       $params[] = $group_pk;
     }
 
+    $licenseTextColumn = $includeLicenseText ? ",\n              lr.rf_text AS license_text" : "";
+
     $sql = "SELECT DISTINCT
               lrb.rf_text,
               lr.rf_shortname,
               lsb.removing,
               lsb.comment,
               lsb.acknowledgement,
-              lr.rf_active
+              lr.rf_active$licenseTextColumn
             FROM license_ref_bulk lrb
             LEFT JOIN license_set_bulk lsb ON lsb.lrb_fk = lrb.lrb_pk
             LEFT JOIN license_ref lr ON lr.rf_pk = lsb.rf_fk
@@ -105,9 +107,9 @@ class BulkTextExport
     $result = $this->dbManager->getRows($sql, $params);
 
     if ($generateJson) {
-      return $this->createJson($result);
+      return $this->createJson($result, $includeLicenseText);
     } else {
-      return $this->createCsvContent($result);
+      return $this->createCsvContent($result, $includeLicenseText);
     }
   }
 
@@ -116,7 +118,7 @@ class BulkTextExport
    * @param array $result Database result array
    * @return array Associative array keyed by rf_text with grouped export fields
    */
-  private function groupResultsByText($result)
+  private function groupResultsByText($result, $includeLicenseText=false)
   {
     $grouped = array();
     foreach ($result as $row) {
@@ -127,7 +129,8 @@ class BulkTextExport
           'licenses_to_remove' => array(),
           'comments'           => array(),
           'acknowledgements'   => array(),
-          'is_active_values'   => array()
+          'is_active_values'   => array(),
+          'license_texts'      => array()
         );
       }
       if (!empty($row['rf_shortname'])) {
@@ -135,6 +138,9 @@ class BulkTextExport
           $grouped[$text]['licenses_to_remove'][] = $row['rf_shortname'];
         } else {
           $grouped[$text]['licenses_to_add'][] = $row['rf_shortname'];
+          if ($includeLicenseText && !empty($row['license_text'])) {
+            $grouped[$text]['license_texts'][$row['rf_shortname']] = $row['license_text'];
+          }
         }
       }
 
@@ -158,6 +164,7 @@ class BulkTextExport
       $grouped[$text]['licenses_to_remove'] = array_values(array_unique($values['licenses_to_remove']));
       $grouped[$text]['comments'] = array_values(array_unique($values['comments']));
       $grouped[$text]['acknowledgements'] = array_values(array_unique($values['acknowledgements']));
+      $grouped[$text]['license_texts'] = array_values($values['license_texts']);
 
       if (empty($values['is_active_values'])) {
         $grouped[$text]['is_active'] = null;
@@ -176,15 +183,18 @@ class BulkTextExport
    * @param array $result Database result array
    * @return string CSV content
    */
-  private function createCsvContent($result)
+  private function createCsvContent($result, $includeLicenseText=false)
   {
     $headers = array('text', 'licenses_to_add', 'licenses_to_remove', 'comments', 'acknowledgements', 'is_active');
+    if ($includeLicenseText) {
+      $headers[] = 'license_text';
+    }
     $out = fopen('php://output', 'w');
     ob_start();
     fputs($out, $bom =( chr(0xEF) . chr(0xBB) . chr(0xBF) ));
     fputcsv($out, $headers, $this->delimiter, $this->enclosure);
 
-    foreach ($this->groupResultsByText($result) as $text => $licenses) {
+    foreach ($this->groupResultsByText($result, $includeLicenseText) as $text => $licenses) {
       $csvRow = array(
         $this->normalizeNewlinesForCsv($text),
         implode('|', array_map(array($this, 'normalizeNewlinesForCsv'), $licenses['licenses_to_add'])),
@@ -193,6 +203,9 @@ class BulkTextExport
         implode('|', array_map(array($this, 'normalizeNewlinesForCsv'), $licenses['acknowledgements'])),
         $licenses['is_active'] === null ? '' : ($licenses['is_active'] ? 'true' : 'false')
       );
+      if ($includeLicenseText) {
+        $csvRow[] = implode('|', array_map(array($this, 'normalizeNewlinesForCsv'), $licenses['license_texts']));
+      }
       fputcsv($out, $csvRow, $this->delimiter, $this->enclosure);
     }
 
@@ -219,12 +232,12 @@ class BulkTextExport
    * @param array $result Database result array
    * @return string JSON content
    */
-  private function createJson($result)
+  private function createJson($result, $includeLicenseText=false)
   {
     $data = array();
 
-    foreach ($this->groupResultsByText($result) as $text => $licenses) {
-      $data[] = array(
+    foreach ($this->groupResultsByText($result, $includeLicenseText) as $text => $licenses) {
+      $entry = array(
         'text'               => $text,
         'licenses_to_add'    => $licenses['licenses_to_add'],
         'licenses_to_remove' => $licenses['licenses_to_remove'],
@@ -232,6 +245,10 @@ class BulkTextExport
         'acknowledgements'   => $licenses['acknowledgements'],
         'is_active'          => $licenses['is_active']
       );
+      if ($includeLicenseText) {
+        $entry['license_text'] = $licenses['license_texts'];
+      }
+      $data[] = $entry;
     }
 
     return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);

--- a/src/lib/php/Application/test/BulkTextExportTest.php
+++ b/src/lib/php/Application/test/BulkTextExportTest.php
@@ -100,4 +100,91 @@ class BulkTextExportTest extends \PHPUnit\Framework\TestCase
     $this->expectException(\InvalidArgumentException::class);
     $bulkTextExport->setEnclosure(',');
   }
+
+  /**
+   * @test
+   * -# Export CSV with includeLicenseText enabled.
+   * -# Verify license_text column appears with rf_text from license_ref for added licenses.
+   */
+  public function testExportBulkTextCsvIncludesLicenseText()
+  {
+    $dbManager = M::mock(DbManager::class);
+    $dbManager->shouldReceive('getRows')->once()->withAnyArgs()->andReturn(array(
+      array(
+        'rf_text' => "some bulk text",
+        'rf_shortname' => 'MIT',
+        'removing' => 'f',
+        'comment' => null,
+        'acknowledgement' => null,
+        'rf_active' => 't',
+        'license_text' => 'Permission is hereby granted, free of charge...'
+      ),
+      array(
+        'rf_text' => "some bulk text",
+        'rf_shortname' => 'Apache-2.0',
+        'removing' => 't',
+        'comment' => null,
+        'acknowledgement' => null,
+        'rf_active' => 't',
+        'license_text' => 'Apache License Version 2.0...'
+      )
+    ));
+
+    $bulkTextExport = new BulkTextExport($dbManager);
+    $csv = $bulkTextExport->exportBulkText(0, 0, false, true);
+
+    $handle = fopen('php://temp', 'r+');
+    fwrite($handle, $csv);
+    rewind($handle);
+
+    $rows = array();
+    while (($row = fgetcsv($handle, 0, ',', '"')) !== false) {
+      $rows[] = $row;
+    }
+    fclose($handle);
+
+    $this->assertCount(2, $rows);
+    $this->assertSame('license_text', $rows[0][6]);
+    $this->assertSame('MIT', $rows[1][1]);
+    $this->assertSame('Apache-2.0', $rows[1][2]);
+    $this->assertStringContainsString('Permission is hereby granted', $rows[1][6]);
+    $this->assertStringNotContainsString('Apache License', $rows[1][6]);
+  }
+
+  /**
+   * @test
+   * -# Export CSV without includeLicenseText.
+   * -# Verify license_text column does NOT appear.
+   */
+  public function testExportBulkTextCsvExcludesLicenseTextByDefault()
+  {
+    $dbManager = M::mock(DbManager::class);
+    $dbManager->shouldReceive('getRows')->once()->withAnyArgs()->andReturn(array(
+      array(
+        'rf_text' => "some text",
+        'rf_shortname' => 'MIT',
+        'removing' => 'f',
+        'comment' => null,
+        'acknowledgement' => null,
+        'rf_active' => 't'
+      )
+    ));
+
+    $bulkTextExport = new BulkTextExport($dbManager);
+    $csv = $bulkTextExport->exportBulkText();
+
+    $handle = fopen('php://temp', 'r+');
+    fwrite($handle, $csv);
+    rewind($handle);
+
+    $rows = array();
+    while (($row = fgetcsv($handle, 0, ',', '"')) !== false) {
+      $rows[] = $row;
+    }
+    fclose($handle);
+
+    $this->assertCount(2, $rows);
+    $this->assertCount(6, $rows[0]);
+    $this->assertSame('is_active', $rows[0][5]);
+  }
 }

--- a/src/www/ui/page/AdminBulkTextExport.php
+++ b/src/www/ui/page/AdminBulkTextExport.php
@@ -83,6 +83,7 @@ class AdminBulkTextExport extends DefaultPlugin
     $group_pk = intval($request->get('selected_group', 0));
     $delimiter = $request->get('delimiter', ',');
     $enclosure = $request->get('enclosure', '"');
+    $includeLicenseText = $request->get('include_license_text', false) ? true : false;
 
     if (!in_array($exportFormat, array('csv', 'json'))) {
       $exportFormat = 'csv';
@@ -117,7 +118,7 @@ class AdminBulkTextExport extends DefaultPlugin
       }
     }
 
-    $content = $bulkTextExporter->exportBulkText($filterUserPk, $filterGroupPk, $generateJson);
+    $content = $bulkTextExporter->exportBulkText($filterUserPk, $filterGroupPk, $generateJson, $includeLicenseText);
 
     return DownloadUtil::getDownloadResponse($content, $fileName, $contentType);
   }

--- a/src/www/ui/template/admin_bulk_text_export.html.twig
+++ b/src/www/ui/template/admin_bulk_text_export.html.twig
@@ -94,6 +94,17 @@
         </div>
       </li>
 
+      <li>
+        <div class="form-group">
+          <label>{{ 'Additional Data' | trans }}:</label>
+          <div class="radio-group">
+            <input type="checkbox" id="includeLicenseText" name="include_license_text" value="1"/>
+            <label for="includeLicenseText" class="d-inline">{{ 'Export License Text with Bulk Text' | trans }}</label>
+            <img src="images/info_16.png" data-toggle="tooltip" title="{{'Include the full license text from license_ref for each added license'|trans}}" alt="" class="info-bullet"/>
+          </div>
+        </div>
+      </li>
+
       <li id="csvOptionsRow">
         <div class="form-group">
           <label>{{ 'CSV Options' | trans }}:</label>


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

There is a need to add additional data export, where if the user wants they can extend `license_text` array, where it contains actual license text of all the licenses to add in monkbulk.

### Changes

1. Included a flag `includeLicenseText` to make sure the output has the required data.
2. Added test cases
3. Added a radio check in twig (Additional Data)

## How to test

1. Admin > Bulk > Bulk Text Export 
2. Select the required filters (without additional data)
3. Select Additional data and export.
