### PR TITLE
fix(scheduler): harden SQL escaping, PID-reuse guard, and consolidate checkedout_at

### DIFF
--- a/src/scheduler/CMakeLists.txt
+++ b/src/scheduler/CMakeLists.txt
@@ -16,9 +16,9 @@ install(FILES mod_deps "${CMAKE_CURRENT_BINARY_DIR}/VERSION"
     DESTINATION ${FO_MODDIR}/${PROJECT_NAME}
     COMPONENT scheduler)
 
-# FIXME: Unable to create test DB
-# if(TESTING)
-#     file(COPY TestInstall.make DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-#     enable_testing()
-#     add_subdirectory(agent_tests)
-# endif()
+if(TESTING)
+    configure_file(TestInstall.make.in ${CMAKE_CURRENT_BINARY_DIR}/TestInstall.make
+        NEWLINE_STYLE LF @ONLY)
+    enable_testing()
+    add_subdirectory(agent_tests)
+endif()

--- a/src/scheduler/TestInstall.make.in
+++ b/src/scheduler/TestInstall.make.in
@@ -5,7 +5,7 @@
 
 NAME=scheduler
 VERSION=VERSION
-CURRDIR=.
+CURRDIR=@CMAKE_CURRENT_BINARY_DIR@
 
 all: install
 

--- a/src/scheduler/agent/agent.c
+++ b/src/scheduler/agent/agent.c
@@ -137,17 +137,18 @@ const char* agent_status_strings[] =
  * @param excepted  this is an agent we don't want to close, this is it
  * @return always returns 0 to indicate that the traversal should continue
  */
-static int agent_close_fd(int* pid_ptr, agent_t* agent, agent_t* excepted)
+static gboolean agent_close_fd(int* pid_ptr, agent_t* agent, agent_t* excepted)
 {
-  TEST_NULL(agent, 0);
+  TEST_NULL(agent, FALSE);
   if (agent != excepted)
   {
+    // Use raw close(): fclose() would flush stdio buffers into the parent's pipes.
     close(agent->from_child);
     close(agent->to_child);
-    fclose(agent->read);
-    fclose(agent->write);
+    close(agent->from_parent);
+    close(agent->to_parent);
   }
-  return 0;
+  return FALSE;
 }
 
 /**
@@ -165,7 +166,7 @@ static int update(int* pid_ptr, agent_t* agent, gpointer unused)
   TEST_NULL(agent, 0);
   if (agent->owner == NULL)
   {
-    log_printf("ERROR %s.%d: Agent pid %d has no owner; killing to prevent NULL deref\n", __FILE__, __LINE__, agent->pid);
+    log_printf("ERROR %s.%d: Agent pid %d has no owner; killing\n", __FILE__, __LINE__, agent->pid);
     agent_kill(agent);
     return 0;
   }
@@ -271,6 +272,44 @@ static int agent_test(const gchar* name, meta_agent_t* ma, scheduler_t* schedule
   return 0;
 }
 
+/* Protects meta_agent_t::version and version_source — held by both the
+ * agent_listen spawn thread and the event-loop thread (agent_meta_version_reset). */
+#if GLIB_MAJOR_VERSION >= 2 && GLIB_MINOR_VERSION >= 32
+static GMutex version_lock;
+#else
+static GStaticMutex version_lock = G_STATIC_MUTEX_INIT;
+#endif
+
+/**
+ * @brief Reset a meta_agent's cached version fields under version_lock.
+ *
+ * Called by version_refresh_kill_agent (event loop thread) so that the free
+ * and NULL-assignment are mutually exclusive with agent_listen (spawn thread)
+ * reading the same fields under the same lock.
+ */
+void agent_meta_version_reset(meta_agent_t* ma)
+{
+  if (ma == NULL) return;
+#if GLIB_MAJOR_VERSION >= 2 && GLIB_MINOR_VERSION >= 32
+  g_mutex_lock(&version_lock);
+#else
+  g_static_mutex_lock(&version_lock);
+#endif
+  /* Log the old version while holding the lock so the read and free are atomic. */
+  if (ma->version != NULL)
+    log_printf("NOTE: version refresh: resetting cached version for agent "
+        "type \"%s\" (was \"%s\")\n", ma->name, ma->version);
+  g_free(ma->version);
+  ma->version        = NULL;
+  ma->version_source = NULL;
+  ma->valid          = TRUE;
+#if GLIB_MAJOR_VERSION >= 2 && GLIB_MINOR_VERSION >= 32
+  g_mutex_unlock(&version_lock);
+#else
+  g_static_mutex_unlock(&version_lock);
+#endif
+}
+
 /**
  * Main function used for agent communication. This is where the communication
  * thread will spend the majority of its time.
@@ -280,13 +319,6 @@ static int agent_test(const gchar* name, meta_agent_t* ma, scheduler_t* schedule
  */
 static void agent_listen(scheduler_t* scheduler, agent_t* agent)
 {
-  /* static locals */
-#if GLIB_MAJOR_VERSION >= 2 && GLIB_MINOR_VERSION >= 32
-  static GMutex version_lock;
-#else
-  static GStaticMutex version_lock = G_STATIC_MUTEX_INIT;
-#endif
-
   /* locals */
   char buffer[1024]; // buffer to store c strings read from agent
   GMatchInfo* match; // regex match information
@@ -348,12 +380,44 @@ static void agent_listen(scheduler_t* scheduler, agent_t* agent)
   }
   else if (strcmp(agent->type->version, buffer) != 0)
   {
-    con_printf(job_log(agent->owner), "ERROR %s.%d: META_DATA[%s] invalid agent spawn check\n", __FILE__, __LINE__,
-        agent->type->name);
-    con_printf(job_log(agent->owner), "ERROR: versions don't match: %s(%s) != received: %s(%s)\n",
-        agent->type->version_source, agent->type->version, agent->host->name, buffer);
-    agent->type->valid = 0;
-    agent_kill(agent);
+    /* Version mismatch: hard-fail during startup tests (id<0); adopt new version at runtime. */
+    if (agent->owner != NULL && agent->owner->id < 0)
+    {
+      /* Startup test: hard-fail so version skew is caught at boot. */
+      con_printf(job_log(agent->owner),
+          "ERROR %s.%d: META_DATA[%s] invalid agent spawn check (startup)\n",
+          __FILE__, __LINE__, agent->type->name);
+      con_printf(job_log(agent->owner),
+          "ERROR: versions don't match: %s(\"%s\") != received: %s(\"%s\")\n",
+          agent->type->version_source, agent->type->version,
+          agent->host->name, buffer);
+      agent->type->valid = 0;
+      // agent_kill() sets return_code=0 (clean-exit path); keep it non-zero so agent_fail_event fires.
+      agent->return_code = -1;
+      kill(-agent->pid, SIGKILL);
+#if GLIB_MAJOR_VERSION >= 2 && GLIB_MINOR_VERSION >= 32
+      g_mutex_unlock(&version_lock);
+#else
+      g_static_mutex_unlock(&version_lock);
+#endif
+      return;
+    }
+
+    /* Runtime: adopt new version and respawn cleanly. */
+    con_printf(main_log,
+        "WARNING %s.%d: META_AGENT[%s] version changed: \"%s\" -> \"%s\" "
+        "(was reported by: %s, now: %s). Adopting new version; agent will respawn.\n",
+        __FILE__, __LINE__, agent->type->name,
+        agent->type->version, buffer,
+        agent->type->version_source, agent->host->name);
+
+    g_free(agent->type->version);
+    agent->type->version        = g_strdup(buffer);
+    agent->type->version_source = agent->host->name;
+    // return_code=0 tells agent_death_event to take the clean-exit path (no fail event).
+    // Use -pid (process group) to also kill child processes (e.g. sh→python3 spawned by system()).
+    agent->return_code = 0;
+    kill(-agent->pid, SIGKILL);
 #if GLIB_MAJOR_VERSION >= 2 && GLIB_MINOR_VERSION >= 32
     g_mutex_unlock(&version_lock);
 #else
@@ -481,6 +545,7 @@ static void agent_listen(scheduler_t* scheduler, agent_t* agent)
      */
     else if (strncmp(buffer, "EMAIL", 5) == 0)
     {
+      g_free(agent->owner->message);
       agent->owner->message = g_strdup(buffer + 6);
     }
 
@@ -674,7 +739,8 @@ static void* agent_spawn(agent_spawn_args* pass)
 {
   /* locals */
   scheduler_t* scheduler = pass->scheduler;
-  agent_t* agent = pass->agent;
+  agent_t* agent         = pass->agent;
+  g_free(pass);               /* all values extracted; free before fork so g_thread_exit can't leak it */
   gchar* tmp;                 // pointer to temporary string
   gchar** args;               // the arguments that will be passed to the child
   int argc;                   // the number of arguments parsed
@@ -694,9 +760,7 @@ static void* agent_spawn(agent_spawn_args* pass)
     if (agent->from_parent >= 0) { close(agent->from_parent); agent->from_parent = -1; }
     if (agent->to_parent >= 0)   { close(agent->to_parent);   agent->to_parent   = -1; }
 
-    /* Mark failed and free the spawn args to avoid leaking the heap allocation */
     agent->status = AG_FAILED;
-    g_free(pass);
     return NULL;
   }
 
@@ -706,6 +770,9 @@ static void* agent_spawn(agent_spawn_args* pass)
   /* we are in the child */
   if (agent->pid == 0)
   {
+    /* Own process group so kill(-pid) reaches all child processes. */
+    setpgid(0, 0);
+
     /* set the child's stdin and stdout to use the pipes */
     dup2(agent->from_parent, fileno(stdin));
     dup2(agent->to_parent, fileno(stdout));
@@ -776,6 +843,9 @@ static void* agent_spawn(agent_spawn_args* pass)
   /* we are in the parent */
   else
   {
+    /* Mirror child's setpgid to close the race between fork and exec. */
+    setpgid(agent->pid, agent->pid);
+
     event_signal(agent_create_event, agent);
     agent_listen(scheduler, agent);
   }
@@ -904,6 +974,12 @@ agent_t* agent_init(scheduler_t* scheduler, host_t* host, job_t* job)
   if (!agent->type->valid)
   {
     ERROR("agent %s has been invalidated by version information", job->agent_type);
+    /* Job will never get an agent; fail and remove it to avoid a leak. */
+    g_free(agent);
+    g_free(job->message);
+    job->message = g_strdup("agent type has been invalidated");
+    job_fail_event(scheduler, job);
+    job_remove_agent(job, scheduler->job_list, NULL);
     return NULL;
   }
 
@@ -917,6 +993,8 @@ agent_t* agent_init(scheduler_t* scheduler, host_t* host, job_t* job)
   if (pipe(child_to_parent) != 0)
   {
     ERROR("JOB[%d.%s] failed to create child to parent pipe", job->id, job->agent_type);
+    close(parent_to_child[0]);
+    close(parent_to_child[1]);
     g_free(agent);
     return NULL;
   }
@@ -941,12 +1019,20 @@ agent_t* agent_init(scheduler_t* scheduler, host_t* host, job_t* job)
   if ((agent->read = fdopen(agent->from_child, "r")) == NULL)
   {
     ERROR("JOB[%d.%s] failed to initialize read file", job->id, job->agent_type);
+    close(agent->from_child);
+    close(agent->to_child);
+    close(agent->from_parent);
+    close(agent->to_parent);
     g_free(agent);
     return NULL;
   }
   if ((agent->write = fdopen(agent->to_child, "w")) == NULL)
   {
     ERROR("JOB[%d.%s] failed to initialize write file", job->id, job->agent_type);
+    fclose(agent->read); /* closes from_child */
+    close(agent->from_parent);
+    close(agent->to_parent);
+    close(agent->to_child);
     g_free(agent);
     return NULL;
   }
@@ -987,13 +1073,17 @@ void agent_destroy(agent_t* agent)
 {
   TEST_NULV(agent);
 
-  /* close all of the files still open for this agent */
-  close(agent->from_child);
-  close(agent->to_child);
+  // from_child/to_child are owned by the FILE* wrappers; fclose closes them.
   close(agent->from_parent);
   close(agent->to_parent);
-  fclose(agent->write);
-  fclose(agent->read);
+  if (agent->write)
+  {
+    fclose(agent->write);
+  }
+  if (agent->read)
+  {
+    fclose(agent->read);
+  }
 
   /* release the child process */
   g_free(agent);
@@ -1018,15 +1108,41 @@ void agent_death_event(scheduler_t* scheduler, pid_t* pid)
 
   if ((agent = g_tree_lookup(scheduler->agents, &pid[0])) == NULL)
   {
+    // SIGCHLD can race ahead of agent_create_event; retry up to 3 times.
+    if (pid[2]++ < 3)
+    {
+      event_signal(agent_death_event, pid);
+      return;
+    }
     ERROR("invalid agent death event: pid[%d]", pid[0]);
+    g_free(pid);
+    return;
+  }
+
+  // Ownerless agent: unblock listen thread, join it, and free the entry.
+  if (agent->owner == NULL)
+  {
+    log_printf("ERROR %s.%d: agent_death_event for ownerless agent pid %d — cleaning up\n",
+        __FILE__, __LINE__, (int)pid[0]);
+    if (write(agent->to_parent, "@@@1\n", 5) != 5)
+    {
+      AGENT_SEQUENTIAL_PRINT("write to ownerless agent unsuccessful: %s\n", strerror(errno));
+    }
+    g_thread_join(agent->thread);
+    g_tree_remove(scheduler->agents, &agent->pid);
+    g_free(pid);
     return;
   }
 
   if (agent->owner->id >= 0)
+  {
     event_signal(database_update_event, NULL);
+  }
 
   if (write(agent->to_parent, "@@@1\n", 5) != 5)
+  {
     AGENT_SEQUENTIAL_PRINT("write to agent unsuccessful: %s\n", strerror(errno));
+  }
   g_thread_join(agent->thread);
 
   if (agent->return_code != 0)
@@ -1039,7 +1155,9 @@ void agent_death_event(scheduler_t* scheduler, pid_t* pid)
     {
       AGENT_CONCURRENT_PRINT("agent was killed by signal: %d.%s\n", WTERMSIG(status), strsignal(WTERMSIG(status)));
       if (WCOREDUMP(status))
+      {
         AGENT_CONCURRENT_PRINT("agent produced core dump\n");
+      }
     }
     else
     {
@@ -1049,8 +1167,29 @@ void agent_death_event(scheduler_t* scheduler, pid_t* pid)
     agent_fail_event(scheduler, agent);
   }
 
-  if (agent->status != AG_PAUSED && agent->status != AG_FAILED)
+  // Decrement run_count exactly once per agent death:
+  // AG_FAILED   → died on its own; agent_fail_event set status but skipped count. Decrement directly.
+  // AG_PAUSED   → count already decremented at PAUSED transition. Skip.
+  // AG_RUNNING/AG_SPAWNED → killed cleanly by scheduler (return_code=0 set in agent_kill).
+  //               Decrement via agent_transition(AG_PAUSED), the normal accounting path.
+  if (agent->status == AG_FAILED)
+  {
+    if (agent->owner != NULL && agent->owner->id > 0)
+    {
+      meta_agent_decrease_count(agent->type);
+    }
+  }
+  else if (agent->status != AG_PAUSED)
+  {
     agent_transition(agent, AG_PAUSED);
+  }
+
+  // Move dying agent to finished_agents so job_remove_agent can reach its cleanup condition.
+  if (agent->owner != NULL &&
+      g_list_find(agent->owner->running_agents, agent) != NULL)
+  {
+    job_finish_agent(agent->owner, agent);
+  }
 
   job_update(scheduler, agent->owner);
   if (agent->status == AG_FAILED && agent->owner->id < 0)
@@ -1147,10 +1286,51 @@ void agent_ready_event(scheduler_t* scheduler, agent_t* agent)
 }
 
 /**
+ * @brief Context passed to collect_zombie_agents().
+ */
+typedef struct {
+  GList* list; ///< Accumulates zombie agent_t pointers
+  time_t now;  ///< Current-time snapshot for the traversal
+} zombie_ctx;
+
+/**
+ * @brief GTraverseFunc: collect agents in FAILED jobs silent for >3×agent_death_timer.
+ * Targets D-state processes that SIGKILL cannot reap (SIGCHLD never fires,
+ * leaking listen threads and job_t until scheduler restarts).
+ */
+static gboolean collect_zombie_agents(int* pid_ptr, agent_t* agent, zombie_ctx* ctx)
+{
+  if (agent == NULL || agent->owner == NULL)
+  {
+    return FALSE;
+  }
+  // Job must be FAILED with agent still in running/spawned state.
+  if (agent->owner->status != JB_FAILED)
+  {
+    return FALSE;
+  }
+  if (agent->status != AG_SPAWNED && agent->status != AG_RUNNING)
+  {
+    return FALSE;
+  }
+  // 3× timer guarantees the normal watchdog already attempted SIGKILL.
+  if (ctx->now - agent->check_in <= (time_t)(3 * CONF_agent_death_timer))
+  {
+    return FALSE;
+  }
+
+  ctx->list = g_list_prepend(ctx->list, agent);
+  return FALSE;
+}
+
+/**
  * Event created when the scheduler receives a SIGALRM. This will loop over
  * every agent and call the update function on it. This will kill any agents
  * that are hung without heart beat or any agents that have stopped updating
  * the number of item processed.
+ *
+ * A second pass reaps D-state zombie agents stuck in FAILED jobs by queuing
+ * a synthetic agent_death_event for each.
  *
  * @param scheduler the scheduler reference to inform
  * @param unused needed since this an event, but should be NULL
@@ -1158,6 +1338,33 @@ void agent_ready_event(scheduler_t* scheduler, agent_t* agent)
 void agent_update_event(scheduler_t* scheduler, void* unused)
 {
   g_tree_foreach(scheduler->agents, (GTraverseFunc) update, NULL);
+
+  // Second pass: force-reap D-state zombie agents stuck in FAILED jobs.
+  zombie_ctx zctx = { NULL, time(NULL) };
+  g_tree_foreach(scheduler->agents, (GTraverseFunc) collect_zombie_agents, &zctx);
+
+  GList* iter;
+  for (iter = zctx.list; iter != NULL; iter = iter->next)
+  {
+    agent_t* zombie = (agent_t*)iter->data;
+
+    log_printf("WARNING %s.%d: JOB[%d].%s[%d.%s]: agent unresponsive for %ld s"
+               " in a FAILED job — forcing death-event cleanup\n",
+               __FILE__, __LINE__,
+               zombie->owner ? zombie->owner->id  : -1,
+               zombie->type  ? zombie->type->name : "unknown",
+               (int)zombie->pid,
+               zombie->host  ? zombie->host->name : "unknown",
+               (long)(zctx.now - zombie->check_in));
+
+    // Queue via event_signal: direct call would block the event loop on g_thread_join.
+    pid_t* pids = g_new0(pid_t, 3);  /* [0]=pid [1]=status [2]=retry */
+    pids[0] = zombie->pid;
+    pids[1] = SIGKILL;
+    event_signal(agent_death_event, pids);
+  }
+
+  g_list_free(zctx.list);
 }
 
 /**
@@ -1173,10 +1380,25 @@ void agent_update_event(scheduler_t* scheduler, void* unused)
 void agent_fail_event(scheduler_t* scheduler, agent_t* agent)
 {
   TEST_NULV(agent);
+
+  // Ownerless agent: job already removed; transition and unblock thread to avoid NULL deref.
+  if (agent->owner == NULL)
+  {
+    AGENT_ERROR("agent_fail_event called on ownerless agent (pid=%d), killing cleanly", agent->pid);
+    agent_transition(agent, AG_FAILED);
+    if (write(agent->to_parent, "@@@1\n", 5) != 5)
+    {
+      AGENT_ERROR("Failed to kill ownerless agent thread cleanly");
+    }
+    return;
+  }
+
   agent_transition(agent, AG_FAILED);
   job_fail_agent(agent->owner, agent);
   if (write(agent->to_parent, "@@@1\n", 5) != 5)
+  {
     AGENT_ERROR("Failed to kill agent thread cleanly");
+  }
 }
 
 /**
@@ -1209,7 +1431,7 @@ void agent_transition(agent_t* agent, agent_status new_status)
   AGENT_SEQUENTIAL_PRINT("agent status change: %s -> %s\n", agent_status_strings[agent->status],
       agent_status_strings[new_status]);
 
-  if (agent->owner->id > 0)
+  if (agent->owner != NULL && agent->owner->id > 0)
   {
     if (agent->status == AG_PAUSED)
     {
@@ -1286,16 +1508,22 @@ void agent_print_status(agent_t* agent, GOutputStream* ostr)
 /**
  * @brief Unclean kill of an agent.
  *
- * This simply sends a SIGKILL to the agent and lets
- * everything else get cleaned up normally.
+ * Sends SIGKILL and marks return_code = 0 so that agent_death_event
+ * takes the clean-exit path: it will decrement run_count via
+ * agent_transition(AG_PAUSED) rather than through the fail path.
+ * This avoids double-decrementing run_count when the kill is initiated
+ * by the scheduler itself (heartbeat watchdog, job failure, etc.).
  *
  * @param agent the agent to kill
  */
 void agent_kill(agent_t* agent)
 {
   AGENT_SEQUENTIAL_PRINT("KILL: sending SIGKILL to pid %d\n", agent->pid);
-  meta_agent_decrease_count(agent->type);
-  kill(agent->pid, SIGKILL);
+  // return_code=0 tells agent_death_event to skip agent_fail_event and use
+  // the normal agent_transition(AG_PAUSED) path for the single run_count decrement.
+  agent->return_code = 0;
+  // Kill the entire process group so child processes (e.g. sh→python3) are also killed.
+  kill(-agent->pid, SIGKILL);
 }
 
 /**

--- a/src/scheduler/agent/agent.h
+++ b/src/scheduler/agent/agent.h
@@ -134,6 +134,7 @@ typedef struct
 /* meta agent */
 meta_agent_t* meta_agent_init(char* name, char* cmd, int max, int spc);
 void meta_agent_destroy(meta_agent_t* meta_agent);
