### PR TITLE
fix(scheduler): exclude in-flight jobs from DB poll via NOT IN

### DIFF
--- a/src/scheduler/agent/database.c
+++ b/src/scheduler/agent/database.c
@@ -840,6 +840,12 @@ void database_exec_event(scheduler_t* scheduler, char* sql)
 /**
  * @brief Checks the job queue for any new entries.
  *
+ * The number of rows fetched from the database is bounded by the sum of
+ * max-agent slots across all configured hosts so that every available slot
+ * can be filled in a single poll cycle.  When the scheduler has not yet
+ * loaded any host configuration (startup path) the query falls back to
+ * CHECKOUT_SIZE as a safe upper bound.
+ *
  * @param scheduler The scheduler_t* that holds the connection
  * @param unused
  */
@@ -850,6 +856,9 @@ void database_update_event(scheduler_t* scheduler, void* unused)
   int i, j_id;
   char* value, * type, * host, * pfile, * jq_cmd_args;
   job_t* job;
+  gchar* checkout_sql;
+  int   checkout_limit;
+  GList* iter;
 
   if(closing)
   {
@@ -857,12 +866,53 @@ void database_update_event(scheduler_t* scheduler, void* unused)
     return;
   }
 
+  /* Compute the checkout limit as the total number of agent slots available
+   * across all configured hosts so that every available slot can be filled
+   * in a single poll cycle. Two distinct cases are handled separately:
+   *  a) host_queue is NULL (startup: no hosts loaded yet)
+   *     -> fall back to CHECKOUT_SIZE so the query runs and finds pending
+   *        jobs even before host configuration has been applied.
+   *  b) hosts are configured
+   *     -> use the sum of their max values directly. LIMIT 0 is valid
+   *        PostgreSQL and returns no rows when all hosts have max=0 config;
+   *        do NOT inflate to CHECKOUT_SIZE here as that would over-fetch
+   *        jobs that can never be dispatched.
+   *        Clamp to 0 if the sum goes negative (e.g. hosts with max<0) to
+   *        avoid a PostgreSQL "LIMIT must not be negative" error. */
+  if(scheduler->host_queue == NULL)
+  {
+    checkout_limit = CHECKOUT_SIZE;
+  }
+  else
+  {
+    checkout_limit = 0;
+    for(iter = scheduler->host_queue; iter != NULL; iter = iter->next)
+    {
+      int host_max = ((host_t*)iter->data)->max;
+      /* Only count hosts that can actually accept agents */
+      if(host_max > 0)
+        checkout_limit += host_max;
+    }
+    /* If the sum wrapped negative (requires INT_MAX total slots across
+     * all hosts – practically impossible), fall back to CHECKOUT_SIZE */
+    if(checkout_limit < 0)
+      checkout_limit = CHECKOUT_SIZE;
+  }
+
   /* one query for the queue rows joined with priority and user info, instead of
    * a basic_checkout plus a per-row jobsql_information lookup */
-  db_result = database_exec(scheduler, basic_checkout);
+  checkout_sql = g_strdup_printf(basic_checkout, checkout_limit);
+  db_result = database_exec(scheduler, checkout_sql);
+  g_free(checkout_sql);
+  if(db_result == NULL)
+  {
+    ERROR("database update: database_exec returned NULL (connection failure)");
+    return;
+  }
   if(PQresultStatus(db_result) != PGRES_TUPLES_OK)
   {
     PQ_ERROR(db_result, "database update failed on call to PQexec");
+    SafePQclear(db_result);
     return;
   }
 

