### PR TITLE
fix(cyclonedx): add license text and copyright to CycloneDX export

### DIFF
--- a/src/cyclonedx/agent/cyclonedx.php
+++ b/src/cyclonedx/agent/cyclonedx.php
@@ -206,18 +206,43 @@ class CycloneDXAgent extends Agent
     $this->reportutils->addCopyrightResults($filesWithLicenses, $uploadId);
     $this->heartbeat(0);
 
+    $customLicenseTexts = $this->clearingDao->getMainLicenseReportInfos($uploadId, $this->groupId);
+
     $upload = $this->uploadDao->getUpload($uploadId);
-    $components = $this->generateFileComponents($filesWithLicenses, $upload->getTreeTableName(), $uploadId, $itemTreeBounds);
+    $components = $this->generateFileComponents($filesWithLicenses, $upload->getTreeTableName(), $uploadId, $itemTreeBounds, $customLicenseTexts);
 
     $mainLicenseIds = $this->clearingDao->getMainLicenseIds($uploadId, $this->groupId);
     $mainLicenses = array();
+    $seenLicenseIds = array();
     foreach ($mainLicenseIds as $licId) {
       $reportedLicenseId = $this->licenseMap->getProjectedId($licId);
       $mainLicObj = $this->licenseDao->getLicenseById($reportedLicenseId, $this->groupId);
-      $licId = $mainLicObj->getId() . "-" . md5($mainLicObj->getText());
-      $licensedata['id'] = $mainLicObj->getSpdxId();
-      $licensedata['url'] = $mainLicObj->getUrl();
+      if ($mainLicObj === null) {
+        continue;
+      }
+
+      $licensedata = $this->getLicenseDataForCycloneDX($mainLicObj, $licId, $customLicenseTexts);
       $mainLicenses[] = $this->reportGenerator->createLicense($licensedata);
+
+      $customText = array_key_exists($licId, $customLicenseTexts) ? $customLicenseTexts[$licId] : null;
+      $licText = !empty($customText) ? $customText : $mainLicObj->getText();
+      $reportLicId = $mainLicObj->getId() . "-" . md5($licText);
+      $seenLicenseIds[$reportLicId] = true;
+    }
+
+    foreach ($filesWithLicenses as $fileNode) {
+      $licenseIds = !empty($fileNode->getConcludedLicenses())
+        ? $fileNode->getConcludedLicenses()
+        : $fileNode->getScanners();
+      foreach ($licenseIds as $licenseId) {
+        if (array_key_exists($licenseId, $this->licensesInDocument) && !array_key_exists($licenseId, $seenLicenseIds)) {
+          $seenLicenseIds[$licenseId] = true;
+          $licObj = $this->licensesInDocument[$licenseId]->getLicenseObj();
+          $isCustomText = $this->licensesInDocument[$licenseId]->isCustomText();
+          $licensedata = $this->getLicenseDataForCycloneDX($licObj, $licenseId, $customLicenseTexts, $isCustomText);
+          $mainLicenses[] = $this->reportGenerator->createLicense($licensedata);
+        }
+      }
     }
 
     $hashes = $this->uploadDao->getUploadHashes($uploadId);
@@ -229,6 +254,15 @@ class CycloneDXAgent extends Agent
       $serializedhash[] = $this->reportGenerator->createHash('SHA-256', $hashes['sha256']);
     }
 
+    $allCopyrights = array();
+    foreach ($filesWithLicenses as $fileNode) {
+      $fileCopyrights = $fileNode->getCopyrights();
+      if (!empty($fileCopyrights)) {
+        $allCopyrights = array_merge($allCopyrights, $fileCopyrights);
+      }
+    }
+    $allCopyrights = array_unique($allCopyrights);
+
     $maincomponentData = array (
       'bomref' => strval($uploadId),
       'type' => 'library',
@@ -236,6 +270,7 @@ class CycloneDXAgent extends Agent
       'hashes' => $serializedhash,
       'scope' => 'required',
       'mimeType' => $this->getMimeType($uploadId),
+      'copyright' => implode("\n", $allCopyrights),
       'licenses' => $mainLicenses
     );
     $maincomponent = $this->reportGenerator->createComponent($maincomponentData);
@@ -256,7 +291,7 @@ class CycloneDXAgent extends Agent
    * @param int $uploadId
    * @return array Components list
    */
