### PR TITLE
feat(copyright): add revert to original for copyright hist

### DIFF
--- a/src/copyright/ui/HistogramBase.php
+++ b/src/copyright/ui/HistogramBase.php
@@ -71,7 +71,7 @@ abstract class HistogramBase extends FO_Plugin
     $output = "<h4>Activated $typeDescriptor statements:</h4>
 <div>
   <div class='btn btn-default' style='float:right; padding:5px; margin:5px;'>
-    <input type='checkbox' style='padding:2px;' id='inverseSearchActivated".$type."' name='inverseSearch'/> 
+    <input type='checkbox' style='padding:2px;' id='inverseSearchActivated".$type."' name='inverseSearch'/>
     <label class='control-label' for='inverseSearchActivated".$type."'>Inverse Search</label>
   </div>
 <table border=1 width='100%' id='copyright".$type."' class='wordbreaktable'></table></div>

--- a/src/copyright/ui/ajax-copyright-hist.php
+++ b/src/copyright/ui/ajax-copyright-hist.php
@@ -11,6 +11,7 @@ use Fossology\Lib\Dao\CopyrightDao;
 use Fossology\Lib\Dao\UploadDao;
 use Fossology\Lib\Db\DbManager;
 use Fossology\Lib\Util\DataTablesUtility;
