### PR TITLE
fix(security): remove eval and escape URI output

### DIFF
--- a/install/db/migratetest.php
+++ b/install/db/migratetest.php
@@ -122,17 +122,26 @@ function bootstrap($sysconfdir="")
    * For example, if PREFIX=/usr/local and BINDIR=$PREFIX/bin, we
    * want BINDIR=/usr/local/bin
    */
+  $resolvedDirectories = array();
   foreach($SysConf['DIRECTORIES'] as $var=>$assign)
   {
-    /* Evaluate the individual variables because they may be referenced
-     * in subsequent assignments.
+    /* Resolve only previously expanded directory variables.
+     * This keeps config substitution behavior without executing PHP code.
      */
-    $toeval = "\$$var = \"$assign\";";
-    eval($toeval);
+    $value = $assign;
+    $previousValue = null;
+    $iterations = 0;
+    while ($value !== $previousValue && $iterations < 10)
+    {
+      $previousValue = $value;
+      $value = strtr($value, $resolvedDirectories);
+      $iterations++;
+    }
 
-    /* now reassign the array value with the evaluated result */
-    $SysConf['DIRECTORIES'][$var] = ${$var};
-    $GLOBALS[$var] = ${$var};
+    /* now reassign the array value with the resolved result */
+    $SysConf['DIRECTORIES'][$var] = $value;
+    $resolvedDirectories['$' . $var] = $value;
+    $GLOBALS[$var] = $value;
   }
 
   if (empty($MODDIR))

--- a/src/demomod/ui/demomod.php
+++ b/src/demomod/ui/demomod.php
@@ -216,7 +216,15 @@ class ui_demomod extends FO_Plugin
     {
       $text = _("cached");
       $text1 = _("Update");
-      echo " <i>$text</i>   <a href=\"$_SERVER[REQUEST_URI]&updcache=1\"> $text1 </a>";
+      $separator = strpos($_SERVER['REQUEST_URI'], '?') === false ? '?' : '&';
+      $updateHref = htmlspecialchars(
+        $_SERVER['REQUEST_URI'] . $separator . 'updcache=1',
+        ENT_QUOTES | ENT_SUBSTITUTE,
+        'UTF-8'
+      );
+      echo ' <i>' . htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') .
+        '</i>   <a href="' . $updateHref . '"> ' .
+        htmlspecialchars($text1, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . ' </a>';
     }
     else
     {

--- a/src/nomos/ui/nomos-diff.php
+++ b/src/nomos/ui/nomos-diff.php
@@ -817,7 +817,15 @@ JSOUT;
     if ($Cached) {
       $text = _("cached");
       $text1 = _("Update");
-      echo " <i>$text</i>   <a href=\"$_SERVER[REQUEST_URI]&updcache=1\"> $text1 </a>";
+      $separator = strpos($_SERVER['REQUEST_URI'], '?') === false ? '?' : '&';
+      $updateHref = htmlspecialchars(
+        $_SERVER['REQUEST_URI'] . $separator . 'updcache=1',
+        ENT_QUOTES | ENT_SUBSTITUTE,
+        'UTF-8'
+      );
+      echo ' <i>' . htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') .
+        '</i>   <a href="' . $updateHref . '"> ' .
+        htmlspecialchars($text1, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . ' </a>';
     } else {
       // Cache Report if this took longer than 1/2 second
       if ($Time > 0.5) {


### PR DESCRIPTION
## Description

* This change replaces the eval-based configuration handling in `install/db/migratetest.php`

* Reflected HTML output is secured with proper escaping in:
 `src/demomod/ui/demomod.php`
 `src/nomos/ui/nomos-diff.php`


