### PR TITLE
feat(reuser): auto select component for reuse

### DIFF
--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -1179,4 +1179,77 @@ INSERT INTO clearing_decision (
 
     return count($countUpdated);
   }
+
+  /**
+   * @brief From a list of candidates, return the one most recently cleared.
+   * @param array[] $candidates Each entry must have 'upload_pk' and 'group_fk' keys.
+   * @return array|null ['uploadId'=>int, 'groupId'=>int] or first candidate if
+   *                    none have clearing timestamps.
+   */
+  public function getMostRecentlyClearedUpload($candidates)
+  {
+    if (empty($candidates)) {
+      return null;
+    }
+    if (count($candidates) === 1) {
+      return [
+        'uploadId' => $candidates[0]['upload_pk'],
+        'groupId' => $candidates[0]['group_fk'],
+        'statusId' => $candidates[0]['status_fk'] ?? 3
+      ];
+    }
+
+    $uploadIds = [];
+    $params = [];
+    foreach ($candidates as $c) {
+      $uploadIds[] = $c['upload_pk'];
+      $params[] = $c['upload_pk'];
+    }
+    $placeholders = [];
+    for ($i = 0; $i < count($uploadIds); $i++) {
+      $placeholders[] = '$' . ($i + 1);
+    }
+    $inClause = implode(',', $placeholders);
+
+    $stmtName = __METHOD__;
+    $this->dbManager->prepare($stmtName,
+      "SELECT ut.upload_fk, MAX(cd.date_added) AS last_cleared
+       FROM clearing_decision cd
+       JOIN uploadtree ut ON ut.uploadtree_pk = cd.uploadtree_fk
+       WHERE ut.upload_fk IN ($inClause)
+       GROUP BY ut.upload_fk
+       ORDER BY MAX(cd.date_added) DESC");
+    $res = $this->dbManager->execute($stmtName, $params);
+
+    $timestamps = [];
+    while ($row = $this->dbManager->fetchArray($res)) {
+      $timestamps[intval($row['upload_fk'])] = $row['last_cleared'];
+    }
+    $this->dbManager->freeResult($res);
+
+    $bestCandidate = null;
+    $bestTimestamp = null;
+    foreach ($candidates as $candidate) {
+      $uploadPk = $candidate['upload_pk'];
+      $ts = $timestamps[$uploadPk] ?? null;
+      if ($ts !== null && ($bestTimestamp === null || $ts > $bestTimestamp)) {
+        $bestTimestamp = $ts;
+        $bestCandidate = $candidate;
+      }
+    }
+
+    if ($bestCandidate !== null) {
+      return [
+        'uploadId' => $bestCandidate['upload_pk'],
+        'groupId' => $bestCandidate['group_fk'],
+        'statusId' => $bestCandidate['status_fk'] ?? 3
+      ];
+    }
+
+    return [
+      'uploadId' => $candidates[0]['upload_pk'],
+      'groupId' => $candidates[0]['group_fk'],
+      'statusId' => $candidates[0]['status_fk'] ?? 3
+    ];
+  }
 }

--- a/src/lib/php/Dao/ClearingDao.php
+++ b/src/lib/php/Dao/ClearingDao.php
@@ -1177,4 +1177,77 @@ INSERT INTO clearing_decision (
 
     return count($countUpdated);
   }
+
+  /**
+   * @brief Get clearing coverage (files of interest vs finally decided) per upload
+   *
+   * Mirrors the clearing-progress semantics of the UI (UploadTreeProxy):
+   * only real files count that are "of interest", i.e. have scanner findings
+   * (license_file rows other than No_license_found/Void) or an explicit
+   * clearing decision for the given group. A file counts as cleared when its
+   * latest decision for the group is one of the final decision types
+   * (Irrelevant, Identified, DoNotUse, NonFunctional).
+   * Note: unlike UploadTreeProxy, license findings are not restricted to the
+   * latest successful agent runs.
+   * @param int[] $uploadIds
+   * @param int $groupId
+   * @return array[] Map of uploadId => ['total'=>int, 'cleared'=>int]
+   */
+  public function getClearingCoverage($uploadIds, $groupId)
+  {
+    $uploadIds = array_values(array_unique(array_map('intval', $uploadIds)));
+    if (empty($uploadIds)) {
+      return [];
+    }
+
+    $placeholders = [];
+    $params = [];
+    for ($i = 0; $i < count($uploadIds); $i++) {
+      $placeholders[] = '$' . ($i + 1);
+      $params[] = $uploadIds[$i];
+    }
+    $inClause = implode(',', $placeholders);
+    $groupIdPlaceholder = '$' . (count($uploadIds) + 1);
+    $params[] = $groupId;
+
+    $finalTypes = implode(',', [
+      DecisionTypes::IRRELEVANT,
+      DecisionTypes::IDENTIFIED,
+      DecisionTypes::DO_NOT_USE,
+      DecisionTypes::NON_FUNCTIONAL]);
+
+    $coverage = [];
+    $stmtName = __METHOD__;
+    $this->dbManager->prepare($stmtName,
+      "SELECT ut.upload_fk, COUNT(*) AS total_files,
+              COUNT(*) FILTER (WHERE ld.decision_type IN ($finalTypes)) AS cleared_files
+       FROM uploadtree ut
+       LEFT JOIN LATERAL (SELECT cd.decision_type
+                          FROM clearing_decision cd
+                          WHERE cd.uploadtree_fk = ut.uploadtree_pk
+                            AND cd.group_fk = $groupIdPlaceholder
+                          ORDER BY cd.clearing_decision_pk DESC LIMIT 1) ld ON TRUE
+       WHERE ut.upload_fk IN ($inClause)
+         AND (ut.ufile_mode & (3<<28)) = 0
+         AND ut.pfile_fk != 0
+         AND (EXISTS (SELECT 1 FROM license_file lf
+                      JOIN license_ref lr ON lr.rf_pk = lf.rf_fk
+                      WHERE lf.pfile_fk = ut.pfile_fk
+                        AND lr.rf_shortname NOT IN ('No_license_found','Void'))
+           OR ld.decision_type IS NOT NULL)
+       GROUP BY ut.upload_fk");
+    $res = $this->dbManager->execute($stmtName, $params);
+    while ($row = $this->dbManager->fetchArray($res)) {
+      $coverage[intval($row['upload_fk'])] =
+        ['total' => intval($row['total_files']), 'cleared' => intval($row['cleared_files'])];
+    }
+    $this->dbManager->freeResult($res);
+
+    foreach ($uploadIds as $uploadId) {
+      if (!isset($coverage[$uploadId])) {
+        $coverage[$uploadId] = ['total' => 0, 'cleared' => 0];
+      }
+    }
+    return $coverage;
+  }
 }

--- a/src/lib/php/Dao/UserDao.php
+++ b/src/lib/php/Dao/UserDao.php
@@ -448,6 +448,27 @@ class UserDao
 
   /**
    * @param int $userId
+   * @return int[]
+   */
+  public function getUserGroupIds($userId)
+  {
+    $groupIds = [];
+    if ($userId <= 0) {
+      return $groupIds;
+    }
+    $stmtName = __METHOD__;
+    $this->dbManager->prepare($stmtName,
+      "SELECT group_fk FROM group_user_member WHERE user_fk = $1");
+    $res = $this->dbManager->execute($stmtName, [$userId]);
+    while ($row = $this->dbManager->fetchArray($res)) {
+      $groupIds[] = intval($row['group_fk']);
+    }
+    $this->dbManager->freeResult($res);
+    return $groupIds;
+  }
+
+  /**
+   * @param int $userId
    * @return string
    */
   public function getUserEmail($userId)

--- a/src/lib/php/Dao/test/ClearingDaoTest.php
+++ b/src/lib/php/Dao/test/ClearingDaoTest.php
@@ -62,6 +62,7 @@ class ClearingDaoTest extends \PHPUnit\Framework\TestCase
             'custom_phrase_license_map',
             'highlight_bulk',
             'highlight_kotoba',
+            'license_file',
             'license_ref',
             'license_ref_bulk',
             'license_set_bulk',
@@ -599,5 +600,95 @@ class ClearingDaoTest extends \PHPUnit\Framework\TestCase
     $rowFuture = $this->dbManager->getSingleRow('SELECT * FROM clearing_event WHERE uploadtree_fk=$1 AND rf_fk=$2 ORDER BY clearing_event_pk DESC LIMIT 1',array($uploadTreeId,$licenseId),__METHOD__.'afterReportinfo');
     assertThat($rowFuture['comment'],equalTo($changeCom));
     assertThat($rowFuture['reportinfo'],equalTo($changeRep));
+  }
+
+  private function insertLicenseFinding($flPk, $rfFk, $pfileFk)
+  {
+    $this->dbManager->insertInto('license_file',
+      'fl_pk, agent_fk, rf_fk, pfile_fk',
+      array($flPk, 1, $rfFk, $pfileFk), 'insert.licenseFinding');
+  }
+
+  private function insertClearingDecision($pk, $uploadTreeId, $dateTs,
+    $decisionType = DecisionTypes::IDENTIFIED)
+  {
+    $this->dbManager->insertInto('clearing_decision',
+      'clearing_decision_pk, uploadtree_fk, pfile_fk, user_fk, group_fk, decision_type, date_added, scope',
+      array($pk, $uploadTreeId, $this->items[$uploadTreeId][2], 1, $this->groupId, $decisionType, $this->getMyDate($dateTs), 1),
+      'insert.clearingDecision');
+  }
+
+  public function testGetClearingCoverageEmpty()
+  {
+    assertThat($this->clearingDao->getClearingCoverage([], $this->groupId), is(emptyArray()));
+  }
+
+  public function testGetClearingCoverageOnlyCountsFilesOfInterest()
+  {
+    $this->dbManager->insertInto('license_ref',
+      'rf_pk, rf_shortname, rf_spdx_id, rf_fullname, rf_text',
+      array(405, 'No_license_found', 'No_license_found', 'no license found', '-'),
+      $logStmt = 'insert.ref.nlf');
+    /* pfile 201 is shared by items 301 (upload 101) and 303+305 (upload 102);
+       a No_license_found finding on pfile 202 must be ignored */
+    $this->insertLicenseFinding(1, 401, 201);
+    $this->insertLicenseFinding(2, 405, 202);
+    $coverage = $this->clearingDao->getClearingCoverage([101, 102], $this->groupId);
+    assertThat($coverage[101], is(array('total' => 1, 'cleared' => 0)));
+    assertThat($coverage[102], is(array('total' => 2, 'cleared' => 0)));
+  }
+
+  public function testGetClearingCoverageFullyCleared()
+  {
+    $this->insertLicenseFinding(1, 401, 201);
+    $this->insertClearingDecision(1, 301, $this->now - 100);
+    $this->insertClearingDecision(2, 305, $this->now - 90, DecisionTypes::IRRELEVANT);
+    $this->insertClearingDecision(3, 306, $this->now - 10); // decided without any finding
+    $coverage = $this->clearingDao->getClearingCoverage([101, 102], $this->groupId);
+    assertThat($coverage[101]['total'], is(1));
+    assertThat($coverage[101]['cleared'], is(1));
+    assertThat($coverage[102]['total'], is(3)); // 303+305 via findings, 306 via decision
+    assertThat($coverage[102]['cleared'], is(2));
+  }
+
+  public function testGetClearingCoverageLatestDecisionWins()
+  {
+    $this->insertLicenseFinding(1, 401, 201);
+    $this->insertClearingDecision(1, 301, $this->now - 100, DecisionTypes::IDENTIFIED);
+    $this->insertClearingDecision(2, 301, $this->now - 50, DecisionTypes::WIP);
+    $this->insertClearingDecision(3, 303, $this->now - 40, DecisionTypes::TO_BE_DISCUSSED);
+    $this->insertClearingDecision(4, 303, $this->now - 10, DecisionTypes::NON_FUNCTIONAL);
+    $coverage = $this->clearingDao->getClearingCoverage([101, 102], $this->groupId);
+    assertThat($coverage[101], is(array('total' => 1, 'cleared' => 0)));
+    assertThat($coverage[102]['total'], is(2));
+    assertThat($coverage[102]['cleared'], is(1));
+  }
+
+  public function testGetClearingCoverageGroupScoping()
+  {
+    $this->insertLicenseFinding(1, 401, 201);
+    $this->insertClearingDecision(1, 301, $this->now - 100);
+    // another group's decision neither clears nor makes item 302 interesting
+    $this->dbManager->insertInto('clearing_decision',
+      'clearing_decision_pk, uploadtree_fk, pfile_fk, user_fk, group_fk, decision_type, date_added, scope',
+      array(2, 302, $this->items[302][2], 1, $this->groupId + 1, DecisionTypes::IDENTIFIED,
+        $this->getMyDate($this->now - 10), 1),
+      'insert.clearingDecision.otherGroup');
+    $coverage = $this->clearingDao->getClearingCoverage([101], $this->groupId);
+    assertThat($coverage[101], is(array('total' => 1, 'cleared' => 1)));
+  }
+
+  public function testGetClearingCoverageUnknownUpload()
+  {
+    $coverage = $this->clearingDao->getClearingCoverage([999], $this->groupId);
+    assertThat($coverage[999], is(array('total' => 0, 'cleared' => 0)));
+  }
+
+  public function testGetClearingCoverageDuplicateIds()
+  {
+    $this->insertLicenseFinding(1, 401, 201);
+    $this->insertClearingDecision(1, 301, $this->now - 100);
+    $coverage = $this->clearingDao->getClearingCoverage([101, 101], $this->groupId);
+    assertThat($coverage[101], is(array('total' => 1, 'cleared' => 1)));
   }
 }

--- a/src/lib/php/Dao/test/UserDaoTest.php
+++ b/src/lib/php/Dao/test/UserDaoTest.php
@@ -143,4 +143,17 @@ class UserDaoTest extends \PHPUnit\Framework\TestCase
     $map = $this->userDao->getUserGroupMap($userId);
     assertThat($map,hasKey($groupId));
   }
+
+  public function testGetUserGroupIds()
+  {
+    $this->testDb->createPlainTables(array('groups','group_user_member'));
+    $this->testDb->insertData(array('groups','group_user_member'));
+
+    assertThat($this->userDao->getUserGroupIds(1), equalTo(array(1)));
+    assertThat($this->userDao->getUserGroupIds(2), equalTo(array(2)));
+
+    assertThat($this->userDao->getUserGroupIds(99), equalTo(array()));
+    assertThat($this->userDao->getUserGroupIds(0), equalTo(array()));
+    assertThat($this->userDao->getUserGroupIds(-5), equalTo(array()));
+  }
 }

--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -25,6 +25,8 @@ define("CONFIG_TYPE_PASSWORD", 4);
 define("CONFIG_TYPE_DROP", 5);
 /** Checkbox type config */
 define("CONFIG_TYPE_BOOL", 6);
+/** Multi-select checkbox (checklist) type config */
+define("CONFIG_TYPE_CHECKLIST", 7);
 
 
 /**
@@ -436,6 +438,20 @@ function Populate_sysconfig()
   $osselotFallbackDesc = _('Fallback domain used when primary domain fails (e.g., osselot.org).');
   $valueArray[$variable] = array("'$variable'", "'osselot.org'", "'$osselotFallbackPrompt'",
     strval(CONFIG_TYPE_TEXT), "'OSSelot'", "4", "'$osselotFallbackDesc'", "'$osselotFallbackValid'", "null");
+
+  /* Reuser */
+  $variable = "ReuserAutoDetect";
+  $prompt = _("Enable Auto Select for Reuse");
+  $desc = _("When enabled, automatically detects and suggests the best matching upload for reuse when selecting a folder to search.");
+  $valueArray[$variable] = array("'$variable'", "'true'", "'$prompt'",
+    strval(CONFIG_TYPE_BOOL), "'Reuser'", "1", "'$desc'", "'check_boolean'", "null");
+
+  $variable = "ReuserSearchStatus";
+  $prompt = _("Upload Statuses for Auto Detect");
+  $desc = _("Select which upload clearing statuses to search for auto-detect.");
+  $valueArray[$variable] = array("'$variable'", "'3'", "'$prompt'",
+    strval(CONFIG_TYPE_CHECKLIST), "'Reuser'", "2", "'$desc'", "null",
+    "'Open{1}|In Progress{2}|Closed{3}|Rejected{4}'");
 
   /*  "Upload from server"-configuration  */
   $variable = "UploadFromServerWhitelist";

