### PR TITLE
fix(reuser): support multiple reuse upload selections in REST API

### DIFF
--- a/src/www/ui/api/Models/Reuser.php
+++ b/src/www/ui/api/Models/Reuser.php
@@ -17,8 +17,8 @@ namespace Fossology\UI\Api\Models;
 class Reuser
 {
   /**
-   * @var integer $reuseUpload
-   * Upload id to reuse
+   * @var integer|integer[] $reuseUpload
+   * Upload id(s) to reuse
    */
   private $reuseUpload;
   /**
@@ -50,7 +50,7 @@ class Reuser
   /**
    * Reuser constructor.
    *
-   * @param integer $reuseUpload
+   * @param integer|integer[] $reuseUpload
    * @param string $reuseGroup
    * @param boolean $reuseMain
    * @param boolean $reuseEnhanced
@@ -60,17 +60,30 @@ class Reuser
   public function __construct($reuseUpload, $reuseGroup, $reuseMain = false,
     $reuseEnhanced = false)
   {
-    if (is_numeric($reuseUpload)) {
+    if (is_array($reuseUpload)) {
+      if (empty($reuseUpload)) {
+        throw new \UnexpectedValueException(
+          "reuse_upload should be integer or array of integers", 400);
+      }
+      $filtered = array_filter($reuseUpload, function ($val) {
+        return filter_var($val, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE) !== null;
+      });
+      if (count($filtered) !== count($reuseUpload)) {
+        throw new \UnexpectedValueException(
+          "reuse_upload should be integer or array of integers", 400);
+      }
+      $this->reuseUpload = array_map('intval', $reuseUpload);
+    } elseif (is_numeric($reuseUpload)) {
       $this->reuseUpload = $reuseUpload;
-      $this->reuseGroup = $reuseGroup;
-      $this->reuseMain = $reuseMain;
-      $this->reuseEnhanced = $reuseEnhanced;
-      $this->reuseReport = false;
-      $this->reuseCopyright = false;
     } else {
       throw new \UnexpectedValueException(
-        "reuse_upload should be integer", 400);
+        "reuse_upload should be integer or array of integers", 400);
     }
+    $this->reuseGroup = $reuseGroup;
+    $this->reuseMain = $reuseMain;
+    $this->reuseEnhanced = $reuseEnhanced;
+    $this->reuseReport = false;
+    $this->reuseCopyright = false;
   }
 
   /**
@@ -101,9 +114,9 @@ class Reuser
     if (array_key_exists(($version == ApiVersion::V2? "reuseCopyright" : "reuse_copyright"), $reuserArray)) {
       $this->setReuseCopyright($reuserArray[$version == ApiVersion::V2? "reuseCopyright" : "reuse_copyright"]);
     }
-    if ($this->reuseUpload === null) {
+    if ($this->reuseUpload === null || (is_array($this->reuseUpload) && empty($this->reuseUpload))) {
       throw new \UnexpectedValueException(
-        "reuse_upload should be integer", 400);
+        "reuse_upload should be integer or array of integers", 400);
     }
     if ($this->reuseGroup === null) {
       throw new \UnexpectedValueException(
@@ -114,11 +127,23 @@ class Reuser
 
   ////// Getters //////
   /**
-   * @return integer
+   * @return integer|integer[]
    */
   public function getReuseUpload()
   {
     return $this->reuseUpload;
+  }
+
+  /**
+   * Always return reuse upload IDs as an array.
+   * @return integer[]
+   */
+  public function getReuseUploads()
+  {
+    if (is_array($this->reuseUpload)) {
+      return $this->reuseUpload;
+    }
+    return [$this->reuseUpload];
   }
 
   /**
@@ -163,14 +188,27 @@ class Reuser
 
   ////// Setters //////
   /**
-   * @param integer $reuseUpload
+   * @param integer|integer[] $reuseUpload
    */
   public function setReuseUpload($reuseUpload)
   {
-    $this->reuseUpload = filter_var($reuseUpload,
-      FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
-    if ($this->reuseUpload === null) {
-      throw new \UnexpectedValueException("Reuse upload should be an integer!", 400);
+    if (is_array($reuseUpload)) {
+      if (empty($reuseUpload)) {
+        throw new \UnexpectedValueException("Reuse upload should be an integer or array of integers!", 400);
+      }
+      $filtered = array_filter($reuseUpload, function ($val) {
+        return filter_var($val, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE) !== null;
+      });
+      if (count($filtered) !== count($reuseUpload)) {
+        throw new \UnexpectedValueException("Reuse upload should be an integer or array of integers!", 400);
+      }
+      $this->reuseUpload = array_map('intval', $reuseUpload);
+    } else {
+      $this->reuseUpload = filter_var($reuseUpload,
+        FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
+      if ($this->reuseUpload === null) {
+        throw new \UnexpectedValueException("Reuse upload should be an integer or array of integers!", 400);
+      }
     }
   }
 

--- a/src/www/ui/api/Models/ScanOptions.php
+++ b/src/www/ui/api/Models/ScanOptions.php
@@ -191,13 +191,17 @@ class ScanOptions
    */
   private function prepareReuser(Request &$request)
   {
-    $reuseUploadId = $this->reuse->getReuseUpload();
-    if ($reuseUploadId == 0) {
-      // No upload to reuse
+    $reuseUploads = $this->reuse->getReuseUploads();
+    $reuseUploads = array_filter($reuseUploads, function ($id) {
+      return $id > 0;
+    });
+    if (empty($reuseUploads)) {
       return;
     }
-    if (!$GLOBALS['container']->get("dao.upload")->isAccessible($reuseUploadId, Auth::getGroupId())) {
-      throw new HttpForbiddenException("Upload $reuseUploadId is not accessible for reuse");
+    foreach ($reuseUploads as $reuseUploadId) {
+      if (!$GLOBALS['container']->get("dao.upload")->isAccessible($reuseUploadId, Auth::getGroupId())) {
+        throw new HttpForbiddenException("Upload $reuseUploadId is not accessible for reuse");
+      }
     }
     $reuserRules = [];
     if ($this->reuse->getReuseMain() === true) {
@@ -213,8 +217,16 @@ class ScanOptions
       $reuserRules[] = 'reuseCopyright';
     }
     $userDao = $GLOBALS['container']->get("dao.user");
-    $reuserSelector = $this->reuse->getReuseUpload() . "," . $userDao->getGroupIdByName($this->reuse->getReuseGroup());
-    $request->request->set('uploadToReuse', $reuserSelector);
+    $groupId = $userDao->getGroupIdByName($this->reuse->getReuseGroup());
+    $reuserSelectors = [];
+    foreach ($reuseUploads as $uploadId) {
+      $reuserSelectors[] = $uploadId . "," . $groupId;
+    }
+    if (count($reuserSelectors) === 1) {
+      $request->request->set('uploadToReuse', $reuserSelectors[0]);
+    } else {
+      $request->request->set('uploadToReuse', $reuserSelectors);
+    }
     $request->request->set('reuseMode', $reuserRules);
   }
 

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -5907,8 +5907,12 @@ components:
       type: object
       properties:
         reuse_upload:
-          type: integer
-          description: The UploadID to reuse.
+          oneOf:
+            - type: integer
+            - type: array
+              items:
+                type: integer
+          description: The UploadID(s) to reuse. Single integer or array of integers.
         reuse_group:
           type: string
           description: The group of the reused upload

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -5801,8 +5801,12 @@ components:
       type: object
       properties:
         reuseUpload:
-          type: integer
-          description: The UploadID to reuse.
+          oneOf:
+            - type: integer
+            - type: array
+              items:
+                type: integer
+          description: The UploadID(s) to reuse. Single integer or array of integers.
         reuseGroup:
           type: string
           description: The group of the reused upload

--- a/src/www/ui_tests/api/Models/ReuserTest.php
+++ b/src/www/ui_tests/api/Models/ReuserTest.php
@@ -62,8 +62,61 @@ class ReuserTest extends \PHPUnit\Framework\TestCase
   public function testReuserException()
   {
     $this->expectException(\UnexpectedValueException::class);
-    $this->expectExceptionMessage("reuse_upload should be integer");
+    $this->expectExceptionMessage("reuse_upload should be integer or array of integers");
     $object = new Reuser('alpha', 2);
+  }
+
+  /**
+   * @test
+   * -# Test constructor with array of upload IDs
+   */
+  public function testReuserMultipleUploads()
+  {
+    $expectedArray = [
+      "reuse_upload"   => [2, 5, 10],
+      "reuse_group"    => 'fossy',
+      "reuse_main"     => true,
+      "reuse_enhanced" => false,
+      "reuse_copyright" => false,
+      "reuse_report"   => false
+    ];
+
+    $actualReuser = new Reuser([2, 5, 10], 'fossy', true);
+
+    $this->assertEquals($expectedArray, $actualReuser->getArray());
+    $this->assertEquals([2, 5, 10], $actualReuser->getReuseUploads());
+  }
+
+  /**
+   * @test
+   * -# Test getReuseUploads returns array for single upload
+   */
+  public function testReuseUploadsSingle()
+  {
+    $reuser = new Reuser(3, 'fossy');
+    $this->assertEquals([3], $reuser->getReuseUploads());
+  }
+
+  /**
+   * @test
+   * -# Test constructor with empty array throws exception
+   */
+  public function testReuserExceptionEmptyArray()
+  {
+    $this->expectException(\UnexpectedValueException::class);
+    $this->expectExceptionMessage("reuse_upload should be integer or array of integers");
+    $object = new Reuser([], 'fossy');
+  }
+
+  /**
+   * @test
+   * -# Test constructor with array containing non-numeric throws exception
+   */
+  public function testReuserExceptionInvalidArray()
+  {
+    $this->expectException(\UnexpectedValueException::class);
+    $this->expectExceptionMessage("reuse_upload should be integer or array of integers");
+    $object = new Reuser([1, 'bad', 3], 'fossy');
   }
 
   /**
@@ -159,9 +212,53 @@ class ReuserTest extends \PHPUnit\Framework\TestCase
     ];
 
     $this->expectException(\UnexpectedValueException::class);
-    $this->expectExceptionMessage("Reuse upload should be an integer");
+    $this->expectExceptionMessage("Reuse upload should be an integer or array of integers!");
 
     $actualReuser = new Reuser(1, 'fossy');
     $actualReuser->setUsingArray($expectedArray);
+  }
+
+  /**
+   * @test
+   * -# Test setUsingArray with array of upload IDs (V1)
+   */
+  public function testSetUsingArrayMultipleUploadsV1()
+  {
+    $inputArray = [
+      "reuse_upload"   => [2, 5, 10],
+      "reuse_group"    => 'fossy',
+      "reuse_main"     => 'true',
+      "reuse_enhanced" => false,
+      "reuse_copyright" => false,
+      "reuse_report"   => false
+    ];
+
+    $reuser = new Reuser(1, 'fossy');
+    $reuser->setUsingArray($inputArray, ApiVersion::V1);
+
+    $this->assertEquals([2, 5, 10], $reuser->getReuseUpload());
+    $this->assertEquals([2, 5, 10], $reuser->getReuseUploads());
+  }
+
+  /**
+   * @test
+   * -# Test setUsingArray with array of upload IDs (V2)
+   */
+  public function testSetUsingArrayMultipleUploadsV2()
+  {
+    $inputArray = [
+      "reuseUpload"   => [2, 5, 10],
+      "reuseGroup"    => 'fossy',
+      "reuseMain"     => 'true',
+      "reuseEnhanced" => false,
+      "reuseCopyright" => false,
+      "reuseReport"   => false
+    ];
+
+    $reuser = new Reuser(1, 'fossy');
+    $reuser->setUsingArray($inputArray, ApiVersion::V2);
+
+    $this->assertEquals([2, 5, 10], $reuser->getReuseUpload());
+    $this->assertEquals([2, 5, 10], $reuser->getReuseUploads());
   }
 }

--- a/src/www/ui_tests/api/Models/ScanOptionsTest.php
+++ b/src/www/ui_tests/api/Models/ScanOptionsTest.php
@@ -89,8 +89,16 @@ namespace Fossology\UI\Api\Test\Models
     private function prepareRequest($request, $reuserOpts, $deciderOpts)
     {
       if (!empty($reuserOpts)) {
-        $reuserSelector = $reuserOpts['upload'] . "," . $reuserOpts['group'];
-        $request->request->set('uploadToReuse', $reuserSelector);
+        if (is_array($reuserOpts['upload'])) {
+          $reuserSelectors = [];
+          foreach ($reuserOpts['upload'] as $uploadId) {
+            $reuserSelectors[] = $uploadId . "," . $reuserOpts['group'];
+          }
+          $request->request->set('uploadToReuse', $reuserSelectors);
+        } else {
+          $reuserSelector = $reuserOpts['upload'] . "," . $reuserOpts['group'];
+          $request->request->set('uploadToReuse', $reuserSelector);
+        }
         if (key_exists('rules', $reuserOpts)) {
           $request->request->set('reuseMode', $reuserOpts['rules']);
         }
@@ -203,6 +211,55 @@ namespace Fossology\UI\Api\Test\Models
         ->withArgs([$groupName])->andReturn($groupId);
       $this->agentAdderMock->shouldReceive('scheduleAgents')
         ->once()
+        ->andReturn(25);
+
+      $scanOption->scheduleAgents($folderId, $uploadId);
+    }
+
+    /**
+     * @test
+     * -# Test for ScanOptions::scheduleAgents() with multiple reuse uploads
+     * -# Verify multiple upload IDs are correctly handled
+     */
+    public function testScheduleAgentsMultipleReuseUploads()
+    {
+      $reuseUploadIds = [2, 5, 10];
+      $uploadId = 4;
+      $folderId = 2;
+      $groupId = 2;
+      $groupName = "fossy";
+      $agentsToAdd = ['agent_nomos', 'agent_ojo', 'agent_monk'];
+
+      $_SERVER['REQUEST_URI'] = "/api/v1/";
+
+      $analysis = new Analysis();
+      $analysis->setUsingString("nomos,ojo,monk");
+
+      $reuse = new Reuser($reuseUploadIds, $groupName);
+
+      $decider = new Decider();
+      $decider->setOjoDecider(true);
+      $decider->setNomosMonk(true);
+      $decider->setConcludeLicenseType("Permissive");
+
+      $scancode = new Scancode();
+
+      $scanOption = new ScanOptions($analysis, $reuse, $decider, $scancode);
+
+      $expectedSelectors = array_map(function ($id) use ($groupId) {
+        return $id . "," . $groupId;
+      }, $reuseUploadIds);
+
+      $this->userDao->shouldReceive('getGroupIdByName')
+        ->withArgs([$groupName])->andReturn($groupId);
+      $this->agentAdderMock->shouldReceive('scheduleAgents')
+        ->once()
+        ->withArgs(function ($scheduledUploadId, $scheduledAgents, $scheduledRequest) use ($uploadId, $agentsToAdd, $expectedSelectors) {
+          return $scheduledUploadId === $uploadId &&
+            $scheduledAgents === $agentsToAdd &&
+            $scheduledRequest instanceof Request &&
+            $scheduledRequest->get('uploadToReuse') === $expectedSelectors;
+        })
         ->andReturn(25);
 
       $scanOption->scheduleAgents($folderId, $uploadId);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description
This PR completes the work that was left in PR #3488 by adding support for multiple upload selections in the REST API reuser functionality.

Previously, the API only accepted a single upload ID for reuse. With this change, clients can provide either a single upload ID or an array of upload IDs while maintaining backward compatibility.

## Screenshots:

<Details>
<summary>Before</summary>
<img width="1008" height="294" alt="Screenshot 2026-06-03 145511" src="https://github.com/user-attachments/assets/accd509b-e4d3-4c41-a2b2-5992364ac518" />
</Details>

<Details>
<summary>After</summary>
<img width="682" height="289" alt="Screenshot 2026-06-03 150250" src="https://github.com/user-attachments/assets/11e86813-1eb3-4e5d-baea-a9aea235f35c" />

<img width="1049" height="171" alt="Screenshot 2026-06-03 150346" src="https://github.com/user-attachments/assets/2f93aa2a-cb21-44ce-9f3b-7e28c0f69c2c" />

</Details>

## How to test

1. Verify single upload reuse (backward compatible):
   ```json
   {
     "reuse": {
       "reuse_upload": 5,
       "reuse_group": "fossy"
     }
   }
   ```

2. Verify multiple upload reuse:
   ```json
   {
     "reuse": {
       "reuse_upload": [5, 10, 15],
       "reuse_group": "fossy"
     }
   }
   ```