### PR TITLE
feat(cyclonedx): add user default settings for CycloneDX export

### DIFF
--- a/src/cyclonedx/agent/cyclonedx.php
+++ b/src/cyclonedx/agent/cyclonedx.php
@@ -330,6 +330,8 @@ class CycloneDXAgent extends Agent
     /* @var $treeDao TreeDao */
     $treeDao = $this->container->get('dao.tree');
 
+    $stateWoInfos = $this->getCycloneDXReportConf($uploadId, 1);
+
     $filesProceeded = 0;
     $lastValue = 0;
     $components = array();
@@ -338,6 +340,11 @@ class CycloneDXAgent extends Agent
       if (($filesProceeded & 2047) == 0) {
         $this->heartbeat($filesProceeded - $lastValue);
         $lastValue = $filesProceeded;
+      }
+
+      if ($stateWoInfos && empty($licenses->getConcludedLicenses()) &&
+          empty($licenses->getScanners()) && empty($licenses->getCopyrights())) {
+        continue;
       }
 
       $hashes = $treeDao->getItemHashes($fileId);
@@ -498,6 +505,26 @@ class CycloneDXAgent extends Agent
 
     $row = $this->dbManager->getSingleRow($sql, [$fileId], __METHOD__);
     return $row['mimetype_name'] ?? 'application/octet-stream';
+  }
+
+  /**
+   * @brief Get CycloneDX report conf state for a given upload
+   *
+   * Reads user default settings from users.cyclonedx_settings.
+   * @param int $uploadId
+   * @param int $key Array key (0=cyclonedxLicenseComment, 1=ignoreFilesWOInfo, 2=osselotExport)
+   * @return bool Configuration state (TRUE/FALSE)
+   */
+  protected function getCycloneDXReportConf($uploadId, $key)
+  {
+    $settings = $this->uploadDao->getCyclonedxSettings($uploadId);
+    if (!empty($settings)) {
+      $settingsArr = explode(',', $settings);
+      if (isset($settingsArr[$key]) && $settingsArr[$key] === "checked") {
+        return true;
+      }
+    }
+    return false;
   }
 }
 

