### PR TITLE
feat(monk): normalize 4-digit year and punctuation tokens,

### DIFF
--- a/src/decider/agent/BulkReuser.php
+++ b/src/decider/agent/BulkReuser.php
@@ -78,7 +78,7 @@ class BulkReuser
       }
       $dependecies = array();
       $sql = "INSERT INTO license_ref_bulk (user_fk,group_fk,rf_text,upload_fk,uploadtree_fk,ignore_irrelevant,bulk_delimiters,scan_findings) "
-              . "SELECT $1 AS user_fk, $2 AS group_fk,rf_text,$3 AS upload_fk, $4 as uploadtree_fk, ignore_irrelevant, bulk_delimiters, scan_findings
+              . "SELECT $1 AS user_fk, $2 AS group_fk,rf_text,$3 AS upload_fk, $4 as uploadtree_fk, ignore_irrelevant, NULL, scan_findings
                 FROM license_ref_bulk WHERE lrb_pk=$5 RETURNING lrb_pk, $5 as lrb_origin";
       $sqlLic = "INSERT INTO license_set_bulk (lrb_fk, rf_fk, removing, comment, reportinfo, acknowledgement) "
               ."SELECT $1 as lrb_fk, rf_fk, removing, comment, reportinfo, acknowledgement FROM license_set_bulk WHERE lrb_fk=$2";

--- a/src/decisionimporter/agent/DecisionImporterDataCreator.php
+++ b/src/decisionimporter/agent/DecisionImporterDataCreator.php
@@ -457,7 +457,7 @@ class DecisionImporterDataCreator
 
       $newLrbId = $this->licenseDao->insertBulkLicense($this->userId, $this->groupId, $parentItem, $licenseRemovals,
         $licenseRefBulkItem["rf_text"], $licenseRefBulkItem["ignore_irrelevant"],
-        $licenseRefBulkItem["bulk_delimiters"], $licenseRefBulkItem["scan_findings"]);
+        $licenseRefBulkItem["scan_findings"]);
       $licenseRefBulkList[$oldId]["new_lrbid"] = $newLrbId;
       $jobId = $this->createMonkBulkJobs($newLrbId);
       $clearingEventList[$oldEventId]["new_lrbid"] = $newLrbId;

--- a/src/lib/php/Dao/LicenseDao.php
+++ b/src/lib/php/Dao/LicenseDao.php
@@ -570,24 +570,17 @@ ORDER BY lft asc
    * @param string $refText
    * @param bool $ignoreIrrelevant Ignore irrelevant files while scanning
    * @param bool $scanOnlyFindings scan the files with license findings only
-   * @param string $delimiters Delimiters for bulk scan,
-   *                           null or "DEFAULT" for default values
    * @return int lrp_pk on success or -1 on fail
    */
