### PR TITLE
feat(REUSE): detect declared licenses from root LICENSE file

### DIFF
--- a/src/lib/php/BusinessRules/DetectLicensesFolder.php
+++ b/src/lib/php/BusinessRules/DetectLicensesFolder.php
@@ -8,8 +8,9 @@
 namespace Fossology\Lib\BusinessRules;
 
 use Fossology\Lib\Auth\Auth;
-use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Dao\ClearingDao;
 use Fossology\Lib\Dao\SearchHelperDao;
+use Fossology\Lib\Dao\UploadDao;
 
 /**
  * @class DetectLicensesFolder
@@ -23,10 +24,14 @@ class DetectLicensesFolder
   /** @var SearchHelperDao */
   private $searchHelperDao;
 
+  /** @var ClearingDao */
+  private $clearingDao;
+
   function __construct()
   {
     $this->uploadDao = $GLOBALS['container']->get('dao.upload');
     $this->searchHelperDao = $GLOBALS['container']->get('dao.searchhelperdao');
+    $this->clearingDao = $GLOBALS['container']->get('dao.clearing');
   }
 
   /**
@@ -65,6 +70,35 @@ class DetectLicensesFolder
     }
 
     return $licenseId;
+  }
+
+  /**
+   * @brief Get licenses declared in root LICENSE file
+   * @param int $uploadId
+   * @return array $licenseId, if found. Empty array otherwise.
+   */
+  function getLicenseFileDeclaredLicenses($uploadId)
+  {
+    $uploadTreeId = $this->uploadDao->getUploadParent($uploadId);
+    $uploadTreeTableName = GetUploadtreeTableName($uploadId);
+    $rootBounds = $this->uploadDao->getItemTreeBounds($uploadTreeId, $uploadTreeTableName);
+
+    $condition = "(ut.ufile_name ilike 'LICENSE' OR ut.ufile_name ilike 'LICENSE.txt' OR ut.ufile_name ilike 'LICENSE.md' OR ut.ufile_name ilike 'LICENSE.rst')";
+    $items = $this->uploadDao->getContainedItems($rootBounds, $condition);
+
+    if (empty($items)) {
+      return array();
+    }
+
+    $itemTreeBounds = $this->uploadDao->getItemTreeBounds($items[0]->getId(), $uploadTreeTableName);
+
+    $clearedLicenses = $this->clearingDao->getClearedLicenses($itemTreeBounds, Auth::getGroupId());
+    $licenseIds = array();
+    foreach ($clearedLicenses as $licenseRef) {
+      $licenseIds[] = $licenseRef->getShortName();
+    }
+
+    return array_unique($licenseIds);
   }
 
   /**

--- a/src/lib/php/BusinessRules/ReuseReportProcessor.php
+++ b/src/lib/php/BusinessRules/ReuseReportProcessor.php
@@ -48,7 +48,10 @@ class ReuseReportProcessor
    */
   public function getReuseSummary($uploadId)
   {
-    $declearedLicenses = $this->detectLicensesFolder->getDeclearedLicenses($uploadId);
+    $declearedLicenses = array_merge(
+      $this->detectLicensesFolder->getDeclearedLicenses($uploadId),
+      $this->detectLicensesFolder->getLicenseFileDeclaredLicenses($uploadId)
+    );
     $groupId = Auth::getGroupId();
     $uploadtreeTablename = GetUploadtreeTableName($uploadId);
     $uploadTreeId = $this->uploadDao->getUploadParent($uploadId);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add support for detecting licenses declared through root LICENSE files in the REUSE Standard compliance report.

Previously, only licenses declared in the `LICENSES/` directory were considered. This change extends the REUSE report to also consider licenses declared through root LICENSE files.

### Changes

* Add detection of root LICENSE files.
* Include licenses declared through root LICENSE files in the REUSE report.
* Update the REUSE API response accordingly.

## How to test

1. Create a test project containing both a root LICENSE file and a `LICENSES/` directory.

   ```text
   LicenseFileTest/
   ├── LICENSE
   ├── LICENSES/
   │   ├── MIT.txt
   │   └── Apache-2.0.txt
   └── hello.c
   ```

2. Upload the project to Fossology.

3. Run the required scanners and complete license clearing.

4. Open the REUSE Standard Report in the License Browser.

5. Verify that licenses declared through both the root LICENSE file and the `LICENSES/` directory are included in the report.

6. Verify the API endpoint:

   ```bash
   GET /uploads/{id}/licenses/reuse
   ```

   and confirm that the response reflects the expected declared licenses.
   
### Screenshots:

<Details>
<summary>Before</summary>
<img width="1901" height="926" alt="Screenshot from 2026-06-06 13-11-11" src="https://github.com/user-attachments/assets/531a836b-8c06-4975-a380-a63be568bddd" />
</Details>

<Details>
<summary>After</summary>
<img width="1901" height="926" alt="Screenshot from 2026-06-06 13-09-01" src="https://github.com/user-attachments/assets/6ebe3a90-1fb2-4417-a034-1dffdb6dc6be" />
<img width="972" height="340" alt="Screenshot from 2026-06-06 13-50-26" src="https://github.com/user-attachments/assets/7ef7d413-a58b-48f8-9197-4b05597e72d7" />
<img width="1028" height="254" alt="Screenshot from 2026-06-06 17-01-36" src="https://github.com/user-attachments/assets/7e4c71e2-6da8-4e76-9927-dbc7d242378e" />

</Details>

cc: @Kaushl2208 @shaheemazmalmmd 
