### PR TITLE
fix(ui): add missing column headers on showjobs

### DIFF
--- a/src/www/ui/css/showjobs.css
+++ b/src/www/ui/css/showjobs.css
@@ -41,12 +41,78 @@
 
 .jobTable {
   width: 100%;
+  height: auto;
+  font: normal 8pt verdana, arial, helvetica;
 }
 
-.jobTable thead th {
+.jobTable thead tr.jobTablePackageLink {
+  background: #ffd700;
+}
+
+.jobTable thead tr.jobTablePackageLink th {
   font: bold 10pt verdana, arial, helvetica;
-  background: gold;
-  color: white;
+  background: #ffd700;
+  color: #000;
+  text-align: center;
+  height: auto;
+  line-height: 1.25;
+  padding: 4px 6px;
+  border-top: 0;
+  border-bottom: 0;
+  background-image: none;
+}
+
+.jobTable thead tr.jobTablePackageName {
+  background: #f2f2f2;
+}
+
+.jobTable thead tr.jobTablePackageName th {
+  font: bold 8pt verdana, arial, helvetica;
+  background: #f2f2f2;
+  color: #000;
+  text-align: center;
+  height: auto;
+  line-height: 1.2;
+  padding: 3px 6px;
+  border-top: 0;
+  border-bottom: 0;
+  background-image: none;
+}
+
+.jobTable thead tr.jobTableColHeaders {
+  background: #f2f2f2;
+}
+
+.jobTable thead tr.jobTableColHeaders th {
+  font: bold 8pt verdana, arial, helvetica;
+  background: #f2f2f2;
+  color: #000;
+  text-align: center;
+  height: auto;
+  line-height: 1.2;
+  padding: 3px 6px;
+  border-top: 0;
+  border-bottom: 0;
+  background-image: none;
+}
+
+.jobTable thead tr.jobTableColHeaders th:last-child {
+  border-top: 0;
+}
+
+.jobTableColHeaders th[tabindex="0"] {
+  cursor: pointer;
+}
+
+.jobTableColHeaders th:focus {
+  outline: 3px solid #005a9c;
+  outline-offset: 2px;
+}
+
+.sort-indicator {
+  margin-left: 6px;
+  font-size: 10px;
+  color: #333;
 }
 
 .jobTableNewJob td {

--- a/src/www/ui/template/ui-showjobs.js.twig
+++ b/src/www/ui/template/ui-showjobs.js.twig
@@ -12,6 +12,10 @@ var allUsers = {{ allusersval }};
 var pageIndex = {{ page }};
 var fullUri = '?mod=showjobs&upload=' + uploadId;
 var allJobsUri = '?mod=all_job_status';
+var currentSortColumn = null;
+var currentSortAsc = true;
+var lastShowJobsSignature = null;
+var lastShowJobsAnchor = null;
 if (allUsers != 0) {
   fullUri += '&allusers=' + allUsers;
 }
@@ -51,9 +55,111 @@ if(clockTime != "0"){
   setInterval('autoRefreshTable()', clockTime*1000); 
 }
 
+function parseNumberString(s) {
+  if (s === null || s === undefined) return NaN;
+  var str = String(s).trim();
+  var neg = false;
+  var mParen = str.match(/^\(\s*(.*)\s*\)$/);
+  if (mParen) {
+    neg = true;
+    str = mParen[1];
+  }
+
+  // Decimal-comma locale: e.g. 1.234.567,89 -> 1234567.89
+  var mDecComma = str.match(/[+-]?(?:\d{1,3}(?:\.\d{3})+)(?:,\d+)?(?:[eE][+-]?\d+)?/);
+  if (mDecComma) {
+    var tokenStr = mDecComma[0];
+    var dotCount = (tokenStr.match(/\./g) || []).length;
+    if (tokenStr.indexOf(',') !== -1 || dotCount > 1) {
+      var token = tokenStr.replace(/\./g, '').replace(/,/g, '.');
+      var v = parseFloat(token);
+      return neg ? -v : v;
+    }
+    // Otherwise fall through: single-dot values like "0.123" will be
+    // handled by the generic/fallback patterns below and parsed as decimals.
+  }
+
+  // Grouping with commas/spaces/apostrophes: 1,234,567 or 1 234 567 or 1'234'567
+  var mGrouping = str.match(/[+-]?(?:\d{1,3}(?:[ ,\u00A0']\d{3})+|\d+)(?:\.\d+)?(?:[eE][+-]?\d+)?/);
+  if (mGrouping) {
+    var token = mGrouping[0].replace(/[ ,\u00A0']/g, '');
+    var v = parseFloat(token);
+    return neg ? -v : v;
+  }
+
+  // Fallback: generic numeric token including exponent and decimal dot
+  var mGeneric = str.match(/[+-]?\d*\.?\d+(?:[eE][+-]?\d+)?/);
+  if (mGeneric) {
+    var token = mGeneric[0];
+    var v = parseFloat(token);
+    return neg ? -v : v;
+  }
+
+  return NaN;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"]|'/g, function(c) {
+    return {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;'
+    }[c];
+  });
+}
+
+// Column types: 3 = Items (numeric), 5 = Average items/sec (numeric),
+// 4 = Start/End time (date), all others sorted as plain strings.
+function getColumnType(colIndex) {
+  if (colIndex === 3 || colIndex === 5) return 'number';
+  if (colIndex === 4) return 'date';
+  return 'string';
+}
+
+function compareKeys(a, b, colIndex, asc) {
+  var type = getColumnType(colIndex);
+  if (type === 'date') {
+    var da = a.dateKey, db = b.dateKey;
+    if (!isNaN(da) && !isNaN(db)) return asc ? da - db : db - da;
+    if (!isNaN(da)) return asc ? -1 : 1;
+    if (!isNaN(db)) return asc ? 1 : -1;
+    return 0;
+  }
+  if (type === 'number') {
+    var na = a.numKey, nb = b.numKey;
+    if (!isNaN(na) && !isNaN(nb)) return asc ? na - nb : nb - na;
+    if (!isNaN(na)) return asc ? -1 : 1;
+    if (!isNaN(nb)) return asc ? 1 : -1;
+    return 0;
+  }
+  var ka = a.strKey || '';
+  var kb = b.strKey || '';
+  var cmp = ka.localeCompare(kb, undefined, { sensitivity: 'base', numeric: true });
+  return asc ? cmp : -cmp;
+}
+
+function parseDateKey(s) {
+  if (s === null || s === undefined) return NaN;
+  var str = String(s);
+  var m = str.match(/(\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(?::\d{2})?)/);
+  if (m) {
+    var ts = m[1].replace('T',' ');
+    var parts = ts.split(/[\s:-]/);
+    var y = +parts[0], mo = +parts[1]-1, d = +parts[2], hh = +parts[3]||0, mm = +parts[4]||0, ss = +parts[5]||0;
+    return Date.UTC(y, mo, d, hh, mm, ss);
+  }
+  var m2 = str.match(/(\d{2})\.(\d{2})\.(\d{4})\s+(\d{2}):(\d{2})(?::(\d{2}))?/);
+  if (m2) {
+    return Date.UTC(+m2[3], +m2[2]-1, +m2[1], +m2[4], +m2[5], +(m2[6]||0));
+  }
+  return NaN;
+}
+
 function createShowJobsTable(data)
 {
-  var mainTBody = $("#showjobstable tbody");
+  var mainTBody = $("#showjobstable > tbody");
   var joblist = data.showJobsData;
 
   mainTBody.empty();
@@ -87,6 +193,7 @@ function createShowJobsTable(data)
     }
   }
   $("#paginationdown").append(data.pagination);
+  applyCurrentSort();
 }
 
 function createTableForJob(job) {
@@ -119,85 +226,109 @@ function createTableForJob(job) {
       }
     }
   });
-  tableTemplate.html('<thead><tr><th></th>' +
+  tableTemplate.html('<thead>' +
+    '<tr class="jobTablePackageLink"><th></th>' +
     '<th colspan="6" class="text-center">' + uploadLink + '</th><th style="color:black">' +
-    allJobsStatus +' '+ uploadETA + '</th></tr>' + '</thead><tbody></tbody>');
+    allJobsStatus +' '+ uploadETA + '</th></tr>' +
+    '<tr class="jobTablePackageName"><th colspan="8" class="text-center">' + (job.job && job.job.jobName ? escapeHtml(job.job.jobName) : '') + '</th></tr>' +
+    '<tr class="jobTableColHeaders">' +
+    '<th scope="col">{{ "Job/Dependency"|trans }}</th>' +
+    '<th scope="col" tabindex="0" aria-sort="none">{{ "Status"|trans }} <span class="sort-indicator"></span></th>' +
+    '<th scope="col" tabindex="0" aria-sort="none">{{ "Agent/Type"|trans }} <span class="sort-indicator"></span></th>' +
+    '<th scope="col" tabindex="0" aria-sort="none">{{ "Items"|trans }} <span class="sort-indicator"></span></th>' +
+    '<th scope="col" tabindex="0" aria-sort="none">{{ "Start Time - End Time"|trans }} <span class="sort-indicator"></span></th>' +
+    '<th scope="col" tabindex="0" aria-sort="none">{{ "Average items/sec"|trans }} <span class="sort-indicator"></span></th>' +
+    '<th scope="col" tabindex="0" aria-sort="none">{{ "ETA"|trans }} <span class="sort-indicator"></span></th>' +
+    '<th scope="col">{{ "Actions"|trans }}</th>' +
+    '</tr>' +
+    '</thead><tbody></tbody>');
   return tableTemplate;
 }
 
 function fillTableWithJobInfo(tableTemplate, job) {
   var tbody = tableTemplate.children("tbody");
-  $('<tr class="jobTableNewJob">' +
-    '<td>{{ "Job/Dependency"|trans }}</td><td>{{ "Status"|trans }}</td>' +
-    '<td colspan="3">' + job.jobName + '</td><td>{{ "Average items/sec"|trans }}' +
-    '</td><td>{{ "ETA"|trans }}</td><td></td></tr>').appendTo(tbody);
   $.each(job.jobQueue, function(jobQueueId, jobQueueData) {
-    var action = "";
-    if (jobQueueData.canDoActions && jobQueueData.isInProgress){
-      if (jobQueueData.jq_endtext == "Paused") {
-        action += '[<a href="' + fullUri + '&action=restart&jobid=' + jobQueueId;
-        action += '" title="{{ 'Un-Pause this job'|trans }}">{{ 'Resume'|trans }}</a>]';
-      } else {
-        action += '[<a href="' + fullUri + '&action=pause&jobid=' + jobQueueId;
-        action += '" title="{{ 'Pause this job'|trans }}">{{ 'Pause'|trans }}</a>]';
-      }
-      action += ' [<a href="' + fullUri + '&action=cancel&jobid=' + jobQueueId;
-      action += '" title="{{ 'Cancel this job'|trans }}">{{ 'Cancel'|trans }}</a>]';
-    } else if (jobQueueData.download.length > 0 && jobQueueData.isReady) {
-      action += '[<a href="?mod=download&report=' + job.jobId + '">Download ' +
-        jobQueueData.download + '</a>]';
-    }
-    if ('isNoOfMonkBulk' in jobQueueData) {
-      action += '[{{ 'Count : '|trans }}<a href="#" title="isNoOfMonkBulk">' +
-        jobQueueData.isNoOfMonkBulk + '</a>]';
-    }
-
-    var jobQD = "<a href='?mod=showjobs&upload=-1&job=" + jobQueueId + "'>" + jobQueueId + "</a>";
-    if(jobQueueData.depends[0] !== null) {
-      var dependsList = [];
-      $.each(jobQueueData.depends, function(i, dependId) {
-        dependsList.push("<a href='?mod=showjobs&upload=-1&job=" + dependId + "'>" + dependId + "</a>");
-      });
-      jobQD += ' / ' + dependsList.join(' / ');
-    }
-    var trClass = "jobQueued";
-    var jqET = "";
-    if (jobQueueData.jq_endtext !== null) {
-      jqET = jobQueueData.jq_endtext;
-    }
-    var jqType = jobQueueData.jq_type;
-    var jqItemsProcessed = jobQueueData.jq_itemsprocessed;
-    var jqTime = "";
-    if (jobQueueData.jq_starttime !== null) {
-      jqTime += jobQueueData.jq_starttime.substring(0,16);
-      trClass = "jobScheduled";
-    }
-    if (jobQueueData.jq_endtime !== null) {
-      jqTime += ' - ' + jobQueueData.jq_endtime.substring(0,16);
-      trClass = "jobFinished";
-    }
-    var jqItemsPerSec = jobQueueData.itemsPerSec.toPrecision(5);
-    var jqETA = "";
-    if ('eta' in jobQueueData) {
-      if (jobQueueData.eta !== null) {
-        jqETA = jobQueueData.eta;
-      }
+    // Render a single job-queue row. Sorting/state is handled elsewhere.
+    var trClass = '';
+    if (jobQueueData.jq_end_bits > 1) {
+      trClass = 'jobFailed';
+    } else if (jobQueueData.jq_starttime && !jobQueueData.jq_endtime) {
+      trClass = 'jobScheduled';
+    } else if (jobQueueData.jq_starttime && jobQueueData.jq_endtime) {
+      trClass = 'jobFinished';
     } else {
-      jqETA = "{{ "Scanned"|trans }}";
-    }
-    if (jqET.indexOf("Fail") !== -1 || jqET.indexOf("kill") !== -1) {
-      trClass = "jobFailed";
+      trClass = 'jobQueued';
     }
 
-    $("<tr class='" + trClass + "'><td>" + jobQD + "</td>" +
-      "<td>" + jqET + "</td>" +
-      "<td>" + jqType + "</td>" +
-      "<td>" + jqItemsProcessed + " {{ "items"|trans }}</td>" +
-      "<td>" + jqTime + "</td>" +
-      "<td>" + jqItemsPerSec + " {{ "items/sec"|trans }}</td>" +
-      "<td>" + jqETA + "</td>" +
-      "<td class='jobAction'>" + action + "</td></tr>"
-    ).appendTo(tbody);
+    // Job/Dependency cell: show job id and dependencies (if any)
+    var jobIds = [];
+    if (jobQueueData.jq_pk) jobIds.push(jobQueueData.jq_pk);
+    if (jobQueueData.depends && jobQueueData.depends.length) {
+      jobQueueData.depends.forEach(function(d) { if (d) jobIds.push(d); });
+    }
+    var jobQD = jobIds.map(function(id) {
+      return '<a href="?mod=showjobs&job=' + id + '">' + id + '</a>';
+    }).join(' / ');
+
+    // Status cell
+    var jqET = jobQueueData.jq_endtext ? jobQueueData.jq_endtext : '';
+    if (!jqET && jobQueueData.jq_end_bits) {
+      if (jobQueueData.jq_end_bits == 1) jqET = '{{ "Success"|trans }}';
+      else if (jobQueueData.jq_end_bits == 2) jqET = '{{ "Failure"|trans }}';
+      else if (jobQueueData.jq_end_bits == 4) jqET = '{{ "Nonfatal"|trans }}';
+    }
+
+    var jqType = jobQueueData.jq_type || '';
+    var jqItemsProcessed = (typeof jobQueueData.jq_itemsprocessed !== 'undefined') ? jobQueueData.jq_itemsprocessed : '';
+    // Preserve previous UX: if only endtime exists, show leading dash (" - 2026-..."),
+    // if only starttime exists, show trailing dash ("2026-... - "), and if neither,
+    // render empty string (avoid bare ' - ').
+    var jqTime = '';
+    if (jobQueueData.jq_starttime || jobQueueData.jq_endtime) {
+      if (jobQueueData.jq_starttime) jqTime += jobQueueData.jq_starttime;
+      jqTime += ' - ';
+      if (jobQueueData.jq_endtime) jqTime += jobQueueData.jq_endtime;
+    }
+    var jqItemsPerSec = (typeof jobQueueData.itemsPerSec !== 'undefined') ? jobQueueData.itemsPerSec : '';
+    var jqETA = '';
+    if (typeof jobQueueData.eta !== 'undefined' && jobQueueData.eta !== null && jobQueueData.eta !== '') {
+      jqETA = jobQueueData.eta;
+    } else if (jobQueueData.jq_end_bits && jobQueueData.jq_end_bits !== 0) {
+      jqETA = '{{ "Scanned"|trans }}';
+    } else {
+      jqETA = '';
+    }
+
+    // Actions: download if ready, and admin/user actions if permitted
+    var action = '';
+    if (jobQueueData.download && jobQueueData.isReady) {
+      action += '<a href="?mod=download&report=' + jobQueueData.jq_job_fk + '">' + jobQueueData.download + '</a>';
+    }
+    if (jobQueueData.canDoActions && jobQueueData.isInProgress) {
+      var jqpk = jobQueueData.jq_pk ? jobQueueData.jq_pk : '';
+      var actionBase = fullUri + '&action=';
+      action += (action ? ' ' : '') + '[<a href="' + actionBase + 'pause&jobid=' + jqpk + '">{{ "Pause"|trans }}</a>]';
+      action += ' [<a href="' + actionBase + 'restart&jobid=' + jqpk + '">{{ "Restart"|trans }}</a>]';
+      action += ' [<a href="' + actionBase + 'cancel&jobid=' + jqpk + '">{{ "Cancel"|trans }}</a>]';
+    }
+
+    // Build row safely with jQuery. Show monk bulk counts in Items column.
+    var $row = $('<tr>').addClass(trClass);
+    $row.append($('<td>').html(jobQD));
+    $row.append($('<td>').text(jqET));
+    $row.append($('<td>').text(jqType));
+    var itemsText = (jqItemsProcessed !== '' ? (String(jqItemsProcessed) + ' ' + "{{ 'items'|trans|e('js') }}") : '');
+    var $tdItems = $('<td>').text(itemsText);
+    if (jobQueueData.isNoOfMonkBulk) {
+      $tdItems.append($('<span>').addClass('monk-bulk-count').text(' (' + String(jobQueueData.isNoOfMonkBulk) + ')'));
+    }
+    $row.append($tdItems);
+    $row.append($('<td>').text(jqTime));
+    var speedText = (jqItemsPerSec !== '' ? (String(jqItemsPerSec) + ' ' + "{{ 'items/sec'|trans|e('js') }}") : '');
+    $row.append($('<td>').text(speedText));
+    $row.append($('<td>').text(jqETA));
+    $row.append($('<td>').addClass('jobAction').html(action));
+    tbody.append($row);
   });
 }
 
@@ -207,13 +338,41 @@ function getTableBody() {
     "allusers":{{ allusersval }},
     "page"    :{{ page }}
   };
+  var scrollPosition = $(window).scrollTop();
+  var anchorBefore = captureCurrentShowJobsAnchor();
   
   $.ajax({
     type: "POST",
     url: "?mod=ajaxShowJobs&do=showjb",
     data: post_data,
     success: function (data) {
+      var signature = JSON.stringify({
+        showJobsData: data.showJobsData,
+        pagination: data.pagination
+      });
+      var anchorAfter = buildShowJobsAnchor(data);
+      if (signature === lastShowJobsSignature) {
+        return;
+      }
+
+      lastShowJobsSignature = signature;
+      lastShowJobsAnchor = anchorAfter;
+
+      var keepSort = true;
+      if (anchorBefore && anchorAfter) {
+        keepSort = anchorBefore.page === anchorAfter.page &&
+          anchorBefore.firstJobId === anchorAfter.firstJobId &&
+          anchorBefore.lastJobId === anchorAfter.lastJobId &&
+          anchorBefore.rowCount === anchorAfter.rowCount;
+      }
+
+      if (!keepSort) {
+        currentSortColumn = null;
+        currentSortAsc = true;
+      }
+
       createShowJobsTable(data);
+      $(window).scrollTop(scrollPosition);
     },
     error: function(responseobject) { }
   });
@@ -222,3 +381,269 @@ function getTableBody() {
 $(document).ready(function (){
   getTableBody();
 });
+
+/*
+ * On-click sorting for job entries.
+ * Toggle sort by clicking a column header (except the first and last).
+ * If the header is inside a nested `table.jobTable`, sort rows inside that
+ * table (preserving each `.jobTableNewJob` group). Otherwise fallback to
+ * the global outer-row sort.
+ */
+// Only attach click handler to headers that are explicitly marked sortable
+$(document).on('click', '.jobTableColHeaders th[tabindex="0"]', function() {
+  var colIndex = $(this).index();
+  var $table = $(this).closest('table.jobTable');
+  // toggle ascending flag on the clicked header
+  var asc = $(this).data('asc') === true ? false : true;
+  currentSortColumn = colIndex;
+  currentSortAsc = asc;
+  // clear asc flag on other sortable headers (in the same table if present, otherwise globally)
+  var $headers = $table.length ? $table.find('.jobTableColHeaders th[tabindex="0"]') : $('.jobTableColHeaders th[tabindex="0"]');
+  $headers.data('asc', false);
+  $(this).data('asc', asc);
+
+  // update visual indicators and ARIA state only on sortable headers
+  $headers.find('.sort-indicator').text('');
+  $headers.attr('aria-sort', 'none');
+  $(this).find('.sort-indicator').text(asc ? '▲' : '▼');
+  $(this).attr('aria-sort', asc ? 'ascending' : 'descending');
+
+  if ($table.length) {
+    sortJobsInTable($table, colIndex, asc);
+  } else {
+    sortJobsByColumn(colIndex, asc);
+  }
+});
+
+/**
+ * Sort groups inside a single nested `table.jobTable`.
+ * Each group starts with a `.jobTableNewJob` row followed by one or more
+ * job-queue rows. Groups are sorted as units by the key found in the first
+ * job-queue row of the group.
+ */
+function sortJobsInTable($table, colIndex, asc) {
+  var $tbody = $table.children('tbody');
+  var $rows = $tbody.children('tr');
+
+  // If there are no explicit per-group header rows (jobTableNewJob), sort
+  // the individual job rows directly. Otherwise preserve groups and sort by
+  // group key (existing behavior).
+  var hasGroupHeaders = $tbody.find('tr.jobTableNewJob').length > 0;
+  if (!hasGroupHeaders) {
+    var rowPairs = $rows.map(function() {
+      var $r = $(this);
+      var key = $r.find('td').eq(colIndex).text().trim();
+      return { row: $r, key: key };
+    }).get();
+
+    rowPairs.forEach(function(p) {
+      p.numKey = parseNumberString(p.key);
+      p.strKey = (p.key === null || p.key === undefined) ? '' : String(p.key).trim();
+      p.dateKey = (colIndex === 4) ? parseDateKey(p.key) : NaN;
+    });
+
+    rowPairs.sort(function(a, b) {
+      return compareKeys(a, b, colIndex, asc);
+    });
+
+    // Rebuild tbody with sorted rows
+    $tbody.empty();
+    rowPairs.forEach(function(p) { $tbody.append(p.row); });
+    return;
+  }
+
+  // --- existing group-aware sort ---
+  var groups = [];
+  var current = null;
+  $rows.each(function() {
+    var $r = $(this);
+    if ($r.hasClass('jobTableNewJob')) {
+      current = { header: $r, rows: [] };
+      groups.push(current);
+    } else {
+      if (!current) {
+        // no explicit header, create an anonymous group
+        current = { header: null, rows: [] };
+        groups.push(current);
+      }
+      current.rows.push($r);
+    }
+  });
+
+  var pairs = groups.map(function(g) {
+    var key = '';
+    if (g.rows.length > 0) {
+      key = g.rows[0].find('td').eq(colIndex).text().trim();
+    } else if (g.header) {
+      key = g.header.text().trim();
+    }
+    return { group: g, key: key };
+  });
+
+  pairs.forEach(function(p) {
+    p.numKey = parseNumberString(p.key);
+    p.strKey = (p.key === null || p.key === undefined) ? '' : String(p.key).trim();
+    p.dateKey = (colIndex === 4) ? parseDateKey(p.key) : NaN;
+  });
+
+  pairs.sort(function(a, b) {
+    return compareKeys(a, b, colIndex, asc);
+  });
+
+  $tbody.empty();
+  pairs.forEach(function(p) {
+    if (p.group.header) $tbody.append(p.group.header);
+    p.group.rows.forEach(function(r) { $tbody.append(r); });
+  });
+}
+
+// keyboard handler: trigger sort on Enter or Space for focusable headers
+$(document).on('keydown', '.jobTableColHeaders th[tabindex="0"]', function(e) {
+  var code = e.key || e.keyCode;
+  if (code === 'Enter' || code === ' ' || code === 13 || code === 32) {
+    e.preventDefault();
+    $(this).trigger('click');
+  }
+});
+
+function sortJobsByColumn(colIndex, asc) {
+  var mainTBody = $("#showjobstable > tbody");
+  var jobRows = mainTBody.children('tr').filter(function() {
+    return $(this).find('table.jobTable').length > 0;
+  });
+  var pairs = [];
+  jobRows.each(function() {
+    var jobRow = $(this);
+    var hrRow = jobRow.next('tr');
+    var key = extractKeyFromRow(jobRow, colIndex);
+    pairs.push({jobRow: jobRow, hrRow: hrRow, key: key});
+  });
+
+  pairs.forEach(function(p) {
+    p.numKey = parseNumberString(p.key);
+    p.strKey = (p.key === null || p.key === undefined) ? '' : String(p.key).trim();
+    p.dateKey = (colIndex === 4) ? parseDateKey(p.key) : NaN;
+  });
+
+  pairs.sort(function(a, b) {
+    return compareKeys(a, b, colIndex, asc);
+  });
+
+  // re-append in sorted order
+  mainTBody.empty();
+  pairs.forEach(function(p) {
+    mainTBody.append(p.jobRow);
+    if (p.hrRow && p.hrRow.length) {
+      mainTBody.append(p.hrRow);
+    }
+  });
+}
+
+function applyCurrentSort() {
+  if (currentSortColumn === null || currentSortColumn === undefined) {
+    return;
+  }
+
+  var $tables = $('table.jobTable');
+  if ($tables.length === 1) {
+    sortJobsInTable($tables, currentSortColumn, currentSortAsc);
+    return;
+  }
+
+  sortJobsByColumn(currentSortColumn, currentSortAsc);
+}
+
+function extractKeyFromRow(jobRow, colIndex) {
+  var table = jobRow.find('table.jobTable').first();
+  var firstJobQueue = table.find('tbody tr').not('.jobTableNewJob').first();
+  // column mapping: jobQueue row tds align with headers
+  var cell = firstJobQueue.find('td').eq(colIndex);
+  if (!cell || cell.length === 0) {
+    return '';
+  }
+  return cell.text().trim();
+}
+
+function captureCurrentShowJobsAnchor() {
+  var $rows = $('#showjobstable > tbody > tr').filter(function() {
+    return $(this).find('table.jobTable').length > 0;
+  });
+  if ($rows.length === 0) {
+    return null;
+  }
+
+  var firstJobId = extractJobIdFromRow($rows.first());
+  var lastJobId = extractJobIdFromRow($rows.last());
+  return {
+    page: pageIndex,
+    firstJobId: firstJobId,
+    lastJobId: lastJobId,
+    rowCount: $rows.length
+  };
+}
+
+function buildShowJobsAnchor(data) {
+  var joblist = data && data.showJobsData ? data.showJobsData : null;
+  if (!joblist || !joblist.length) {
+    return null;
+  }
+
+  var firstJob = joblist[0];
+  var lastJob = joblist[joblist.length - 1];
+  return {
+    page: pageIndex,
+    firstJobId: extractJobIdFromJob(firstJob),
+    lastJobId: extractJobIdFromJob(lastJob),
+    rowCount: joblist.length
+  };
+}
+
+function extractJobIdFromRow(jobRow) {
+  var table = jobRow.find('table.jobTable').first();
+  var firstJobQueue = table.find('tbody tr').not('.jobTableNewJob').first();
+  return extractJobIdFromJobQueueRow(firstJobQueue);
+}
+
+function extractJobIdFromJob(job) {
+  if (!job || !job.jobQueue || !job.jobQueue.length) {
+    return '';
+  }
+  var firstQueue = job.jobQueue[0];
+  return extractJobIdFromJobQueueData(firstQueue);
+}
+
+function extractJobIdFromJobQueueRow($jobQueueRow) {
+  if (!$jobQueueRow || $jobQueueRow.length === 0) {
+    return '';
+  }
+  var cell = $jobQueueRow.find('td').first();
+  if (!cell || cell.length === 0) {
+    return '';
+  }
+  return extractJobIdFromHtml(cell.html());
+}
+
+function extractJobIdFromJobQueueData(jobQueueData) {
+  if (!jobQueueData) {
+    return '';
+  }
+  if (jobQueueData.jq_pk) {
+    return String(jobQueueData.jq_pk);
+  }
+  if (jobQueueData.depends && jobQueueData.depends.length) {
+    for (var i = 0; i < jobQueueData.depends.length; i++) {
+      if (jobQueueData.depends[i]) {
+        return String(jobQueueData.depends[i]);
+      }
+    }
+  }
+  return '';
+}
+
+function extractJobIdFromHtml(html) {
+  if (!html) {
+    return '';
+  }
+  var match = String(html).match(/>(\d+)</);
+  return match ? match[1] : '';
+}


### PR DESCRIPTION
This PR updates the “showjobs” UI to make nearly all job table column headers visible and sortable (on client-side) when clicking those headers (excluding the first and last columns: Job/Dependency and Actions). 

Asked/Proposed in https://github.com/fossology/fossology/discussions/3400

## Changes

* Updated the `.jobTable` class to use a smaller, consistent font and set `height: auto` for better layout control.
* Redesigned table headers (`.jobTablePackageName`, `.jobTableColHeaders`) with a light gray background, centered bold text, and improved padding for clarity.
* Added a `.sort-indicator` class for visual feedback on sorting, with adjusted spacing and color.
* Enhanced accessibility by adding focus outlines to column headers and making sortable columns indicate pointer cursor and focus state.

**Changed Files:**
 - src/www/ui/template/ui-showjobs.js.twig
 - src/www/ui/css/showjobs.css

**Limitations / Notes**
 - Sorting is performed client-side and only applies to the currently loaded page for the selected package(s).
 - There is a configurable refresh interval from 'ShowJobsAutoRefresh' in sysconfig (default: 10 seconds). On each refresh, the page re-fetches the job data, rebuilds the table, and reapplies the current sort order. If the user navigates to another page, or the packages moves to a different page, the current sort order is not preserved.

I am aware that there is a project for a refreshed UI/UX. These changes shouldn't conflict with that.

**Before/current:**

<img width="1592" height="371" alt="3400_before" src="https://github.com/user-attachments/assets/3c76e637-62c5-4aef-9242-e0c3ffb41f92" />

**With change:**

<img width="800" height="330" alt="3400_sort_items" src="https://github.com/user-attachments/assets/d4e16aad-9cdc-44e4-ac6d-590b19144226" />
<img width="400" height="330" alt="3400_sort_agent" src="https://github.com/user-attachments/assets/d1563b40-3802-47ad-884d-862dd47733bc" />