--- a/src/scheduler/agent/database.c
+++ b/src/scheduler/agent/database.c
@@ -838,6 +838,27 @@ void database_exec_event(scheduler_t* scheduler, char* sql)
 }
 
 /**
+ * @brief GTraverseFunc callback: append each job's id (jq_pk) to a
+ *        comma-separated GString for use in a SQL NOT IN clause.
+ *
+ * Called by g_tree_foreach() on scheduler->job_list inside
+ * database_update_event() to build the exclusion list that prevents
+ * in-flight JB_CHECKEDOUT jobs (whose jq_starttime is still NULL in the
+ * database) from being re-fetched and consuming LIMIT slots.
+ *
+ * @param key   Pointer to the job id (int*) stored as the GTree key
+ * @param val   Unused job_t* value
+ * @param data  GString* to append to
+ * @return FALSE to continue the traversal
+ */
+static gboolean collect_known_pks(gpointer key, gpointer val, gpointer data)
+{
+  (void)val;
+  g_string_append_printf((GString*)data, ",%d", *(int*)key);
+  return FALSE;
+}
+
+/**
  * @brief Checks the job queue for any new entries.
  *
  * The number of rows fetched from the database is bounded by the sum of
@@ -858,6 +879,7 @@ void database_update_event(scheduler_t* scheduler, void* unused)
   job_t* job;
   gchar* checkout_sql;
   int   checkout_limit;
+  GString* excl_pks;
   GList* iter;
 
   if(closing)
@@ -866,42 +888,44 @@ void database_update_event(scheduler_t* scheduler, void* unused)
     return;
   }
 
-  /* Compute the checkout limit as the total number of agent slots available
-   * across all configured hosts so that every available slot can be filled
-   * in a single poll cycle. Two distinct cases are handled separately:
-   *  a) host_queue is NULL (startup: no hosts loaded yet)
-   *     -> fall back to CHECKOUT_SIZE so the query runs and finds pending
-   *        jobs even before host configuration has been applied.
-   *  b) hosts are configured
-   *     -> use the sum of their max values directly. LIMIT 0 is valid
-   *        PostgreSQL and returns no rows when all hosts have max=0 config;
-   *        do NOT inflate to CHECKOUT_SIZE here as that would over-fetch
-   *        jobs that can never be dispatched.
-   *        Clamp to 0 if the sum goes negative (e.g. hosts with max<0) to
-   *        avoid a PostgreSQL "LIMIT must not be negative" error. */
+  /* Compute the checkout limit from configured host capacity.
+   *  a) No hosts loaded yet (startup): fall back to CHECKOUT_SIZE.
+   *  b) Hosts configured: sum max values for hosts with max > 0 only
+   *     (max <= 0 provides no real slots per get_host() and must not reduce
+   *     the total). LIMIT 0 is valid SQL and correct when all hosts have
+   *     max=0; do NOT inflate to CHECKOUT_SIZE or jobs that can never run
+   *     would be over-fetched. On integer overflow (requires INT_MAX
+   *     slots – practically impossible) fall back to CHECKOUT_SIZE. */
   if(scheduler->host_queue == NULL)
   {
     checkout_limit = CHECKOUT_SIZE;
   }
   else
   {
-    checkout_limit = 0;
+    gint64 limit64 = 0;
     for(iter = scheduler->host_queue; iter != NULL; iter = iter->next)
     {
       int host_max = ((host_t*)iter->data)->max;
       /* Only count hosts that can actually accept agents */
       if(host_max > 0)
-        checkout_limit += host_max;
+        limit64 += host_max;
     }
-    /* If the sum wrapped negative (requires INT_MAX total slots across
-     * all hosts – practically impossible), fall back to CHECKOUT_SIZE */
-    if(checkout_limit < 0)
-      checkout_limit = CHECKOUT_SIZE;
+    /* Accumulating positive ints into gint64 cannot overflow in practice,
+     * but guard the cast back to int to avoid UB (requires >2^31 total slots). */
+    checkout_limit = (limit64 <= INT_MAX) ? (int)limit64 : CHECKOUT_SIZE;
   }
+
+  /* Exclude in-memory jobs from the poll: JB_CHECKEDOUT jobs have
+   * jq_starttime NULL in the DB until the agent handshake completes, so
+   * basic_checkout would otherwise re-fetch them and waste LIMIT slots.
+   * Sentinel 0 keeps the list non-empty when job_list is empty. */
+  excl_pks = g_string_new("0");
+  g_tree_foreach(scheduler->job_list, collect_known_pks, excl_pks);
 
   /* one query for the queue rows joined with priority and user info, instead of
    * a basic_checkout plus a per-row jobsql_information lookup */
-  checkout_sql = g_strdup_printf(basic_checkout, checkout_limit);
+  checkout_sql = g_strdup_printf(basic_checkout, excl_pks->str, checkout_limit);
+  g_string_free(excl_pks, TRUE);
   db_result = database_exec(scheduler, checkout_sql);
   g_free(checkout_sql);
   if(db_result == NULL)

--- a/src/scheduler/agent/scheduler.h
+++ b/src/scheduler/agent/scheduler.h
@@ -117,6 +117,10 @@
 /* fo library includes */
 #include <fossconfig.h>
 
