### PR TITLE
feat(SWH): add aggregrated SWH view for sub folders

### DIFF
--- a/src/lib/php/Dao/SoftwareHeritageDao.php
+++ b/src/lib/php/Dao/SoftwareHeritageDao.php
@@ -8,6 +8,7 @@
 
 namespace Fossology\Lib\Dao;
 
+use Fossology\Lib\Data\Tree\ItemTreeBounds;
 use Fossology\Lib\Db\DbManager;
 use Monolog\Logger;
 
@@ -89,5 +90,78 @@ class SoftwareHeritageDao
       $img = '<img alt="done" src="images/green.png" class="icon-small"/>';
     }
     return ["license" => $row['swh_shortnames'], "img" => $img];
+  }
+
+  /**
+   * @brief Get aggregated SWH status for all files under a folder
+   * @param ItemTreeBounds $itemTreeBounds
+   * @return array
+   */
+  public function getAggregatedSWHRecord(ItemTreeBounds $itemTreeBounds)
+  {
+    $uploadTreeTableName = $itemTreeBounds->getUploadTreeTableName();
+    $uploadId = $itemTreeBounds->getUploadId();
+    $left = $itemTreeBounds->getLeft();
+    $right = $itemTreeBounds->getRight();
+
+    $stmt = __METHOD__ . $uploadTreeTableName;
+    $sql = "SELECT
+              COUNT(*) AS total_files,
+              COUNT(SWH.pfile_fk) AS checked_files,
+              SUM(CASE WHEN SWH.swh_status = $1 THEN 1 ELSE 0 END) AS ok_files
+            FROM $uploadTreeTableName UT
+            LEFT JOIN software_heritage SWH ON SWH.pfile_fk = UT.pfile_fk
+            WHERE UT.upload_fk = $2
+              AND UT.lft BETWEEN $3 AND $4
+              AND UT.ufile_mode & (1<<29) = 0";
+
+    $row = $this->dbManager->getSingleRow($sql, array(self::SWH_STATUS_OK, $uploadId, $left, $right), $stmt);
+
+    $totalFiles = intval($row['total_files']);
+    $checkedFiles = intval($row['checked_files']);
+    $okFiles = intval($row['ok_files']);
+
+    if ($totalFiles == 0) {
+      return ["license" => null, "img" => ""];
+    }
+
+    $licenseNames = [];
+    if ($checkedFiles > 0) {
+      $licenseStmt = __METHOD__ . 'licenses' . $uploadTreeTableName;
+      $licenseSql = "SELECT DISTINCT SWH.swh_shortnames
+                     FROM $uploadTreeTableName UT
+                     INNER JOIN software_heritage SWH ON SWH.pfile_fk = UT.pfile_fk
+                     WHERE UT.upload_fk = $1
+                       AND UT.lft BETWEEN $2 AND $3
+                       AND UT.ufile_mode & (1<<29) = 0
+                       AND SWH.swh_shortnames IS NOT NULL
+                       AND SWH.swh_shortnames != ''";
+      $licenseRows = $this->dbManager->getRows($licenseSql, array($uploadId, $left, $right), $licenseStmt);
+      foreach ($licenseRows as $licenseRow) {
+        $parts = explode(',', $licenseRow['swh_shortnames']);
+        foreach ($parts as $part) {
+          $trimmed = trim($part);
+          if (!empty($trimmed)) {
+            $licenseNames[$trimmed] = true;
+          }
+        }
+      }
+    }
+
+    if ($checkedFiles == 0) {
+      return [
+        "license" => null,
+        "img" => '<img alt="pending" src="images/grey.png" class="icon-small"/>'
+      ];
+    }
+
+    if ($okFiles == $totalFiles) {
+      $img = '<img alt="done" src="images/green.png" class="icon-small"/>';
+    } else {
+      $img = '<img alt="needs-attention" src="images/red.png" class="icon-small"/>';
+    }
+
+    $licenseStr = !empty($licenseNames) ? implode(', ', array_keys($licenseNames)) : null;
+    return ["license" => $licenseStr, "img" => $img];
   }
 }

