### PR TITLE
feat(reuse): show bulk scan reuse info in file info and unified report

### DIFF
--- a/src/lib/php/Dao/UploadDao.php
+++ b/src/lib/php/Dao/UploadDao.php
@@ -29,6 +29,7 @@ class UploadDao
   const REUSE_NONE = 0;
   const REUSE_ENHANCED = 2;
   const REUSE_MAIN = 4;
+  const REUSE_BULK = 8;
   const REUSE_CONF = 16;
   const REUSE_COPYRIGHT = 128;
   const UNIFIED_REPORT_HEADINGS = array(

--- a/src/reuser/ui/agent-reuser.php
+++ b/src/reuser/ui/agent-reuser.php
@@ -124,7 +124,14 @@ class ReuserAgentPlugin extends AgentPlugin
         case 'reuseCopyright':
           $reuseMode |= UploadDao::REUSE_COPYRIGHT;
           break;
+        case 'reuseBulk':
+          $reuseMode |= UploadDao::REUSE_BULK;
+          break;
       }
+    }
+    $deciderRules = $request->get('deciderRules', []);
+    if (is_array($deciderRules) && in_array('reuseBulk', $deciderRules)) {
+      $reuseMode |= UploadDao::REUSE_BULK;
     }
 
     $reuseSelections = $request->get(self::UPLOAD_TO_REUSE_SELECTOR_NAME);

--- a/src/unifiedreport/agent/unifiedreport.php
+++ b/src/unifiedreport/agent/unifiedreport.php
@@ -331,6 +331,39 @@ class UnifiedReport extends Agent
     $otherStatement['includeDNU'] = (count($licensesDNU["statements"]) > 0) ? true : false;
     $otherStatement['includeNonFunctional'] = (count($licensesNonFunctional["statements"]) > 0) ? true : false;
 
+    $reusedPackages = array();
+    $reusedInfo = $this->uploadDao->getReusedUpload($uploadId, $groupId);
+    foreach ($reusedInfo as $row) {
+      $reuseUploadFk = $row['reused_upload_fk'];
+      $reuseGroupFk = $row['reused_group_fk'];
+      $reusedUpload = $this->uploadDao->getUpload($reuseUploadFk);
+      $reuseModes = array();
+      if ($row['reuse_mode'] & UploadDao::REUSE_ENHANCED) {
+        $reuseModes[] = "Enhanced";
+      } else {
+        $reuseModes[] = "Normal";
+      }
+      if ($row['reuse_mode'] & UploadDao::REUSE_MAIN) {
+        $reuseModes[] = "Main license";
+      }
+      if ($row['reuse_mode'] & UploadDao::REUSE_BULK) {
+        $reuseModes[] = "Bulk scan";
+      }
+      if ($row['reuse_mode'] & UploadDao::REUSE_CONF) {
+        $reuseModes[] = "Report configuration settings";
+      }
+      if ($row['reuse_mode'] & UploadDao::REUSE_COPYRIGHT) {
+        $reuseModes[] = "Copyright";
+      }
+      $hashes = $this->uploadDao->getUploadHashes($reuseUploadFk);
+      $reusedPackages[] = array(
+        'name' => $reusedUpload->getFilename(),
+        'sha1' => $hashes['sha1'],
+        'group' => $this->userDao->getGroupNameById($reuseGroupFk) . " ($reuseGroupFk)",
+        'mode' => implode(", ", $reuseModes) . " reuse"
+      );
+    }
+
     $contents = array(
                         "licenses" => $licenses,
                         "bulkLicenses" => $bulkLicenses,
@@ -347,7 +380,8 @@ class UnifiedReport extends Agent
                         "licensesNonFunctionalComment" => $licensesNonFunctionalComment,
                         "licensesMain" => $licensesMain,
                         "licensesHist" => $licensesHist,
-                        "otherStatement" => $otherStatement
+                        "otherStatement" => $otherStatement,
+                        "reusedPackages" => $reusedPackages
                      );
 
     $this->writeReport($contents, $uploadId, $groupId, $userId);
