### PR TITLE
fix(report): keep report export job status current

### DIFF
--- a/src/clixml/ui/CliXmlGeneratorUi.php
+++ b/src/clixml/ui/CliXmlGeneratorUi.php
@@ -88,6 +88,7 @@ class CliXmlGeneratorUi extends DefaultPlugin
 
     $vars = array('jqPk' => $jobQueueId,
                   'downloadLink' => Traceback_uri(). "?mod=download&report=".$jobId,
+                  'showJobsLink' => Traceback_uri(). "?mod=showjobs&upload=".$upload->getId(),
                   'reportType' => $this->outputFormat);
     $text = sprintf(_("Generating ". $this->outputFormat . " report for '%s'"), $upload->getFilename());
     $vars['content'] = "<h2>".$text."</h2>";

--- a/src/cyclonedx/ui/CycloneDXGeneratorUi.php
+++ b/src/cyclonedx/ui/CycloneDXGeneratorUi.php
@@ -88,6 +88,7 @@ class CycloneDXGeneratorUi extends DefaultPlugin
 
     $vars = array('jqPk' => $jobQueueId,
                   'downloadLink' => Traceback_uri(). "?mod=download&report=".$jobId,
+                  'showJobsLink' => Traceback_uri(). "?mod=showjobs&upload=".$upload->getId(),
                   'reportType' => $this->outputFormat);
     $text = sprintf(_("Generating ". $this->outputFormat . " report for '%s'"), $upload->getFilename());
     $vars['content'] = "<h2>".$text."</h2>";

--- a/src/decisionexporter/ui/FoDecisionExporter.php
+++ b/src/decisionexporter/ui/FoDecisionExporter.php
@@ -60,6 +60,7 @@ class FoDecisionExporter extends DefaultPlugin
 
     $vars = array('jqPk' => $jobQueueId,
                   'downloadLink' => Traceback_uri(). "?mod=download&report=".$jobId,
+                  'showJobsLink' => Traceback_uri(). "?mod=showjobs&upload=".$upload->getId(),
                   'reportType' => "dumpexporter");
     $text = sprintf(_("Generating FOSSology Decisions for '%s'"), $upload->getFilename());
     $vars['content'] = "<h2>".$text."</h2>";

--- a/src/readmeoss/ui/ReadMeOssPlugin.php
+++ b/src/readmeoss/ui/ReadMeOssPlugin.php
@@ -89,6 +89,7 @@ class ReadMeOssPlugin extends DefaultPlugin
 
     $vars = array('jqPk' => $jobQueueId,
                   'downloadLink' => Traceback_uri(). "?mod=download&report=".$jobId,
+                  'showJobsLink' => Traceback_uri(). "?mod=showjobs&upload=".$upload->getId(),
                   'reportType' => "ReadMe_OSS");
     $text = sprintf(_("Generating ReadMe_OSS for '%s'"), $upload->getFilename());
     $vars['content'] = "<h2>".$text."</h2>";

--- a/src/spdx/ui/SpdxThreeGeneratorUi.php
+++ b/src/spdx/ui/SpdxThreeGeneratorUi.php
@@ -104,6 +104,7 @@ class SpdxThreeGeneratorUi extends DefaultPlugin
 
     $vars = array('jqPk' => $jobQueueId,
                   'downloadLink' => Traceback_uri(). "?mod=download&report=".$jobId,
+                  'showJobsLink' => Traceback_uri(). "?mod=showjobs&upload=".$upload->getId(),
                   'reportType' => $this->outputFormat);
     $text = sprintf(_("Generating ". $this->outputFormat . " report for '%s'"), $upload->getFilename());
     $vars['content'] = "<h2>".$text."</h2>";

--- a/src/spdx/ui/SpdxTwoGeneratorUi.php
+++ b/src/spdx/ui/SpdxTwoGeneratorUi.php
@@ -103,6 +103,7 @@ class SpdxTwoGeneratorUi extends DefaultPlugin
 
     $vars = array('jqPk' => $jobQueueId,
                   'downloadLink' => Traceback_uri(). "?mod=download&report=".$jobId,
+                  'showJobsLink' => Traceback_uri(). "?mod=showjobs&upload=".$upload->getId(),
                   'reportType' => $this->outputFormat);
     $text = sprintf(_("Generating ". $this->outputFormat . " report for '%s'"), $upload->getFilename());
     $vars['content'] = "<h2>".$text."</h2>";

--- a/src/unifiedreport/ui/agent-foreport.php
+++ b/src/unifiedreport/ui/agent-foreport.php
@@ -57,6 +57,7 @@ class FoUnifiedReportGenerator extends DefaultPlugin
 
     $vars = array('jqPk' => $jobQueueId,
                   'downloadLink' => Traceback_uri(). "?mod=download&report=".$jobId,
+                  'showJobsLink' => Traceback_uri(). "?mod=showjobs&upload=".$upload->getId(),
                   'reportType' => "Unified");
     $text = sprintf(_("Generating new report for '%s'"), $upload->getFilename());
     $vars['content'] = "<h2>".$text."</h2>";

