### PR TITLE
fix(auth): add timestamp to time fields in pat table to remove unusable token window

### DIFF
--- a/install/db/dbmigrate_token.php
+++ b/install/db/dbmigrate_token.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Siemens AG
+ SPDX-FileContributor: Dearsh Oberoi <dearsh.oberoi@siemens.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+function Token_timestamp_migration(): void
+{
+    global $PG_CONN;
+
+    $sql = "ALTER TABLE \"personal_access_tokens\"\n"
+                . "ALTER COLUMN \"created_on\" TYPE TIMESTAMP WITH TIME ZONE USING \"created_on\"::TIMESTAMP WITH TIME ZONE, "
+                . "ALTER COLUMN \"created_on\" SET DEFAULT NOW();";
+    $result_alter_column = pg_query($PG_CONN, $sql);
+    DBCheckResult($result_alter_column, $sql, __FILE__, __LINE__);
+    pg_free_result($result_alter_column);
+
+    $sql = "ALTER TABLE \"personal_access_tokens\"\n"
+                . "ALTER COLUMN \"expire_on\" TYPE TIMESTAMP WITH TIME ZONE USING \"expire_on\"::TIMESTAMP WITH TIME ZONE;";
+    $result_alter_column = pg_query($PG_CONN, $sql);
+    DBCheckResult($result_alter_column, $sql, __FILE__, __LINE__);
+    pg_free_result($result_alter_column);
+}

--- a/install/fossinit.php
+++ b/install/fossinit.php
@@ -440,6 +440,9 @@ $errors = $checker->check();
 require_once("$LIBEXECDIR/dbmigrate_licensedb_compatibility.php");
 LicenseDB_compatibility_migration();
 
+require_once("$LIBEXECDIR/dbmigrate_token.php");
+Token_timestamp_migration();
+
 if($errors>0)
 {
   echo "ERROR: $errors sanity check".($errors>1?'s':'')." failed\n";


### PR DESCRIPTION
### Description
Fixes the issue where there was a period of time for which a personal access token was unusable after issuance in some cases due to diff in time from utc. Before, only the date of issuance was stored in the database. So, for example, if we create a token at 2026-07-15 01:00 A.M. IST, only 2026-07-15 was stored in database. This field was used as nbf value in the token. The function strtotime, which was used to convert this date to unix timestamp assumed the date was in utc and not ist as no timestamp was given. So, the nbf value was stored as 2026-07-15 00:00 A.M. UTC. When a user tries to use this token at an arbitrary time, let's say 2026-07-15 02:00 A.M. IST, which corresponds to 2026-07-14 08:30 P.M. UTC, he cannot use it because of the nbf time set.