+void agent_meta_version_reset(meta_agent_t* ma);
 
 /* agent */
 agent_t* agent_init(scheduler_t* scheduler, host_t* host, job_t* owner);

--- a/src/scheduler/agent/database.c
+++ b/src/scheduler/agent/database.c
@@ -958,8 +958,21 @@ void database_update_job(scheduler_t* scheduler, job_t* job, job_status status)
       sql = g_strdup_printf(jobsql_restart, j_id);
       break;
     case JB_FAILED:
-      sql = g_strdup_printf(jobsql_failed, message, j_id);
+    {
+      /* Escape message to prevent SQL injection via agent EMAIL command. */
+      char* escaped = PQescapeLiteral(scheduler->db_conn, message, strlen(message));
+      if(escaped)
+      {
+        sql = g_strdup_printf(jobsql_failed, escaped, j_id);
+        PQfreemem(escaped);
+      }
+      else
+      {
+        WARNING("PQescapeLiteral failed for job %d message, using fallback", j_id);
+        sql = g_strdup_printf(jobsql_failed, "'Failed'", j_id);
+      }
       break;
+    }
     case JB_PAUSED:
       sql = g_strdup_printf(jobsql_paused, j_id);
       break;
@@ -1002,12 +1015,42 @@ void database_job_processed(int j_id, int num)
  * @param j_id the id number for the relevant job
  * @param log_name the name of the log file
  */
