### PR TITLE
feat(api): add link action to PUT /folders/{id} and block duplicate folder contents

### DIFF
--- a/src/lib/php/Dao/FolderDao.php
+++ b/src/lib/php/Dao/FolderDao.php
@@ -382,6 +382,23 @@ WHERE fc.parent_fk = $1 AND fc.foldercontents_mode = " . self::MODE_UPLOAD . ";"
     return !empty($cycle);
   }
 
+  /**
+   * Check if a folder already contains the given content
+   * @param integer $childId  Id of the child
+   * @param integer $mode     Mode of the child
+   * @param integer $folderId Folder to look in
+   * @return boolean True if the folder contains the content, false otherwise
+   */
+  public function isContentInFolder($childId, $mode, $folderId)
+  {
+    $content = $this->dbManager->getSingleRow(
+      'SELECT foldercontents_pk FROM foldercontents '.
+      'WHERE parent_fk=$1 AND foldercontents_mode=$2 AND child_id=$3',
+      array($folderId, $mode, $childId),
+      __METHOD__);
+    return !empty($content);
+  }
+
   public function getContent($folderContentId)
   {
     $content = $this->dbManager->getSingleRow('SELECT * FROM foldercontents WHERE foldercontents_pk=$1',
@@ -403,6 +420,10 @@ WHERE fc.parent_fk = $1 AND fc.foldercontents_mode = " . self::MODE_UPLOAD . ";"
       __METHOD__ . '.getParent');
     if (empty($newParent)) {
       throw new \Exception('invalid parent folder');
+    }
+    if ($this->isContentInFolder($content['child_id'],
+        $content['foldercontents_mode'], $newParentId)) {
+      throw new \Exception('the content already exists in the target folder');
     }
 
     if ($content['foldercontents_mode'] == self::MODE_FOLDER) {

--- a/src/lib/php/Dao/test/FolderDaoTest.php
+++ b/src/lib/php/Dao/test/FolderDaoTest.php
@@ -175,6 +175,41 @@ class FolderDaoTest extends \PHPUnit\Framework\TestCase
     assertThat($this->folderDao->getFolderChildFolders(FolderDao::TOP_LEVEL),is(arrayWithSize(3)));
   }
 
+  public function testCopyContentShouldFailIfContentAlreadyExistsInTargetFolder()
+  {
+    $this->expectException(Exception::class);
+    $this->expectExceptionMessage('the content already exists in the target folder');
+    $this->folderDao->ensureTopLevelFolder();
+    $folderA = $this->folderDao->insertFolder($folderName='A', '/A', FolderDao::TOP_LEVEL);
+    $folderB = $this->folderDao->insertFolder($folderName='B', '/A/B', $folderA);
+    $fc = $this->dbManager->getSingleRow('SELECT foldercontents_pk FROM foldercontents WHERE child_id=$1',
+            array($folderB),__METHOD__.'.needs.the.foldercontent_pk');
+    $this->folderDao->copyContent($fc['foldercontents_pk'], FolderDao::TOP_LEVEL);
+    $this->folderDao->copyContent($fc['foldercontents_pk'], FolderDao::TOP_LEVEL);
+  }
+
+  public function testMoveContentShouldFailIfContentAlreadyExistsInTargetFolder()
+  {
+    $this->expectException(Exception::class);
+    $this->expectExceptionMessage('the content already exists in the target folder');
+    $this->folderDao->ensureTopLevelFolder();
+    $folderA = $this->folderDao->insertFolder($folderName='A', '/A', FolderDao::TOP_LEVEL);
+    $folderB = $this->folderDao->insertFolder($folderName='B', '/A/B', $folderA);
+    $fc = $this->dbManager->getSingleRow('SELECT foldercontents_pk FROM foldercontents WHERE child_id=$1',
+            array($folderB),__METHOD__.'.needs.the.foldercontent_pk');
+    $this->folderDao->copyContent($fc['foldercontents_pk'], FolderDao::TOP_LEVEL);
+    $this->folderDao->moveContent($fc['foldercontents_pk'], FolderDao::TOP_LEVEL);
+  }
+
+  public function testIsContentInFolder()
+  {
+    $this->folderDao->ensureTopLevelFolder();
+    $folderA = $this->folderDao->insertFolder($folderName='A', '/A', FolderDao::TOP_LEVEL);
+    assertThat($this->folderDao->isContentInFolder($folderA, FolderDao::MODE_FOLDER, FolderDao::TOP_LEVEL), is(TRUE));
+    assertThat($this->folderDao->isContentInFolder($folderA, FolderDao::MODE_UPLOAD, FolderDao::TOP_LEVEL), is(FALSE));
+    assertThat($this->folderDao->isContentInFolder(FolderDao::TOP_LEVEL, FolderDao::MODE_FOLDER, $folderA), is(FALSE));
+  }
+
   public function testGetRemovableContents()
   {
     $this->folderDao->ensureTopLevelFolder();

--- a/src/www/ui/api/Controllers/FolderController.php
+++ b/src/www/ui/api/Controllers/FolderController.php
@@ -15,6 +15,7 @@ namespace Fossology\UI\Api\Controllers;
 use Fossology\Lib\Dao\FolderDao;
 use Fossology\UI\Ajax\AjaxFolderContents;
 use Fossology\UI\Api\Exceptions\HttpBadRequestException;
+use Fossology\UI\Api\Exceptions\HttpConflictException;
 use Fossology\UI\Api\Exceptions\HttpErrorException;
 use Fossology\UI\Api\Exceptions\HttpForbiddenException;
 use Fossology\UI\Api\Exceptions\HttpInternalServerErrorException;
@@ -202,7 +203,7 @@ class FolderController extends RestController
   }
 
   /**
-   * Copy/move the folder
+   * Copy/move/link the folder
    *
    * @param ServerRequestInterface $request
    * @param ResponseHelper $response
@@ -241,15 +242,21 @@ class FolderController extends RestController
         $this->restHelper->getUserId())) {
       throw new HttpForbiddenException("Parent folder is not accessible!");
     }
-    if (strcmp($action, "copy") != 0 && strcmp($action, "move") != 0) {
+    if (strcmp($action, "copy") != 0 && strcmp($action, "move") != 0
+        && strcmp($action, "link") != 0) {
       throw new HttpBadRequestException(
-        "Action can be one of [copy,move]!");
+        "Action can be one of [copy,move,link]!");
+    }
+    if ($folderDao->isContentInFolder($folderId, $folderDao::MODE_FOLDER,
+        $newParent)) {
+      throw new HttpConflictException(
+        "Folder is already present under the new parent!");
     }
     /** @var \AdminContentMove $folderMove */
     $folderMove = $this->restHelper->getPlugin('content_move');
     $folderName = FolderGetName($folderId);
     $parentFolderName = FolderGetName($newParent);
-    $isCopy = (strcmp($action, "copy") == 0);
+    $isCopy = (strcmp($action, "move") != 0);
     $message = $folderMove->copyContent(
       [
         $folderDao->getFolderContentsId($folderId, $folderDao::MODE_FOLDER)

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -3814,12 +3814,13 @@ paths:
             enum:
               - copy
               - move
-      summary: Copy/Move a folder
+              - link
+      summary: Copy/Move/Link a folder
       description: >
-        Copy or move a folder by id
+        Copy, move or link a folder by id
       responses:
         '202':
-          description: Folder will be copied/moved
+          description: Folder will be copied/moved/linked
           content:
             application/json:
               schema:

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -3651,12 +3651,13 @@ paths:
             enum:
               - copy
               - move
-      summary: Copy/Move a folder
+              - link
+      summary: Copy/Move/Link a folder
       description: >
-        Copy or move a folder by id
+        Copy, move or link a folder by id
       responses:
         '202':
-          description: Folder will be copied/moved
+          description: Folder will be copied/moved/linked
           content:
             application/json:
               schema:

--- a/src/www/ui_tests/api/Controllers/FolderControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/FolderControllerTest.php
@@ -54,6 +54,7 @@ namespace Fossology\UI\Api\Test\Controllers
   use Fossology\Lib\Data\Folder\Folder;
   use Fossology\UI\Api\Controllers\FolderController;
   use Fossology\UI\Api\Exceptions\HttpBadRequestException;
+  use Fossology\UI\Api\Exceptions\HttpConflictException;
   use Fossology\UI\Api\Exceptions\HttpForbiddenException;
   use Fossology\UI\Api\Exceptions\HttpNotFoundException;
   use Fossology\UI\Api\Helper\DbHelper;
@@ -792,6 +793,9 @@ namespace Fossology\UI\Api\Test\Controllers
       $this->folderDao->shouldReceive('isFolderAccessible')
         ->withArgs([$parentId,
           $this->userId])->andReturn(true);
+      $this->folderDao->shouldReceive('isContentInFolder')
+        ->withArgs([$folderId, FolderDao::MODE_FOLDER, $parentId])
+        ->andReturn(false);
       $this->folderDao->shouldReceive('getFolderContentsId')
         ->withArgs(array($folderId, 1))->andReturn($folderContentPk);
       $this->folderContentPlugin->shouldReceive('copyContent')
@@ -859,6 +863,9 @@ namespace Fossology\UI\Api\Test\Controllers
           $this->userId))->andReturn(true);
       $this->folderDao->shouldReceive('isFolderAccessible')
         ->withArgs([$parentId, $this->userId])->andReturn(true);
+      $this->folderDao->shouldReceive('isContentInFolder')
+        ->withArgs([$folderId, FolderDao::MODE_FOLDER, $parentId])
+        ->andReturn(false);
       $this->folderDao->shouldReceive('getFolderContentsId')
         ->withArgs(array($folderId, 1))->andReturn($folderContentPk);
       $this->folderContentPlugin->shouldReceive('copyContent')
@@ -884,6 +891,132 @@ namespace Fossology\UI\Api\Test\Controllers
         $actualResponse->getStatusCode());
       $this->assertEquals($expectedResponse->getArray(),
         $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test for link action on FolderController::copyFolder() with version 1 attributes
+     * -# Check for 202 response
+     */
+    public function testLinkFolderV1()
+    {
+      $this->testLinkFolder(ApiVersion::V1);
+    }
+    /**
+     * @test
+     * -# Test for link action on FolderController::copyFolder() with version 2 attributes
+     * -# Check for 202 response
+     */
+    public function testLinkFolderV2()
+    {
+      $this->testLinkFolder();
+    }
+
+    /**
+     * @param $version to test
+     * @return void
+     */
+    private function testLinkFolder($version = ApiVersion::V2)
+    {
+      $folderId = 3;
+      $parentId = 2;
+      $folderContentPk = 5;
+      $folderName = \Fossology\UI\Api\Controllers\FolderGetName($folderId);
+      $parentFolderName = \Fossology\UI\Api\Controllers\FolderGetName($parentId);
+
+      $this->folderDao->shouldReceive('getFolder')
+        ->andReturnUsing([$this, 'getFolder']);
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array(M::anyOf($folderId, "$parentId"),
+          $this->userId))->andReturn(true);
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs([$parentId, $this->userId])->andReturn(true);
+      $this->folderDao->shouldReceive('isContentInFolder')
+        ->withArgs([$folderId, FolderDao::MODE_FOLDER, $parentId])
+        ->andReturn(false);
+      $this->folderDao->shouldReceive('getFolderContentsId')
+        ->withArgs(array($folderId, 1))->andReturn($folderContentPk);
+      $this->folderContentPlugin->shouldReceive('copyContent')
+        ->withArgs(array([$folderContentPk], $parentId, true))->andReturn("");
+      $requestHeaders = new Headers();
+      $body = $this->streamFactory->createStream();
+      $request = new Request("PUT", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $body);
+      $response = new ResponseHelper();
+      if ($version == ApiVersion::V2) {
+        $request = $request->withQueryParams(['parent'=>$parentId, 'action'=>'link']);
+      } else {
+        $request = $request->withHeader('parent', $parentId)
+          ->withHeader('action', "link");
+      }
+      $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,$version);
+      $actualResponse = $this->folderController->copyFolder($request,
+        $response, ["id" => $folderId]);
+      $expectedResponse = new Info(202,
+        "Folder \"$folderName\" link(ed) under \"$parentFolderName\".",
+        InfoType::INFO);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test for copy action on FolderController::copyFolder() when the folder
+     *    is already present under the new parent, with version 1 attributes
+     * -# Check if the HttpConflictException is thrown
+     */
+    public function testCopyFolderAlreadyPresentV1()
+    {
+      $this->testCopyFolderAlreadyPresent(ApiVersion::V1);
+    }
+    /**
+     * @test
+     * -# Test for copy action on FolderController::copyFolder() when the folder
+     *    is already present under the new parent, with version 2 attributes
+     * -# Check if the HttpConflictException is thrown
+     */
+    public function testCopyFolderAlreadyPresentV2()
+    {
+      $this->testCopyFolderAlreadyPresent();
+    }
+
+    /**
+     * @param $version to test
+     * @return void
+     */
+    private function testCopyFolderAlreadyPresent($version = ApiVersion::V2)
+    {
+      $folderId = 3;
+      $parentId = 2;
+
+      $this->folderDao->shouldReceive('getFolder')
+        ->andReturnUsing([$this, 'getFolder']);
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array(M::anyOf($folderId, "$parentId"),
+          $this->userId))->andReturn(true);
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs([$parentId, $this->userId])->andReturn(true);
+      $this->folderDao->shouldReceive('isContentInFolder')
+        ->withArgs([$folderId, FolderDao::MODE_FOLDER, $parentId])
+        ->andReturn(true);
+      $requestHeaders = new Headers();
+      $body = $this->streamFactory->createStream();
+      $request = new Request("PUT", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $body);
+      if ($version == ApiVersion::V2) {
+        $request = $request->withQueryParams(['parent'=>$parentId, 'action'=>'copy']);
+      } else {
+        $request = $request->withHeader('parent', $parentId)
+          ->withHeader('action', "copy");
+      }
+      $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME,$version);
+      $response = new ResponseHelper();
+      $this->expectException(HttpConflictException::class);
+
+      $this->folderController->copyFolder($request, $response,
+        ["id" => $folderId]);
     }
 
     /**


### PR DESCRIPTION
## What this does

Adds `action=link` to `PUT /folders/{id}` and blocks duplicate folder contents, complementing #3692 (which adds the same for uploads).

In FOSSology, "copy" of a folder or upload never duplicates data — `FolderDao::copyContent()` just inserts another row into `foldercontents`, so the item becomes visible in a second folder while remaining a single logical object. That is exactly the UI "Move or Alias" behaviour. The uploads endpoint is being taught the `link` name in #3692; this PR does the folder side and adds the missing duplicate guard that #3687 asks for.

## Changes

- **`FolderController::copyFolder()`** — `PUT /folders/{id}` now accepts `action=link` alongside `copy`/`move`. When the folder is already present under the target parent it returns `409 Conflict` instead of inserting a second identical row.
- **`FolderDao`** — new `isContentInFolder()` helper, used in `isContentMovable()` so any copy/link/move that would create a duplicate `(parent_fk, foldercontents_mode, child_id)` entry fails with a clear message rather than silently duplicating. This also protects the uploads endpoint and the web UI, since both go through the same path.
- **`openapi.yaml` / `openapiv2.yaml`** — document `link` as a valid action on `PUT /folders/{id}`.
- **Tests** — `FolderControllerTest`: link action (V1/V2) and the 409 conflict. `FolderDaoTest`: duplicate guard for copy and move, plus `isContentInFolder()`.

## Testing

```
vendor/bin/phpunit src/www/ui_tests/api/Controllers/FolderControllerTest.php   # 47 tests
vendor/bin/phpunit src/lib/php/Dao/test/FolderDaoTest.php                       # 19 tests
```

Also verified end to end against a running instance (API 1.6.2): `action=link` on a folder returns `202 ... link(ed) ...` and adds a single `foldercontents` row; repeating it (or a copy) returns `409`; and a copy/link/move that would duplicate an upload now fails cleanly instead of adding a duplicate row.

Related to #3687.
