### PR TITLE
fix(scheduler): auto-scale interface pool and guard agent_init failures

### DIFF
--- a/install/defconf/fossology.conf.in
+++ b/install/defconf/fossology.conf.in
@@ -36,6 +36,13 @@ path = @FO_REPODIR@
 [HOSTS]
 localhost = localhost @FO_SYSCONFDIR@ 10
 
+[SCHEDULER]
+; Number of threads in the interface thread pool (default: 10).
+; The scheduler automatically raises this to the sum of all host 'max' values,
+; so that UI/CLI connections are never queued behind active agent threads.
+; Only set this explicitly when you need a fixed value larger than host maximum.
+;interface_nthreads = 10
+
 [REPOSITORY]
 localhost[] = * 00 ff
 

--- a/src/scheduler/agent/host.c
+++ b/src/scheduler/agent/host.c
@@ -176,3 +176,35 @@ void print_host_load(GTree* host_list, GOutputStream* ostr)
   g_tree_foreach(host_list, (GTraverseFunc)print_host_all, ostr);
   g_output_stream_write(ostr, "\nend\n", 5, NULL, NULL);
 }
+
+/**
+ * @brief GTraverseFunc that accumulates host->max values.
+ *
+ * Only positive max values contribute: a host with max <= 0 has no effective
+ * capacity (the scheduler never dispatches to it), so including it would
+ * under-size the interface thread pool floor.
+ */
+static int sum_host_max_fn(gchar* host_name, host_t* host, gpointer data)
+{
+  (void)host_name;
+  if(host->max > 0)
+    *(gint*)data += host->max;
+  return FALSE;
+}
+
+/**
+ * @brief Returns the sum of all host->max values across all configured hosts.
+ *
+ * Used by interface_init() and scheduler_config_event() to size the interface
+ * thread pool so it is never a bottleneck when host.max exceeds
+ * CONF_interface_nthreads.
+ *
+ * @param host_list  GTree of host_t pointers (scheduler->host_list)
+ * @return Total maximum agent slots across all configured hosts
+ */
+gint host_total_max(GTree* host_list)
+{
+  gint total = 0;
+  g_tree_foreach(host_list, (GTraverseFunc)sum_host_max_fn, &total);
+  return total;
+}

--- a/src/scheduler/agent/host.h
+++ b/src/scheduler/agent/host.h
@@ -49,5 +49,6 @@ void host_print(host_t* host, GOutputStream* ostr);
 
 host_t* get_host(GList** queue, uint8_t num);
 void    print_host_load(GTree* host_list, GOutputStream* ostr);
+gint    host_total_max(GTree* host_list);
 
 #endif /* HOST_H_INCLUDE */

--- a/src/scheduler/agent/interface.c
+++ b/src/scheduler/agent/interface.c
@@ -577,6 +577,31 @@ void* interface_listen_thread(scheduler_t* scheduler)
 /* ************************************************************************** */
 
 /**
+ * @brief Compute the interface thread-pool size, honoring GLib's contract.
+ *
+ * CONF_interface_nthreads < 0 is GLib's "unlimited" sentinel and is passed
+ * through unchanged. Otherwise the pool is raised to at least host_total_max()
+ * so UI/CLI connections are never queued behind agent threads - but never 0,
+ * which would stall the pool.
+ *
+ * @param scheduler  the scheduler whose host_list drives the floor value
+ * @return the number of threads to give the interface pool (or -1 for unlimited)
+ */
+gint interface_pool_size(scheduler_t* scheduler)
+{
+  gint nthreads = CONF_interface_nthreads;
+  if(nthreads >= 0)                       /* not the unlimited sentinel */
+  {
+    gint total = host_total_max(scheduler->host_list);
+    if(total > nthreads)
+      nthreads = total;
+    if(nthreads < 1)
+      nthreads = 1;                        /* never hand GLib a 0-thread pool */
+  }
+  return nthreads;
+}
+
+/**
  * @brief Create the interface thread and thread pool that handle UI connections
  *
  * The GUI and the CLI use a socket connection to communicate with the
@@ -590,12 +615,14 @@ void interface_init(scheduler_t* scheduler)
 {
   if(!scheduler->i_created)
   {
+    gint nthreads = interface_pool_size(scheduler);
+
     scheduler->i_created = 1;
     scheduler->i_terminate = 0;
 
     scheduler->cancel = NULL;
     scheduler->workers = g_thread_pool_new((GFunc)interface_thread,
-        scheduler, CONF_interface_nthreads, FALSE, NULL);
+        scheduler, nthreads, FALSE, NULL);
 
 #if GLIB_CHECK_VERSION(2, 32, 0)
     scheduler->server = g_thread_new("interface",

--- a/src/scheduler/agent/interface.h
+++ b/src/scheduler/agent/interface.h
@@ -19,5 +19,6 @@
 
 void interface_init(scheduler_t* scheduler);
 void interface_destroy(scheduler_t* scheduler);
+gint interface_pool_size(scheduler_t* scheduler);
 
 #endif /* INTERFACE_H_INCLUDE */