+/** Maximum number of jobs to fetch from the database in a single poll cycle
+ *  when no host configuration has been loaded yet (startup fallback).
+ *  At runtime the actual limit is the sum of max-agent slots across all
+ *  configured hosts; see database_update_event() in database.c. */
 #define CHECKOUT_SIZE 100
 
 #define AGENT_BINARY "%s/%s/%s/agent/%s"  ///< Format to get agent binary

--- a/src/scheduler/agent/sqlstatements.h
+++ b/src/scheduler/agent/sqlstatements.h
@@ -107,6 +107,12 @@ const char* jobsql_email_job =
  * Fetch the next batch of schedulable jobs with their user and priority.
  * The users table is LEFT JOINed so a job whose user was deleted shows up with a
  * NULL user_pk and can be skipped instead of silently dropped.
+ *
+ * This is a printf format string: the single '%d' placeholder is filled with
+ * the dynamic checkout limit computed in database_update_event() as the sum of
+ * max-agent slots across all configured hosts (falling back to CHECKOUT_SIZE).
+ * Do NOT use this string directly with database_exec(); always format it first
+ * via g_strdup_printf().
  */
 const char* basic_checkout =
     " SELECT jq.jq_pk, jq.jq_job_fk, jq.jq_type, jq.jq_host,"
@@ -123,7 +129,7 @@ const char* basic_checkout =
     "       AND NOT (dep.jq_endtime IS NOT NULL AND dep.jq_end_bits < 2)"
     "   )"
     " ORDER BY j.job_priority DESC"
-    " LIMIT 10;";
+    " LIMIT %d;";
 
 /**
  * Mark the given job id as started

--- a/src/scheduler/agent/sqlstatements.h
+++ b/src/scheduler/agent/sqlstatements.h
@@ -108,9 +108,10 @@ const char* jobsql_email_job =
  * The users table is LEFT JOINed so a job whose user was deleted shows up with a
  * NULL user_pk and can be skipped instead of silently dropped.
  *
- * This is a printf format string: the single '%d' placeholder is filled with
- * the dynamic checkout limit computed in database_update_event() as the sum of
- * max-agent slots across all configured hosts (falling back to CHECKOUT_SIZE).
+ * printf format string with two placeholders:
+ *  %s  known jq_pk list for NOT IN (sentinel "0" when empty; prevents
+ *      re-fetching JB_CHECKEDOUT jobs whose jq_starttime is still NULL).
+ *  %d  checkout limit (sum of host max slots, fallback CHECKOUT_SIZE).
  * Do NOT use this string directly with database_exec(); always format it first
  * via g_strdup_printf().
  */
@@ -122,6 +123,7 @@ const char* basic_checkout =
     " INNER JOIN job j     ON j.job_pk  = jq.jq_job_fk"
     " LEFT JOIN users u    ON u.user_pk = j.job_user_fk"
     " WHERE jq.jq_starttime IS NULL AND jq.jq_end_bits < 2"
+    "   AND jq.jq_pk NOT IN (%s)"
     "   AND NOT EXISTS("
     "     SELECT 1 FROM jobdepends jd"
     "     INNER JOIN jobqueue dep ON dep.jq_pk = jd.jdep_jq_depends_fk"

