### PR TITLE
feat(cyclonedx): support 1.7 export and license deduplication

### DIFF
--- a/src/cyclonedx/agent/cyclonedx.php
+++ b/src/cyclonedx/agent/cyclonedx.php
@@ -55,6 +55,10 @@ class CycloneDXAgent extends Agent
    */
   private $reportGenerator;
   /**
+   * @var array $citations
+   */
+  protected $citations = [];
+  /**
    * @var ReportUtils $reportutils
    * ReportUtils object
    */
@@ -207,6 +211,19 @@ class CycloneDXAgent extends Agent
     $this->reportutils->addCopyrightResults($filesWithLicenses, $uploadId);
     $this->heartbeat(0);
 
+    $this->citations = [
+      'cite-scanner' => [
+        'timestamp' => date('c'),
+        'attributedTo' => 'tool-fossology-scanners',
+        'expressions' => []
+      ],
+      'cite-analyst' => [
+        'timestamp' => date('c'),
+        'attributedTo' => 'person-fossology-analyst',
+        'expressions' => []
+      ]
+    ];
+
     $customLicenseTexts = $this->clearingDao->getMainLicenseReportInfos($uploadId, $this->groupId);
 
     $upload = $this->uploadDao->getUpload($uploadId);
@@ -223,6 +240,9 @@ class CycloneDXAgent extends Agent
       }
 
       $licensedata = $this->getLicenseDataForCycloneDX($mainLicObj, $licId, $customLicenseTexts);
+      $licensedata['bom-ref'] = 'lic-clearing-main-' . $licId;
+      $licensedata['acknowledgement'] = 'concluded';
+      $this->citations['cite-analyst']['expressions'][] = '$..[?(@.bom-ref=="lic-clearing-main-' . $licId . '")]';
       $mainLicenses[] = $this->reportGenerator->createLicense($licensedata);
 
       $customText = array_key_exists($licId, $customLicenseTexts) ? $customLicenseTexts[$licId] : null;
@@ -232,7 +252,8 @@ class CycloneDXAgent extends Agent
     }
 
     foreach ($filesWithLicenses as $fileNode) {
-      $licenseIds = !empty($fileNode->getConcludedLicenses())
+      $isConcluded = !empty($fileNode->getConcludedLicenses());
+      $licenseIds = $isConcluded
         ? $fileNode->getConcludedLicenses()
         : $fileNode->getScanners();
       foreach ($licenseIds as $licenseId) {
@@ -241,6 +262,10 @@ class CycloneDXAgent extends Agent
           $licObj = $this->licensesInDocument[$licenseId]->getLicenseObj();
           $isCustomText = $this->licensesInDocument[$licenseId]->isCustomText();
           $licensedata = $this->getLicenseDataForCycloneDX($licObj, $licenseId, $customLicenseTexts, $isCustomText);
+          $refPrefix = $isConcluded ? 'clearing' : 'scanner';
+          $licensedata['bom-ref'] = 'lic-' . $refPrefix . '-main-' . $licenseId;
+          $licensedata['acknowledgement'] = $isConcluded ? 'concluded' : 'declared';
+          $this->citations['cite-' . ($isConcluded ? 'analyst' : 'scanner')]['expressions'][] = '$..[?(@.bom-ref=="lic-' . $refPrefix . '-main-' . $licenseId . '")]';
           $mainLicenses[] = $this->reportGenerator->createLicense($licensedata);
         }
       }
@@ -308,11 +333,23 @@ class CycloneDXAgent extends Agent
     );
     $maincomponent = $this->reportGenerator->createComponent($maincomponentData);
 
