### PR TITLE
fix: harden shell command, SQL, and password-hashing handling

### DIFF
--- a/src/lib/php/Util/DataTablesUtility.php
+++ b/src/lib/php/Util/DataTablesUtility.php
@@ -67,7 +67,7 @@ class DataTablesUtility
       $name = $columNamesInDatabase[$colNumber];
 
       $whichDir = 'sSortDir_' . $i;
-      $order = $inputArray[$whichDir];
+      $order = $this->sanitizeSortDirection($inputArray[$whichDir]);
       $orderArray[] = $name . " " . $order;
     }
 
@@ -83,9 +83,23 @@ class DataTablesUtility
       }
 
       $name = $columNamesInDatabase[$colNumber];
-      $orderArray[] = $name . " " . $order;
+      $orderArray[] = $name . " " . $this->sanitizeSortDirection($order);
     }
     return $orderArray;
+  }
+
+  /**
+   * @brief Validate sort direction for SQL ORDER BY.
+   *
+   * Only "asc" and "desc" are accepted. Any other value defaults
+   * to "ASC" to prevent SQL injection via user-controlled input.
+   *
+   * @param mixed $direction
+   * @return string "ASC" or "DESC"
+   */
+  private function sanitizeSortDirection($direction)
+  {
+    return (is_string($direction) && strcasecmp($direction, 'desc') === 0) ? 'DESC' : 'ASC';
   }
 
 

