### PR TITLE
refactor(nomos): pre-compiling nomos regex patterns once at startup i…

### DIFF
--- a/src/nomos/agent/licenses.c
+++ b/src/nomos/agent/licenses.c
@@ -239,7 +239,30 @@ void licenseInit() {
       continue;
     }
   }
+
+  /* pre-compile all non-plain patterns once; idx_regc[] reused in idxGrep_base() */
+  for (i = 0; i < NFOOTPRINTS; i++) {
+    if (!licText[i].plain && licText[i].regex != NULL_STR) {
+      int rc = regcomp(&idx_regc[i], licText[i].regex, REG_ICASE | REG_EXTENDED);
+      if (rc == 0) {
+        licText[i].compiled = 1;
+      } else {
+        LOG_WARNING("nomos: failed to pre-compile regex #%d: %s", i, licText[i].regex);
+      }
+    }
+  }
   return;
+}
+
+void licenseRegexFree(void)
+{
+  int i;
+  for (i = 0; i < NFOOTPRINTS; i++) {
+    if (licText[i].compiled) {
+      regfree(&idx_regc[i]);
+      licText[i].compiled = 0;
+    }
+  }
 }
 
 #define	LINE_BYTES	50	/**< fudge for punctuation, etc. */

--- a/src/nomos/agent/licenses.h
+++ b/src/nomos/agent/licenses.h
@@ -8,6 +8,7 @@
 #define _LICENSES_H
 
 void licenseInit();
+void licenseRegexFree(void);
 int ignoreFileForScan(char *s);
 void licenseScan(list_t *l);
 

--- a/src/nomos/agent/nomos_regex.c
+++ b/src/nomos/agent/nomos_regex.c
@@ -328,11 +328,10 @@ int idxGrep_base(int index, char *data, int flags, int mode)
 
   int show = flags & FL_SHOWMATCH;
   licText_t *ltp = licText + index;
-  /**
-   * \todo is idx_regc needed? Here we set the pointer to our array and later
-   * we fill it, but we never reuse the regex_t
-   */
   regex_t *rp = idx_regc + index;
+
+  /* skip regcomp/regfree for pre-compiled patterns; REG_NEWLINE changes ^/$ semantics so always recompile those */
+  int use_precompiled = ltp->compiled && !(flags & REG_NEWLINE);
 
   CALL_IF_DEBUG_MODE(printf(" %i %i \"", index, ltp->plain);)
 
@@ -354,32 +353,35 @@ int idxGrep_base(int index, char *data, int flags, int mode)
     return (0);
   }
 
