### PR TITLE
fix(Bulk): Fix bulk recognition UI in tree view and bulk scan agent query

### DIFF
--- a/src/monk/agent/database.c
+++ b/src/monk/agent/database.c
@@ -36,13 +36,15 @@ PGresult* queryFileIdsForUploadAndLimits(fo_dbManager* dbManager, int uploadId,
                              " WHERE upload_fk=$1 AND (ufile_mode&x'3C000000'::int)=0 AND (lft BETWEEN $2 AND $3) AND ut.pfile_fk != 0"
                              " ORDER BY ut.uploadtree_pk, scopesort, ut.pfile_fk, clearing_decision_pk DESC"
                              ") itemView WHERE decision_type!=$4 OR decision_type IS NULL";
-  char* nonVoidPfile = "SELECT pfile_fk FROM allPfileData"
-                       " WHERE pfile_fk NOT IN (SELECT lf.pfile_fk"
+  char* nonVoidPfile = ", realFindings AS ("
+                       " SELECT DISTINCT lf.pfile_fk"
                        " FROM license_file lf"
-                       " JOIN ars_master am ON lf.agent_fk = am.agent_fk"
-                       " JOIN " LICENSE_REF_TABLE " lr ON lf.rf_fk = lr.rf_pk"
-                       " WHERE am.upload_fk = $1"
-                       " AND lr.rf_shortname = ANY(VALUES('No_license_found'), ('Void')))";
+                       " INNER JOIN ars_master am ON lf.agent_fk = am.agent_fk AND am.upload_fk = $1"
+                       " INNER JOIN " LICENSE_REF_TABLE " lr ON lf.rf_fk = lr.rf_pk"
+                       " WHERE lr.rf_shortname NOT IN ('No_license_found', 'Void')"
+                       ")"
+                       " SELECT pfile_fk FROM allPfileData"
+                       " WHERE pfile_fk IN (SELECT pfile_fk FROM realFindings)";
 
   if (!ignoreIrre && !scanFindings)
   {

--- a/src/www/ui/async/AjaxExplorer.php
+++ b/src/www/ui/async/AjaxExplorer.php
@@ -447,7 +447,7 @@ class AjaxExplorer extends DefaultPlugin
 
     if ($isContainer) {
       $getTextEditBulk = _("Bulk");
-      $fileListLinks .= "[<a href='#' data-toggle='modal' data-target='#bulkModal' onclick='openBulkModal($childUploadTreeId)' >$getTextEditBulk</a>]";
+      $fileListLinks .= "[<a href='#' onclick='openBulkModal($childUploadTreeId)' >$getTextEditBulk</a>]";
     }
     $fileListLinks .= "<input type='checkbox' class='selectedForIrrelevant' class='info-bullet view-license-rc-size' value='".$childUploadTreeId."'>";
     $filesThatShouldStillBeCleared = array_key_exists($childItemTreeBounds->getItemId()

--- a/src/www/ui/scripts/change-license-browse.js
+++ b/src/www/ui/scripts/change-license-browse.js
@@ -37,24 +37,23 @@ $(document).ready(function () {
 });
 
 $("#textModal").on('show.bs.modal', function (e) {
-    $("#bulkModal").modal("hide");
+    $("#bulkModal").hide();
 });
 
 $("#textModal").on('hide.bs.modal', function (e) {
-    $("#bulkModal").modal("show");
+    $("#bulkModal").show();
 });
 
 function openBulkModal(uploadTreeId) {
-  bulkModal = $('#bulkModal').modal('hide');
   $('#bulkScope').val("f");
   $('#bulkScope').attr("disabled", true);
   $('#uploadTreeId').val(uploadTreeId);
-  bulkModal.toggle();
+  $('#bulkModal').modal('show');
 }
 
 function closeBulkModal() {
   $('#editFilter').val(0);
-  $('#bulkModal').hide();
+  $('#bulkModal').modal('hide');
 }
 
 // Hide backdrop for bulk modal

--- a/src/www/ui/scripts/change-license-common.js
+++ b/src/www/ui/scripts/change-license-common.js
@@ -82,10 +82,13 @@ function selectNoLicenseFound(left, right) {
 function scheduledDeciderSuccess (data, resultEntity, callbackSuccess, callbackCloseModal) {
   var jqPk = data.jqid;
   if (jqPk) {
-    resultEntity.html("scan scheduled as " + linkToJob(jqPk));
+    var jqPks = Array.isArray(jqPk) ? jqPk : [jqPk];
+    resultEntity.html("scan scheduled as " + jqPks.map(linkToJob).join(', '));
     if (callbackSuccess) {
-      queueUpdateCheck(jqPk, callbackSuccess, function() {
-        resultEntity.html("job failed (see " + linkToJob(jqPk) + ")");
+      jqPks.forEach(function(pk) {
+        queueUpdateCheck(pk, callbackSuccess, function() {
+          resultEntity.html("job failed (see " + linkToJob(pk) + ")");
+        });
       });
     }
     callbackCloseModal();
@@ -248,15 +251,20 @@ function openTextModel(uploadTreeId, licenseId, what, type) {
     type = 0;
   }
 
+  var titleMap = {
+    2: 'License Text', 'reportinfo': 'License Text',
+    3: 'Acknowledgement', 'acknowledgement': 'Acknowledgement',
+    4: 'Comment', 'comment': 'Comment'
+  };
+  $('#textModal .modal-title').text(titleMap[what] || 'Enter Content');
+
   if (what == 3 || what === 'acknowledgement') {
-    // clicked to add button to display child modal
     $('#selectFromNoticeFile').css('display','inline-block');
   } else {
     $('#selectFromNoticeFile').css('display','none');
   }
 
   if (what == 2 || what === 'reportinfo') {
-    // clicked to add button to display child modal
     $('#clearText').show();
   } else {
     $('#clearText').hide();
@@ -302,6 +310,7 @@ function openTextModel(uploadTreeId, licenseId, what, type) {
 }
 
 function closeTextModal() {
+  if (document.activeElement) document.activeElement.blur();
   textModal.modal('hide');
 }
 
@@ -356,6 +365,7 @@ function selectNoticeFile() {
 }
 
 function submitTextModal(){
+  if (document.activeElement) document.activeElement.blur();
   var refTextId = "#referenceText"
   var ConcludeLicenseUrl = "?mod=conclude-license&do=updateClearings";
   if(whatType == 0) {
@@ -372,12 +382,12 @@ function submitTextModal(){
     });
   } else {
     textModal.modal('hide');
-    $("#"+ whatLicId + whatCol +"Bulk").attr('title', $(refTextId).val());
-    referenceText = $(refTextId).val().trim();
-    if(referenceText !== null && referenceText !== '') {
-      $("#"+ whatLicId + whatCol + whatType).html($("#"+ whatLicId + whatCol + whatType).attr('title').slice(0, 10) + "...");
+    var enteredText = $(refTextId).val();
+    if (typeof setBulkLicenseText === 'function') {
+      setBulkLicenseText(whatLicId, whatCol, enteredText);
     } else {
-      $("#"+ whatLicId + whatCol +"Bulk").attr('title','');
+      var displayText = enteredText.trim() !== '' ? enteredText.slice(0, 10) + "..." : 'Click to add';
+      $("#"+ whatLicId + whatCol +"Bulk").attr('title', enteredText).html(displayText);
     }
   }
 }
@@ -408,7 +418,7 @@ function openAckInputModal(){
 }
 
 function closeAckInputModal(){
-  $('#textAckInputModal').modal('show');
+  $('#textAckInputModal').modal('hide');
 }
 
 function doOnSuccess(textModal) {
@@ -455,7 +465,6 @@ $(document).ready(function () {
 function createDropDown(element, textBox) {
   let dropDown = null;
   if ($("#licenseStdCommentDropDown").length) {
-    // The dropdown already exists
     $("#licenseStdCommentDropDown-text").show();
     dropDown = $("#licenseStdCommentDropDown");
     dropDown.val(null).trigger('change');
@@ -519,7 +528,6 @@ function getStdLicenseComments(scope, callback) {
 function createAcknowledgementDropDown(element, textBox) {
   let dropDown = null;
   if ($("#licenseAcknowledgementDropDown").length) {
-    // The dropdown already exists
     $("#licenseAcknowledgementDropDown-text").show();
     dropDown = $("#licenseAcknowledgementDropDown");
     dropDown.val(null).trigger('change');

--- a/src/www/ui/scripts/change-license-view.js
+++ b/src/www/ui/scripts/change-license-view.js
@@ -17,12 +17,12 @@ function openBulkModal() {
   $('#userModal').hide();
   $('#ClearingHistoryDataModal').hide();
   bulkModalOpened = 1;
-  $('#bulkModal').toggle();
+  $('#bulkModal').modal('show');
 }
 
 function closeBulkModal() {
   bulkModalOpened = 0;
-  $('#bulkModal').hide();
+  $('#bulkModal').modal('hide');
 }
 
 // Hide backdrop for bulk modal
@@ -48,13 +48,13 @@ function closeUserModal() {
 
 $("#textModal").on('show.bs.modal', function (e) {
   if(bulkModalOpened) {
-    $("#bulkModal").modal("hide");
+    $("#bulkModal").hide();
   }
 });
 
 $("#textModal").on('hide.bs.modal', function (e) {
   if(bulkModalOpened) {
-    $("#bulkModal").modal("show");
+    $("#bulkModal").show();
   }
 });
 

--- a/src/www/ui/scripts/ui-clearing-view_bulk.js
+++ b/src/www/ui/scripts/ui-clearing-view_bulk.js
@@ -11,49 +11,29 @@ var bulkFormTableContent = (function(){
     var s = "";
     var uploadTreeId = $('#uploadTreeId').val();
     for (i = 0; i < content.length; ++i) {
-      // Set defaults
-      var licenseTitle = $(`#${content[i].licenseId}reportinfoBulk`)
-        .attr('title');
-      var licenseText = 'Click to add';
-      var ackTitle = $(`#${content[i].licenseId}acknowledgementBulk`)
-        .attr('title');
-      var ackText = 'Click to add';
-      var commentTitle = $(`#${content[i].licenseId}commentBulk`)
-        .attr('title');
-      var commentText = 'Click to add';
-
-      // If titles are undefined, make them empty string
-      licenseTitle ??= "";
-      ackTitle ??= "";
-      commentTitle ??= "";
-
-      // Change display text if value exists
-      if (licenseTitle.length != 0) {
-        licenseText = licenseTitle.slice(0, 10) + "...";
-      }
-      if (ackTitle.length != 0) {
-        ackText = ackTitle.slice(0, 10) + "...";
-      }
-      if (commentTitle.length != 0) {
-        commentText = commentTitle.slice(0, 10) + "...";
-      }
+      var licenseTitle = content[i].reportinfo || '';
+      var licenseText = licenseTitle.length > 0 ? licenseTitle.slice(0, 10) + "..." : 'Click to add';
+      var ackTitle = content[i].acknowledgement || '';
+      var ackText = ackTitle.length > 0 ? ackTitle.slice(0, 10) + "..." : 'Click to add';
+      var commentTitle = content[i].comment || '';
+      var commentText = commentTitle.length > 0 ? commentTitle.slice(0, 10) + "..." : 'Click to add';
 
       s += `<tr class='${(i % 2 == 1) ? "even" : "odd"}'>
         <td align='center'>${content[i].action}</td>
         <td>${content[i].licenseName}</td>
         <td><a href='javascript:;' style='color:#000;'
           id='${content[i].licenseId}reportinfoBulk'
-          onClick="openTextModel(${uploadTreeId}, ${content[i].licenseId},
+          onClick="openTextModel('${uploadTreeId}', ${content[i].licenseId},
             'reportinfo', 'Bulk');" title='${licenseTitle}'>
           ${licenseText}</a></td>
         <td><a href='javascript:;' style='color:#000;'
           id='${content[i].licenseId}acknowledgementBulk'
-          onClick="openTextModel(${uploadTreeId}, ${content[i].licenseId},
+          onClick="openTextModel('${uploadTreeId}', ${content[i].licenseId},
             'acknowledgement', 'Bulk');" title='${ackTitle}'>
           ${ackText}</a></td>
         <td><a href='javascript:;' style='color:#000;'
           id='${content[i].licenseId}commentBulk'
-          onClick="openTextModel(${uploadTreeId}, ${content[i].licenseId},
+          onClick="openTextModel('${uploadTreeId}', ${content[i].licenseId},
             'comment', 'Bulk');" title='${commentTitle}'>
           ${commentText}</a></td>
         <td><a href='#'
@@ -83,7 +63,10 @@ var bulkFormTableContent = (function(){
         content.push({
           licenseId: lic,
           licenseName: $('#bulkLicense option:selected').text(),
-          action: "Add"
+          action: "Add",
+          reportinfo: '',
+          acknowledgement: '',
+          comment: ''
           });
     }
       updateTable();
@@ -95,7 +78,10 @@ var bulkFormTableContent = (function(){
         content.push({
           licenseId: lic,
           licenseName: $('#bulkLicense option:selected').text(),
-          action: "Remove"
+          action: "Remove",
+          reportinfo: '',
+          acknowledgement: '',
+          comment: ''
           });
     }
       updateTable();
@@ -103,10 +89,21 @@ var bulkFormTableContent = (function(){
   function getContent(){
       return content;
   }
-    return [addLicense,rmLicense,removeOldEntry,getContent];
+  function setLicenseText(licenseId, field, text) {
+    for (var i = 0; i < content.length; i++) {
+      if (content[i].licenseId === licenseId) {
+        content[i][field] = text;
+        var displayText = text.trim() !== '' ? text.slice(0, 10) + "..." : 'Click to add';
+        $('#' + licenseId + field + 'Bulk').attr('title', text).html(displayText);
+        break;
+      }
+    }
+  }
+    return [addLicense, rmLicense, removeOldEntry, getContent, setLicenseText];
 }());
 
 $('#bulkFormAddLicense').click(function(){ bulkFormTableContent[0](); });
 $('#bulkFormRmLicense').click(function(){ bulkFormTableContent[1](); });
 
 function getBulkFormTableContent(){ return bulkFormTableContent[3](); }
+function setBulkLicenseText(licenseId, field, text){ bulkFormTableContent[4](licenseId, field, text); }

--- a/src/www/ui/template/ui-clearing-view_bulk.html.twig
+++ b/src/www/ui/template/ui-clearing-view_bulk.html.twig
@@ -23,8 +23,8 @@
         <div class="modal-footer">
           <button type="button" class="btn" id="selectFromNoticeFile" style="display:none;width:96%;" onclick="openAckInputModal();">Select from Notice File</button>
           <button type="button" class="btn" id="clearText" style="display:none;width:96%;" onclick="cleanText( $('#referenceText') );">{{ 'Clean Text'|trans }}</button>
-          <button type="button" class="btn btn-danger" onclick="closeTextModal();" data-dismiss="modal">{{ 'Cancel'|trans }}</button>
-          <button type="button" class="btn btn-success" onclick="submitTextModal();" data-dismiss="modal">{{ 'Ok'|trans }}</button>
+          <button type="button" class="btn btn-danger" onclick="closeTextModal();">{{ 'Cancel'|trans }}</button>
+          <button type="button" class="btn btn-success" onclick="submitTextModal();">{{ 'Ok'|trans }}</button>
         </div>
       </div>
     </div>

--- a/src/www/ui/template/ui-clearing-view_rhs.html.twig
+++ b/src/www/ui/template/ui-clearing-view_rhs.html.twig
@@ -129,7 +129,7 @@
       {{ 'User Decision ...'| trans }}
     </button><img src="images/info_16.png" data-toggle="tooltip" title="{{ 'Add manually a license that is not found by scanners or bulk'|trans }}" alt="" class="info-bullet"/>
     &nbsp;
-    <button type="button" data-toggle="modal" data-backdrop="false" data-target="#bulkModal" class="btn btn-default btn-sm" onclick="openBulkModal();">
+    <button type="button" class="btn btn-default btn-sm" onclick="openBulkModal();">
       {{ 'Bulk Recognition ...'| trans }}
     </button><img src="images/info_16.png" data-toggle="tooltip" title="{{ 'Adding or removing a license based on a text fragment that is searched for across the relevant files'|trans }}" alt="" class="info-bullet"/>
     &nbsp;


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

use bootstrap hide and show instead of CSS toggle. Change query to pull files for bulk when different scanners finds license and no license found at once.

## How to test

* Upload a component.
* Go to tree view and select multiple folders. 
* Open select option and click on bulk recognation.
* Add license text, acknowledgement and comment.
* Schedule the scan.