--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -26,6 +26,7 @@
   <testsuites>
     <testsuite name="Fossology PhpUnit Test Suite">
       <directory suffix="Test.php">lib/php</directory>
+      <directory suffix="Test.php">reuser/ui</directory>
       <file>www/ui_tests/startUpTest.php</file>
       <file>www/ui_tests/Unit/AgentAdderTest.php</file>
       <directory suffix="Test.php">www/ui_tests/api</directory>

--- a/src/reuser/ui/ReuseAutoDetect.php
+++ b/src/reuser/ui/ReuseAutoDetect.php
@@ -1,0 +1,303 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\Reuse;
+
+use Fossology\Lib\Dao\ClearingDao;
+use Fossology\Lib\Db\DbManager;
+
+/**
+ * @class ReuseAutoDetect
+ * @brief Pure decision logic for auto-selecting a reuse upload
+ *
+ * Kept free of Auth/container/global state so it can be unit tested
+ * directly. The UI plugin passes in the current user id, the db manager
+ * and the clearing dao as plain parameters.
+ */
+class ReuseAutoDetect
+{
+  /**
+   * @brief Parse package name and version from a filename
+   * @param string $filename
+   * @return array ['baseName'=>string, 'versionParts'=>int[]|null,
+   *                'prerelease'=>int]
+   */
+  public static function parsePackageName($filename)
+  {
+    if (empty($filename)) {
+      return ['baseName' => '', 'versionParts' => null, 'prerelease' => 0];
+    }
+    $nameWithoutExt = preg_replace('/\.[^.]+$/', '', $filename);
+    $nameWithoutExt = preg_replace('/\.(tar|zip|gz|bz2|xz|tgz|tbz2|txz|rar|7z)(\..*)?$/i', '', $nameWithoutExt);
+    $nameWithoutExt = preg_replace('/\.(tar|zip|gz|bz2|xz|tgz|tbz2|txz|rar|7z)$/i', '', $nameWithoutExt);
+    $nameWithoutExt = preg_replace('/[-_]\d{8}$/', '', $nameWithoutExt);
+    if (preg_match('/[-_](v?\d+(?:\.\d+)*)(?:[-_](?:alpha|beta|rc|pre|patch|p)\d*)?$/i', $nameWithoutExt, $m)) {
+      $baseName = substr($nameWithoutExt, 0, -strlen($m[0]));
+      $versionParts = array_map('intval', explode('.', preg_replace('/^v/i', '', $m[1])));
+      $prerelease = preg_match('/[-_](?:alpha|beta|rc|pre|patch|p)\d*$/i', $nameWithoutExt) ? 1 : 0;
+      return ['baseName' => $baseName, 'versionParts' => $versionParts, 'prerelease' => $prerelease];
+    }
+    $parts = explode('-', $nameWithoutExt);
+    return ['baseName' => $parts[0], 'versionParts' => null, 'prerelease' => 0];
+  }
+
+  /**
+   * @brief Digits of |parts - requestedParts| in base $R
+   * @param int[] $parts
+   * @param int[] $requestedParts
+   * @param int $L Common padded length
+   * @param int $R Radix (larger than any component)
+   * @return int[] Most-significant-first digits of the absolute difference
+   */
+  private static function computeVersionDistance($parts, $requestedParts, $L, $R)
+  {
+    $digits = [];
+    $borrow = 0;
+    for ($i = $L - 1; $i >= 0; $i--) {
+      $v = (isset($parts[$i]) ? $parts[$i] : 0)
+        - (isset($requestedParts[$i]) ? $requestedParts[$i] : 0) - $borrow;
+      if ($v < 0) {
+        $v += $R;
+        $borrow = 1;
+      } else {
+        $borrow = 0;
+      }
+      $digits[$i] = $v;
+    }
+    if ($borrow === 1) {
+      for ($i = 0; $i < $L; $i++) {
+        $digits[$i] = ($R - 1) - $digits[$i];
+      }
+      $carry = 1;
+      for ($i = $L - 1; $i >= 0; $i--) {
+        $s = $digits[$i] + $carry;
+        if ($s >= $R) {
+          $digits[$i] = $s - $R;
+          $carry = 1;
+        } else {
+          $digits[$i] = $s;
+          $carry = 0;
+        }
+      }
+    }
+    return $digits;
+  }
+
+  /**
+   * @brief Compare two version tuples for numeric closeness to a requested version
+   *
+   * Measures |a - requested| and |b - requested| as numbers in base $R
+   * (larger than any single component), so a difference in a higher
+   * component correctly outweighs differences in lower ones. For example,
+   * requested 1.0 ranks 0.9 closer than 0.8 (0.1 apart vs 0.2 apart).
+   * @param int[]|null $requestedParts Requested version tuple
+   * @param int[]|null $aParts
+   * @param int[]|null $bParts
+   * @param int $L Common padded length of all version tuples
+   * @param int $R Radix (max component + 1, at least 10)
+   * @return int negative if $aParts is closer, positive if $bParts is closer
+   */
+  public static function compareVersionCloseness($requestedParts, $aParts, $bParts, $L, $R)
+  {
+    if ($requestedParts === null) {
+      return 0;
+    }
+    if ($aParts === null && $bParts === null) {
+      return 0;
+    }
+    if ($aParts === null) {
+      return 1;
+    }
+    if ($bParts === null) {
+      return -1;
+    }
+    $distA = self::computeVersionDistance($aParts, $requestedParts, $L, $R);
+    $distB = self::computeVersionDistance($bParts, $requestedParts, $L, $R);
+    for ($i = 0; $i < $L; $i++) {
+      if ($distA[$i] !== $distB[$i]) {
+        return $distA[$i] <=> $distB[$i];
+      }
+    }
+    return 0;
+  }
+
+  /**
+   * @brief Rank candidates by nearest version, then release, then clearing/upload date
+   * @param array $candidates Each with versionParts, prerelease, clearedAt, timestamp
+   * @param int[]|null $requestedVersionParts
+   */
+  public static function rankCandidates(&$candidates, $requestedVersionParts)
+  {
+    $L = 0;
+    $R = 10;
+    $all = $candidates;
+    if ($requestedVersionParts !== null) {
+      $all[] = ['versionParts' => $requestedVersionParts];
+      $L = count($requestedVersionParts);
+    }
+    foreach ($all as $candidate) {
+      $parts = $candidate['versionParts'];
+      if ($parts === null) {
+        continue;
+      }
+      $L = max($L, count($parts));
+      foreach ($parts as $component) {
+        $R = max($R, $component + 1);
+      }
+    }
+    usort($candidates, function ($a, $b) use ($requestedVersionParts, $L, $R) {
+      if ($requestedVersionParts !== null) {
+        $cmp = self::compareVersionCloseness($requestedVersionParts,
+          $a['versionParts'], $b['versionParts'], $L, $R);
+        if ($cmp !== 0) {
+          return $cmp;
+        }
+        if ($a['prerelease'] !== $b['prerelease']) {
+          return $a['prerelease'] <=> $b['prerelease'];
+        }
+      }
+      $tsA = empty($a['clearedAt']) ? null : strtotime($a['clearedAt']);
+      $tsB = empty($b['clearedAt']) ? null : strtotime($b['clearedAt']);
+      if ($tsA !== null && $tsB !== null && $tsA !== $tsB) {
+        return $tsB - $tsA;
+      }
+      if ($tsA !== null) {
+        return -1;
+      }
+      if ($tsB !== null) {
+        return 1;
+      }
+      return ($b['timestamp'] ?? 0) - ($a['timestamp'] ?? 0);
+    });
+  }
+
+  /**
+   * @brief Select the single best candidate based on clearing decisions
+   *
+   * Prefers the first fully cleared candidate in rank order, then the
+   * candidate with the highest cleared-files percentage, and finally falls
+   * back to the first candidate (best by version/date).
+   * @param array $candidates Each with uploadId and groupId, ranked best-first
+   * @param ClearingDao $clearingDao
+   * @return array|null Selected candidate or null
+   */
+  public static function selectWinnerByClearing($candidates, ClearingDao $clearingDao)
+  {
+    if (empty($candidates)) {
+      return null;
+    }
+    $groups = [];
+    foreach ($candidates as $candidate) {
+      $groups[$candidate['groupId']] = true;
+    }
+    $coverage = [];
+    foreach (array_keys($groups) as $groupId) {
+      $ids = [];
+      foreach ($candidates as $candidate) {
+        if ($candidate['groupId'] === $groupId) {
+          $ids[] = $candidate['uploadId'];
+        }
+      }
+      $coverage[$groupId] = $clearingDao->getClearingCoverage($ids, $groupId);
+    }
+    foreach ($candidates as $candidate) {
+      $cov = isset($coverage[$candidate['groupId']][$candidate['uploadId']])
+        ? $coverage[$candidate['groupId']][$candidate['uploadId']] : null;
+      if ($cov !== null && $cov['total'] > 0 && $cov['cleared'] >= $cov['total']) {
+        return $candidate;
+      }
+    }
+    $best = null;
+    $bestRatio = -1.0;
+    foreach ($candidates as $candidate) {
+      $cov = isset($coverage[$candidate['groupId']][$candidate['uploadId']])
+        ? $coverage[$candidate['groupId']][$candidate['uploadId']] : null;
+      if ($cov === null || $cov['total'] <= 0 || $cov['cleared'] <= 0) {
+        continue;
+      }
+      $ratio = $cov['cleared'] / $cov['total'];
+      if ($ratio > $bestRatio) {
+        $bestRatio = $ratio;
+        $best = $candidate;
+      }
+    }
+    if ($best !== null) {
+      return $best;
+    }
+    return $candidates[0];
+  }
+
+  /**
+   * @brief Restrict candidate pairs to uploads owned by $currentUserId in
+   *        a group the user can access
+   *
+   * Mirrors the eligibility rule enforced in primarySearchFromPlugin(): the
+   * upload must have been uploaded by $currentUserId, and the requested
+   * group must be a real upload_clearing group for that upload for which
+   * $currentUserId has group membership with group_perm >= 1. This
+   * re-checks ownership/access server-side instead of trusting client-
+   * supplied uploadId/groupId pairs.
+   * @param array $pairs List of ['uploadId'=>int,'groupId'=>int]
+   * @param int $currentUserId
+   * @param DbManager $dbManager
+   * @return array[] Filtered list of eligible pairs, in the original order
+   */
+  public static function filterEligibleCandidates($pairs, $currentUserId, DbManager $dbManager)
+  {
+    if ($currentUserId <= 0 || empty($pairs)) {
+      return [];
+    }
+
+    $uploadIds = array_values(array_unique(array_map(function ($pair) {
+      return $pair['uploadId'];
+    }, $pairs)));
+
+    $placeholders = [];
+    for ($i = 0; $i < count($uploadIds); $i++) {
+      $placeholders[] = '$' . ($i + 2);
+    }
+    $stmtName = __METHOD__;
+    $dbManager->prepare($stmtName,
+      "SELECT DISTINCT u.upload_pk, uc.group_fk
+       FROM upload u
+       JOIN upload_clearing uc ON uc.upload_fk = u.upload_pk
+       WHERE u.user_fk = $1
+         AND u.upload_pk IN (" . implode(',', $placeholders) . ")
+         AND EXISTS (SELECT 1 FROM group_user_member gum
+                     WHERE gum.group_fk = uc.group_fk AND gum.user_fk = $1 AND gum.group_perm >= 1)");
+    $params = array_merge([$currentUserId], $uploadIds);
+    $res = $dbManager->execute($stmtName, $params);
+    $eligibleKeys = [];
+    while ($row = $dbManager->fetchArray($res)) {
+      $eligibleKeys[$row['upload_pk'] . ',' . $row['group_fk']] = true;
+    }
+    $dbManager->freeResult($res);
+
+    $eligiblePairs = [];
+    foreach ($pairs as $pair) {
+      if (isset($eligibleKeys[$pair['uploadId'] . ',' . $pair['groupId']])) {
+        $eligiblePairs[] = $pair;
+      }
+    }
+    return $eligiblePairs;
+  }
+
+  /**
+   * @brief Whether the status list is a specific filter (neither empty nor
+   *        covering all upload statuses)
+   *
+   * A specific filter selects exactly one upload; an empty or full status
+   * list selects up to AUTO_DETECT_LIMIT candidates which are then
+   * narrowed by clearing decisions.
+   * @param int[] $statusIds
+   * @return bool
+   */
+  public static function isStatusSpecific($statusIds)
+  {
+    return !empty($statusIds) && count($statusIds) < 4;
+  }
+}

--- a/src/reuser/ui/reuser-plugin.php
+++ b/src/reuser/ui/reuser-plugin.php
@@ -128,6 +128,19 @@ class ReuserPlugin extends DefaultPlugin
         return new JsonResponse(['packageName' => $packageName], JsonResponse::HTTP_OK);
     }
 
+    if ($ajax === 'autoDetectReuse') {
+        $filename = trim($request->get('filename', ''));
+      if ($filename === '') {
+          return new JsonResponse([], JsonResponse::HTTP_OK);
+      }
+      try {
+          $result = $this->autoDetectReuseFromFilename($filename);
+          return new JsonResponse($result, JsonResponse::HTTP_OK);
+      } catch (\Exception $e) {
+          return new JsonResponse([], JsonResponse::HTTP_OK);
+      }
+    }
+
     return new Response('called without valid method', Response::HTTP_METHOD_NOT_ALLOWED);
   }
 
@@ -198,6 +211,10 @@ class ReuserPlugin extends DefaultPlugin
     $vars['folderParameterName'] = self::FOLDER_PARAMETER_NAME;
     $vars['uploadToReuseSelectorName'] = self::UPLOAD_TO_REUSE_SELECTOR_NAME;
     $vars['osselotAvailable']           = $osselotAvailable;
+    $vars['autoDetectEnabled'] = filter_var(
+      $SysConf['SYSCONFIG']['ReuserAutoDetect'] ?? 'true',
+      FILTER_VALIDATE_BOOLEAN
+    );
 
     $renderer = $this->getObject('twig.environment');
     return $renderer->load('agent_reuser.js.twig')->render($vars);
@@ -238,6 +255,242 @@ class ReuserPlugin extends DefaultPlugin
       $uploadsById[$key] = $display;
     }
     return $uploadsById;