--- a/src/scheduler/agent_tests/Unit/testDatabase.c
+++ b/src/scheduler/agent_tests/Unit/testDatabase.c
@@ -177,6 +177,107 @@ void test_database_update_job()
 }
 
 /**
+ * \brief Test that database_update_event() excludes already-known jobs via
+ *        the NOT IN clause.
+ *
+ * A host with max=1 forces checkout_limit=1 (LIMIT=1 per poll). Two jobs are
+ * created: job1 at high priority (returned first) and job2 at low priority.
+ * After the first poll loads job1, the second poll must load job2 -- which is
+ * only possible if job1 is excluded by the NOT IN clause. Without the clause
+ * job1 (jq_starttime IS NULL) would re-occupy the sole slot and job2 would
+ * never be fetched.
+ * \test
+ * -# Add a host with max=1 to constrain LIMIT to 1 per poll
+ * -# Insert job1 (priority 9999) and job2 (priority 0)
+ * -# First poll: job1 loaded (highest priority wins LIMIT=1)
+ * -# Second poll: job1 excluded by NOT IN → job2 loaded (fix validated)
+ */
+void test_database_update_event_excludes_known()
+{
+  scheduler_t* scheduler;
+  host_t* host;
+  char sql[512];
+  PGresult* db_result;
+  int jq_pk1, jq_pk2, job_pk2, user_pk, upload_pk;
+
+  scheduler = scheduler_init(testdb, NULL);
+  FO_ASSERT_PTR_NULL(scheduler->db_conn);
+  database_init(scheduler);
+  FO_ASSERT_PTR_NOT_NULL(scheduler->db_conn);
+
+  /* Clean up any leftover job2 from a previous run. */
+  db_result = database_exec(scheduler,
+      "DELETE FROM jobqueue WHERE jq_job_fk IN "
+      "(SELECT job_pk FROM job WHERE job_name = 'testing file 2')");
+  SafePQclear(db_result);
+  db_result = database_exec(scheduler, "DELETE FROM job WHERE job_name = 'testing file 2'");
+  SafePQclear(db_result);
+
+  /* job1 at high priority (9999) via the standard helper. */
+  jq_pk1 = Prepare_Testing_Data(scheduler);
+
+  /* Retrieve user_pk and upload_pk from job1 to reuse in job2's INSERT. */
+  sprintf(sql,
+      "SELECT j.job_user_fk, j.job_upload_fk"
+      " FROM job j INNER JOIN jobqueue jq ON jq.jq_job_fk = j.job_pk"
+      " WHERE jq.jq_pk = %d",
+      jq_pk1);
+  db_result = database_exec(scheduler, sql);
+  user_pk   = (PQresultStatus(db_result) == PGRES_TUPLES_OK && PQntuples(db_result) > 0)
+              ? atoi(PQgetvalue(db_result, 0, 0)) : 1;
+  upload_pk = (PQresultStatus(db_result) == PGRES_TUPLES_OK && PQntuples(db_result) > 0)
+              ? atoi(PQgetvalue(db_result, 0, 1)) : 0;
+  PQclear(db_result);
+
+  /* job2 at priority 0: always ranked below job1 by ORDER BY priority DESC,
+   * so job1 is deterministically returned first when LIMIT=1. */
+  sprintf(sql,
+      "INSERT INTO job"
+      " (job_pk, job_user_fk, job_queued, job_priority, job_name, job_upload_fk)"
+      " VALUES (nextval('job_job_pk_seq'), %d, now(), 0, 'testing file 2', %d)"
+      " RETURNING job_pk",
+      user_pk, upload_pk);
+  db_result = database_exec(scheduler, sql);
+  job_pk2 = (PQresultStatus(db_result) == PGRES_TUPLES_OK && PQntuples(db_result) > 0)
+            ? atoi(PQgetvalue(db_result, 0, 0)) : 0;
+  PQclear(db_result);
+  FO_ASSERT_NOT_EQUAL(job_pk2, 0);
+
+  sprintf(sql,
+      "INSERT INTO jobqueue"
+      " (jq_pk, jq_job_fk, jq_type, jq_args, jq_runonpfile,"
+      "  jq_starttime, jq_endtime, jq_end_bits, jq_host)"
+      " VALUES (nextval('jobqueue_jq_pk_seq'), %d, 'ununpack', '0',"
+      "  NULL, NULL, NULL, 0, NULL)"
+      " RETURNING jq_pk",
+      job_pk2);
+  db_result = database_exec(scheduler, sql);
+  jq_pk2 = (PQresultStatus(db_result) == PGRES_TUPLES_OK && PQntuples(db_result) > 0)
+           ? atoi(PQgetvalue(db_result, 0, 0)) : 0;
+  PQclear(db_result);
+  FO_ASSERT_NOT_EQUAL(jq_pk2, 0);
+
+  /* Force checkout_limit=1: exposes the regression where the sole LIMIT slot
+   * is wasted by a re-fetched in-flight job. */
+  host = host_init("limit_test_host", "localhost", ".", 1);
+  host_insert(host, scheduler);
+
+  /* First poll: LIMIT=1, NOT IN(0) → job1 (priority 9999) loaded. */
+  database_update_event(scheduler, NULL);
+  FO_ASSERT_PTR_NOT_NULL_FATAL(g_tree_lookup(scheduler->job_list, &jq_pk1));
+
+  /* Second poll: LIMIT=1.
+   * Without NOT IN: job1 (jq_starttime IS NULL) re-fetched, skipped by
+   * g_tree_lookup, slot wasted → job2 never loaded. Regression.
+   * With NOT IN: job1 excluded → job2 loaded. Fix validated. */
+  database_update_event(scheduler, NULL);
+  FO_ASSERT_PTR_NOT_NULL(g_tree_lookup(scheduler->job_list, &jq_pk2));
+
+  database_reset_queue(scheduler);
+  scheduler_destroy(scheduler);
+}
+
+/**
  * \brief Test for database_job_processed(),database_job_log(),database_job_priority()
  * \test
  * -# Initialize test database
@@ -261,11 +362,12 @@ void test_email_notify()
 
 CU_TestInfo tests_database[] =
 {
-    {"Test database_init",          test_database_init        },
-    {"Test database_exec_event",    test_database_exec_event  },
-    {"Test database_update_event",  test_database_update_event},
-    {"Test database_update_job",    test_database_update_job  },
-    {"Test database_job",           test_database_job         },
+    {"Test database_init",                         test_database_init                        },
+    {"Test database_exec_event",                   test_database_exec_event                  },
+    {"Test database_update_event",                 test_database_update_event                },
+    {"Test database_update_event excludes known",  test_database_update_event_excludes_known },
+    {"Test database_update_job",                   test_database_update_job                  },
+    {"Test database_job",                          test_database_job                         },
     CU_TEST_INFO_NULL
 };
 

--- a/src/scheduler/agent_tests/Unit/utils.c
+++ b/src/scheduler/agent_tests/Unit/utils.c
@@ -26,7 +26,8 @@ int Prepare_Testing_Data(scheduler_t * scheduler)
   int upload_pk, job_pk, jq_pk, user_pk, folder_pk;
   PGresult* db_result;
 
-  /* Remove stale test data so basic_checkout's LIMIT 10 always includes ours. */
+  /* Remove stale test data so the test job is not already in job_list and is
+   * returned by basic_checkout (NOT IN exclusion skips known jobs). */
   database_exec(scheduler,
       "DELETE FROM jobqueue WHERE jq_job_fk IN "
       "(SELECT job_pk FROM job WHERE job_name = 'testing file')");
