### PR TITLE
fix(schema): transformation logic needed a unique execution

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -40,15 +40,6 @@ jobs:
       matrix:
         config:
           - {
-              name: "Ubuntu 22.04 GCC 9",
-              os: ubuntu-22.04,
-              build_type: "Debug",
-              cc: "gcc-9",
-              cxx: "g++-9",
-              php: "8.1",
-              experimental: false,
-            }
-          - {
               name: "Ubuntu 22.04 GCC 11",
               os: ubuntu-22.04,
               build_type: "Debug",
@@ -99,10 +90,6 @@ jobs:
           extensions: gettext, mbstring, gd, json, xml, zip, pgsql, curl, uuid, posix, sqlite3
         env:
           fail-fast: true
-
-      - name: Install additional Dependencies
-        if: ${{ matrix.config.cc == 'gcc-9' }}
-        run: sudo apt install -y gcc-9 g++-9
 
       - name: Configure and Generate CMake Project
         run: |

--- a/cmake/FoPackaging.cmake
+++ b/cmake/FoPackaging.cmake
@@ -129,6 +129,11 @@ set(CPACK_DEBIAN_FOSSOLOGY-COMMON_PACKAGE_DEPENDS
     php7.2-gd | php7.3-gd | php7.4-gd | php8.1-gd | php8.2-gd | php8.3-gd | php8.4-gd,
     php7.2-yaml | php7.3-yaml | php7.4-yaml | php8.1-yaml | php8.2-yaml | php8.3-yaml | php8.4-yaml | php-yaml")
 
+set(CPACK_DEBIAN_FOSSOLOGY-COMMON_PACKAGE_CONFLICTS
+    "fossology-spdx2 (<< 4.5.0)")
+set(CPACK_DEBIAN_FOSSOLOGY-COMMON_PACKAGE_REPLACES
+    "fossology-spdx2 (<< 4.5.0)")
+
 set(CPACK_DEBIAN_FOSSOLOGY-COMMON_PACKAGE_SECTION "utils")
 set(CPACK_DEBIAN_FOSSOLOGY-COMMON_PACKAGE_CONTROL_EXTRA
 "${FO_DEBDIR}/common/postinst;${FO_DEBDIR}/common/postrm;${FO_DEBDIR}/common/conffiles")
@@ -193,6 +198,9 @@ and consult the README.Debian file included in the fossology-common
 package.")
 
 set(CPACK_DEBIAN_DB_PACKAGE_DEPENDS "postgresql")
+
+set(CPACK_DEBIAN_DB_PACKAGE_REPLACES
+    "fossology-common (<< 4.5.0)")
 
 set(CPACK_DEBIAN_DB_PACKAGE_SECTION "utils")
 set(CPACK_DEBIAN_DB_PACKAGE_CONTROL_EXTRA
@@ -587,7 +595,7 @@ set(CPACK_DEBIAN_SPDX_PACKAGE_DEPENDS
     "fossology-common")
 
 set(CPACK_DEBIAN_SPDX_PACKAGE_CONFLICTS
-    "fossology-spdx2 (< 4.5.0)")
+    "fossology-spdx2 (<< 4.5.0)")
 set(CPACK_DEBIAN_SPDX_PACKAGE_REPLACES
     "fossology-spdx2")
 

--- a/install/fossinit.php
+++ b/install/fossinit.php
@@ -506,7 +506,6 @@ function insertInToLicenseRefTableUsingJson($tableName)
   ];
 
   $jsonData = json_decode(file_get_contents("$LIBEXECDIR/licenseRef.json"), true);
-  $statementName = __METHOD__.'.insertInTo'.$tableName;
   foreach($jsonData as $licenseArray) {
     foreach ($keysToReplicate as $duplicateKey => $originalKey) {
       if ($licenseArray['rf_spdx_compatible'] == 't') {
@@ -522,6 +521,7 @@ function insertInToLicenseRefTableUsingJson($tableName)
     $arrayKeys = array_keys($licenseArray);
     $arrayValues = array_values($licenseArray);
     $keys = strtr(implode(",", $arrayKeys), $keysToBeChanged);
+    $statementName = __METHOD__ . '.insertInTo' . $tableName . '.' . md5($tableName . $keys);
     $valuePlaceHolders = "$" . join(",$",range(1, count($arrayKeys)));
     $md5PlaceHolder = "$". (count($arrayKeys) + 1);
     $arrayValues[] = $licenseArray['rf_text'];


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Migrations between version fail with a specific `license_ref_2` insert failure due to postgres statement cache. 
Package conflicts were also breaking the script flow.

Error:

```
PHP Warning:  pg_prepare(): Query failed: ERROR:  column "rf_spdx_compatible" of relation "license_ref_2" does no
t exist
LINE 1: ...text_updatable,rf_detector_type,rf_source,rf_risk,rf_spdx_co...
                                                            ^ in /usr/share/fossology/lib/php/Db/Driver/Postgres
.php on line 60
[2026-05-04T06:43:53.819814+00:00] /usr/share/fossology/lib/php/libschema.php.CRITICAL: ERROR:  column "rf_spdx_c
ompatible" of relation "license_ref_2" does not exist LINE 1: ...text_updatable,rf_detector_type,rf_source,rf_ris
k,rf_spdx_co...                                                              ^ [] []
PHP Fatal error:  Uncaught Fossology\Lib\Exception: error executing: INSERT INTO license_ref_2 ( rf_shortname,rf_
text,rf_url,rf_add_date,rf_copyleft,"rf_OSIapproved",rf_fullname,"rf_FSFfree","rf_GPLv2compatible","rf_GPLv3compa
tible",rf_notes,"rf_Fedora",marydone,rf_active,rf_text_updatable,rf_detector_type,rf_source,rf_risk,rf_spdx_compa
tible,rf_flag,rf_md5 ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,md5($21)); 
-- insertInToLicenseRefTableUsingJson.insertInTolicense_ref_2
```


### Changes

1. Extended statement with `tablename + keys` md5 support to the statement name., that is enough to differentiate between a normal `postinstall` or `version migration` action.
2. Add Conflicts resolution in `FoPackagin.cmake`
3. Update `Build&Test` Action, `gcc-9` support is not there in our supported OS, they have moved to 10 or later.

## How to Test

1. Download fossology `4.1.0` deb packages and install them in an environment
4. Create deb packages from this branch, and migrate from `4.1.0` 
5. You should not see any conflicts or any key error to `license_ref` table