### PR TITLE
feat(folder): add dedicated folder management page

### DIFF
--- a/src/www/ui/page/Folder.php
+++ b/src/www/ui/page/Folder.php
@@ -1,0 +1,240 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\FolderDao;
+use Fossology\Lib\Plugin\DefaultPlugin;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class Folder extends DefaultPlugin
+{
+  const NAME = 'folder';
+
+  /** @var FolderDao */
+  private $folderDao;
+
+  public function __construct()
+  {
+    parent::__construct(self::NAME, array(
+        self::TITLE => _('Folder'),
+        self::MENU_LIST => 'Organize::Folders',
+        self::PERMISSION => Auth::PERM_WRITE,
+        self::REQUIRES_LOGIN => TRUE
+    ));
+    $this->folderDao = $this->getObject('dao.folder');
+  }
+
+  /**
+   * @param Request $request
+   * @return Response
+   */
+  protected function handle(Request $request)
+  {
+    $action = $request->get('action', 'create');
+    if (!in_array($action, array('create', 'delete', 'edit', 'move', 'unlink'))) {
+      $action = 'create';
+    }
+
+    if ($action === 'unlink' && !Auth::isAdmin()) {
+      $action = 'create';
+    }
+
+    $vars = array();
+    $dbManager = $this->getObject('db.manager');
+    $userId = Auth::getUserId();
+    $rootFolderId = GetUserRootFolder();
+
+    if ($request->isMethod('POST')) {
+      if ($action === 'create') {
+        $parentId = intval($request->get('parentid'));
+        $newFolder = $request->get('newname');
+        $desc = $request->get('description');
+        if ($parentId && $newFolder) {
+          $folderName = trim($newFolder);
+          if (!empty($folderName)) {
+            $parentExists = $this->folderDao->getFolder($parentId);
+            if ($parentExists) {
+              $folderWithSameNameUnderParent = $this->folderDao->getFolderId($folderName, $parentId);
+              if (!empty($folderWithSameNameUnderParent)) {
+                $vars['message'] = _("Folder") . " " . htmlentities($newFolder) . " " . _("Exists");
+              } else {
+                $this->folderDao->createFolder($folderName, $desc, $parentId);
+                $vars['message'] = _("Folder") . " " . htmlentities($newFolder) . " " . _("Created");
+              }
+            } else {
+              $vars['message'] = _("Parent folder does not exist");
+            }
+          }
+        }
+      } elseif ($action === 'delete') {
+        $folder = $request->get('folder');
+        if (!empty($folder)) {
+          $splitFolder = explode(" ", $folder);
+          if (count($splitFolder) >= 2) {
+            $folderId = intval($splitFolder[1]);
+            $sql = "SELECT folder_name FROM folder join users on (users.user_pk = folder.user_fk or users.user_perm = 10) where folder_pk = $1 and users.user_pk = $2;";
+            $FolderRow = $dbManager->getSingleRow($sql, array($folderId, $userId), __METHOD__."GetRowWithFolderName");
+            if (!empty($FolderRow['folder_name'])) {
+              $folderDelete = plugin_find('admin_folder_delete');
+              if ($folderDelete) {
+                $rc = $folderDelete->Delete($folder, $userId);
+                if (empty($rc)) {
+                  $vars['message'] = _("Deletion of folder ") . $FolderRow['folder_name'] . _(" added to job queue");
+                } else {
+                  $vars['message'] = _("Deletion of ") . $FolderRow['folder_name'] . _(" failed: ") . $rc;
+                }
+              } else {
+                $rc = $this->deleteFolderDirectly($folder, $userId);
+                if (empty($rc)) {
+                  $vars['message'] = _("Deletion of folder ") . $FolderRow['folder_name'] . _(" added to job queue");
+                } else {
+                  $vars['message'] = _("Deletion of ") . $FolderRow['folder_name'] . _(" failed: ") . $rc;
+                }
+              }
+            } else {
+              $vars['message'] = _("Cannot delete this folder :: Permission denied");
+            }
+          } else {
+            $vars['message'] = _("Invalid folder selection");
+          }
+        }
+      } elseif ($action === 'edit') {
+        $folderId = intval($request->get('oldfolderid'));
+        $newName = $request->get('newname');
+        $newDesc = $request->get('newdesc');
+        if ($folderId) {
+          $sql = 'SELECT * FROM folder where folder_pk = $1;';
+          $Row = $dbManager->getSingleRow($sql, array($folderId), __METHOD__."Get");
+          if ($Row['folder_pk'] == $folderId) {
+            $newName = trim($newName);
+            if (empty($newName)) {
+              $newName = $Row['folder_name'];
+            }
+            if (empty($newDesc)) {
+              $newDesc = $Row['folder_desc'];
+            }
+            $sql = 'UPDATE folder SET folder_name = $1, folder_desc = $2 WHERE folder_pk = $3;';
+            $dbManager->getSingleRow($sql, array($newName, $newDesc, $folderId), __METHOD__."Set");
+            $vars["message"] = _("Folder Properties changed");
+          }
+        }
+      } elseif ($action === 'move') {
+        $folderContentIds = $request->get('foldercontent', array());
+        $parentFolderId = intval($request->get('toFolder'));
+        $isCopyRequest = $request->get('copy');
+
+        $message = "";
+        for ($i = 0; $i < sizeof($folderContentIds); $i++) {
+          $folderContentId = intval($folderContentIds[$i]);
+          if ($folderContentId && $parentFolderId && $isCopyRequest) {
+            try {
+              $this->folderDao->copyContent($folderContentId, $parentFolderId);
+            } catch (\Exception $ex) {
+              $message .= $ex->getMessage();
+            }
+          } elseif ($folderContentId && $parentFolderId) {
+            try {
+              $this->folderDao->moveContent($folderContentId, $parentFolderId);
+            } catch (\Exception $ex) {
+              $message .= $ex->getMessage();
+            }
+          }
+        }
+        $vars['message'] = $message;
+      } elseif ($action === 'unlink') {
+        $folderContentId = intval($request->get('foldercontent'));
+        if ($folderContentId) {
+          try {
+            $this->folderDao->removeContent($folderContentId);
+          } catch (\Exception $ex) {
+            $vars['message'] = $ex->getMessage();
+          }
+        }
+      }
+    }
+
+    // Populate variables depending on current action
+    if ($action === 'create') {
+      $vars['folderOptions'] = FolderListOption($rootFolderId, 0);
+    } elseif ($action === 'delete') {
+      $vars['deleteFolderOptions'] = FolderListOption(-1, 0, 1, -1, true);
+    } elseif ($action === 'edit') {
+      $folderSelectId = intval($request->get('selectfolderid'));
+      if (empty($folderSelectId)) {
+        $folderSelectId = FolderGetTop();
+      }
+      $sql = 'SELECT * FROM folder WHERE folder_pk = $1;';
+      $FolderRow = $dbManager->getSingleRow($sql, array($folderSelectId), __METHOD__."getFolderRow");
+
+      $vars["onchangeURI"] = '?mod=folder&action=edit&selectfolderid=';
+      $vars["folderListOption"] = FolderListOption(-1, 0, 1, $folderSelectId);
+      $vars["folder_name"] = $FolderRow['folder_name'];
+      $vars["folder_desc"] = $FolderRow['folder_desc'];
+      $vars["folderSelectId"] = $folderSelectId;
+    } elseif ($action === 'move') {
+      $rootFolderId = $this->folderDao->getRootFolder($userId)->getId();
+      $uiFolderNav = $this->getObject('ui.folder.nav');
+      $vars['folderTree'] = $uiFolderNav->showFolderTree($rootFolderId);
+      $vars['folderStructure'] = $this->folderDao->getFolderStructure($rootFolderId);
+    } elseif ($action === 'unlink') {
+      $rootFolderId = $this->folderDao->getRootFolder($userId)->getId();
+      $uiFolderNav = $this->getObject('ui.folder.nav');
+      $vars['folderTree'] = $uiFolderNav->showFolderTree($rootFolderId);
+    }
+
+    $vars['activeAction'] = $action;
+    $vars['isAdmin'] = Auth::isAdmin();
+
+    return $this->render('folder.html.twig', $this->mergeWithDefault($vars));
+  }
+
+  /**
+   * @param string $folderpk
+   * @param int $userId
+   * @return string|null
+   */
+  private function deleteFolderDirectly($folderpk, $userId)
+  {
+    $splitFolder = explode(" ", $folderpk);
+    if (count($splitFolder) < 2) {
+      return _("Invalid folder selection");
+    }
+    $folderId = intval($splitFolder[1]);
+    if (!$this->folderDao->isFolderAccessible($folderId, $userId)) {
+      return _("No access to delete this folder");
+    }
+    /* Can't remove top folder */
+    if ($folderId == FolderGetTop()) {
+      return _("Can Not Delete Root Folder");
+    }
+    /* Get the folder's name */
+    $FolderName = FolderGetName($folderId);
+    /* Prepare the job: job "Delete" */
+    $groupId = Auth::getGroupId();
+    $jobpk = JobAddJob($userId, $groupId, "Delete Folder: $FolderName");
+    if (empty($jobpk) || ($jobpk < 0)) {
+      return _("Failed to create job record");
+    }
+    /* Add job: job "Delete" has jobqueue item "delagent" */
+    $jqargs = "DELETE FOLDER $folderpk";
+    $jobqueuepk = JobQueueAdd($jobpk, "delagent", $jqargs, NULL, NULL);
+    if (empty($jobqueuepk)) {
+      return _("Failed to place delete in job queue");
+    }
+
+    /* Tell the scheduler to check the queue. */
+    $success = fo_communicate_with_scheduler("database", $output, $error_msg);
+    if (!$success) {
+      return $error_msg . "\n" . $output;
+    }
+
+    return null;
+  }
+}
+
+register_plugin(new Folder());