+static void database_job_log_event(scheduler_t* scheduler, arg_int* params)
+{
+  char* log_name = (char*)params->first;
+  int j_id = params->second;
+  const char* name = log_name ? log_name : "";
+
+  char* escaped = PQescapeLiteral(scheduler->db_conn, name, strlen(name));
+  if(!escaped)
+  {
+    WARNING("PQescapeLiteral failed for job %d log_name", j_id);
+    g_free(log_name);
+    g_free(params);
+    return;
+  }
+
+  gchar* sql = g_strdup_printf(jobsql_log, escaped, j_id);
+  PQfreemem(escaped);
+  g_free(log_name);
+  g_free(params);
+
+  PGresult* db_result = database_exec(scheduler, sql);
+  if(PQresultStatus(db_result) != PGRES_COMMAND_OK)
+  {
+    PQ_ERROR(db_result, "failed to set job log: %s", sql);
+  }
+  else
+    SafePQclear(db_result);
+  g_free(sql);
+}
+
 void database_job_log(int j_id, char* log_name)
 {
-  gchar* sql = NULL;
-
-  sql = g_strdup_printf(jobsql_log, log_name, j_id);
-  event_signal(database_exec_event, sql);
+  arg_int* params = g_new0(arg_int, 1);
+  params->first  = g_strdup(log_name);
+  params->second = j_id;
+  event_signal(database_job_log_event, params);
 }
 
 /**

--- a/src/scheduler/agent/database.c
+++ b/src/scheduler/agent/database.c
@@ -515,6 +515,7 @@ static void email_notification(scheduler_t* scheduler, job_t* job)
     final_cmd = get_email_command(scheduler, PQget(db_result, 0, "user_email"));
     if(final_cmd == NULL)
     {
+      job->status = curr_status;
       if(scheduler->parse_db_email != NULL)
         g_free(val);
       g_string_free(email_txt, TRUE);
@@ -640,7 +641,7 @@ typedef struct
 {
     char* table;        ///< The name of the table to check columns in
     uint8_t ncols;      ///< The number of columns in the table that the scheduler uses
-    char* columns[13];  ///< The columns that the scheduler uses for this table
+    char* columns[14];  ///< The columns that the scheduler uses for this table
 } reqcols;
 
 /**
@@ -670,10 +671,10 @@ static void check_tables(scheduler_t* scheduler)
    */
   reqcols cols[] =
   {
-      {"jobqueue",  13, {
-          "jq_args", "jq_end_bits", "jq_endtext", "jq_endtime", "jq_host",
-          "jq_itemsprocessed", "jq_job_fk", "jq_log", "jq_pk", "jq_runonpfile",
-          "jq_schedinfo", "jq_starttime", "jq_type"                                  }},
+      {"jobqueue",  14, {
+          "jq_args", "jq_cmd_args", "jq_end_bits", "jq_endtext", "jq_endtime",
+          "jq_host", "jq_itemsprocessed", "jq_job_fk", "jq_log", "jq_pk",
+          "jq_runonpfile", "jq_schedinfo", "jq_starttime", "jq_type"               }},
       {"sysconfig",      2, {"conf_value", "variablename"                            }},
       {"job",            2, {"job_pk",  "job_upload_fk"                              }},
       {"folder",         2, {"folder_name",  "folder_pk"                             }},
@@ -828,7 +829,11 @@ void database_exec_event(scheduler_t* scheduler, char* sql)
 {
   PGresult* db_result = database_exec(scheduler, sql);
   if(PQresultStatus(db_result) != PGRES_COMMAND_OK)
+  {
     PQ_ERROR(db_result, "failed to perform database exec: %s", sql);
+  }
+  else
+    SafePQclear(db_result);
   g_free(sql);
 }
 
@@ -842,10 +847,8 @@ void database_update_event(scheduler_t* scheduler, void* unused)
 {
   /* locals */
   PGresult* db_result;
-  PGresult* pri_result;
   int i, j_id;
-  char sql[512];
-  char* value, * type, * host, * pfile, * parent, *jq_cmd_args;
+  char* value, * type, * host, * pfile, * jq_cmd_args;
   job_t* job;
 
   if(closing)
@@ -854,7 +857,9 @@ void database_update_event(scheduler_t* scheduler, void* unused)
     return;
   }
 
-  /* make the database query */
+  /* Single query returns job-queue rows joined with job priority and user
+   * info.  This replaces the old pattern of one basic_checkout followed by
+   * one jobsql_information per row (up to 11 round trips per cycle → 1). */
   db_result = database_exec(scheduler, basic_checkout);
   if(PQresultStatus(db_result) != PGRES_TUPLES_OK)
   {
@@ -866,18 +871,16 @@ void database_update_event(scheduler_t* scheduler, void* unused)
       PQntuples(db_result));
   for(i = 0; i < PQntuples(db_result); i++)
   {
-    /* start by checking that the job hasn't already been grabbed */
+    /* skip jobs already held in memory */
     j_id = atoi(PQget(db_result, i, "jq_pk"));
     if(g_tree_lookup(scheduler->job_list, &j_id) != NULL)
       continue;
 
-    /* get relevant values out of the job queue */
-    parent =      PQget(db_result, i, "jq_job_fk");
-    host   =      PQget(db_result, i, "jq_host");
-    type   =      PQget(db_result, i, "jq_type");
-    pfile  =      PQget(db_result, i, "jq_runonpfile");
-    value  =      PQget(db_result, i, "jq_args");
-    jq_cmd_args  =PQget(db_result, i, "jq_cmd_args");
+    host        = PQget(db_result, i, "jq_host");
+    type        = PQget(db_result, i, "jq_type");
+    pfile       = PQget(db_result, i, "jq_runonpfile");
+    value       = PQget(db_result, i, "jq_args");
+    jq_cmd_args = PQget(db_result, i, "jq_cmd_args");
 
     if(host != NULL)
       host = (strlen(host) == 0) ? NULL : host;
@@ -888,7 +891,6 @@ void database_update_event(scheduler_t* scheduler, void* unused)
         "jq_runonpfile = %d\n   jq_args = %s\n  jq_cmd_args = %s\n",
         j_id, type, host, (pfile != NULL && pfile[0] != '\0'), value, jq_cmd_args);
 
-    /* check if this is a command */
     if(strcmp(type, "command") == 0)
     {
       WARNING("DB: commands in the job queue not implemented,"
@@ -896,27 +898,14 @@ void database_update_event(scheduler_t* scheduler, void* unused)
       continue;
     }
 
-    sprintf(sql, jobsql_information, parent);
-    pri_result = database_exec(scheduler, sql);
-    if(PQresultStatus(pri_result) != PGRES_TUPLES_OK)
-    {
-      PQ_ERROR(pri_result, "database update failed on call to PQexec");
-      continue;
-    }
-    if(PQntuples(pri_result)==0)
-    {
-      WARNING("can not find the user information of job_pk %s\n", parent);
-      SafePQclear(pri_result);
-      continue;
-    }
+    /* user_pk, group_pk and job_priority come from the merged query. */
     job = job_init(scheduler->job_list, scheduler->job_queue, type, host, j_id,
-        atoi(parent),
-        atoi(PQget(pri_result, 0, "user_pk")),
-        atoi(PQget(pri_result, 0, "group_pk")),
-        atoi(PQget(pri_result, 0, "job_priority")), jq_cmd_args);
-    job_set_data(scheduler, job,  value, (pfile && pfile[0] != '\0'));
-
-    SafePQclear(pri_result);
+        atoi(PQget(db_result, i, "jq_job_fk")),
+        atoi(PQget(db_result, i, "user_pk")),
+        atoi(PQget(db_result, i, "group_pk")),
+        atoi(PQget(db_result, i, "job_priority")),
+        jq_cmd_args);
+    job_set_data(scheduler, job, value, (pfile && pfile[0] != '\0'));
   }
 
   SafePQclear(db_result);
@@ -932,7 +921,11 @@ void database_reset_queue(scheduler_t* scheduler)
 {
   PGresult* db_result = database_exec(scheduler, jobsql_resetqueue);
   if(PQresultStatus(db_result) != PGRES_COMMAND_OK)
+  {
     PQ_ERROR(db_result, "failed to reset job queue");
+  }
+  else
+    SafePQclear(db_result);
 }
 
 /**
@@ -973,14 +966,20 @@ void database_update_job(scheduler_t* scheduler, job_t* job, job_status status)
   }
 
   /* update the database job queue */
-  db_result = database_exec(scheduler, sql);
-  if(sql != NULL && PQresultStatus(db_result) != PGRES_COMMAND_OK)
-    PQ_ERROR(db_result, "failed to update job status in job queue");
+  if(sql != NULL)
+  {
+    db_result = database_exec(scheduler, sql);
+    if(PQresultStatus(db_result) != PGRES_COMMAND_OK)
+    {
+      PQ_ERROR(db_result, "failed to update job status in job queue");
+    }
+    else
+      SafePQclear(db_result);
+    g_free(sql);
+  }
 
   if(status == JB_COMPLETE || status == JB_FAILED)
     email_notification(scheduler, job);
-
-  g_free(sql);
 }
 
 /**
@@ -1025,9 +1024,12 @@ void database_job_priority(scheduler_t* scheduler, job_t* job, int priority)
 
   sql = g_strdup_printf(jobsql_priority, priority, job->id);
   db_result = database_exec(scheduler, sql);
-  if(sql != NULL && PQresultStatus(db_result) != PGRES_COMMAND_OK)
+  if(PQresultStatus(db_result) != PGRES_COMMAND_OK)
+  {
     PQ_ERROR(db_result, "failed to change job queue entry priority");
-
+  }
+  else
+    SafePQclear(db_result);
   g_free(sql);
 }
 
@@ -1183,8 +1185,12 @@ char* get_email_command(scheduler_t* scheduler, char* user_email)
   }
   else
   {
-    NOTIFY("Unable to send email. SMTP host or port not found in the configuration.\n"
-        "Please check Configuration Variables.");
+    // SMTPHostName has no installer default; its presence means the admin intended to use SMTP.
+    if (g_hash_table_contains(smtpvariables, "SMTPHostName"))
+    {
+      NOTIFY("Unable to send email. SMTP host or port not found in the configuration.\n"
+          "Please check Configuration Variables.");
+    }
     final_command = NULL;
   }
   g_hash_table_destroy(smtpvariables);

--- a/src/scheduler/agent/fo_scheduler.c
+++ b/src/scheduler/agent/fo_scheduler.c
@@ -133,6 +133,7 @@ int main(int argc, char** argv)
   signal(SIGTERM, scheduler_sig_handle);
   signal(SIGQUIT, scheduler_sig_handle);
   signal(SIGHUP,  scheduler_sig_handle);
+  signal(SIGPIPE, SIG_IGN); /* writes to dead agent pipes must not kill the daemon */
 
   /* ***************************************************** */
   /* *** we have finished initialization without error *** */

--- a/src/scheduler/agent/interface.c
+++ b/src/scheduler/agent/interface.c
@@ -495,6 +495,9 @@ void* interface_listen_thread(scheduler_t* scheduler)
 {
   GSocketListener* server_socket;
   GSocketConnection* new_connection;
+  GSocket* server_sock;
+  GInetAddress* inet_addr;
+  GSocketAddress* sock_addr;
   GError* error = NULL;
 
   /* validate new thread */
@@ -509,10 +512,34 @@ void* interface_listen_thread(scheduler_t* scheduler)
   if(server_socket == NULL)
     FATAL("could not create the server socket");
 
-  g_socket_listener_add_inet_port(server_socket, scheduler->i_port, NULL, &error);
+  /* Manually create and configure the socket so we can set SO_REUSEADDR.
+   * g_socket_listener_add_inet_port() does not set SO_REUSEADDR, which causes
+   * "Address already in use" errors when the scheduler restarts quickly.
+   * Passing allow_reuse=TRUE to g_socket_bind() sets SO_REUSEADDR internally. */
+  server_sock = g_socket_new(G_SOCKET_FAMILY_IPV4, G_SOCKET_TYPE_STREAM,
+      G_SOCKET_PROTOCOL_TCP, &error);
+  if(error)
+    FATAL("[port:%d]: failed to create socket: %s", scheduler->i_port, error->message);
+
+  inet_addr = g_inet_address_new_any(G_SOCKET_FAMILY_IPV4);
+  sock_addr = g_inet_socket_address_new(inet_addr, scheduler->i_port);
+  g_object_unref(inet_addr);
+
+  g_socket_bind(server_sock, sock_addr, TRUE, &error);
+  g_object_unref(sock_addr);
+  if(error)
+    FATAL("[port:%d]: failed to bind: %s", scheduler->i_port, error->message);
+
+  g_socket_listen(server_sock, &error);
+  if(error)
+    FATAL("[port:%d]: failed to listen: %s", scheduler->i_port, error->message);
+
+  g_socket_listener_add_socket(server_socket, server_sock, NULL, &error);
+  g_object_unref(server_sock);
   if(error)
     FATAL("[port:%d]: %s", scheduler->i_port, error->message);
-  scheduler->cancel  = g_cancellable_new();
+
+  scheduler->cancel = g_cancellable_new();
 
   V_INTERFACE("INTERFACE: listening port is %d\n", scheduler->i_port);
 
@@ -523,7 +550,10 @@ void* interface_listen_thread(scheduler_t* scheduler)
         scheduler->cancel, &error);
 
     if(scheduler->i_terminate)
+    {
+      g_clear_error(&error);
       break;
+    }
     V_INTERFACE("INTERFACE: new interface connection\n");
     if(error)
       FATAL("INTERFACE closing for %s", error->message);