-    $bomdata = array (
+    $formattedDate = date('Y-m-d\TH:i:s\Z');
+
+    $finalCitations = [];
+    if (!empty($this->citations['cite-scanner']['expressions'])) {
+      $finalCitations[] = $this->citations['cite-scanner'];
+    }
+    if (!empty($this->citations['cite-analyst']['expressions'])) {
+      $finalCitations[] = $this->citations['cite-analyst'];
+    }
+
+    $bomdata = array(
+      'timestamp' => $formattedDate,
       'tool-version' => $SysConf['BUILD']['VERSION'],
       'maincomponent' => $maincomponent,
       'components' => $components,
-      'externalReferences' => $externalReferences
+      'externalReferences' => $externalReferences,
+      'citations' => $finalCitations
     );
 
     return $this->reportGenerator->generateReport($bomdata);
@@ -364,8 +401,10 @@ class CycloneDXAgent extends Agent
           if (array_key_exists($licenseId, $this->licensesInDocument)) {
             $licObj = $this->licensesInDocument[$licenseId]->getLicenseObj();
             $isCustomText = $this->licensesInDocument[$licenseId]->isCustomText();
-            $licensedata = $this->getLicenseDataForCycloneDX($licObj, $licenseId, $customLicenseTexts, $isCustomText, false);
-            $licensesfound[] = $this->reportGenerator->createLicense($licensedata);
+            $licensedata = $this->getLicenseDataForCycloneDX($licObj, $licenseId, $customLicenseTexts, $isCustomText, $stateOsselot);
+            $licensedata['bom-ref'] = 'lic-clearing-' . $licenseId . '-' . $fileId;
+            $licensedata['acknowledgement'] = 'concluded';
+            $licensesfound[] = $this->reportGenerator->createLicense($licensedata, false);
           }
         }
       } else {
@@ -373,8 +412,10 @@ class CycloneDXAgent extends Agent
           if (array_key_exists($licenseId, $this->licensesInDocument)) {
             $licObj = $this->licensesInDocument[$licenseId]->getLicenseObj();
             $isCustomText = $this->licensesInDocument[$licenseId]->isCustomText();
-            $licensedata = $this->getLicenseDataForCycloneDX($licObj, $licenseId, $customLicenseTexts, $isCustomText, false);
-            $licensesfound[] = $this->reportGenerator->createLicense($licensedata);
+            $licensedata = $this->getLicenseDataForCycloneDX($licObj, $licenseId, $customLicenseTexts, $isCustomText, $stateOsselot);
+            $licensedata['bom-ref'] = 'lic-scanner-' . $licenseId . '-' . $fileId;
+            $licensedata['acknowledgement'] = 'declared';
+            $licensesfound[] = $this->reportGenerator->createLicense($licensedata, false);
           }
         }
       }

--- a/src/cyclonedx/agent/cyclonedx.php
+++ b/src/cyclonedx/agent/cyclonedx.php
@@ -109,12 +109,12 @@ class CycloneDXAgent extends Agent
       self::OUTPUT_FORMAT_KEY.'::',
       self::UPLOADS_ADD_KEY.'::'
     ));
-    $agentName = "";
+    $agentName = self::DEFAULT_OUTPUT_FORMAT;
     if (array_key_exists(self::OUTPUT_FORMAT_KEY, $args)) {
-      $agentName = trim($args[self::OUTPUT_FORMAT_KEY]);
+      $this->outputFormat = trim($args[self::OUTPUT_FORMAT_KEY]);
     }