@@ -648,6 +682,46 @@ class UnifiedReport extends Agent
   }
 
   /**
+   * @brief Reused component section in report.
+   * @param Section $section
+   * @param string $title
+   * @param array $reusedPackages
+   * @param array $titleSubHeading
+   */
+  private function reusedComponentTable(Section $section, $title, $reusedPackages, $titleSubHeading)
+  {
+    $firstColLen = 3000;
+    $secondColLen = 3000;
+    $thirdColLen = 4500;
+    $fourthColLen = 4500;
+
+    $section->addTitle(htmlspecialchars($title), 2);
+    $section->addText($titleSubHeading, $this->subHeadingStyle);
+
+    $table = $section->addTable($this->tablestyle);
+    if (!empty($reusedPackages)) {
+      foreach ($reusedPackages as $reusedPkg) {
+        $table->addRow($this->rowHeight);
+        $cell1 = $table->addCell($firstColLen);
+        $cell1->addText(htmlspecialchars($reusedPkg['name']), $this->licenseColumn, "pStyle");
+        $cell2 = $table->addCell($secondColLen);
+        $cell2->addText(htmlspecialchars($reusedPkg['sha1']), $this->filePathColumn, "pStyle");
+        $cell3 = $table->addCell($thirdColLen);
+        $cell3->addText(htmlspecialchars($reusedPkg['group']), $this->filePathColumn, "pStyle");
+        $cell4 = $table->addCell($fourthColLen);
+        $cell4->addText(htmlspecialchars($reusedPkg['mode']), $this->filePathColumn, "pStyle");
+      }
+    } else {
+      $table->addRow($this->rowHeight);
+      $table->addCell($firstColLen)->addText("");
+      $table->addCell($secondColLen)->addText("");
+      $table->addCell($thirdColLen)->addText("");
+      $table->addCell($fourthColLen)->addText("");
+    }
+    $section->addTextBreak();
+  }
+
+  /**
    * @brief License histogram into report.
    * @param Section $section
    * @param array $dataHistogram
@@ -900,6 +974,12 @@ class UnifiedReport extends Agent
       $section->addTitle(htmlspecialchars("$subHeading"), 3);
       $titleSubHeadingNotes = "(License name, Comment Entered, File path)";
       $this->bulkLicenseTable($section, "", $contents['licensesIrreComment']['statements'], $titleSubHeadingNotes);
+    }
+
+    if (!empty($contents['reusedPackages'])) {
+      $heading = "Reused component";
+      $titleSubHeadingReuse = "(Package name, SHA1, Group, Mode)";
+      $this->reusedComponentTable($section, $heading, $contents['reusedPackages'], $titleSubHeadingReuse);
     }
 
     $heading = array_keys($unifiedColumns['dnufiles'])[0];

--- a/src/www/ui/api/Models/ScanOptions.php
+++ b/src/www/ui/api/Models/ScanOptions.php
@@ -202,6 +202,9 @@ class ScanOptions
     if ($this->reuse->getReuseCopyright() === true) {
       $reuserRules[] = 'reuseCopyright';
     }
+    if ($this->decider !== null && $this->decider->getBulkReused() === true) {
+      $reuserRules[] = 'reuseBulk';
+    }
     $userDao = $GLOBALS['container']->get("dao.user");
     $reuserSelector = $this->reuse->getReuseUpload() . "," . $userDao->getGroupIdByName($this->reuse->getReuseGroup());
     $request->request->set('uploadToReuse', $reuserSelector);

--- a/src/www/ui/ui-view-info.php
+++ b/src/www/ui/ui-view-info.php
@@ -564,8 +564,14 @@ class ui_view_info extends FO_Plugin
       if ($row['reuse_mode'] & UploadDao::REUSE_MAIN) {
         $reuseMode[] = "Main license";
       }
+      if ($row['reuse_mode'] & UploadDao::REUSE_BULK) {
+        $reuseMode[] = "Bulk scan";
+      }
       if ($row['reuse_mode'] & UploadDao::REUSE_CONF) {
         $reuseMode[] = "Report configuration settings";
+      }
+      if ($row['reuse_mode'] & UploadDao::REUSE_COPYRIGHT) {
+        $reuseMode[] = "Copyright";
       }
       $entry['name'] = $reusedUpload->getFilename();
       $entry['url'] = Traceback_uri() .


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add support for displaying bulk scan and copyright reuse information in File Info and Unified Report. This change ensures that these reuse selections are persisted, shown in reuse details, and included in generated reports.

Closes #1281

### Changes

* Added a new `REUSE_BULK` reuse mode bit flag.
* Persisted bulk scan reuse selections from both UI and API reuse workflows.
* Updated File Info reuse details to display all configured reuse modes, including:

  * Main license
  * Bulk scan
  * Copyright
  * Report configuration settings
* Added reused package information to the Unified Report.
* Added a new **Reused Components** table to the DOCX Unified Report containing:

  * Package name
  * SHA1
  * Group
  * Reuse mode(s)
* Display reused package information after the **Comment for Irrelevant files** section.

## How to test

1. Upload a package and perform scans.
2. Reuse the package in another upload and enable **Bulk Scan Reuse** and/or **Copyright Reuse**.
3. Open **File Info** for the reused upload.
4. Verify that the selected reuse modes (**Bulk scan**, **Copyright**, etc.) are displayed in the reuse information section.
5. Generate a **Unified Report** for the reused upload.
6. Verify that a **Reused Components** table is present after the **Comment for Irrelevant files** section.
7. Confirm that the table contains the expected package name, SHA1, group, and reuse mode information.

## Screenshots:

### Before

<img width="1902" height="433" alt="Screenshot from 2026-06-06 01-39-57" src="https://github.com/user-attachments/assets/bf98d612-2ff1-4321-aeda-ed0914374301" />


### After
<img width="1907" height="446" alt="Screenshot from 2026-06-06 01-27-01" src="https://github.com/user-attachments/assets/90693a3f-210d-4fcd-985d-13e8005e6e8e" />

<img width="1124" height="596" alt="Screenshot from 2026-06-06 01-28-22" src="https://github.com/user-attachments/assets/94bdfba2-3f54-4085-926d-42f2647b3d18" />

cc: @shaheemazmalmmd @Kaushl2208 