+  }
+  /**
+   * @brief Extract base package name from filename by removing version suffix
+   * @param string $filename
+   * @return string
+   */
+  private function extractBasePackageNameFromPlugin($filename)
+  {
+    if (empty($filename)) {
+      return '';
+    }
+    $nameWithoutExt = preg_replace('/\.[^.]+$/', '', $filename);
+    $nameWithoutExt = preg_replace('/\.(tar|zip|gz|bz2|xz|tgz|tbz2|txz|rar|7z)(\..*)?$/i', '', $nameWithoutExt);
+    $nameWithoutExt = preg_replace('/\.(tar|zip|gz|bz2|xz|tgz|tbz2|txz|rar|7z)$/i', '', $nameWithoutExt);
+    $baseName = preg_replace('/[-_](v?\d+[\.\d]*(?:[-_](?:alpha|beta|rc|pre|patch|p)\d*)?)$/i', '', $nameWithoutExt);
+    $baseName = preg_replace('/[-_]\d{8}$/', '', $baseName);
+    if ($baseName === $nameWithoutExt) {
+      $parts = explode('-', $nameWithoutExt);
+      $baseName = $parts[0];
+    }
+    return $baseName;
+  }
+
+  /**
+   * @brief Auto-detect best reuse upload for a given filename
+   * @param string $filename
+   * @return array ['uploadId'=>int, 'groupId'=>int, 'display'=>string] or []
+   */
+  private function autoDetectReuseFromFilename($filename)
+  {
+    global $SysConf;
+
+    $autoDetectEnabled = filter_var(
+      $SysConf['SYSCONFIG']['ReuserAutoDetect'] ?? 'true',
+      FILTER_VALIDATE_BOOLEAN
+    );
+    if (!$autoDetectEnabled) {
+      return [];
+    }
+
+    $statusFilter = $SysConf['SYSCONFIG']['ReuserSearchStatus'] ?? '3';
+    $statusIds = array_map('intval', array_filter(explode(',', $statusFilter)));
+    if (empty($statusIds)) {
+      $statusIds = [3];
+    }
+
+    $dbManager = $GLOBALS['container']->get('db.manager');
+    $basePackageName = $this->extractBasePackageNameFromPlugin($filename);
+    if (empty($basePackageName)) {
+      return [];
+    }
+
+    $uploaderUserId = Auth::getUserId();
+
+    $statusType = new \Fossology\Lib\Data\UploadStatus();
+    $match = $this->primarySearchFromPlugin($basePackageName, $uploaderUserId, $dbManager, $statusIds);
+    if ($match !== null) {
+      $uploadDao = $GLOBALS['container']->get('dao.upload');
+      $upload = $uploadDao->getUpload($match['uploadId']);
+      if ($upload !== null) {
+        $statusName = $statusType->getTypeName($match['statusId']);
+        $display = $upload->getFilename() . _(" from ")
+          . Convert2BrowserTime(date("Y-m-d H:i:s", $upload->getTimestamp()))
+          . ' (' . $statusName . ')';
+        return ['uploadId' => $match['uploadId'], 'groupId' => $match['groupId'], 'display' => $display];
+      }
+    }
+
+    return [];
+  }
+
+  /**
+   * @brief Primary search: package name matching (UI-level)
+   * @param string $basePackageName
+   * @param int $uploaderUserId
+   * @param \Fossology\Lib\Db\DbManager $dbManager
+   * @param int[] $statusIds Upload clearing status IDs to filter
+   * @return array|null ['uploadId'=>int, 'groupId'=>int, 'statusId'=>int] or null
+   */
+  private function primarySearchFromPlugin($basePackageName, $uploaderUserId, $dbManager, $statusIds)
+  {
+    $currentUserId = Auth::getUserId();
+    $userDao = $GLOBALS['container']->get('dao.user');
+    $uploaderGroups = $userDao->getUserGroupIds($uploaderUserId);
+    $currentUserGroups = $userDao->getUserGroupIds($currentUserId);
+
+    $matchTypes = [
+      'exact' => function($filename) use ($basePackageName) {
+        $candidateBase = $this->extractBasePackageNameFromPlugin($filename);
+        return strcasecmp($candidateBase, $basePackageName) === 0 && $candidateBase === $basePackageName;
+      },
+      'case_insensitive' => function($filename) use ($basePackageName) {
+        $candidateBase = $this->extractBasePackageNameFromPlugin($filename);
+        return strcasecmp($candidateBase, $basePackageName) === 0;
+      },
+      'prefix' => function($filename) use ($basePackageName) {
+        $nameWithoutExt = preg_replace('/\.[^.]+$/', '', $filename);
+        return stripos($nameWithoutExt, $basePackageName) === 0;
+      },
+      'ilike' => function($filename) use ($basePackageName) {
+        return stripos($filename, $basePackageName) !== false;
+      }
+    ];
+
+    $priorityQueries = [];
+
+    if ($uploaderUserId > 0) {
+      $stmtName = __METHOD__ . '.sameUploader';
+      $params = array_merge([$uploaderUserId], $statusIds, [$basePackageName]);
+      $statusOffset = 2;
+      $statusCount = count($statusIds);
+      $namePlaceholder = '$' . ($statusCount + 2);
+      $statusList = $this->buildStatusPlaceholders($statusIds, $statusOffset);
+      $dbManager->prepare($stmtName,
+        "SELECT DISTINCT u.upload_pk, u.upload_filename, uc.group_fk, uc.status_fk
+         FROM upload u
+         JOIN upload_clearing uc ON uc.upload_fk = u.upload_pk
+         WHERE u.upload_mode IN (100, 104)
+           AND u.pfile_fk IS NOT NULL
+           AND uc.group_fk IN ($groupIdPlaceholders)
+           AND uc.status_fk IN ($statusList)
+           AND EXISTS (SELECT 1 FROM group_user_member gum WHERE gum.group_fk = uc.group_fk AND gum.user_fk = $permPlaceholder AND gum.group_perm >= 2)
+           AND u.upload_filename ILIKE '%' || $namePlaceholder || '%'
+         ORDER BY u.upload_ts DESC
+         LIMIT 200");
+      $priorityQueries[] = ['stmt' => $stmtName, 'params' => $params];
+    }
+
+    if (!empty($uploaderGroups)) {
+      $stmtName = __METHOD__ . '.sameGroup';
+      $groupCount = count($uploaderGroups);
+      $statusCount = count($statusIds);
+      $permPlaceholder = '$' . ($groupCount + $statusCount + 1);
+      $namePlaceholder = '$' . ($groupCount + $statusCount + 2);
+      $params = array_merge($uploaderGroups, $statusIds, [$currentUserId, $basePackageName]);
+      $statusOffset = $groupCount + 1;
+      $statusList = $this->buildStatusPlaceholders($statusIds, $statusOffset);
+      $groupIdPlaceholders = $this->buildPlaceholders($groupCount);
+      $dbManager->prepare($stmtName,
+        "SELECT DISTINCT u.upload_pk, u.upload_filename, uc.group_fk, uc.status_fk
+         FROM upload u
+         JOIN upload_clearing uc ON uc.upload_fk = u.upload_pk
+         WHERE u.upload_mode IN (100, 104)
+           AND u.pfile_fk IS NOT NULL
+           AND uc.group_fk IN ($groupIdPlaceholders)
+           AND uc.status_fk IN ($statusList)
+           AND EXISTS (SELECT 1 FROM group_user_member gum WHERE gum.group_fk = uc.group_fk AND gum.user_fk = $permPlaceholder AND gum.group_perm >= 2)
+           AND u.upload_filename ILIKE '%' || $namePlaceholder || '%'
+         ORDER BY u.upload_ts DESC
+         LIMIT 200");
+      $priorityQueries[] = ['stmt' => $stmtName, 'params' => $params];
+    }
+
+    if (!empty($currentUserGroups)) {
+      $stmtName = __METHOD__ . '.anyAccessible';
+      $groupCount = count($currentUserGroups);
+      $statusCount = count($statusIds);
+      $permPlaceholder = '$' . ($groupCount + $statusCount + 1);
+      $namePlaceholder = '$' . ($groupCount + $statusCount + 2);
+      $params = array_merge($currentUserGroups, $statusIds, [$currentUserId, $basePackageName]);
+      $statusOffset = $groupCount + 1;
+      $statusList = $this->buildStatusPlaceholders($statusIds, $statusOffset);
+      $groupIdPlaceholders = $this->buildPlaceholders($groupCount);
+      $dbManager->prepare($stmtName,
+        "SELECT DISTINCT u.upload_pk, u.upload_filename, uc.group_fk, uc.status_fk
+         FROM upload u
+         JOIN upload_clearing uc ON uc.upload_fk = u.upload_pk
+         WHERE u.upload_mode IN (100, 104)
+           AND u.pfile_fk IS NOT NULL
+           AND uc.group_fk IN ($groupIdPlaceholders)
+           AND uc.status_fk IN ($statusList)
+           AND EXISTS (SELECT 1 FROM group_user_member gum WHERE gum.group_fk = uc.group_fk AND gum.user_fk = $permPlaceholder AND gum.group_perm >= 2)
+           AND u.upload_filename ILIKE '%' || $namePlaceholder || '%'
+         ORDER BY u.upload_ts DESC
+         LIMIT 200");
+      $priorityQueries[] = ['stmt' => $stmtName, 'params' => $params];
+    }
+
+    foreach ($priorityQueries as $pq) {
+      $res = $dbManager->execute($pq['stmt'], $pq['params']);
+      $candidates = [];
+      while ($row = $dbManager->fetchArray($res)) {
+        $candidates[] = [
+          'upload_pk' => intval($row['upload_pk']),
+          'upload_filename' => $row['upload_filename'],
+          'group_fk' => intval($row['group_fk']),
+          'status_fk' => intval($row['status_fk'])
+        ];
+      }
+      $dbManager->freeResult($res);
+
+      if (empty($candidates)) {
+        continue;
+      }
+
+      foreach ($matchTypes as $matchFn) {
+        $matched = [];
+        foreach ($candidates as $candidate) {
+          if ($matchFn($candidate['upload_filename'])) {
+            $matched[] = $candidate;
+          }
+        }
+        if (!empty($matched)) {
+          $clearingDao = $GLOBALS['container']->get('dao.clearing');
+          return $clearingDao->getMostRecentlyClearedUpload($matched);
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * @brief Build comma-separated placeholder list starting at offset
+   * @param int $count Number of placeholders
+   * @param int $start Offset (1-based)
+   * @return string e.g. "$2,$3,$4"
+   */
+  private function buildPlaceholders($count, $start = 1)
+  {
+    $placeholders = [];
+    for ($i = 0; $i < $count; $i++) {
+      $placeholders[] = '$' . ($start + $i);
+    }
+    return implode(',', $placeholders);
+  }
+
+  /**
+   * @brief Build status placeholder list
+   * @param int[] $statusIds
+   * @param int $start Offset for placeholder numbering
+   * @return string e.g. "$2,$3"
+   */
+  private function buildStatusPlaceholders($statusIds, $start)
+  {
+    return $this->buildPlaceholders(count($statusIds), $start);
   }
 }
 

--- a/src/reuser/ui/reuser-plugin.php
+++ b/src/reuser/ui/reuser-plugin.php
@@ -16,8 +16,13 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Fossology\Lib\Util\OsselotLookupHelper;
+use Fossology\Reuse\ReuseAutoDetect;
+use Monolog\Handler\BrowserConsoleHandler;
+use Monolog\Handler\NullHandler;
+use Monolog\Logger;
 
 include_once(__DIR__ . "/../agent/version.php");
+require_once(__DIR__ . "/ReuseAutoDetect.php");
 
 /**
  * @class ReuserPlugin
@@ -30,6 +35,7 @@ class ReuserPlugin extends DefaultPlugin
   const REUSE_FOLDER_SELECTOR_NAME = 'reuseFolderSelectorName'; ///< Reuse upload folder element name
   const UPLOAD_TO_REUSE_SELECTOR_NAME = 'uploadToReuse';  ///< Upload to reuse HTML element name
   const FOLDER_PARAMETER_NAME = 'folder';   ///< Folder parameter HTML element name
+  const AUTO_DETECT_LIMIT = 4;              ///< Max uploads suggested by auto-detection
 
   /**
    * Extract package name from filename
@@ -70,21 +76,13 @@ class ReuserPlugin extends DefaultPlugin
 
   /**
    * @brief Get all uploads accessible to current user
-   * @return array Key as upload id
+   * @return array[] List of structured upload entries
    */
   function getAllUploads()
   {
     $trustGroupId = Auth::getGroupId();
     $folderUploads = $this->folderDao->getAllUploadsForGroup($trustGroupId);
-    $uploadsById = array();
-    foreach ($folderUploads as $uploadProgress) {
-      $key = $uploadProgress->getId();
-      $display = $uploadProgress->getFilename() . _(" from ")
-            . Convert2BrowserTime(date("Y-m-d H:i:s", $uploadProgress->getTimestamp()))
-            . ' (' . $uploadProgress->getStatusString() . ')';
-      $uploadsById[$key] = $display;
-    }
-    return $uploadsById;
+    return $this->buildStructuredUploads($folderUploads, $trustGroupId);
   }
 
   /**
@@ -95,6 +93,15 @@ class ReuserPlugin extends DefaultPlugin
   {
     $this->folderDao->ensureTopLevelFolder();
     $ajax = $request->get('do');
+
+    // Every branch below returns JSON (or a plain-text error), never HTML.
+    // The DI bootstrap unconditionally attaches a BrowserConsoleHandler that
+    // appends a <script> debug dump to the response body on shutdown, which
+    // would corrupt the JSON payload; suppress it the same way ui-download.php
+    // does for its binary responses.
+    $logger = $GLOBALS['container']->get('logger');
+    $logger->pushHandler(new NullHandler(Logger::DEBUG));
+    BrowserConsoleHandler::resetStatic();
 
     if ($ajax === 'getUploads') {
         list($fid, $tgid) = $this->getFolderIdAndTrustGroup($request->get(self::FOLDER_PARAMETER_NAME, ''));
@@ -126,6 +133,28 @@ class ReuserPlugin extends DefaultPlugin
 
         $packageName = $this->extractPackageNameFromFilename($filename);
         return new JsonResponse(['packageName' => $packageName], JsonResponse::HTTP_OK);
+    }
+
+    if ($ajax === 'autoDetectReuse') {
+        $candidatesParam = trim($request->get('candidates', ''));
+      if (!empty($candidatesParam)) {
+        try {
+            return new JsonResponse($this->narrowCandidates($candidatesParam), JsonResponse::HTTP_OK);
+        } catch (\Exception $e) {
+            return new JsonResponse([], JsonResponse::HTTP_OK);
+        }
+      }
+        $filename = trim($request->get('filename', ''));
+      if ($filename === '') {
+          return new JsonResponse([], JsonResponse::HTTP_OK);
+      }
+      $folderGroupPair = trim($request->get(self::FOLDER_PARAMETER_NAME, ''));
+      try {
+          $result = $this->autoDetectReuseFromFilename($filename, $folderGroupPair);
+          return new JsonResponse($result, JsonResponse::HTTP_OK);
+      } catch (\Exception $e) {
+          return new JsonResponse([], JsonResponse::HTTP_OK);
+      }
     }
 
     return new Response('called without valid method', Response::HTTP_METHOD_NOT_ALLOWED);
@@ -198,6 +227,14 @@ class ReuserPlugin extends DefaultPlugin
     $vars['folderParameterName'] = self::FOLDER_PARAMETER_NAME;
     $vars['uploadToReuseSelectorName'] = self::UPLOAD_TO_REUSE_SELECTOR_NAME;
     $vars['osselotAvailable']           = $osselotAvailable;
+    $vars['autoDetectEnabled'] = filter_var(
+      $SysConf['SYSCONFIG']['ReuserAutoDetect'] ?? 'true',
+      FILTER_VALIDATE_BOOLEAN
+    );
+    $statusFilter = $SysConf['SYSCONFIG']['ReuserSearchStatus'] ?? '3';
+    $statusIds = array_map('intval', array_filter(explode(',', $statusFilter)));
+    $vars['reuserSearchStatusesJson'] = json_encode($statusIds);
+    $vars['reuserCurrentUserId'] = Auth::getUserId();
 
     $renderer = $this->getObject('twig.environment');
     return $renderer->load('agent_reuser.js.twig')->render($vars);
@@ -216,11 +253,11 @@ class ReuserPlugin extends DefaultPlugin
   /**
    * @brief For a given folder id, collect all uploads
    *
-   * Creates an array of uploads with `<upload_id,group_id>` as the key and
-   * `<upload_name> from <Y-m-d H:i> (<status>)` as value.
+   * Creates a structured list of uploads with upload id, group id, filename,
+   * timestamp, status id, most recent clearing time and display string.
    * @param int $folderId
    * @param int $trustGroupId
-   * @return UploadProgress[]
+   * @return array[]
    */
   protected function prepareFolderUploads($folderId, $trustGroupId=null)
   {
@@ -229,15 +266,391 @@ class ReuserPlugin extends DefaultPlugin
     }
     $folderUploads = $this->folderDao->getFolderUploads($folderId, $trustGroupId);
 
-    $uploadsById = array();
-    foreach ($folderUploads as $uploadProgress) {
-      $key = $uploadProgress->getId().','.$uploadProgress->getGroupId();
-      $display = $uploadProgress->getFilename() . _(" from ")
-               . Convert2BrowserTime(date("Y-m-d H:i:s",$uploadProgress->getTimestamp()))
-               . ' ('. $uploadProgress->getStatusString() . ')';
-      $uploadsById[$key] = $display;
+    return $this->buildStructuredUploads($folderUploads, $trustGroupId);
+  }
+
+  /**
+   * @brief Build a structured upload list with most recent clearing time
+   * @param UploadProgress[] $uploadProgresses
+   * @param int $groupId Group to scope clearing decisions to
+   * @return array[] List of ['uploadId','groupId','filename','timestamp',
+   *                          'statusId','clearedAt','display']
+   */
+  private function buildStructuredUploads($uploadProgresses, $groupId)
+  {
+    $uploads = array();
+    $uploadIds = array();
+    foreach ($uploadProgresses as $uploadProgress) {
+      $uploadIds[] = $uploadProgress->getId();
+      $uploads[] = array(
+        'uploadId' => $uploadProgress->getId(),
+        'groupId' => $uploadProgress->getGroupId(),
+        'userId' => 0,
+        'filename' => $uploadProgress->getFilename(),
+        'timestamp' => date("Y-m-d H:i:s", $uploadProgress->getTimestamp()),
+        'statusId' => $uploadProgress->getStatusId(),
+        'clearedAt' => null,
+        'display' => $uploadProgress->getFilename() . _(" from ")
+          . Convert2BrowserTime(date("Y-m-d H:i:s", $uploadProgress->getTimestamp()))
+          . ' (' . $uploadProgress->getStatusString() . ')'
+      );
     }
-    return $uploadsById;
+    if (empty($uploadIds)) {
+      return array();
+    }
+
+    $placeholders = array();
+    $params = array();
+    for ($i = 0; $i < count($uploadIds); $i++) {
+      $placeholders[] = '$' . ($i + 1);
+      $params[] = $uploadIds[$i];
+    }
+    $groupIdPlaceholder = '$' . (count($uploadIds) + 1);
+    $params[] = $groupId;
+
+    $dbManager = $GLOBALS['container']->get('db.manager');
+    $stmtUser = __METHOD__ . '.uploader';
+    $dbManager->prepare($stmtUser,
+      "SELECT upload_pk, user_fk
+       FROM upload
+       WHERE upload_pk IN (" . implode(',', $placeholders) . ")");
+    $res = $dbManager->execute($stmtUser, array_slice($params, 0, count($uploadIds)));
+    $userIdByUpload = array();
+    while ($row = $dbManager->fetchArray($res)) {
+      $userIdByUpload[intval($row['upload_pk'])] = intval($row['user_fk']);
+    }
+    $dbManager->freeResult($res);
+
+    $stmtName = __METHOD__ . '.lastCleared';
+    $dbManager->prepare($stmtName,
+      "SELECT ut.upload_fk, MAX(cd.date_added) AS last_cleared
+       FROM clearing_decision cd
+       JOIN uploadtree ut ON ut.uploadtree_pk = cd.uploadtree_fk
+       WHERE ut.upload_fk IN (" . implode(',', $placeholders) . ")
+         AND cd.group_fk = $groupIdPlaceholder
+       GROUP BY ut.upload_fk");
+    $res = $dbManager->execute($stmtName, $params);
+    $clearedById = array();
+    while ($row = $dbManager->fetchArray($res)) {
+      $clearedById[intval($row['upload_fk'])] =
+        date("Y-m-d H:i:s", strtotime($row['last_cleared']));
+    }
+    $dbManager->freeResult($res);
+
+    foreach ($uploads as &$entry) {
+      if (array_key_exists($entry['uploadId'], $clearedById)) {
+        $entry['clearedAt'] = $clearedById[$entry['uploadId']];
+      }
+      if (array_key_exists($entry['uploadId'], $userIdByUpload)) {
+        $entry['userId'] = $userIdByUpload[$entry['uploadId']];
+      }
+    }
+    unset($entry);
+    return $uploads;
+  }
+  /**
+   * @brief Narrow a client-provided candidate list to a single upload
+   *
+   * The candidate pairs come from the client's local ranking and are not
+   * trusted as-is: only pairs whose upload is owned by the current user
+   * and whose group is one the current user can access (same eligibility
+   * rule as primarySearchFromPlugin()) are considered.
+   * @param string $candidatesParam "uploadId,groupId;uploadId,groupId;..."
+   * @return array[] Single result ['uploadId'=>int,'groupId'=>int] or []
+   */
+  private function narrowCandidates($candidatesParam)
+  {
+    $pairs = [];
+    foreach (explode(';', $candidatesParam) as $pairStr) {
+      $parts = explode(',', trim($pairStr));
+      if (count($parts) === 2 && is_numeric($parts[0]) && is_numeric($parts[1])) {
+        $pairs[] = ['uploadId' => intval($parts[0]), 'groupId' => intval($parts[1])];
+      }
+    }
+    if (empty($pairs)) {
+      return [];
+    }
+    $dbManager = $GLOBALS['container']->get('db.manager');
+    $eligiblePairs = ReuseAutoDetect::filterEligibleCandidates($pairs, Auth::getUserId(), $dbManager);
+    if (empty($eligiblePairs)) {
+      return [];
+    }
+    $clearingDao = $GLOBALS['container']->get('dao.clearing');
+    $winner = ReuseAutoDetect::selectWinnerByClearing($eligiblePairs, $clearingDao);
+    if ($winner === null) {
+      return [];
+    }
+    return [['uploadId' => $winner['uploadId'], 'groupId' => $winner['groupId']]];
+  }
+
+  /**
+   * @brief Convert a candidate into an auto-detect result with display
+   * @param array $candidate Candidate with uploadId, groupId and either
+   *        display or statusId
+   * @return array|null ['uploadId'=>int,'groupId'=>int,'display'=>string] or null
+   */
+  private function candidateToResult($candidate)
+  {
+    if (!empty($candidate['display'])) {
+      return ['uploadId' => $candidate['uploadId'], 'groupId' => $candidate['groupId'], 'display' => $candidate['display']];
+    }
+    $uploadDao = $GLOBALS['container']->get('dao.upload');
+    $statusType = new \Fossology\Lib\Data\UploadStatus();
+    $upload = $uploadDao->getUpload($candidate['uploadId']);
+    if ($upload === null) {
+      return null;
+    }
+    $statusId = isset($candidate['statusId']) ? $candidate['statusId'] : 3;
+    $display = $upload->getFilename() . _(" from ")
+      . Convert2BrowserTime(date("Y-m-d H:i:s", $upload->getTimestamp()))
+      . ' (' . $statusType->getTypeName($statusId) . ')';
+    return ['uploadId' => $candidate['uploadId'], 'groupId' => $candidate['groupId'], 'display' => $display];
+  }
+
+  /**
+   * @brief Auto-detect best reuse upload for a given filename
+   *
+   * Eligibility: uploads uploaded by the current user in groups the user
+   * can access. When a specific upload status filter is configured, the
+   * single best match (nearest version, then date) is selected. Without a
+   * status filter the top candidates are evaluated by clearing decisions:
+   * first fully cleared, then highest cleared percentage, finally the best
+   * by version/date.
+   * @param string $filename
+   * @param string $folderGroupPair "folderId,trustGroupId" pair; when given,
+   *        the search is restricted to that folder's uploads
+   * @return array[] Single result ['uploadId'=>int,'groupId'=>int,'display'=>string]
+   *                 or []
+   */
+  private function autoDetectReuseFromFilename($filename, $folderGroupPair = '')
+  {
+    global $SysConf;
+
+    $autoDetectEnabled = filter_var(
+      $SysConf['SYSCONFIG']['ReuserAutoDetect'] ?? 'true',
+      FILTER_VALIDATE_BOOLEAN
+    );
+    if (!$autoDetectEnabled) {
+      return [];
+    }
+
+    $statusFilter = $SysConf['SYSCONFIG']['ReuserSearchStatus'] ?? '3';
+    $statusIds = array_map('intval', array_filter(explode(',', $statusFilter)));
+    $statusSpecific = ReuseAutoDetect::isStatusSpecific($statusIds);
+    $limit = $statusSpecific ? 1 : self::AUTO_DETECT_LIMIT;
+
+    $parsed = ReuseAutoDetect::parsePackageName($filename);
+    $basePackageName = $parsed['baseName'];
+    if (empty($basePackageName)) {
+      return [];
+    }
+
+    list($folderId, $trustGroupId) = $this->getFolderIdAndTrustGroup($folderGroupPair);
+    if (!empty($folderId) && !empty($trustGroupId)) {
+      return $this->autoDetectInFolder($folderId, $trustGroupId, $basePackageName,
+        $parsed['versionParts'], $statusIds, $limit);
+    }
+
+    $dbManager = $GLOBALS['container']->get('db.manager');
+    $uploaderUserId = Auth::getUserId();
+
+    $matches = $this->primarySearchFromPlugin($basePackageName, $parsed['versionParts'],
+      $uploaderUserId, $dbManager, $statusIds, $limit);
+    if (empty($matches)) {
+      return [];
+    }
+    if (!$statusSpecific) {
+      $clearingDao = $GLOBALS['container']->get('dao.clearing');
+      $winner = ReuseAutoDetect::selectWinnerByClearing($matches, $clearingDao);
+      if ($winner === null) {
+        return [];
+      }
+      $matches = [$winner];
+    } else {
+      $matches = [$matches[0]];
+    }
+
+    $results = [];
+    foreach ($matches as $match) {
+      $result = $this->candidateToResult($match);
+      if ($result !== null) {
+        $results[] = $result;
+      }
+    }
+    return $results;
+  }
+
+  /**
+   * @brief Auto-detect reuse uploads restricted to a single folder
+   * @param int $folderId
+   * @param int $trustGroupId
+   * @param string $basePackageName
+   * @param int[]|null $requestedVersionParts
+   * @param int[] $statusIds Upload clearing status IDs to filter; empty for all
+   * @param int $limit Number of candidates (1 when status filter set)
+   * @return array[] Single result ['uploadId'=>int,'groupId'=>int,'display'=>string]
+   *                 or []
+   */
+  private function autoDetectInFolder($folderId, $trustGroupId, $basePackageName, $requestedVersionParts, $statusIds, $limit)
+  {
+    $uploaderUserId = Auth::getUserId();
+    $folderUploads = $this->prepareFolderUploads($folderId, $trustGroupId);
+    if (empty($folderUploads)) {
+      return [];
+    }
+
+    $candidates = [];
+    foreach ($folderUploads as $item) {
+      if ($uploaderUserId > 0 && intval($item['userId']) !== $uploaderUserId) {
+        continue;
+      }
+      $parsed = ReuseAutoDetect::parsePackageName($item['filename']);
+      if (strcasecmp($parsed['baseName'], $basePackageName) !== 0) {
+        continue;
+      }
+      if (!empty($statusIds) && !in_array($item['statusId'], $statusIds)) {
+        continue;
+      }
+      $candidates[] = [
+        'uploadId' => $item['uploadId'],
+        'groupId' => $item['groupId'],
+        'statusId' => $item['statusId'],
+        'versionParts' => $parsed['versionParts'],
+        'prerelease' => $parsed['prerelease'],
+        'clearedAt' => $item['clearedAt'],
+        'timestamp' => strtotime($item['timestamp']),
+        'display' => $item['display']
+      ];
+    }
+    if (empty($candidates)) {
+      return [];
+    }
+
+    ReuseAutoDetect::rankCandidates($candidates, $requestedVersionParts);
+    $candidates = array_slice($candidates, 0, $limit);
+    if ($limit > 1) {
+      $clearingDao = $GLOBALS['container']->get('dao.clearing');
+      $winner = ReuseAutoDetect::selectWinnerByClearing($candidates, $clearingDao);
+      if ($winner === null) {
+        return [];
+      }
+      $candidates = [$winner];
+    }
+
+    $results = [];
+    foreach ($candidates as $candidate) {
+      $result = $this->candidateToResult($candidate);
+      if ($result !== null) {
+        $results[] = $result;
+      }
+    }
+    return $results;
+  }
+
+  /**
+   * @brief Primary search: eligible uploads of the current user with
+   *        matching package name
+   *
+   * Eligibility: uploads uploaded by the current user whose clearing group
+   * is accessible to the user. Candidates are ranked by nearest version,
+   * then date.
+   * @param string $basePackageName
+   * @param int[]|null $requestedVersionParts
+   * @param int $uploaderUserId
+   * @param \Fossology\Lib\Db\DbManager $dbManager
+   * @param int[] $statusIds Upload clearing status IDs to filter; empty for all
+   * @param int $limit Maximum number of candidates
+   * @return array[] List of ['uploadId','groupId','statusId','versionParts',
+   *                          'prerelease','timestamp'] ranked best-first, or []
+   */
+  private function primarySearchFromPlugin($basePackageName, $requestedVersionParts, $uploaderUserId, $dbManager, $statusIds, $limit)
+  {
+    $currentUserId = Auth::getUserId();
+    $userDao = $GLOBALS['container']->get('dao.user');
+    $currentUserGroups = $userDao->getUserGroupIds($currentUserId);
+    if (empty($currentUserGroups) || $uploaderUserId <= 0) {
+      return [];
+    }
+
+    $groupCount = count($currentUserGroups);
+    $params = array_merge([$uploaderUserId], $currentUserGroups);
+    if (!empty($statusIds)) {
+      array_push($params, ...$statusIds);
+    }
+    $params[] = $currentUserId;
+    $params[] = $basePackageName;
+    $permPlaceholder = '$' . (count($params) - 1);
+    $namePlaceholder = '$' . count($params);
+    $statusOffset = $groupCount + 2;
+    $statusList = $this->buildStatusPlaceholders($statusIds, $statusOffset);
+    $statusClause = empty($statusIds) ? '' : " AND uc.status_fk IN ($statusList)";
+    $groupIdPlaceholders = $this->buildPlaceholders($groupCount, 2);
+
+    $stmtName = __METHOD__ . '.eligible';
+    $dbManager->prepare($stmtName,
+      "SELECT DISTINCT u.upload_pk, u.upload_filename, u.upload_ts, uc.group_fk, uc.status_fk
+       FROM upload u
+       JOIN upload_clearing uc ON uc.upload_fk = u.upload_pk
+       WHERE u.upload_mode IN (100, 104)
+         AND u.pfile_fk IS NOT NULL
+         AND u.user_fk = $1
+         AND uc.group_fk IN ($groupIdPlaceholders)
+         AND EXISTS (SELECT 1 FROM group_user_member gum
+                     WHERE gum.group_fk = uc.group_fk AND gum.user_fk = $permPlaceholder AND gum.group_perm >= 1)
+         $statusClause
+         AND u.upload_filename ILIKE '%' || $namePlaceholder || '%'
+       ORDER BY u.upload_ts DESC
+       LIMIT 200");
+    $res = $dbManager->execute($stmtName, $params);
+    $candidates = [];
+    while ($row = $dbManager->fetchArray($res)) {
+      $parsed = ReuseAutoDetect::parsePackageName($row['upload_filename']);
+      if (strcasecmp($parsed['baseName'], $basePackageName) !== 0) {
+        continue;
+      }
+      $candidates[] = [
+        'uploadId' => intval($row['upload_pk']),
+        'groupId' => intval($row['group_fk']),
+        'statusId' => intval($row['status_fk']),
+        'versionParts' => $parsed['versionParts'],
+        'prerelease' => $parsed['prerelease'],
+        'clearedAt' => null,
+        'timestamp' => strtotime($row['upload_ts'])
+      ];
+    }
+    $dbManager->freeResult($res);
+
+    if (empty($candidates)) {
+      return [];
+    }
+    ReuseAutoDetect::rankCandidates($candidates, $requestedVersionParts);
+    return array_slice($candidates, 0, $limit);
+  }
+
+  /**
+   * @brief Build comma-separated placeholder list starting at offset
+   * @param int $count Number of placeholders
+   * @param int $start Offset (1-based)
+   * @return string e.g. "$2,$3,$4"
+   */
+  private function buildPlaceholders($count, $start = 1)
+  {
+    $placeholders = [];
+    for ($i = 0; $i < $count; $i++) {
+      $placeholders[] = '$' . ($start + $i);
+    }
+    return implode(',', $placeholders);
+  }
+
+  /**
+   * @brief Build status placeholder list
+   * @param int[] $statusIds
+   * @param int $start Offset for placeholder numbering
+   * @return string e.g. "$2,$3"
+   */
+  private function buildStatusPlaceholders($statusIds, $start)
+  {
+    return $this->buildPlaceholders(count($statusIds), $start);
   }
 }
 

--- a/src/reuser/ui/template/agent_reuser.html.twig
+++ b/src/reuser/ui/template/agent_reuser.html.twig
@@ -64,10 +64,13 @@
         <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="reuseMode[]" value="reuseCopyright"/>
         {{ 'Reuse deactivated copyrights'|trans }}
         <img src="images/info_16.png" data-toggle="tooltip" title="{{'Use to copy edited and deactivated copyrights from the reused package'|trans}}" alt="" class="info-bullet"/>
-      </label><br/>
+      </label>      <br/>
       
       <label for="{{ uploadToReuseSelectorName }}">{{ 'Upload to reuse'|trans }}:</label><br/>
       {{ macro.select(uploadToReuseSelectorName ~ '[]', folderUploads, uploadToReuseSelectorName, reuseUploadId, 'style="min-width:420px;"', 5) }}
+      <div id="auto-detect-loading" class="dataTables_processing" style="display:none;">
+        {{ 'Searching…'|trans }}
+      </div>
     </div>
 
     {% if osselotAvailable %}

--- a/src/reuser/ui/template/agent_reuser.html.twig
+++ b/src/reuser/ui/template/agent_reuser.html.twig
@@ -2,7 +2,6 @@
 
    SPDX-License-Identifier: GPL-2.0-only
 #}
-{% import "include/macros.html.twig" as macro %}
 
 <li>
   <div class="form-group">
@@ -64,10 +63,17 @@
         <input type="checkbox" class="browse-upload-checkbox view-license-rc-size" name="reuseMode[]" value="reuseCopyright"/>
         {{ 'Reuse deactivated copyrights'|trans }}
         <img src="images/info_16.png" data-toggle="tooltip" title="{{'Use to copy edited and deactivated copyrights from the reused package'|trans}}" alt="" class="info-bullet"/>
-      </label><br/>
+      </label>      <br/>
       
       <label for="{{ uploadToReuseSelectorName }}">{{ 'Upload to reuse'|trans }}:</label><br/>
-      {{ macro.select(uploadToReuseSelectorName ~ '[]', folderUploads, uploadToReuseSelectorName, reuseUploadId, 'style="min-width:420px;"', 5) }}
+      <select name="{{ uploadToReuseSelectorName }}[]" id="{{ uploadToReuseSelectorName }}" style="min-width:420px;" size="5" multiple="multiple">
+        {% for upload in folderUploads %}
+          <option value="{{ upload.uploadId }},{{ upload.groupId }}">{{ upload.display|e }}</option>
+        {% endfor %}
+      </select>
+      <div id="auto-detect-loading" class="dataTables_processing" style="display:none;">
+        {{ 'Searching…'|trans }}
+      </div>
     </div>
 
     {% if osselotAvailable %}

--- a/src/reuser/ui/template/agent_reuser.js.twig
+++ b/src/reuser/ui/template/agent_reuser.js.twig
@@ -37,12 +37,78 @@ function reloadUploads(folderGroupPair, groupIndex) {
     .always(function () { _reloadUploadsXhr = null; });
 }
 
+let _autoDetectXhr = null;
+
+function runAutoDetect(groupIndex) {
+  {% if not autoDetectEnabled %}
+  return;
+  {% endif %}
+  if (window.currentReuseSource && window.currentReuseSource !== 'local') {
+    return;
+  }
+  if (!lastUploadedFiles || lastUploadedFiles.length === 0) {
+    return;
+  }
+  const fileIndex = parseInt(groupIndex) || 0;
+  const file = lastUploadedFiles[fileIndex] || lastUploadedFiles[0];
+  if (!file || !file.name) {
+    return;
+  }
+  const filename = file.name;
+  const selectId = `#{{ uploadToReuseSelectorName }}${groupIndex}`;
+  const $select = $(selectId);
+  const $autoDetectIndicator = $(`#auto-detect-loading${groupIndex}`);
+
+  if ($select.length === 0) {
+    return;
+  }
+
+  if (_autoDetectXhr) {
+    _autoDetectXhr.abort();
+    _autoDetectXhr = null;
+  }
+
+  $autoDetectIndicator.show();
+  _autoDetectXhr = $.ajax({
+    url: '?mod=plugin_reuser&do=autoDetectReuse',
+    method: 'GET',
+    data: { filename: filename },
+    dataType: 'json',
+    success: function(data) {
+      if (data && data.uploadId && data.groupId && data.display) {
+        const optionValue = data.uploadId + ',' + data.groupId;
+        const exists = $select.find('option[value="' + optionValue + '"]').length > 0;
+        if (!exists) {
+          const selectEl = $select[0];
+          const opt = document.createElement('option');
+          opt.value = optionValue;
+          opt.textContent = data.display;
+          selectEl.insertBefore(opt, selectEl.firstChild);
+        }
+        $select.val(optionValue);
+        $select.trigger('change');
+        $select[0].size = $select[0].size;
+      }
+    },
+    error: function(xhr, status, error) {
+    },
+    complete: function() {
+      _autoDetectXhr = null;
+      $autoDetectIndicator.hide();
+    }
+  });
+}
+
 function toggleDisabled() {
   $(document).off('click.reuseSearchInFolder').on('click.reuseSearchInFolder', '.reuseSearchInFolder', function () {
     const gi = $(this).attr('id').replace('reuseSearchInFolder', '');
     const fs = $(`#{{ reuseFolderSelectorName }}${gi}`);
     fs.prop('disabled', !this.checked);
-    this.checked ? fs.trigger('change') : reloadUploads('', gi);
+    if (this.checked) {
+      fs.trigger('change');
+    } else {
+      reloadUploads('', gi);
+    }
   });
   registerFolderSelectorChange();
 }

--- a/src/reuser/ui/template/agent_reuser.js.twig
+++ b/src/reuser/ui/template/agent_reuser.js.twig
@@ -4,6 +4,9 @@
 #}
 let osselotVersions = [];
 let lastUploadedFiles = [];
+let lastGetUploadsDataByGroup = {};
+const reuserSearchStatuses = {{ reuserSearchStatusesJson|raw }};
+const reuserCurrentUserId = {{ reuserCurrentUserId|raw }};
 let _reloadUploadsXhr = null;
 function registerFolderSelectorChange() {
   $(document)
@@ -11,11 +14,12 @@ function registerFolderSelectorChange() {
     .on('change.reuseFolderSelector', '[id^={{ reuseFolderSelectorName }}]', function () {
       const groupIndex = $(this).attr('id').replace('{{ reuseFolderSelectorName }}', '');
       const folderGroupPair = this.selectedOptions[0].value;
-      reloadUploads('&{{ folderParameterName }}=' + folderGroupPair, groupIndex);
+      reloadUploads('&{{ folderParameterName }}=' + folderGroupPair, groupIndex,
+        function () { runAutoDetect(groupIndex); });
     });
 }
 
-function reloadUploads(folderGroupPair, groupIndex) {
+function reloadUploads(folderGroupPair, groupIndex, onDone) {
   if (_reloadUploadsXhr) {
     _reloadUploadsXhr.abort();
     _reloadUploadsXhr = null;
@@ -23,21 +27,322 @@ function reloadUploads(folderGroupPair, groupIndex) {
   const packageForReuse = $(`#{{ uploadToReuseSelectorName }}${groupIndex}`);
   _reloadUploadsXhr = $.getJSON("?mod=plugin_reuser&do=getUploads" + folderGroupPair)
     .done(function (data) {
-      const entries = Object.entries(data).map(([key, value]) => ({ key, value }));
-      entries.sort(function (a, b) { return String(a.value).localeCompare(String(b.value)); });
+      const entries = Array.isArray(data) ? data : [];
+      lastGetUploadsDataByGroup[groupIndex] = entries;
+      entries.sort(function (a, b) { return String(a.display).localeCompare(String(b.display)); });
       const fragment = document.createDocumentFragment();
-      entries.forEach(function ({ key, value }) {
+      entries.forEach(function (item) {
         const option = document.createElement("option");
-        option.textContent = value;
-        option.value = key;
+        option.textContent = item.display;
+        option.value = item.uploadId + ',' + item.groupId;
         fragment.appendChild(option);
       });
       packageForReuse.empty();
       packageForReuse[0].appendChild(fragment);
       packageForReuse.trigger('change.select2');
+      if (typeof onDone === 'function') {
+        onDone();
+      }
     })
     .fail(function (xhr) { if (xhr.statusText !== 'abort') failed(xhr); })
     .always(function () { _reloadUploadsXhr = null; });
+}
+
+let _autoDetectXhr = null;
+
+function parsePackageNameFromFilename(filename) {
+  if (!filename) {
+    return { baseName: '', versionParts: null, prerelease: 0 };
+  }
+  let nameWithoutExt = filename.replace(/\.[^.]+$/, '');
+  nameWithoutExt = nameWithoutExt.replace(/\.(tar|zip|gz|bz2|xz|tgz|tbz2|txz|rar|7z)(\..*)?$/i, '');
+  nameWithoutExt = nameWithoutExt.replace(/\.(tar|zip|gz|bz2|xz|tgz|tbz2|txz|rar|7z)$/i, '');
+  nameWithoutExt = nameWithoutExt.replace(/[-_]\d{8}$/, '');
+  const versionMatch = nameWithoutExt.match(/[-_](v?\d+(?:\.\d+)*)(?:[-_](?:alpha|beta|rc|pre|patch|p)\d*)?$/i);
+  if (versionMatch) {
+    const baseName = nameWithoutExt.substring(0, nameWithoutExt.length - versionMatch[0].length);
+    const versionParts = versionMatch[1].replace(/^v/i, '').split('.').map(function (s) { return parseInt(s, 10); });
+    const prerelease = /[-_](?:alpha|beta|rc|pre|patch|p)\d*$/i.test(nameWithoutExt) ? 1 : 0;
+    return { baseName: baseName, versionParts: versionParts, prerelease: prerelease };
+  }
+  return { baseName: nameWithoutExt.split('-')[0], versionParts: null, prerelease: 0 };
+}
+
+function computeVersionDistance(parts, requestedParts, L, R) {
+  const digits = new Array(L);
+  let borrow = 0;
+  for (let i = L - 1; i >= 0; i--) {
+    let v = (i < parts.length ? parts[i] : 0) - (i < requestedParts.length ? requestedParts[i] : 0) - borrow;
+    if (v < 0) {
+      v += R;
+      borrow = 1;
+    } else {
+      borrow = 0;
+    }
+    digits[i] = v;
+  }
+  if (borrow === 1) {
+    for (let i = 0; i < L; i++) {
+      digits[i] = (R - 1) - digits[i];
+    }
+    let carry = 1;
+    for (let i = L - 1; i >= 0; i--) {
+      const s = digits[i] + carry;
+      if (s >= R) {
+        digits[i] = s - R;
+        carry = 1;
+      } else {
+        digits[i] = s;
+        carry = 0;
+      }
+    }
+  }
+  return digits;
+}
+
+function compareVersionCloseness(requestedParts, aParts, bParts, L, R) {
+  if (!requestedParts) {
+    return 0;
+  }
+  if (!aParts && !bParts) {
+    return 0;
+  }
+  if (!aParts) {
+    return 1;
+  }
+  if (!bParts) {
+    return -1;
+  }
+  const distA = computeVersionDistance(aParts, requestedParts, L, R);
+  const distB = computeVersionDistance(bParts, requestedParts, L, R);
+  for (let i = 0; i < L; i++) {
+    if (distA[i] !== distB[i]) {
+      return distA[i] - distB[i];
+    }
+  }
+  return 0;
+}
+
+function rankCandidates(candidates, requestedVersionParts) {
+  let L = 0;
+  let R = 10;
+  const all = requestedVersionParts
+    ? candidates.concat([{ versionParts: requestedVersionParts }])
+    : candidates;
+  all.forEach(function (c) {
+    const parts = c.versionParts;
+    if (!parts) {
+      return;
+    }
+    L = Math.max(L, parts.length);
+    parts.forEach(function (component) { R = Math.max(R, component + 1); });
+  });
+  candidates.sort(function (a, b) {
+    if (requestedVersionParts) {
+      const cmp = compareVersionCloseness(requestedVersionParts, a.versionParts, b.versionParts, L, R);
+      if (cmp !== 0) {
+        return cmp;
+      }
+      if (a.prerelease !== b.prerelease) {
+        return a.prerelease - b.prerelease;
+      }
+    }
+    const tsA = a.clearedAt ? Date.parse(a.clearedAt) : null;
+    const tsB = b.clearedAt ? Date.parse(b.clearedAt) : null;
+    if (tsA !== null && tsB !== null && tsA !== tsB) {
+      return tsB - tsA;
+    }
+    if (tsA !== null) {
+      return -1;
+    }
+    if (tsB !== null) {
+      return 1;
+    }
+    return Date.parse(b.timestamp) - Date.parse(a.timestamp);
+  });
+}
+
+function clientSideAutoDetect(filename, groupIndex) {
+  const lastGetUploadsData = lastGetUploadsDataByGroup[groupIndex] || [];
+  if (lastGetUploadsData.length === 0) {
+    return [];
+  }
+  const parsed = parsePackageNameFromFilename(filename);
+  const basePackageName = parsed.baseName;
+  if (!basePackageName) {
+    return [];
+  }
+  const statusSpecific = reuserSearchStatuses && reuserSearchStatuses.length > 0 && reuserSearchStatuses.length < 4;
+  const limit = statusSpecific ? 1 : 4;
+  const candidates = [];
+  lastGetUploadsData.forEach(function (item) {
+    if (reuserCurrentUserId > 0 && item.userId && item.userId !== reuserCurrentUserId) {
+      return;
+    }
+    const itemParsed = parsePackageNameFromFilename(item.filename);
+    if (itemParsed.baseName.toLowerCase() !== basePackageName.toLowerCase()) {
+      return;
+    }
+    if (statusSpecific && reuserSearchStatuses.indexOf(item.statusId) === -1) {
+      return;
+    }
+    candidates.push({
+      uploadId: item.uploadId,
+      groupId: item.groupId,
+      statusId: item.statusId,
+      versionParts: itemParsed.versionParts,
+      prerelease: itemParsed.prerelease,
+      clearedAt: item.clearedAt,
+      timestamp: item.timestamp
+    });
+  });
+  if (candidates.length === 0) {
+    return [];
+  }
+  rankCandidates(candidates, parsed.versionParts);
+  const selected = candidates.slice(0, limit);
+  return selected.map(function (item) {
+    return item.uploadId + ',' + item.groupId;
+  });
+}
+
+function serverNarrowReuse(candidateValues, $select, $autoDetectIndicator) {
+  if (_autoDetectXhr) {
+    _autoDetectXhr.abort();
+    _autoDetectXhr = null;
+  }
+  const candidatesParam = candidateValues.join(';');
+  $autoDetectIndicator.show();
+  _autoDetectXhr = $.ajax({
+    url: '?mod=plugin_reuser&do=autoDetectReuse',
+    method: 'GET',
+    data: { candidates: candidatesParam },
+    dataType: 'json',
+    success: function(data) {
+      const winner = Array.isArray(data) && data.length === 1 && data[0].uploadId && data[0].groupId
+        ? data[0]
+        : null;
+      if (!winner) {
+        return;
+      }
+      const optionValue = winner.uploadId + ',' + winner.groupId;
+      $select.val([optionValue]);
+      $select.trigger('change');
+    },
+    error: function() {
+    },
+    complete: function() {
+      _autoDetectXhr = null;
+      $autoDetectIndicator.hide();
+    }
+  });
+}
+
+function serverAutoDetect(filename, folderGroupPair, $select, $autoDetectIndicator) {
+  if (_autoDetectXhr) {
+    _autoDetectXhr.abort();
+    _autoDetectXhr = null;
+  }
+
+  $autoDetectIndicator.show();
+  _autoDetectXhr = $.ajax({
+    url: '?mod=plugin_reuser&do=autoDetectReuse',
+    method: 'GET',
+    data: folderGroupPair
+      ? { filename: filename, folder: folderGroupPair }
+      : { filename: filename },
+    dataType: 'json',
+    success: function(data) {
+      const results = Array.isArray(data)
+        ? data
+        : (data && data.uploadId && data.groupId && data.display ? [data] : []);
+      if (results.length === 0) {
+        return;
+      }
+      const selectedValues = [];
+      results.forEach(function (match) {
+        if (match && match.uploadId && match.groupId && match.display) {
+          selectedValues.push(match.uploadId + ',' + match.groupId);
+        }
+      });
+      selectedValues.forEach(function (optionValue) {
+        $select.find('option[value="' + optionValue + '"]').remove();
+      });
+      const selectEl = $select[0];
+      const insertBeforeNode = selectEl.firstChild;
+      results.forEach(function (match) {
+        if (!match || !match.uploadId || !match.groupId || !match.display) {
+          return;
+        }
+        const optionValue = match.uploadId + ',' + match.groupId;
+        const opt = document.createElement('option');
+        opt.value = optionValue;
+        opt.textContent = match.display;
+        selectEl.insertBefore(opt, insertBeforeNode);
+      });
+      if (selectedValues.length > 0) {
+        $select.val(selectedValues);
+      }
+      $select.trigger('change');
+    },
+    error: function(xhr, status, error) {
+    },
+    complete: function() {
+      _autoDetectXhr = null;
+      $autoDetectIndicator.hide();
+    }
+  });
+}
+
+function runAutoDetect(groupIndex) {
+  {% if not autoDetectEnabled %}
+  return;
+  {% endif %}
+  if (window.currentReuseSource && window.currentReuseSource !== 'local') {
+    return;
+  }
+  if (!lastUploadedFiles || lastUploadedFiles.length === 0) {
+    return;
+  }
+  const fileIndex = parseInt(groupIndex) || 0;
+  const file = lastUploadedFiles[fileIndex] || lastUploadedFiles[0];
+  if (!file || !file.name) {
+    return;
+  }
+  const filename = file.name;
+  const selectId = `#{{ uploadToReuseSelectorName }}${groupIndex}`;
+  const $select = $(selectId);
+  const $autoDetectIndicator = $(`#auto-detect-loading${groupIndex}`);
+
+  if ($select.length === 0) {
+    return;
+  }
+
+  const $folderSelect = $(`#{{ reuseFolderSelectorName }}${groupIndex}`);
+  const folderGroupPair = $folderSelect.length > 0 && !$folderSelect.prop('disabled')
+    ? ($folderSelect.val() || '')
+    : '';
+
+  const localMatches = clientSideAutoDetect(filename, groupIndex);
+  if (localMatches.length === 1) {
+    $select.val(localMatches);
+    $select.trigger('change');
+    return;
+  }
+  if (localMatches.length > 1) {
+    const statusSpecific = reuserSearchStatuses && reuserSearchStatuses.length > 0 && reuserSearchStatuses.length < 4;
+    if (statusSpecific) {
+      $select.val([localMatches[0]]);
+      $select.trigger('change');
+      return;
+    }
+    $select.val(localMatches);
+    $select.trigger('change');
+    serverNarrowReuse(localMatches, $select, $autoDetectIndicator);
+    return;
+  }
+
+  serverAutoDetect(filename, folderGroupPair, $select, $autoDetectIndicator);
 }
 
 function toggleDisabled() {
@@ -45,7 +350,11 @@ function toggleDisabled() {
     const gi = $(this).attr('id').replace('reuseSearchInFolder', '');
     const fs = $(`#{{ reuseFolderSelectorName }}${gi}`);
     fs.prop('disabled', !this.checked);
-    this.checked ? fs.trigger('change') : reloadUploads('', gi);
+    if (this.checked) {
+      fs.trigger('change');
+    } else {
+      reloadUploads('', gi, function () { runAutoDetect(gi); });
+    }
   });
   registerFolderSelectorChange();
   if ($('#hiddenFormHolder').length === 0) {
@@ -153,7 +462,7 @@ function initializeOsselotFields() {
         if ($checkbox.length > 0 && $checkbox.is(':checked')) {
           $(`#{{ reuseFolderSelectorName }}${groupIndex}`).prop('disabled', false).trigger('change');
         } else {
-          reloadUploads('', groupIndex);
+          reloadUploads('', groupIndex, function () { runAutoDetect(groupIndex); });
         }
       }
     }

--- a/src/reuser/ui/test/ReuseAutoDetectTest.php
+++ b/src/reuser/ui/test/ReuseAutoDetectTest.php
@@ -1,0 +1,601 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\Reuse;
+
+use Fossology\Lib\Dao\ClearingDao;
+use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\Test\TestPgDb;
+use Mockery as M;
+
+require_once(__DIR__ . '/../ReuseAutoDetect.php');
+
+class ReuseAutoDetectTest extends \PHPUnit\Framework\TestCase
+{
+  /** @var TestPgDb */
+  private $testDb;
+  /** @var DbManager */
+  private $dbManager;
+  /** @var int */
+  private $now;
+  /** @var int */
+  private $assertCountBefore;
+
+  protected function setUp(): void
+  {
+    $this->testDb = new TestPgDb();
+    $this->dbManager = &$this->testDb->getDbManager();
+    $this->testDb->createPlainTables([
+        'clearing_decision',
+        'uploadtree',
+        'upload',
+        'upload_clearing',
+        'group_user_member',
+        'users'
+    ]);
+    $this->now = time();
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+  }
+
+  protected function tearDown(): void
+  {
+    $this->addToAssertionCount(\Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    $this->testDb = null;
+    $this->dbManager = null;
+  }
+
+  /**
+   * Build a ClearingDao mock that returns a fixed coverage map.
+   * @param array $coverageByGroup groupId => [uploadId => ['total'=>, 'cleared'=>]]
+   */
+  private function mockClearingDao($coverageByGroup)
+  {
+    $clearingDao = M::mock(ClearingDao::class);
+    $clearingDao->shouldReceive('getClearingCoverage')
+      ->with(M::any(), M::any())
+      ->andReturnUsing(function ($ids, $groupId) use ($coverageByGroup) {
+        $map = isset($coverageByGroup[$groupId]) ? $coverageByGroup[$groupId] : [];
+        $result = [];
+        foreach ($ids as $id) {
+          $result[$id] = isset($map[$id]) ? $map[$id] : ['total' => 0, 'cleared' => 0];
+        }
+        return $result;
+      });
+    return $clearingDao;
+  }
+
+  private function uploadOrder($candidates)
+  {
+    return array_map(function ($c) {
+      return $c['uploadId'];
+    }, $candidates);
+  }
+
+  private function makeCandidate($uploadId, $versionParts, $prerelease = 0, $clearedAt = null, $timestamp = 0, $groupId = 601)
+  {
+    return [
+      'uploadId' => $uploadId,
+      'groupId' => $groupId,
+      'versionParts' => $versionParts,
+      'prerelease' => $prerelease,
+      'clearedAt' => $clearedAt,
+      'timestamp' => $timestamp
+    ];
+  }
+
+  /* ---------------------------------------------------------------------
+   * parsePackageName
+   * --------------------------------------------------------------------- */
+
+  public function testParseEmptyFilename()
+  {
+    $parsed = ReuseAutoDetect::parsePackageName('');
+    assertThat($parsed['baseName'], is(''));
+    assertThat($parsed['versionParts'], is(nullValue()));
+  }
+
+  public function testParseNoVersionArchive()
+  {
+    $parsed = ReuseAutoDetect::parsePackageName('foo.tar.gz');
+    assertThat($parsed['baseName'], is('foo'));
+    assertThat($parsed['versionParts'], is(nullValue()));
+  }
+
+  public function testParseSimpleVersion()
+  {
+    $parsed = ReuseAutoDetect::parsePackageName('foo-1.0.tar.gz');
+    assertThat($parsed['baseName'], is('foo'));
+    assertThat($parsed['versionParts'], is(array(1, 0)));
+    assertThat($parsed['prerelease'], is(0));
+  }
+
+  public function testParseVPrefixVersion()
+  {
+    $parsed = ReuseAutoDetect::parsePackageName('foo-v2.3.4.zip');
+    assertThat($parsed['baseName'], is('foo'));
+    assertThat($parsed['versionParts'], is(array(2, 3, 4)));
+  }
+
+  public function testParseUnderscoreSeparator()
+  {
+    $parsed = ReuseAutoDetect::parsePackageName('foo_1.0.0.tar.bz2');
+    assertThat($parsed['baseName'], is('foo'));
+    assertThat($parsed['versionParts'], is(array(1, 0, 0)));
+  }
+
+  public function testParsePrereleaseSuffix()
+  {
+    $parsed = ReuseAutoDetect::parsePackageName('foo-1.0.0-rc1.tar.gz');
+    assertThat($parsed['baseName'], is('foo'));
+    assertThat($parsed['versionParts'], is(array(1, 0, 0)));
+    assertThat($parsed['prerelease'], is(1));
+  }
+
+  public function testParseUnderscorePrereleaseSuffix()
+  {
+    $parsed = ReuseAutoDetect::parsePackageName('foo-2.0-beta2.tar.gz');
+    assertThat($parsed['baseName'], is('foo'));
+    assertThat($parsed['versionParts'], is(array(2, 0)));
+    assertThat($parsed['prerelease'], is(1));
+  }
+
+  public function testParseDateStampOnly()
+  {
+    $parsed = ReuseAutoDetect::parsePackageName('foo-20240101.tar.gz');
+    assertThat($parsed['baseName'], is('foo'));
+    assertThat($parsed['versionParts'], is(nullValue()));
+  }
+
+  public function testParseVersionAndDateStamp()
+  {
+    $parsed = ReuseAutoDetect::parsePackageName('foo-1.2-20240101.tar.gz');
+    assertThat($parsed['baseName'], is('foo'));
+    assertThat($parsed['versionParts'], is(array(1, 2)));
+  }
+
+  public function testParseDashedNameWithoutVersion()
+  {
+    $parsed = ReuseAutoDetect::parsePackageName('foo-lib.tar.gz');
+    assertThat($parsed['baseName'], is('foo'));
+    assertThat($parsed['versionParts'], is(nullValue()));
+  }
+
+  public function testParseSingleComponentVersion()
+  {
+    $parsed = ReuseAutoDetect::parsePackageName('foo-3.tar.gz');
+    assertThat($parsed['baseName'], is('foo'));
+    assertThat($parsed['versionParts'], is(array(3)));
+  }
+
+  public function testParseTripleExtension()
+  {
+    $parsed = ReuseAutoDetect::parsePackageName('foo-1.1.tar.gz.tar');
+    assertThat($parsed['baseName'], is('foo'));
+    assertThat($parsed['versionParts'], is(array(1, 1)));
+  }
+
+  public function testParseUppercaseExtension()
+  {
+    $parsed = ReuseAutoDetect::parsePackageName('foo-1.0.TGZ');
+    assertThat($parsed['baseName'], is('foo'));
+    assertThat($parsed['versionParts'], is(array(1, 0)));
+  }
+
+  /* ---------------------------------------------------------------------
+   * compareVersionCloseness
+   * --------------------------------------------------------------------- */
+
+  public function testCompareCloserMinorVersionWins()
+  {
+    // requested 1.0: 0.9 is closer than 0.8 (the spec's worked example)
+    $cmp = ReuseAutoDetect::compareVersionCloseness([1, 0], [0, 9], [0, 8], 2, 10);
+    assertThat($cmp, lessThan(0));
+    $reverse = ReuseAutoDetect::compareVersionCloseness([1, 0], [0, 8], [0, 9], 2, 10);
+    assertThat($reverse, greaterThan(0));
+  }
+
+  public function testCompareExactMatchClosest()
+  {
+    $cmp = ReuseAutoDetect::compareVersionCloseness([1, 0], [1, 0], [0, 9], 2, 10);
+    assertThat($cmp, lessThan(0));
+  }
+
+  public function testCompareEquidistantVersionsTie()
+  {
+    $cmp = ReuseAutoDetect::compareVersionCloseness([1, 5], [1, 4], [1, 6], 2, 7);
+    assertThat($cmp, is(0));
+  }
+
+  public function testCompareCrossMajor()
+  {
+    // requested 2.0: 2.0 closer than 1.9.9
+    $cmp = ReuseAutoDetect::compareVersionCloseness([2, 0], [2, 0], [1, 9, 9], 3, 10);
+    assertThat($cmp, lessThan(0));
+  }
+
+  public function testCompareNullRequestedTies()
+  {
+    assertThat(ReuseAutoDetect::compareVersionCloseness(null, [1, 0], [2, 0], 2, 10), is(0));
+  }
+
+  public function testCompareNullCandidateFarthest()
+  {
+    assertThat(ReuseAutoDetect::compareVersionCloseness([1, 0], null, [0, 9], 2, 10), greaterThan(0));
+    assertThat(ReuseAutoDetect::compareVersionCloseness([1, 0], [0, 9], null, 2, 10), lessThan(0));
+    assertThat(ReuseAutoDetect::compareVersionCloseness([1, 0], null, null, 2, 10), is(0));
+  }
+
+  /* ---------------------------------------------------------------------
+   * rankCandidates - the duplicate-upload / selection scenarios
+   * --------------------------------------------------------------------- */
+
+  public function testRankMultipleVersionsOfSamePackage()
+  {
+    // The spec example: upload-1.0, upload-0.9, upload-0.8, upload-0.7
+    $candidates = [
+      $this->makeCandidate(4, [0, 7], 0, null, 400),
+      $this->makeCandidate(3, [0, 8], 0, null, 300),
+      $this->makeCandidate(2, [0, 9], 0, null, 200),
+      $this->makeCandidate(1, [1, 0], 0, null, 100),
+    ];
+    ReuseAutoDetect::rankCandidates($candidates, [1, 0]);
+    assertThat($this->uploadOrder($candidates), is(array(1, 2, 3, 4)));
+  }
+
+  public function testRankWithoutExactVersionMatch()
+  {
+    $candidates = [
+      $this->makeCandidate(3, [0, 7], 0, null, 300),
+      $this->makeCandidate(2, [0, 8], 0, null, 200),
+      $this->makeCandidate(1, [0, 9], 0, null, 100),
+    ];
+    ReuseAutoDetect::rankCandidates($candidates, [1, 0]);
+    assertThat($this->uploadOrder($candidates), is(array(1, 2, 3)));
+  }
+
+  public function testRankDuplicateCandidateEntries()
+  {
+    // Same upload listed twice plus a weaker version
+    $candidates = [
+      $this->makeCandidate(1, [1, 0], 0, null, 100),
+      $this->makeCandidate(2, [0, 9], 0, null, 200),
+      $this->makeCandidate(1, [1, 0], 0, null, 100),
+    ];
+    ReuseAutoDetect::rankCandidates($candidates, [1, 0]);
+    $order = $this->uploadOrder($candidates);
+    assertThat($order[0], is(1));
+    assertThat($order[1], is(1));
+    assertThat($order[2], is(2));
+  }
+
+  public function testRankVersionDistanceTieBreaksByClearedAt()
+  {
+    // 1.1 and 0.9 are both 0.1 away from 1.0 -> clearedAt decides
+    $candidates = [
+      $this->makeCandidate(1, [1, 1], 0, '2020-01-01 00:00:00', 999999999),
+      $this->makeCandidate(2, [0, 9], 0, '2024-01-01 00:00:00', 100),
+    ];
+    ReuseAutoDetect::rankCandidates($candidates, [1, 0]);
+    assertThat($this->uploadOrder($candidates), is(array(2, 1)));
+  }
+
+  public function testRankVersionTieClearedAtBeatsTimestamp()
+  {
+    $candidates = [
+      $this->makeCandidate(1, [1, 0], 0, '2020-01-01 00:00:00', 999999999),
+      $this->makeCandidate(2, [1, 0], 0, '2024-01-01 00:00:00', 100),
+    ];
+    ReuseAutoDetect::rankCandidates($candidates, [1, 0]);
+    assertThat($this->uploadOrder($candidates), is(array(2, 1)));
+  }
+
+  public function testRankReleaseBeatsPrerelease()
+  {
+    $candidates = [
+      $this->makeCandidate(1, [1, 1], 1, null, 100),
+      $this->makeCandidate(2, [1, 0], 0, null, 200),
+    ];
+    ReuseAutoDetect::rankCandidates($candidates, [1, 0]);
+    assertThat($this->uploadOrder($candidates), is(array(2, 1)));
+  }
+
+  public function testRankVersionlessCandidateLast()
+  {
+    $candidates = [
+      $this->makeCandidate(1, [1, 0], 0, null, 100),
+      $this->makeCandidate(2, null, 0, null, 500),
+    ];
+    ReuseAutoDetect::rankCandidates($candidates, [1, 0]);
+    assertThat($this->uploadOrder($candidates), is(array(1, 2)));
+  }
+
+  public function testRankNoRequestedVersionSortsByDate()
+  {
+    $candidates = [
+      $this->makeCandidate(1, [1, 0], 0, null, 100),
+      $this->makeCandidate(2, [2, 0], 0, null, 200),
+    ];
+    ReuseAutoDetect::rankCandidates($candidates, null);
+    assertThat($this->uploadOrder($candidates), is(array(2, 1)));
+  }
+
+  public function testRankVersionTieFallsBackToTimestamp()
+  {
+    $candidates = [
+      $this->makeCandidate(1, [1, 0], 0, null, 100),
+      $this->makeCandidate(2, [1, 0], 0, null, 200),
+    ];
+    ReuseAutoDetect::rankCandidates($candidates, [1, 0]);
+    assertThat($this->uploadOrder($candidates), is(array(2, 1)));
+  }
+
+  public function testRankCrossMajorVersions()
+  {
+    $candidates = [
+      $this->makeCandidate(1, [1, 9, 9], 0, null, 200),
+      $this->makeCandidate(2, [2, 0], 0, null, 100),
+    ];
+    ReuseAutoDetect::rankCandidates($candidates, [2, 0]);
+    assertThat($this->uploadOrder($candidates), is(array(2, 1)));
+  }
+
+  /* ---------------------------------------------------------------------
+   * selectWinnerByClearing
+   * --------------------------------------------------------------------- */
+
+  public function testSelectWinnerFullyClearedWinsEvenIfNotRankFirst()
+  {
+    $coverage = [601 => [
+      101 => ['total' => 2, 'cleared' => 2],
+      102 => ['total' => 3, 'cleared' => 0]
+    ]];
+    $candidates = [
+      $this->makeCandidate(102, null, 0, null, 0),
+      $this->makeCandidate(101, null, 0, null, 0),
+    ];
+    $winner = ReuseAutoDetect::selectWinnerByClearing($candidates, $this->mockClearingDao($coverage));
+    assertThat($winner['uploadId'], is(101));
+  }
+
+  public function testSelectWinnerHighestRatioWins()
+  {
+    $coverage = [601 => [
+      101 => ['total' => 2, 'cleared' => 1],
+      102 => ['total' => 3, 'cleared' => 1]
+    ]];
+    $candidates = [
+      $this->makeCandidate(101, null, 0, null, 0),
+      $this->makeCandidate(102, null, 0, null, 0),
+    ];
+    $winner = ReuseAutoDetect::selectWinnerByClearing($candidates, $this->mockClearingDao($coverage));
+    assertThat($winner['uploadId'], is(101));
+  }
+
+  public function testSelectWinnerFallsBackToFirstCandidate()
+  {
+    $coverage = [601 => [
+      101 => ['total' => 0, 'cleared' => 0],
+      102 => ['total' => 0, 'cleared' => 0]
+    ]];
+    $candidates = [
+      $this->makeCandidate(102, null, 0, null, 0),
+      $this->makeCandidate(101, null, 0, null, 0),
+    ];
+    $winner = ReuseAutoDetect::selectWinnerByClearing($candidates, $this->mockClearingDao($coverage));
+    assertThat($winner['uploadId'], is(102));
+  }
+
+  public function testSelectWinnerEmptyCandidatesReturnsNull()
+  {
+    assertThat(ReuseAutoDetect::selectWinnerByClearing([], $this->mockClearingDao([])), is(nullValue()));
+  }
+
+  public function testSelectWinnerSingleCandidate()
+  {
+    $coverage = [601 => [101 => ['total' => 5, 'cleared' => 0]]];
+    $candidates = [$this->makeCandidate(101, null, 0, null, 0)];
+    $winner = ReuseAutoDetect::selectWinnerByClearing($candidates, $this->mockClearingDao($coverage));
+    assertThat($winner['uploadId'], is(101));
+  }
+
+  public function testSelectWinnerTiedRatioPicksRankFirst()
+  {
+    $coverage = [601 => [
+      101 => ['total' => 2, 'cleared' => 1],
+      102 => ['total' => 2, 'cleared' => 1]
+    ]];
+    $candidates = [
+      $this->makeCandidate(101, null, 0, null, 0),
+      $this->makeCandidate(102, null, 0, null, 0),
+    ];
+    $winner = ReuseAutoDetect::selectWinnerByClearing($candidates, $this->mockClearingDao($coverage));
+    assertThat($winner['uploadId'], is(101));
+  }
+
+  public function testSelectWinnerTiedFullyClearedPicksRankFirst()
+  {
+    $coverage = [601 => [
+      101 => ['total' => 2, 'cleared' => 2],
+      102 => ['total' => 3, 'cleared' => 3]
+    ]];
+    $candidates = [
+      $this->makeCandidate(102, null, 0, null, 0),
+      $this->makeCandidate(101, null, 0, null, 0),
+    ];
+    $winner = ReuseAutoDetect::selectWinnerByClearing($candidates, $this->mockClearingDao($coverage));
+    assertThat($winner['uploadId'], is(102));
+  }
+
+  public function testSelectWinnerDuplicateCandidatePairs()
+  {
+    $coverage = [601 => [
+      101 => ['total' => 2, 'cleared' => 2]
+    ]];
+    $candidates = [
+      $this->makeCandidate(101, null, 0, null, 0),
+      $this->makeCandidate(101, null, 0, null, 0),
+    ];
+    $winner = ReuseAutoDetect::selectWinnerByClearing($candidates, $this->mockClearingDao($coverage));
+    assertThat($winner['uploadId'], is(101));
+  }
+
+  public function testSelectWinnerZeroClearedSkippedInRatioStep()
+  {
+    $coverage = [601 => [
+      101 => ['total' => 2, 'cleared' => 0],
+      102 => ['total' => 3, 'cleared' => 1]
+    ]];
+    $candidates = [
+      $this->makeCandidate(101, null, 0, null, 0),
+      $this->makeCandidate(102, null, 0, null, 0),
+    ];
+    $winner = ReuseAutoDetect::selectWinnerByClearing($candidates, $this->mockClearingDao($coverage));
+    assertThat($winner['uploadId'], is(102));
+  }
+
+  public function testSelectWinnerAcrossMultipleGroups()
+  {
+    $coverage = [
+      601 => [101 => ['total' => 2, 'cleared' => 0]],
+      602 => [102 => ['total' => 1, 'cleared' => 1]]
+    ];
+    $candidates = [
+      $this->makeCandidate(101, null, 0, null, 0, 601),
+      $this->makeCandidate(102, null, 0, null, 0, 602),
+    ];
+    $winner = ReuseAutoDetect::selectWinnerByClearing($candidates, $this->mockClearingDao($coverage));
+    assertThat($winner['uploadId'], is(102));
+  }
+
+  /* ---------------------------------------------------------------------
+   * filterEligibleCandidates - authorization (real DB)
+   * --------------------------------------------------------------------- */
+
+  private function seedEligibilityData()
+  {
+    $this->dbManager->insertInto('upload', 'upload_pk, user_fk, upload_filename',
+      array(101, 1, 'upload-1.0.tar.gz'));
+    $this->dbManager->insertInto('upload', 'upload_pk, user_fk, upload_filename',
+      array(102, 2, 'upload-2.0.tar.gz'));
+    $this->dbManager->insertInto('upload_clearing', 'upload_fk, group_fk, status_fk',
+      array(101, 601, 3));
+    $this->dbManager->insertInto('upload_clearing', 'upload_fk, group_fk, status_fk',
+      array(102, 601, 3));
+    $this->dbManager->insertInto('upload_clearing', 'upload_fk, group_fk, status_fk',
+      array(101, 602, 3));
+    $this->dbManager->insertInto('group_user_member', 'group_fk, user_fk, group_perm',
+      array(601, 1, 1));
+    $this->dbManager->insertInto('group_user_member', 'group_fk, user_fk, group_perm',
+      array(601, 2, 1));
+    $this->dbManager->insertInto('group_user_member', 'group_fk, user_fk, group_perm',
+      array(602, 1, 1));
+    $this->dbManager->insertInto('group_user_member', 'group_fk, user_fk, group_perm',
+      array(603, 1, 0));
+  }
+
+  public function testFilterEligibleLegitimatePairPasses()
+  {
+    $this->seedEligibilityData();
+    $result = ReuseAutoDetect::filterEligibleCandidates(
+      [['uploadId' => 101, 'groupId' => 601]], 1, $this->dbManager);
+    assertThat($result, is(array(['uploadId' => 101, 'groupId' => 601])));
+  }
+
+  public function testFilterEligibleRejectsForeignUpload()
+  {
+    $this->seedEligibilityData();
+    $result = ReuseAutoDetect::filterEligibleCandidates(
+      [['uploadId' => 102, 'groupId' => 601]], 1, $this->dbManager);
+    assertThat($result, is(emptyArray()));
+  }
+
+  public function testFilterEligibleRejectsUnknownGroup()
+  {
+    $this->seedEligibilityData();
+    $result = ReuseAutoDetect::filterEligibleCandidates(
+      [['uploadId' => 101, 'groupId' => 999]], 1, $this->dbManager);
+    assertThat($result, is(emptyArray()));
+  }
+
+  public function testFilterEligibleRejectsInsufficientPermission()
+  {
+    $this->seedEligibilityData();
+    $result = ReuseAutoDetect::filterEligibleCandidates(
+      [['uploadId' => 101, 'groupId' => 603]], 1, $this->dbManager);
+    assertThat($result, is(emptyArray()));
+  }
+
+  public function testFilterEligibleRejectsUnknownUpload()
+  {
+    $this->seedEligibilityData();
+    $result = ReuseAutoDetect::filterEligibleCandidates(
+      [['uploadId' => 999, 'groupId' => 601]], 1, $this->dbManager);
+    assertThat($result, is(emptyArray()));
+  }
+
+  public function testFilterEligibleRejectsTamperedMixKeepsLegit()
+  {
+    $this->seedEligibilityData();
+    $result = ReuseAutoDetect::filterEligibleCandidates([
+      ['uploadId' => 101, 'groupId' => 601],
+      ['uploadId' => 102, 'groupId' => 601],
+      ['uploadId' => 101, 'groupId' => 999],
+    ], 1, $this->dbManager);
+    assertThat($result, is(array(['uploadId' => 101, 'groupId' => 601])));
+  }
+
+  public function testFilterEligiblePreservesOrderAndDuplicates()
+  {
+    $this->seedEligibilityData();
+    $result = ReuseAutoDetect::filterEligibleCandidates([
+      ['uploadId' => 101, 'groupId' => 601],
+      ['uploadId' => 101, 'groupId' => 601],
+      ['uploadId' => 101, 'groupId' => 602],
+    ], 1, $this->dbManager);
+    assertThat($result, is(array(
+      ['uploadId' => 101, 'groupId' => 601],
+      ['uploadId' => 101, 'groupId' => 601],
+      ['uploadId' => 101, 'groupId' => 602],
+    )));
+  }
+
+  public function testFilterEligibleEmptyPairs()
+  {
+    assertThat(ReuseAutoDetect::filterEligibleCandidates([], 1, $this->dbManager), is(emptyArray()));
+  }
+
+  public function testFilterEligibleInvalidUserId()
+  {
+    $this->seedEligibilityData();
+    assertThat(ReuseAutoDetect::filterEligibleCandidates(
+      [['uploadId' => 101, 'groupId' => 601]], 0, $this->dbManager), is(emptyArray()));
+  }
+
+  /* ---------------------------------------------------------------------
+   * isStatusSpecific - the 1-vs-4 branching
+   * --------------------------------------------------------------------- */
+
+  public function testStatusSpecificEmptyConfigIsNotSpecific()
+  {
+    assertThat(ReuseAutoDetect::isStatusSpecific([]), is(false));
+  }
+
+  public function testStatusSpecificSingleStatus()
+  {
+    assertThat(ReuseAutoDetect::isStatusSpecific([3]), is(true));
+  }
+
+  public function testStatusSpecificPartialStatuses()
+  {
+    assertThat(ReuseAutoDetect::isStatusSpecific([1, 2, 3]), is(true));
+  }
+
+  public function testStatusSpecificAllStatusesIsNotSpecific()
+  {
+    assertThat(ReuseAutoDetect::isStatusSpecific([1, 2, 3, 4]), is(false));
+  }
+}

--- a/src/www/ui/admin-config.php
+++ b/src/www/ui/admin-config.php
@@ -82,7 +82,7 @@ class foconfig extends FO_Plugin
           $OutBuf .= "<select name='new[$row[variablename]]' title='$row[description]' $InputStyle>";
           foreach ($Options as $Option) {
             $matches = array();
-            preg_match('/([ \\w]+)[{​​​​](.*)[}​​​​]/', $Option, $matches);
+            preg_match('/([ \\w]+)\\{(.*)\\}/', $Option, $matches);
             $Option_display = $matches[1];
             $Option_value = $matches[2];
             $OutBuf .= "<option $InputStyle value='$Option_value' ";
@@ -104,6 +104,25 @@ class foconfig extends FO_Plugin
           $OutBuf .= "<label for='" . $row['variablename'] .
             "'>" . $row['description'] . "</label>";
           break;
+        case CONFIG_TYPE_CHECKLIST:
+          $ConfVal = $row['conf_value'];
+          $selectedIds = array_map('trim', explode(',', $ConfVal));
+          $Options = explode("|", $row['option_value']);
+          $OutBuf .= "<div id='" . $row['variablename'] . "Div' style='display:inline-block; padding:5px;'>";
+          foreach ($Options as $Option) {
+            $matches = array();
+            preg_match('/([ \\w]+)\\{(.*)\\}/', $Option, $matches);
+            $Option_display = $matches[1];
+            $Option_value = $matches[2];
+            $isChecked = in_array($Option_value, $selectedIds) ? "checked" : "";
+            $OutBuf .= "<label style='margin-right:15px;'>";
+            $OutBuf .= "<input type='checkbox' name='new[" . $row['variablename'] . "][]' " .
+              "value='$Option_value' $isChecked /> $Option_display";
+            $OutBuf .= "</label>";
+          }
+          $OutBuf .= "</div>";
+          $OutBuf .= "<br>$row[description]";
+          break;
         default:
           $OutBuf .= "Invalid configuration variable. Unknown type.";
       }
@@ -116,6 +135,23 @@ class foconfig extends FO_Plugin
     $btnlabel = _("Update");
     $OutBuf .= "<p><input type='submit' value='$btnlabel'>";
     $OutBuf .= "</form>";
+
+    $OutBuf .= "<script>
+      (function () {
+        var autoDetect = document.getElementById('ReuserAutoDetect');
+        var statusDiv = document.getElementById('ReuserSearchStatusDiv');
+        if (!autoDetect || !statusDiv) {
+          return;
+        }
+        var toggle = function () {
+          var greyed = !autoDetect.checked;
+          statusDiv.style.opacity = greyed ? '0.4' : '1';
+          statusDiv.style.pointerEvents = greyed ? 'none' : 'auto';
+        };
+        autoDetect.addEventListener('change', toggle);
+        toggle();
+      })();
+    </script>";
 
     return $OutBuf;
   }
@@ -136,12 +172,25 @@ class foconfig extends FO_Plugin
       // Get missing keys from new array (unchecked checkboxes are not sent)
       $boolFalseArray = array_diff_key($oldarray, $newarray);
       foreach ($boolFalseArray as $varname => $value) {
-        // Make sure it was boolean data
+        // Make sure it was boolean or checklist data
         $isBoolean = $this->dbManager->getSingleRow("SELECT 1 FROM sysconfig " .
           "WHERE variablename = $1 AND vartype = " . CONFIG_TYPE_BOOL,
           array($varname), __METHOD__ . '.checkIfBool');
         if (! empty($isBoolean)) {
           $newarray[$varname] = 'false';
+          continue;
+        }
+        $isChecklist = $this->dbManager->getSingleRow("SELECT 1 FROM sysconfig " .
+          "WHERE variablename = $1 AND vartype = " . CONFIG_TYPE_CHECKLIST,
+          array($varname), __METHOD__ . '.checkIfChecklist');
+        if (! empty($isChecklist)) {
+          $newarray[$varname] = '';
+        }
+      }
+      // Normalize checklist arrays to comma-separated strings
+      foreach ($newarray as $varname => $value) {
+        if (is_array($value)) {
+          $newarray[$varname] = implode(',', $value);
         }
       }
     }

--- a/src/www/ui/admin-config.php
+++ b/src/www/ui/admin-config.php
@@ -104,6 +104,25 @@ class foconfig extends FO_Plugin
           $OutBuf .= "<label for='" . $row['variablename'] .
             "'>" . $row['description'] . "</label>";
           break;
+        case CONFIG_TYPE_CHECKLIST:
+          $ConfVal = $row['conf_value'];
+          $selectedIds = array_map('trim', explode(',', $ConfVal));
+          $Options = explode("|", $row['option_value']);
+          $OutBuf .= "<div style='display:inline-block; padding:5px;'>";
+          foreach ($Options as $Option) {
+            $matches = array();
+            preg_match('/([ \\w]+)[{​​​​](.*)[}​​​​]/', $Option, $matches);
+            $Option_display = $matches[1];
+            $Option_value = $matches[2];
+            $isChecked = in_array($Option_value, $selectedIds) ? "checked" : "";
+            $OutBuf .= "<label style='margin-right:15px;'>";
+            $OutBuf .= "<input type='checkbox' name='new[" . $row['variablename'] . "][]' " .
+              "value='$Option_value' $isChecked /> $Option_display";
+            $OutBuf .= "</label>";
+          }
+          $OutBuf .= "</div>";
+          $OutBuf .= "<br>$row[description]";
+          break;
         default:
           $OutBuf .= "Invalid configuration variable. Unknown type.";
       }
@@ -136,12 +155,25 @@ class foconfig extends FO_Plugin
       // Get missing keys from new array (unchecked checkboxes are not sent)
       $boolFalseArray = array_diff_key($oldarray, $newarray);
       foreach ($boolFalseArray as $varname => $value) {
-        // Make sure it was boolean data
+        // Make sure it was boolean or checklist data
         $isBoolean = $this->dbManager->getSingleRow("SELECT 1 FROM sysconfig " .
           "WHERE variablename = $1 AND vartype = " . CONFIG_TYPE_BOOL,
           array($varname), __METHOD__ . '.checkIfBool');
         if (! empty($isBoolean)) {
           $newarray[$varname] = 'false';
+          continue;
+        }
+        $isChecklist = $this->dbManager->getSingleRow("SELECT 1 FROM sysconfig " .
+          "WHERE variablename = $1 AND vartype = " . CONFIG_TYPE_CHECKLIST,
+          array($varname), __METHOD__ . '.checkIfChecklist');
+        if (! empty($isChecklist)) {
+          $newarray[$varname] = '';
+        }
+      }
+      // Normalize checklist arrays to comma-separated strings
+      foreach ($newarray as $varname => $value) {
+        if (is_array($value)) {
+          $newarray[$varname] = implode(',', $value);
         }
       }
     }

--- a/src/www/ui/api/Models/Reuser.php
+++ b/src/www/ui/api/Models/Reuser.php
@@ -267,21 +267,21 @@ class Reuser
   {
     if ($version == ApiVersion::V2) {
       return [
-        "reuseUpload"    => $this->reuseUpload,
-        "reuseGroup"     => $this->reuseGroup,
-        "reuseMain"      => $this->reuseMain,
-        "reuseEnhanced"  => $this->reuseEnhanced,
-        "reuseReport"    => $this->reuseReport,
-        "reuseCopyright" => $this->reuseCopyright
+        "reuseUpload"     => $this->reuseUpload,
+        "reuseGroup"      => $this->reuseGroup,
+        "reuseMain"       => $this->reuseMain,
+        "reuseEnhanced"   => $this->reuseEnhanced,
+        "reuseReport"     => $this->reuseReport,
+        "reuseCopyright"  => $this->reuseCopyright
       ];
     } else {
       return [
-        "reuse_upload"    => $this->reuseUpload,
-        "reuse_group"     => $this->reuseGroup,
-        "reuse_main"      => $this->reuseMain,
-        "reuse_enhanced"  => $this->reuseEnhanced,
-        "reuse_report"    => $this->reuseReport,
-        "reuse_copyright" => $this->reuseCopyright
+        "reuse_upload"     => $this->reuseUpload,
+        "reuse_group"      => $this->reuseGroup,
+        "reuse_main"       => $this->reuseMain,
+        "reuse_enhanced"   => $this->reuseEnhanced,
+        "reuse_report"     => $this->reuseReport,
+        "reuse_copyright"  => $this->reuseCopyright
       ];
     }
   }

--- a/src/www/ui/api/Models/Reuser.php
+++ b/src/www/ui/api/Models/Reuser.php
@@ -114,7 +114,7 @@ class Reuser
     if (array_key_exists(($version == ApiVersion::V2? "reuseCopyright" : "reuse_copyright"), $reuserArray)) {
       $this->setReuseCopyright($reuserArray[$version == ApiVersion::V2? "reuseCopyright" : "reuse_copyright"]);
     }
-    if ($this->reuseUpload === null || (is_array($this->reuseUpload) && empty($this->reuseUpload))) {
+    if ($this->reuseUpload === null) {
       throw new \UnexpectedValueException(
         "reuse_upload should be integer or array of integers", 400);
     }
@@ -267,21 +267,21 @@ class Reuser
   {
     if ($version == ApiVersion::V2) {
       return [
-        "reuseUpload"    => $this->reuseUpload,
-        "reuseGroup"     => $this->reuseGroup,
-        "reuseMain"      => $this->reuseMain,
-        "reuseEnhanced"  => $this->reuseEnhanced,
-        "reuseReport"    => $this->reuseReport,
-        "reuseCopyright" => $this->reuseCopyright
+        "reuseUpload"     => $this->reuseUpload,
+        "reuseGroup"      => $this->reuseGroup,
+        "reuseMain"       => $this->reuseMain,
+        "reuseEnhanced"   => $this->reuseEnhanced,
+        "reuseReport"     => $this->reuseReport,
+        "reuseCopyright"  => $this->reuseCopyright
       ];
     } else {
       return [
-        "reuse_upload"    => $this->reuseUpload,
-        "reuse_group"     => $this->reuseGroup,
-        "reuse_main"      => $this->reuseMain,
-        "reuse_enhanced"  => $this->reuseEnhanced,
-        "reuse_report"    => $this->reuseReport,
-        "reuse_copyright" => $this->reuseCopyright
+        "reuse_upload"     => $this->reuseUpload,
+        "reuse_group"      => $this->reuseGroup,
+        "reuse_main"       => $this->reuseMain,
+        "reuse_enhanced"   => $this->reuseEnhanced,
+        "reuse_report"     => $this->reuseReport,
+        "reuse_copyright"  => $this->reuseCopyright
       ];
     }
   }

--- a/src/www/ui/api/Models/ScanOptions.php
+++ b/src/www/ui/api/Models/ScanOptions.php
@@ -195,7 +195,7 @@ class ScanOptions
     $reuseUploads = array_filter($reuseUploads, function ($id) {
       return $id > 0;
     });
-    if (empty($reuseUploads)) {
+    if (empty($reuseUploads) && $this->reuse->getAutoSelectReuse() !== true) {
       return;
     }
     foreach ($reuseUploads as $reuseUploadId) {
@@ -216,6 +216,8 @@ class ScanOptions
     if ($this->reuse->getReuseCopyright() === true) {
       $reuserRules[] = 'reuseCopyright';
     }
+    $request->request->set('reuseMode', $reuserRules);
+
     $userDao = $GLOBALS['container']->get("dao.user");
     $groupId = $userDao->getGroupIdByName($this->reuse->getReuseGroup());
     $reuserSelectors = [];
@@ -224,10 +226,9 @@ class ScanOptions
     }
     if (count($reuserSelectors) === 1) {
       $request->request->set('uploadToReuse', $reuserSelectors[0]);
-    } else {
+    } elseif (count($reuserSelectors) > 1) {
       $request->request->set('uploadToReuse', $reuserSelectors);
     }
-    $request->request->set('reuseMode', $reuserRules);
   }
 
   /**

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -5913,9 +5913,10 @@ components:
               items:
                 type: integer
           description: The UploadID(s) to reuse. Single integer or array of integers.
+          example: 42
         reuse_group:
           type: string
-          description: The group of the reused upload
+          description: The group of the reused upload.
         reuse_main:
           type: boolean
           description: Copy the main license from reused package?

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -6176,7 +6176,7 @@ components:
           description: The UploadID(s) to reuse. Single integer or array of integers.
         reuseGroup:
           type: string
-          description: The group of the reused upload
+          description: The group of the reused upload.
         reuseMain:
           type: boolean
           description: Copy the main license from reused package?

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -5809,7 +5809,7 @@ components:
           description: The UploadID(s) to reuse. Single integer or array of integers.
         reuseGroup:
           type: string
-          description: The group of the reused upload
+          description: The group of the reused upload.
         reuseMain:
           type: boolean
           description: Copy the main license from reused package?

--- a/src/www/ui/template/upload_file.html.twig
+++ b/src/www/ui/template/upload_file.html.twig
@@ -182,6 +182,7 @@ function updateReuseIds(index, name, element, navContentDom) {
     element.find("label[for='reuseFolderSelectorName']").attr('for', `reuseFolderSelectorName${index}`);
     element.find("#uploadToReuse").attr('id', `uploadToReuse${index}`);
     element.find("label[for='uploadToReuse']").attr('for', `uploadToReuse${index}`);
+    element.find("#auto-detect-loading").attr('id', `auto-detect-loading${index}`);
     
     element.find("#osselot-download-report").attr("id", `osselot-download-report${index}`);
     element.find("#osselot-download-confirm").attr("id", `osselot-download-confirm${index}`);
@@ -468,6 +469,21 @@ $(document).ready(function() {
     });
     $('#reuseModal').on('shown.bs.modal', function () {
       $(this).find('[data-toggle="tooltip"]').tooltip();
+      const $activeTab = $('#reuse-name-tab').find('.nav-link.active');
+      if ($activeTab.length > 0) {
+        const tabId = $activeTab.attr('id');
+        const match = tabId && tabId.match(/reuse-name-(\d+)/);
+        if (match) {
+          runAutoDetect(match[1]);
+        }
+      }
+    });
+    $(document).on('shown.bs.tab', '#reuse-name-tab .nav-link', function () {
+      const tabId = $(this).attr('id');
+      const match = tabId && tabId.match(/reuse-name-(\d+)/);
+      if (match) {
+        runAutoDetect(match[1]);
+      }
     });
 });
   </script>

--- a/src/www/ui_tests/api/Models/ReuserTest.php
+++ b/src/www/ui_tests/api/Models/ReuserTest.php
@@ -41,12 +41,12 @@ class ReuserTest extends \PHPUnit\Framework\TestCase
   public function testReuserConst()
   {
     $expectedArray = [
-      "reuse_upload"   => 2,
-      "reuse_group"    => 'fossy',
-      "reuse_main"     => true,
-      "reuse_enhanced" => false,
-      "reuse_copyright" => false,
-      "reuse_report"   => false
+      "reuse_upload"     => 2,
+      "reuse_group"      => 'fossy',
+      "reuse_main"       => true,
+      "reuse_enhanced"   => false,
+      "reuse_copyright"  => false,
+      "reuse_report"     => false
     ];
 
     $actualReuser = new Reuser(2, 'fossy', true);
@@ -73,12 +73,12 @@ class ReuserTest extends \PHPUnit\Framework\TestCase
   public function testReuserMultipleUploads()
   {
     $expectedArray = [
-      "reuse_upload"   => [2, 5, 10],
-      "reuse_group"    => 'fossy',
-      "reuse_main"     => true,
-      "reuse_enhanced" => false,
+      "reuse_upload"    => [2, 5, 10],
+      "reuse_group"     => 'fossy',
+      "reuse_main"      => true,
+      "reuse_enhanced"  => false,
       "reuse_copyright" => false,
-      "reuse_report"   => false
+      "reuse_report"    => false
     ];
 
     $actualReuser = new Reuser([2, 5, 10], 'fossy', true);
@@ -148,21 +148,21 @@ class ReuserTest extends \PHPUnit\Framework\TestCase
   {
     if ($version == ApiVersion::V1) {
       $expectedArray = [
-        "reuse_upload"   => 2,
-        "reuse_group"    => 'fossy',
-        "reuse_main"     => 'true',
-        "reuse_enhanced" => false,
-        "reuse_copyright" => false,
-        "reuse_report"   => false
+        "reuse_upload"     => 2,
+        "reuse_group"      => 'fossy',
+        "reuse_main"       => 'true',
+        "reuse_enhanced"   => false,
+        "reuse_copyright"  => false,
+        "reuse_report"     => false
       ];
     } else {
       $expectedArray = [
-        "reuseUpload"   => 2,
-        "reuseGroup"    => 'fossy',
-        "reuseMain"     => 'true',
-        "reuseEnhanced" => false,
-        "reuseCopyright" => false,
-        "reuseReport"   => false
+        "reuseUpload"     => 2,
+        "reuseGroup"      => 'fossy',
+        "reuseMain"       => 'true',
+        "reuseEnhanced"   => false,
+        "reuseCopyright"  => false,
+        "reuseReport"     => false
       ];
     }
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Introduce an **_Auto Select_** for Reuse option in Reuser Configuration that automatically discovers and selects the most suitable previously cleared upload for reuse. The feature searches for reusable uploads using package name matching and PFile overlap analysis before job(reuser) scheduling, then executes the existing reuse workflow without requiring manual upload selection.

<Details>
<summary> Primary Search </summary>

# Primary Search: Matching Uploaded Components to Cleared Uploads

## Step 1 — Extract Base Package Name

Strip the version suffix from the uploaded package name.

| Uploaded Package | Base Package Name |
|-----------------|-------------------|
| `zlib-1.2.10` | `zlib` |

---

## Step 2 — Search for Matching Uploads

Matches are attempted in order, stopping as soon as candidates are found:

| Priority | Match Type | Example |
|----------|------------|---------|
| 1 | **Exact match** | `zlib` → `zlib` |
| 2 | **Case-insensitive exact** | `ZLIB` → `zlib` |
| 3 | **Prefix match** | `zlib` → `zlib-ng` |
| 4 | **ILIKE fallback** | `%zlib%` (partial string) |

---

## Step 3 — Apply Search Priority

Within each match type, candidates are ranked by uploader relationship:

1. Same uploader
2. Same group(s)
3. Any accessible upload

> **Example:** If `zlib` matches Uploads A (same uploader), B (same group), and C (accessible) — only Upload A is considered.

---

## Step 4 — Resolve Ties

If multiple uploads share the same match type and priority level, the **most recently cleared** upload wins.

| Upload | Last Cleared |
|--------|-------------|
| Upload A | Jan 10 |
| Upload B | Feb 15 ✓ |

Upload B is selected.
</Details>

<Details>
<summary> Secondary Search </summary>

# Secondary Search: PFile Overlap Search

> Only executed if the **primary search** finds no suitable upload.
> Instead of comparing package names, it compares actual upload contents via PFiles.

---

## Step 1 — Identify Candidate Uploads

Gather all previously cleared uploads available for reuse.

---

## Step 2 — Calculate PFile Overlap

Compare the uploaded component's PFiles against each candidate's PFiles.

**Current Upload PFiles:** `a.c`, `b.c`, `c.c`, `d.c`

| Candidate | Matching PFiles | Overlap Score |
|-----------|----------------|---------------|
| Upload A | `a.c`, `b.c`, `c.c` | 3 |
| Upload B | `a.c`, `b.c`, `c.c`, `d.c` | 4 |
| Upload C | `a.c` | 1 |

---

## Step 3 — Select Highest Overlap

The candidate with the highest overlap score is selected.

> **Example:** Upload B scores 4 — the highest — and is selected.

---

## Step 4 — Resolve Ties

If multiple candidates share the same overlap score, select the **most recently cleared** upload.

| Upload | Overlap | Last Cleared |
|--------|---------|-------------|
| Upload A | 10 | Jan 20 |
| Upload B | 10 | Mar 05 ✓ |

Upload B is selected.
</Details>

> **Note**
>
> Both the primary and secondary searches only consider candidate uploads whose clearing status is **Closed**.
> There is a limit of a maximum of 50 to consider as candidate uploads in the secondary search.

Part of issue: #3631 

### Testing

<Details>
<summary> Primary Search </summary>

https://github.com/user-attachments/assets/6ab82d98-ecf4-4486-8240-10a74d588257


</Details>

<Details>
<summary> Secondary Search </summary>

<img width="1423" height="593" alt="Screenshot 2026-06-12 230347" src="https://github.com/user-attachments/assets/f8262ca3-892b-4677-b234-8bb27842d6f5" />
<img width="1424" height="466" alt="Screenshot 2026-06-12 230357" src="https://github.com/user-attachments/assets/404f32be-f294-420a-aa97-cd68f898acec" />
<img width="1416" height="595" alt="Screenshot 2026-06-12 230320" src="https://github.com/user-attachments/assets/978ecb15-b88e-444a-aab6-87c186ffdb1b" />
<img width="1424" height="512" alt="Screenshot 2026-06-12 230335" src="https://github.com/user-attachments/assets/4546da6b-bed8-44fd-925d-5554fbbe8572" />

Performed the **reuse** analysis on `wild.zip` and since `cigar.zip` had **_7 pfle_** in common, it was selected by **_auto select_** :

<img width="1334" height="213" alt="Screenshot 2026-06-13 003636" src="https://github.com/user-attachments/assets/526dea7d-fa9c-4e58-a20e-636f70de0a52" />


</Details>

<Details>
<summary> REST api </summary>

<img width="619" height="316" alt="Screenshot 2026-06-12 213431" src="https://github.com/user-attachments/assets/ba2a8c96-89ea-47ae-85c0-57ff0e487779" />
<img width="610" height="294" alt="Screenshot 2026-06-12 183227" src="https://github.com/user-attachments/assets/ad83fef9-3f00-47ec-8e91-bc2d2d269892" />
</Details>

cc: @shaheemazmalmmd @Kaushl2208 