### PR TITLE
perf(copyright): skip db transaction for files with no matches

### DIFF
--- a/src/copyright/agent/copyrightUtils.cc
+++ b/src/copyright/agent/copyrightUtils.cc
@@ -299,6 +299,10 @@ bool saveToDatabase(const string& s, const list<match>& matches, unsigned long p
     int agentId, const CopyrightDatabaseHandler& copyrightDatabaseHandler,
     int uploadId, const string& uploadTreeTableName)
 {
+  if(matches.empty())
+  {
+    return true;
+  }
   if (!copyrightDatabaseHandler.begin())
   {
     return false;


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Add an early return in `saveToDatabase()` when `matches.empty()` is true, avoiding unnecessary `BEGIN`/`COMMIT` database transactions for files with no scanner findings.

**Function call:** ```processUploadId → matchPFileWithLicenses → matchFileWithLicenses → saveToDatabase```

For packages containing a large number of files where most files produce no matches, this reduces database round-trips and can significantly improve overall upload processing time by eliminating redundant transaction overhead.

## Screenshots
<Details>
<summary>Added this in code for debug testing</summary>
<img width="757" height="170" alt="Screenshot 2026-06-05 140555" src="https://github.com/user-attachments/assets/bbe7dbac-7012-40ae-ac41-a59220b038da" />
</Details>

<Details>
<summary>Agent Schedule</summary>
<img width="883" height="619" alt="Screenshot 2026-06-05 140508" src="https://github.com/user-attachments/assets/4365f897-0540-481d-b3d9-8870a031a991" />
</Details>

 **linux-6.9.tar.xz Copyright Agent log file:**    [link](https://github.com/sakshammishra112/Components-Report/blob/main/linux-6.9.tar.xz_copyright_agent_logs)

> Note :
>
> Skipped the db transaction for ~ 22, 233 pfiles in package.


cc: @Kaushl2208 @shaheemazmalmmd 