--- a/src/softwareHeritage/ui/AjaxSHDetailsBrowser.php
+++ b/src/softwareHeritage/ui/AjaxSHDetailsBrowser.php
@@ -16,7 +16,7 @@ use Fossology\Lib\Plugin\DefaultPlugin;
 use Fossology\Lib\Proxy\ScanJobProxy;
 use Fossology\Lib\Proxy\UploadTreeProxy;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use \Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class AjaxSHDetailsBrowser extends DefaultPlugin
@@ -129,7 +129,9 @@ class AjaxSHDetailsBrowser extends DefaultPlugin
     if ($isFlat) {
       $options = array(UploadTreeProxy::OPT_RANGE => $itemTreeBounds);
     } else {
-      $options = array(UploadTreeProxy::OPT_REALPARENT => $itemTreeBounds->getItemId());
+      $options = array(
+        UploadTreeProxy::OPT_ITEM_FILTER => "AND ut.ufile_mode & (1<<28) = 0 AND ut.realparent=" . $itemTreeBounds->getItemId()
+      );
     }
 
     $searchMap = array();
@@ -267,23 +269,30 @@ class AjaxSHDetailsBrowser extends DefaultPlugin
       $fileName = "<a href='$linkUri'>$fileName</a>";
     }
 
-    $pfileHash = $this->uploadDao->getUploadHashesFromPfileId($fileId);
-    $shRecord = $this->shDao->getSoftwareHetiageRecord($fileId);
     $fileListLinks = FileListLinks($uploadId, $childUploadTreeId, 0, $fileId, true, $UniqueTagArray, $this->uploadtree_tablename, !$isFlat);
 
-    if (! $isContainer) {
-      $text = _("Software Heritage");
-      $shLink = $this->configuration['url'] .
-        $this->configuration['uri'] . strtolower($pfileHash["sha256"]) .
-        $this->configuration['content'];
-      $fileListLinks .= "[<a href='".$shLink."' target=\"_blank\">$text</a>]";
-    }
-    $img = "";
-    if (! $isContainer) {
-      $img = $shRecord["img"];
+    if ($isContainer) {
+      $childBounds = new ItemTreeBounds(
+        $child['uploadtree_pk'],
+        $this->uploadtree_tablename,
+        $uploadId,
+        $child['lft'],
+        $child['rgt']
+      );
+      $shRecord = $this->shDao->getAggregatedSWHRecord($childBounds);
+      return [$fileName, "", $shRecord["license"], $shRecord["img"], $fileListLinks];
     }
 
-    return [$fileName, $pfileHash["sha256"], $shRecord["license"], $img, $fileListLinks];
+    $pfileHash = $this->uploadDao->getUploadHashesFromPfileId($fileId);
+    $shRecord = $this->shDao->getSoftwareHetiageRecord($fileId);
+
+    $text = _("Software Heritage");
+    $shLink = $this->configuration['url'] .
+      $this->configuration['uri'] . strtolower($pfileHash["sha256"]) .
+      $this->configuration['content'];
+    $fileListLinks .= "[<a href='".$shLink."' target=\"_blank\">$text</a>]";
+
+    return [$fileName, $pfileHash["sha256"], $shRecord["license"], $shRecord["img"], $fileListLinks];
   }
 }
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Aggregate SW Heritage status for folders in the browse view, showing distinct SWH licenses and status icons per folder.

Closes: #1627 
### Changes

- Added `getAggregatedSWHRecord()` to `SoftwareHeritageDao` to compute aggregate SWH status (distinct licenses, status icon) for all files under a folder
- Modified `AjaxSHDetailsBrowser` tree view to include subdirectories alongside files.
- Added folder row handling in `createFileDataRow` to display aggregated SWH license names and status icon instead of empty columns

### Screenshots:
<img width="1917" height="531" alt="image" src="https://github.com/user-attachments/assets/6c57efb5-dd47-4c5a-975b-e3da1efaf71d" />


