### PR TITLE
fix(security): remove some eval() / escape request URIs

### DIFF
--- a/install/fo_dbcheck.php
+++ b/install/fo_dbcheck.php
@@ -29,6 +29,24 @@ $DatabaseName = "fossology";
 $UpdateLiceneseRef = false;
 $sysconfdir = '';
 
+
+/**
+ * Resolve simple $VAR and ${VAR} placeholders against already-known values.
+ *
+ * @param string $value The raw config value.
+ * @param array $scope Previously resolved values.
+ * @return string
+ */
+if (!function_exists('resolve_config_value')) {
+  function resolve_config_value($value, array $scope)
+  {
+    return preg_replace_callback('/\$(?:([A-Za-z_][A-Za-z0-9_]*)|\{([A-Za-z_][A-Za-z0-9_]*)\})/', static function ($matches) use ($scope) {
+      $name = !empty($matches[1]) ? $matches[1] : $matches[2];
+      return array_key_exists($name, $scope) ? $scope[$name] : $matches[0];
+    }, $value);
+  }
+}
+
 /* command-line options */
 $Options = getopt($AllPossibleOpts);
 foreach($Options as $Option => $OptVal)
@@ -146,17 +164,16 @@ function bootstrap($sysconfdir="")
    * For example, if PREFIX=/usr/local and BINDIR=$PREFIX/bin, we
    * want BINDIR=/usr/local/bin
    */
+  $resolvedValues = array();
   foreach($SysConf['DIRECTORIES'] as $var=>$assign)
   {
-    /* Evaluate the individual variables because they may be referenced
-     * in subsequent assignments. 
-     */
-    $toeval = "\$$var = \"$assign\";";
-    eval($toeval);
+    $resolvedValue = resolve_config_value($assign, $resolvedValues);
+    $resolvedValues[$var] = $resolvedValue;
 
     /* now reassign the array value with the evaluated result */
-    $SysConf['DIRECTORIES'][$var] = ${$var};
-    $GLOBALS[$var] = ${$var};
+    $SysConf['DIRECTORIES'][$var] = $resolvedValue;
+    ${$var} = $resolvedValue;
+    $GLOBALS[$var] = $resolvedValue;
   }
 
   if (empty($MODDIR))

--- a/install/fossinit-common.php
+++ b/install/fossinit-common.php
@@ -12,6 +12,24 @@
  */
 
 
