### PR TITLE
fix(reuser): check upload accessibility before scheduling reuse

### DIFF
--- a/src/www/ui/api/Models/ScanOptions.php
+++ b/src/www/ui/api/Models/ScanOptions.php
@@ -185,9 +185,13 @@ class ScanOptions
    */
   private function prepareReuser(Request &$request)
   {
-    if ($this->reuse->getReuseUpload() == 0) {
+    $reuseUploadId = $this->reuse->getReuseUpload();
+    if ($reuseUploadId == 0) {
       // No upload to reuse
       return;
+    }
+    if (!$GLOBALS['container']->get("dao.upload")->isAccessible($reuseUploadId, Auth::getGroupId())) {
+      throw new HttpForbiddenException("Upload $reuseUploadId is not accessible for reuse");
     }
     $reuserRules = [];
     if ($this->reuse->getReuseMain() === true) {

--- a/src/www/ui_tests/api/Models/ScanOptionsTest.php
+++ b/src/www/ui_tests/api/Models/ScanOptionsTest.php
@@ -18,6 +18,7 @@ namespace Fossology\UI\Api\Test\Models
   use Fossology\UI\Api\Models\Reuser;
   use Fossology\UI\Api\Models\Decider;
   use Fossology\UI\Api\Models\Scancode;
+  use Fossology\Lib\Dao\UploadDao;
   use Fossology\Lib\Dao\UserDao;
   use Fossology\Lib\Auth\Auth;
   use Symfony\Component\HttpFoundation\Request;
@@ -57,8 +58,13 @@ namespace Fossology\UI\Api\Test\Models
       $container = M::mock('ContainerBuilder');
       $this->agentAdderMock = M::mock('overload:\AgentAdder');
       $this->userDao = M::mock(UserDao::class);
+      $uploadDao = M::mock(UploadDao::class);
+      $uploadDao->shouldReceive('isAccessible')->andReturn(true);
+      $container->shouldReceive('get')->withArgs(["dao.upload"])
+        ->andReturn($uploadDao);
       $container->shouldReceive('get')->withArgs(["dao.user"])
         ->andReturn($this->userDao);
+      $GLOBALS['SysConf']['auth'][Auth::GROUP_ID] = 2;
       $container->shouldReceive('get')->andReturn(null);
 
       self::$functions = M::mock(\stdClass::class);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description
Added authorisation check for the reused upload in `ScanOptions::prepareReuser()` to prevent users from reusing uploads they don't have access to via the **_REST API_**. The UI path already has permission filtering via the reuser plugin's `getFolderUploads() / getAllUploadsForGroup()` when populating the dropdown, so only the REST API path needed this server-side check.

### Changes:
- Added `isAccessible()` call on the reused upload in `prepareReuser()`, throwing `HttpForbiddenException (403)` if the user's group lacks access

### Screenshots

<Details>
<summary>Before</summary>
<img width="621" height="272" alt="Screenshot 2026-06-16 085209" src="https://github.com/user-attachments/assets/26be8700-12df-4554-8766-e5021a5075d3" />
</Details>

<Details>
<summary>After</summary>
<img width="774" height="274" alt="Screenshot 2026-06-16 094529" src="https://github.com/user-attachments/assets/262c5842-003c-4e34-acaa-0b8c5ecb4dfb" />
</Details>
