### PR TITLE
chore(ci): fix release information deprecation warning

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -69,17 +69,9 @@ jobs:
       run: |
         git fetch --tags
 
-    - name: Get release info
-      id: get_release
-      uses: bruceadams/get-release@v1.3.2
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-
     - name: Set environment
-      env:
-        VERSION: ${{ steps.get_release.outputs.tag_name }}
       run: |
-        echo PACKAGE_NAME=$(echo "FOSSology-${VERSION}-$(lsb_release -si | tr [:upper:] [:lower:])-$(lsb_release -sc | tr [:upper:] [:lower:]).tar.gz") >> $GITHUB_ENV
+        echo PACKAGE_NAME=$(echo "FOSSology-${{ github.event.release.tag_name }}-$(lsb_release -si | tr [:upper:] [:lower:])-$(lsb_release -sc | tr [:upper:] [:lower:]).tar.gz") >> $GITHUB_ENV
     - name: Configure and Generate CMake Project
       run: |
         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DFO_SYSCONFDIR=/etc/fossology -DFO_LOCALSTATEDIR=/var -S. -B./build -G Ninja
@@ -106,7 +98,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.get_release.outputs.upload_url }}
+        upload_url: ${{ github.event.release.upload_url }}
         asset_path: ${{ env.PACKAGE_NAME }}
         asset_name: ${{ env.PACKAGE_NAME }}
         asset_content_type: application/gzip
@@ -133,29 +125,23 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Get release info
-      id: get_release
-      uses: bruceadams/get-release@v1.3.2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Build and push main image
       uses: docker/build-push-action@v7
       with:
         push: true
-        tags: fossology/fossology:${{ steps.get_release.outputs.tag_name }}
+        tags: fossology/fossology:${{ github.event.release.tag_name }}
         labels: |
-          org.opencontainers.image.version=${{ steps.get_release.outputs.tag_name }}.0
+          org.opencontainers.image.version=${{ github.event.release.tag_name }}.0
         context: .
 
     - name: Build and push runner image
       uses: docker/build-push-action@v7
       with:
         push: true
-        tags: fossology/fossology:${{ steps.get_release.outputs.tag_name }}-scanner
+        tags: fossology/fossology:${{ github.event.release.tag_name }}-scanner
         file: utils/automation/Dockerfile.ci
         labels: |
-          org.opencontainers.image.version=${{ steps.get_release.outputs.tag_name }}.0
+          org.opencontainers.image.version=${{ github.event.release.tag_name }}.0
 
   nomossa-build:
     runs-on: ubuntu-latest
@@ -177,18 +163,12 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DAGENTS="nomos" -DBUILD_SHARED_LIBS="off" -DCMAKE_EXE_LINKER_FLAGS="-static" -B nomossa-build -S . -G Ninja
           ninja -C ./nomossa-build/ nomossa
 
-      - name: Get release info
-        id: get_release
-        uses: bruceadams/get-release@v1.3.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Upload Nomossa Binary
         uses: shogo82148/actions-upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          upload_url: ${{ github.event.release.upload_url }}
           asset_path: nomossa-build/src/nomos/agent/nomossa
           asset_name: FOSSology-nomossa
           asset_content_type: application/octet-stream


### PR DESCRIPTION
## Description

`bruceadams/get-release@v1.3.2` is a GitHub Action that runs JavaScript compiled for Node.js 20. GitHub is deprecating Node.js 20 on runners from June 2, 2026, Node.js 24 becomes the default, and Node.js 20 is removed entirely. After that, this action will simply fail.

The action's sole purpose was to fetch two pieces of information from the GitHub API:

`tag_name` : the version tag of the release (e.g. 5.0.0)
`upload_url` :  the URL to attach release asset files to

ERROR:

<img width="690" height="204" alt="image" src="https://github.com/user-attachments/assets/2efc806b-df27-4e64-a5e4-6dd5414a49bf" />


### Changes

When GitHub triggers a workflow from a release event, it automatically injects the full release payload into `github.event.release`. Everything `bruceadams/get-release` was fetching from the API is already available in the event context no API call needed, no Node.js runtime needed

`.github/workflows/release-publish.yml` : Remove Get Release Info stage.

## How to test
1. Check release stage working properly with the correct `tag_name` and `upload_url`

Example: https://github.com/Kaushl2208/fossology/releases/tag/5.0.2-personal

CC: @GMishx 