+/**
+ * Resolve simple $VAR and ${VAR} placeholders against already-known values.
+ *
+ * @param string $value The raw config value.
+ * @param array $scope Previously resolved values.
+ * @return string
+ */
+if (!function_exists('resolve_config_value')) {
+  function resolve_config_value($value, array $scope)
+  {
+    return preg_replace_callback('/\$(?:([A-Za-z_][A-Za-z0-9_]*)|\{([A-Za-z_][A-Za-z0-9_]*)\})/', static function ($matches) use ($scope) {
+      $name = !empty($matches[1]) ? $matches[1] : $matches[2];
+      return array_key_exists($name, $scope) ? $scope[$name] : $matches[0];
+    }, $value);
+  }
+}
+
+
 function guessSysconfdir()
 {
   $rcfile = "fossology.rc";
@@ -86,14 +104,16 @@ function bootstrap($sysconfdir="")
    * For example, if PREFIX=/usr/local and BINDIR=$PREFIX/bin, we
    * want BINDIR=/usr/local/bin
    */
+  $resolvedValues = array();
   foreach($SysConf['DIRECTORIES'] as $var=>$assign)
   {
-    $toeval = "\$$var = \"$assign\";";
-    eval($toeval);
+    $resolvedValue = resolve_config_value($assign, $resolvedValues);
+    $resolvedValues[$var] = $resolvedValue;
 
     /* now reassign the array value with the evaluated result */
-    $SysConf['DIRECTORIES'][$var] = ${$var};
-    $GLOBALS[$var] = ${$var};
+    $SysConf['DIRECTORIES'][$var] = $resolvedValue;
+    ${$var} = $resolvedValue;
+    $GLOBALS[$var] = $resolvedValue;
   }
 
   if (empty($MODDIR))

--- a/src/buckets/ui/bucket-diff.php
+++ b/src/buckets/ui/bucket-diff.php
@@ -672,7 +672,8 @@ return;
     {
       $text = _("cached");
       $text1 = _("Update");
-      echo " <i>$text</i>   <a href=\"$_SERVER[REQUEST_URI]&updcache=1\"> $text1 </a>";
+      $updateUri = $_SERVER['REQUEST_URI'] . '&updcache=1';
+      echo " <i>$text</i>   <a href=\"" . htmlspecialchars($updateUri, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . "\"> $text1 </a>";
     }
     else if ($Time > 0.5)
     {

--- a/src/buckets/ui/ui-buckets.php
+++ b/src/buckets/ui/ui-buckets.php
@@ -583,7 +583,8 @@ return;
     if ($Cached){
       $text = _("cached");
       $text1 = _("Update");
-      echo " <i>$text</i>   <a href=\"$_SERVER[REQUEST_URI]&updcache=1\"> $text1 </a>";
+      $updateUri = $_SERVER['REQUEST_URI'] . '&updcache=1';
+      $V .= " <i>$text</i>   <a href=\"" . htmlspecialchars($updateUri, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . "\"> $text1 </a>";
     }
     else if ($Time > 0.5)
     {

--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -28,6 +28,24 @@ define("CONFIG_TYPE_BOOL", 6);
 
 
 /**
+ * Resolve simple $VAR and ${VAR} placeholders against already-known values.
+ *
+ * @param string $value The raw config value.
+ * @param array $scope Previously resolved values.
+ * @return string
+ */
+if (!function_exists('resolve_sysconfig_value')) {
+  function resolve_sysconfig_value($value, array $scope)
+  {
+    return preg_replace_callback('/\$(?:([A-Za-z_][A-Za-z0-9_]*)|\{([A-Za-z_][A-Za-z0-9_]*)\})/', static function ($matches) use ($scope) {
+      $name = !empty($matches[1]) ? $matches[1] : $matches[2];
+      return array_key_exists($name, $scope) ? $scope[$name] : $matches[0];
+    }, $value);
+  }
+}
+
+
+/**
  * \brief Initialize the fossology system after bootstrap().
  *
  * This function also opens a database connection (global PG_CONN).
@@ -87,16 +105,18 @@ function get_pg_conn($sysconfdir, &$SysConf, $exitOnDbFail=true)
   /*************  Parse VERSION *******************/
   $versionFile = "{$sysconfdir}/VERSION";
   $versionConf = parse_ini_file($versionFile, true);
+  $resolvedValues = array();
 
-  /* Add this file contents to $SysConf, then destroy $VersionConf
-   * This file can define its own groups and is eval'd.
+  /* Add this file contents to $SysConf, then destroy $VersionConf.
+   * This file can define its own groups and uses simple placeholder expansion.
    */
   foreach ($versionConf as $groupName => $groupArray) {
     foreach ($groupArray as $var => $assign) {
-      $toeval = "\$$var = \"$assign\";";
-      eval($toeval);
-      $SysConf[$groupName][$var] = ${$var};
-      $GLOBALS[$var] = ${$var};
+      $resolvedValue = resolve_sysconfig_value($assign, $resolvedValues);
+      $resolvedValues[$var] = $resolvedValue;
+      $SysConf[$groupName][$var] = $resolvedValue;
+      ${$var} = $resolvedValue;
+      $GLOBALS[$var] = $resolvedValue;
     }
   }
   unset($versionConf);


### PR DESCRIPTION
## Description

* Safely resolve placeholders in configuration values using known values, replacing the previous use of `eval()`:
 `install/fo_dbcheck.php` > resolve_config_value()
 `install/fossinit-common.php` > resolve_config_value()
 `src/lib/php/common-sysconfig.php` > resolve_sysconfig_value()

* Updated the `bootstrap` and `get_pg_conn` functions to use the new resolver functions for configuration variable assignment

* Escape URLs with `htmlspecialchars` before outputting them in links, preventing potential XSS vulnerabilities:
`src/buckets/ui/bucket-diff.php`
`src/buckets/ui/ui-buckets.php` 


## Note

The resolver functions are more-or-less code duplication with the 3 time usage in different files. Shall I instead create helper for that in "src/lib/php/"? Like "sysconfig-placeholder.php" or so?
