### PR TITLE
fix(report): add checks and rout to parent if the path not found for …

### DIFF
--- a/src/lib/php/Dao/TreeDao.php
+++ b/src/lib/php/Dao/TreeDao.php
@@ -82,6 +82,14 @@ class TreeDao
         $params, $statementName);
 
     if (false === $row) {
+      if ($parentId > 0) {
+        $this->logger->warning(
+          "getFullPath: could not find path of $itemId relative to parent $parentId" .
+          " in $tableName - item is not a descendant of that parent." .
+          " Falling back to root-based path."
+        );
+        return $this->getFullPath($itemId, $tableName, 0, $dropArtifactPrefix);
+      }
       throw new \Exception("could not find path of $itemId:\n$sql--".print_r($params,true));
     }
 
@@ -117,8 +125,13 @@ class TreeDao
    */
   public function getItemHashes($uploadtreeId, $uploadtreeTablename='uploadtree')
   {
-    $pfile = $this->dbManager->getSingleRow("SELECT pfile.* FROM $uploadtreeTablename, pfile WHERE uploadtree_pk=$1 AND pfile_fk=pfile_pk",
-        array($uploadtreeId), __METHOD__);
+    $statementName = __METHOD__ . "." . $uploadtreeTablename;
+    $pfile = $this->dbManager->getSingleRow(
+      "SELECT pfile.* FROM $uploadtreeTablename, pfile WHERE uploadtree_pk=$1 AND pfile_fk=pfile_pk",
+      array($uploadtreeId), $statementName);
+    if (empty($pfile)) {
+      return array('sha1' => '', 'md5' => '', 'sha256' => '');
+    }
     return array('sha1'=>$pfile['pfile_sha1'],'md5'=>$pfile['pfile_md5'],'sha256'=>$pfile['pfile_sha256']);
   }
 

--- a/src/lib/php/Dao/test/TreeDaoTest.php
+++ b/src/lib/php/Dao/test/TreeDaoTest.php
@@ -245,6 +245,24 @@ class TreeDaoTest extends \PHPUnit\Framework\TestCase
     assertThat($this->treeDao->getFullPath(3665, "uploadtree",0,true), equalTo(                  "uploadDaoTest/L/L2/L2a"));
   }
 
+  public function testGetFullPathFallsBackToRootWhenItemNotUnderParent()
+  {
+    $this->prepareModularTable(array(array(6,5,1,0,0,5,6,"file",5)));
+
+    $nonAncestorParentId = 9999;
+    $pathWithFallback = $this->treeDao->getFullPath(6, "uploadtree", $nonAncestorParentId);
+    $pathFromRoot     = $this->treeDao->getFullPath(6, "uploadtree", 0);
+
+    assertThat($pathWithFallback, equalTo($pathFromRoot));
+  }
+
+  public function testGetItemHashesReturnsEmptyArrayForMissingPfile()
+  {
+    $this->testDb->createPlainTables(array('pfile'));
+    $hashes = $this->treeDao->getItemHashes(9999, 'uploadtree');
+    assertThat($hashes, equalTo(array('sha1' => '', 'md5' => '', 'sha256' => '')));
+  }
+
   public function testGetUploadHashes()
   {
     $this->testDb->createPlainTables(array('pfile'));

--- a/src/lib/php/Report/ClearedGetterCommon.php
+++ b/src/lib/php/Report/ClearedGetterCommon.php
@@ -9,6 +9,7 @@ namespace Fossology\Lib\Report;
 
 use Fossology\Lib\Dao\TreeDao;
 use Fossology\Lib\Dao\UploadDao;
+use Monolog\Logger;
 
 abstract class ClearedGetterCommon
 {
@@ -17,6 +18,9 @@ abstract class ClearedGetterCommon
 
   /** @var TreeDao */
   protected $treeDao;
+
+  /** @var Logger */
+  private $logger;
 
   /** @var array $fileNameCache */
   private $fileNameCache = array();
@@ -35,6 +39,7 @@ abstract class ClearedGetterCommon
 
     $this->uploadDao = $container->get('dao.upload');
     $this->treeDao = $container->get('dao.tree');
+    $this->logger = new Logger(self::class);
 
     $this->groupBy = $groupBy;
   }
@@ -97,12 +102,23 @@ abstract class ClearedGetterCommon
       unset($statement['uploadtree_pk']);
 
       if (!array_key_exists($uploadTreeId, $this->fileNameCache)) {
-        $this->fileNameCache[$uploadTreeId] = $this->treeDao->getFullPath($uploadTreeId, $uploadTreeTableName, $parentId);
-        $this->fileHashes[$uploadTreeId] = $this->treeDao->getItemHashes($uploadTreeId);
+        try {
+          $this->fileNameCache[$uploadTreeId] = $this->treeDao->getFullPath(
+            $uploadTreeId, $uploadTreeTableName, $parentId);
+          $this->fileHashes[$uploadTreeId] = $this->treeDao->getItemHashes(
+            $uploadTreeId, $uploadTreeTableName);
+        } catch (\Exception $e) {
+          $this->logger->error(
+            "Failed to resolve path for uploadtree_pk=$uploadTreeId" .
+            " in upload=$uploadId: " . $e->getMessage()
+          );
+          $this->fileNameCache[$uploadTreeId] = '';
+          $this->fileHashes[$uploadTreeId] = array('sha1' => '', 'md5' => '', 'sha256' => '');
+        }
       }
 
       $statement['fileName'] = $this->fileNameCache[$uploadTreeId];
-      $statement['fileHash'] = strtolower($this->fileHashes[$uploadTreeId]["sha1"]);
+      $statement['fileHash'] = strtolower($this->fileHashes[$uploadTreeId]['sha1'] ?? '');
     }
     unset($statement);
   }

