### PR TITLE
chore(install): upgrade safaa version to latest

### DIFF
--- a/install/fo-install-pythondeps
+++ b/install/fo-install-pythondeps
@@ -161,7 +161,7 @@ if [[ $RUNTIME ]]; then
       # Include experimental dependencies
       su --login --whitelist-environment="http_proxy,HTTP_PROXY,https_proxy,HTTPS_PROXY" $TARGETUSER -c 'PYTHONPATH="$HOME/pythondeps" python3 -m pip install \
         --target=$HOME/pythondeps --no-input --upgrade \
-        scancode-toolkit==32.4.1 scanoss==1.5.1 safaa==0.0.3'
+        scancode-toolkit==32.4.1 scanoss==1.5.1 safaa==0.0.4'
       su --login --whitelist-environment="http_proxy,HTTP_PROXY,https_proxy,HTTPS_PROXY" $TARGETUSER -c 'PYTHONPATH="$HOME/pythondeps" python3 -m spacy \
         download en_core_web_sm --target=$HOME/pythondeps'
     else


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Decider was throwing a lot of import warnings from Safaa, We have now shifted to the latest version --> (0.0.4)

### Changes

Update the install script with latest safaa version `0.0.4`

## How to test

1. Checkout the PR
2. Schedule copyright scanning with False Positive detection
3. Check decider logs.
4. Also, the build should work perfectly.

1. Check one component with older version
2. Match the outputs with the newer safaa version.

No warnings:

<img width="1366" height="612" alt="image" src="https://github.com/user-attachments/assets/d9e47417-d43e-4ea4-aeeb-e6f79b9af11e" />