--- a/src/lib/php/common-auth.php
+++ b/src/lib/php/common-auth.php
@@ -162,7 +162,7 @@ function account_check(&$user, &$passwd, &$group = "")
       } else if (! empty($row['user_seed'])) {
         $passwd_hash = sha1($row['user_seed'] . $passwd);
         /* If verify with new hash fails check with the old hash */
-        if (strcmp($passwd_hash, $row['user_pass']) == 0) {
+        if (hash_equals($row['user_pass'], $passwd_hash)) {
           $newHash = password_hash($passwd, PASSWORD_DEFAULT, $options);
           /* Update old hash with new hash */
           update_password_hash($user, $newHash);

--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -852,18 +852,19 @@ function is_available($url, $timeout = 2, $tries = 2)
   $proxyStmts = "";
   if (array_key_exists('http_proxy', $SysConf['FOSSOLOGY']) &&
     $SysConf['FOSSOLOGY']['http_proxy']) {
-    $proxyStmts .= "export http_proxy={$SysConf['FOSSOLOGY']['http_proxy']};";
+    $proxyStmts .= "export http_proxy=" . escapeshellarg($SysConf['FOSSOLOGY']['http_proxy']) . ";";
   }
   if (array_key_exists('https_proxy', $SysConf['FOSSOLOGY']) &&
     $SysConf['FOSSOLOGY']['https_proxy']) {
-    $proxyStmts .= "export https_proxy={$SysConf['FOSSOLOGY']['https_proxy']};";
+    $proxyStmts .= "export https_proxy=" . escapeshellarg($SysConf['FOSSOLOGY']['https_proxy']) . ";";
   }
   if (array_key_exists('ftp_proxy', $SysConf['FOSSOLOGY']) &&
     $SysConf['FOSSOLOGY']['ftp_proxy']) {
-    $proxyStmts .= "export ftp_proxy={$SysConf['FOSSOLOGY']['ftp_proxy']};";
+    $proxyStmts .= "export ftp_proxy=" . escapeshellarg($SysConf['FOSSOLOGY']['ftp_proxy']) . ";";
   }
 
-  $commands = "$proxyStmts wget --spider '$url' --tries=$tries --timeout=$timeout";
+  $commands = $proxyStmts . "wget --spider " . escapeshellarg($url) .
+    " --tries=" . (int) $tries . " --timeout=" . (int) $timeout;
   system($commands, $return_var);
   if (0 == $return_var) {
     return 1;

--- a/src/monk/ui/oneshot.php
+++ b/src/monk/ui/oneshot.php
@@ -109,7 +109,7 @@ class OneShot extends DefaultPlugin
   public function scanMonk($fileName)
   {
     global $SYSCONFDIR;
-    $cmd = dirname(__DIR__).'/agent/monk -c '.$SYSCONFDIR.' '.$fileName;
+    $cmd = dirname(__DIR__).'/agent/monk -c '.escapeshellarg($SYSCONFDIR).' '.escapeshellarg($fileName);
     exec($cmd, $output, $returnVar);
     if ($returnVar != 0) {
       throw new \Exception("scan failed with $returnVar");

--- a/src/nomos/ui/agent-nomos-once.php
+++ b/src/nomos/ui/agent-nomos-once.php
@@ -50,7 +50,7 @@ class agent_nomos_once extends FO_Plugin
   {
     global $SYSCONFDIR;
 
-    exec("$SYSCONFDIR/mods-enabled/nomos/agent/nomos -S $FilePath", $out, $rtn);
+    exec("$SYSCONFDIR/mods-enabled/nomos/agent/nomos -S " . escapeshellarg($FilePath), $out, $rtn);
     $licensesFromAgent = explode('contains license(s)', $out[0]);
     $licenses_and_Highlight = end($licensesFromAgent);
     $licenses = explode('Highlighting Info at', $licenses_and_Highlight);

--- a/src/www/ui/async/AjaxExplorer.php
+++ b/src/www/ui/async/AjaxExplorer.php
@@ -211,8 +211,8 @@ class AjaxExplorer extends DefaultPlugin
 
     $orderString = $this->getObject('utils.data_tables_utility')->getSortingString($request->get('fromRest') ? $request->request->all(): $request->query->all(), $columnNamesInDatabase, $defaultOrder);
 
-    $offset = $request->get('iDisplayStart');
-    $limit = $request->get('iDisplayLength');
+    $offset = intval($request->get('iDisplayStart'));
+    $limit = intval($request->get('iDisplayLength'));
     if ($offset) {
       $orderString .= " OFFSET $offset";
     }

--- a/src/www/ui/change-license-processPost.php
+++ b/src/www/ui/change-license-processPost.php
@@ -60,8 +60,8 @@ class changeLicenseProcessPost extends FO_Plugin
     $uploadId = GetParm("upload", PARM_STRING);
     $uploadTreeId = GetParm("item", PARM_STRING);
 
-    $sql = "SELECT bucketpool_fk from bucket_ars where upload_fk = $uploadId;";
-    $result = pg_query($PG_CONN, $sql);
+    $sql = "SELECT bucketpool_fk from bucket_ars where upload_fk = $1;";
+    $result = pg_query_params($PG_CONN, $sql, array($uploadId));
     DBCheckResult($result, $sql, __FILE__, __LINE__);
     $bucketpool_array = pg_fetch_all_columns($result, 0);
     pg_free_result($result);

--- a/src/www/ui/core-auth.php
+++ b/src/www/ui/core-auth.php
@@ -410,7 +410,7 @@ class core_auth extends FO_Plugin
         } else if (! empty($row['user_seed'])) {
           $passwordHash = sha1($row['user_seed'] . $password);
           /* If verify with new hash fails check with the old hash */
-          if (strcmp($passwordHash, $row['user_pass']) == 0) {
+          if (hash_equals($row['user_pass'], $passwordHash)) {
             $newHash = password_hash($password, PASSWORD_DEFAULT, $options);
             /* Update old hash with new hash */
             update_password_hash($userName, $newHash);


### PR DESCRIPTION
## Description

Some gaps in the input handling of core PHP code paths that build shell commands, SQL queries, and password hashes from user-influenced or externally influenced values have been closed. 
Additional safeguards have been added to these code paths to prevent values from being interpolated directly into command strings, SQL statements, or comparison logic without proper escaping, type casting, or validation against an allowlist.

### Changes

- common-sysconfig.php
escape URL and proxy values passed to wget in is_available(), and cast timeout/retry parameters to int, removing a shell-metacharacter injection point reachable via the logo URL system setting

- change-license-processPost.php
use a parameterized query instead of string-interpolated SQL when looking up bucketpool_fk in ChangeBuckets()

- agent-nomos-once.php, monk/ui/oneshot.php
escape file path arguments before passing them to exec()

- lib/php/Util/DataTablesUtility.php
restrict sort direction to an ASC/DESC allow-list instead of passing the raw client-supplied value into the generated ORDER BY clause

- common-auth.php, core-auth.php:
verify passwords with password_verify() first, only falling back to the legacy seeded-sha1 check for accounts not yet migrated, and transparently rehash to bcrypt on successful login

## Testing

Expected:
- `is_available()` still returns 1/0 correctly for well-formed URLs after the escaping change.
- `ChangeBuckets()` still resolves the correct `bucketpool_fk` rows with the parameterized query.
- DataTables sorting still produces `ASC`/`DESC` output for all existing UI call sites; non-`asc`/`desc` input now defaults safely to `ASC` instead of being injected.
- Login still succeeds for accounts on both the legacy and bcrypt hash formats, and that legacy accounts are rehashed to bcrypt after a successful login.