@@ -88,7 +89,7 @@ int Prepare_Testing_Data(scheduler_t * scheduler)
       upload_pk);
   database_exec(scheduler, sql);
 
-  /* High priority ensures this job is within basic_checkout's LIMIT 10. */
+  /* High priority ensures this job is ordered first in basic_checkout results. */
   sprintf(sql,
       "INSERT INTO job"
       " (job_pk, job_user_fk, job_queued, job_priority, job_name, job_upload_fk)"


### PR DESCRIPTION
This PR includes changes from https://github.com/fossology/fossology/pull/3696

I would suggest to have separate reviews. Each PR represents one logical step, keeping the diff smaller (after merge of the PR before) and easier to review (hopefully ).

Pays credits to https://github.com/fossology/fossology/issues/3700 (1+2)

## Description

Jobs in JB_CHECKEDOUT state have jq_starttime = NULL in the database until the agent completes its handshake (VERSION → OK → JB_STARTED).
In cross-container Docker deployments this window is measurably wider, causing basic_checkout to re-fetch the same in-flight jobs on every poll cycle and waste LIMIT slots that should be filled by new entries.

## Changes

1) Build a comma-separated exclusion list of all jq_pk values currently held in scheduler->job_list and inject it as a NOT IN(...) clause into basic_checkout at query time. A sentinel value of 0 (never a valid jq_pk) keeps the list syntactically valid when job_list is empty. All values are scheduler-internal integers, so there is no SQL-injection risk.

This complements the fix (dynamic LIMIT tied to host max #3696) which ensures enough slots are requested per cycle; 
This PR ensures those slots are filled with genuinely new jobs rather than already-known ones.

### File changes in detail
* `src/scheduler/agent/sqlstatements.h`: add AND jq.jq_pk NOT IN (%s) to basic_checkout; document the two format placeholders (%s exclusion list, %d limit)
* `src/scheduler/agent/database.c`: add collect_known_pks() GTraverseFunc callback; build excl_pks GString in database_update_event() before exec
* `src/scheduler/agent_tests/Unit/testDatabase.c`: add test_database_update_event_excludes_known to verify that a second poll does not re-fetch an already-known job
* `src/scheduler/agent_tests/Unit/utils.c`: Remove hardcoded limit usage in two comments