-  public function insertBulkLicense($userId, $groupId, $uploadTreeId, $licenseRemovals, $refText, $ignoreIrrelevant=true, $delimiters=null, $scanFindingsOnly=false)
+  public function insertBulkLicense($userId, $groupId, $uploadTreeId, $licenseRemovals, $refText, $ignoreIrrelevant=true, $scanFindingsOnly=false)
   {
-    if (strcasecmp($delimiters, "DEFAULT") === 0) {
-      $delimiters = null;
-    } elseif ($delimiters !== null) {
-      $delimiters = StringOperation::replaceUnicodeControlChar($delimiters);
-    }
     $licenseRefBulkIdResult = $this->dbManager->getSingleRow(
         "INSERT INTO license_ref_bulk (user_fk, group_fk, uploadtree_fk, rf_text, ignore_irrelevant, bulk_delimiters, scan_findings)
       VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING lrb_pk",
         array($userId, $groupId, $uploadTreeId,
           StringOperation::replaceUnicodeControlChar($refText),
           $this->dbManager->booleanToDb($ignoreIrrelevant),
-          $delimiters,
+          null,
           $this->dbManager->booleanToDb($scanFindingsOnly)),
         __METHOD__ . '.getLrb'
     );

--- a/src/monk/agent/buildSquareVisitor.c
+++ b/src/monk/agent/buildSquareVisitor.c
@@ -25,12 +25,14 @@ typedef struct {
 } point;
 
 gint pointSorter(gconstpointer a, gconstpointer b) {
-  unsigned int aTime = ((const point *) a)->time;
-  unsigned int bTime = ((const point *) b)->time;
-  if (aTime > bTime)
-    return 1;
-  if (aTime < bTime)
-    return -1;
+  const point* pa = (const point*)a;
+  const point* pb = (const point*)b;
+  unsigned int aDist2 = pa->x * pa->x + pa->y * pa->y;
+  unsigned int bDist2 = pb->x * pb->x + pb->y * pb->y;
+  if (aDist2 > bDist2) return 1;
+  if (aDist2 < bDist2) return -1;
+  if (pa->time > pb->time) return 1;
+  if (pa->time < pb->time) return -1;
   return 0;
 }
 
@@ -84,6 +86,14 @@ int writeVisitorToSourceFiles(GArray* visitor) {
   for (size_t i = 1; i < visitor->len; i++) {
     point p = g_array_index(visitor, point, i);
     fprintf(fc, ",\n\t%u", p.y);
+  }
+  fprintf(fc, "};\n");
+
+  fprintf(fc, "unsigned int squareVisitorDist2[] = ");
+  fprintf(fc, "{%u", p0.x * p0.x + p0.y * p0.y);
+  for (size_t i = 1; i < visitor->len; i++) {
+    point p = g_array_index(visitor, point, i);
+    fprintf(fc, ",\n\t%u", p.x * p.x + p.y * p.y);
   }
   fprintf(fc, "};\n");
 

--- a/src/monk/agent/diff.c
+++ b/src/monk/agent/diff.c
@@ -49,9 +49,16 @@ int lookForDiff(const GArray* textTokens, const GArray* searchTokens,
   size_t searchStopAt = MIN(iSearch + maxAllowedDiff, searchLength);
   size_t textStopAt = MIN(iText + maxAllowedDiff, textLength);
 
+  unsigned int tw = (textStopAt > iText) ? (unsigned int)(textStopAt - iText) - 1 : 0;
+  unsigned int sw = (searchStopAt > iSearch) ? (unsigned int)(searchStopAt - iSearch) - 1 : 0;
+  unsigned int maxDist2 = tw * tw + sw * sw;
+
   size_t textPos;
   size_t searchPos;
   for (unsigned int i = 0; i < SQUARE_VISITOR_LENGTH; i++) {
+    if (squareVisitorDist2[i] > maxDist2)
+      break;
+
     textPos = iText + squareVisitorX[i];
     searchPos = iSearch + squareVisitorY[i];
 

--- a/src/monk/agent/file_operations.c
+++ b/src/monk/agent/file_operations.c
@@ -1,6 +1,7 @@
 /*
  Author: Daniele Fognini, Andreas Wuerl
  SPDX-FileCopyrightText: © 2013-2014 Siemens AG
+ SPDX-FileCopyrightText: © 2026 Siemens AG
 
  SPDX-License-Identifier: GPL-2.0-only
 */
@@ -98,6 +99,9 @@ int readTokensFromFile(const char* fileName, GArray** tokens, const char* delimi
   {
     iconv_close(converter);
   }
+
+  /* normalize years so year-only differences don't break full matches */
+  *tokens = mergeYearTokenSequences(*tokens);
 
   return 1;
 }

--- a/src/monk/agent/generator/_squareVisitor.h.post
+++ b/src/monk/agent/generator/_squareVisitor.h.post
@@ -6,5 +6,6 @@
 
 extern unsigned int squareVisitorX[SQUARE_VISITOR_LENGTH];
 extern unsigned int squareVisitorY[SQUARE_VISITOR_LENGTH];
+extern unsigned int squareVisitorDist2[SQUARE_VISITOR_LENGTH];
 
 #endif // SQUAREVISITOR_H

--- a/src/monk/agent/license.c
+++ b/src/monk/agent/license.c
@@ -47,7 +47,7 @@ Licenses* extractLicenses(fo_dbManager* dbManager, PGresult* licensesResult, uns
     license.shortname = g_strdup(licShortName);
 
     char* licenseText = getLicenseTextForLicenseRefId(dbManager, refId);
-    GArray* licenseTokens = tokenize(licenseText, DELIMITERS);
+    GArray* licenseTokens = mergeYearTokenSequences(tokenize(licenseText, DELIMITERS));
 
     free(licenseText);
     license.tokens = licenseTokens;
@@ -110,7 +110,7 @@ uint32_t getKey(const GArray* tokens, unsigned minAdjacentMatches, unsigned sear
   for (guint i = 0; (i < minAdjacentMatches) && (i+searchedStart < tokens->len); i++)
   {
     Token* nToken = tokens_index(tokens, i+searchedStart);
-    result = (result << 1) + nToken->hashedContent;
+    result = (result << 6) + result + nToken->hashedContent;
   }
 
   return result;

--- a/src/monk/agent/match.c
+++ b/src/monk/agent/match.c
@@ -31,6 +31,7 @@ GArray* findAllMatchesBetween(const File* file, const Licenses* licenses,
 
   const GArray* textTokens = file->tokens;
   const guint textLength = textTokens->len;
+  const GArray* shortLicenses = getShortLicenseArray(licenses);
 
   for (guint tPos = 0; tPos < textLength; tPos++) {
     for (guint sPos = 0; sPos <= maxLeadingDiff; sPos++) {
@@ -39,7 +40,6 @@ GArray* findAllMatchesBetween(const File* file, const Licenses* licenses,
     }
 
     /* now search short licenses only fully (i.e. maxAllowedDiff = 0, minAdjacentMatches = 1) */
-    const GArray* shortLicenses = getShortLicenseArray(licenses);
     doFindAllMatches(file, shortLicenses, tPos, 0, 0, 1, matches);
   }
 
@@ -164,8 +164,18 @@ static unsigned short match_rank(Match* match) {
     size_t numberOfMatches = diffResult->matched;
     size_t numberOfAdditions = diffResult->added;
 
-    // calculate result percentage as jaccard index
-    double rank = (100.0 * numberOfMatches) / (licenseLength + numberOfAdditions);
+    // head-removal (sPos>0): applyDiff stores it as a DIFF_TYPE_REMOVAL
+    // with search.start==0 and text.length==0
+    size_t leadingDiff = 0;
+    if (diffResult->matchedInfo->len > 0) {
+      DiffMatchInfo firstInfo = g_array_index(diffResult->matchedInfo, DiffMatchInfo, 0);
+      if (firstInfo.search.start == 0 && firstInfo.text.length == 0)
+        leadingDiff = firstInfo.search.length;
+    }
+
+    // calculate result percentage as jaccard index with leading-diff penalty
+    double rank = (100.0 * numberOfMatches) /
+                  (licenseLength + numberOfAdditions + leadingDiff * LEADING_DIFF_RANK_WEIGHT);
     int result = (int) rank;
 
     result = MIN(result, 99);
@@ -304,6 +314,26 @@ int match_partialComparator(const Match* thisMatch, const Match* otherMatch) {
 
     return (compareMatchByRank(thisMatch, otherMatch) >= 0) ? 1 : -1;
   }
+
+  // Nearly-identical licenses can match the same region where neither
+  // strictly contains the other (tail-removal shifts getEnd()). Require
+  // >50% overlap to avoid triggering on adjacent-section boundaries.
+  const size_t thisStart  = match_getStart(thisMatch);
+  const size_t thisEnd    = match_getEnd(thisMatch);
+  const size_t otherStart = match_getStart(otherMatch);
+  const size_t otherEnd   = match_getEnd(otherMatch);
+  if (thisStart < otherEnd && otherStart < thisEnd) {
+    const size_t overlapStart = (thisStart > otherStart) ? thisStart : otherStart;
+    const size_t overlapEnd   = (thisEnd   < otherEnd)   ? thisEnd   : otherEnd;
+    const size_t overlapSize  = (overlapEnd > overlapStart) ? overlapEnd - overlapStart : 0;
+    const size_t thisSize     = (thisEnd  > thisStart)  ? thisEnd  - thisStart  : 1;
+    const size_t otherSize    = (otherEnd > otherStart) ? otherEnd - otherStart : 1;
+    const size_t minSize      = (thisSize < otherSize)  ? thisSize : otherSize;
+    if (overlapSize * 2 > minSize) { /* overlap > 50% of smaller match */
+      return (compareMatchByRank(thisMatch, otherMatch) >= 0) ? 1 : -1;
+    }
+  }
+
   return 0;
 }
 

--- a/src/monk/agent/monk.h
+++ b/src/monk/agent/monk.h
@@ -31,6 +31,10 @@
 #define MIN_ADJACENT_MATCHES 3
 #define MAX_LEADING_DIFF 10
 #define MIN_ALLOWED_RANK 66
+/* Penalty per skipped leading token (license title/identifier absent from
+ * file). W=200: sPos=10 on a ~23k-token license drops rank ~8%, below a
+ * sPos=0 match. */
+#define LEADING_DIFF_RANK_WEIGHT 200
 
 #include <glib.h>
 #include <stdbool.h>

--- a/src/monk/agent/monkbulk.c
+++ b/src/monk/agent/monkbulk.c
@@ -179,7 +179,8 @@ int bulk_identification(MonkState* state) {
   License license = (License){
     .refId = bulkArguments->licenseId,
   };
-  license.tokens = tokenize(bulkArguments->refText, bulkArguments->delimiters);
+  license.tokens = mergeYearTokenSequences(
+    tokenize(bulkArguments->refText, bulkArguments->delimiters));
 
   GArray* licenseArray = g_array_new(FALSE, FALSE, sizeof (License));
   g_array_append_val(licenseArray, license);

--- a/src/monk/agent/serialize.c
+++ b/src/monk/agent/serialize.c
@@ -13,6 +13,14 @@
 #include <stdio.h>
 #include <errno.h>
 
+/* tokenType is NOT serialized; re-derived on load for backward compat
+ * with old knowledgebases. */
+typedef struct {
+  unsigned int length;
+  unsigned int removedBefore;
+  uint32_t     hashedContent;
+} TokenOnDisk;
+
 /*
  * serialization
  */
@@ -62,7 +70,9 @@ int serializeOneShortname(License* license, FILE* fp) {
 
 int serializeOneTokens(GArray* tokens, FILE* fp) {
   for (guint i = 0; i < tokens->len; i++) {
-    if (fwrite(tokens_index(tokens,i), sizeof(Token), 1, fp) != 1) {
+    Token* t = tokens_index(tokens, i);
+    TokenOnDisk td = { t->length, t->removedBefore, t->hashedContent };
+    if (fwrite(&td, sizeof(TokenOnDisk), 1, fp) != 1) {
       return 0;
     }
   }
@@ -104,15 +114,22 @@ Licenses* deserialize(FILE* fp, unsigned minAdjacentMatches, unsigned maxLeading
 }
 
 GArray* deserializeTokens(FILE* fp, guint tokensLen) {
-  Token* freadResult = malloc(sizeof(Token) * tokensLen);
-  if(fread(freadResult, sizeof(Token), tokensLen, fp) != tokensLen){
+  TokenOnDisk* freadResult = malloc(sizeof(TokenOnDisk) * tokensLen);
+  if (fread(freadResult, sizeof(TokenOnDisk), tokensLen, fp) != tokensLen) {
     strerror(errno);
   }
 
   GArray* tokens = g_array_new(FALSE, FALSE, sizeof(Token));
-  g_array_append_vals(tokens,
-                      freadResult,
-                      tokensLen);
+  for (guint i = 0; i < tokensLen; i++) {
+    Token t;
+    t.length        = freadResult[i].length;
+    t.removedBefore = freadResult[i].removedBefore;
+    t.hashedContent = freadResult[i].hashedContent;
+    /* YEAR_CANONICAL_HASH maps to TOKEN_YEAR; activates year-normalization
+     * for imported knowledgebases */
+    t.tokenType = (t.hashedContent == YEAR_CANONICAL_HASH) ? TOKEN_YEAR : TOKEN_NORMAL;
+    g_array_append_vals(tokens, &t, 1);
+  }
   free(freadResult);
 
   return tokens;

--- a/src/monk/agent/string_operations.c
+++ b/src/monk/agent/string_operations.c
@@ -1,6 +1,7 @@
 /*
  Author: Daniele Fognini, Andreas Wuerl
  SPDX-FileCopyrightText: © 2013-2015 Siemens AG
+ SPDX-FileCopyrightText: © 2026 Siemens AG
 
  SPDX-License-Identifier: GPL-2.0-only
 */
@@ -18,6 +19,21 @@
 
 #define MAX_TOKENS_ARRAY_SIZE 4194304
 #define MAX_DELIMIT_LEN 255
+
+/* Per-character state flags; internal to streamTokenize, converted to
+ * TOKEN_* by classifyToken(). */
+#define TOK_STATE_ALL_DIGITS 0x10u /* every char so far is a digit */
+#define TOK_STATE_HAS_HYPHEN 0x20u /* saw a hyphen after leading digits */
+#define TOK_STATE_DIGIT_AFTER 0x40u /* saw a digit after the hyphen */
+#define TOK_STATE_ALL_PUNCT 0x80u /* every char is non-alphanumeric */
+
+/** Initial tokenType for a new token: optimistically assume year/punct. */
+#define TOK_STATE_INIT (TOK_STATE_ALL_DIGITS | TOK_STATE_ALL_PUNCT)
+
+/* A year is a 4-digit number (e.g. 1998, 2026). Range forms anchor on a
+ * 4-digit leading year, e.g. "2000-2009" or "2024-25". Shorter digit runs
+ * (section numbers, list items, versions like "10", "20") are NOT years. */
+#define YEAR_DIGIT_LEN 4
 
 unsigned splittingDelim(char a, const char* delimiters) {
   if (a == '\0')
@@ -63,6 +79,61 @@ static inline void initStateToken(Token* stateToken) {
   stateToken->hashedContent = hash_init();
   stateToken->length = 0;
   stateToken->removedBefore = 0;
+  stateToken->tokenType = TOK_STATE_INIT;
+}
+
+/** TOKEN_YEAR: 4-digit number or 4-digit-led range; TOKEN_PUNCT: all
+ * non-alnum; otherwise TOKEN_NORMAL. */
+static uint8_t classifyToken(const Token* t)
+{
+  uint8_t f = t->tokenType;
+
+  int isYearLike =
+    ((f & TOK_STATE_ALL_DIGITS) && t->length == YEAR_DIGIT_LEN) ||
+    ((f & TOK_STATE_HAS_HYPHEN) && (f & TOK_STATE_DIGIT_AFTER));
+
+  if (isYearLike)
+    return TOKEN_YEAR;
+
+  if ((f & TOK_STATE_ALL_PUNCT) && t->length > 0)
+    return TOKEN_PUNCT;
+
+  return TOKEN_NORMAL;
+}
+
+/** Update tokenType flags. Must be called BEFORE incrementing length;
+ * the hyphen check reads the current digit count. */
+static inline void updateTokenTypeFlags(Token* stateToken, char c)
+{
+  uint8_t* f = &stateToken->tokenType;
+
+  if (isdigit((unsigned char)c)) {
+    if (*f & TOK_STATE_HAS_HYPHEN)
+      *f |= TOK_STATE_DIGIT_AFTER;
+    *f &= (uint8_t)~TOK_STATE_ALL_PUNCT; /* digit is alphanumeric */
+    /* TOK_STATE_ALL_DIGITS preserved */
+  } else if (c == '-') {
+    if ((*f & TOK_STATE_ALL_DIGITS) && stateToken->length == YEAR_DIGIT_LEN
+        && !(*f & TOK_STATE_HAS_HYPHEN)) {
+      /* year-range hyphen: exactly 4 leading digits, e.g. "2000-" */
+      *f |= TOK_STATE_HAS_HYPHEN;
+      *f &= (uint8_t)~TOK_STATE_ALL_DIGITS;
+    } else {
+      /* not a 4-digit year prefix, second hyphen, or hyphen after non-digits */
+      *f &= (uint8_t)~(TOK_STATE_ALL_DIGITS | TOK_STATE_HAS_HYPHEN | TOK_STATE_DIGIT_AFTER);
+    }
+    /* hyphen is non-alphanumeric: TOK_STATE_ALL_PUNCT preserved */
+  } else if (isalpha((unsigned char)c) || (unsigned char)c >= 0x80) {
+    /* ASCII letter or any non-ASCII (UTF-8 multibyte) byte is real content:
+       it ends year/punctuation-only status. Non-ASCII words (accented
+       Latin, Cyrillic, CJK, ...) must not be dropped as punctuation. */
+    *f &= (uint8_t)~(TOK_STATE_ALL_DIGITS | TOK_STATE_HAS_HYPHEN |
+                     TOK_STATE_DIGIT_AFTER | TOK_STATE_ALL_PUNCT);
+  } else {
+    /* ASCII punctuation, non-hyphen (e.g. '@', '$', '&', '.', '!') */
+    *f &= (uint8_t)~(TOK_STATE_ALL_DIGITS | TOK_STATE_HAS_HYPHEN | TOK_STATE_DIGIT_AFTER);
+    /* TOK_STATE_ALL_PUNCT preserved: still possibly all-punctuation */
+  }
 }
 
 static int isIgnoredToken(Token* token) {
@@ -75,6 +146,7 @@ static int isIgnoredToken(Token* token) {
 #endif
   remToken.length = 3;
   remToken.removedBefore = 0;
+  remToken.tokenType = TOKEN_NORMAL; /* explicit: avoids year short-circuit */
 
   return tokenEquals(token, &remToken);
 }
@@ -86,9 +158,14 @@ int streamTokenize(const char* inputChunk, size_t inputSize, const char* delimit
   unsigned int initialTokenCount = tokens->len;
 
   if (!inputChunk) {
+    /* Flush the final in-progress token */
     if ((stateToken = *remainder)) {
-      if ((stateToken->length > 0) && !isIgnoredToken(stateToken)) {
-        g_array_append_val(tokens, *stateToken);
+      if (stateToken->length > 0 && !isIgnoredToken(stateToken)) {
+        stateToken->tokenType = classifyToken(stateToken);
+        if (stateToken->tokenType == TOKEN_YEAR)
+          stateToken->hashedContent = YEAR_CANONICAL_HASH;
+        if (stateToken->tokenType != TOKEN_PUNCT)
+          g_array_append_val(tokens, *stateToken);
       }
       free(stateToken);
     }
@@ -97,7 +174,6 @@ int streamTokenize(const char* inputChunk, size_t inputSize, const char* delimit
   }
 
   if (!*remainder) {
-    //initialize state
     stateToken = malloc(sizeof (Token));
     *remainder = stateToken;
     initStateToken(stateToken);
@@ -125,12 +201,25 @@ int streamTokenize(const char* inputChunk, size_t inputSize, const char* delimit
     if (delimLen > 0) {
       if (stateToken->length > 0) {
         if (isIgnoredToken(stateToken)) {
+          /* REM keyword: treat as invisible (existing behavior) */
           stateToken->removedBefore += stateToken->length;
           stateToken->length = 0;
           stateToken->hashedContent = hash_init();
+          stateToken->tokenType = TOK_STATE_INIT;
         } else {
-          g_array_append_val(tokens, *stateToken);
-          initStateToken(stateToken);
+          stateToken->tokenType = classifyToken(stateToken);
+          if (stateToken->tokenType == TOKEN_PUNCT) {
+            /* all-punctuation token: absorbed into the gap before next token */
+            stateToken->removedBefore += stateToken->length;
+            stateToken->length = 0;
+            stateToken->hashedContent = hash_init();
+            stateToken->tokenType = TOK_STATE_INIT;
+          } else {
+            if (stateToken->tokenType == TOKEN_YEAR)
+              stateToken->hashedContent = YEAR_CANONICAL_HASH;
+            g_array_append_val(tokens, *stateToken);
+            initStateToken(stateToken);
+          }
         }
       }
 
@@ -139,6 +228,8 @@ int streamTokenize(const char* inputChunk, size_t inputSize, const char* delimit
       ptr += delimLen;
       readBytes += delimLen;
     } else {
+      updateTokenTypeFlags(stateToken, *ptr);
+
 #ifndef MONK_CASE_INSENSITIVE
       const char* newCharPtr = ptr;
 #else
@@ -217,6 +308,38 @@ size_t token_position_of(size_t index, const GArray* tokens) {
     printf("WARNING: requested calculation of token index after the END token\n");
   }
 
+  return result;
+}
+
+GArray* mergeYearTokenSequences(GArray* tokens)
+{
+  GArray* result = tokens_new();
+
+  for (size_t i = 0; i < tokens->len; ) {
+    Token* t = tokens_index(tokens, i);
+
+    if (t->tokenType != TOKEN_YEAR) {
+      g_array_append_val(result, *t);
+      i++;
+      continue;
+    }
+
+    /* Start a year group: copy the first year token and absorb followers. */
+    Token merged = *t;
+    i++;
+
+    while (i < tokens->len) {
+      Token* next = tokens_index(tokens, i);
+      if (next->tokenType != TOKEN_YEAR) break;
+      /* include gap so highlights span the full year group */
+      merged.length += next->removedBefore + next->length;
+      i++;
+    }
+
+    g_array_append_val(result, merged);
+  }
+
+  tokens_free(tokens);
   return result;
 }
 

--- a/src/monk/agent/string_operations.h
+++ b/src/monk/agent/string_operations.h
@@ -1,6 +1,7 @@
 /*
  Author: Daniele Fognini, Andreas Wuerl
  SPDX-FileCopyrightText: © 2013-2015 Siemens AG
+ SPDX-FileCopyrightText: © 2026 Siemens AG
 
  SPDX-License-Identifier: GPL-2.0-only
 */
@@ -12,10 +13,19 @@
 #include <string.h>
 #include <stdint.h>
 
+/* Token semantic types stored in tokenType after classification */
+#define TOKEN_NORMAL 0 /**< ordinary word, exact match required */
+#define TOKEN_YEAR 1 /**< year or year-range, matches any other TOKEN_YEAR */
+#define TOKEN_PUNCT 2 /**< all-punctuation token, treated as invisible */
+
+/** Canonical hash assigned to every TOKEN_YEAR so they compare equal */
+#define YEAR_CANONICAL_HASH 0x00594541u /* "YEA" */
+
 typedef struct {
-  unsigned int length;
-  unsigned int removedBefore;
-  uint32_t hashedContent;
+  unsigned int length; /**< byte length of the token in the source text */
+  unsigned int removedBefore; /**< delimiter bytes before this token */
+  uint32_t hashedContent; /**< rolling hash of the token characters */
+  uint8_t tokenType; /**< TOKEN_NORMAL, TOKEN_YEAR or TOKEN_PUNCT */
 } Token;
 
 #define token_length(token) (token).length
@@ -30,12 +40,19 @@ GArray* tokenize(const char* inputString, const char* delimiters);
 int streamTokenize(const char* inputChunk, size_t inputSize, const char* delimiters,
         GArray** output, Token** remainder);
 
-#define tokenEquals(a, b) (((a)->length == (b)->length ) && ((a)->hashedContent == (b)->hashedContent))
+/** TOKEN_YEAR matches any TOKEN_YEAR; otherwise exact (length + hash). */
+#define tokenEquals(a, b) \
+  (((a)->tokenType == TOKEN_YEAR && (b)->tokenType == TOKEN_YEAR) || \
+   (((a)->length == (b)->length) && ((a)->hashedContent == (b)->hashedContent)))
 
 int tokensEquals(const GArray* a, const GArray* b);
 
 size_t token_position_of(size_t index, const GArray* tokens);
 
 char* normalize_escape_string(char* input);
+
+/** Collapse consecutive TOKEN_YEAR runs into one spanning the full byte
+ * range (gaps included). Frees input; caller owns the returned array. */
+GArray* mergeYearTokenSequences(GArray* tokens);
 
 #endif // MONK_AGENT_STRING_OPERATIONS_H

--- a/src/monk/agent_tests/Unit/test_string_operations.c
+++ b/src/monk/agent_tests/Unit/test_string_operations.c
@@ -222,6 +222,205 @@ void test_token_equal() {
   g_free(search);
 }
 
+/* -------------------------------------------------------------------------
+ * Tests for TOKEN_YEAR classification and year-sequence merging
+ * ---------------------------------------------------------------------- */
+
+/** Helper: tokenize a string and return token at index i */
+static Token getToken(const char* str, const char* delim, guint i)
+{
+  GArray* tokens = tokenize(str, delim);
+  CU_ASSERT_FATAL(tokens->len > i);
+  Token t = g_array_index(tokens, Token, i);
+  g_array_free(tokens, TRUE);
+  return t;
+}
+
+void test_yearTokenClassification()
+{
+  /* Only 4-digit numbers (and 4-digit-led ranges) are years */
+  Token t;
+
+  t = getToken("2024", " ", 0);
+  CU_ASSERT_EQUAL(t.tokenType, TOKEN_YEAR);
+  CU_ASSERT_EQUAL(t.hashedContent, YEAR_CANONICAL_HASH);
+  CU_ASSERT_EQUAL(t.length, 4);
+
+  t = getToken("1998", " ", 0);
+  CU_ASSERT_EQUAL(t.tokenType, TOKEN_YEAR);
+
+  /* Short digit runs are NOT years (section/list/version numbers) */
+  t = getToken("5", " ", 0);
+  CU_ASSERT_EQUAL(t.tokenType, TOKEN_NORMAL);
+
+  t = getToken("34", " ", 0);
+  CU_ASSERT_EQUAL(t.tokenType, TOKEN_NORMAL);
+
+  t = getToken("10", " ", 0);
+  CU_ASSERT_EQUAL(t.tokenType, TOKEN_NORMAL);
+  CU_ASSERT_NOT_EQUAL(t.hashedContent, YEAR_CANONICAL_HASH);
+
+  t = getToken("100", " ", 0);
+  CU_ASSERT_EQUAL(t.tokenType, TOKEN_NORMAL);
+
+  /* Long digit runs (>4) are NOT years */
+  t = getToken("20000", " ", 0);
+  CU_ASSERT_EQUAL(t.tokenType, TOKEN_NORMAL);
+
+  t = getToken("12345", " ", 0);
+  CU_ASSERT_EQUAL(t.tokenType, TOKEN_NORMAL);
+
+  /* Year range with hyphen -> TOKEN_YEAR */
+  t = getToken("2000-2009", " ", 0);
+  CU_ASSERT_EQUAL(t.tokenType, TOKEN_YEAR);
+  CU_ASSERT_EQUAL(t.hashedContent, YEAR_CANONICAL_HASH);
+  CU_ASSERT_EQUAL(t.length, 9);
+
+  t = getToken("2024-23", " ", 0);
+  CU_ASSERT_EQUAL(t.tokenType, TOKEN_YEAR);
+
+  /* Non-year ranges (leading part is not a 4-digit year) -> TOKEN_NORMAL */
+  t = getToken("10-99", " ", 0);
+  CU_ASSERT_EQUAL(t.tokenType, TOKEN_NORMAL);
+  CU_ASSERT_NOT_EQUAL(t.hashedContent, YEAR_CANONICAL_HASH);
+
+  t = getToken("1-2", " ", 0);
+  CU_ASSERT_EQUAL(t.tokenType, TOKEN_NORMAL);
+
+  /* Mixed letter+digit -> TOKEN_NORMAL */
+  t = getToken("v2", " ", 0);
+  CU_ASSERT_EQUAL(t.tokenType, TOKEN_NORMAL);
+  CU_ASSERT_NOT_EQUAL(t.hashedContent, YEAR_CANONICAL_HASH);
+
+  t = getToken("GPL-2.0", " ", 0);
+  CU_ASSERT_EQUAL(t.tokenType, TOKEN_NORMAL);
+
+  /* Trailing hyphen only -> TOKEN_NORMAL (no digit after hyphen) */
+  t = getToken("2000-", " ", 0);
+  CU_ASSERT_EQUAL(t.tokenType, TOKEN_NORMAL);
+}
+
+void test_punctTokenClassification()
+{
+  GArray* tokens;
+
+  /* Standalone all-punctuation tokens must be invisible (skipped) */
+  tokens = tokenize("foo @ bar", " ");
+  CU_ASSERT_EQUAL(tokens->len, 2); /* '@' eaten, only foo and bar */
+  g_array_free(tokens, TRUE);
+
+  tokens = tokenize("foo $& bar", " ");
+  CU_ASSERT_EQUAL(tokens->len, 2); /* '$&' eaten */
+  g_array_free(tokens, TRUE);
+
+  tokens = tokenize("foo --- bar", " ");
+  CU_ASSERT_EQUAL(tokens->len, 2); /* '---' eaten */
+  g_array_free(tokens, TRUE);
+
+  /* Mixed alnum+punct -> TOKEN_NORMAL, kept */
+  tokens = tokenize("(c)", " ");
+  CU_ASSERT_EQUAL(tokens->len, 1);
+  CU_ASSERT_EQUAL(g_array_index(tokens, Token, 0).tokenType, TOKEN_NORMAL);
+  g_array_free(tokens, TRUE);
+
+  /* Non-ASCII (UTF-8 multibyte) words are real content, NOT punctuation.
+     "\xc3\xa9" = e-acute, "\xc3\x9f" = sharp-s. They must be kept. */
+  tokens = tokenize("foo \xc3\xa9 bar", " ");
+  CU_ASSERT_EQUAL(tokens->len, 3);
+  CU_ASSERT_EQUAL(g_array_index(tokens, Token, 1).tokenType, TOKEN_NORMAL);
+  g_array_free(tokens, TRUE);
+
+  tokens = tokenize("\xc3\x9f", " ");
+  CU_ASSERT_EQUAL(tokens->len, 1);
+  CU_ASSERT_EQUAL(g_array_index(tokens, Token, 0).tokenType, TOKEN_NORMAL);
+  g_array_free(tokens, TRUE);
+}
+
+void test_yearTokensEqual()
+{
+  /* Two year tokens of different content must match each other */
+  GArray* a = tokenize("2000-2009", " ");
+  GArray* b = tokenize("2024", " ");
+
+  CU_ASSERT_EQUAL(a->len, 1);
+  CU_ASSERT_EQUAL(b->len, 1);
+
+  Token* ta = tokens_index(a, 0);
+  Token* tb = tokens_index(b, 0);
+
+  CU_ASSERT_EQUAL(ta->tokenType, TOKEN_YEAR);
+  CU_ASSERT_EQUAL(tb->tokenType, TOKEN_YEAR);
+  CU_ASSERT_TRUE(tokenEquals(ta, tb));
+
+  /* Year token must NOT match a plain word */
+  GArray* c = tokenize("Copyright", " ");
+  Token* tc = tokens_index(c, 0);
+  CU_ASSERT_EQUAL(tc->tokenType, TOKEN_NORMAL);
+  CU_ASSERT_FALSE(tokenEquals(ta, tc));
+
+  g_array_free(a, TRUE);
+  g_array_free(b, TRUE);
+  g_array_free(c, TRUE);
+}
+
+void test_mergeYearTokenSequences()
+{
+  GArray* tokens;
+
+  /* Comma-separated years (comma is a delimiter) become multiple TOKEN_YEAR;
+   * after merge: one TOKEN_YEAR whose length spans the whole group */
+  tokens = mergeYearTokenSequences(tokenize("2000,2001,2002", ","));
+  CU_ASSERT_EQUAL(tokens->len, 1);
+  CU_ASSERT_EQUAL(g_array_index(tokens, Token, 0).tokenType, TOKEN_YEAR);
+  /* length = 4+1+4+1+4 = 14 (each year=4, each comma=1 absorbed) */
+  CU_ASSERT_EQUAL(g_array_index(tokens, Token, 0).length, 14);
+  g_array_free(tokens, TRUE);
+
+  /* Non-year tokens are kept intact; year group between them is merged */
+  tokens = mergeYearTokenSequences(tokenize("Copyright^2000^2001^2002^Inc", "^"));
+  CU_ASSERT_EQUAL(tokens->len, 3); /* Copyright | YEAR_SEQ | Inc */
+  CU_ASSERT_EQUAL(g_array_index(tokens, Token, 0).tokenType, TOKEN_NORMAL);
+  CU_ASSERT_EQUAL(g_array_index(tokens, Token, 1).tokenType, TOKEN_YEAR);
+  CU_ASSERT_EQUAL(g_array_index(tokens, Token, 2).tokenType, TOKEN_NORMAL);
+  g_array_free(tokens, TRUE);
+
+  /* A single year range token (no merging needed) passes through unchanged */
+  tokens = mergeYearTokenSequences(tokenize("2000-2009", " "));
+  CU_ASSERT_EQUAL(tokens->len, 1);
+  CU_ASSERT_EQUAL(g_array_index(tokens, Token, 0).tokenType, TOKEN_YEAR);
+  CU_ASSERT_EQUAL(g_array_index(tokens, Token, 0).length, 9);
+  g_array_free(tokens, TRUE);
+
+  /* Empty input -> empty output */
+  tokens = mergeYearTokenSequences(tokens_new());
+  CU_ASSERT_EQUAL(tokens->len, 0);
+  g_array_free(tokens, TRUE);
+}
+
+void test_yearMergeProducesFullMatch()
+{
+  /* Simulate the core scenario from issue #647:
+   * reference "Copyright 2000-2009 Foo" (1 year token)
+   * file "Copyright 2000,2001,...,2009 Foo" (many year tokens, 1 after merge)
+   * After merging both sides, tokenEquals on the year tokens must be true
+   * and the token counts must match, enabling MATCH_TYPE_FULL. */
+  GArray* ref  = mergeYearTokenSequences(tokenize("Copyright^2000-2009^Foo", "^"));
+  GArray* file = mergeYearTokenSequences(tokenize("Copyright^2000^2001^2002^2003^2004^2005^2006^2007^2008^2009^Foo", "^"));
+
+  CU_ASSERT_EQUAL(ref->len, 3); /* Copyright | YEAR | Foo */
+  CU_ASSERT_EQUAL(file->len, 3); /* same count after merge */
+
+  /* All three token positions must compare equal */
+  for (guint i = 0; i < 3; i++) {
+    Token* tr = tokens_index(ref, i);
+    Token* tf = tokens_index(file, i);
+    CU_ASSERT_TRUE_FATAL(tokenEquals(tr, tf));
+  }
+
+  g_array_free(ref,  TRUE);
+  g_array_free(file, TRUE);
+}
+
 CU_TestInfo string_operations_testcases[] = {
   {"Testing tokenize:", test_tokenize},
   {"Testing tokenize with special delimiters:", test_tokenizeWithSpecialDelims},
@@ -230,5 +429,10 @@ CU_TestInfo string_operations_testcases[] = {
   {"Testing find token position in string:", test_tokenPosition},
   {"Testing find token position at end:", test_tokenPositionAtEnd},
   {"Testing token equals:", test_token_equal},
+  {"Testing year token classification:", test_yearTokenClassification},
+  {"Testing punct token classification:", test_punctTokenClassification},
+  {"Testing year tokens equal each other:", test_yearTokensEqual},
+  {"Testing mergeYearTokenSequences:", test_mergeYearTokenSequences},
+  {"Testing year merge enables full match:", test_yearMergeProducesFullMatch},
   CU_TEST_INFO_NULL
 };

--- a/src/www/ui/api/Controllers/UploadTreeController.php
+++ b/src/www/ui/api/Controllers/UploadTreeController.php
@@ -744,7 +744,7 @@ class UploadTreeController extends RestController
     $errors = [];
 
     // Verify if each element from $body was given in the request
-    $requiredFields = ['bulkActions', 'refText', 'bulkScope', 'forceDecision', 'ignoreIrre', 'delimiters', 'scanOnlyFindings'];
+    $requiredFields = ['bulkActions', 'refText', 'bulkScope', 'forceDecision', 'ignoreIrre', 'scanOnlyFindings'];
 
     foreach ($requiredFields as $field) {
       if (!array_key_exists($field, $body)) {
@@ -763,11 +763,6 @@ class UploadTreeController extends RestController
       if (!in_array($body['forceDecision'], [true, false]) || !in_array($body['ignoreIrre'], [true, false]) || !in_array($body['scanOnlyFindings'], [true, false])) {
         $isValid = false;
         $errors[] = "forceDecision, ignoreIrre and scanOnlyFindings should be either true or false";
-      }
-      // Check if delimiters is a string
-      if (!is_string($body['delimiters'])) {
-        $isValid = false;
-        $errors[] = "delimiters should be a string";
       }
       // check if bulkScope value is either folder or upload
       if (!in_array($body['bulkScope'], ["folder", "upload"])) {
@@ -814,7 +809,6 @@ class UploadTreeController extends RestController
     $symfonyRequest->request->set('uploadTreeId', $uploadTreeId);
     $symfonyRequest->request->set('forceDecision', $body['forceDecision'] ? 1 : 0);
     $symfonyRequest->request->set('ignoreIrre', $body['ignoreIrre'] ? 1 : 0);
-    $symfonyRequest->request->set('delimiters', $body['delimiters']);
     $symfonyRequest->request->set('scanOnlyFindings', $body['scanOnlyFindings'] ? 1 : 0);
 
     /** @var \ChangeLicenseBulk $changeLicenseBulk */

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -6935,9 +6935,6 @@ components:
         ignoreIrre:
           type: boolean
           example: false
-        delimiters:
-          type: string
-          example: "DEFAULT"
         scanOnlyFindings:
           type: boolean
           example: false

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -6827,9 +6827,6 @@ components:
         ignoreIrre:
           type: boolean
           example: false
-        delimiters:
-          type: string
-          example: "DEFAULT"
     ScannedEditedLicense:
       type: object
       properties:

--- a/src/www/ui/change-license-bulk.php
+++ b/src/www/ui/change-license-bulk.php
@@ -121,15 +121,13 @@ class ChangeLicenseBulk extends DefaultPlugin
     $actions = $request->get('bulkAction');
     $ignoreIrrelevantFiles = (intval($request->get('ignoreIrre')) == 1);
     $scanFindingsOnly = boolval(intval($request->get('scanOnlyFindings')));
-    $delimiters = $request->get('delimiters');
-
     $licenseRemovals = array();
     foreach ($actions as $licenseAction) {
       $licenseRemovals[$licenseAction['licenseId']] = array(($licenseAction['action']=='Remove'), $licenseAction['comment'], $licenseAction['reportinfo'], $licenseAction['acknowledgement']);
     }
     $bulkId = $this->licenseDao->insertBulkLicense($userId, $groupId,
       $uploadTreeId, $licenseRemovals, $refText, $ignoreIrrelevantFiles,
-      $delimiters, $scanFindingsOnly);
+      $scanFindingsOnly);
 
     if ($bulkId <= 0) {
       throw new Exception('cannot insert bulk reference');

--- a/src/www/ui/scripts/change-license-browse.js
+++ b/src/www/ui/scripts/change-license-browse.js
@@ -132,11 +132,7 @@ function markDecisions(decisionToBeApplied, isRemoval) {
 function cleanText(textField) {
   var text = textField.val();
 
-  var delimiters = $("#delimdrop").val();
-  if (delimiters.toLowerCase() === "default") {
-    delimiters = '\t\f#^%*';
-  }
-  delimiters = escapeRegExp(delimiters);
+  var delimiters = escapeRegExp('\t\f#^%*');
   var re = new RegExp("[" + delimiters + "]+", "gi");
   text = text.replace(/ [ ]*/gi, ' ')
              .replace(/(^|\n) ?\/[\*\/]+/gi, '$1')

--- a/src/www/ui/scripts/change-license-common.js
+++ b/src/www/ui/scripts/change-license-common.js
@@ -152,7 +152,6 @@ function scheduleBulkScanCommon(resultEntity, callbackSuccess) {
     "forceDecision": $('#forceDecision').is(':checked')?1:0,
     "scanOnlyFindings": $('#scanOnlyFindings').is(':checked') ? 1 : 0,
     "ignoreIrre": $('#bulkIgnoreIrre').is(':checked') ? 1 : 0,
-    "delimiters": $("#delimdrop").val(),
     "addToCustomPhrase": $('#addToCustomPhrase').is(':checked') ? 1 : 0
   };
 
@@ -449,18 +448,6 @@ $(document).ready(function () {
     }
   });
 
-  $('#custDelim').change(function () {
-    if (this.checked) {
-      $('#delimRow').removeClass("invisible").addClass("visible");
-    } else {
-      $('#delimRow').removeClass("visible").addClass("invisible");
-      $('#resetDel').click();
-    }
-  });
-
-  $('#resetDel').click(function () {
-    $('#delimdrop').val('DEFAULT');
-  });
 });
 
 function createDropDown(element, textBox) {

--- a/src/www/ui/scripts/change-license-view.js
+++ b/src/www/ui/scripts/change-license-view.js
@@ -86,11 +86,7 @@ function scheduleBulkScan() {
 function cleanText(textField) {
   var text = textField.val();
 
-  var delimiters = $("#delimdrop").val();
-  if (delimiters.toLowerCase() === "default") {
-    delimiters = '\t\f#^%*';
-  }
-  delimiters = escapeRegExp(delimiters);
+  var delimiters = escapeRegExp('\t\f#^%*');
   var re = new RegExp("[" + delimiters + "]+", "gi");
   text = text.replace(/ [ ]*/gi, ' ')
              .replace(/(^|\n) ?\/[\*\/]+/gi, '$1')

--- a/src/www/ui/template/ui-clearing-view_bulk.html.twig
+++ b/src/www/ui/template/ui-clearing-view_bulk.html.twig
@@ -67,12 +67,10 @@
         </div>
         <!-- Modal body -->
         <div class="modal-body">
-          {{ 'Notice'|trans }}: {{ 'Since punctuation is included in the matching process, periods needs to be included in the phrases if the word just before is included.'|trans }}
-          <br/>
           {{ 'Hint'|trans }}: {{ 'New license candidates can be added via'|trans }}
           <a href="?mod=advice_license">{{ 'menu Organize&raquo;Licenses'|trans }}</a><br/>
           <form name="bulkForm">
-            <table>
+            <table width="100%">
               <tr>
                 <td id="bulkExistingLicense">
                   <select id="bulkLicense" class="ui-render-select2 w-100">
@@ -95,6 +93,14 @@
                 </td>
                 <td>
                   <button type="button" class="btn btn-light btn-sm" onclick="popUpLicenseText('{{ bulkUri }}&rf=', '{{ 'License Text'| trans }}');">{{ 'Show license'| trans }}</button>
+                </td>
+                <td style="width:100%;"></td>
+                <td style="white-space:nowrap;">
+                  <select name="bulkScope" class="form-control-sm" id="bulkScope">
+                    <option value="u">{{ 'scan whole Upload'| trans }}</option>
+                    <option value="f">{{ 'scan only current Folder'| trans }}</option>
+                  </select>
+                  <img src="images/info_16.png" data-toggle="tooltip" data-placement="left" title="{{ 'Scan whole upload or this folder determines the scope of files where the text phrase is searched for. If “scan whole upload” is selected, the text phrase is searched in all files of the entire upload'|trans }}" alt="" class="info-bullet"/></img>
                 </td>
               </tr>
             </table>
@@ -119,13 +125,6 @@
             <textarea name="bulkRefText" id="bulkRefText" type="text" rows="12" class="form-control"></textarea>
             <div class="container-fluid pt-2">
               <div class="row justify-content-start">
-                <div class="col-sm-auto pr-0">
-                  <select name="bulkScope" class="form-control-sm" id="bulkScope">
-                    <option value="u">{{ 'scan whole Upload'| trans }}</option>
-                    <option value="f">{{ 'scan only current Folder'| trans }}</option>
-                  </select>
-                  <img src="images/info_16.png" data-toggle="tooltip" data-placement="left" title="{{ 'Scan whole upload or this folder determines the scope of files where the text phrase is searched for. If “scan whole upload” is selected, the text phrase is searched in all files of the entire upload'|trans }}" alt="" class="info-bullet"/></img>
-                </div>
                 <div class="col-sm-auto pr-0">
                   <div class="form-check form-check-inline">
                     <input type="checkbox" class="form-check-input" id="forceDecision"/>
@@ -157,45 +156,14 @@
                 </div>
                 <div class="col-sm-auto pr-0">
                   <div class="form-check form-check-inline">
-                    <input type="checkbox" class="form-check-input" id="custDelim"/>
-                    <label for="custDelim" class="form-check-label">
-                      {{ 'Custom delimiters'|trans }}
-                      <img src="images/info_16.png" data-toggle="tooltip"
-                      data-placement="left" style="vertical-align:middle !important;"
-                      title="{{ 'Provide custom list of characters for spliting tokens for scan. Note, the characters will be ignored.'|trans }}"
-                      alt="" class="info-bullet"/>
-                    </label>
-                  </div>
-                </div>
-                <div class="col-sm-auto pr-0">
-                  <div class="form-check form-check-inline">
                     <input type="checkbox" class="form-check-input" id="addToCustomPhrase"/>
                     <label for="addToCustomPhrase" class="form-check-label">
-                      {{ 'Add text phrase to custom phrase table'|trans }}
+                      {{ 'Save phrase for kotoba'|trans }}
                       <img src="images/info_16.png" data-toggle="tooltip"
                       data-placement="left" style="vertical-align:middle !important;"
-                      title="{{ 'When checked, the reference text and associated licenses will be saved to the custom phrase table for future scanning with the kotoba agent'|trans }}"
+                      title="{{ 'When enabled, the reference text and its associated licenses will be saved to the custom phrase table and used for future scans by the Kotoba agent.'|trans }}"
                       alt="" class="info-bullet"/>
                     </label>
-                  </div>
-                </div>
-              </div>
-              <div class="row pt-2 invisible" id="delimRow">
-                <div class="col-md-auto">
-                  <label for="delimdrop" class="col-form-label">
-                    Delimiters:
-                  </label>&nbsp;<img src="images/info_16.png"
-                    data-toggle="tooltip"
-                    data-placement="left"
-                    title="{{ 'Use default list of delimiters (\' \\t\\n\\r\\f#^%,*\') or type your own in the box. Currently limited to single characters only and space is always a delimiter.'|trans }}"
-                    alt="" class="info-bullet"/>
-                </div>
-                <div class="col">
-                  <div class="input-group input-group-sm">
-                    <div class="input-group-prepend">
-                      <button class="btn btn-outline-secondary" type="button" id="resetDel">Reset</button>
-                    </div>
-                    <input class="form-control" id="delimdrop" type="text" value="DEFAULT">
                   </div>
                 </div>
               </div>


### PR DESCRIPTION


<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

* Normalize 4-digit year.
* Normalize Punctuation tokens.
* Preserve non-ASCII words   
* Drop custom-delimiter support

## How to test

* Upload a component.
* Run monk bulk scan with different delimiters.
* Run monk bulk scan with different years.
* Fossology shall decide the files.