--- a/src/www/ui/template/folder.html.twig
+++ b/src/www/ui/template/folder.html.twig
@@ -1,0 +1,158 @@
+{# SPDX-FileCopyrightText: © Fossology contributors
+
+   SPDX-License-Identifier: FSFAP
+#}
+{% extends "include/base.html.twig" %}
+
+{% block styles %}
+  {{ parent() }}
+  {% if activeAction == 'move' or activeAction == 'unlink' %}
+    <link rel="stylesheet" href="css/jquery.treeview.css"/>
+  {% endif %}
+  {% if activeAction == 'move' %}
+    <link rel="stylesheet" href="css/select2.min.css"/>
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+  <div class="container-fluid py-3">
+    <h1 class="h2 mb-3">
+      {% if activeAction == 'create' %}
+        {{ 'Create a new Fossology folder'|trans }}
+      {% elseif activeAction == 'delete' %}
+        {{ 'Delete Folder'|trans }}
+      {% elseif activeAction == 'edit' %}
+        {{ 'Edit Folder Properties'|trans }}
+      {% elseif activeAction == 'move' %}
+        {{ 'Move upload or folder'|trans }}
+      {% elseif activeAction == 'unlink' %}
+        {{ 'Unlink upload or folder'|trans }}
+      {% endif %}
+    </h1>
+
+    <ul class="nav nav-tabs mb-3">
+      <li class="nav-item">
+        <a class="nav-link{% if activeAction == 'create' %} active{% endif %}" href="?mod=folder&action=create">{{ 'Create'|trans }}</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link{% if activeAction == 'delete' %} active{% endif %}" href="?mod=folder&action=delete">{{ 'Delete'|trans }}</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link{% if activeAction == 'edit' %} active{% endif %}" href="?mod=folder&action=edit">{{ 'Edit Properties'|trans }}</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link{% if activeAction == 'move' %} active{% endif %}" href="?mod=folder&action=move">{{ 'Move or Copy'|trans }}</a>
+      </li>
+      {% if isAdmin %}
+        <li class="nav-item">
+          <a class="nav-link{% if activeAction == 'unlink' %} active{% endif %}" href="?mod=folder&action=unlink">{{ 'Unlink Content'|trans }}</a>
+        </li>
+      {% endif %}
+    </ul>
+
+    <div class="pt-2">
+      {% if message is defined and message is not empty %}
+        <div class="alert alert-info">{{ message }}</div>
+      {% endif %}
+
+      {% if activeAction == 'create' %}
+        {% include 'admin-folder-create-form.html.twig' %}
+      {% elseif activeAction == 'delete' %}
+        <form method="post">
+          <p>{{ "Select the folder to delete."|trans }}</p>
+          <ul>
+            <li>{{ "This will delete the folder, all subfolders, and all uploaded files stored within the folder!"|trans }}</li>
+            <li><strong>{{ "Be very careful with your selection since you can delete a lot of work!"|trans }}</strong></li>
+            <li>{{ "All analysis only associated with the deleted uploads will also be deleted."|trans }}</li>
+            <li>{{ "THERE IS NO UNDELETE. When you select something to delete, it will be removed from the database and file repository."|trans }}</li>
+          </ul>
+          <div class="form-group mb-3">
+            <label class="form-label" for="folder">{{ "Select the folder to delete:"|trans }}</label>
+            <select name="folder" id="folder" class="ui-render-select2 form-control">
+              <option value="" disabled selected>[{{ "select folder"|trans }}]</option>
+              {{ deleteFolderOptions|raw }}
+            </select>
+          </div>
+          <button type="submit" class="btn btn-danger">{{ "Delete"|trans }}</button>
+        </form>
+      {% elseif activeAction == 'edit' %}
+        {% include 'admin-folder-edit-form.html.twig' %}
+      {% elseif activeAction == 'move' %}
+        {{ 'Select a folder on the left hand side to move or copy content to a different folder'|trans }}
+        <table>
+          <tr style="vertical-align:top;">
+            <td id="sidetree">
+              <div id="sidetreecontrol" style="display:inline;"><a href="?#">{{ 'Collapse All'|trans }}</a> | <a href="?#">{{ 'Expand All'|trans }}</a></div>
+              {{ folderTree|raw }}
+            </td>
+            <td style="padding-left:20px;">
+              <form name="formy" method="post">
+                <input type="hidden" name="fromFolder" id="fromFolder" value="-1"/>
+
+                <label for="foldercontent">{{ 'Select uploads or folders you wish to move'|trans }}:<br/>
+                  <select name="foldercontent[]" id="foldercontent" multiple="multiple" size="20">
+                  </select>
+                </label>
+                <br/>
+                <br/>
+
+                <label for="toFolder">{{ 'Select the folder where the content shall be placed'| trans }}:<br/>
+                  {% include 'components/select-folder.html.twig' with {'name':'toFolder', 'id': 'toFolder'}  %}
+                </label>
+                <br/>
+                <br/>
+
+                <input type="submit" name="move" value="{{ 'Move'|trans }}"/> &nbsp; <input type="submit" name="copy" value="{{ 'Alias'|trans }}"/>
+                <img src="images/info_16.png" data-toggle="tooltip" title="{{ 'Copy creates an alias; changes appear in all aliases. Use content_unlink to remove a single instance.'|trans }}" alt="" class="info-bullet"/>
+              </form>
+            </td>
+          </tr>
+        </table>
+      {% elseif activeAction == 'unlink' %}
+        {{ 'Only folders or uploads that can be accessed via a different path can be deleted'| trans }}
+        <table>
+          <tr style="vertical-align:top;">
+            <td id="sidetree">
+              <div id="sidetreecontrol" style="display:inline;"><a href="?#">{{ 'Collapse All'|trans }}</a> | <a href="?#">{{ 'Expand All'|trans }}</a></div>
+              {{ folderTree|raw }}
+            </td>
+            <td style="padding-left:20px;">
+              <form name="formy" method="post">
+                <label for="foldercontent">{{ 'Select the upload or folder you wish to unlink'|trans }}:<br/>
+                  <select name="foldercontent" id="foldercontent" size="20">
+                  </select>
+                </label>
+                <br/>
+
+                <input type="submit" name="move" id="movebutton" value="{{ 'Delete'|trans }}"/>
+              </form>
+            </td>
+          </tr>
+        </table>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}
+
+{% block foot %}
+  {{ parent() }}
+  {% if activeAction == 'move' or activeAction == 'unlink' %}
+    <script src="scripts/tools.js" type="text/javascript"></script>
+    <script src="scripts/jquery.treeview.js" type="text/javascript"></script>
+  {% endif %}
+  {% if activeAction == 'move' %}
+    <script src="scripts/select2.full.min.js" type="text/javascript"></script>
+    <script>
+      $(document).ready(function () {
+        $('#toFolder').select2({
+          "placeholder": "Select folder"
+        });
+        $('[data-toggle="tooltip"]').tooltip();
+      });
+    </script>
+    <script type="text/javascript">{% include 'admin_content_move.js.twig' %}</script>
+  {% endif %}
+  {% if activeAction == 'unlink' %}
+    <script type="text/javascript">{% include 'admin_content_move.js.twig' with {'removable':1} %}</script>
+  {% endif %}
+{% endblock %}