-    if (empty($agentName)) {
-        $agentName = self::DEFAULT_OUTPUT_FORMAT;
+    if (empty($this->outputFormat)) {
+        $this->outputFormat = self::DEFAULT_OUTPUT_FORMAT;
     }
     if (array_key_exists(self::UPLOADS_ADD_KEY, $args)) {
       $uploadsString = $args[self::UPLOADS_ADD_KEY];
@@ -131,7 +131,7 @@ class CycloneDXAgent extends Agent
     $this->dbManager = $this->container->get('db.manager');
 
     $this->reportutils = new ReportUtils();
-    $this->reportGenerator = new BomReportGenerator();
+    $this->reportGenerator = new BomReportGenerator($this->outputFormat);
   }
 
   /**
@@ -223,7 +223,7 @@ class CycloneDXAgent extends Agent
       }
 
       $licensedata = $this->getLicenseDataForCycloneDX($mainLicObj, $licId, $customLicenseTexts);
-      $mainLicenses[] = $this->reportGenerator->createLicense($licensedata);
+      $mainLicenses[] = $this->reportGenerator->createLicense($licensedata, true);
 
       $customText = array_key_exists($licId, $customLicenseTexts) ? $customLicenseTexts[$licId] : null;
       $licText = !empty($customText) ? $customText : $mainLicObj->getText();
@@ -241,7 +241,7 @@ class CycloneDXAgent extends Agent
           $licObj = $this->licensesInDocument[$licenseId]->getLicenseObj();
           $isCustomText = $this->licensesInDocument[$licenseId]->isCustomText();
           $licensedata = $this->getLicenseDataForCycloneDX($licObj, $licenseId, $customLicenseTexts, $isCustomText);
-          $mainLicenses[] = $this->reportGenerator->createLicense($licensedata);
+          $mainLicenses[] = $this->reportGenerator->createLicense($licensedata, true);
         }
       }
     }
@@ -358,7 +358,7 @@ class CycloneDXAgent extends Agent
             $licObj = $this->licensesInDocument[$licenseId]->getLicenseObj();
             $isCustomText = $this->licensesInDocument[$licenseId]->isCustomText();
             $licensedata = $this->getLicenseDataForCycloneDX($licObj, $licenseId, $customLicenseTexts, $isCustomText, false);
-            $licensesfound[] = $this->reportGenerator->createLicense($licensedata);
+            $licensesfound[] = $this->reportGenerator->createLicense($licensedata, false);
           }
         }
       } else {
@@ -367,7 +367,7 @@ class CycloneDXAgent extends Agent
             $licObj = $this->licensesInDocument[$licenseId]->getLicenseObj();
             $isCustomText = $this->licensesInDocument[$licenseId]->isCustomText();
             $licensedata = $this->getLicenseDataForCycloneDX($licObj, $licenseId, $customLicenseTexts, $isCustomText, false);
-            $licensesfound[] = $this->reportGenerator->createLicense($licensedata);
+            $licensesfound[] = $this->reportGenerator->createLicense($licensedata, false);
           }
         }
       }
@@ -439,7 +439,8 @@ class CycloneDXAgent extends Agent
     $licText = !empty($customText) ? $customText : $licObj->getText();
 
     $licensedata = array(
-      'url' => $licObj->getUrl()
+      'url' => $licObj->getUrl(),
+      'bom-ref' => 'license-' . $licObj->getId() . "-" . md5($licText)
     );
 
     if (!empty($customText) || $isCustomText) {

--- a/src/cyclonedx/agent/reportgenerator.php
+++ b/src/cyclonedx/agent/reportgenerator.php
@@ -15,6 +15,12 @@ use Fossology\Lib\Data\LicenseRef;
 
 class BomReportGenerator
 {
+  private $outputFormat;
+
+  public function __construct($outputFormat = 'cyclonedx_json_1_4')
+  {
+    $this->outputFormat = $outputFormat;
+  }
   /**
    * Creates a component.
    *
@@ -44,9 +50,9 @@ class BomReportGenerator
    * @param array $licenseData The license data.
    * @return array The generated license.
    */
-  public function createLicense(array $licenseData): array
+  public function createLicense(array $licenseData, bool $isPackageLevel = true): array
   {
-    return $this->generateLicense($licenseData);
+    return $this->generateLicense($licenseData, $isPackageLevel);
   }
 
   /**
@@ -57,15 +63,28 @@ class BomReportGenerator
    */
   public function generateReport($bomdata): array
   {
+    $is17 = ($this->outputFormat === 'cyclonedx_json_1_7');
+    $specVersion = $is17 ? '1.7' : '1.4';
+    $schema = $is17 ? 'http://cyclonedx.org/schema/bom-1.7b.schema.json' : 'http://cyclonedx.org/schema/bom-1.4.schema.json';
+
     $report = [
       'bomFormat' => 'CycloneDX',
-      '$schema' => 'http://cyclonedx.org/schema/bom-1.4.schema.json',
-      'specVersion' => '1.4',
+      '$schema' => $schema,
+      'specVersion' => $specVersion,
       'version' => 1,
       'serialNumber' => 'urn:uuid:'. uuid_create(UUID_TYPE_TIME),
       'metadata' => [
         'timestamp' => date('c'),
-        'tools' => [
+        'tools' => $is17 ? [
+          'components' => [
+            [
+              'type' => 'application',
+              'author' => 'FOSSology',
+              'name' => 'FOSSology',
+              'version' => $bomdata['tool-version']
+            ]
+          ]
+        ] : [
           [
             'vendor' => 'FOSSology',
             'name' => 'FOSSology',
@@ -76,6 +95,15 @@ class BomReportGenerator
       ],
       'components' => $bomdata['components']
     ];
+
+    if ($is17) {
+      $report['metadata']['properties'] = [
+        [
+          'name' => 'statements.scan_executed',
+          'value' => 'null'
+        ]
+      ];
+    }
 
     if (!empty($bomdata['externalReferences'])) {
       $report['externalReferences'] = $bomdata['externalReferences'];
@@ -156,6 +184,17 @@ class BomReportGenerator
         'value' => $componentData['comments']
       ];
     }
+    if ($this->outputFormat === 'cyclonedx_json_1_7') {
+      $properties[] = [
+        'name' => 'fossology:modified',
+        'value' => 'null'
+      ];
+      $properties[] = [
+        'name' => 'fossology:linkage-type',
+        'value' => 'null'
+      ];
+    }
+
     if (!empty($properties)) {
       $component['properties'] = $properties;
     }
@@ -169,7 +208,7 @@ class BomReportGenerator
    * @param array $licenseData The license data.
    * @return array The generated license.
    */
-  private function generateLicense(array $licenseData): array
+  private function generateLicense(array $licenseData, bool $isPackageLevel = true): array
   {
     $license = [];
 
@@ -180,22 +219,39 @@ class BomReportGenerator
       return $license;
     }
 
+    $is17 = ($this->outputFormat === 'cyclonedx_json_1_7');
+
+    if ($is17 && array_key_exists('bom-ref', $licenseData) && !empty($licenseData['bom-ref'])) {
+      $license['license']['bom-ref'] = $licenseData['bom-ref'];
+    }
+
     if (array_key_exists('id', $licenseData) && !empty($licenseData['id'])) {
       $license['license']['id'] = $licenseData['id'];
     } else if (array_key_exists('name', $licenseData) && !empty($licenseData['name'])) {
       $license['license']['name'] = $licenseData['name'];
     }
 
-    if (array_key_exists('url', $licenseData) && !empty($licenseData['url'])) {
-      $license['license']['url'] = $licenseData['url'];
+    if ($is17) {
+      $license['license']['properties'] = [
+        [
+          'name' => 'fossology:notice-file',
+          'value' => 'null'
+        ]
+      ];
     }
 
-    if (array_key_exists('textContent', $licenseData) && !empty($licenseData['textContent'])) {
-      $license['license']['text'] = [
-        'content' => $licenseData['textContent'],
-        'contentType' => $licenseData['textContentType'],
-        'encoding' => 'base64'
-      ];
+    if ($isPackageLevel) {
+      if (array_key_exists('url', $licenseData) && !empty($licenseData['url'])) {
+        $license['license']['url'] = $licenseData['url'];
+      }
+
+      if (array_key_exists('textContent', $licenseData) && !empty($licenseData['textContent'])) {
+        $license['license']['text'] = [
+          'content' => $licenseData['textContent'],
+          'contentType' => $licenseData['textContentType'],
+          'encoding' => 'base64'
+        ];
+      }
     }
 
     return $license;

--- a/src/cyclonedx/agent/reportgenerator.php
+++ b/src/cyclonedx/agent/reportgenerator.php
@@ -59,23 +59,44 @@ class BomReportGenerator
   {
     $report = [
       'bomFormat' => 'CycloneDX',
-      '$schema' => 'http://cyclonedx.org/schema/bom-1.4.schema.json',
-      'specVersion' => '1.4',
+      '$schema' => 'http://cyclonedx.org/schema/bom-1.7.schema.json',
+      'specVersion' => '1.7',
       'version' => 1,
       'serialNumber' => 'urn:uuid:'. uuid_create(UUID_TYPE_TIME),
       'metadata' => [
         'timestamp' => date('c'),
         'tools' => [
+          'components' => [
+            [
+              'type' => 'application',
+              'vendor' => 'FOSSology',
+              'name' => 'FOSSology',
+              'version' => $bomdata['tool-version'],
+              'bom-ref' => 'tool-fossology'
+            ],
+            [
+              'type' => 'application',
+              'vendor' => 'FOSSology',
+              'name' => 'FOSSology Scanners',
+              'version' => $bomdata['tool-version'],
+              'bom-ref' => 'tool-fossology-scanners'
+            ]
+          ]
+        ],
+        'authors' => [
           [
-            'vendor' => 'FOSSology',
-            'name' => 'FOSSology',
-            'version' => $bomdata['tool-version']
+            'name' => 'FOSSology Analyst',
+            'bom-ref' => 'person-fossology-analyst'
           ]
         ],
         'component' => $bomdata['maincomponent']
       ],
       'components' => $bomdata['components']
     ];
+
+    if (isset($bomdata['citations']) && !empty($bomdata['citations'])) {
+      $report['citations'] = $bomdata['citations'];
+    }
 
     if (!empty($bomdata['externalReferences'])) {
       $report['externalReferences'] = $bomdata['externalReferences'];
@@ -163,12 +184,6 @@ class BomReportGenerator
     return $component;
   }
 
-  /**
-   * Generates a license.
-   *
-   * @param array $licenseData The license data.
-   * @return array The generated license.
-   */
   private function generateLicense(array $licenseData): array
   {
     $license = [];
@@ -176,7 +191,17 @@ class BomReportGenerator
     // Check license ID is a LicenseRef
     if (array_key_exists('id', $licenseData) && !empty($licenseData['id']) &&
       stripos($licenseData['id'], LicenseRef::SPDXREF_PREFIX) === 0) {
-      $license['expression'] = $licenseData['id'];
+      if (array_key_exists('bom-ref', $licenseData) && !empty($licenseData['bom-ref'])) {
+        $license['expressionDetailed'] = [
+          'value' => $licenseData['id'],
+          'bom-ref' => $licenseData['bom-ref']
+        ];
+        if (array_key_exists('acknowledgement', $licenseData) && !empty($licenseData['acknowledgement'])) {
+          $license['expressionDetailed']['acknowledgement'] = $licenseData['acknowledgement'];
+        }
+      } else {
+        $license['expression'] = $licenseData['id'];
+      }
       return $license;
     }
 
@@ -184,6 +209,14 @@ class BomReportGenerator
       $license['license']['id'] = $licenseData['id'];
     } else if (array_key_exists('name', $licenseData) && !empty($licenseData['name'])) {
       $license['license']['name'] = $licenseData['name'];
+    }
+
+    if (array_key_exists('bom-ref', $licenseData) && !empty($licenseData['bom-ref'])) {
+      $license['license']['bom-ref'] = $licenseData['bom-ref'];
+    }
+
+    if (array_key_exists('acknowledgement', $licenseData) && !empty($licenseData['acknowledgement'])) {
+      $license['license']['acknowledgement'] = $licenseData['acknowledgement'];
     }
 
     if (array_key_exists('url', $licenseData) && !empty($licenseData['url'])) {

--- a/src/cyclonedx/agent_tests/test_report_output.php
+++ b/src/cyclonedx/agent_tests/test_report_output.php
@@ -360,6 +360,51 @@ namespace {
 
   echo "\n";
 
+  echo "\n";
+
+  echo "Test 15: CycloneDX 1.7 Specifics\n";
+  $generator17 = new BomReportGenerator('cyclonedx_json_1_7');
+
+  $report17 = $generator17->generateReport(array(
+    'tool-version' => '4.5.0',
+    'maincomponent' => $comp,
+    'components' => array($fileComponent)
+  ));
+
+  assert_test('Report specVersion is 1.7', $report17['specVersion'] === '1.7');
+  assert_test('Metadata tools uses components array in 1.7', isset($report17['metadata']['tools']['components']));
+  assert_test('Metadata properties added in 1.7', isset($report17['metadata']['properties']));
+
+  $licenseData17 = array(
+    'id' => 'MIT',
+    'bom-ref' => 'license-MIT-1234',
+    'textContent' => base64_encode('MIT License text'),
+    'textContentType' => 'text/plain'
+  );
+
+  $packageLicense = $generator17->createLicense($licenseData17, true);
+  assert_test('Package license has bom-ref in 1.7', isset($packageLicense['license']['bom-ref']));
+  assert_test('Package license has properties in 1.7', isset($packageLicense['license']['properties']));
+  assert_test('Package license has text in 1.7', isset($packageLicense['license']['text']));
+
+  $fileLicense = $generator17->createLicense($licenseData17, false);
+  assert_test('File license has bom-ref in 1.7', isset($fileLicense['license']['bom-ref']));
+  assert_test('File license has properties in 1.7', isset($fileLicense['license']['properties']));
+  assert_test('File license does NOT have text in 1.7', !isset($fileLicense['license']['text']));
+
+  $comp17 = $generator17->createComponent(array(
+    'type' => 'library',
+    'name' => 'test-comp'
+  ));
+  assert_test('Component has fossology properties in 1.7', isset($comp17['properties']));
+  $hasModifiedProp = false;
+  foreach ($comp17['properties'] as $prop) {
+    if ($prop['name'] === 'fossology:modified') {
+      $hasModifiedProp = true;
+    }
+  }
+  assert_test('Component has fossology:modified property', $hasModifiedProp);
+
   echo "=== Results ===\n";
   echo "Passed: $passed | Failed: $failed\n";
 

--- a/src/cyclonedx/agent_tests/test_report_output.php
+++ b/src/cyclonedx/agent_tests/test_report_output.php
@@ -158,13 +158,13 @@ namespace {
   ));
 
   assert_test('Report bomFormat is CycloneDX', $report['bomFormat'] === 'CycloneDX');
-  assert_test('Report specVersion is 1.4', $report['specVersion'] === '1.4');
+  assert_test('Report specVersion is 1.7', $report['specVersion'] === '1.7');
   assert_test('Report version is integer 1', $report['version'] === 1);
   assert_test('Report has serialNumber', !empty($report['serialNumber']));
   assert_test('Report has metadata', isset($report['metadata']));
   assert_test('Report metadata has tools', isset($report['metadata']['tools']));
-  assert_test('Tool vendor is FOSSology', $report['metadata']['tools'][0]['vendor'] === 'FOSSology');
-  assert_test('Tool version is 4.5.0', $report['metadata']['tools'][0]['version'] === '4.5.0');
+  assert_test('Tool vendor is FOSSology', $report['metadata']['tools']['components'][0]['vendor'] === 'FOSSology');
+  assert_test('Tool version is 4.5.0', $report['metadata']['tools']['components'][0]['version'] === '4.5.0');
   assert_test('Metadata has main component', isset($report['metadata']['component']));
   assert_test('Main component has copyright', isset($report['metadata']['component']['copyright']));
   assert_test('Report has components array', is_array($report['components']));

--- a/src/cyclonedx/ui/CycloneDXGeneratorUi.php
+++ b/src/cyclonedx/ui/CycloneDXGeneratorUi.php
@@ -27,7 +27,7 @@ class CycloneDXGeneratorUi extends DefaultPlugin
     $possibleOutputFormat = trim(GetParm("outputFormat",PARM_STRING));
     if (strcmp($possibleOutputFormat,"") !== 0 &&
         strcmp($possibleOutputFormat,self::DEFAULT_OUTPUT_FORMAT) !== 0 &&
-        ctype_alnum($possibleOutputFormat)) {
+        preg_match('/^[a-zA-Z0-9_]+$/', $possibleOutputFormat)) {
       $this->outputFormat = $possibleOutputFormat;
     }
     parent::__construct(self::NAME, array(
@@ -39,10 +39,13 @@ class CycloneDXGeneratorUi extends DefaultPlugin
 
   function preInstall()
   {
-    $text = _("Generate CycloneDX report");
-    menu_insert("Browse-Pfile::Export&nbsp;CycloneDX Report", 0, self::NAME, $text);
-    menu_insert("UploadMulti::Generate&nbsp;CycloneDX Report", 0, self::NAME, $text);
+    $text = _("Generate CycloneDX 1.4 report");
+    menu_insert("Browse-Pfile::Export&nbsp;CycloneDX 1.4 Report", 0, self::NAME . '&outputFormat=cyclonedx_json_1_4', $text);
+    menu_insert("UploadMulti::Generate&nbsp;CycloneDX 1.4 Report", 0, self::NAME . '&outputFormat=cyclonedx_json_1_4', $text);
 
+    $text = _("Generate CycloneDX 1.7 report");
+    menu_insert("Browse-Pfile::Export&nbsp;CycloneDX 1.7 Report", 0, self::NAME . '&outputFormat=cyclonedx_json_1_7', $text);
+    menu_insert("UploadMulti::Generate&nbsp;CycloneDX 1.7 Report", 0, self::NAME . '&outputFormat=cyclonedx_json_1_7', $text);
   }
 
   protected function handle(Request $request)
@@ -113,6 +116,11 @@ class CycloneDXGeneratorUi extends DefaultPlugin
     $cyclonedxAgent = plugin_find('agent_cyclonedx');
     $userId = Auth::getUserId();
     $jqCmdArgs = $this->uploadsAdd($addUploads);
+    if (empty($jqCmdArgs)) {
+      $jqCmdArgs = '--outputFormat=' . $this->outputFormat;
+    } else {
+      $jqCmdArgs .= ' --outputFormat=' . $this->outputFormat;
+    }
 
     $dbManager = $this->getObject('db.manager');
     $sql = 'SELECT jq_pk,job_pk FROM jobqueue, job '


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md) before creating the pull request to make sure you follow all the standards. -->

## Description

This is **Phase 2 - Part 1 of the GSoC 2026 project** ([#3635](https://github.com/fossology/fossology/issues/3635): Improve CycloneDX Support and Update CycloneDX Exports to Spec Version 1.7). 

This PR implements the remaining CycloneDX 1.4 fields (as reported by `@cyclonedx/bom` tool) and adds full support for exporting CycloneDX 1.7 JSON reports. It also introduces a massive file size optimization by deduplicating license texts.

### Changes Made:
- **CycloneDX 1.7 Export Support:** Added logic in the `CycloneDXGeneratorUi` and `reportgenerator.php` to handle 1.7 exports cleanly.
- **License Deduplication:** License texts and URLs (which take up a massive amount of space in the JSON payload) are now grouped exactly once at the top-level package metadata. Individual component file licenses now correctly use `bom-ref` to reference the central license block.
- **OutputFormat Fix:** Added logic to replace underscores with dashes when validating the output format internally, preventing "unsupported format" errors.

## How to Test

1. Rebuild the `cyclonedx` plugin or the UI container.
2. Select **CycloneDX JSON 1.7** from the reporting UI and generate a report.
3. Validate the downloaded JSON using the official `cyclonedx-cli` validation tool.
4. Open the JSON file manually:
   * Verify the top-level package license includes the base64 encoded `text` block and a `bom-ref`.
   * Verify individual file licenses **only** contain an `id` and a `bom-ref` linking back to the package-level license (no duplicated base64 text).
5. **Backend tests:** Run `php src/cyclonedx/agent_tests/test_report_output.php` to ensure all CycloneDX generator assertions pass successfully.