--- a/src/scheduler/agent/scheduler.c
+++ b/src/scheduler/agent/scheduler.c
@@ -678,7 +678,17 @@ void scheduler_update(scheduler_t* scheduler)
       }
 
       V_SCHED("Starting JOB[%d].%s\n", job->id, job->agent_type);
-      agent_init(scheduler, host, job);
+      {
+        /* Capture the pk before agent_init. */
+        int jq_pk = job->id;
+        if(agent_init(scheduler, host, job) == NULL &&
+           (job = g_tree_lookup(scheduler->job_list, &jq_pk)) != NULL)
+        {
+          /* agent_init() failed but did NOT remove the job (e.g. pipe creation). */
+          job->checkedout_at = time(NULL);
+          skipped_jobs = g_list_prepend(skipped_jobs, job);
+        }
+      }
       job = NULL;
     }
 
@@ -692,7 +702,16 @@ void scheduler_update(scheduler_t* scheduler)
 
   if(job != NULL && n_agents == 0 && n_jobs == 0)
   {
-    agent_init(scheduler, host, job);
+    /* Capture the pk before agent_init() may free the job (see regular path). */
+    int jq_pk = job->id;
+    if(agent_init(scheduler, host, job) == NULL &&
+       (job = g_tree_lookup(scheduler->job_list, &jq_pk)) != NULL)
+    {
+      /* exclusive job: agent_init() failed without removing the job;
+       * re-queue it for retry on the next cycle. */
+      job->checkedout_at = time(NULL);
+      g_sequence_insert_sorted(scheduler->job_queue, job, job_compare, NULL);
+    }
     lockout = 1;
     job  = NULL;
     host = NULL;
@@ -1201,6 +1220,18 @@ void scheduler_config_event(scheduler_t* scheduler, void* unused)
 
   scheduler_foss_config(scheduler);
   scheduler_agent_config(scheduler);
+
+  if(scheduler->workers)
+  {
+    GError* err = NULL;
+    gint nthreads = interface_pool_size(scheduler);
+    if(!g_thread_pool_set_max_threads(scheduler->workers, nthreads, &err))
+    {
+      WARNING("interface pool resize to %d failed: %s",
+              nthreads, err ? err->message : "unknown error");
+      g_clear_error(&err);
+    }
+  }
 
   database_init(scheduler);
   email_init(scheduler);

--- a/src/scheduler/agent_tests/Unit/testHost.c
+++ b/src/scheduler/agent_tests/Unit/testHost.c
@@ -178,6 +178,33 @@ void test_get_host()
   g_free(name);
 }
 
+/**
+ * \brief Test for host_total_max()
+ * \test
+ * -# Initialize scheduler using scheduler_init()
+ * -# Verify host_total_max() returns 0 on an empty host list
+ * -# Insert three hosts with known max values
+ * -# Verify host_total_max() returns the correct sum
+ */
+void test_host_total_max()
+{
+  scheduler_t* scheduler;
+
+  scheduler = scheduler_init(testdb, NULL);
+
+  /* empty host list: sum must be 0 */
+  FO_ASSERT_EQUAL(host_total_max(scheduler->host_list), 0);
+
+  host_insert(host_init("host_a", "localhost", "/tmp",  5), scheduler);
+  host_insert(host_init("host_b", "localhost", "/tmp", 10), scheduler);
+  host_insert(host_init("host_c", "localhost", "/tmp", 15), scheduler);
+
+  /* 5 + 10 + 15 = 30 */
+  FO_ASSERT_EQUAL(host_total_max(scheduler->host_list), 30);
+
+  scheduler_destroy(scheduler);
+}
+
 /* ************************************************************************** */
 /* *** suite declaration **************************************************** */
 /* ************************************************************************** */
@@ -189,6 +216,7 @@ CU_TestInfo tests_host[] =
     {"Test host_increase_load", test_host_increase_load },
     {"Test host_decrease_load", test_host_decrease_load },
     {"Test host_get_host",      test_get_host           },
+    {"Test host_total_max",     test_host_total_max     },
     CU_TEST_INFO_NULL
 };
 

--- a/src/scheduler/agent_tests/Unit/testInterface.c
+++ b/src/scheduler/agent_tests/Unit/testInterface.c
@@ -224,7 +224,7 @@ void test_interface_pool()
   interface_init(scheduler);
   sleep(1);
 
