### PR TITLE
ci: restrict GITHUB_TOKEN permissions in all workflows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,6 +7,9 @@ concurrency:
   group: build-${{ github.head_ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]

--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -9,6 +9,7 @@ on:
     types: [synchronize]
 
 permissions:
+  contents: read
   pull-requests: write # to label PRs
 
 jobs:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -4,6 +4,9 @@
 
 name: GitHub Pages Deploy
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,6 +8,9 @@ concurrency:
   group: docker-${{ github.head_ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: GPL-2.0-only AND LGPL-2.1-only
 name: Docker test
 
+permissions:
+  contents: read
+
 on:
   pull_request
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,6 +9,9 @@ on:
     types:
       - published
 
+permissions:
+  contents: write # required to upload release assets
+
 env:
   DEBIAN_FRONTEND: noninteractive
 

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -9,6 +9,9 @@ concurrency:
   group: static-${{ github.head_ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]
@@ -119,6 +122,11 @@ jobs:
 
   lint-commits:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read   # wagoid/commitlint reads PR commits
+      checks: write         # wagoid/commitlint posts check annotations
+      statuses: write       # christophebedard/dco-check posts commit statuses
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5


### PR DESCRIPTION
## Description

Set explicit least-privilege permissions on all GitHub Actions workflows.
See 'Principle of least privilege' on: https://docs.github.com/en/actions/reference/security/secure-use

### Changes

- Add `permissions: contents: read` as workflow-level default to .yml files:
  build-test
  docker-test
  docker-build
  deploy-pages
  static-checks
- Add job-level override for lint-commits in static-checks.yml
- Add `contents: read` to conflict-check.yml
- Set `contents: write` for release-publish.yml

## IMPORTANT

I cannot guarantee or personally test every workflow to see if the permissions might be too restrictive.

 