--- a/src/lib/php/Report/tests/ClearedGetterCommonTest.php
+++ b/src/lib/php/Report/tests/ClearedGetterCommonTest.php
@@ -100,7 +100,7 @@ class ClearedGetterCommonTest extends \PHPUnit\Framework\TestCase
 
     $this->treeDao
          ->shouldReceive('getItemHashes')
-         ->with(1)
+         ->with(1, $uploadTreeTableName)
          ->andReturn(array('sha1'=> "9B12538E" ,'md5'=> "MD52538E"));
 
     $this->treeDao
@@ -110,7 +110,7 @@ class ClearedGetterCommonTest extends \PHPUnit\Framework\TestCase
 
     $this->treeDao
          ->shouldReceive('getItemHashes')
-         ->with(2)
+         ->with(2, $uploadTreeTableName)
          ->andReturn(array('sha1'=> "8C2275AE" ,'md5'=> "MD5275AE"));
 
     $this->treeDao
@@ -120,7 +120,7 @@ class ClearedGetterCommonTest extends \PHPUnit\Framework\TestCase
 
     $this->treeDao
          ->shouldReceive('getItemHashes')
-         ->with(3)
+         ->with(3, $uploadTreeTableName)
          ->andReturn(array('sha1'=> "CA10238C" ,'md5'=> "MD50238C"));
 
     $this->treeDao
@@ -130,7 +130,7 @@ class ClearedGetterCommonTest extends \PHPUnit\Framework\TestCase
 
     $this->treeDao
          ->shouldReceive('getItemHashes')
-         ->with(4)
+         ->with(4, $uploadTreeTableName)
          ->andReturn(array('sha1'=> "AB12838A" ,'md5'=> "MD52838A"));
 
     $statements = $this->clearedGetterTest->getCleared($uploadId, null);
@@ -201,7 +201,7 @@ class ClearedGetterCommonTest extends \PHPUnit\Framework\TestCase
 
     $this->treeDao
          ->shouldReceive('getItemHashes')
-         ->with(1)
+         ->with(1, $uploadTreeTableName)
          ->andReturn(array('sha1'=> "9B12538E" ,'md5'=> "MD52538E"));
 
     $this->treeDao
@@ -211,7 +211,7 @@ class ClearedGetterCommonTest extends \PHPUnit\Framework\TestCase
 
     $this->treeDao
          ->shouldReceive('getItemHashes')
