### PR TITLE
fix(schema): add index on jobdepends.jdep_jq_fk

### DIFF
--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -2856,6 +2856,8 @@
   $Schema["INDEX"]["ipra_decision"]["ipra_decision_user_fk_index"] = "CREATE INDEX ipra_decision_user_fk_index ON ipra_decision USING btree (user_fk);";
   $Schema["INDEX"]["ipra_decision"]["ipra_decision_pfile_hash_index"] = "CREATE INDEX ipra_decision_pfile_hash_index ON ipra_decision USING btree (hash, pfile_fk);";
 
+  $Schema["INDEX"]["jobdepends"]["jobdepends_jq_fk_idx"] = "CREATE INDEX jobdepends_jq_fk_idx ON jobdepends USING btree (jdep_jq_fk);";
+
   $Schema["INDEX"]["keyword"]["keyword_pfile_fk_is_enabled_false_idx"] = "CREATE INDEX keyword_pfile_fk_is_enabled_false_idx ON keyword USING btree (pfile_fk, is_enabled) WHERE (is_enabled = false);";
   $Schema["INDEX"]["keyword"]["keyword_agent_fk_index"] = "CREATE INDEX keyword_agent_fk_index ON keyword USING btree (agent_fk);";
   $Schema["INDEX"]["keyword"]["keyword_hash_index"] = "CREATE INDEX keyword_hash_index ON keyword USING btree (hash);";


### PR DESCRIPTION
## Description

jobdepends rows are removed only via ON DELETE CASCADE when jobqueue rows are deleted, which happens only when an upload is explicitly deleted through the UI or delagent.

The table is accessed in three places, all of which filter or join on the **jdep_jq_fk** column:
1) \src\scheduler\agent\sqlstatements.h - basic_checkout : executed on every scheduler poll cycle
2) \src\scheduler\agent\sqlstatements.h - jobsql_anyrunnable : executed on every job completion
3) \src\lib\php\Dao\ShowJobsDao.php - attachJobQueueData() : job list UI / REST API

| Query | Before | After |
|-------|--------|-------|
| `basic_checkout` `NOT EXISTS` | Seq scan of full table per candidate row | Index seek, O(log n) |
| `jobsql_anyrunnable` `NOT EXISTS` | Seq scan of full table per candidate row | Index seek, O(log n) |
| `ShowJobsDao` `LEFT JOIN` | Seq scan | Index nested-loop join |


### Changes

Add a single btree index on the lookup column (jdep_jq_fk) in _core-schema.dat_.