-  protected function generateFileComponents($filesWithLicenses, $treeTableName, $uploadId, $itemTreeBounds)
+  protected function generateFileComponents($filesWithLicenses, $treeTableName, $uploadId, $itemTreeBounds, $customLicenseTexts = array())
   {
     /* @var $treeDao TreeDao */
     $treeDao = $this->container->get('dao.tree');
@@ -286,22 +321,18 @@ class CycloneDXAgent extends Agent
       if (!empty($licenses->getConcludedLicenses())) {
         foreach ($licenses->getConcludedLicenses() as $licenseId) {
           if (array_key_exists($licenseId, $this->licensesInDocument)) {
-            $licensedata = array(
-              "id"   => $this->licensesInDocument[$licenseId]->getLicenseObj()->getSpdxId(),
-              "name" => $this->licensesInDocument[$licenseId]->getLicenseObj()->getFullName(),
-              "url"  => $this->licensesInDocument[$licenseId]->getLicenseObj()->getUrl()
-            );
+            $licObj = $this->licensesInDocument[$licenseId]->getLicenseObj();
+            $isCustomText = $this->licensesInDocument[$licenseId]->isCustomText();
+            $licensedata = $this->getLicenseDataForCycloneDX($licObj, $licenseId, $customLicenseTexts, $isCustomText, false);
             $licensesfound[] = $this->reportGenerator->createLicense($licensedata);
           }
         }
       } else {
         foreach ($licenses->getScanners() as $licenseId) {
           if (array_key_exists($licenseId, $this->licensesInDocument)) {
-            $licensedata = array(
-              "id"   => $this->licensesInDocument[$licenseId]->getLicenseObj()->getSpdxId(),
-              "name" => $this->licensesInDocument[$licenseId]->getLicenseObj()->getFullName(),
-              "url"  => $this->licensesInDocument[$licenseId]->getLicenseObj()->getUrl()
-            );
+            $licObj = $this->licensesInDocument[$licenseId]->getLicenseObj();
+            $isCustomText = $this->licensesInDocument[$licenseId]->isCustomText();
+            $licensedata = $this->getLicenseDataForCycloneDX($licObj, $licenseId, $customLicenseTexts, $isCustomText, false);
             $licensesfound[] = $this->reportGenerator->createLicense($licensedata);
           }
         }
@@ -355,6 +386,48 @@ class CycloneDXAgent extends Agent
   protected function updateReportTable($uploadId, $jobId, $fileName)
   {
     $this->reportutils->updateOrInsertReportgenEntry($uploadId, $jobId, $fileName);
+  }
+
+  /**
+   * @brief Helper to create license data array taking custom text into account
+   * @param \Fossology\Lib\Data\License $licObj
+   * @param string|int $licenseId
+   * @param array $customLicenseTexts
+   * @param bool $isCustomText
+   * @param bool $includeText
+   * @return array
+   */
+  private function getLicenseDataForCycloneDX($licObj, $licenseId, $customLicenseTexts, $isCustomText = false, $includeText = true)
+  {
+    $customText = array_key_exists($licenseId, $customLicenseTexts) ? $customLicenseTexts[$licenseId] : null;
+    $licText = !empty($customText) ? $customText : $licObj->getText();
+
+    $licensedata = array(
+      'url' => $licObj->getUrl()
+    );
+
+    if (!empty($customText) || $isCustomText) {
+      if (!empty($customText)) {
+        $prefix = \Fossology\Lib\Data\LicenseRef::SPDXREF_PREFIX;
+        $licensedata['name'] = $prefix . $licObj->getShortName() . '-' . md5($customText);
+      } else {
+        $licensedata['name'] = $licObj->getShortName();
+      }
+    } else {
+      $spdxId = $licObj->getSpdxId();
+      if (!empty($spdxId)) {
+        $licensedata['id'] = $spdxId;
+      } else {
+        $licensedata['name'] = $licObj->getFullName();
+      }
+    }
+
+    if ($includeText && !empty($licText)) {
+      $licensedata['textContent'] = base64_encode($licText);
+      $licensedata['textContentType'] = 'text/plain';
+    }
+
+    return $licensedata;
   }
 
   /**


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
This is **Phase 1 - Part 1 of the GSoC 2026 project** ([#3635](https://github.com/fossology/fossology/issues/3635): Improve CycloneDX Support and Update CycloneDX Exports to Spec Version 1.7).
The CycloneDX agent was missing license text bodies and copyright notices in the SBOM output. The data was already available via `License::getText()` and `FileNode::getCopyrights()`, and `reportgenerator.php` already supported the `textContent` field, it just wasn't being passed through from `cyclonedx.php`.
### Changes
1. **License text on main component**: Include full license text (base64-encoded) in the main component's licenses using `License::getText()`. Custom license text overrides are supported via `ClearingDao::getMainLicenseReportInfos()`.
2. **Copyright on main component**: Aggregate all file-level copyright notices (via `FileNode::getCopyrights()`) into a deduplicated list and add a `copyright` field to the main component (`metadata.component`).
3. **Null-safety**: Added a null check for `$mainLicObj` to prevent errors if a license ID cannot be resolved.
<details>
<summary>View JSON Output Snippet</summary>

```json
{
  "copyright": "Copyright (c) 1999-2005, 2007, 2013-2015\nCopyright (c) 1999-2005\nCopyright (c) 2013\nCopyright 1998-2023",
  "licenses": [
    {
      "license": {
        "id": "MIT",
        "url": "http://opensource.org/licenses/MIT",
        "text": {
          "contentType": "text/plain",
          "encoding": "base64",
          "content": "KioqCiAqIENvcHlyaWdodCAoYykgMTk5OS0yMDA1LCAyMDA3LCAyMDEzLTIwMTUgCiAqIFRvZGQgQy4gTWlsbGVyIDxUb2RkLk1pbGxlckBzdWRvLndzPg..."
        }
      }
    }
  ]
}
```
</details>

### How to test

1. Upload a package to FOSSology
2. Run the CycloneDX agent on it
3. Download the generated CycloneDX JSON
4. Verify:
    - metadata.component.licenses[].license.text.content contains base64-encoded license text
    - metadata.component.copyright contains aggregated copyright notices

Related Issue - #3635
<img width="1443" height="801" alt="Screenshot 2026-06-01 at 10 58 38 PM" src="https://github.com/user-attachments/assets/f6c1a9c9-99a6-4721-b40c-242f05e41ce2" />

cc - @JanAltenberg @shaheemazmalmmd 