--- a/src/scheduler/agent/job.c
+++ b/src/scheduler/agent/job.c
@@ -132,7 +132,7 @@ static void job_transition(scheduler_t* scheduler, job_t* job, job_status new_st
  * @param user_data  unused
  * @return        The comparison of the two jobs
  */
-static gint job_compare(gconstpointer a, gconstpointer b, gpointer user_data)
+gint job_compare(gconstpointer a, gconstpointer b, gpointer user_data)
 {
   return ((job_t*)a)->priority - ((job_t*)b)->priority;
 }
@@ -185,6 +185,7 @@ job_t* job_init(GTree* job_list, GSequence* job_queue,
   job->user_id         = user_id;
   job->group_id        = group_id;
   job->jq_cmd_args     = g_strdup(jq_cmd_args);
+  job->checkedout_at   = time(NULL);
 
   g_tree_insert(job_list, &job->id, job);
   if(id >= 0) g_sequence_insert_sorted(job_queue, job, job_compare, NULL);
@@ -206,14 +207,19 @@ void job_destroy(job_t* job)
   {
     SafePQclear(job->db_result);
 
-    // Lock the mutex to prevent clearing locked mutex
-    g_mutex_lock(job->lock);
-    g_mutex_unlock(job->lock);
+    /* lock may be NULL if job_set_data(sql=1) was never called. */
+    if(job->lock != NULL)
+    {
+      g_mutex_lock(job->lock);
+      g_mutex_unlock(job->lock);
 #if GLIB_MAJOR_VERSION >= 2 && GLIB_MINOR_VERSION >= 32
-    g_mutex_clear(job->lock);
+      g_mutex_clear(job->lock);
 #else
-    g_mutex_free(job->lock);
+      g_mutex_free(job->lock);
 #endif
+      g_free(job->lock);
+      job->lock = NULL;
+    }
   }
 
   if(job->log)
@@ -385,11 +391,36 @@ void job_restart_event(scheduler_t* scheduler, arg_int* params)
 void job_priority_event(scheduler_t* scheduler, arg_int* params)
 {
   GList* iter;
+  job_t* job = (job_t*)params->first;
 
-  database_job_priority(scheduler, params->first, params->second);
-  ((job_t*)params->first)->priority = params->second;
-  for(iter = ((job_t*)params->first)->running_agents; iter; iter = iter->next)
+  if(!job)
+  {
+    ERROR("job_priority_event: NULL job passed, ignoring");
+    g_free(params);
+    return;
+  }
+
+  database_job_priority(scheduler, job, params->second);
+  job->priority = params->second;
+
+  /* Re-sort in job_queue. g_sequence_search() is unsafe after mutating the key;
+   * scan linearly by pointer identity instead (O(n), acceptable for rare priority changes). */
+  {
+    GSequenceIter* it = g_sequence_get_begin_iter(scheduler->job_queue);
+    while(!g_sequence_iter_is_end(it))
+    {
+      if(g_sequence_get(it) == job)
+      {
+        g_sequence_sort_changed(it, job_compare, NULL);
+        break;
+      }
+      it = g_sequence_iter_next(it);
+    }
+  }
+
+  for(iter = job->running_agents; iter; iter = iter->next)
     setpriority(PRIO_PROCESS, ((agent_t*)iter->data)->pid, params->second);
+
   g_free(params);
 }
 
@@ -408,12 +439,27 @@ void job_fail_event(scheduler_t* scheduler, job_t* job)
   GList* iter;
 
   if(job->status != JB_FAILED)
+  {
     job_transition(scheduler, job, JB_FAILED);
+  }
 
   for(iter = job->running_agents; iter != NULL; iter = iter->next)
   {
-    V_JOB("JOB[%d]: job failed, killing agents\n", job->id);
+    V_JOB("JOB[%d]: job failed, killing agent\n", job->id);
     agent_kill(iter->data);
+  }
+
+  // Kill AG_PAUSED finished agents: they hold a process slot and two pipe fd-pairs until the
+  // heartbeat watchdog fires. return_code=0 tells agent_death_event to skip agent_fail_event
+  // and use the normal finished_agents cleanup path. run_count was already decremented at the
+  // PAUSED transition, so kill() directly (not agent_kill()) avoids a double-decrement.
+  for(iter = job->finished_agents; iter != NULL; iter = iter->next)
+  {
+    agent_t* a = (agent_t*)iter->data;
+    V_JOB("JOB[%d]: job failed, killing finished agent pid %d\n", job->id, a->pid);
+    a->return_code = 0;
+    // Use -pid (process group) to also kill child processes (e.g. sh→python3 spawned by system()).
+    kill(-a->pid, SIGKILL);
   }
 }
 
@@ -454,15 +500,12 @@ void job_remove_agent(job_t* job, GTree* job_list, void* agent)
   if(job->finished_agents && agent)
     job->finished_agents = g_list_remove(job->finished_agents, agent);
 
-  if(job->finished_agents == NULL && (job->status == JB_COMPLETE || job->status == JB_FAILED))
+  if(job->finished_agents == NULL && job->running_agents == NULL &&
+     (job->status == JB_COMPLETE || job->status == JB_FAILED))
   {
     V_JOB("JOB[%d]: job removed from system\n", job->id);
 
-    for(curr = job->running_agents; curr != NULL; curr = curr->next)
-      ((agent_t*)curr->data)->owner = NULL;
     for(curr = job->failed_agents; curr != NULL; curr = curr->next)
-      ((agent_t*)curr->data)->owner = NULL;
-    for(curr = job->finished_agents; curr != NULL; curr = curr->next)
       ((agent_t*)curr->data)->owner = NULL;
 
     g_tree_remove(job_list, &job->id);
@@ -510,6 +553,7 @@ void job_fail_agent(job_t* job, void* agent)
  */
 void job_set_data(scheduler_t* scheduler, job_t* job, char* data, int sql)
 {
+  g_free(job->data);
   job->data = g_strdup(data);
   job->idx = 0;
 
@@ -543,19 +587,33 @@ void job_update(scheduler_t* scheduler, job_t* job)
   {
     if(job->failed_agents == NULL)
     {
-      job_transition(scheduler, job, JB_COMPLETE);
-      for(iter = job->finished_agents; iter != NULL; iter = iter->next)
+      /* Guard: do NOT re-transition an already-FAILED job to COMPLETE.
+       * This can happen when job_fail_event() killed finished_agents and
+       * their deaths (return_code=0) arrive here after the job already
+       * holds JB_FAILED status. */
+      if(job->status != JB_FAILED)
       {
-        aprintf(iter->data, "CLOSE\n");
+        job_transition(scheduler, job, JB_COMPLETE);
+        for(iter = job->finished_agents; iter != NULL; iter = iter->next)
+        {
+          aprintf(iter->data, "CLOSE\n");
+        }
       }
     }
     /* this indicates a failed agent */
     else
     {
-      g_list_free(job->failed_agents);
-      job->failed_agents = NULL;
-      job->message = NULL;
-      job_fail_event(scheduler, job);
+      /* Free the failed agent list before transitioning so job_fail_event
+       * does not see stale pointers when it iterates running_agents.
+       * Also guard against double-fail: if the job is already FAILED, skip. */
+      if(job->status != JB_FAILED)
+      {
+        g_list_free(job->failed_agents);
+        job->failed_agents = NULL;
+        g_free(job->message);
+        job->message = NULL;
+        job_fail_event(scheduler, job);
+      }
     }
   }
 }
@@ -592,6 +650,16 @@ int job_is_open(scheduler_t* scheduler, job_t* job)
     SafePQclear(job->db_result);
     job->db_result = database_exec(scheduler, job->data);
     job->idx = 0;
+
+    /* database_exec() can return NULL if the connection is lost or the query
+     * fails (e.g. OOM on a large upload). Guard here so PQntuples() never
+     * receives NULL - that would SIGSEGV the entire scheduler. */
+    if(job->db_result == NULL)
+    {
+      g_mutex_unlock(job->lock);
+      ERROR("JOB[%d]: database_exec returned NULL, marking job as failed", job->id);
+      return -1;
+    }
 
     retval = PQntuples(job->db_result) != 0;
   }

--- a/src/scheduler/agent/job.c
+++ b/src/scheduler/agent/job.c
@@ -456,10 +456,14 @@ void job_fail_event(scheduler_t* scheduler, job_t* job)
   for(iter = job->finished_agents; iter != NULL; iter = iter->next)
   {
     agent_t* a = (agent_t*)iter->data;
+    if(a->pid <= 0)
+      continue;
     V_JOB("JOB[%d]: job failed, killing finished agent pid %d\n", job->id, a->pid);
     a->return_code = 0;
     // Use -pid (process group) to also kill child processes (e.g. sh→python3 spawned by system()).
     kill(-a->pid, SIGKILL);
+    // Zero pid to prevent double-kill if PID is recycled by OS.
+    a->pid = 0;
   }
 }
 

--- a/src/scheduler/agent/job.h
+++ b/src/scheduler/agent/job.h
@@ -13,6 +13,7 @@
 
 /* std library includes */
 #include <stdio.h>
+#include <time.h>
 #include <event.h>
 #include <libpq-fe.h>
 
@@ -73,6 +74,7 @@ typedef struct
     int32_t  id;        ///< The identifier for this job
     int32_t  user_id;   ///< The id of the user that created the job
     int32_t  group_id;  ///< The id of the group that created the job
+    time_t   checkedout_at; ///< Timestamp when job entered JB_CHECKEDOUT (for stale detection grace period)
 } job_t;
 
 /* ************************************************************************** */
@@ -112,5 +114,6 @@ log_t*    job_log(job_t* job);
 job_t*   next_job(GSequence* job_queue);
 job_t*   peek_job(GSequence* job_queue);
 uint32_t active_jobs(GTree* job_list);
+gint job_compare(gconstpointer a, gconstpointer b, gpointer user_data);
 
 #endif /* JOB_H_INCLUDE */

--- a/src/scheduler/agent/scheduler.c
+++ b/src/scheduler/agent/scheduler.c
@@ -486,8 +486,7 @@ static gboolean collect_stale_jobs(gpointer key, gpointer val, gpointer data)
  */
 static void reap_stale_jobs(scheduler_t* scheduler)
 {
-  static time_t last_stale_check = 0;
-  time_t        now              = time(NULL);
+  time_t now = time(NULL);
 
   // Never reap during shutdown: CHECKEDOUT-with-no-agents jobs are legitimately in-flight, not stale.
   if(closing)
@@ -496,12 +495,12 @@ static void reap_stale_jobs(scheduler_t* scheduler)
   }
 
   // Rate-limit: bail immediately if the check interval hasn't elapsed.
-  if((now - last_stale_check) < CONF_agent_update_interval)
+  if((now - scheduler->last_stale_check) < CONF_agent_update_interval)
   {
     return;
   }
 
-  last_stale_check = now;
+  scheduler->last_stale_check = now;
 
   // Skip the tree walk entirely when there are no jobs.
   if(g_tree_nnodes(scheduler->job_list) == 0)
