### PR TITLE
feat(reuseCompare): add file diff view for reuse upload

### DIFF
--- a/src/lib/php/common-compare.php
+++ b/src/lib/php/common-compare.php
@@ -47,31 +47,46 @@ function FuzzyCmp($Master1, $Master2)
 function MakeMaster($Children1, $Children2)
 {
   $Master = array();
-  $row =  -1;   // Master row number
+  $row = -1;
 
-  if (! empty($Children1) && (! empty($Children2))) {
+  if (!empty($Children1) && !empty($Children2)) {
+    /* Build hash-map indices for fast matching */
+    $allChildren2 = [];
+    $byName  = [];
+    $byFuzzyExt = [];
+    $byFuzzy = [];
+    foreach ($Children2 as $idx => $child) {
+      $allChildren2[$idx] = $child;
+      $byName[$child['ufile_name']][$idx] = $idx;
+      $byFuzzyExt[$child['fuzzynameext']][$idx] = $idx;
+      $byFuzzy[$child['fuzzyname']][$idx] = $idx;
+    }
+    $consumed = [];
+
     foreach ($Children1 as $Child1) {
       $done = false;
       $row++;
 
       /* find complete name match */
-      foreach ($Children2 as $key => $Child2) {
-        if ($Child1['ufile_name'] == $Child2['ufile_name']) {
-          $Master[$row][1] = $Child1;
-          $Master[$row][2] = $Child2;
-          unset($Children2[$key]);
-          $done = true;
-          break;
+      if (!$done && !empty($byName[$Child1['ufile_name']])) {
+        foreach ($byName[$Child1['ufile_name']] as $idx) {
+          if (!isset($consumed[$idx])) {
+            $Master[$row][1] = $Child1;
+            $Master[$row][2] = $allChildren2[$idx];
+            $consumed[$idx] = true;
+            $done = true;
+            break;
+          }
         }
       }
 
       /* find fuzzy+extension match */
-      if (! $done) {
-        foreach ($Children2 as $key => $Child2) {
-          if ($Child1['fuzzynameext'] == $Child2['fuzzynameext']) {
+      if (!$done && !empty($byFuzzyExt[$Child1['fuzzynameext']])) {
+        foreach ($byFuzzyExt[$Child1['fuzzynameext']] as $idx) {
+          if (!isset($consumed[$idx])) {
             $Master[$row][1] = $Child1;
-            $Master[$row][2] = $Child2;
-            unset($Children2[$key]);
+            $Master[$row][2] = $allChildren2[$idx];
+            $consumed[$idx] = true;
             $done = true;
             break;
           }
@@ -79,25 +94,33 @@ function MakeMaster($Children1, $Children2)
       }
 
       /* find files that only differ by 1 character in fuzzyext */
-      if (! $done) {
-        foreach ($Children2 as $key => $Child2) {
-          if (levenshtein($Child1['fuzzynameext'], $Child2['fuzzynameext']) == 1) {
-            $Master[$row][1] = $Child1;
-            $Master[$row][2] = $Child2;
-            unset($Children2[$key]);
-            $done = true;
-            break;
+      if (!$done) {
+        $best = null;
+        foreach ($byFuzzyExt as $key => $indices) {
+          if (levenshtein($Child1['fuzzynameext'], $key) == 1) {
+            foreach ($indices as $idx) {
+              if (!isset($consumed[$idx])) {
+                $best = $idx;
+                break 2;
+              }
+            }
           }
+        }
+        if ($best !== null) {
+          $Master[$row][1] = $Child1;
+          $Master[$row][2] = $allChildren2[$best];
+          $consumed[$best] = true;
+          $done = true;
         }
       }
 
       /* Look for fuzzy match */
-      if (! $done) {
-        foreach ($Children2 as $key => $Child2) {
-          if ($Child1['fuzzyname'] == $Child2['fuzzyname']) {
+      if (!$done && !empty($byFuzzy[$Child1['fuzzyname']])) {
+        foreach ($byFuzzy[$Child1['fuzzyname']] as $idx) {
+          if (!isset($consumed[$idx])) {
             $Master[$row][1] = $Child1;
-            $Master[$row][2] = $Child2;
-            unset($Children2[$key]);
+            $Master[$row][2] = $allChildren2[$idx];
+            $consumed[$idx] = true;
             $done = true;
             break;
           }
@@ -105,24 +128,43 @@ function MakeMaster($Children1, $Children2)
       }
 
       /* no match so add it in by itself */
-      if (! $done) {
+      if (!$done) {
         $Master[$row][1] = $Child1;
         $Master[$row][2] = array();
       }
     }
+  } elseif (!empty($Children1)) {
+    /* Only Children1 exists */
+    foreach ($Children1 as $Child1) {
+      $row++;
+      $Master[$row][1] = $Child1;
+      $Master[$row][2] = array();
+    }
   }
 
   /* Remaining Child2 recs */
-  foreach ($Children2 as $Child) {
-    $row ++;
-    $Master[$row][1] = '';
-    $Master[$row][2] = $Child;
+  if (!empty($Children2)) {
+    if (!isset($consumed)) {
+      foreach ($Children2 as $Child) {
+        $row++;
+        $Master[$row][1] = '';
+        $Master[$row][2] = $Child;
+      }
+    } else {
+      foreach ($allChildren2 as $idx => $child) {
+        if (!isset($consumed[$idx])) {
+          $row++;
+          $Master[$row][1] = '';
+          $Master[$row][2] = $child;
+        }
+      }
+    }
   }
 
   /* Sort master by child1 */
   usort($Master, "FuzzyCmp");
 
-  return($Master);
+  return $Master;
 } // MakeMaster()
 
 

--- a/src/reuser/ui/ReuseComparePlugin.php
+++ b/src/reuser/ui/ReuseComparePlugin.php
@@ -1,0 +1,385 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @dir
+ * @brief UI element of reuser agent
+ * @file
+ */
+
+namespace Fossology\Reuser;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\Plugin\DefaultPlugin;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @class ReuseComparePlugin
+ * @brief Compare files in the current upload against their counterparts
+ *        from the reused upload source. Shows histogram, diff tree, and
+ *        license comparison similar to the Enhanced Reuse view.
+ */
+class ReuseComparePlugin extends DefaultPlugin
+{
+  const NAME = "reusecompare";
+
+  /** @var DbManager */
+  private $dbManager;
+
+  /** @var UploadDao */
+  private $uploadDao;
+
+  function __construct()
+  {
+    parent::__construct(self::NAME, [
+      self::TITLE => _("Reuse Compare"),
+      self::DEPENDENCIES => ["browse", "view"],
+      self::PERMISSION => Auth::PERM_READ,
+      self::REQUIRES_LOGIN => true,
+    ]);
+    $this->dbManager = $this->getObject('db.manager');
+    $this->uploadDao = $this->getObject('dao.upload');
+  }
+
+  function preInstall()
+  {
+    menu_insert("Browse-Pfile::Reuse Compare", 3, self::NAME,
+      _("Compare files with reused upload source."));
+  }
+
+  /**
+   * @param Request $request
+   * @return Response
+   */
+  protected function handle(Request $request)
+  {
+    $uploadId = (int)$request->get('upload', 0);
+    $item = (int)$request->get('item', 0);
+
+    if (empty($uploadId) || empty($item)) {
+      return $this->flushContent(
+        "<h3>" . _("Missing upload or item parameter.") . "</h3>");
+    }
+
+    $groupId = Auth::getGroupId();
+    if (!$this->uploadDao->isAccessible($uploadId, $groupId)) {
+      return $this->flushContent(
+        "<h2>" . _("Permission Denied") . "</h2>");
+    }
+
+    $tableName = $this->uploadDao->getUploadtreeTableName($uploadId);
+
+    /* Get reuse sources */
+    $reusedUploads = $this->uploadDao->getReusedUpload($uploadId, $groupId);
+    if (empty($reusedUploads)) {
+      return $this->flushContent(
+        "<h3>" . _("No reused upload sources found for this upload.") . "</h3>");
+    }
+
+    $selectedReuseId = (int)$request->get('reuse', 0);
+    $reuseUploadId = 0;
+    $reuseSources = [];
+
+    foreach ($reusedUploads as $ru) {
+      $rid = intval($ru['reused_upload_fk']);
+      $ruUpload = $this->uploadDao->getUpload($rid);
+      $ruName = $ruUpload ? $ruUpload->getFilename() : "unknown";
+      $ruMode = intval($ru['reuse_mode']);
+      $reuseSources[] = [
+        'id'   => $rid,
+        'name' => $ruName,
+        'mode' => $ruMode,
+      ];
+      if ($reuseUploadId === 0 ||
+          ($selectedReuseId > 0 && $rid === $selectedReuseId) ||
+          ($selectedReuseId === 0 && $reuseUploadId === 0)) {
+        $reuseUploadId = $rid;
+      }
+    }
+
+    $reuseTableName = $this->uploadDao->getUploadtreeTableName($reuseUploadId);
+    $reuseRootPk = $this->uploadDao->getUploadParent($reuseUploadId);
+
+    /* Determine which node to list children from */
+    $itemRow = $this->uploadDao->getUploadEntry($item, $tableName);
+    if (empty($itemRow)) {
+      return $this->flushContent("<h3>" . _("Item not found.") . "</h3>");
+    }
+
+    /* Get all descendant files (not just one level) using lft/rgt range */
+    $children1 = $this->getAllNonArtifactDescendants($itemRow, $tableName);
+    $reuseRootRow = $this->uploadDao->getUploadEntry($reuseRootPk, $reuseTableName);
+    $children2 = [];
+    if (!empty($reuseRootRow)) {
+      $children2 = $this->getAllNonArtifactDescendants($reuseRootRow, $reuseTableName);
+    }
+    FuzzyName($children1);
+    FuzzyName($children2);
+    $master = MakeMaster($children1, $children2);
+
+    /* Build diff tree, stats, and license data */
+    $diffTree = [];
+    $stats = [
+      'IDENTICAL' => 0, 'MODIFIED' => 0, 'NEW' => 0, 'REMOVED' => 0
+    ];
+
+    $licenseMapUploadPfiles = $this->batchGetLicensesForUpload($uploadId, $itemRow['lft'], $itemRow['rgt'], $tableName);
+    $reuseRootLft = $reuseRootRow['lft'] ?? 0;
+    $reuseRootRgt = $reuseRootRow['rgt'] ?? 0;
+    $licenseMapReusePfiles = !empty($reuseRootRow) ?
+      $this->batchGetLicensesForUpload($reuseUploadId, $reuseRootLft, $reuseRootRgt, $reuseTableName) : [];
+
+    $uploadPathUri = Traceback_uri();
+    $licenseMapUpload = [];
+    $licenseMapReuse = [];
+
+    foreach ($master as $idx => $pair) {
+      $child1 = !empty($pair[1]) ? $pair[1] : null;
+      $child2 = !empty($pair[2]) ? $pair[2] : null;
+
+      $row = $this->buildDiffRow($child1, $child2, $uploadId, $reuseUploadId,
+        $tableName, $reuseTableName, $uploadPathUri);
+
+      $stats[$row['classification']]++;
+      $diffTree[] = $row;
+
+      /* Collect licenses for comparison (from pre-fetched batch) */
+      if ($child1 && !empty($child1['pfile_fk'])) {
+        $lics1 = $licenseMapUploadPfiles[(int)$child1['pfile_fk']] ?? [];
+        foreach ($lics1 as $lic) {
+          $licenseMapUpload[$lic] = isset($licenseMapUpload[$lic]) ?
+            $licenseMapUpload[$lic] + 1 : 1;
+        }
+      }
+      if ($child2 && !empty($child2['pfile_fk'])) {
+        $lics2 = $licenseMapReusePfiles[(int)$child2['pfile_fk']] ?? [];
+        foreach ($lics2 as $lic) {
+          $licenseMapReuse[$lic] = isset($licenseMapReuse[$lic]) ?
+            $licenseMapReuse[$lic] + 1 : 1;
+        }
+      }
+    }
+
+    /* Build license comparison stats */
+    $allLicenses = array_unique(array_merge(
+      array_keys($licenseMapUpload), array_keys($licenseMapReuse)));
+    sort($allLicenses);
+
+    $licenseSummary = ['new' => 0, 'deleted' => 0, 'modified' => 0, 'unchanged' => 0];
+    $licenseCategories = ['new' => [], 'deleted' => [], 'modified' => [], 'unchanged' => []];
+
+    foreach ($allLicenses as $lic) {
+      $upCount = $licenseMapUpload[$lic] ?? 0;
+      $reCount = $licenseMapReuse[$lic] ?? 0;
+      if ($upCount > 0 && $reCount == 0) {
+        $licenseSummary['new']++;
+        $licenseCategories['new'][] = $lic;
+      } elseif ($upCount == 0 && $reCount > 0) {
+        $licenseSummary['deleted']++;
+        $licenseCategories['deleted'][] = $lic;
+      } elseif ($upCount != $reCount) {
+        $licenseSummary['modified']++;
+        $licenseCategories['modified'][] = $lic;
+      } else {
+        $licenseSummary['unchanged']++;
+        $licenseCategories['unchanged'][] = $lic;
+      }
+    }
+    $licenseFilter = $request->get('license_filter', '');
+    if (!in_array($licenseFilter, ['new', 'deleted', 'modified', 'unchanged', ''])) {
+      $licenseFilter = '';
+    }
+
+    /* Apply search and status filter server-side before pagination */
+    $searchQuery = $request->get('search', '');
+    $statusFilterQuery = $request->get('statusFilter', '');
+    $queryParams = $request->query->all();
+    $queryParams['search'] = $searchQuery;
+    $queryParams['statusFilter'] = $statusFilterQuery;
+    unset($queryParams['page']);
+
+    $filteredDiffTree = [];
+    foreach ($diffTree as $row) {
+      if (!empty($statusFilterQuery) && $row['classification'] !== $statusFilterQuery) {
+        continue;
+      }
+      if (!empty($searchQuery)) {
+        $match = false;
+        if (stripos($row['upload_file_name'], $searchQuery) !== false ||
+            stripos($row['reuse_file_name'], $searchQuery) !== false) {
+          $match = true;
+        }
+        if (!$match) {
+          continue;
+        }
+      }
+      $filteredDiffTree[] = $row;
+    }
+    $diffTree = $filteredDiffTree;
+
+    /* Paginate the diff tree */
+    $page = (int)$request->get('page', 0);
+    if ($page < 0) {
+      $page = 0;
+    }
+    $perPage = 25;
+    $totalDiffRows = count($diffTree);
+    $totalPages = $totalDiffRows > 0 ? (int)ceil($totalDiffRows / $perPage) - 1 : 0;
+    if ($page > $totalPages) {
+      $page = 0;
+    }
+    $offset = $page * $perPage;
+    $pagedDiffTree = array_slice($diffTree, $offset, $perPage);
+    $pageUri = '?' . http_build_query($queryParams);
+
+    $vars = [
+      'uploadId'         => $uploadId,
+      'itemId'           => $item,
+      'reuseUploadId'    => $reuseUploadId,
+      'reuseSources'     => $reuseSources,
+      'stats'            => $stats,
+      'diffTree'         => $pagedDiffTree,
+      'pageUri'          => $pageUri,
+      'currentPage'      => $page + 1,
+      'totalPagesView'   => $totalPages + 1,
+      'perPage'          => $perPage,
+      'totalDiffRows'    => $totalDiffRows,
+      'licenseSummary'   => $licenseSummary,
+      'licenseCategories'=> $licenseCategories,
+      'licenseFilter'    => $licenseFilter,
+      'totalUpload'      => count($children1),
+      'totalReuse'       => count($children2),
+      'searchQuery'      => $searchQuery,
+      'statusFilterQuery'=> $statusFilterQuery,
+    ];
+
+    $defaultVars = $this->mergeWithDefault([]);
+    $defaultVars['styles'] .= "<link rel='stylesheet' href='css/highlights.css'>\n";
+    $vars = array_merge($defaultVars, $vars);
+
+    return $this->render('reusecompare.html.twig', $vars);
+  }
+
+  /**
+   * Build a diff tree row for a matched/unmatched file pair.
+   */
+  private function buildDiffRow($child1, $child2, $uploadId, $reuseUploadId,
+                                $tableName, $reuseTableName, $uri)
+  {
+    $row = [
+      'upload_file_name' => '',
+      'reuse_file_name'  => '',
+      'classification'   => '',
+      'upload_pfile_fk'  => 0,
+      'reused_pfile_fk'  => 0,
+      'upload_href'      => '',
+      'reuse_href'       => '',
+    ];
+
+    if ($child1 && $child2) {
+      $row['upload_file_name'] = $child1['ufile_name'];
+      $row['reuse_file_name'] = $child2['ufile_name'];
+      $row['upload_pfile_fk'] = intval($child1['pfile_fk']);
+      $row['reused_pfile_fk'] = intval($child2['pfile_fk']);
+
+      $upPk = $child1['uploadtree_pk'];
+      $rePk = $child2['uploadtree_pk'];
+      $row['upload_href'] = $uri . "?mod=view-license&upload=$uploadId&item=$upPk";
+      $row['reuse_href'] = $uri . "?mod=view-license&upload=$reuseUploadId&item=$rePk";
+
+      if ($child1['pfile_fk'] == $child2['pfile_fk']) {
+        $row['classification'] = 'IDENTICAL';
+      } else {
+        $row['classification'] = 'MODIFIED';
+      }
+    } elseif ($child1) {
+      $row['upload_file_name'] = $child1['ufile_name'];
+      $row['upload_pfile_fk'] = intval($child1['pfile_fk']);
+      $row['classification'] = 'NEW';
+      $upPk = $child1['uploadtree_pk'];
+      $row['upload_href'] = $uri . "?mod=view-license&upload=$uploadId&item=$upPk";
+    } elseif ($child2) {
+      $row['reuse_file_name'] = $child2['ufile_name'];
+      $row['reused_pfile_fk'] = intval($child2['pfile_fk']);
+      $row['classification'] = 'REMOVED';
+      $rePk = $child2['uploadtree_pk'];
+      $row['reuse_href'] = $uri . "?mod=view-license&upload=$reuseUploadId&item=$rePk";
+    }
+
+    return $row;
+  }
+
+  /**
+   * Get licenses for all files within an upload tree boundary via subquery.
+   */
+  private function batchGetLicensesForUpload($uploadFk, $lft, $rgt, $tableName)
+  {
+    $sql = "SELECT ut.pfile_fk, lr.rf_shortname
+            FROM $tableName ut
+            JOIN license_file lf ON lf.pfile_fk = ut.pfile_fk
+            JOIN license_ref lr ON lf.rf_fk = lr.rf_pk
+            WHERE ut.upload_fk = $1
+              AND ut.lft BETWEEN $2 AND $3
+              AND ut.ufile_mode & (3<<28) = 0
+              AND ut.pfile_fk IS NOT NULL
+              AND lr.rf_shortname IS NOT NULL
+              AND lr.rf_shortname NOT IN ('Void')
+            ORDER BY lr.rf_shortname";
+    $stmtName = __METHOD__ . '_' . $tableName;
+    $this->dbManager->prepare($stmtName, $sql);
+    $res = $this->dbManager->execute($stmtName, [$uploadFk, $lft, $rgt]);
+    $map = [];
+    while ($row = $this->dbManager->fetchArray($res)) {
+      $pid = (int)$row['pfile_fk'];
+      if (!isset($map[$pid])) {
+        $map[$pid] = [];
+      }
+      $map[$pid][] = $row['rf_shortname'];
+    }
+    $this->dbManager->freeResult($res);
+    return $map;
+  }
+
+  /**
+   * Recursively get all non-artifact descendant files under an upload tree node
+   * using the lft/rgt nested-set range. Returns rows in the same format as
+   * GetNonArtifactChildren (uploadtree + pfile columns).
+   *
+   * @param array $itemRow  Row from uploadtree table (must have lft, rgt, uploadtree_pk, upload_fk)
+   * @param string $tableName
+   * @return array
+   */
+  private function getAllNonArtifactDescendants($itemRow, $tableName)
+  {
+    $lft = (int)$itemRow['lft'];
+    $rgt = (int)$itemRow['rgt'];
+    $pk = (int)$itemRow['uploadtree_pk'];
+    $uploadFk = (int)$itemRow['upload_fk'];
+
+    $sql = "SELECT ut.*, pfile_size, pfile_mimetypefk
+            FROM $tableName ut
+            LEFT JOIN pfile ON (pfile_pk = ut.pfile_fk)
+            WHERE ut.upload_fk = $1
+              AND ut.lft BETWEEN $2 AND $3
+              AND ut.uploadtree_pk != $4
+              AND ut.ufile_mode & (3<<28) = 0
+            ORDER BY ut.lft";
+    $this->dbManager->prepare($stmt = __METHOD__ . ".$tableName", $sql);
+    $res = $this->dbManager->execute($stmt, [$uploadFk, $lft, $rgt, $pk]);
+    $children = [];
+    while ($row = $this->dbManager->fetchArray($res)) {
+      $children[] = $row;
+    }
+    $this->dbManager->freeResult($res);
+    return $children;
+  }
+}
+
+register_plugin(new ReuseComparePlugin());

--- a/src/reuser/ui/ReuseFileDiffViewPlugin.php
+++ b/src/reuser/ui/ReuseFileDiffViewPlugin.php
@@ -1,0 +1,417 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @dir
+ * @brief UI element of reuser agent
+ * @file
+ */
+
+namespace Fossology\Reuser;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\Plugin\DefaultPlugin;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * @class ReuseFileDiffViewPlugin
+ * @brief Display a two-column file diff view for reuse comparison,
+ *        matching the EnhancedReuser diff view structure.
+ */
+class ReuseFileDiffViewPlugin extends DefaultPlugin
+{
+  const NAME = "reusediffview";
+
+  /** @var DbManager */
+  private $dbManager;
+
+  /** @var UploadDao */
+  private $uploadDao;
+
+  function __construct()
+  {
+    parent::__construct(self::NAME, [
+      self::TITLE => _("File Diff View"),
+      self::PERMISSION => Auth::PERM_READ,
+      self::DEPENDENCIES => ["browse"],
+    ]);
+    $this->dbManager = $this->getObject('db.manager');
+    $this->uploadDao = $this->getObject('dao.upload');
+  }
+
+  /**
+   * @param Request $request
+   * @return Response
+   */
+  protected function handle(Request $request)
+  {
+    $uploadId = intval($request->get('upload'));
+    $item = intval($request->get('item'));
+    $currentPfile = intval($request->get('currentPfile'));
+    $reusedPfile = intval($request->get('reusedPfile'));
+    $reuseId = intval($request->get('reuse', 0));
+
+    if ($uploadId <= 0) {
+      return new Response(
+        '<div class="alert alert-danger">' . _("Invalid parameters for diff view") . '</div>',
+        Response::HTTP_BAD_REQUEST
+      );
+    }
+
+    if ($currentPfile <= 0 || $reusedPfile <= 0) {
+      $reuseParam = $reuseId > 0 ? '&reuse=' . $reuseId : '';
+      return new RedirectResponse(
+        Traceback_uri() . "?mod=reusecompare&upload=$uploadId&item=$item$reuseParam"
+      );
+    }
+
+    $groupId = Auth::getGroupId();
+    if (!$this->uploadDao->isAccessible($uploadId, $groupId)) {
+      return new Response(
+        '<div class="alert alert-danger">' . _("Permission Denied") . '</div>',
+        Response::HTTP_FORBIDDEN
+      );
+    }
+
+    /* Get pfile data */
+    $currentFile = $this->getPfileData($currentPfile);
+    $reusedFile = $this->getPfileData($reusedPfile);
+
+    if (!$currentFile || !$reusedFile) {
+      return new Response(
+        '<div class="alert alert-danger">' . _("File not found") . '</div>',
+        Response::HTTP_NOT_FOUND
+      );
+    }
+
+    /* Generate diff */
+    $diffData = $this->generateDiff($currentPfile, $reusedPfile);
+
+    /* Get scanner findings and clearing-decision license sets */
+    $curScanner = $this->getScannerFindings($currentPfile);
+    $reScanner = $this->getScannerFindings($reusedPfile);
+    list($curAdded, $curRemoved) = $this->getClearingDecisionSets($currentPfile, $uploadId);
+    list($reAdded, $reRemoved) = $this->getClearingDecisionSets($reusedPfile, $reuseId);
+
+    $curScannerF = array_flip($curScanner);
+    $reScannerF = array_flip($reScanner);
+    $curAddedF = array_flip($curAdded);
+    $reAddedF = array_flip($reAdded);
+    $curRemovedF = array_flip($curRemoved);
+    $reRemovedF = array_flip($reRemoved);
+
+    /* Collect all unique license names from every source */
+    $allNames = array_unique(array_merge(
+      $curScanner, $reScanner, $curAdded, $reAdded, $curRemoved, $reRemoved
+    ));
+    sort($allNames);
+
+    /* Determine source for each license:
+       Priority: removed > both scanners > from-reuse > added-on-target */
+    $allLicenses = [];
+    foreach ($allNames as $name) {
+      $inCurScanner  = isset($curScannerF[$name]);
+      $inReScanner   = isset($reScannerF[$name]);
+      $inCurAdded    = isset($curAddedF[$name]);
+      $inReAdded     = isset($reAddedF[$name]);
+      $inCurRemoved  = isset($curRemovedF[$name]);
+      $inReRemoved   = isset($reRemovedF[$name]);
+
+      $inReEffective = $inReScanner || $inReAdded;
+
+      if ($inReRemoved) {
+        $status = 'removed-in-reuse';
+      } elseif ($inCurRemoved) {
+        $status = 'removed-in-current';
+      } elseif ($inCurScanner && $inReScanner) {
+        $status = 'both';
+      } elseif ($inReEffective && !$inCurScanner) {
+        $status = 'added-in-reuse';
+      } elseif ($inCurAdded && !$inReEffective) {
+        $status = 'added-in-current';
+      } else {
+        continue;
+      }
+      $allLicenses[$name] = ['status' => $status];
+    }
+    ksort($allLicenses);
+
+    $tableName = $this->uploadDao->getUploadtreeTableName($uploadId);
+
+    /* Look up the actual file's uploadtree_pk for the breadcrumb path */
+    $fileItem = $this->uploadDao->getUploadtreeIdFromPfile($uploadId, $currentPfile);
+    if (empty($fileItem)) {
+      $fileItem = $item;
+    }
+
+    $micromenu = Dir2Browse("license", $fileItem, null, 0, "View",
+      -1, '', '', $tableName);
+
+    $vars = [
+      "uploadId" => $uploadId,
+      "item" => $item,
+      "reuse" => $reuseId,
+      "currentFile" => $currentFile,
+      "reusedFile" => $reusedFile,
+      "diffData" => $diffData,
+      "allLicenses" => $allLicenses,
+      "pageMenu" => $micromenu,
+      "micromenu" => $micromenu,
+    ];
+
+    $defaultVars = $this->mergeWithDefault([]);
+    $defaultVars['styles'] .= "<link rel='stylesheet' href='css/highlights.css'>\n";
+    $vars = array_merge($defaultVars, $vars);
+
+    return $this->render("reusediffview.html.twig", $vars);
+  }
+
+  /**
+   * Generate diff between two pfiles using system `diff -u`.
+   * Handles arbitrarily large files by delegating to C.
+   * @return array diff lines
+   */
+  private function generateDiff($pfileA, $pfileB)
+  {
+    $pathReused = RepPath($pfileB);
+    $pathCurrent = RepPath($pfileA);
+
+    if (!$pathReused || !file_exists($pathReused) ||
+        !$pathCurrent || !file_exists($pathCurrent)) {
+      return [['type' => 'unchanged', 'line_number' => 1,
+        'content' => _('Unable to load files for diff.')]];
+    }
+
+    $tmpReused = tempnam(sys_get_temp_dir(), 'fosdiff_');
+    $tmpCurrent = tempnam(sys_get_temp_dir(), 'fosdiff_');
+    if ($tmpReused === false || $tmpCurrent === false) {
+      return [['type' => 'unchanged', 'line_number' => 1,
+        'content' => _('Unable to create temp files for diff.')]];
+    }
+    if (!copy($pathReused, $tmpReused) || !copy($pathCurrent, $tmpCurrent)) {
+      @unlink($tmpReused);
+      @unlink($tmpCurrent);
+      return [['type' => 'unchanged', 'line_number' => 1,
+        'content' => _('Unable to copy files for diff.')]];
+    }
+
+    $diffOutput = null;
+    $exitCode = -1;
+    $cmd = "diff -u " . escapeshellarg($tmpReused) . " " . escapeshellarg($tmpCurrent);
+    exec($cmd, $diffOutput, $exitCode);
+
+    $contentCurrent = file_get_contents($pathCurrent);
+    $linesCurrent = explode("\n", $contentCurrent);
+
+    unlink($tmpReused);
+    unlink($tmpCurrent);
+
+    if ($exitCode === 0) {
+      $diff = [];
+      foreach ($linesCurrent as $i => $line) {
+        $diff[] = ['type' => 'unchanged', 'line_number' => $i + 1, 'content' => $line];
+      }
+      return $diff;
+    }
+
+    if ($exitCode === 2 || empty($diffOutput)) {
+      return [['type' => 'unchanged', 'line_number' => 1,
+        'content' => _('Unable to compute diff for this file.')]];
+    }
+
+    return $this->parseUnifiedDiff($diffOutput, $linesCurrent);
+  }
+
+  /**
+   * Parse `diff -u` output into a complete per-line diff,
+   * filling in all unchanged lines from the current file content.
+   */
+  private function parseUnifiedDiff(array $diffLines, array $linesCurrent)
+  {
+    /* Parse hunk headers to get line number offsets */
+    $hunks = [];
+    foreach ($diffLines as $raw) {
+      if (preg_match('/^@@ -(\d+),?\d* \+(\d+),?\d* @@/', $raw, $m)) {
+        $hunks[] = ['old_start' => (int)$m[1], 'new_start' => (int)$m[2]];
+      }
+    }
+
+    if (empty($hunks)) {
+      return [];
+    }
+
+    /* Build the per-hunk change data */
+    $hunkData = [];
+    $hunkIdx = -1;
+    $inHunk = false;
+
+    foreach ($diffLines as $raw) {
+      if (preg_match('/^@@ -(\d+),?\d* \+(\d+),?\d* @@/', $raw)) {
+        $hunkIdx++;
+        $hunkData[$hunkIdx] = ['changes' => []];
+        $inHunk = true;
+        continue;
+      }
+      if (!$inHunk || strlen($raw) === 0) {
+        continue;
+      }
+      $prefix = $raw[0];
+      if ($prefix === ' ' || $prefix === '-' || $prefix === '+') {
+        $hunkData[$hunkIdx]['changes'][] = $raw;
+      }
+    }
+
+    /* Build the complete diff by walking line-by-line through the current file */
+    $diff = [];
+    $currentLineIdx = 1;
+
+    foreach ($hunkData as $hIdx => $hunk) {
+      $newStart = $hunks[$hIdx]['new_start'];
+
+      /* Fill in unchanged lines before this hunk */
+      while ($currentLineIdx < $newStart) {
+        $diff[] = ['type' => 'unchanged', 'line_number' => $currentLineIdx,
+          'content' => $linesCurrent[$currentLineIdx - 1]];
+        $currentLineIdx++;
+      }
+
+      /* Process the hunk changes */
+      foreach ($hunk['changes'] as $raw) {
+        $prefix = $raw[0];
+        $content = substr($raw, 1);
+        if ($prefix === ' ') {
+          $diff[] = ['type' => 'unchanged', 'line_number' => $currentLineIdx,
+            'content' => $content];
+          $currentLineIdx++;
+        } elseif ($prefix === '-') {
+          $diff[] = ['type' => 'deleted', 'line_number' => $currentLineIdx,
+            'content' => $content];
+        } else {
+          $diff[] = ['type' => 'added', 'line_number' => $currentLineIdx,
+            'content' => $content];
+          $currentLineIdx++;
+        }
+      }
+    }
+
+    /* Fill in remaining unchanged lines after last hunk */
+    while ($currentLineIdx <= count($linesCurrent)) {
+      $diff[] = ['type' => 'unchanged', 'line_number' => $currentLineIdx,
+        'content' => $linesCurrent[$currentLineIdx - 1]];
+      $currentLineIdx++;
+    }
+
+    return $diff;
+  }
+
+  /**
+   * Get pfile data from DB.
+   */
+  private function getPfileData($pfileId)
+  {
+    $sql = "SELECT pfile_pk, pfile_size, pfile_sha1, pfile_md5, pfile_sha256, pfile_mimetypefk
+            FROM pfile WHERE pfile_pk = $1";
+    $this->dbManager->prepare($stmt = __METHOD__ . '_pfile', $sql);
+    $row = $this->dbManager->getSingleRow($sql, [$pfileId], $stmt);
+    return $row ?: null;
+  }
+
+  /**
+   * Get scanner-agent license findings for a pfile.
+   *
+   * @param int $pfileId
+   * @return string[] License shortnames found by scanners
+   */
+  private function getScannerFindings($pfileId)
+  {
+    if (empty($pfileId)) {
+      return [];
+    }
+
+    $sql = "SELECT DISTINCT lr.rf_shortname
+            FROM license_file lf
+            JOIN license_ref lr ON lr.rf_pk = lf.rf_fk
+            WHERE lf.pfile_fk = $1
+              AND lr.rf_shortname IS NOT NULL
+              AND lr.rf_shortname != 'Void'";
+    $this->dbManager->prepare($stmt = __METHOD__ . '_scan', $sql);
+    $res = $this->dbManager->execute($stmt, [$pfileId]);
+    $findings = [];
+    while ($row = $this->dbManager->fetchArray($res)) {
+      $findings[$row['rf_shortname']] = true;
+    }
+    $this->dbManager->freeResult($res);
+    return array_keys($findings);
+  }
+
+  /**
+   * Get clearing-decision license sets for a pfile in a specific upload.
+   * Returns two arrays: user-added (type_fk=1 USER, removed=false/null)
+   * and user-removed (removed=true) from clearing events.
+   *
+   * @param int $pfileId
+   * @param int $uploadId
+   * @return array [added[], removed[]]
+   */
+  private function getClearingDecisionSets($pfileId, $uploadId)
+  {
+    $added = [];
+    $removed = [];
+
+    if (empty($pfileId) || empty($uploadId)) {
+      return [$added, $removed];
+    }
+
+    $uploadtreePk = $this->uploadDao->getUploadtreeIdFromPfile($uploadId, $pfileId);
+    if (empty($uploadtreePk)) {
+      return [$added, $removed];
+    }
+
+    /* User-added licenses (type_fk=1 USER, removed=false or null) */
+    $sql = "SELECT DISTINCT lr.rf_shortname
+            FROM clearing_decision cd
+            JOIN clearing_decision_event cde ON cde.clearing_decision_fk = cd.clearing_decision_pk
+            JOIN clearing_event ce ON ce.clearing_event_pk = cde.clearing_event_fk
+            JOIN license_ref lr ON lr.rf_pk = ce.rf_fk
+            WHERE cd.uploadtree_fk = $1
+              AND (ce.removed IS NULL OR ce.removed = false)
+              AND ce.type_fk = 1
+              AND lr.rf_shortname IS NOT NULL
+              AND lr.rf_shortname != 'Void'";
+    $this->dbManager->prepare($stmt = __METHOD__ . '_add', $sql);
+    $res = $this->dbManager->execute($stmt, [$uploadtreePk]);
+    while ($row = $this->dbManager->fetchArray($res)) {
+      $added[$row['rf_shortname']] = true;
+    }
+    $this->dbManager->freeResult($res);
+
+    /* User-removed licenses (removed = true) */
+    $sql = "SELECT DISTINCT lr.rf_shortname
+            FROM clearing_decision cd
+            JOIN clearing_decision_event cde ON cde.clearing_decision_fk = cd.clearing_decision_pk
+            JOIN clearing_event ce ON ce.clearing_event_pk = cde.clearing_event_fk
+            JOIN license_ref lr ON lr.rf_pk = ce.rf_fk
+            WHERE cd.uploadtree_fk = $1
+              AND ce.removed = true
+              AND lr.rf_shortname IS NOT NULL
+              AND lr.rf_shortname != 'Void'";
+    $this->dbManager->prepare($stmt = __METHOD__ . '_rem', $sql);
+    $res = $this->dbManager->execute($stmt, [$uploadtreePk]);
+    while ($row = $this->dbManager->fetchArray($res)) {
+      $removed[$row['rf_shortname']] = true;
+    }
+    $this->dbManager->freeResult($res);
+
+    return [array_keys($added), array_keys($removed)];
+  }
+}
+
+register_plugin(new ReuseFileDiffViewPlugin());

--- a/src/reuser/ui/template/reusecompare.html.twig
+++ b/src/reuser/ui/template/reusecompare.html.twig
@@ -1,0 +1,340 @@
+{# SPDX-FileCopyrightText: © 2026 Siemens AG
+
+   SPDX-License-Identifier: GPL-2.0-only
+#}
+{% extends "include/base.html.twig" %}
+
+{% block content %}
+  <div class="container-fluid mt-3">
+    <!-- Reuse info header -->
+    <div class="row mb-3">
+      <div class="col-12">
+        <div style="padding:10px;background:#f8f9fa;border:1px solid #dee2e6;border-radius:4px">
+          <strong>{{ 'Reuse source'|trans }}:</strong>
+          <select id="reuse-source-select" class="form-select form-select-sm" style="margin-left:8px">
+            {% for src in reuseSources %}
+              <option value="{{ src.id }}"
+                {% if src.id == reuseUploadId %}selected{% endif %}>
+                {{ src.name }} (ID: {{ src.id }})
+              </option>
+            {% endfor %}
+          </select>
+          &nbsp;|&nbsp; <a href="javascript:history.back()" class="small">&larr; {{ 'Back'|trans }}</a>
+        </div>
+        <script type="text/javascript">
+          document.getElementById('reuse-source-select').addEventListener('change', function() {
+            var url = new URL(window.location.href);
+            url.searchParams.set('reuse', this.value);
+            url.searchParams.delete('page');
+            window.location.href = url.toString();
+          });
+        </script>
+      </div>
+    </div>
+
+    <!-- Main content: diff tree table + stats sidebar -->
+    <div class="row">
+      <!-- Diff tree table -->
+      <div class="col-md-9">
+        <div class="d-flex flex-wrap align-items-center mb-2 p-2 bg-light border rounded">
+          <span class="mr-2 font-weight-bold">{{ 'Search'|trans }}:</span>
+          <input type="text" id="fileSearch" class="form-control form-control-sm d-inline-block w-auto mr-3"
+                 placeholder="{{ 'File name'|trans }}..."
+                 value="{{ searchQuery }}" onkeyup="filterDiffTable()">
+          <span class="mr-2 font-weight-bold">{{ 'Status'|trans }}:</span>
+          <select id="statusFilter" class="form-control form-control-sm d-inline-block w-auto"
+                  onchange="applyStatusFilter()">
+            <option value="">{{ 'All'|trans }}</option>
+            <option value="IDENTICAL"{% if statusFilterQuery == 'IDENTICAL' %} selected{% endif %}>{{ 'Identical'|trans }}</option>
+            <option value="MODIFIED"{% if statusFilterQuery == 'MODIFIED' %} selected{% endif %}>{{ 'Modified'|trans }}</option>
+            <option value="NEW"{% if statusFilterQuery == 'NEW' %} selected{% endif %}>{{ 'New'|trans }}</option>
+            <option value="REMOVED"{% if statusFilterQuery == 'REMOVED' %} selected{% endif %}>{{ 'Removed'|trans }}</option>
+          </select>
+        </div>
+        <table class="simpleTable w-100" id="diffTreeTable" cellpadding="3">
+          <thead>
+            <tr>
+              <th>{{ 'Upload'|trans }}</th>
+              <th>{{ 'Reuse'|trans }}</th>
+              <th>{{ 'Status'|trans }}</th>
+              <th>{{ 'Diff'|trans }}</th>
+            </tr>
+          </thead>
+          <tbody>
+          {% for row in diffTree %}
+            <tr class="{{ cycle(['odd', 'even'], loop.index0) }}" data-status="{{ row.classification }}">
+              <td class="td-upload">
+                {% if row.upload_file_name %}
+                  {% if row.upload_href %}
+                    <a href="{{ row.upload_href }}">{{ row.upload_file_name }}</a>
+                  {% else %}
+                    {{ row.upload_file_name }}
+                  {% endif %}
+                {% else %}
+                  -
+                {% endif %}
+              </td>
+              <td class="td-reuse">
+                {% if row.reuse_file_name %}
+                  {% if row.reuse_href %}
+                    <a href="{{ row.reuse_href }}">{{ row.reuse_file_name }}</a>
+                  {% else %}
+                    {{ row.reuse_file_name }}
+                  {% endif %}
+                {% else %}
+                  -
+                {% endif %}
+              </td>
+              <td>
+                {% set s = row.classification %}
+                {% if s == 'IDENTICAL' %}
+                  <span class="text-success" style="background:#d4edda;padding:0 6px;font-weight:600;">{{ 'Identical'|trans }}</span>
+                {% elseif s == 'MODIFIED' %}
+                  <span class="text-warning" style="background:#fff3cd;padding:0 6px;font-weight:600;">{{ 'Modified'|trans }}</span>
+                {% elseif s == 'NEW' %}
+                  <span class="text-info" style="background:#d1ecf1;padding:0 6px;font-weight:600;">{{ 'New'|trans }}</span>
+                {% elseif s == 'REMOVED' %}
+                  <span class="text-danger" style="background:#f8d7da;padding:0 6px;font-weight:600;">{{ 'Removed'|trans }}</span>
+                {% endif %}
+              </td>
+              <td>
+                {% if row.classification == 'MODIFIED' and row.upload_pfile_fk > 0 and row.reused_pfile_fk > 0 %}
+                  <a href="?mod=reusediffview&upload={{ uploadId }}&item={{ itemId }}&currentPfile={{ row.upload_pfile_fk }}&reusedPfile={{ row.reused_pfile_fk }}&reuse={{ reuseUploadId }}">
+                    {{ 'View Diff'|trans }}
+                  </a>
+                {% else %}
+                  -
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+        <div id="paginationContainer" class="d-flex align-items-center justify-content-between mt-2">
+          <div>
+            <small class="text-muted">
+              {{ 'Showing'|trans }}
+              {% if totalDiffRows > 0 %}
+                {{ (currentPage - 1) * perPage + 1 }}-{{ min(currentPage * perPage, totalDiffRows) }}
+              {% else %}
+                0-0
+              {% endif %}
+              {{ 'of'|trans }}
+              {{ totalDiffRows }}
+              {{ 'files'|trans }}
+            </small>
+          </div>
+          <div class="d-flex align-items-center">
+            {% if totalPagesView > 1 %}
+              <nav>
+                <ul class="pagination pagination-sm mb-0">
+                  <li class="page-item {{ currentPage <= 1 ? 'disabled' : '' }}">
+                    <a class="page-link" href="{{ currentPage > 1 ? pageUri ~ '&page=' ~ (currentPage - 2) : '#' }}">&laquo; {{ 'Prev'|trans }}</a>
+                  </li>
+                  <li class="page-item">
+                    <span class="page-link">
+                      <select id="pageSelect" class="form-control form-control-sm d-inline-block" style="width:auto;padding:0 4px;height:auto;font-size:12px;" onchange="goToPage(this.value)">
+                        {% for i in 1..totalPagesView %}
+                          <option value="{{ i - 1 }}" {{ i == currentPage ? 'selected' : '' }}>{{ i }}</option>
+                        {% endfor %}
+                      </select>
+                      <span class="ml-1">{{ 'of'|trans }} {{ totalPagesView }}</span>
+                    </span>
+                  </li>
+                  <li class="page-item {{ currentPage >= totalPagesView ? 'disabled' : '' }}">
+                    <a class="page-link" href="{{ currentPage < totalPagesView ? pageUri ~ '&page=' ~ currentPage : '#' }}">{{ 'Next'|trans }} &raquo;</a>
+                  </li>
+                </ul>
+              </nav>
+            {% endif %}
+          </div>
+        </div>
+        <script type="text/javascript">
+          function goToPage(page) {
+            var url = new URL(window.location.href);
+            url.searchParams.set('page', page);
+            window.location.href = url.toString();
+          }
+          function updatePaginationLinks(search) {
+            var prevLink = document.querySelector('#paginationContainer .pagination li:first-child a');
+            var nextLink = document.querySelector('#paginationContainer .pagination li:last-child a');
+            var base = window.location.pathname + '?' + new URLSearchParams(window.location.search).toString();
+            base = base.replace(/[?&]page=[^&]*/g, '').replace(/[?&]search=[^&]*/g, '').replace(/[?&]statusFilter=[^&]*/g, '');
+            var sep = base.indexOf('?') !== -1 ? '&' : '?';
+            if (prevLink && !prevLink.parentElement.classList.contains('disabled')) {
+              var prevPage = parseInt(document.getElementById('pageSelect').value) - 1;
+              prevLink.href = base + sep + 'page=' + prevPage + (search ? '&search=' + encodeURIComponent(search) : '');
+            }
+            if (nextLink && !nextLink.parentElement.classList.contains('disabled')) {
+              var nextPage = parseInt(document.getElementById('pageSelect').value) + 1;
+              nextLink.href = base + sep + 'page=' + nextPage + (search ? '&search=' + encodeURIComponent(search) : '');
+            }
+            var pageSelect = document.getElementById('pageSelect');
+            if (pageSelect && search) {
+              var currentBase = base;
+              for (var i = 0; i < pageSelect.options.length; i++) {
+                var opt = pageSelect.options[i];
+                var pageUri = currentBase + sep + 'page=' + opt.value + '&search=' + encodeURIComponent(search);
+                opt.setAttribute('data-href', pageUri);
+              }
+            }
+          }
+          function applyStatusFilter() {
+            var statusEl = document.getElementById('statusFilter');
+            var status = statusEl.value || '';
+            var url = new URL(window.location.href);
+            if (status) {
+              url.searchParams.set('statusFilter', status);
+            } else {
+              url.searchParams.delete('statusFilter');
+            }
+            url.searchParams.delete('page');
+            window.location.href = url.toString();
+          }
+          function filterDiffTable() {
+            var searchEl = document.getElementById('fileSearch');
+            var search = (searchEl.value || '').toLowerCase();
+            var rows = document.querySelectorAll('#diffTreeTable tbody tr');
+            var visibleCount = 0;
+            for (var i = 0; i < rows.length; i++) {
+              var row = rows[i];
+              var upload = (row.querySelector('.td-upload')?.textContent || '').toLowerCase();
+              var reuse = (row.querySelector('.td-reuse')?.textContent || '').toLowerCase();
+              var matchesSearch = !search || upload.indexOf(search) !== -1 || reuse.indexOf(search) !== -1;
+              if (matchesSearch) {
+                row.style.display = '';
+                visibleCount++;
+              } else {
+                row.style.display = 'none';
+              }
+            }
+            var pagination = document.getElementById('paginationContainer');
+            if (pagination) {
+              pagination.style.display = visibleCount === 0 ? 'none' : '';
+            }
+            updatePaginationLinks(searchEl.value);
+          }
+          (function() {
+            var searchEl = document.getElementById('fileSearch');
+            if (searchEl.value) {
+              filterDiffTable();
+            }
+          })();
+        </script>
+      </div>
+
+      <!-- Stats sidebar -->
+      <div class="col-md-3">
+        <div class="card mb-3">
+          <div class="card-header py-2 px-3">
+            <strong>{{ 'File Classification'|trans }}</strong>
+          </div>
+          <div class="card-body p-0">
+            <table class="simpleTable w-100" cellpadding="3">
+              <thead>
+                <tr>
+                  <th>{{ 'Type'|trans }}</th>
+                  <th class="text-center">{{ 'Count'|trans }}</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="odd">
+                  <td>{{ 'Total (upload)'|trans }}</td>
+                  <td class="text-center font-weight-bold">{{ totalUpload }}</td>
+                </tr>
+                <tr class="even">
+                  <td>{{ 'Total (reuse)'|trans }}</td>
+                  <td class="text-center font-weight-bold">{{ totalReuse }}</td>
+                </tr>
+                <tr class="odd">
+                  <td class="text-success">{{ 'Identical'|trans }}</td>
+                  <td class="text-center font-weight-bold">{{ stats.IDENTICAL|default(0) }}</td>
+                </tr>
+                <tr class="even">
+                  <td class="text-warning">{{ 'Modified'|trans }}</td>
+                  <td class="text-center font-weight-bold">{{ stats.MODIFIED|default(0) }}</td>
+                </tr>
+                <tr class="odd">
+                  <td class="text-info">{{ 'New'|trans }}</td>
+                  <td class="text-center font-weight-bold">{{ stats.NEW|default(0) }}</td>
+                </tr>
+                <tr class="even">
+                  <td class="text-danger">{{ 'Removed'|trans }}</td>
+                  <td class="text-center font-weight-bold">{{ stats.REMOVED|default(0) }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="card-header py-2 px-3">
+            <strong>{{ 'License Statistics'|trans }}</strong>
+          </div>
+          <div class="card-body p-0">
+            <table class="simpleTable w-100" cellpadding="3">
+              <thead class="thead-light">
+                <tr>
+                  <th>{{ 'Type'|trans }}</th>
+                  <th class="text-center">{{ 'Count'|trans }}</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="odd">
+                  <td class="text-success">{{ 'New'|trans }}</td>
+                  <td class="text-center font-weight-bold">
+                    {% if licenseSummary.new > 0 %}
+                      <a href="?mod=reusecompare&upload={{ uploadId }}&item={{ itemId }}&license_filter=new&reuse={{ reuseUploadId }}">{{ licenseSummary.new }}</a>
+                    {% else %}
+                      {{ licenseSummary.new }}
+                    {% endif %}
+                  </td>
+                </tr>
+                <tr class="even">
+                  <td class="text-danger">{{ 'Removed'|trans }}</td>
+                  <td class="text-center font-weight-bold">
+                    {% if licenseSummary.deleted > 0 %}
+                      <a href="?mod=reusecompare&upload={{ uploadId }}&item={{ itemId }}&license_filter=deleted&reuse={{ reuseUploadId }}">{{ licenseSummary.deleted }}</a>
+                    {% else %}
+                      {{ licenseSummary.deleted }}
+                    {% endif %}
+                  </td>
+                </tr>
+                <tr class="odd">
+                  <td class="text-warning">{{ 'Modified'|trans }}</td>
+                  <td class="text-center font-weight-bold">
+                    {% if licenseSummary.modified > 0 %}
+                      <a href="?mod=reusecompare&upload={{ uploadId }}&item={{ itemId }}&license_filter=modified&reuse={{ reuseUploadId }}">{{ licenseSummary.modified }}</a>
+                    {% else %}
+                      {{ licenseSummary.modified }}
+                    {% endif %}
+                  </td>
+                </tr>
+                <tr class="even">
+                  <td class="text-info">{{ 'Unchanged'|trans }}</td>
+                  <td class="text-center font-weight-bold">
+                    {% if licenseSummary.unchanged > 0 %}
+                      <a href="?mod=reusecompare&upload={{ uploadId }}&item={{ itemId }}&license_filter=unchanged&reuse={{ reuseUploadId }}">{{ licenseSummary.unchanged }}</a>
+                    {% else %}
+                      {{ licenseSummary.unchanged }}
+                    {% endif %}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            {% if licenseFilter and licenseCategories[licenseFilter] is defined and licenseCategories[licenseFilter]|length > 0 %}
+              <div class="px-3 py-2" style="border-top:1px solid #dee2e6;background:#fff;">
+                <strong>{{ licenseFilter|capitalize }} {{ 'licenses'|trans }}:</strong>
+                <ul class="list-unstyled mb-0 mt-1" style="font-size:13px;">
+                  {% for lic in licenseCategories[licenseFilter] %}
+                    <li><a href="?mod=license_list_files&item={{ itemId }}&lic={{ lic|url_encode }}&reuse={{ reuseUploadId }}">{{ lic }}</a></li>
+                  {% endfor %}
+                </ul>
+              </div>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/src/reuser/ui/template/reusediffview.html.twig
+++ b/src/reuser/ui/template/reusediffview.html.twig
@@ -1,0 +1,175 @@
+{# SPDX-FileCopyrightText: © 2026 Siemens AG
+
+   SPDX-License-Identifier: GPL-2.0-only
+#}
+{% extends "include/base.html.twig" %}
+
+{% block content %}
+<style>
+  .diff-lines-container { font-family:monospace;font-size:0;line-height:0;margin:0;padding:4px; }
+  .diff-line { margin:0;padding:0;line-height:1.2;font-size:12px;white-space:pre-wrap; }
+  .diff-line-added { background-color:#d4edda;color:#155724; }
+  .diff-line-deleted { background-color:#f8d7da;color:#721c24; }
+  .diff-line-unchanged { color:#6c757d; }
+  .legend-box { background-color:white;padding:2px;border:1px outset #222222;width:150px;position:absolute;right:17px;bottom:17px; }
+</style>
+  <div id="leftrightalignment" name="leftrightalignment">
+    <table border="0" style="padding:0px; height:100%; width:100%">
+      <tr>
+        <td style="padding:0px; position:relative; height: 100%; width:50%">
+          <div class="centered" style='padding:2px;'>
+            <a href="?mod=reusecompare&upload={{ uploadId }}&item={{ item|default('') }}{% if reuse > 0 %}&reuse={{ reuse }}{% endif %}" class="btn btn-default btn-sm">
+              &larr; {{ 'Back to Reuse Compare'|trans }}
+            </a>
+
+            <button class="legendHider btn btn-default btn-sm">
+              {{ 'Hide Legend'|trans }}
+            </button>
+            <button class="legendShower btn btn-default btn-sm">
+              {{ 'Show Legend'|trans }}
+            </button>
+          </div>
+
+          <div class="boxnew" id="fileTextView" style="overflow:scroll;">
+            <div class="diff-lines-container">
+{%- for line in diffData %}{% if line.type == 'added' %}<div class="diff-line diff-line-added">+ {{ line.content|e }}</div>{% elseif line.type == 'deleted' %}<div class="diff-line diff-line-deleted">- {{ line.content|e }}</div>{% else %}<div class="diff-line diff-line-unchanged">  {{ line.content|e }}</div>{% endif %}
+{%- endfor %}
+            </div>
+          </div>
+
+          <div id="legendBox" name="legendBox" class="legend-box">
+            <u><b>{{ 'Legend:'|trans }}</b></u><br/>
+            <span class="hi-added diff-line-added" style="display:inline-block;">+ {{ 'Added lines'|trans }}</span><br/>
+            <span class="hi-deleted diff-line-deleted" style="display:inline-block;">- {{ 'Deleted lines'|trans }}</span><br/>
+            <span class="diff-line-unchanged" style="display:inline-block;">  {{ 'Unchanged lines'|trans }}</span>
+          </div>
+        </td>
+        <td style="width:50%;vertical-align:top;padding:0;overflow:auto;background:#fff;">
+          {% block rhs %}
+            {% set totalLines = diffData|length %}
+            {% set addedLines = diffData|filter(line => line.type == 'added')|length %}
+            {% set deletedLines = diffData|filter(line => line.type == 'deleted')|length %}
+            {% set unchangedLines = diffData|filter(line => line.type == 'unchanged')|length %}
+
+            <div class="p-3">
+              <!-- Diff Statistics -->
+{% if diffData is not empty %}
+              <div class="card mb-3">
+                <div class="card-header py-2 px-3">
+                  <strong>{{ 'Diff Statistics'|trans }}</strong>
+                </div>
+                <div class="card-body p-0">
+                  <table class="simpleTable w-100" cellpadding="3">
+                    <thead>
+                      <tr>
+                        <th>{{ 'Metric'|trans }}</th>
+                        <th class="text-center">{{ 'Count'|trans }}</th>
+                        <th class="text-center">{{ 'Percent'|trans }}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr class="odd">
+                        <td>{{ 'Total'|trans }}</td>
+                        <td class="text-center">{{ totalLines }}</td>
+                        <td class="text-center">100%</td>
+                      </tr>
+                      <tr class="even">
+                        <td class="text-success">{{ 'Added'|trans }}</td>
+                        <td class="text-center">{{ addedLines }}</td>
+                        <td class="text-center">{{ totalLines > 0 ? ((addedLines / totalLines) * 100)|number_format(1) : 0 }}%</td>
+                      </tr>
+                      <tr class="odd">
+                        <td class="text-danger">{{ 'Deleted'|trans }}</td>
+                        <td class="text-center">{{ deletedLines }}</td>
+                        <td class="text-center">{{ totalLines > 0 ? ((deletedLines / totalLines) * 100)|number_format(1) : 0 }}%</td>
+                      </tr>
+                      <tr class="even">
+                        <td class="text-info">{{ 'Unchanged'|trans }}</td>
+                        <td class="text-center">{{ unchangedLines }}</td>
+                        <td class="text-center">{{ totalLines > 0 ? ((unchangedLines / totalLines) * 100)|number_format(1) : 0 }}%</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+{% endif %}
+
+              <!-- File Details -->
+              <div class="card mb-3">
+                <div class="card-header py-2 px-3">
+                  <strong>{{ 'File Details'|trans }}</strong>
+                </div>
+                <div class="card-body p-0">
+                  <table class="simpleTable w-100" cellpadding="3">
+                    <thead>
+                      <tr>
+                        <th>{{ 'Property'|trans }}</th>
+                        <th>{{ 'Current'|trans }}</th>
+                        <th>{{ 'Reused'|trans }}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr class="odd">
+                        <td>{{ 'Size'|trans }}</td>
+                        <td>{{ currentFile.pfile_size|e }} bytes</td>
+                        <td>{{ reusedFile.pfile_size|e }} bytes</td>
+                      </tr>
+                      <tr class="even">
+                        <td class="align-middle">{{ 'SHA1'|trans }}</td>
+                        <td style="font-family:monospace;"><code>{{ currentFile.pfile_sha1|e }}</code></td>
+                        <td style="font-family:monospace;"><code>{{ reusedFile.pfile_sha1|e }}</code></td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              <!-- License Comparison -->
+              <div class="card mb-3">
+                <div class="card-header py-2 px-3">
+                  <strong>{{ 'Licenses'|trans }}</strong>
+                </div>
+                <div class="card-body p-0">
+                  <table class="simpleTable w-100" cellpadding="3">
+                    <thead>
+                      <tr>
+                        <th>{{ 'License'|trans }}</th>
+                        <th>{{ 'Status'|trans }}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {% for licenseName, licenseData in allLicenses %}
+                        <tr class="{{ cycle(['odd', 'even'], loop.index0) }}">
+                          <td>{{ licenseName|e }}</td>
+                          <td>
+                            {% if licenseData.status == 'both' %}
+                              <span class="text-success font-weight-bold">{{ 'Common'|trans }}</span>
+                            {% elseif licenseData.status == 'removed-in-current' %}
+                              <span class="text-danger font-weight-bold">{{ 'Removed from Current'|trans }}</span>
+                            {% elseif licenseData.status == 'removed-in-reuse' %}
+                              <span class="text-warning font-weight-bold">{{ 'Removed from Reuse'|trans }}</span>
+                            {% elseif licenseData.status == 'added-in-current' %}
+                              <span class="text-info font-weight-bold">{{ 'Added to Current'|trans }}</span>
+                            {% elseif licenseData.status == 'added-in-reuse' %}
+                              <span class="text-success font-weight-bold">{{ 'Added to Reuse'|trans }}</span>
+                            {% endif %}
+                          </td>
+                        </tr>
+                      {% endfor %}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          {% endblock %}
+        </td>
+      </tr>
+    </table>
+  </div>
+{% endblock %}
+
+{% block foot %}
+  {{ parent() }}
+  <script src="scripts/legend.js" type="text/javascript"></script>
+  <script src="scripts/tools.js" type="text/javascript"></script>
+{% endblock %}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->
## Description
Adds a "Reuse Diff View" that lets users compare a file against the file it was reused from, showing a line-by-line diff alongside license and metadata changes.

Part of #3631 
### Changes
- Added `handle($request)` entry point for the reuse diff view, parsing `upload`, `item`, `currentPfile`, `reusedPfile`, and `reuse` request parameters.
- Added an access check via `Auth::getGroupId()` and `isAccessible()`, returning a 403 when the user lacks permission to the upload.
- Added `getPfileData()` lookups for both the current and reused pfiles (size, SHA1, mimetype).
- Implemented `generateDiff()`:
  - Resolves both file paths via `RepPath()` and validates they exist.
  - Copies both files to temp locations with `tempnam()` and `copy()`, with error handling at each step (missing path, failed tempnam, failed copy).
  - Runs `diff -u` on the two temp files and captures output/exit code.
  - Reads and explodes the current file's contents for line-level reconstruction.
  - Cleans up temp files and branches on exit code (no differences / differences found / diff execution error).
- Implemented `parseUnifiedDiff()` to convert raw unified diff output into a structured array of unchanged/added/deleted lines with line numbers, by parsing hunk headers and walking the current file's lines.
- Added logic to merge and sort (via `ksort()`) the current and reused license lists by `rf_shortname`, so licenses can be flagged as added, removed, or present in both.
- Added `getUploadtreeIdFromPfile()` and `Dir2Browse()` integration to build the breadcrumb trail for navigation.
- Added new template `reusediffview.html.twig` with a two-panel layout:
  - Left panel: line-by-line diff view with a legend (added/deleted/unchanged).
  - Right panel: diff statistics (counts and percentages), file details (size, SHA1, MIME type for both files), and a license comparison table.

### Screen recording


https://github.com/user-attachments/assets/5e94518b-9530-4b13-86d8-7180676a04c6
