### PR TITLE
fix(multicompare): descend into archive wrapper directories

### DIFF
--- a/src/lib/php/common-multicompare.php
+++ b/src/lib/php/common-multicompare.php
@@ -10,6 +10,33 @@
  * \brief N-way file matching and link generation for multi-component comparison.
  */
 
+/**
+ * \brief Select the effective comparison root for a tree item.
+ *
+ * Archive uploads commonly contain one extracted, non-artifact wrapper
+ * directory below the upload root.  In that specific case, compare the
+ * wrapper's children instead of comparing the wrapper name itself.
+ *
+ * @param int   $selectedItem Selected uploadtree_pk
+ * @param array $children     Non-artifact children of the selected item
+ * @return int Original item, or its sole directory child's uploadtree_pk
+ */
+function NormalizeMultiCompareRoot(int $selectedItem, array $children): int
+{
+  if (count($children) !== 1) {
+    return $selectedItem;
+  }
+
+  $child = reset($children);
+  if (empty($child['uploadtree_pk']) ||
+      !isset($child['ufile_mode']) ||
+      !Isdir($child['ufile_mode'])) {
+    return $selectedItem;
+  }
+
+  return intval($child['uploadtree_pk']);
+}
+
 
 /**
  * \brief Remove one key from a name-index bucket list (used by MakeMasterN).

--- a/src/lib/php/tests/test_common_multicompare.php
+++ b/src/lib/php/tests/test_common_multicompare.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+require_once(dirname(__FILE__) . '/../common-dir.php');
+require_once(dirname(__FILE__) . '/../common-multicompare.php');
+
+class test_common_multicompare extends \PHPUnit\Framework\TestCase
+{
+  public function testNormalizesSoleDirectoryChild(): void
+  {
+    $children = [[
+      'uploadtree_pk' => 42,
+      'ufile_mode' => (1 << 18) | (1 << 29),
+    ]];
+
+    $this->assertSame(42, NormalizeMultiCompareRoot(10, $children));
+  }
+
+  public function testKeepsRootWithMultipleChildren(): void
+  {
+    $children = [
+      ['uploadtree_pk' => 42, 'ufile_mode' => (1 << 18) | (1 << 29)],
+      ['uploadtree_pk' => 43, 'ufile_mode' => 0100644],
+    ];
+
+    $this->assertSame(10, NormalizeMultiCompareRoot(10, $children));
+  }
+
+  public function testKeepsRootWithSoleFileChild(): void
+  {
+    $children = [[
+      'uploadtree_pk' => 42,
+      'ufile_mode' => 0100644,
+    ]];
+
+    $this->assertSame(10, NormalizeMultiCompareRoot(10, $children));
+  }
+
+  public function testKeepsRootWithoutChildren(): void
+  {
+    $this->assertSame(10, NormalizeMultiCompareRoot(10, []));
+  }
+}

--- a/src/lib/php/tests/tests.xml
+++ b/src/lib/php/tests/tests.xml
@@ -10,6 +10,7 @@
       <file>test_common_cache.php</file>
       <file>test_common_cli.php</file>
       <file>test_common_dir.php</file>
+      <file>test_common_multicompare.php</file>
       <file>test_common_license_file.php</file>
       <file>test_common_menu.php</file>
       <file>test_common_parm.php</file>

--- a/src/www/ui/MultiComparePlugin.php
+++ b/src/www/ui/MultiComparePlugin.php
@@ -168,6 +168,32 @@ class MultiComparePlugin extends DefaultPlugin
   }
 
   /**
+   * Descend through a sole non-artifact directory child for each selected
+   * comparison root. Roots with zero/multiple children or a sole file child
+   * are left unchanged.
+   */
+  private function normalizeComparisonRoots(array $items): array
+  {
+    foreach ($items as $idx => $itemPk) {
+      $row = $this->dbManager->getSingleRow(
+        "SELECT u.uploadtree_tablename
+         FROM uploadtree ut
+         JOIN upload u ON u.upload_pk = ut.upload_fk
+         WHERE ut.uploadtree_pk = \$1",
+        [$itemPk], __METHOD__ . '.table'
+      );
+      if (!$row) {
+        continue;
+      }
+
+      $children = GetNonArtifactChildren($itemPk, $row['uploadtree_tablename']);
+      $items[$idx] = NormalizeMultiCompareRoot($itemPk, $children);
+    }
+
+    return $items;
+  }
+
+  /**
    * Populate dataarray and datastr on every child for the given mode.
    * License and copyright/ECC data are fetched in single batch queries
    * (one per column) instead of one query per child.
@@ -778,6 +804,8 @@ class MultiComparePlugin extends DefaultPlugin
         }
       }
     }
+
+    $items = $this->normalizeComparisonRoots($items);
 
     $cacheKey = "?mod=" . self::NAME
         . "&items=" . implode(",", $items)


### PR DESCRIPTION
## Summary

Multi-Component Comparison compares the immediate non-artifact children of
each selected uploadtree item.

Uploaded archives often contain a single extracted wrapper directory:

```text
first.zip              second.zip
└── first/             └── second/
    ├── file1.c            ├── file1.c
    └── file2.c            └── file2.c
```

When users selected the archive roots, the comparison matched `first/` against
`second/`. Because the wrapper names differed, they appeared as unique or
missing, and the files inside them were not compared.

<img width="959" height="490" alt="original state of compare" src="https://github.com/user-attachments/assets/8af56bb3-8d3b-4e79-9bbc-817da9e99470" />


## Changes Made

Added a conservative root-normalization step before building the comparison.

If a selected root has exactly one non-artifact child and that child is a
directory, the directory becomes the effective comparison root. Otherwise,
the selected root remains unchanged.

Normalization happens before generating the cache key and comparison data.
Therefore, file matching, summaries, filters, links, breadcrumbs, and
histograms all use the normalized roots.

Added unit tests covering:

- A sole directory child.
- Multiple children.
- A sole file child.
- No children.

<img width="959" height="502" alt="fixed version of compare" src="https://github.com/user-attachments/assets/83f48044-cca7-41f3-b04c-f7c1790746aa" />