--- a/src/www/ui/template/ui-browse.js.twig
+++ b/src/www/ui/template/ui-browse.js.twig
@@ -90,10 +90,7 @@ function createBrowseTable() {
 $(document).ready(function() {
   browseTable = createBrowseTable();
   $('.clickable-folder').click(function(event){
-    folder = $(this).attr('data-folder');
-    browseTable.draw();
-    $('#current-folder').text($(this).text());
-    $('#browse-upload-all').val(folder);
+    window.location.href = $(this).attr('href');
     return false;
   });
   $('#browse-upload-all').button().change(function ( event ){


### PR DESCRIPTION
## Description

Introduces a dedicated Folder Management page and consolidates folder-related operations into a single interface.

Previously, folder operations such as Create, Delete, Edit Properties, Move/Copy, and Unlink Content were accessible through separate routes under the **Organize → Folders** submenu. This implementation aligns the functionality with the intended UI/UX design by providing direct access to all folder operations from a dedicated page.

Closes #3662 

### Changes

* Added a dedicated Folder Management page.
* Moved folder operations from submenu-based navigation to page-level tabs.
* Added tabs for:
  * Create
  * Delete
  * Edit Properties
  * Move or Copy
  * Unlink Content
* Updated routing to support direct access to folder operations.
* Improved discoverability and usability of folder management features.
* Aligned implementation with the approved UI/UX design.

## Ui Changes
https://github.com/user-attachments/assets/4c04f36c-6325-4a59-9bb3-7ab772ab17f7

## How to test

1. Build and run Fossology.
2. Log in to the application.
3. Navigate to **Organize → Folder Management** (or the corresponding menu entry).
4. Verify that the Folder Management page is displayed.
5. Verify that the following tabs are available:
   * Create
   * Delete
   * Edit Properties
   * Move or Copy
   * Unlink Content
6. Test each operation and confirm it behaves as expected.
7. Verify that folder creation, deletion, property updates, move/copy operations, and unlink actions work correctly.
8. Confirm that navigation between tabs works without issues.
9. Compare the implementation against the provided UI/UX design and verify consistency.