--- a/src/lib/php/Dao/UploadDao.php
+++ b/src/lib/php/Dao/UploadDao.php
@@ -906,6 +906,45 @@ ORDER BY lft asc
   }
 
   /**
+   * @brief Get cyclone dx settings for a user
+   * @param int $uploadId Upload ID to get user for
+   * @return string Comma separated values for cyclonedxLicenseComment, ignoreFilesWOInfo, osselotExport
+   */
+  public function getCyclonedxSettings($uploadId)
+  {
+    $stmt = __METHOD__ . '.getOwner';
+    $sql = "SELECT user_fk FROM upload WHERE upload_pk = $1";
+    $uploadOwner = $this->dbManager->getSingleRow($sql, array($uploadId), $stmt);
+
+    if (empty($uploadOwner)) {
+      return "unchecked,unchecked,unchecked";
+    }
+
+    $userId = $uploadOwner['user_fk'];
+
+    $stmt = __METHOD__ . '.getUserDefaults';
+    $sql = "SELECT cyclonedx_settings FROM users WHERE user_pk = $1";
+    $userDefaults = $this->dbManager->getSingleRow($sql, array($userId), $stmt);
+
+    if (empty($userDefaults) || empty($userDefaults['cyclonedx_settings'])) {
+      return "unchecked,unchecked,unchecked";
+    }
+
+    $settings = explode(',', $userDefaults['cyclonedx_settings']);
+    if (count($settings) < 3) {
+      $settings = array_pad($settings, 3, 'unchecked');
+    }
+
+    $osselotExport = $settings[0];
+    $cyclonedxLicenseComment = $settings[1];
+    $ignoreFilesWOInfo = $settings[2];
+
+    $result = "$cyclonedxLicenseComment,$ignoreFilesWOInfo,$osselotExport";
+
+    return $result;
+  }
+
+  /**
    * @brief Update report info for upload
    * @param int $uploadId  Upload ID to update
    * @param string $column Column to update

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -2320,6 +2320,10 @@
   $Schema["TABLE"]["users"]["spdx_settings"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"spdx_settings\" text DEFAULT 'unchecked,unchecked,unchecked'::text";
   $Schema["TABLE"]["users"]["spdx_settings"]["ALTER"] = "ALTER TABLE \"users\" ALTER COLUMN \"spdx_settings\" DROP NOT NULL, ALTER COLUMN \"spdx_settings\" SET DEFAULT 'unchecked,unchecked,unchecked'::text";
 
+  $Schema["TABLE"]["users"]["cyclonedx_settings"]["DESC"] = "COMMENT ON COLUMN \"users\".\"cyclonedx_settings\" IS 'Comma-separated CycloneDX export settings: osselot_export,cyclonedx_license_comment,ignore_files_wo_info as checked/unchecked values'";
+  $Schema["TABLE"]["users"]["cyclonedx_settings"]["ADD"] = "ALTER TABLE \"users\" ADD COLUMN \"cyclonedx_settings\" text DEFAULT 'unchecked,unchecked,unchecked'::text";
+  $Schema["TABLE"]["users"]["cyclonedx_settings"]["ALTER"] = "ALTER TABLE \"users\" ALTER COLUMN \"cyclonedx_settings\" DROP NOT NULL, ALTER COLUMN \"cyclonedx_settings\" SET DEFAULT 'unchecked,unchecked,unchecked'::text";
+
   $Schema["TABLE"]["report_info"]["ri_pk"]["DESC"] = "";
   $Schema["TABLE"]["report_info"]["ri_pk"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_pk\" int4 DEFAULT nextval('report_info_pk_seq'::regclass)";
   $Schema["TABLE"]["report_info"]["ri_pk"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_pk\" SET NOT NULL, ALTER COLUMN \"ri_pk\" SET DEFAULT nextval('report_info_pk_seq'::regclass)";

--- a/src/www/ui/template/user_edit.html.twig
+++ b/src/www/ui/template/user_edit.html.twig
@@ -114,6 +114,27 @@
       </th>
       <td><input type="checkbox" name="ignore_files_wo_info_default" {% if ignoreFilesWOInfoDefault %}checked{% endif %}></td>
     </tr>
+    <tr class="classic">
+      <th width="25%">
+        {{ "Enable CycloneDX OSSelot export by default"|trans }}
+        <img src="images/info_16.png" data-toggle="tooltip" title="{{ 'When enabled, CycloneDX exports will be OSSelot-compatible.'|trans }}" alt="" class="info-bullet"/>
+      </th>
+      <td><input type="checkbox" name="cyclonedx_osselot_export_enabled" id="cyclonedxOsselotExportEnabledCheckbox" {% if cyclonedxOsselotExportEnabled %}checked{% endif %}></td>
+    </tr>
+    <tr class="classic">
+      <th width="25%">
+        {{ "Show CycloneDX license comments by default"|trans }}
+        <img src="images/info_16.png" data-toggle="tooltip" title="{{ 'When enabled, CycloneDX reports will include license comments by default.'|trans }}" alt="" class="info-bullet"/>
+      </th>
+      <td><input type="checkbox" name="cyclonedx_license_comment_default" id="cyclonedxLicenseCommentDefaultCheckbox" {% if cyclonedxLicenseCommentDefault %}checked{% endif %}></td>
+    </tr>
+    <tr class="classic">
+      <th width="25%">
+        {{ "Ignore files with no info in CycloneDX by default"|trans }}
+        <img src="images/info_16.png" data-toggle="tooltip" title="{{ 'When enabled, CycloneDX reports will ignore files with no license information by default.'|trans }}" alt="" class="info-bullet"/>
+      </th>
+      <td><input type="checkbox" name="cyclonedx_ignore_files_wo_info_default" {% if cyclonedxIgnoreFilesWOInfoDefault %}checked{% endif %}></td>
+    </tr>
     {%  if isSessionAdmin %}
       <tr class="classic">
         <th width="25%">{{ "Select user's default group."|trans }}</th>
@@ -531,6 +552,17 @@
       $('#spdxLicenseCommentDefaultCheckbox').change(function() {
         if (!$(this).is(':checked')) {
           $('#osselotExportEnabledCheckbox').prop('checked', false);
+        }
+      });
+
+      $('#cyclonedxOsselotExportEnabledCheckbox').change(function() {
+        if ($(this).is(':checked')) {
+          $('#cyclonedxLicenseCommentDefaultCheckbox').prop('checked', true);
+        }
+      });
+      $('#cyclonedxLicenseCommentDefaultCheckbox').change(function() {
+        if (!$(this).is(':checked')) {
+          $('#cyclonedxOsselotExportEnabledCheckbox').prop('checked', false);
         }
       });
     });

--- a/src/www/ui/user-edit.php
+++ b/src/www/ui/user-edit.php
@@ -198,6 +198,14 @@ class UserEditPage extends DefaultPlugin
     $vars['spdxLicenseCommentDefault'] = ($spdxSettings[1] === 'checked');
     $vars['ignoreFilesWOInfoDefault'] = ($spdxSettings[2] === 'checked');
 
+    $cyclonedxSettings = isset($UserRec['cyclonedx_settings']) ? explode(',', $UserRec['cyclonedx_settings']) : ['unchecked', 'unchecked', 'unchecked'];
+    if (count($cyclonedxSettings) < 3) {
+      $cyclonedxSettings = array_pad($cyclonedxSettings, 3, 'unchecked');
+    }
+    $vars['cyclonedxOsselotExportEnabled'] = ($cyclonedxSettings[0] === 'checked');
+    $vars['cyclonedxLicenseCommentDefault'] = ($cyclonedxSettings[1] === 'checked');
+    $vars['cyclonedxIgnoreFilesWOInfoDefault'] = ($cyclonedxSettings[2] === 'checked');
+
     if ($SessionIsAdmin) {
       $vars['allAccessLevels'] = array(
           PLUGIN_DB_NONE => _("None (very basic, no database access)"),
@@ -459,6 +467,14 @@ class UserEditPage extends DefaultPlugin
         $ignoreFilesEnabled = !empty($request->get('ignore_files_wo_info_default')) ? 'checked' : 'unchecked';
 
         $UserRec['spdx_settings'] = "$osselotEnabled,$spdxCommentEnabled,$ignoreFilesEnabled";
+      }
+
+      if ($this->dbManager->existsColumn('users', 'cyclonedx_settings')) {
+        $cyclonedxOsselotEnabled = !empty($request->get('cyclonedx_osselot_export_enabled')) ? 'checked' : 'unchecked';
+        $cyclonedxCommentEnabled = !empty($request->get('cyclonedx_license_comment_default')) ? 'checked' : 'unchecked';
+        $cyclonedxIgnoreFilesEnabled = !empty($request->get('cyclonedx_ignore_files_wo_info_default')) ? 'checked' : 'unchecked';
+
+        $UserRec['cyclonedx_settings'] = "$cyclonedxOsselotEnabled,$cyclonedxCommentEnabled,$cyclonedxIgnoreFilesEnabled";
       }
     }
     return $UserRec;


### PR DESCRIPTION
This is **Phase 2 - Part 2 of the GSoC 2026 project** (#3635): Improve CycloneDX Support and Update CycloneDX Exports to Spec Version 1.7.

This PR implements user-configurable default settings for CycloneDX exports, mirroring the existing behavior for SPDX exports. It allows users to set their default preferences for CycloneDX once via the UI, removing the need to configure them for every export.

**Changes Made:**

- **Database Update:** Added the `cyclonedx_settings` column to the `users` table via `core-schema.dat` to persistently store user defaults.
- **Backend DAO:** Implemented `getCyclonedxSettings()` in `UploadDao.php` to fetch the user settings cleanly.
- **UI Logic:** Updated `user-edit.php` to handle parsing the settings string from the database on page load and constructing the string on save.
- **UI Template:** Added checkboxes for CycloneDX OSSelot Export, License Comments, and Ignore Files Without Info to the `user_edit.html.twig` template, along with matching JavaScript logic to handle their dependencies.

**How to Test**

1. Rebuild the `cyclonedx` plugin or the UI container.
2. Go to **Administration > Users > Manage Users > Edit User**.
3. Scroll down and locate the new CycloneDX checkboxes below the SPDX settings.
4. Toggle the settings (e.g., enable OSSelot export) and click **Update**.
5. Reload the page and verify your checkbox states were saved correctly and persist.