-  if (ltp->plain )
+  if (ltp->plain)
   {
     ret = strNbuf(data, ltp->regex);
-    if(ret == 0) return (ret);
+    if (ret == 0) return (ret);
   }
   else {
-    if ((ret = regcomp(rp, ltp->regex, flags)))
+    if (!use_precompiled)
     {
-      fprintf(stderr, "Compile failed, regex #%d\n", index);
-      regexError(ret, rp, ltp->regex);
-      regfree(rp);
-      printf("Compile error \n");
-      return (-1); /* <0 indicates compile failure */
+      if ((ret = regcomp(rp, ltp->regex, flags)))
+      {
+        fprintf(stderr, "Compile failed, regex #%d\n", index);
+        regexError(ret, rp, ltp->regex);
+        regfree(rp);
+        printf("Compile error \n");
+        return (-1); /* <0 indicates compile failure */
+      }
     }
 
     if (regexec(rp, data, 1, &cur.regm, 0))
     {
-      regfree(rp);
+      if (!use_precompiled) regfree(rp);
       return (0);
     }
-    else ret  =1;
+    else ret = 1;
 
   #ifdef  QA_CHECKS
     if (cur.regm.rm_so == cur.regm.rm_eo)
     {
-      regfree(rp);
+      if (!use_precompiled) regfree(rp);
       Assert(NO, "start/end offsets are identical in idxGrep(%d)",
           index);
     }
@@ -405,16 +407,15 @@ int idxGrep_base(int index, char *data, int flags, int mode)
 
   //! Now we have a match
 
-  if (mode == 3 ) {
-      recordIndex(cur.indexList, index);
-    }
-  else if (mode==1 || mode == 2)
+  if (mode == 3) {
+    recordIndex(cur.indexList, index);
+  }
+  else if (mode == 1 || mode == 2)
   {
     CALL_IF_DEBUG_MODE(printf("MATCH!\n");)
     //! All sanity checks have passed and we have at least one match
 
     CALL_IF_DEBUG_MODE(printf("%s", data);)
-
 
     GArray* allmatches = g_array_new(FALSE, FALSE, sizeof(regmatch_t));
     regmatch_t currentRegMatch;
@@ -424,24 +425,23 @@ int idxGrep_base(int index, char *data, int flags, int mode)
 
     lastmatch = storeOneMatch(cur.regm, lastmatch, allmatches, &tmpData, data);
 
-    while (!matchOnce(ltp->plain,tmpData, ltp->regex, rp, &currentRegMatch )  )
+    while (!matchOnce(ltp->plain, tmpData, ltp->regex, rp, &currentRegMatch))
     {
       lastmatch = storeOneMatch(currentRegMatch, lastmatch, allmatches, &tmpData, data);
     }
 
-
-    if(index >= _KW_first  && index <= _KW_last ) {
+    if (index >= _KW_first && index <= _KW_last) {
       rememberWhatWeFound(cur.keywordPositions, allmatches, index, mode);
     }
-    else if (cur.currentLicenceIndex > -1 ) {
-       rememberWhatWeFound( getLicenceAndMatchPositions(cur.theMatches, cur.currentLicenceIndex )->matchPositions , allmatches, index, mode);
+    else if (cur.currentLicenceIndex > -1) {
+      rememberWhatWeFound(getLicenceAndMatchPositions(cur.theMatches, cur.currentLicenceIndex)->matchPositions, allmatches, index, mode);
     }
     g_array_free(allmatches, 1);
     CALL_IF_DEBUG_MODE(printf("Bye!\n");)
- }
+  }
 
-  if (!ltp->plain ) regfree(rp);
-return (1);
+  if (!ltp->plain && !use_precompiled) regfree(rp);
+  return (1);
 }
 
 /**

--- a/src/nomos/agent/nomos_regex.h
+++ b/src/nomos/agent/nomos_regex.h
@@ -14,6 +14,7 @@
 #include <_autodefs.h>
 
 extern regex_t regc[NFOOTPRINTS];
+extern regex_t idx_regc[NFOOTPRINTS];
 
 void regexError(int ret, regex_t *regc, char *regex);
 int endsIn(char *s, char *suffix);

--- a/src/nomos/agent/nomos_utils.c
+++ b/src/nomos/agent/nomos_utils.c
@@ -10,6 +10,7 @@
 
 #include "nomos_utils.h"
 #include "nomos.h"
+#include "licenses.h"
 
 extern int should_connect_to_db;  /* Global variable to control DB connection */
 
@@ -546,6 +547,8 @@ FUNCTION void Bail(int exitval)
     memCacheDump("Mem-cache @ Bail() time:");
   }
 #endif /* MEMORY_TRACING && MEM_ACCT */
+
+  licenseRegexFree();
 
   /* close database and scheduler connections */
   if (gl.pgConn) {


### PR DESCRIPTION
…nstead

<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Pre-compile nomos regex at once instead of everytime. 

### Before Fix

<img width="1831" height="103" alt="image" src="https://github.com/user-attachments/assets/3c6570f8-d915-4334-a6fa-a132938bb226" />


### After Fix

<img width="1837" height="105" alt="image" src="https://github.com/user-attachments/assets/5eb3fcfa-d192-4f34-8406-952c694806d9" />


## How to test

* do general testing using nomos agent