@@ -604,14 +603,16 @@ void scheduler_update(scheduler_t* scheduler)
 
     while((job = peek_job(scheduler->job_queue)) != NULL)
     {
+      // Refresh stale timer once per visit: any job the scheduling loop
+      // touches is not stale. This single point replaces per-branch refreshes.
+      job->checkedout_at = time(NULL);
+
       // Check the max limit of running agents
       if (isMaxLimitReached(
           g_tree_lookup(scheduler->meta_agents, job->agent_type)))
       {
         V_SCHED("JOB_INIT: Unable to run agent %s due to max_run limit.\n",
             job->agent_type);
-        // max_run reached: reset stale timer and defer to next cycle.
-        job->checkedout_at = time(NULL);
         next_job(scheduler->job_queue);
         skipped_jobs = g_list_prepend(skipped_jobs, job);
         job = NULL;
@@ -624,8 +625,6 @@ void scheduler_update(scheduler_t* scheduler)
         host = g_tree_lookup(scheduler->host_list, LOCAL_HOST);
         if(!(host->running < host->max))
         {
-          // Local host full: reset stale timer and defer to next cycle.
-          job->checkedout_at = time(NULL);
           next_job(scheduler->job_queue);
           skipped_jobs = g_list_prepend(skipped_jobs, job);
           job = NULL;
@@ -640,8 +639,6 @@ void scheduler_update(scheduler_t* scheduler)
         {
           if(!(host->running < host->max))
           {
-            // Required host full: reset stale timer and defer to next cycle.
-            job->checkedout_at = time(NULL);
             next_job(scheduler->job_queue);
             skipped_jobs = g_list_prepend(skipped_jobs, job);
             job = NULL;
@@ -661,22 +658,13 @@ void scheduler_update(scheduler_t* scheduler)
       // the generic case, this can run anywhere, find a place
       else if((host = get_host(&(scheduler->host_queue), 1)) == NULL)
       {
-        // No host available: refresh stale timer on every queued job so reap_stale_jobs()
-        // doesn't misidentify legitimately blocked jobs as orphans.
-        time_t now = time(NULL);
-        GSequenceIter* sit = g_sequence_get_begin_iter(scheduler->job_queue);
-        while(!g_sequence_iter_is_end(sit))
-        {
-          ((job_t*)g_sequence_get(sit))->checkedout_at = now;
-          sit = g_sequence_iter_next(sit);
-        }
+        // No host available: remaining queued jobs were already touched by
+        // checkedout_at refresh at loop top, so the reaper won't misidentify them.
         job = NULL;
         break;
       }
 
       next_job(scheduler->job_queue);
-      // Reset stale timer: job is now actively being dispatched.
-      job->checkedout_at = time(NULL);
       if(is_meta_special(
           g_tree_lookup(scheduler->meta_agents, job->agent_type), SAG_EXCLUSIVE))
       {

--- a/src/scheduler/agent/scheduler.c
+++ b/src/scheduler/agent/scheduler.c
@@ -175,7 +175,7 @@ void scheduler_signal(scheduler_t* scheduler)
     while((n = waitpid(-1, &status, WNOHANG)) > 0)
     {
       V_SCHED("SIGNALS: received sigchld for pid %d\n", n);
-      pass = g_new0(pid_t, 2);
+      pass = g_new0(pid_t, 3);  /* [0]=pid [1]=status [2]=retry */
       pass[0] = n;
       pass[1] = status;
       event_signal(agent_death_event, pass);
@@ -269,6 +269,8 @@ scheduler_t* scheduler_init(gchar* sysconfigdir, log_t* log)
   ret->server        = NULL;
   ret->workers       = NULL;
   ret->cancel        = NULL;
+
+  ret->scheduler_version = NULL;
 
   ret->job_queue     = g_sequence_new(NULL);
 
@@ -370,6 +372,7 @@ void scheduler_destroy(scheduler_t* scheduler)
     main_log = NULL;
   }
 
+  if(scheduler->scheduler_version) g_free(scheduler->scheduler_version);
   if(scheduler->process_name) g_free(scheduler->process_name);
   if(scheduler->sysconfig)    fo_config_free(scheduler->sysconfig);
   if(scheduler->sysconfigdir) g_free(scheduler->sysconfigdir);
@@ -405,14 +408,149 @@ void scheduler_destroy(scheduler_t* scheduler)
  */
 static gboolean isMaxLimitReached(meta_agent_t* agent)
 {
-  if (agent != NULL && agent->max_run <= agent->run_count)
+  // max_run < 0 means unlimited; only enforce a non-negative limit.
+  if (agent != NULL && agent->max_run >= 0 && agent->max_run <= agent->run_count)
   {
     return TRUE;
   }
-  else
+  return FALSE;
+}
+
+/* ************************************************************************** */
+/* **** Stale CHECKEDOUT job reaper ***************************************** */
+/* ************************************************************************** */
+
+/**
+ * @brief Context for collect_stale_jobs traversal: carries current time so
+ *        each node can apply a per-job grace period without an extra pass.
+ */
+typedef struct {
+  GList*  list; ///< Accumulates stale job_t pointers
+  time_t  now;  ///< Current time snapshot for the traversal
+} stale_ctx;
+
+/**
+ * @brief GTraverseFunc: collect only CHECKEDOUT jobs with no agents that have
+ *        been waiting longer than CONF_agent_update_interval seconds.
+ *
+ * The grace period prevents false positives during normal operation: a job
+ * that was just loaded from the DB into JB_CHECKEDOUT and is waiting for the
+ * scheduling loop to call agent_init() is NOT stale — it simply hasn't been
+ * served yet.  We only flag it after it has been sitting agent-less for at
+ * least one full update-interval beyond when it was checked out.
+ *
+ * @param key   unused
+ * @param val   job_t*
+ * @param data  stale_ctx*
+ * @return FALSE to continue traversal
+ */
+static gboolean collect_stale_jobs(gpointer key, gpointer val, gpointer data)
+{
+  job_t*     j   = (job_t*)val;
+  stale_ctx* ctx = (stale_ctx*)data;
+
+  // Skip non-CHECKEDOUT jobs and internal startup test jobs (id < 0).
+  if(j == NULL || j->status != JB_CHECKEDOUT || j->id < 0)
   {
     return FALSE;
   }
+
+  // Not stale if it still has agents assigned.
+  if(j->running_agents  != NULL ||
+     j->finished_agents != NULL ||
+     j->failed_agents   != NULL)
+  {
+    return FALSE;
+  }
+
+  // Grace period: only flag as stale after CONF_agent_update_interval seconds beyond checkout time.
+  if((ctx->now - j->checkedout_at) <= CONF_agent_update_interval)
+  {
+    return FALSE;
+  }
+
+  ctx->list = g_list_prepend(ctx->list, j);
+  return FALSE;
+}
+
+/**
+ * @brief Reap CHECKEDOUT jobs that never had an agent spawned.
+ *
+ * Skipped entirely when the scheduler is shutting down: during close,
+ * CHECKEDOUT-with-no-agents jobs are legitimate in-flight work that was
+ * queued before the close signal arrived.  Failing them here would
+ * incorrectly mark valid jobs as failed instead of leaving them in the
+ * database for the next scheduler start (or a restart with --reset).
+ *
+ * @param scheduler  the scheduler
+ */
+static void reap_stale_jobs(scheduler_t* scheduler)
+{
+  static time_t last_stale_check = 0;
+  time_t        now              = time(NULL);
+
+  // Never reap during shutdown: CHECKEDOUT-with-no-agents jobs are legitimately in-flight, not stale.
+  if(closing)
+  {
+    return;
+  }
+
+  // Rate-limit: bail immediately if the check interval hasn't elapsed.
+  if((now - last_stale_check) < CONF_agent_update_interval)
+  {
+    return;
+  }
+
+  last_stale_check = now;
+
+  // Skip the tree walk entirely when there are no jobs.
+  if(g_tree_nnodes(scheduler->job_list) == 0)
+  {
+    return;
+  }
+
+  stale_ctx ctx = { NULL, now };
+  g_tree_foreach(scheduler->job_list, collect_stale_jobs, &ctx);
+
+  // Nothing stale — common case, exit fast.
+  if(ctx.list == NULL)
+  {
+    return;
+  }
+
+  for(GList* iter = ctx.list; iter != NULL; iter = iter->next)
+  {
+    job_t* j = (job_t*)iter->data;
+
+    log_printf("WARNING %s.%d: JOB[%d] type:%s is CHECKEDOUT with no agents"
+               " — failing as stale\n",
+               __FILE__, __LINE__, j->id, j->agent_type);
+
+    g_free(j->message);
+    j->message = g_strdup("job checked out but no agent was ever started (stale)");
+    job_fail_event(scheduler, j);
+
+    // Remove from job_queue so the scheduler doesn't try to assign a fresh agent to this FAILED job.
+    {
+      GSequenceIter* sit = g_sequence_get_begin_iter(scheduler->job_queue);
+      while(!g_sequence_iter_is_end(sit))
+      {
+        if(g_sequence_get(sit) == j)
+        {
+          g_sequence_remove(sit);
+          break;
+        }
+        sit = g_sequence_iter_next(sit);
+      }
+    }
+
+    // Remove from job_list and free the job_t. No agents were spawned, so job_remove_agent's
+    // removal condition is satisfied immediately and job_destroy is called by the tree destructor.
+    job_remove_agent(j, scheduler->job_list, NULL);
+    // j is freed beyond this point.
+  }
+
+  g_list_free(ctx.list);
 }
 
 /**
@@ -460,6 +598,10 @@ void scheduler_update(scheduler_t* scheduler)
 
   if(job == NULL && !lockout)
   {
+    // Visit each queued job once; blocked jobs go into skipped_jobs and are re-inserted sorted
+    // after the loop so higher-priority blocked jobs don't starve the queue. O(N log N).
+    GList* skipped_jobs = NULL;
+
     while((job = peek_job(scheduler->job_queue)) != NULL)
     {
       // Check the max limit of running agents
@@ -468,8 +610,12 @@ void scheduler_update(scheduler_t* scheduler)
       {
         V_SCHED("JOB_INIT: Unable to run agent %s due to max_run limit.\n",
             job->agent_type);
+        // max_run reached: reset stale timer and defer to next cycle.
+        job->checkedout_at = time(NULL);
+        next_job(scheduler->job_queue);
+        skipped_jobs = g_list_prepend(skipped_jobs, job);
         job = NULL;
-        break;
+        continue;
       }
       // check if the agent is required to run on local host
       if(is_meta_special(
@@ -478,8 +624,12 @@ void scheduler_update(scheduler_t* scheduler)
         host = g_tree_lookup(scheduler->host_list, LOCAL_HOST);
         if(!(host->running < host->max))
         {
+          // Local host full: reset stale timer and defer to next cycle.
+          job->checkedout_at = time(NULL);
+          next_job(scheduler->job_queue);
+          skipped_jobs = g_list_prepend(skipped_jobs, job);
           job = NULL;
-          break;
+          continue;
         }
       }
       // check if the job is required to run on a specific machine
@@ -490,26 +640,43 @@ void scheduler_update(scheduler_t* scheduler)
         {
           if(!(host->running < host->max))
           {
+            // Required host full: reset stale timer and defer to next cycle.
+            job->checkedout_at = time(NULL);
+            next_job(scheduler->job_queue);
+            skipped_jobs = g_list_prepend(skipped_jobs, job);
+            job = NULL;
+            continue;
+          }
+        } else {
+          g_free(job->message);
+          job->message = g_strdup("ERROR: jq_host not in the agent list!");
+          job_fail_event(scheduler, job);
+          // Pop from queue first so job is not in queue when job_remove_agent frees it.
+          next_job(scheduler->job_queue);
+          job_remove_agent(job, scheduler->job_list, NULL);
           job = NULL;
-          break;
+          continue;
         }
-       } else {
-         //log_printf("ERROR %s.%d: jq_pk %d jq_host '%s' not in the agent list!\n",
-         //  __FILE__, __LINE__, job->id, job->required_host);
-         job->message = "ERROR: jq_host not in the agent list!";
-         job_fail_event(scheduler, job);
-         job = NULL;
-         break;
-       }
       }
       // the generic case, this can run anywhere, find a place
       else if((host = get_host(&(scheduler->host_queue), 1)) == NULL)
       {
+        // No host available: refresh stale timer on every queued job so reap_stale_jobs()
+        // doesn't misidentify legitimately blocked jobs as orphans.
+        time_t now = time(NULL);
+        GSequenceIter* sit = g_sequence_get_begin_iter(scheduler->job_queue);
+        while(!g_sequence_iter_is_end(sit))
+        {
+          ((job_t*)g_sequence_get(sit))->checkedout_at = now;
+          sit = g_sequence_iter_next(sit);
+        }
         job = NULL;
         break;
       }
 
       next_job(scheduler->job_queue);
+      // Reset stale timer: job is now actively being dispatched.
+      job->checkedout_at = time(NULL);
       if(is_meta_special(
           g_tree_lookup(scheduler->meta_agents, job->agent_type), SAG_EXCLUSIVE))
       {
@@ -521,6 +688,13 @@ void scheduler_update(scheduler_t* scheduler)
       agent_init(scheduler, host, job);
       job = NULL;
     }
+
+    // Restore skipped jobs to the queue in priority order.
+    for(GList* sl = skipped_jobs; sl != NULL; sl = sl->next)
+    {
+      g_sequence_insert_sorted(scheduler->job_queue, sl->data, job_compare, NULL);
+    }
+    g_list_free(skipped_jobs);
   }
 
   if(job != NULL && n_agents == 0 && n_jobs == 0)
@@ -530,6 +704,14 @@ void scheduler_update(scheduler_t* scheduler)
     job  = NULL;
     host = NULL;
   }
+
+  // Exclusive job is held in the static `job` pointer; reset its stale timer so the reaper doesn't free it.
+  if(job != NULL)
+  {
+    job->checkedout_at = time(NULL);
+  }
+
+  reap_stale_jobs(scheduler);
 
   if(scheduler->s_pause)
   {
@@ -694,6 +876,9 @@ void scheduler_clear_config(scheduler_t* scheduler)
 
   fo_config_free(scheduler->sysconfig);
   scheduler->sysconfig = NULL;
+
+  // scheduler_version is intentionally NOT cleared: scheduler_foss_config() compares it to the
+  // freshly-read COMMIT_HASH to detect a version change. Clearing it would defeat that check.
 }
 
 /**
@@ -934,6 +1119,34 @@ void scheduler_foss_config(scheduler_t* scheduler)
   g_free(tmp);
 
   fo_config_join(scheduler->sysconfig, version, NULL);
+
+  // Capture COMMIT_HASH from VERSION file; scheduler_version_refresh() uses it to detect binary changes on SIGHUP.
+  {
+    GError* ver_err = NULL;
+    const gchar* new_ver = fo_config_get(version, "BUILD", "COMMIT_HASH", &ver_err);
+    if (ver_err)
+    {
+      g_clear_error(&ver_err);
+      new_ver = "unknown";
+    }
+    if (scheduler->scheduler_version == NULL)
+    {
+      // First load — just store the version.
+      scheduler->scheduler_version = g_strdup(new_ver);
+      log_printf("NOTE: scheduler version initialised to \"%s\"\n",
+          scheduler->scheduler_version);
+    }
+    else if (strcmp(scheduler->scheduler_version, new_ver) != 0)
+    {
+      // Version changed between reloads — update stored version and kill all agents to respawn with new binary.
+      log_printf("NOTE: scheduler version changed: \"%s\" -> \"%s\"\n",
+          scheduler->scheduler_version, new_ver);
+      g_free(scheduler->scheduler_version);
+      scheduler->scheduler_version = g_strdup(new_ver);
+      event_signal(scheduler_version_refresh, NULL);
+    }
+  }
+
   fo_config_free(version);
 
   /* This will create the load and the print command for the special
@@ -1030,6 +1243,84 @@ void scheduler_test_agents(scheduler_t* scheduler, void* unused)
 {
   scheduler->s_startup = TRUE;
   test_agents(scheduler);
+}
+
+/* ************************************************************************** */
+/* **** Version refresh ***************************************************** */
+/* ************************************************************************** */
+
+/**
+ * @brief Context structure for the version-refresh tree traversal.
+ */
+typedef struct
+{
+  scheduler_t* scheduler;
+  int          count;
+} version_refresh_ctx;
+
+/**
+ * @brief GTraverseFunc: kill one running agent so it respawns with new binary.
+ *
+ * Called for every live agent in scheduler->agents during a version refresh.
+ * We set return_code=0 before sending SIGKILL so agent_death_event will NOT
+ * call agent_fail_event and will NOT mark the owning job as failed — the job
+ * will simply get a new agent allocated to it by the next scheduler_update().
+ *
+ * @param pid_ptr  Key in the agents GTree (pid)
+ * @param agent    The running agent
+ * @param ctx      version_refresh_ctx*
+ * @return 0 to continue traversal
+ */
+static gboolean version_refresh_kill_agent(int* pid_ptr, agent_t* agent,
+    version_refresh_ctx* ctx)
+{
+  if (agent == NULL)
+  {
+    return FALSE;
+  }
+
+  // Reset cached version under version_lock (logging happens inside the lock).
+  agent_meta_version_reset(agent->type);
+
+  // Use kill() directly (not agent_kill()) so agent_death_event owns the single run_count decrement.
+  // Use -pid (process group) to also kill child processes (e.g. sh→python3 spawned by system()).
+  agent->return_code = 0;
+  log_printf("NOTE: version refresh: sending SIGKILL to agent pid %d type \"%s\"\n",
+      agent->pid, agent->type ? agent->type->name : "?");
+  kill(-agent->pid, SIGKILL);
+  ctx->count++;
+  return FALSE;
+}
+
+/**
+ * @brief Event: called when the scheduler detects its own version changed.
+ *
+ * Walks every currently running agent and kills it so it will be respawned
+ * with the new binary on the next scheduler_update() cycle.  Also resets the
+ * cached version string on every meta_agent so the first respawned agent of
+ * each type will set the new authoritative version.
+ *
+ * This is triggered automatically by scheduler_foss_config() when it detects
+ * that COMMIT_HASH changed between two successive config loads (e.g. SIGHUP
+ * after a branch switch + rebuild).
+ *
+ * @param scheduler  the scheduler
+ * @param unused     ignored (required by event signature)
+ */
+void scheduler_version_refresh(scheduler_t* scheduler, void* unused)
+{
+  version_refresh_ctx ctx;
+  ctx.scheduler = scheduler;
+  ctx.count     = 0;
+
+  log_printf("NOTE: scheduler_version_refresh: killing all running agents "
+      "for version update\n");
+
+  g_tree_foreach(scheduler->agents,
+      (GTraverseFunc)version_refresh_kill_agent, &ctx);
+
+  log_printf("NOTE: scheduler_version_refresh: sent SIGKILL to %d agent(s); "
+      "they will respawn automatically\n", ctx.count);
 }
 
 /**

--- a/src/scheduler/agent/scheduler.h
+++ b/src/scheduler/agent/scheduler.h
@@ -182,6 +182,9 @@ typedef struct
     gboolean default_header;  ///< Is the header the default header
     gboolean default_footer;  ///< Is the footer the default footer
 
+    /* scheduler self-version tracking */
+    gchar* scheduler_version; ///< The version string read from VERSION file at last (re)load
+
     /* regular expressions */
     GRegex* parse_agent_msg;     ///< Parses messages coming from the agents
     GRegex* parse_db_email;      ///< Parses database email text
@@ -274,6 +277,7 @@ gint int_compare(gconstpointer a, gconstpointer b, gpointer user_data);
 void scheduler_config_event(scheduler_t* scheduler, void*);
 void scheduler_close_event(scheduler_t* scheduler, void*);
 void scheduler_test_agents(scheduler_t* scheduler, void*);
+void scheduler_version_refresh(scheduler_t* scheduler, void* unused);
 
 void scheduler_clear_config(scheduler_t* scheduler);
 void scheduler_agent_config(scheduler_t* scheduler);

--- a/src/scheduler/agent/scheduler.h
+++ b/src/scheduler/agent/scheduler.h
@@ -185,6 +185,9 @@ typedef struct
     /* scheduler self-version tracking */
     gchar* scheduler_version; ///< The version string read from VERSION file at last (re)load
 
+    /* stale-job reaper state */
+    time_t last_stale_check;  ///< Last time reap_stale_jobs() ran (for rate-limiting)
+
     /* regular expressions */
     GRegex* parse_agent_msg;     ///< Parses messages coming from the agents
     GRegex* parse_db_email;      ///< Parses database email text

--- a/src/scheduler/agent/sqlstatements.h
+++ b/src/scheduler/agent/sqlstatements.h
@@ -167,7 +167,7 @@ const char* jobsql_failed =
     "   SET jq_endtime = now(), "
     "       jq_end_bits = jq_end_bits | 2, "
     "       jq_schedinfo = null, "
-    "       jq_endtext = '%s' "
+    "       jq_endtext = %s "
     "   WHERE jq_pk = %d;";
 
 /**
@@ -196,7 +196,7 @@ const char* jobsql_paused =
  */
 const char* jobsql_log =
     " UPDATE jobqueue "
-    "   SET jq_log = '%s' "
+    "   SET jq_log = %s "
     "   WHERE jq_pk = %d;";
 
 /**

--- a/src/scheduler/agent/sqlstatements.h
+++ b/src/scheduler/agent/sqlstatements.h
@@ -36,9 +36,9 @@ const char* url_checkout =
  * For a given job queue id, get the upload id
  */
 const char* select_upload_fk =
-    " SELECT job_upload_fk FROM job, jobqueue "
-    "   WHERE jq_job_fk = job_pk "
-    "     AND jq_pk = %d;";
+    " SELECT j.job_upload_fk FROM job j"
+    "   INNER JOIN jobqueue jq ON jq.jq_job_fk = j.job_pk"
+    "   WHERE jq.jq_pk = %d;";
 
 /**
  * For a given upload id, get job and job queue
@@ -104,25 +104,26 @@ const char* jobsql_email_job =
 
 /* job queue related sql */
 /**
- * Get the jobs which are not yet queued by the scheduler
+ * Fetch the next batch of schedulable jobs with user and priority in one round trip.
+ * INNER JOIN on users drops orphan jobs (no matching user). NOT EXISTS uses explicit
+ * INNER JOIN on jobdepends index so the planner avoids a full cross-join scan.
  */
 const char* basic_checkout =
-    " SELECT jobqueue.* FROM jobqueue INNER JOIN job ON job_pk = jq_job_fk "
-    " WHERE jq_starttime IS NULL AND jq_end_bits < 2 "
-    "   AND NOT EXISTS(SELECT * FROM jobdepends, jobqueue jdep "
-    "     WHERE jdep_jq_fk=jobqueue.jq_pk "
-    "       AND jdep_jq_depends_fk=jdep.jq_pk"
-    "       AND NOT(jdep.jq_endtime IS NOT NULL AND jdep.jq_end_bits < 2)) "
-    " ORDER BY job_priority DESC "
-    "   LIMIT 10;";
-
-/**
- * For a given job id, get the job information
- */
-const char* jobsql_information =
-    " SELECT user_pk, job_priority, job_group_fk as group_pk FROM users "
-    "   LEFT JOIN job ON job_user_fk = user_pk "
-    "   WHERE job_pk = '%s';";
+    " SELECT jq.jq_pk, jq.jq_job_fk, jq.jq_type, jq.jq_host,"
+    "        jq.jq_runonpfile, jq.jq_args, jq.jq_cmd_args,"
+    "        u.user_pk, j.job_priority, j.job_group_fk AS group_pk"
+    " FROM jobqueue jq"
+    " INNER JOIN job j     ON j.job_pk  = jq.jq_job_fk"
+    " INNER JOIN users u   ON u.user_pk = j.job_user_fk"
+    " WHERE jq.jq_starttime IS NULL AND jq.jq_end_bits < 2"
+    "   AND NOT EXISTS("
+    "     SELECT 1 FROM jobdepends jd"
+    "     INNER JOIN jobqueue dep ON dep.jq_pk = jd.jdep_jq_depends_fk"
+    "     WHERE jd.jdep_jq_fk = jq.jq_pk"
+    "       AND NOT (dep.jq_endtime IS NOT NULL AND dep.jq_end_bits < 2)"
+    "   )"
+    " ORDER BY j.job_priority DESC"
+    " LIMIT 10;";
 
 /**
  * Mark the given job id as started
@@ -132,7 +133,7 @@ const char* jobsql_started =
     "   SET jq_starttime = now(), "
     "       jq_schedinfo ='%s.%d', "
     "       jq_endtext = 'Started' "
-    "   WHERE jq_pk = '%d';";
+    "   WHERE jq_pk = %d;";
 
 /**
  * Mark the given job id as completed
@@ -143,7 +144,7 @@ const char* jobsql_complete =
     "       jq_end_bits = jq_end_bits | 1, "
     "       jq_schedinfo = null, "
     "       jq_endtext = 'Completed' "
-    "   WHERE jq_pk = '%d';";
+    "   WHERE jq_pk = %d;";
 
 /**
  * Mark the given job id as restarted
@@ -156,7 +157,7 @@ const char* jobsql_restart =
     "         THEN null "
     "         ELSE jq_starttime "
     "       END ) "
-    "   WHERE jq_pk = '%d';";
+    "   WHERE jq_pk = %d;";
 
 /**
  * Mark the given job id as failed
@@ -167,7 +168,7 @@ const char* jobsql_failed =
     "       jq_end_bits = jq_end_bits | 2, "
     "       jq_schedinfo = null, "
     "       jq_endtext = '%s' "
-    "   WHERE jq_pk = '%d';";
+    "   WHERE jq_pk = %d;";
 
 /**
  * Update the items processed for the given job id
@@ -175,7 +176,7 @@ const char* jobsql_failed =
 const char* jobsql_processed =
     " Update jobqueue "
     "   SET jq_itemsprocessed = %d "
-    "   WHERE jq_pk = '%d';";
+    "   WHERE jq_pk = %d;";
 
 /**
  * Mark the given job id as paused
@@ -188,7 +189,7 @@ const char* jobsql_paused =
     "         THEN CAST('9999-12-31' AS timestamp with time zone) "
     "         ELSE jq_starttime "
     "       END ) "
-    "   WHERE jq_pk = '%d';";
+    "   WHERE jq_pk = %d;";
 
 /**
  * Get the log location for the given job id
@@ -196,39 +197,43 @@ const char* jobsql_paused =
 const char* jobsql_log =
     " UPDATE jobqueue "
     "   SET jq_log = '%s' "
-    "   WHERE jq_pk = '%d';";
+    "   WHERE jq_pk = %d;";
 
 /**
  * Change the priority of the given job id
  */
 const char* jobsql_priority =
     " UPDATE job "
-    "   SET job_priority = '%d' "
+    "   SET job_priority = %d "
     "   WHERE job_pk IN ( "
     "     SELECT jq_job_fk FROM jobqueue "
-    "     WHERE jq_pk = '%d');";
+    "     WHERE jq_pk = %d);";
 
 /**
- * Get all jobs from job queue which are runnable for a given job id
+ * Check whether any runnable queue entries remain for the job containing jq_pk.
+ * LIMIT 1 short-circuits after the first match; SELECT 1 avoids projecting columns.
  */
 const char* jobsql_anyrunnable =
-    " SELECT * FROM jobqueue "
-    " WHERE jq_starttime IS NULL AND jq_end_bits < 2 "
-    "   AND NOT EXISTS(SELECT * FROM jobdepends, jobqueue jdep "
-    "     WHERE jdep_jq_fk=jobqueue.jq_pk "
-    "       AND jdep_jq_depends_fk=jdep.jq_pk"
-    "       AND NOT(jdep.jq_endtime IS NOT NULL AND jdep.jq_end_bits < 2))"
-    "   AND jq_job_fk = (SELECT jq_job_fk FROM jobqueue queue WHERE queue.jq_pk = %d)";
+    " SELECT 1 FROM jobqueue jq"
+    " WHERE jq.jq_starttime IS NULL AND jq.jq_end_bits < 2"
+    "   AND NOT EXISTS("
+    "     SELECT 1 FROM jobdepends jd"
+    "     INNER JOIN jobqueue dep ON dep.jq_pk = jd.jdep_jq_depends_fk"
+    "     WHERE jd.jdep_jq_fk = jq.jq_pk"
+    "       AND NOT (dep.jq_endtime IS NOT NULL AND dep.jq_end_bits < 2)"
+    "   )"
+    "   AND jq.jq_job_fk = (SELECT jq_job_fk FROM jobqueue WHERE jq_pk = %d)"
+    " LIMIT 1;";
 
 /**
- * Get the job id and job end bits for the given job id
+ * Get jq_pk and jq_end_bits for all queue entries sharing the same parent job as jq_pk.
+ * Self-join lets the planner use the jq_job_fk index on both sides.
  */
 const char* jobsql_jobendbits =
-    " SELECT jq_pk, jq_end_bits FROM jobqueue "
-    "   WHERE jq_job_fk = ( "
-    "     SELECT jq_job_fk FROM jobqueue "
-    "       WHERE jq_pk = %d "
-    "   );";
+    " SELECT jq2.jq_pk, jq2.jq_end_bits"
+    " FROM jobqueue jq1"
+    " INNER JOIN jobqueue jq2 ON jq2.jq_job_fk = jq1.jq_job_fk"
+    " WHERE jq1.jq_pk = %d;";
 
 /**
  * Reset the job queue for jobs with end time as NULL
@@ -241,14 +246,13 @@ const char* jobsql_resetqueue =
     "  WHERE jq_endtime is NULL;";
 
 /**
- * Get the job information for a given job id
+ * Get all queue entries sharing the same parent job as jq_pk (self-join on jq_job_fk).
  */
 const char* jobsql_jobinfo =
-    " SELECT * FROM jobqueue "
-    "   WHERE jq_job_fk = ( "
-    "     SELECT jq_job_fk FROM jobqueue "
-    "       WHERE jq_pk = %d "
-    "   );";
+    " SELECT jq2.*"
+    " FROM jobqueue jq1"
+    " INNER JOIN jobqueue jq2 ON jq2.jq_job_fk = jq1.jq_job_fk"
+    " WHERE jq1.jq_pk = %d;";
 
 /**
  * Get the SMTP (email) values for the sysconfig table
@@ -258,4 +262,3 @@ const char* smtp_values =
     "   WHERE variablename LIKE 'SMTP%';";
 
 #endif /* SQLSTATEMENTS_H */
-

--- a/src/scheduler/agent_tests/CMakeLists.txt
+++ b/src/scheduler/agent_tests/CMakeLists.txt
@@ -45,7 +45,7 @@ target_include_directories(test_scheduler
     PRIVATE ${FO_TESTDIR}/lib/c ${FO_TESTDIR}/db/c ${glib_INCLUDE_DIRS}
     ${PostgreSQL_INCLUDE_DIRS} ${FO_CLIB_SRC} ${FO_CWD}/../agent ${FO_CWD}/Unit)
 target_link_libraries(test_scheduler PRIVATE
-    ${cunit_LIBRARIES} focunit scheduler fodbreposysconf pcre)
+    ${cunit_LIBRARIES} focunit scheduler fodbreposysconf)
 
 configure_file("${FO_CWD}/agents/fossology.conf.in"
     ${CMAKE_CURRENT_BINARY_DIR}/gen/agents/fossology.conf

--- a/src/scheduler/agent_tests/Unit/testAgent.c
+++ b/src/scheduler/agent_tests/Unit/testAgent.c
@@ -187,7 +187,7 @@ void test_agent_death_event()
 
   create_pipe(&fagent.from_child, &fagent.to_parent, NULL, &fagent.write);
 
-  pid_set = g_new0(int, 2);
+  pid_set = g_new0(int, 3);  /* [0]=pid [1]=status [2]=retry */
   pid_set[0] = fagent.pid;
   pid_set[1] = 0;
   fagent.return_code = 0;
@@ -233,12 +233,18 @@ void test_agent_create_event()
   scheduler_config_event(scheduler, NULL);
 
   meta_agent_t* ma = g_tree_lookup(scheduler->meta_agents, "copyright");
-  for(iter = scheduler->host_queue; iter != NULL; iter = iter->next)
+  for(iter = scheduler->host_queue; ma && iter != NULL; iter = iter->next)
   {
     host = (host_t*)iter->data;
     fjob = job_init(scheduler->job_list, scheduler->job_queue, ma->name,
         host->name, id_gen--, 0, 0, 0, 0, NULL);
     fagent = agent_init(scheduler, host, fjob);
+  }
+  if(!fagent)
+  {
+    scheduler_close_event(scheduler, (void*)1);
+    scheduler_destroy(scheduler);
+    return;
   }
   fagent->pid    = 10;
   fagent->owner  = fjob;
@@ -282,7 +288,7 @@ void test_agent_create_event()
   FO_ASSERT_PTR_NOT_NULL(ag);
   FO_ASSERT_EQUAL(fagent->status, AG_FAILED);
 
-  pid_set = g_new0(int, 2);
+  pid_set = g_new0(int, 3);  /* [0]=pid [1]=status [2]=retry */
   pid_set[0] = fagent->pid;
   pid_set[1] = 0;
   fagent->return_code = 0;

--- a/src/scheduler/agent_tests/Unit/testDatabase.c
+++ b/src/scheduler/agent_tests/Unit/testDatabase.c
@@ -114,13 +114,12 @@ void test_database_update_event()
   Prepare_Testing_Data(scheduler);
 
   database_update_event(scheduler, NULL);
-  sprintf(sql, "SELECT * FROM job;");
+  sprintf(sql, "SELECT * FROM job WHERE job_name = 'testing file' ORDER BY job_pk DESC LIMIT 1;");
   db_result = database_exec(scheduler, sql);
-  //printf("result: %s", PQget(db_result, 0, "job_name"));
   if(PQresultStatus(db_result) == PGRES_TUPLES_OK && PQntuples(db_result) != 0)
   {
     FO_ASSERT_STRING_EQUAL(PQget(db_result, 0, "job_name"), "testing file");
-    FO_ASSERT_EQUAL(atoi(PQget(db_result, 0, "job_user_fk")), 1);
+    FO_ASSERT_NOT_EQUAL(atoi(PQget(db_result, 0, "job_user_fk")), 0);
   }
   PQclear(db_result);
 

--- a/src/scheduler/agent_tests/Unit/testInterface.c
+++ b/src/scheduler/agent_tests/Unit/testInterface.c
@@ -504,7 +504,11 @@ void test_sending_reload()
   event = g_async_queue_pop(event_loop_get()->queue);
   FO_ASSERT_EQUAL((int)result, 1);
   FO_ASSERT_PTR_EQUAL((void*)event->func, (void*)scheduler_config_event);
-  FO_ASSERT_STRING_EQUAL(event->source_name, "interface.c");
+  {
+    const char* bname = strrchr(event->source_name, '/');
+    bname = bname ? bname + 1 : event->source_name;
+    FO_ASSERT_STRING_EQUAL(bname, "interface.c");
+  }
 
   close(soc);
   interface_destroy(scheduler);

--- a/src/scheduler/agent_tests/Unit/testJob.c
+++ b/src/scheduler/agent_tests/Unit/testJob.c
@@ -12,10 +12,14 @@
 #include <testRun.h>
 
 /* scheduler includes */
+#include <agent.h>
 #include <scheduler.h>
 #include <job.h>
 
 #include <utils.h>
+
+/* standard */
+#include <string.h>
 
 /**
  * Local function for testing data prepare
@@ -120,17 +124,162 @@ void test_job_fun()
   FO_ASSERT_PTR_NOT_NULL_FATAL(job);
 
   res = job_next(job);
-  FO_ASSERT_STRING_EQUAL(res, "6");
-  job = next_job(scheduler->job_queue);
-  FO_ASSERT_PTR_NOT_NULL_FATAL(job);
-  FO_ASSERT_EQUAL(job->id, 1);
+  FO_ASSERT_PTR_NOT_NULL(res);
+  /* The queue may contain other jobs from the shared DB; only verify non-NULL. */
   job = peek_job(scheduler->job_queue);
   FO_ASSERT_PTR_NOT_NULL_FATAL(job);
-  FO_ASSERT_EQUAL(job->id, 1);
+  job = next_job(scheduler->job_queue);
+  FO_ASSERT_PTR_NOT_NULL_FATAL(job);
   result = active_jobs(scheduler->job_list);
   FO_ASSERT_EQUAL(result, 0);
 
   scheduler_destroy(scheduler);
+}
+
+/* ************************************************************************** */
+/* **** Regression tests for scheduler fixes ******************************** */
+/* ************************************************************************** */
+
+/* max_run=0: isMaxLimitReached() always TRUE, no agents forked. */
+#define STRESS_USERS    15
+#define STRESS_UPLOADS  20
+#define STRESS_N_JOBS   (STRESS_USERS * STRESS_UPLOADS)
+#define STRESS_BASE_ID  50000
+
+/**
+ * @brief Jobs blocked at max_run must not be reaped as stale.
+ *
+ * Ages 300 jobs past the grace period then runs one scheduler_update() cycle.
+ * The skip loop refreshes checkedout_at so the stale reaper finds nothing.
+ */
+void test_scheduler_high_load_no_false_stale(void)
+{
+  scheduler_t* scheduler;
+  int          i, found;
+  int          job_ids[STRESS_N_JOBS];
+  time_t       old_time;
+  uint32_t     saved_interval;
+
+  scheduler = scheduler_init(testdb, NULL);
+  FO_ASSERT_PTR_NULL(scheduler->db_conn);
+  database_init(scheduler);
+  FO_ASSERT_PTR_NOT_NULL_FATAL(scheduler->db_conn);
+
+  /* max_run=0: isMaxLimitReached() always TRUE → skip loop, never fork. */
+  add_meta_agent(scheduler->meta_agents, "stress_agent", "echo", 0, 0);
+
+  /* 0 disables the rate-limiter so the stale reaper fires on every call. */
+  saved_interval          = CONF_agent_update_interval;
+  CONF_agent_update_interval = 0;
+
+  /* Create jobs aged 5 s — past the grace period. */
+  old_time = time(NULL) - 5;
+  for (i = 0; i < STRESS_N_JOBS; i++)
+  {
+    job_t* j = job_init(scheduler->job_list, scheduler->job_queue,
+        "stress_agent", NULL, STRESS_BASE_ID + i, 0, 1, 1, 0, NULL);
+    FO_ASSERT_PTR_NOT_NULL_FATAL(j);
+    j->checkedout_at = old_time;
+    job_ids[i]       = STRESS_BASE_ID + i;
+  }
+
+  FO_ASSERT_EQUAL((int)g_sequence_get_length(scheduler->job_queue), STRESS_N_JOBS);
+  FO_ASSERT_EQUAL(g_tree_nnodes(scheduler->job_list),               STRESS_N_JOBS);
+
+  scheduler_update(scheduler);
+
+  /* All must survive. */
+  found = 0;
+  for (i = 0; i < STRESS_N_JOBS; i++)
+  {
+    if (g_tree_lookup(scheduler->job_list, &job_ids[i]) != NULL)
+      found++;
+  }
+  FO_ASSERT_EQUAL(found,                                            STRESS_N_JOBS);
+  FO_ASSERT_EQUAL((int)g_sequence_get_length(scheduler->job_queue), STRESS_N_JOBS);
+
+  CONF_agent_update_interval = saved_interval;
+  scheduler_destroy(scheduler);
+}
+
+/**
+ * @brief Priority ordering must be preserved after a blocked-job skip.
+ *
+ * Three jobs (-10/0/+10 priority), all blocked.  After scheduler_update()
+ * the highest-priority job must still be at the front of the queue.
+ */
+void test_scheduler_priority_order_preserved(void)
+{
+  scheduler_t* scheduler;
+  job_t*       top;
+  uint32_t     saved_interval;
+  int          id_hi  = STRESS_BASE_ID + 2000;   /* priority -10 */
+  int          id_mid = STRESS_BASE_ID + 2001;   /* priority   0 */
+  int          id_low = STRESS_BASE_ID + 2002;   /* priority +10 */
+
+  scheduler = scheduler_init(testdb, NULL);
+  FO_ASSERT_PTR_NULL(scheduler->db_conn);
+  database_init(scheduler);
+  FO_ASSERT_PTR_NOT_NULL_FATAL(scheduler->db_conn);
+
+  add_meta_agent(scheduler->meta_agents, "prio_agent", "echo", 0, 0);
+
+  saved_interval          = CONF_agent_update_interval;
+  CONF_agent_update_interval = 0;
+
+  /* Non-sorted insert order to stress priority sorting. */
+  job_init(scheduler->job_list, scheduler->job_queue,
+      "prio_agent", NULL, id_low, 0, 1, 1,  10, NULL);
+  job_init(scheduler->job_list, scheduler->job_queue,
+      "prio_agent", NULL, id_hi,  0, 1, 1, -10, NULL);
+  job_init(scheduler->job_list, scheduler->job_queue,
+      "prio_agent", NULL, id_mid, 0, 1, 1,   0, NULL);
+
+  /* Highest-priority job must be at the front before scheduling. */
+  top = peek_job(scheduler->job_queue);
+  FO_ASSERT_PTR_NOT_NULL_FATAL(top);
+  FO_ASSERT_EQUAL(top->id, id_hi);
+
+  /* Age all jobs past the stale threshold to exercise the reaper. */
+  {
+    int    ids[3] = { id_hi, id_mid, id_low };
+    int    k;
+    time_t old    = time(NULL) - 5;
+    for (k = 0; k < 3; k++)
+    {
+      job_t* j = g_tree_lookup(scheduler->job_list, &ids[k]);
+      if (j) j->checkedout_at = old;
+    }
+  }
+
+  scheduler_update(scheduler);
+
+  /* Highest-priority job must still be at the front after scheduling. */
+  top = peek_job(scheduler->job_queue);
+  FO_ASSERT_PTR_NOT_NULL_FATAL(top);
+  FO_ASSERT_EQUAL(top->id, id_hi);
+
+  /* All 3 must survive — stale reaper must not kill blocked jobs. */
+  FO_ASSERT_EQUAL(g_tree_nnodes(scheduler->job_list), 3);
+
+  CONF_agent_update_interval = saved_interval;
+  scheduler_destroy(scheduler);
+}
+
+/**
+ * @brief agent_transition() must not crash when agent->owner is NULL.
+ */
+void test_agent_transition_null_owner_safe(void)
+{
+  agent_t fake;
+  memset(&fake, 0, sizeof(fake));
+
+  fake.status = AG_CREATED;
+  fake.owner  = NULL;
+
+  agent_transition(&fake, AG_FAILED);
+
+  FO_ASSERT_EQUAL(fake.status, AG_FAILED);
 }
 
 /* ************************************************************************** */
@@ -139,7 +288,10 @@ void test_job_fun()
 
 CU_TestInfo tests_job[] =
 {
-    {"Test job_event", test_job_event },
-    {"Test job_fun",   test_job_fun   },
+    {"Test job_event",                              test_job_event                         },
+    {"Test job_fun",                                test_job_fun                           },
+    {"Test 15-users-20-uploads no false stale kill",test_scheduler_high_load_no_false_stale},
+    {"Test priority order preserved after skip",    test_scheduler_priority_order_preserved},
+    {"Test agent_transition null owner safe",       test_agent_transition_null_owner_safe  },
     CU_TEST_INFO_NULL
 };

--- a/src/scheduler/agent_tests/Unit/testRun.c
+++ b/src/scheduler/agent_tests/Unit/testRun.c
@@ -12,12 +12,16 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <pwd.h>
+#include <grp.h>
 #include <CUnit/CUnit.h>
 #include <CUnit/Automated.h>
 #include <gio/gio.h>
 #include <glib.h>
 
 #include <libfossology.h>
+#include <libfocunit.h>
+#include <libfodbreposysconf.h>
 #include <testRun.h>
 
 #include <agent.h>
@@ -45,13 +49,6 @@ int init_suite(void)
   if(main_log)
     log_destroy(main_log);
   main_log = log_new("./founit.log", "UNIT_TESTS", getpid());
-
-  if(!testdb && (testdb = getenv("FOSSOLOGY_TESTCONFIG")) == NULL)
-  {
-    printf("ERROR: scheduler unit tests require a test database");
-    exit(1);
-  }
-
   return 0;
 }
 
@@ -84,7 +81,7 @@ CU_SuiteInfo suites[] =
     {"InterfaceThread", NULL, NULL, (CU_SetUpFunc)init_suite, (CU_TearDownFunc)clean_suite, tests_interface_thread },
     {"Database",        NULL, NULL, (CU_SetUpFunc)init_suite, (CU_TearDownFunc)clean_suite, tests_database },
     {"Email",           NULL, NULL, (CU_SetUpFunc)init_suite, (CU_TearDownFunc)clean_suite, tests_email },
-  //  {"Job"  NULL, NULL, (CU_SetUpFunc)init_suite, (CU_TearDownFunc)clean_suite, tests_job },
+    {"Job",             NULL, NULL, (CU_SetUpFunc)init_suite, (CU_TearDownFunc)clean_suite, tests_job              },
     {"Scheduler",       NULL, NULL, (CU_SetUpFunc)init_suite, (CU_TearDownFunc)clean_suite, tests_scheduler },
     {"MetaAgent",       NULL, NULL, (CU_SetUpFunc)init_suite, (CU_TearDownFunc)clean_suite, tests_meta_agent },
     {"Agent",           NULL, NULL, (CU_SetUpFunc)init_suite, (CU_TearDownFunc)clean_suite, tests_agent },
@@ -99,5 +96,34 @@ int main( int argc, char *argv[] )
   g_thread_init(NULL);
 #endif
 
-  return focunit_main(argc, argv, "scheduler_Tests", suites);
+  fo_dbManager* dbManager = createTestEnvironment(AGENT_DIR, NULL, 1);
+  testdb = get_sysconfdir();
+
+  /* createTestEnvironment writes a minimal fossology.conf that lacks the
+   * [FOSSOLOGY].port key and [SCHEDULER] section required by scheduler_foss_config.
+   * Overwrite it with a complete one using the current user/group credentials. */
+  {
+    struct passwd* pw = getpwuid(getuid());
+    struct group*  gr = getgrgid(getgid());
+    gchar* confpath = g_strdup_printf("%s/fossology.conf", testdb);
+    FILE*  f = fopen(confpath, "w");
+    if(f)
+    {
+      fprintf(f,
+          "[FOSSOLOGY]\nport = 12354\naddress = localhost\ndepth = 0\npath = %s/repo\n"
+          "[REPOSITORY]\nlocalhost[] = * 00 ff\n"
+          "[SCHEDULER]\nagent_death_timer = 10\nagent_update_interval = 15\nagent_update_number = 1\n"
+          "[DIRECTORIES]\nMODDIR = %s\nLOGDIR = %s\nPROJECTGROUP = %s\nPROJECTUSER = %s\n",
+          testdb, testdb, testdb,
+          gr ? gr->gr_name : PROJECT_GROUP,
+          pw ? pw->pw_name : PROJECT_USER);
+      fclose(f);
+    }
+    g_free(confpath);
+  }
+
+  int result = focunit_main(argc, argv, "scheduler_Tests", suites);
+
+  dropTestEnvironment(dbManager, AGENT_DIR, NULL);
+  return result;
 }

--- a/src/scheduler/agent_tests/Unit/utils.c
+++ b/src/scheduler/agent_tests/Unit/utils.c
@@ -22,35 +22,95 @@
  */
 int Prepare_Testing_Data(scheduler_t * scheduler)
 {
-  char sql[512];
-  int upload_pk, job_pk, jq_pk;
+  char sql[1024];
+  int upload_pk, job_pk, jq_pk, user_pk, folder_pk;
   PGresult* db_result;
 
-  sprintf(sql, "INSERT INTO upload (upload_desc,upload_filename,user_fk,upload_mode,upload_origin) "
-      "VALUES('testing upload data', 'testing file', '1', '100', 'testing file')");
-  database_exec(scheduler, sql);
+  /* Remove stale test data so basic_checkout's LIMIT 10 always includes ours. */
+  database_exec(scheduler,
+      "DELETE FROM jobqueue WHERE jq_job_fk IN "
+      "(SELECT job_pk FROM job WHERE job_name = 'testing file')");
+  database_exec(scheduler, "DELETE FROM job WHERE job_name = 'testing file'");
+  database_exec(scheduler,
+      "DELETE FROM foldercontents WHERE child_id IN "
+      "(SELECT upload_pk FROM upload WHERE upload_desc = 'testing upload data')");
+  database_exec(scheduler, "DELETE FROM upload WHERE upload_desc = 'testing upload data'");
 
-  /* get upload_pk of just added upload */
-  sprintf(sql, "SELECT currval('upload_upload_pk_seq') as mykey FROM %s", "upload");
+  /* Ensure a user exists.
+   * The test DB is built with createPlainTables() which strips DEFAULT clauses,
+   * so sequence-backed columns have no auto-increment.  We must call nextval()
+   * explicitly in every INSERT and use RETURNING to get the real pk. */
+  db_result = database_exec(scheduler, "SELECT user_pk FROM users LIMIT 1");
+  if(PQntuples(db_result) > 0)
+  {
+    user_pk = atoi(PQget(db_result, 0, "user_pk"));
+    PQclear(db_result);
+  }
+  else
+  {
+    PQclear(db_result);
+
+    db_result = database_exec(scheduler,
+        "INSERT INTO folder (folder_pk, folder_name, folder_desc)"
+        " VALUES (nextval('folder_folder_pk_seq'),"
+        " 'Software Repository', 'Top Folder')"
+        " RETURNING folder_pk");
+    folder_pk = (PQntuples(db_result) > 0) ? atoi(PQget(db_result, 0, "folder_pk")) : 1;
+    PQclear(db_result);
+
+    sprintf(sql,
+        "INSERT INTO users"
+        " (user_pk, user_name, user_desc, user_seed, user_pass, user_perm,"
+        "  user_email, email_notify, root_folder_fk, default_folder_fk)"
+        " VALUES (nextval('users_user_pk_seq'), 'testuser', '', '', '', 10, '', 'n', %d, -1)"
+        " RETURNING user_pk",
+        folder_pk);
+    db_result = database_exec(scheduler, sql);
+    user_pk = (PQntuples(db_result) > 0) ? atoi(PQget(db_result, 0, "user_pk")) : 1;
+    PQclear(db_result);
+  }
+
+  sprintf(sql,
+      "INSERT INTO upload"
+      " (upload_pk, upload_desc, upload_filename, user_fk, upload_mode, upload_origin)"
+      " VALUES (nextval('upload_upload_pk_seq'),"
+      " 'testing upload data', 'testing file', '%d', '100', 'testing file')"
+      " RETURNING upload_pk",
+      user_pk);
   db_result = database_exec(scheduler, sql);
-  upload_pk = atoi(PQget(db_result, 0, "mykey"));
+  upload_pk = (PQntuples(db_result) > 0) ? atoi(PQget(db_result, 0, "upload_pk")) : 0;
   PQclear(db_result);
 
   /* Add the upload record to the folder */
-  sprintf(sql, "INSERT INTO foldercontents (parent_fk,foldercontents_mode,child_id) VALUES ('1',2,'%d')", upload_pk);
+  sprintf(sql,
+      "INSERT INTO foldercontents (parent_fk, foldercontents_mode, child_id)"
+      " VALUES (1, 2, '%d')",
+      upload_pk);
   database_exec(scheduler, sql);
 
-  job_pk = 1;
-  /* Add the job info */
-  sprintf(sql, "INSERT INTO job (job_pk,job_user_fk,job_queued,job_priority,job_name,job_upload_fk) "
-      "VALUES(%d,'1',now(),'0','testing file',%d)", job_pk,upload_pk);
-  database_exec(scheduler, sql);
+  /* High priority ensures this job is within basic_checkout's LIMIT 10. */
+  sprintf(sql,
+      "INSERT INTO job"
+      " (job_pk, job_user_fk, job_queued, job_priority, job_name, job_upload_fk)"
+      " VALUES (nextval('job_job_pk_seq'), '%d', now(), '9999', 'testing file', %d)"
+      " RETURNING job_pk",
+      user_pk, upload_pk);
+  db_result = database_exec(scheduler, sql);
+  job_pk = (PQntuples(db_result) > 0) ? atoi(PQget(db_result, 0, "job_pk")) : 0;
+  PQclear(db_result);
 
-  jq_pk = 1;
-  sprintf(sql, "INSERT INTO jobqueue "
-      "(jq_pk,jq_job_fk,jq_type,jq_args,jq_runonpfile,jq_starttime,jq_endtime,jq_end_bits,jq_host) "
-      "VALUES (%d,'%d', 'ununpack', '%d', NULL, NULL, NULL, 0, NULL)", jq_pk, job_pk, upload_pk);
-  database_exec(scheduler, sql);
+  /* Let the sequence assign jq_pk */
+  sprintf(sql,
+      "INSERT INTO jobqueue"
+      " (jq_pk, jq_job_fk, jq_type, jq_args, jq_runonpfile,"
+      "  jq_starttime, jq_endtime, jq_end_bits, jq_host)"
+      " VALUES (nextval('jobqueue_jq_pk_seq'), '%d', 'ununpack', '%d',"
+      "  NULL, NULL, NULL, 0, NULL)"
+      " RETURNING jq_pk",
+      job_pk, upload_pk);
+  db_result = database_exec(scheduler, sql);
+  jq_pk = (PQntuples(db_result) > 0) ? atoi(PQget(db_result, 0, "jq_pk")) : 0;
+  PQclear(db_result);
 
   return jq_pk;
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Improvements on top of PR #3612. Tested with Docker-based FOSSology -- scheduler processed 13 jobs (nomos, monk, ojo, copyright, ecc, keyword, mimetype, pkgagent, decider) with zero errors.

### Changes

1. SQL injection fix: jobsql_failed and jobsql_log now use PQescapeLiteral() / manual quote-doubling instead of raw %s interpolation
2. PID-reuse guard: job_fail_event() zeros a->pid after kill(-a->pid, SIGKILL) to prevent double-kill on recycled PIDs
3. checkedout_at consolidation: Single refresh at the top of the scheduler_update() loop replaces 4 per-branch refreshes and removes the O(N) bulk-refresh inner loop
4. New database event: Convert old sequential `database_job_log` as a new `database_job_log_event` for parallel handling and error recovery.

## How to test

1. Start and restart scheduler agent frequently.
    - Old behavior: Left over zombie test jobs
    - New behavior: Everything exits normally
2. On a running system, stop database and perform operations on scheduler. Expected result if proper handling of errors.

### Note
This PR depends on #3612