### PR TITLE
fix(test): dangling reference pointer failing test

### DIFF
--- a/src/nomos/agent_tests/Unit/test_DoctoredBuffer.c
+++ b/src/nomos/agent_tests/Unit/test_DoctoredBuffer.c
@@ -142,8 +142,6 @@ void test_doctorBuffer_fromFile()
   report_Match(undoc);
   freeAndClearScan(&cur);
 
-  report_Match(undoc);
-
   initializeCurScan(&cur);
   cur.currentLicenceIndex=0;
   g_array_append_val(cur.indexList, licence_index);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

CTEST for nomos failing for `debian:trixie`. There is a dangling pointer which leads to the error.

### Changes

Remove unwanted `report_Match(undoc)`