-         ->with(2)
+         ->with(2, $uploadTreeTableName)
          ->andReturn(array('sha1'=> "8C2275AE" ,'md5'=> "MD5275AE"));
 
     $this->treeDao
@@ -221,7 +221,7 @@ class ClearedGetterCommonTest extends \PHPUnit\Framework\TestCase
 
     $this->treeDao
          ->shouldReceive('getItemHashes')
-         ->with(3)
+         ->with(3, $uploadTreeTableName)
          ->andReturn(array('sha1'=> "CA10238C" ,'md5'=> "MD50238C"));
 
     $this->treeDao
@@ -231,7 +231,7 @@ class ClearedGetterCommonTest extends \PHPUnit\Framework\TestCase
 
     $this->treeDao
          ->shouldReceive('getItemHashes')
-         ->with(4)
+         ->with(4, $uploadTreeTableName)
          ->andReturn(array('sha1'=> "AB12838A" ,'md5'=> "MD52838A"));
 
     $tester = new TestClearedGetter("text");
@@ -277,6 +277,72 @@ class ClearedGetterCommonTest extends \PHPUnit\Framework\TestCase
       )
     );
     assertThat(arsort($expected), equalTo($statements));
+  }
+
+  /**
+   * Verify that a single uploadtree item whose path cannot be resolved (e.g. the
+   * item is not a descendant of the minimal covering item) does NOT abort the whole
+   * report.  The item should be included with an empty fileName/fileHash and all
+   * other items should be processed normally.
+   */
+  public function testChangeTreeIdsToPathsHandlesGetFullPathException()
+  {
+    $uploadId = 1;
+    $parentId = 112;
+    $uploadTreeTableName = "ut";
+
+    $this->uploadDao
+         ->shouldReceive('getUploadtreeTableName')
+         ->with($uploadId)
+         ->andReturn($uploadTreeTableName);
+
+    $this->treeDao
+         ->shouldReceive('getMinimalCoveringItem')
+         ->with($uploadId, $uploadTreeTableName)
+         ->andReturn($parentId);
+
+    // Item 1: getFullPath throws (simulates the "could not find path" scenario)
+    $this->treeDao
+         ->shouldReceive('getFullPath')
+         ->with(1, $uploadTreeTableName, $parentId)
+         ->andThrow(new \Exception("could not find path of 1"));
+
+    // Item 2: resolves normally
+    $this->treeDao
+         ->shouldReceive('getFullPath')
+         ->with(2, $uploadTreeTableName, $parentId)
+         ->andReturn("a/2");
+
+    $this->treeDao
+         ->shouldReceive('getItemHashes')
+         ->with(2, $uploadTreeTableName)
+         ->andReturn(array('sha1' => "8C2275AE", 'md5' => "MD5275AE"));
+
+    // Item 3: resolves normally
+    $this->treeDao
+         ->shouldReceive('getFullPath')
+         ->with(3, $uploadTreeTableName, $parentId)
+         ->andReturn("a/b/1");
+
+    $this->treeDao
+         ->shouldReceive('getItemHashes')
+         ->with(3, $uploadTreeTableName)
+         ->andReturn(array('sha1' => "CA10238C", 'md5' => "MD50238C"));
+
+    $clearedGetter = new TestClearedGetter();
+    // Must not throw — exception from getFullPath must be caught internally.
+    $result = $clearedGetter->getCleared($uploadId, null);
+
+    assertThat($result, hasKey('statements'));
+    $statements = $result['statements'];
+
+    // Item 1 (unresolvable) should still appear, with empty fileName and fileHash.
+    $fileNames = array_merge(...array_column($statements, 'files'));
+    assertThat($fileNames, hasItem(''));
+
+    // Items 2 and 3 should be present with their correct paths.
+    assertThat($fileNames, hasItem('a/2'));
+    assertThat($fileNames, hasItem('a/b/1'));
   }
 
   function testWeirdChars()


### PR DESCRIPTION
…uploadid

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add additional checks and rout to parent if the path not found.

## How to test

* Upload a component and do clearing with all the possible options using fossolofy.
* Generate a clearing report using all reporting options. 
* Very the data correctness and reports shall not fail.
