### PR TITLE
fix(REST): improve error handling for unsupported methods

### DIFF
--- a/src/lib/php/common-container.php
+++ b/src/lib/php/common-container.php
@@ -70,7 +70,9 @@ $GLOBALS['container'] = $container;
 $logger = $container->get('logger');
 $logger->pushHandler(
   new ErrorLogHandler(ErrorLogHandler::OPERATING_SYSTEM, Logger::INFO));
-$logger->pushHandler(new BrowserConsoleHandler(Logger::DEBUG));
+if (!$restCall) {
+  $logger->pushHandler(new BrowserConsoleHandler(Logger::DEBUG));
+}
 
 $timeZone = $container->getParameter('time.zone');
 if (! empty($timeZone)) {

--- a/src/www/ui/api/Controllers/UserController.php
+++ b/src/www/ui/api/Controllers/UserController.php
@@ -89,6 +89,12 @@ class UserController extends RestController
     $this->throwNotAdminException();
     $apiVersion = ApiVersion::getVersion($request);
     $userDetails = $this->getParsedBody($request);
+    if ($userDetails === null || !is_array($userDetails)) {
+      throw new HttpBadRequestException("Request body is empty or malformed.");
+    }
+    if (empty($userDetails['name'])) {
+      throw new HttpBadRequestException("Username must be specified.");
+    }
     $userHelper = new UserHelper();
     // creating symphony request
     $symfonyRequest = new \Symfony\Component\HttpFoundation\Request();

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -492,10 +492,9 @@ $errorMiddleware->setErrorHandler(
 $errorMiddleware->setErrorHandler(
   HttpMethodNotAllowedException::class,
   function (ServerRequestInterface $request, Throwable $exception, bool $displayErrorDetails) {
-    $response = new Response();
-    $response->getBody()->write('405 NOT ALLOWED');
-
-    $response = $response->withStatus(405);
+    $response = new ResponseHelper();
+    $error = new Info(405, "Method not allowed", InfoType::ERROR);
+    $response = $response->withJson($error->getArray(), $error->getCode());
     plugin_unload();
     return CorsHelper::addCorsHeaders($response);
   });

--- a/src/www/ui_tests/api/Controllers/UserControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UserControllerTest.php
@@ -15,6 +15,7 @@ namespace Fossology\UI\Api\Test\Controllers;
 require_once dirname(__DIR__, 4) . '/lib/php/Plugin/FO_Plugin.php';
 
 use Fossology\Lib\Auth\Auth;
+use Fossology\UI\Api\Exceptions\HttpBadRequestException;
 use Fossology\UI\Api\Exceptions\HttpNotFoundException;
 use Mockery as M;
 use Fossology\UI\Api\Controllers\UserController;
@@ -392,5 +393,43 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
       $actualResponse->getStatusCode());
     $this->assertEquals($this->getResponseJson($expectedResponse),
       $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test UserController::addUser() with empty request body
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testAddUserEmptyBody()
+  {
+    $request = M::mock(Request::class);
+    $request->shouldReceive('getHeaderLine')
+      ->withArgs(['Content-Type'])->andReturn('');
+    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V1);
+    $request->shouldReceive('getParsedBody')->andReturn(null);
+
+    $this->expectException(HttpBadRequestException::class);
+    $this->expectExceptionMessage("Request body is empty or malformed.");
+
+    $this->userController->addUser($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::addUser() with missing username
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testAddUserMissingName()
+  {
+    $request = M::mock(Request::class);
+    $request->shouldReceive('getHeaderLine')
+      ->withArgs(['Content-Type'])->andReturn('');
+    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V1);
+    $request->shouldReceive('getParsedBody')->andReturn(['email' => 'test@test.com']);
+
+    $this->expectException(HttpBadRequestException::class);
+    $this->expectExceptionMessage("Username must be specified.");
+
+    $this->userController->addUser($request, new ResponseHelper(), []);
   }
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
Improve REST API error handling to return proper HTTP status codes instead of 500 for unsupported methods and missing input, and remove debug logging output from API responses.
closes: #2037 

### Changes

- Return a proper JSON `405 Method Not Allowed` response for unsupported HTTP methods.
- Prevent debug console scripts from being injected into REST API responses.
- Add request validation in user creation API to return `400 Bad Request` for invalid input instead of `500 Internal Server Error`.
- Add unit tests covering invalid user creation requests.

## How to test
1. Send POST to /users without body:
```bash
curl -i -X POST "http://localhost/repo/api/v1/users" -H "Authorization: $TOKEN"
```
2. Send PATCH to /users (unsupported method):
```bash
curl -i -X PATCH "http://localhost/repo/api/v1/users" -H "Authorization: $TOKEN"
```
## Screenshots:

<Details>
<summary>Before</summary>
<img width="1069" height="503" alt="Screenshot from 2026-06-06 15-24-20" src="https://github.com/user-attachments/assets/b85ea96c-8e8d-45d7-9c6e-c494fc1e29c0" />
<img width="1069" height="1213" alt="Screenshot from 2026-06-06 15-24-01" src="https://github.com/user-attachments/assets/98b14bf9-1881-4105-b9a2-4768bde464b2" />


</Details>

<Details>
<summary>After</summary>
<img width="1065" height="489" alt="Screenshot from 2026-06-06 15-25-46" src="https://github.com/user-attachments/assets/92abf4b9-3187-48ee-9187-eb9806fb75a1" />

<img width="1065" height="489" alt="Screenshot from 2026-06-06 15-26-26" src="https://github.com/user-attachments/assets/d247862b-7a35-4493-b201-a86e3d5b96dd" />

</Details>