### PR TITLE
fix(bulkScan): use uploadtreetablename, fix logic to get latest decis…

### DIFF
--- a/src/deciderjob/agent/DeciderJobAgent.php
+++ b/src/deciderjob/agent/DeciderJobAgent.php
@@ -113,7 +113,7 @@ class DeciderJobAgent extends Agent
   /**
    * @brief Process clearing events of current job handled by agent
    */
-  function processClearingEventOfCurrentJob()
+  function processClearingEventOfCurrentJob($uploadId)
   {
     $userId = $this->userId;
     $groupId = $this->groupId;
@@ -121,7 +121,7 @@ class DeciderJobAgent extends Agent
 
     $eventsOfThisJob = $this->clearingDao->getEventIdsOfJob($jobId);
     foreach ($eventsOfThisJob as $uploadTreeId => $additionalEventsFromThisJob) {
-      $containerBounds = $this->uploadDao->getItemTreeBounds($uploadTreeId);
+      $containerBounds = $this->uploadDao->getItemTreeBoundsFromUploadId($uploadTreeId, $uploadId);
       foreach ($this->loopContainedItems($containerBounds) as $itemTreeBounds) {
         $this->processClearingEventsForItem($itemTreeBounds, $userId, $groupId, $additionalEventsFromThisJob);
       }
@@ -172,7 +172,7 @@ class DeciderJobAgent extends Agent
       }
       $this->heartbeat($this->clearingDao->marklocalDecisionsAsGlobal($uploadId));
     } else {
-      $this->processClearingEventOfCurrentJob();
+      $this->processClearingEventOfCurrentJob($uploadId);
     }
     return true;
   }

--- a/src/deciderjob/agent_tests/Functional/schedulerTest.php
+++ b/src/deciderjob/agent_tests/Functional/schedulerTest.php
@@ -334,8 +334,8 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
     $bounds1->shouldReceive('getUploadTreeTableName')->andReturn('uploadtree');
     $bounds = array($bounds0, $bounds1);
 
-    $uploadDao->shouldReceive('getItemTreeBounds')->with($itemIds[0])->andReturn($bounds[0]);
-    $uploadDao->shouldReceive('getItemTreeBounds')->with($itemIds[1])->andReturn($bounds[1]);
+    $uploadDao->shouldReceive('getItemTreeBoundsFromUploadId')->with($itemIds[0], $uploadId)->andReturn($bounds[0]);
+    $uploadDao->shouldReceive('getItemTreeBoundsFromUploadId')->with($itemIds[1], $uploadId)->andReturn($bounds[1]);
     $uploadDao->shouldReceive('getUploadEntry')->with($itemIds[0], 'uploadtree')
       ->andReturn(array('pfile_fk' => 1));
     $uploadDao->shouldReceive('getUploadEntry')->with($itemIds[1], 'uploadtree')

--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -69,7 +69,7 @@ class ClearingDao
     }
 
     $filterClause = $onlyCurrent ? "DISTINCT ON(itemid)" : "";
-    $sortClause = $onlyCurrent ? "ORDER BY itemid, scope, id DESC" : "";
+    $sortClause = $onlyCurrent ? "ORDER BY itemid, id DESC" : "";
 
     $statementName .= "." . $uploadTreeTable . ($onlyCurrent ? ".current": "");
 
@@ -261,7 +261,7 @@ class ClearingDao
       $reportInfo = $row['reportinfo'];
       $acknowledgement = $row['acknowledgement'];
 
-      if ($clearingId !== $previousClearingId && $itemId !== $previousItemId) {
+      if ($clearingId !== $previousClearingId || $itemId !== $previousItemId) {
         //store the old one
         if (!$firstMatch) {
           $clearingsWithLicensesArray[] = $clearingDecisionBuilder->setClearingEvents($clearingEvents)->build();
@@ -269,11 +269,8 @@ class ClearingDao
 
         $firstMatch = false;
         //prepare the new one
-        if ($forClearingHistory) {
-          $previousClearingId = $clearingId;
-        } else {
-          $previousItemId = $itemId;
-        }
+        $previousClearingId = $clearingId;
+        $previousItemId = $itemId;
         $clearingEvents = array();
         $clearingDecisionBuilder = ClearingDecisionBuilder::create()
             ->setClearingId($row['id'])

--- a/src/lib/php/Dao/LicenseDao.php
+++ b/src/lib/php/Dao/LicenseDao.php
@@ -73,7 +73,7 @@ class LicenseDao
           INNER JOIN $uploadTreeTableName as UT ON UT.pfile_fk = LFR.pfile_fk
           INNER JOIN agent as AG ON AG.agent_pk = LFR.agent_fk
           WHERE AG.agent_enabled='true' and
-           UT.upload_fk=$1 AND UT.lft BETWEEN $2 and $3
+           UT.upload_fk=$1 AND UT.lft BETWEEN $2 AND $3
           ORDER BY license_shortname ASC, percent_match DESC");
     $result = $this->dbManager->execute($statementName, $params);
     $matches = array();


### PR DESCRIPTION

## Description

* If the clearing decision is changed multiple times then the clearing history is not correct.
* If the clearing decision is changed from local to global then the edit licenses in tree view doesn't contain all the licenses.
* Make use of Uploadtree_a and uploadtree_uploadid to fetch tree bonds. (faster when large uploads) 

### Changes

* Change logic to fetch clearing hostory.
* Remove scope from the order clause.
* add upload id and change the item bonds function name.

## How to test

* Upload a component.
* Do clearing using single file view. 
* Now change the license and decision type to repo. 
* Go to tree View and check the edited license, also check the clearing history.

Closes #1245 