--- a/src/www/ui/template/report.html.twig
+++ b/src/www/ui/template/report.html.twig
@@ -5,21 +5,55 @@
   <script src="scripts/job-queue-poll.js" type="text/javascript"></script>
   <script>
     var resultEntity = $("#jobResult");
+    var downloadLink = {{ downloadLink|json_encode|raw }};
+    var reportType = {{ reportType|json_encode|raw }};
+    var showJobsLink = {{ showJobsLink|json_encode|raw }};
 
-    function linkDownloadReport() {
-      resultEntity.html("<a href='{{ downloadLink }}'>Download {{ reportType }} report</a>");
-      window.location = "{{ downloadLink }}";
+    function replaceReportHistory() {
+      if (showJobsLink && window.history && window.history.replaceState) {
+        window.history.replaceState(null, document.title, showJobsLink);
+      }
+    }
+
+    function markReportJobFinished(jqPk) {
+      var jobRow = $("#showjobstable tr").filter(function () {
+        return $.trim($(this).children("td:first").text()).split(/\s+/)[0] === String(jqPk);
+      });
+      var downloadAction = $("<span>").append("[")
+        .append($("<a>").attr("href", downloadLink).text("Download " + reportType + " report"))
+        .append("]");
+
+      jobRow.removeClass("jobQueued jobScheduled jobFailed").addClass("jobFinished");
+      jobRow.children("td").eq(1).text("Completed");
+      jobRow.children("td").eq(6).text("Scanned");
+      jobRow.children("td.jobAction").empty().append(downloadAction);
+    }
+
+    function linkDownloadReport(jqPk) {
+      markReportJobFinished(jqPk);
+      resultEntity.empty().append(
+        $("<a>").attr("href", downloadLink).text("Download " + reportType + " report")
+      );
+      window.setTimeout(function () {
+        if (typeof getTableBody === "function") {
+          getTableBody(function () {
+            window.location = downloadLink;
+          });
+        } else {
+          window.location = downloadLink;
+        }
+      }, 1000);
     }
     function genereationFailed(jqPk) {
       var text = (jqPk > 0) ? linkToJob(jqPk) : "no job scheduled";
-      resultEntity.html("{{ reportType }} generation failed: " + text);
+      resultEntity.html(reportType + " generation failed: " + text);
     }
 
     function addLinkAndQueueAjaxPolling() {
       var jqPk = {{ jqPk }};
       if (jqPk > 0)
       {
-        resultEntity.html("{{ reportType }} report generation scheduled as " + linkToJob(jqPk));
+        resultEntity.html(reportType + " report generation scheduled as " + linkToJob(jqPk));
         queueUpdateCheck(jqPk, linkDownloadReport, genereationFailed);
       }
       else
@@ -29,6 +63,7 @@
     }
 
     $(document).ready(function () {
+      replaceReportHistory();
       addLinkAndQueueAjaxPolling();
     });
   </script>

--- a/src/www/ui/template/ui-showjobs.js.twig
+++ b/src/www/ui/template/ui-showjobs.js.twig
@@ -201,7 +201,7 @@ function fillTableWithJobInfo(tableTemplate, job) {
   });
 }
 
-function getTableBody() {
+function getTableBody(callback) {
   var post_data = {
     "upload"  :{{ uploadId }},
     "allusers":{{ allusersval }},
@@ -215,7 +215,12 @@ function getTableBody() {
     success: function (data) {
       createShowJobsTable(data);
     },
-    error: function(responseobject) { }
+    error: function(responseobject) { },
+    complete: function () {
+      if (typeof callback === "function") {
+        callback();
+      }
+    }
   });
 }
 


### PR DESCRIPTION
## Description

Fixes a report export UI inconsistency where generated reports could download successfully while the “My Recent Jobs” table still showed the report job as running with `[Pause] [Cancel]`.

This also prevents browser refresh from re-triggering the same report export by replacing the export URL with the stable `showjobs` URL after scheduling.

## Changes Made

- Added a stable `showJobsLink` to report generator UI plugins.
- Updated the shared report generation template to replace browser history with the `showjobs` URL.
- Updated the report completion callback to immediately mark the active report job row as completed.
- Added a download link to the completed job row and removed stale pause/cancel actions.
- Allowed `getTableBody()` to accept an optional callback so report download can wait for the table refresh path when available.

## Proof that issue exists

https://github.com/user-attachments/assets/75064dab-a085-4a11-9541-42cda427ccd4

