### PR TITLE
fix(scheduler): parametrize basic_checkout LIMIT from host max config

### DIFF
--- a/src/scheduler/agent/database.c
+++ b/src/scheduler/agent/database.c
@@ -840,6 +840,12 @@ void database_exec_event(scheduler_t* scheduler, char* sql)
 /**
  * @brief Checks the job queue for any new entries.
  *
+ * The number of rows fetched from the database is bounded by the sum of
+ * max-agent slots across all configured hosts so that every available slot
+ * can be filled in a single poll cycle.  When the scheduler has not yet
+ * loaded any host configuration (startup path) the query falls back to
+ * CHECKOUT_SIZE as a safe upper bound.
+ *
  * @param scheduler The scheduler_t* that holds the connection
  * @param unused
  */
@@ -850,6 +856,9 @@ void database_update_event(scheduler_t* scheduler, void* unused)
   int i, j_id;
   char* value, * type, * host, * pfile, * jq_cmd_args;
   job_t* job;
+  gchar* checkout_sql;
+  int   checkout_limit;
+  GList* iter;
 
   if(closing)
   {
@@ -857,12 +866,47 @@ void database_update_event(scheduler_t* scheduler, void* unused)
     return;
   }
 
+  /* Compute the checkout limit from configured host capacity.
+   *  a) No hosts loaded yet (startup): fall back to CHECKOUT_SIZE.
+   *  b) Hosts configured: sum max values for hosts with max > 0 only
+   *     (max <= 0 provides no real slots per get_host() and must not reduce
+   *     the total). LIMIT 0 is valid SQL and correct when all hosts have
+   *     max=0; do NOT inflate to CHECKOUT_SIZE or jobs that can never run
+   *     would be over-fetched. On integer overflow (requires INT_MAX
+   *     slots – practically impossible) fall back to CHECKOUT_SIZE. */
+  if(scheduler->host_queue == NULL)
+  {
+    checkout_limit = CHECKOUT_SIZE;
+  }
+  else
+  {
+    gint64 limit64 = 0;
+    for(iter = scheduler->host_queue; iter != NULL; iter = iter->next)
+    {
+      int host_max = ((host_t*)iter->data)->max;
+      /* Only count hosts that can actually accept agents */
+      if(host_max > 0)
+        limit64 += host_max;
+    }
+    /* Accumulating positive ints into gint64 cannot overflow in practice,
+     * but guard the cast back to int to avoid UB (requires >2^31 total slots). */
+    checkout_limit = (limit64 <= INT_MAX) ? (int)limit64 : CHECKOUT_SIZE;
+  }
+
   /* one query for the queue rows joined with priority and user info, instead of
    * a basic_checkout plus a per-row jobsql_information lookup */
-  db_result = database_exec(scheduler, basic_checkout);
+  checkout_sql = g_strdup_printf(basic_checkout, checkout_limit);
+  db_result = database_exec(scheduler, checkout_sql);
+  g_free(checkout_sql);
+  if(db_result == NULL)
+  {
+    ERROR("database update: database_exec returned NULL (connection failure)");
+    return;
+  }
   if(PQresultStatus(db_result) != PGRES_TUPLES_OK)
   {
     PQ_ERROR(db_result, "database update failed on call to PQexec");
+    SafePQclear(db_result);
     return;
   }
 

--- a/src/scheduler/agent/scheduler.h
+++ b/src/scheduler/agent/scheduler.h
@@ -117,6 +117,10 @@
 /* fo library includes */
 #include <fossconfig.h>
 
+/** Maximum number of jobs to fetch from the database in a single poll cycle
+ *  when no host configuration has been loaded yet (startup fallback).
+ *  At runtime the actual limit is the sum of max-agent slots across all
+ *  configured hosts; see database_update_event() in database.c. */
 #define CHECKOUT_SIZE 100
 
 #define AGENT_BINARY "%s/%s/%s/agent/%s"  ///< Format to get agent binary

--- a/src/scheduler/agent/sqlstatements.h
+++ b/src/scheduler/agent/sqlstatements.h
@@ -107,6 +107,12 @@ const char* jobsql_email_job =
  * Fetch the next batch of schedulable jobs with their user and priority.
  * The users table is LEFT JOINed so a job whose user was deleted shows up with a
  * NULL user_pk and can be skipped instead of silently dropped.
+ *
+ * This is a printf format string: the single '%d' placeholder is filled with
+ * the dynamic checkout limit computed in database_update_event() as the sum of
+ * max-agent slots across all configured hosts (falling back to CHECKOUT_SIZE).
+ * Do NOT use this string directly with database_exec(); always format it first
+ * via g_strdup_printf().
  */
 const char* basic_checkout =
     " SELECT jq.jq_pk, jq.jq_job_fk, jq.jq_type, jq.jq_host,"
@@ -123,7 +129,7 @@ const char* basic_checkout =
     "       AND NOT (dep.jq_endtime IS NOT NULL AND dep.jq_end_bits < 2)"
     "   )"
     " ORDER BY j.job_priority DESC"
-    " LIMIT 10;";
+    " LIMIT %d;";
 
 /**
  * Mark the given job id as started


### PR DESCRIPTION
## Description / Intention

The basic_checkout SQL query had a hardcoded LIMIT 10 that caused the scheduler to stop dispatching new jobs when the host max was set above 10. 
Only 10 rows were fetched per poll cycle; since JB_CHECKEDOUT jobs retain jq_starttime IS NULL until the agent handshake completes, the next poll returned the same 10 rows and skipped them all > leading in some cases to leaving all remaining queued jobs stuck.

Pays credits to #3700  (1)

## Changes

Compute the checkout limit dynamically in database_update_event():
- If no hosts are loaded yet (host_queue == NULL, startup path), fall back to CHECKOUT_SIZE so the query runs before host configuration has been applied.
- If hosts are configured, sum only hosts whose max > 0. Hosts with max <= 0 never satisfy (max - running >= 1) in get_host(), so they provide zero real slots and must not reduce the total limit. LIMIT 0 is valid PostgreSQL and correctly returns no rows when all hosts have max=0; do NOT inflate to CHECKOUT_SIZE as that would over-fetch jobs that can never be dispatched.
- If the accumulated sum wraps negative (integer overflow; requires INT_MAX total slots - practically impossible), fall back to CHECKOUT_SIZE rather than clamping to 0, which would block fetching.

Guard database_exec() return value against NULL before passing to PQresultStatus(); ensure SafePQclear() runs on every error path.
Existing configs with max=10 see identical behavior.

### File changes in detail

* `src/scheduler/agent/database.c`, `src/scheduler/agent/sqlstatements.h`: The number of jobs fetched from the database in each poll cycle is now dynamically set to the sum of `max` agent slots across all configured hosts. If no hosts are configured (startup), it falls back to the constant `CHECKOUT_SIZE`.
* `src/scheduler/agent/sqlstatements.h`: The SQL query for fetching jobs (`basic_checkout`) now uses a `%d` placeholder for the limit, which is filled at runtime with the dynamically computed value. 
* `src/scheduler/agent/sqlstatements.h`, `src/scheduler/agent/database.c`, `src/scheduler/agent/scheduler.h`: Added and updated comments to explain the new logic, including how the limit is computed and why it is necessary to format the SQL string before execution.
* `src/scheduler/agent/database.c`: Ensured proper cleanup and error handling when the database query fails.

