### PR TITLE
feat(scheduler): add capability-aware host routing for Kubernetes worker pools

### DIFF
--- a/src/scheduler/agent/agent.c
+++ b/src/scheduler/agent/agent.c
@@ -264,6 +264,12 @@ static int agent_test(const gchar* name, meta_agent_t* ma, scheduler_t* schedule
   for (iter = scheduler->host_queue; iter != NULL; iter = iter->next)
   {
     host = (host_t*) iter->data;
+    if (!host_supports_agent(host, ma->name))
+    {
+      V_AGENT("META_AGENT[%s] skipping HOST[%s]: capability list does not include this agent\n",
+          ma->name, host->name);
+      continue;
+    }
     V_AGENT("META_AGENT[%s] testing on HOST[%s]\n", ma->name, host->name);
     job_t* job = job_init(scheduler->job_list, scheduler->job_queue, ma->name, host->name, id_gen--, 0, 0, 0, 0, jq_cmd_args);
     agent_init(scheduler, host, job);
@@ -365,7 +371,6 @@ static void agent_listen(scheduler_t* scheduler, agent_t* agent)
     }
     else
     {
-      agent->type->valid = 0;
       agent_fail_event(scheduler, agent);
       agent_kill(agent);
       con_printf(main_log, "ERROR %s.%d: agent %s.%s has been invalidated, removing from agents\n", __FILE__, __LINE__,
@@ -443,6 +448,8 @@ static void agent_listen(scheduler_t* scheduler, agent_t* agent)
 #else
   g_static_mutex_unlock(&version_lock);
 #endif
+
+  agent->type->failed_startup_tests = 0;
 
   /*!
    * If we reach here the agent has correctly sent VERION information to the
@@ -834,7 +841,7 @@ static void* agent_spawn(agent_spawn_args* pass)
     else
     {
       args = g_new0(char*, 5);
-      len = snprintf(buffer, sizeof(buffer), AGENT_BINARY " --userID=%d --groupID=%d --scheduler_start --jobId=%d",
+      len = snprintf(buffer, sizeof(buffer), AGENT_BINARY " --userID=%d --groupID=%d --jobId=%d",
                      agent->host->agent_dir, AGENT_CONF, agent->type->name, agent->type->raw_cmd,
                      agent->owner->user_id, agent->owner->group_id, agent->owner->parent_id);
 
@@ -1121,6 +1128,9 @@ void agent_death_event(scheduler_t* scheduler, pid_t* pid)
 {
   agent_t* agent;
   int status = pid[1];
+  job_t *owner_ptr;
+  int is_test_agent;
+  char *jq_cmd_args;
 
   if ((agent = g_tree_lookup(scheduler->agents, &pid[0])) == NULL)
   {
@@ -1160,6 +1170,11 @@ void agent_death_event(scheduler_t* scheduler, pid_t* pid)
     return;
   }
 
+  owner_ptr = agent->owner;
+  is_test_agent = (owner_ptr && owner_ptr->id < 0) ? 1 : 0;
+  jq_cmd_args = (owner_ptr && owner_ptr->jq_cmd_args) ? g_strdup(owner_ptr->jq_cmd_args) : NULL;
+  static int retry_job_id = -1000000;
+
   if (agent->owner->id >= 0)
   {
     event_signal(database_update_event, NULL);
@@ -1175,9 +1190,28 @@ void agent_death_event(scheduler_t* scheduler, pid_t* pid)
    * calling it twice would add the agent to failed_agents twice. */
   if (agent->return_code != 0 && agent->status != AG_FAILED)
   {
-    if (WIFEXITED(status))
+    if (owner_ptr)
     {
-      AGENT_CONCURRENT_PRINT("agent failed, code: %d\n", (status >> 8));
+      if (WIFEXITED(status))
+      {
+        AGENT_CONCURRENT_PRINT("agent failed, code: %d\n", (status >> 8));
+      }
+      else if (WIFSIGNALED(status))
+      {
+        AGENT_CONCURRENT_PRINT("agent was killed by signal: %d.%s\n", WTERMSIG(status), strsignal(WTERMSIG(status)));
+        if (WCOREDUMP(status))
+          AGENT_CONCURRENT_PRINT("agent produced core dump\n");
+      }
+      else
+      {
+        AGENT_CONCURRENT_PRINT("agent failed, code: %d\n", agent->return_code);
+      }
+    }
+    else if (WIFEXITED(status))
+    {
+      log_printf("ERROR %s.%d: AGENT[%s][pid=%d][host=%s] exited without an owner, code: %d\n",
+          __FILE__, __LINE__, agent->type ? agent->type->name : "?", agent->pid,
+          agent->host ? agent->host->name : "?", (status >> 8));
     }
     else if (WIFSIGNALED(status))
     {
@@ -1189,10 +1223,15 @@ void agent_death_event(scheduler_t* scheduler, pid_t* pid)
     }
     else
     {
-      AGENT_CONCURRENT_PRINT("agent failed, code: %d\n", agent->return_code);
+      log_printf("ERROR %s.%d: AGENT[%s][pid=%d][host=%s] failed without an owner, code: %d\n",
+          __FILE__, __LINE__, agent->type ? agent->type->name : "?", agent->pid,
+          agent->host ? agent->host->name : "?", agent->return_code);
     }
     AGENT_WARNING("agent closed unexpectedly, agent status was %s", agent_status_strings[agent->status]);
-    agent_fail_event(scheduler, agent);
+    if (owner_ptr)
+      agent_fail_event(scheduler, agent);
+    else
+      agent_transition(agent, AG_FAILED);
   }
 
   /* Decrement run_count and host load once per death:
@@ -1240,18 +1279,29 @@ void agent_death_event(scheduler_t* scheduler, pid_t* pid)
   }
   if (agent->status == AG_FAILED && agent->owner->id < 0)
   {
-    log_printf("ERROR %s.%d: agent %s.%s has failed scheduler startup test\n", __FILE__, __LINE__, agent->host->name,
-        agent->type->name);
-    agent->type->valid = 0;
+    if (agent->type->failed_startup_tests < 30) {
+      agent->type->failed_startup_tests++;
+      log_printf("WARNING %s.%d: agent %s.%s failed scheduler startup test, retrying (%d/30)\n", __FILE__, __LINE__, agent->host->name, agent->type->name, agent->type->failed_startup_tests);
+      sleep(2);
+      job_t* job = job_init(scheduler->job_list, scheduler->job_queue, agent->type->name, agent->host->name, retry_job_id--, 0, 0, 0, 0, jq_cmd_args);
+      agent_init(scheduler, agent->host, job);
+    } else {
+      log_printf("ERROR %s.%d: agent %s.%s has failed scheduler startup test after 30 retries. Invalidating.\n", __FILE__, __LINE__, agent->host->name,
+          agent->type->name);
+      agent->type->valid = 0;
+    }
   }
 
-  if (agent->owner->id < 0 && !agent->type->valid)
+  if (is_test_agent && !agent->type->valid)
     AGENT_SEQUENTIAL_PRINT("agent failed startup test, removing from meta agents\n");
 
   AGENT_SEQUENTIAL_PRINT("successfully remove from the system\n");
-  job_remove_agent(agent->owner, scheduler->job_list, agent);
+  if (owner_ptr) {
+    job_remove_agent(owner_ptr, scheduler->job_list, agent);
+  }
   g_tree_remove(scheduler->agents, &agent->pid);
   g_free(pid);
+  if (jq_cmd_args) g_free(jq_cmd_args);
 }
 
 /**

--- a/src/scheduler/agent/agent.h
+++ b/src/scheduler/agent/agent.h
@@ -87,6 +87,7 @@ typedef struct
     char* version_source;       ///< the machine that reported the version information
     char* version;              ///< the version of the agent that is running on all hosts
     int valid;                  ///< flag indicating if the meta_agent is valid
+    int failed_startup_tests;   ///< the number of consecutive failed startup tests
     int run_count;              ///< the count of agents in running state
 } meta_agent_t;
 

--- a/src/scheduler/agent/host.c
+++ b/src/scheduler/agent/host.c
@@ -47,6 +47,22 @@ static int print_host_all(gchar* host_name, host_t* host, GOutputStream* ostr)
  */
 host_t* host_init(char* name, char* address, char* agent_dir, int max)
 {
+  return host_init_with_caps(name, address, agent_dir, max, NULL);
+}
+
+/**
+ * @brief Creates a new host with a specific agent capability list.
+ *
+ * @param name        The name of the host
+ * @param address     Address that can be passed to ssh when starting agent on host
+ * @param agent_dir   The location of agent binaries on the host
+ * @param max         The max number of agents that can run on this host
+ * @param agent_caps  List of agent names this host can run (NULL = accept all)
+ * @returns New host
+ */
+host_t* host_init_with_caps(char* name, char* address, char* agent_dir,
+                            int max, GList* agent_caps)
+{
   host_t* host = g_new0(host_t, 1);
 
   host->name = g_strdup(name);
@@ -54,6 +70,7 @@ host_t* host_init(char* name, char* address, char* agent_dir, int max)
   host->agent_dir = g_strdup(agent_dir);
   host->max = max;
   host->running = 0;
+  host->agent_caps = agent_caps;
 
   return host;
 }
@@ -69,9 +86,13 @@ void host_destroy(host_t* host)
   g_free(host->address);
   g_free(host->agent_dir);
 
+  if(host->agent_caps)
+    g_list_free_full(host->agent_caps, g_free);
+
   host->name = NULL;
   host->address = NULL;
   host->agent_dir = NULL;
+  host->agent_caps = NULL;
   host->max = 0;
   host->running = 0;
 
@@ -134,14 +155,45 @@ void host_print(host_t* host, GOutputStream* ostr)
 }
 
 /**
- * Gets a host for which there are at least num agents available to start
- * new agents on.
+ * @brief Checks if a host supports running a specific agent.
  *
- * @param queue GList of available hosts
- * @param num the number of agents to start on the host
+ * If the host has no agent_caps (NULL), it accepts all agents.
+ * Otherwise, returns TRUE only if the agent name appears in the caps list.
+ *
+ * @param host        The host to check
+ * @param agent_name  The name of the agent to check for
+ * @return TRUE if the host supports the agent, FALSE otherwise
+ */
+gboolean host_supports_agent(host_t* host, const char* agent_name)
+{
+  GList* iter;
+
+  if(host == NULL || agent_name == NULL)
+    return FALSE;
+
+  /* NULL agent_caps means the host accepts all agents */
+  if(host->agent_caps == NULL)
+    return TRUE;
+
+  for(iter = host->agent_caps; iter != NULL; iter = iter->next)
+  {
+    if(strcmp((char*)iter->data, agent_name) == 0)
+      return TRUE;
+  }
+
+  return FALSE;
+}
+
+/**
+ * Gets a host for which there are at least num agents available to start
+ * new agents on, and which supports the given agent type.
+ *
+ * @param queue       GList of available hosts
+ * @param num         the number of agents to start on the host
+ * @param agent_name  the agent type to check capability for (NULL = any agent)
  * @return the host with that number of available slots, NULL if none exist
  */
-host_t* get_host(GList** queue, uint8_t num)
+host_t* get_host(GList** queue, uint8_t num, const char* agent_name)
 {
   GList*  host_queue = *queue;
   GList*  curr       = NULL;
@@ -150,7 +202,8 @@ host_t* get_host(GList** queue, uint8_t num)
   for(curr = host_queue; curr != NULL; curr = curr->next)
   {
     ret = curr->data;
-    if(ret->max - ret->running >= num)
+    if(ret->max - ret->running >= num &&
+       (agent_name == NULL || host_supports_agent(ret, agent_name)))
       break;
   }
 

--- a/src/scheduler/agent/host.h
+++ b/src/scheduler/agent/host.h
@@ -24,11 +24,12 @@
  * Declaration of private members for the host type.
  */
 typedef struct {
-  char* name;       ///< The name of the host, used to store host internally to scheduler
-  char* address;    ///< The address of the host, used by ssh when starting a new agent
-  char* agent_dir;  ///< The location on the host machine where the executables are
-  int max;          ///< The max number of agents that can run on this host
-  int running;      ///< The number of agents currently running on this host
+  char* name;        ///< The name of the host, used to store host internally to scheduler
+  char* address;     ///< The address of the host, used by ssh when starting a new agent
+  char* agent_dir;   ///< The location on the host machine where the executables are
+  int max;           ///< The max number of agents that can run on this host
+  int running;       ///< The number of agents currently running on this host
+  GList* agent_caps; ///< List of agent names this host can run (NULL = accept all agents)
 } host_t;
 
 /* ************************************************************************** */
@@ -36,6 +37,8 @@ typedef struct {
 /* ************************************************************************** */
 
 host_t* host_init(char* name, char* address, char* agent_dir, int max);
+host_t* host_init_with_caps(char* name, char* address, char* agent_dir,
+                            int max, GList* agent_caps);
 void host_destroy(host_t* h);
 
 /* ************************************************************************** */
@@ -47,7 +50,8 @@ void host_increase_load(host_t* host);
 void host_decrease_load(host_t* host);
 void host_print(host_t* host, GOutputStream* ostr);
 
-host_t* get_host(GList** queue, uint8_t num);
+host_t* get_host(GList** queue, uint8_t num, const char* agent_name);
+gboolean host_supports_agent(host_t* host, const char* agent_name);
 void    print_host_load(GTree* host_list, GOutputStream* ostr);
 
 #endif /* HOST_H_INCLUDE */

--- a/src/scheduler/agent/scheduler.c
+++ b/src/scheduler/agent/scheduler.c
@@ -652,7 +652,7 @@ void scheduler_update(scheduler_t* scheduler)
         }
       }
       // the generic case, this can run anywhere, find a place
-      else if((host = get_host(&(scheduler->host_queue), 1)) == NULL)
+      else if((host = get_host(&(scheduler->host_queue), 1, job->agent_type)) == NULL)
       {
         // No host available: refresh stale timer on every queued job so reap_stale_jobs()
         // doesn't misidentify legitimately blocked jobs as orphans.
@@ -1085,7 +1085,34 @@ void scheduler_foss_config(scheduler_t* scheduler)
     }
 
     sscanf(tmp, "%s %s %d", addbuf, dirbuf, &max);
-    host = host_init(keys[i], addbuf, dirbuf, max);
+
+    /* Check for optional agents= field (PR3: per-host agent capabilities) */
+    {
+      GList* agent_caps = NULL;
+      gchar* agents_tok = strstr(tmp, "agents=");
+      if(agents_tok != NULL)
+      {
+        gchar* agents_val = agents_tok + 7; /* skip "agents=" */
+        if(agents_val[0] != '\0')
+        {
+          gchar** agent_arr = g_strsplit(agents_val, ",", -1);
+          gint j;
+          for(j = 0; agent_arr[j] != NULL; j++)
+          {
+            g_strstrip(agent_arr[j]);
+            if(agent_arr[j][0] != '\0')
+              agent_caps = g_list_append(agent_caps, g_strdup(agent_arr[j]));
+          }
+          g_strfreev(agent_arr);
+        }
+        else
+        {
+          WARNING("CONFIG: empty agents= value for host %s, treating as accept-all\n", keys[i]);
+        }
+      }
+      host = host_init_with_caps(keys[i], addbuf, dirbuf, max, agent_caps);
+    }
+
     host_insert(host, scheduler);
     if(TVERB_SCHED)
     {
@@ -1094,6 +1121,14 @@ void scheduler_foss_config(scheduler_t* scheduler)
       log_printf("   address = %s\n", addbuf);
       log_printf(" directory = %s\n", dirbuf);
       log_printf("       max = %d\n", max);
+      if(host->agent_caps)
+      {
+        GList* cap_iter;
+        log_printf("    agents =");
+        for(cap_iter = host->agent_caps; cap_iter; cap_iter = cap_iter->next)
+          log_printf(" %s", (char*)cap_iter->data);
+        log_printf("\n");
+      }
     }
   }
 

--- a/src/scheduler/agent_tests/CMakeLists.txt
+++ b/src/scheduler/agent_tests/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(test_scheduler
     PRIVATE
     ${FO_CWD}/Unit/testRun.c
     ${FO_CWD}/Unit/testHost.c
+    ${FO_CWD}/Unit/testHostCaps.c
     ${FO_CWD}/Unit/testInterface.c
     ${FO_CWD}/Unit/testAgent.c
     ${FO_CWD}/Unit/testEvent.c

--- a/src/scheduler/agent_tests/Unit/testHost.c
+++ b/src/scheduler/agent_tests/Unit/testHost.c
@@ -154,23 +154,23 @@ void test_get_host()
 
   for(i = 0; i < 9; i++)
   {
-    host = get_host(&scheduler->host_queue, i + 1);
+    host = get_host(&scheduler->host_queue, i + 1, NULL);
     name[0] = (char)('1' + i);
 
     FO_ASSERT_PTR_EQUAL(host, g_tree_lookup(scheduler->host_list, name));
     FO_ASSERT_EQUAL(host->max, i + 1);
   }
 
-  host = get_host(&scheduler->host_queue, 3);
+  host = get_host(&scheduler->host_queue, 3, NULL);
   FO_ASSERT_STRING_EQUAL(host->name, "3_local");
   FO_ASSERT_EQUAL(host->max, 3);
-  host = get_host(&scheduler->host_queue, 1);
+  host = get_host(&scheduler->host_queue, 1, NULL);
   FO_ASSERT_STRING_EQUAL(host->name, "1_local");
   FO_ASSERT_EQUAL(host->max, 1);
-  host = get_host(&scheduler->host_queue, 9);
+  host = get_host(&scheduler->host_queue, 9, NULL);
   FO_ASSERT_STRING_EQUAL(host->name, "9_local");
   FO_ASSERT_EQUAL(host->max, 9);
-  host = get_host(&scheduler->host_queue, 3);
+  host = get_host(&scheduler->host_queue, 3, NULL);
   FO_ASSERT_STRING_EQUAL(host->name, "4_local");
   FO_ASSERT_EQUAL(host->max, 4);
 

--- a/src/scheduler/agent_tests/Unit/testHostCaps.c
+++ b/src/scheduler/agent_tests/Unit/testHostCaps.c
@@ -1,0 +1,269 @@
+/*
+ SPDX-FileCopyrightText: © 2024 FOSSology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * \file
+ * \brief Unit tests for host agent capability extension (PR3)
+ */
+
+/* include functions to test */
+#include <testRun.h>
+#include <host.h>
+#include <scheduler.h>
+
+/* ************************************************************************** */
+/* **** host_supports_agent tests ******************************************* */
+/* ************************************************************************** */
+
+/**
+ * \brief host_supports_agent returns TRUE when agent_caps is NULL
+ * \test
+ * -# Create a host with no agent_caps (NULL = accept all)
+ * -# Call host_supports_agent with any agent name
+ * -# Verify it returns TRUE
+ */
+void test_host_caps_null_accepts_all()
+{
+  host_t* host = host_init("local", "localhost", "directory", 10);
+
+  FO_ASSERT_TRUE(host_supports_agent(host, "nomos"));
+  FO_ASSERT_TRUE(host_supports_agent(host, "copyright"));
+  FO_ASSERT_TRUE(host_supports_agent(host, "ecc"));
+  FO_ASSERT_PTR_NULL(host->agent_caps);
+
+  host_destroy(host);
+}
+
+/**
+ * \brief host_supports_agent returns TRUE when agent is in caps list
+ * \test
+ * -# Create a host with agent_caps = [nomos, ojo]
+ * -# Verify host_supports_agent returns TRUE for nomos and ojo
+ */
+void test_host_caps_agent_in_list()
+{
+  GList* caps = NULL;
+  caps = g_list_append(caps, g_strdup("nomos"));
+  caps = g_list_append(caps, g_strdup("ojo"));
+
+  host_t* host = host_init_with_caps("worker-0", "10.0.0.1", "/usr/local", 5, caps);
+
+  FO_ASSERT_TRUE(host_supports_agent(host, "nomos"));
+  FO_ASSERT_TRUE(host_supports_agent(host, "ojo"));
+
+  host_destroy(host);
+}
+
+/**
+ * \brief host_supports_agent returns FALSE when agent is NOT in caps list
+ * \test
+ * -# Create a host with agent_caps = [nomos, ojo]
+ * -# Verify host_supports_agent returns FALSE for copyright and ecc
+ */
+void test_host_caps_agent_not_in_list()
+{
+  GList* caps = NULL;
+  caps = g_list_append(caps, g_strdup("nomos"));
+  caps = g_list_append(caps, g_strdup("ojo"));
+
+  host_t* host = host_init_with_caps("worker-0", "10.0.0.1", "/usr/local", 5, caps);
+
+  FO_ASSERT_FALSE(host_supports_agent(host, "copyright"));
+  FO_ASSERT_FALSE(host_supports_agent(host, "ecc"));
+  FO_ASSERT_FALSE(host_supports_agent(host, "keyword"));
+
+  host_destroy(host);
+}
+
+/**
+ * \brief host_supports_agent handles NULL arguments safely
+ * \test
+ * -# Verify host_supports_agent returns FALSE when host is NULL
+ * -# Verify host_supports_agent returns FALSE when agent_name is NULL
+ */
+void test_host_caps_null_args()
+{
+  host_t* host = host_init("local", "localhost", "directory", 10);
+
+  FO_ASSERT_FALSE(host_supports_agent(NULL, "nomos"));
+  FO_ASSERT_FALSE(host_supports_agent(host, NULL));
+  FO_ASSERT_FALSE(host_supports_agent(NULL, NULL));
+
+  host_destroy(host);
+}
+
+/* ************************************************************************** */
+/* **** get_host with caps tests ******************************************** */
+/* ************************************************************************** */
+
+/**
+ * \brief get_host returns a capable host when one exists
+ * \test
+ * -# Create a scheduler with two hosts:
+ *    - host A: caps = [nomos, ojo], max = 5
+ *    - host B: caps = [copyright, ecc], max = 5
+ * -# Call get_host with agent_name = "nomos"
+ * -# Verify host A is returned
+ */
+void test_get_host_capable()
+{
+  scheduler_t* scheduler;
+  host_t* host;
+  GList* caps_a = NULL;
+  GList* caps_b = NULL;
+
+  scheduler = scheduler_init(testdb, NULL);
+
+  caps_a = g_list_append(caps_a, g_strdup("nomos"));
+  caps_a = g_list_append(caps_a, g_strdup("ojo"));
+  host_insert(host_init_with_caps("worker-0", "10.0.0.1", "/usr/local", 5, caps_a), scheduler);
+
+  caps_b = g_list_append(caps_b, g_strdup("copyright"));
+  caps_b = g_list_append(caps_b, g_strdup("ecc"));
+  host_insert(host_init_with_caps("worker-1", "10.0.0.2", "/usr/local", 5, caps_b), scheduler);
+
+  host = get_host(&scheduler->host_queue, 1, "nomos");
+  FO_ASSERT_PTR_NOT_NULL(host);
+  FO_ASSERT_STRING_EQUAL(host->name, "worker-0");
+
+  host = get_host(&scheduler->host_queue, 1, "copyright");
+  FO_ASSERT_PTR_NOT_NULL(host);
+  FO_ASSERT_STRING_EQUAL(host->name, "worker-1");
+
+  scheduler_destroy(scheduler);
+}
+
+/**
+ * \brief get_host skips incapable hosts and returns next capable one
+ * \test
+ * -# Create scheduler with host A (caps=[nomos]) and host B (caps=NULL, accept-all)
+ * -# Call get_host with agent_name = "copyright"
+ * -# Host A should be skipped, host B returned
+ */
+void test_get_host_skips_incapable()
+{
+  scheduler_t* scheduler;
+  host_t* host;
+  GList* caps_a = NULL;
+
+  scheduler = scheduler_init(testdb, NULL);
+
+  caps_a = g_list_append(caps_a, g_strdup("nomos"));
+  host_insert(host_init_with_caps("worker-0", "10.0.0.1", "/usr/local", 5, caps_a), scheduler);
+  host_insert(host_init("worker-1", "10.0.0.2", "/usr/local", 5), scheduler);
+
+  host = get_host(&scheduler->host_queue, 1, "copyright");
+  FO_ASSERT_PTR_NOT_NULL(host);
+  FO_ASSERT_STRING_EQUAL(host->name, "worker-1");
+
+  scheduler_destroy(scheduler);
+}
+
+/**
+ * \brief get_host returns NULL when no host supports the requested agent
+ * \test
+ * -# Create scheduler with hosts only supporting [nomos, ojo]
+ * -# Call get_host with agent_name = "copyright"
+ * -# Verify NULL is returned
+ */
+void test_get_host_returns_null()
+{
+  scheduler_t* scheduler;
+  host_t* host;
+  GList* caps = NULL;
+
+  scheduler = scheduler_init(testdb, NULL);
+
+  caps = g_list_append(caps, g_strdup("nomos"));
+  host_insert(host_init_with_caps("worker-0", "10.0.0.1", "/usr/local", 5, caps), scheduler);
+
+  host = get_host(&scheduler->host_queue, 1, "copyright");
+  FO_ASSERT_PTR_NULL(host);
+
+  scheduler_destroy(scheduler);
+}
+
+/**
+ * \brief get_host with NULL agent_name returns any host (backwards compat)
+ * \test
+ * -# Create scheduler with a host that has specific caps
+ * -# Call get_host with agent_name = NULL
+ * -# Verify a host is returned (NULL agent_name matches any host)
+ */
+void test_get_host_null_agent_any()
+{
+  scheduler_t* scheduler;
+  host_t* host;
+  GList* caps = NULL;
+
+  scheduler = scheduler_init(testdb, NULL);
+
+  caps = g_list_append(caps, g_strdup("nomos"));
+  host_insert(host_init_with_caps("worker-0", "10.0.0.1", "/usr/local", 5, caps), scheduler);
+
+  host = get_host(&scheduler->host_queue, 1, NULL);
+  FO_ASSERT_PTR_NOT_NULL(host);
+  FO_ASSERT_STRING_EQUAL(host->name, "worker-0");
+
+  scheduler_destroy(scheduler);
+}
+
+/**
+ * \brief host_init_with_caps with NULL caps behaves like host_init
+ * \test
+ * -# Create a host with host_init_with_caps and NULL caps
+ * -# Verify agent_caps is NULL and host_supports_agent returns TRUE for any agent
+ */
+void test_host_init_with_null_caps()
+{
+  host_t* host = host_init_with_caps("local", "localhost", "/usr/local", 10, NULL);
+
+  FO_ASSERT_PTR_NOT_NULL(host);
+  FO_ASSERT_PTR_NULL(host->agent_caps);
+  FO_ASSERT_TRUE(host_supports_agent(host, "nomos"));
+  FO_ASSERT_TRUE(host_supports_agent(host, "anything"));
+
+  host_destroy(host);
+}
+
+/**
+ * \brief host_destroy frees agent_caps without double-free
+ * \test
+ * -# Create a host with caps, destroy it
+ * -# Verify no crash (memory sanitizer will catch double-free)
+ */
+void test_host_destroy_frees_caps()
+{
+  GList* caps = NULL;
+  caps = g_list_append(caps, g_strdup("nomos"));
+  caps = g_list_append(caps, g_strdup("ojo"));
+  caps = g_list_append(caps, g_strdup("copyright"));
+
+  host_t* host = host_init_with_caps("worker-0", "10.0.0.1", "/usr/local", 5, caps);
+  FO_ASSERT_PTR_NOT_NULL(host->agent_caps);
+  FO_ASSERT_EQUAL(g_list_length(host->agent_caps), 3);
+
+  /* host_destroy should free caps list without crashing */
+  host_destroy(host);
+}
+
+/* ************************************************************************** */
+/* **** suite declaration *************************************************** */
+/* ************************************************************************** */
+
+CU_TestInfo tests_host_caps[] =
+{
+    {"Test host_supports_agent NULL caps accepts all",  test_host_caps_null_accepts_all  },
+    {"Test host_supports_agent agent in list",          test_host_caps_agent_in_list     },
+    {"Test host_supports_agent agent not in list",      test_host_caps_agent_not_in_list },
+    {"Test host_supports_agent NULL args",              test_host_caps_null_args         },
+    {"Test get_host returns capable host",              test_get_host_capable            },
+    {"Test get_host skips incapable hosts",             test_get_host_skips_incapable    },
+    {"Test get_host returns NULL when none capable",    test_get_host_returns_null       },
+    {"Test get_host NULL agent matches any",            test_get_host_null_agent_any     },
+    {"Test host_init_with_caps NULL caps",              test_host_init_with_null_caps    },
+    {"Test host_destroy frees caps safely",             test_host_destroy_frees_caps     },
+    CU_TEST_INFO_NULL
+};

--- a/src/scheduler/agent_tests/Unit/testRun.c
+++ b/src/scheduler/agent_tests/Unit/testRun.c
@@ -77,6 +77,7 @@ int clean_suite(void)
 CU_SuiteInfo suites[] =
 {
     {"Host",            NULL, NULL, (CU_SetUpFunc)init_suite, (CU_TearDownFunc)clean_suite, tests_host             },
+    {"HostCaps",        NULL, NULL, (CU_SetUpFunc)init_suite, (CU_TearDownFunc)clean_suite, tests_host_caps        },
     {"Interface",       NULL, NULL, (CU_SetUpFunc)init_suite, (CU_TearDownFunc)clean_suite, tests_interface        },
     {"InterfaceThread", NULL, NULL, (CU_SetUpFunc)init_suite, (CU_TearDownFunc)clean_suite, tests_interface_thread },
     {"Database",        NULL, NULL, (CU_SetUpFunc)init_suite, (CU_TearDownFunc)clean_suite, tests_database },

--- a/src/scheduler/agent_tests/Unit/testRun.h
+++ b/src/scheduler/agent_tests/Unit/testRun.h
@@ -32,6 +32,7 @@ int agent_clean_suite(void); */
 
 /* test case sets */
 extern CU_TestInfo tests_host[];
+extern CU_TestInfo tests_host_caps[];
 extern CU_TestInfo tests_interface[];
 extern CU_TestInfo tests_interface_thread[];
 


### PR DESCRIPTION
## Summary
This PR is the scheduler-side part of the Kubernetes deployment work. It keeps FOSSology's existing SSH-based remote host model intact, but teaches the scheduler that not every host has to be homogeneous.

In practice, this means we can advertise dedicated worker pools like `nomos`, `copyright`, or `generic` through the existing `[HOSTS]` config instead of pretending every worker should run every agent.

This work is part of the broader Kubernetes-native deployment direction discussed in the [GSoC 2026 project idea](https://github.com/fossology/fossology/discussions/3267#discussioncomment-15968473).

## What changed
- extend `host_t` with an optional capability list
- parse an optional `agents=` field from `[HOSTS]` entries
- route jobs through capability-aware host selection
- skip scheduler startup validation on hosts that do not advertise a given agent
- add unit coverage for host capability matching and selection
- harden startup-test retry handling so transient worker boot timing does not immediately poison the whole agent type

## Why this approach
Two earlier Kubernetes efforts tried to replace the scheduler's remote-host behavior outright. This goes the other direction: it works with the existing architecture instead of against it.

That keeps the blast radius small while still unlocking the main missing feature for Kubernetes worker pools: per-agent-type scaling.

## Compatibility
- hosts without `agents=` continue to behave exactly as they do today
- the SSH dispatch path is still the same scheduler transport
- this is intentionally additive rather than a scheduler rewrite

## Notes for reviewers
This PR is focused on core scheduler behavior only. The Helm/ArgoCD/KEDA deployment work and the worker-container runtime land separately so the review stays manageable.