-  FO_ASSERT_EQUAL(g_thread_pool_get_max_threads(scheduler->workers), CONF_interface_nthreads);
+  FO_ASSERT_TRUE(g_thread_pool_get_max_threads(scheduler->workers) >= CONF_interface_nthreads);
   FO_ASSERT_EQUAL(g_thread_pool_unprocessed(scheduler->workers), 0);
 
   snprintf(buffer, sizeof(buffer), "%d", scheduler->i_port);
@@ -553,16 +553,55 @@ void test_sending_agents()
   scheduler_destroy(scheduler);
 }
 
+/**
+ * \brief Test that interface_init() grows the pool when host max exceeds CONF_interface_nthreads
+ * \test
+ * -# Initialize scheduler using scheduler_init() (no foss config, host_list is empty)
+ * -# Fix CONF_interface_nthreads to 10 so the test is independent of global state
+ * -# Insert a host with max = 25 > CONF_interface_nthreads (10)
+ * -# Initialize interface using interface_init()
+ * -# Check the pool's max threads equals the host max, not CONF_interface_nthreads
+ */
+void test_interface_pool_scales_with_host_max()
+{
+  scheduler_t* scheduler;
+  gint saved_nthreads = CONF_interface_nthreads;
+
+  /* Pin the global to a known value so the test is not affected by other tests
+   * that call scheduler_foss_config() and may have set a different value
+   * (including the -1 unlimited sentinel). */
+  CONF_interface_nthreads = 10;
+
+  scheduler = scheduler_init(testdb, NULL);
+  scheduler->i_terminate = FALSE;
+  scheduler->i_created   = FALSE;
+
+  /* Insert a host whose max (25) exceeds CONF_interface_nthreads (10). */
+  host_insert(host_init("bighost", "localhost", "/tmp", 25), scheduler);
+
+  interface_init(scheduler);
+  sleep(1);
+
+  /* Pool must have grown to host_total_max (25), not stayed at CONF_interface_nthreads (10). */
+  FO_ASSERT_EQUAL(g_thread_pool_get_max_threads(scheduler->workers), 25);
+
+  interface_destroy(scheduler);
+  scheduler_destroy(scheduler);
+
+  CONF_interface_nthreads = saved_nthreads;
+}
+
 /* ************************************************************************** */
 /* **** suite declaration *************************************************** */
 /* ************************************************************************** */
 
 CU_TestInfo tests_interface[] =
 {
-    {"Test interface_init",          test_interface_init          },
-    {"Test interface_destroy",       test_interface_destroy       },
-    {"Test interface_listen_thread", test_interface_listen_thread },
-    {"Test interface_pool",          test_interface_pool          },
+    {"Test interface_init",                      test_interface_init                      },
+    {"Test interface_destroy",                   test_interface_destroy                   },
+    {"Test interface_listen_thread",             test_interface_listen_thread             },
+    {"Test interface_pool",                      test_interface_pool                      },
+    {"Test interface_pool scales with host max", test_interface_pool_scales_with_host_max },
     CU_TEST_INFO_NULL
 };
 


### PR DESCRIPTION
Pays credits to https://github.com/fossology/fossology/issues/3700 (3+4)

## Description

Under high system load, the scheduler can experience two issues that negatively impact performance and job processing:
 - The scheduler interface is limited by a hardcoded fallback of 10 interface threads (interface_nthreads). When more than 10 agents are active, interface requests (e.g. web commands and status updates) can queue behind agent communication, increasing scheduler latency and potentially reducing overall throughput.
 - reap_stale_jobs() can incorrectly classify valid jobs as stale while they are still waiting for an agent to start. Since the timeout reset currently only applies to exclusive (SAG_EXCLUSIVE) jobs, regular jobs may be prematurely marked as failed and removed from the queue under heavy load.

## Changes

 - Added logic to compute the interface thread pool size based on the sum of all hosts' maximum agent slots (incl new functions for that)
- Updated the configuration file (fossology.conf.in) to document the new [SCHEDULER] section and the interface_nthreads setting > was missing till now
 - Improved job handling in scheduler_update to correctly handle cases where agent_init fails but does not remove the job

### File changes in detail

- `install/defconf/fossology.conf.in`: Document interface_nthreads.
- `src/scheduler/agent/scheduler.c`: Re-queue jobs on agent_init() failure; resize interface pool on config reload.
- `src/scheduler/agent/interface.c`: Sizes interface pool at init time using host_total_max().
- `src/scheduler/agent/host.h` + `src/scheduler/agent/host.c`:  host_total_max() via g_tree_foreach() summation
- `src/scheduler/agent_tests/Unit/testInterface.c` and `src/scheduler/agent_tests/Unit/testHost.c` - Added tests
 
  