### PR TITLE
feat(uploads): improve upload browse search and filter controls

### DIFF
--- a/src/www/ui/template/ui-browse.html.twig
+++ b/src/www/ui/template/ui-browse.html.twig
@@ -54,7 +54,7 @@
            <th></th>
            <th>
              <select id="statusSelector" class="form-control-sm" onchange="filterStatus();">
-               <option value="0" selected> </option>
+               <option value="0" selected>-- Select --</option>
             {% for key,disp in statusOptions %}
               <option value="{{ key }}">{{ disp }}</option>
             {% endfor %}
@@ -66,7 +66,7 @@
            <th>
              <select id="assigneeSelector" style="max-width:250px;" class="form-control-sm" onchange="filterAssignee();">
              {% for key,disp in assigneeOptions %}
-               <option value="{{ key }}" {%if key == 0 %} selected{% endif %}>{{ disp }}</option>
+               <option value="{{ key }}" {%if key == 0 %} selected{% endif %}>{% if key == 0 %}-- Select --{% else %}{{ disp }}{% endif %}</option>
              {% endfor %}
              </select>
            </th>

--- a/src/www/ui/template/ui-browse.js.twig
+++ b/src/www/ui/template/ui-browse.js.twig
@@ -3,7 +3,7 @@
    SPDX-License-Identifier: FSFAP
 #}
 tableColumns = [
-  {"sTitle": "{{ "Upload Name and Description"|trans }}", "sClass": "left"},
+  {"sTitle": "{{ "Upload Name and Description"|trans }}", "sClass": "left", "sSearchPlaceholder": "Search Name"},
   {"sTitle": "{{ "Action"|trans }}", "sClass": "center", "bSortable": false, "bSearchable": false},
   {"sTitle": "{{ "Status"|trans }}", "sClass": "center", "bSortable": false, "bSearchable": false},
   {"sTitle": "{{ "Comment"|trans }}", "sClass": "center cc", "bSortable": false, "bSearchable": false, "mRender": function(data) {
@@ -57,6 +57,9 @@ var browseTable;
 
 dataTableConfig =
     {
+      "oLanguage": {
+        "sSearchPlaceholder": "Search..."
+      },
       "bServerSide": true,
       "sAjaxSource": "?mod=browse-processPost",
       "fnServerData": function (sSource, aoData, fnCallback) {


### PR DESCRIPTION
## Description

Improve the Upload Browse page search and filter experience by enhancing the usability and visibility of table controls. The update makes search and filtering options easier to understand for users while preserving the existing workflow.

### Changes
### Before

<img width="1532" height="224" alt="Image" src="https://github.com/user-attachments/assets/e30b3f60-2690-4354-9d69-347adf1ff3b9" />

### After
<img width="1520" height="278" alt="Image" src="https://github.com/user-attachments/assets/340b9d6b-ce9d-4a88-a681-90fd29106c3d" />

* Added placeholder text to the search input field for better discoverability.
* Improved default labels for filter dropdowns.
* Enhanced the visual clarity of search and filter controls.
* Improved usability of upload action selection controls.
* Maintained existing filtering and table functionality.

## How to test

1. Navigate to **Browse Uploads**.
2. Verify the search field displays a helpful placeholder.
3. Verify filter dropdowns show appropriate default options.
4. Use the search box to search for an upload and confirm results are filtered correctly.
5. Apply different filter options and verify the table updates as expected.
6. Confirm upload actions remain functional.
7. Run project lint checks and ensure no errors are reported.

Closes #3647