+use Fossology\Lib\Util\StringOperation;
 use Fossology\Agent\Copyright\UI\TextFindingsAjax;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -92,7 +93,7 @@ class CopyrightHistogramProcessPost extends FO_Plugin
       $pfile = GetParm("pfile", PARM_INTEGER);
     } elseif ($action=="deleteHashDecision" || $action=="undoHashDecision") {
       $hash = GetParm("hash", PARM_STRING);
-    } elseif ($action=="update" || $action=="delete" || $action=="undo") {
+    } elseif ($action=="update" || $action=="delete" || $action=="undo" || $action=="revertToOriginal") {
       $id = GetParm("id", PARM_STRING);
       $getEachID = array_filter(explode(",", trim($id, ',')), function($var) {
           return $var !== "";
@@ -141,6 +142,9 @@ class CopyrightHistogramProcessPost extends FO_Plugin
           break;
         case "undo":
           $returnValue = $this->doUndo($item, $hash, $type);
+          break;
+        case "revertToOriginal":
+          $returnValue = $this->doRevertToOriginal($item, $type);
           break;
         case "deletedecision":
           $returnValue = $this->doDeleteDecision($decision, $pfile, $type);
@@ -521,6 +525,26 @@ count(*) AS copyright_count " .
     $cpTable = $this->getTableName($type);
     $this->copyrightDao->updateTable($item, $hash, '', Auth::getUserId(), $cpTable, 'rollback');
     return new Response('Successfully restored', Response::HTTP_OK, array('Content-type'=>'text/plain'));
+  }
+
+  /**
+   * @brief Revert an edited result back to its original scanner text
+   * @param int    $itemId Upload tree id of the item
+   * @param string $type   'copyright'|'ecc'|'keyword'
+   * @return Response
+   */
+  protected function doRevertToOriginal($itemId, $type)
+  {
+    $newContent = GetParm("newContent", PARM_RAW);
+    if (empty($newContent)) {
+      return new Response('empty content',
+        Response::HTTP_BAD_REQUEST, array('Content-type'=>'text/plain'));
+    }
+    $newHash = md5(StringOperation::replaceUnicodeControlChar($newContent));
+    $item = $this->uploadDao->getItemTreeBounds($itemId, $this->uploadtree_tablename);
+    $cpTable = $this->getTableName($type);
+    $this->copyrightDao->updateTable($item, $newHash, '', Auth::getUserId(), $cpTable, 'revertToOriginal');
+    return new Response('Successfully reverted', Response::HTTP_OK, array('Content-type'=>'text/plain'));
   }
 
   /**

--- a/src/copyright/ui/template/histTable.js.twig
+++ b/src/copyright/ui/template/histTable.js.twig
@@ -3,6 +3,7 @@
    SPDX-License-Identifier: FSFAP
 #}
 
+
 function createTableBase{{ table.type }}(activated) {
   var aoColumns = [
       { "sTitle": "{{ 'Count'| trans }}", "sClass": "right read_only", "sWidth": "5%" },
@@ -78,16 +79,38 @@ function createTable{{ table.type }}() {
       var value = aInput[0].value;
       var isValid = (value) && !(/^\s*$/.test(value));
       if (isValid) {
-        var id = aInput.parents("tr:first")[0].id;
-        var hash = id.split(",")[2];
-        $("#delete{{ table.type }}" + hash).hide();
-        var updateElement = $("#update{{ table.type }}" + hash);
-        updateElement.text("updating...");
-        updateElement.show();
+        var $tr = aInput.parents("tr:first");
+        var rowData = enabledTable.api().row($tr[0]).data();
+        var dtRowId = (rowData && rowData['DT_RowId']) ? rowData['DT_RowId'] : $tr.attr('id');
+        var parts = dtRowId.split(",");
+        var hash = parts[2];
+        if (hash) {
+          $("#delete{{ table.type }}" + hash).hide();
+          var updateElement = $("#update{{ table.type }}" + hash);
+          updateElement.text("updating...");
+          updateElement.show();
+        }
       }
       return isValid;
     },
+    "fnOnEdited": function(status, sOldValue, sNewCellDisplayValue, rowIdx) {
+      if (status === "success" && sNewCellDisplayValue) {
+        var rowData = enabledTable.api().row(rowIdx).data();
+        if (rowData && rowData['DT_RowId']) {
+          var parts = rowData['DT_RowId'].split(",");
+          var upload = parts[0], item = parts[1], hash = parts[2], type = parts[3];
+          startRevert{{ table.type }}(upload, item, hash, sNewCellDisplayValue, type);
+        }
+      }
+    },
     "sSuccessResponse": "success"
+  });
+
+  enabledTable.api().on('draw.dt', function() {
+    var s = _revertState{{ table.type }};
+    if (s && Date.now() < s.expiresAt) {
+      applyRevertButton{{ table.type }}(s);
+    }
   });
 
   createTableBase{{ table.type }}(false);
@@ -165,14 +188,16 @@ function createTable{{ table.type }}() {
         ajaxList.push(updateRows{{ table.type }}(currUploadData[0],
           currUploadData[1], currUploadData[2], currUploadData[3], newValue));
       });
-      // Wait for all ajax calls to resolve
       $.when.apply($, ajaxList).done(function(){
-        location.reload(true)
+        $('#copyright{{ table.type }}').DataTable().ajax.reload(null, false);
       });
     }
   });
 
   $('#copyright{{ table.type }} tbody').on('click', 'tr td:nth-child(3)', function (event) {
+    if ($(event.target).closest('.revert-link').length > 0) {
+      return;
+    }
     if ($(this).find('img:visible').length > 0) {
       if ($(event.target).is('img')) {
         return;
@@ -333,5 +358,89 @@ function undo{{ table.type }}(upload, item, hash, kind) {
       error: function(errorResponse) {
         alert(errorResponse.responseText);
       }
+  });
+}
+
+var _revertState{{ table.type }} = null;
+
+function startRevert{{ table.type }}(upload, item, hash, newContent, type) {
+  if (_revertState{{ table.type }}) {
+    clearInterval(_revertState{{ table.type }}.timerId);
+    _revertState{{ table.type }} = null;
+  }
+  var state = {
+    upload: upload, item: item, hash: hash,
+    newContent: newContent, type: type,
+    expiresAt: Date.now() + 5000,
+    timerId: null
+  };
+  state.timerId = setInterval(function() {
+    var remaining = Math.ceil((state.expiresAt - Date.now()) / 1000);
+    var $btn = $('#revert{{ table.type }}' + state.hash);
+    if ($btn.length) {
+      $btn.find('.revert-countdown').text(Math.max(0, remaining));
+    }
+    if (remaining <= 0) {
+      clearInterval(state.timerId);
+      _revertState{{ table.type }} = null;
+      var $b = $('#revert{{ table.type }}' + state.hash);
+      $("tr.row" + state.hash + " td").removeAttr("style");
+      if ($b.length) {
+        $b.fadeOut(300, function() {
+          $(this).remove();
+          $('#copyright{{ table.type }}').DataTable().ajax.reload(null, false);
+        });
+      } else {
+        $('#copyright{{ table.type }}').DataTable().ajax.reload(null, false);
+      }
+    }
+  }, 1000);
+  _revertState{{ table.type }} = state;
+  applyRevertButton{{ table.type }}(state);
+}
+
+function applyRevertButton{{ table.type }}(state) {
+  var hash = state.hash;
+  var revertId = "revert{{ table.type }}" + hash;
+  if ($('#' + revertId).length) {
+    return;
+  }
+  var $deleteBtn = $('#delete{{ table.type }}' + hash);
+  if (!$deleteBtn.length) {
+    return;
+  }
+  $deleteBtn.hide();
+  $('#update{{ table.type }}' + hash).hide();
+  var $td = $deleteBtn.closest('td');
+  var remaining = Math.max(1, Math.ceil((state.expiresAt - Date.now()) / 1000));
+  var $btn = $('<span id="' + revertId + '">[<strong><a href="#" class="revert-link">Revert to original</a></strong> (<span class="revert-countdown">' + remaining + '</span>s)]</span>');
+  $td.prepend($btn);
+  $("tr.row" + hash + " td").attr("style", "background-color:#d4edda !important");
+  $btn.find('.revert-link').on('click', function(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (_revertState{{ table.type }}) {
+      clearInterval(_revertState{{ table.type }}.timerId);
+      _revertState{{ table.type }} = null;
+    }
+    $btn.remove();
+    $deleteBtn.show();
+    $("tr.row" + hash + " td").removeAttr("style");
+    revertToOriginal{{ table.type }}(state.upload, state.item, state.hash, state.newContent, state.type);
+  });
+}
+
+function revertToOriginal{{ table.type }}(upload, item, hash, newContent, type) {
+  $.ajax({
+    type: 'POST',
+    dataType: 'text',
+    url: '?mod=ajax-copyright-hist&action=revertToOriginal',
+    data: { id: upload + ',' + item + ',' + hash + ',' + type, newContent: newContent },
+    success: function(data) {
+      $('#copyright{{ table.type }}').DataTable().ajax.reload(null, false);
+    },
+    error: function(errorResponse) {
+      alert(errorResponse.responseText);
+    }
   });
 }

--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -511,10 +511,16 @@ WHERE $withHash ( ut.lft BETWEEN $1 AND $2 ) $agentFilter AND ut.upload_fk = $3"
           $sqlEvent = "INSERT INTO $cpTableEvent (upload_fk, $cpTableEventFk, uploadtree_fk, is_enabled, scope) VALUES($1, $2, $3, 'f', $4)";
           $statement = "$stmt.delete";
         }
+      } else if ($action == "revertToOriginal") {
+        if (!$eventExists) {
+          continue;
+        }
+        $sqlEvent = "DELETE FROM $cpTableEvent WHERE upload_fk = $1 AND $cpTableEventFk = $2 AND uploadtree_fk = $3 AND is_enabled = true";
+        $statement = "$stmt.revertToOriginal";
       } else if ($action == "rollback" && $eventExists) {
-          $sqlEvent = "UPDATE $cpTableEvent SET scope = 1, is_enabled = true
+        $sqlEvent = "UPDATE $cpTableEvent SET scope = 1, is_enabled = true
           WHERE upload_fk = $1 AND $cpTableEventFk = $2 AND uploadtree_fk = $3";
-          $statement = "$stmt.rollback.up";
+        $statement = "$stmt.rollback.up";
       } else {
         $paramEvent[] = StringOperation::replaceUnicodeControlChar($content);
 

--- a/src/www/ui/scripts/jquery.dataTables.editable.js
+++ b/src/www/ui/scripts/jquery.dataTables.editable.js
@@ -729,12 +729,12 @@ returns true if plugin should continue with sending AJAX request, false will abo
           ///</summary>
 
           //To refresh table with preserver pagination on cell edit
-          //if (oSettings.oFeatures.bServerSide === false) {
+          if (oSettings.oFeatures.bServerSide === false) {
               oSettings._iDisplayStart = iDisplayStart;
               oSettings.oApi._fnCalculateEnd(oSettings);
               //draw the 'current' page
               oSettings.oApi._fnDraw(oSettings);
-          //}
+          }
       }
 
       function _fnOnBeforeAction(sAction) {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add a new feature in copyright to capture unintentional edits from copyright-hist

### Changes

* Add new functions in JS to handle revert to original. 

## How to test

* Upload a component with copyright scanning.
* Go to tree view and edit the copyright. 
* Check in the place of delete icon the revert to original link shall appear.
