### PR TITLE
fix(ui): resolve HTML validation errors and improve accessibility in templates

### DIFF
--- a/src/lib/php/UI/template/components/login-form.html.twig
+++ b/src/lib/php/UI/template/components/login-form.html.twig
@@ -19,19 +19,18 @@
     {% endif %}
     {% if loginProvider == 'password' %}
       <div class="form-group">
-        <label class="control-label col-sm-2">{{ 'Username'|trans }}:</label>
+        <label class="control-label col-sm-2" for="unamein">{{ 'Username'|trans }}:</label>
         <div class="col-sm-10">
           <input id="unamein" type="text" class="form-control" name="username" placeholder="Enter username" autofocus="autofocus" value="{{ userName|e }}">
         </div>
       </div>
-      <title>Toggle Password Visibility</title>
       <div class="form-group">
         <label class="control-label col-sm-2" for="pwd">{{ 'Password'|trans }}:</label>
         <div class="col-sm-10">
           <div class="row ml-0 mr-0">
             <input type="password" id="pwd" class="form-control col-sm-10" placeholder="Enter password" name="password"/>
             <span class="container col-sm-2">
-              <img src="images/eyes.png" class="bi bi-eye-slash" id="togglePassword" />
+              <img src="images/eyes.png" class="bi bi-eye-slash" id="togglePassword" alt="Toggle password visibility" />
             </span>
           </div>
         </div>

--- a/src/www/ui/template/ui-clearing-view_bulk.html.twig
+++ b/src/www/ui/template/ui-clearing-view_bulk.html.twig
@@ -124,14 +124,14 @@
                     <option value="u">{{ 'scan whole Upload'| trans }}</option>
                     <option value="f">{{ 'scan only current Folder'| trans }}</option>
                   </select>
-                  <img src="images/info_16.png" data-toggle="tooltip" data-placement="left" title="{{ 'Scan whole upload or this folder determines the scope of files where the text phrase is searched for. If “scan whole upload” is selected, the text phrase is searched in all files of the entire upload'|trans }}" alt="" class="info-bullet"/></img>
+                  <img src="images/info_16.png" data-toggle="tooltip" data-placement="left" title="{{ 'Scan whole upload or this folder determines the scope of files where the text phrase is searched for. If “scan whole upload” is selected, the text phrase is searched in all files of the entire upload'|trans }}" alt="" class="info-bullet"/>
                 </div>
                 <div class="col-sm-auto pr-0">
                   <div class="form-check form-check-inline">
                     <input type="checkbox" class="form-check-input" id="forceDecision"/>
                     <label for="forceDecision" class="form-check-label">
                       {{ 'Ignore conflicts'|trans }}
-                      <img src="images/info_16.png" data-toggle="tooltip" data-placement="left" title="{{ 'The bulk scan will create a clearing result, if the resulting list of licenses does not show conflicts. A conflict would be two different license ids for example. Imagine Nomos has found “Apache-1.0” and a bulk scan finds a text phrase with Apache-2.0 set, this represents a conflict. Otherwise if Nomos found Apache-2.0 and the bulk scan find a text phrase with “Apache-2.0” set, this is free from conflicts and a clearing result is set. Normally conflicts prevent clearing results. Checking the “ignore conflicts” will set a clearing decision in any case'|trans }}" alt="" class="info-bullet"/></img>
+                      <img src="images/info_16.png" data-toggle="tooltip" data-placement="left" title="{{ 'The bulk scan will create a clearing result, if the resulting list of licenses does not show conflicts. A conflict would be two different license ids for example. Imagine Nomos has found “Apache-1.0” and a bulk scan finds a text phrase with Apache-2.0 set, this represents a conflict. Otherwise if Nomos found Apache-2.0 and the bulk scan find a text phrase with “Apache-2.0” set, this is free from conflicts and a clearing result is set. Normally conflicts prevent clearing results. Checking the “ignore conflicts” will set a clearing decision in any case'|trans }}" alt="" class="info-bullet"/>
                     </label>
                   </div>
                 </div>
@@ -140,7 +140,7 @@
                     <input type="checkbox" class="form-check-input" id="scanOnlyFindings" name="scanOnlyFindings" checked="checked"/>
                     <label for="scanOnlyFindings" class="form-check-label">
                       {{ 'Scan files with findings'|trans }}
-                      <img src="images/info_16.png" data-toggle="tooltip" data-placement="left" title="{{ 'The bulk scan will be executed on the files where there is atleast one license finding'|trans }}" alt="" class="info-bullet"/></img>
+                      <img src="images/info_16.png" data-toggle="tooltip" data-placement="left" title="{{ 'The bulk scan will be executed on the files where there is atleast one license finding'|trans }}" alt="" class="info-bullet"/>
                     </label>
                   </div>
                 </div>
@@ -207,7 +207,7 @@
         <div class="modal-footer">
           <button type="button" class="btn btn-danger" onclick="closeBulkModal();" data-dismiss="modal">Cancel</button>
           <button type="button" class="btn btn-success" onclick="cleanText( $('#bulkRefText') );">{{ 'Clean text'|trans }}</button>
-          <img src="images/info_16.png" data-toggle="tooltip" style="vertical-align:middle;" title="{{ 'The matching process ignores comment symbols, e.g. double-slashes. Hence, these symbols can be remove from bulk text.'|trans }}" alt="" class="info-bullet"/></img>
+          <img src="images/info_16.png" data-toggle="tooltip" style="vertical-align:middle;" title="{{ 'The matching process ignores comment symbols, e.g. double-slashes. Hence, these symbols can be remove from bulk text.'|trans }}" alt="" class="info-bullet"/>
           <button type="button" class="btn btn-success" onclick="scheduleBulkScan();" data-dismiss="modal">{{ 'Schedule Bulk scan'|trans }}</button>
         </div>
       </div>

--- a/src/www/ui/template/ui-clearing-view_rhs.html.twig
+++ b/src/www/ui/template/ui-clearing-view_rhs.html.twig
@@ -15,16 +15,16 @@
         <button type="submit" name="update" class="btn btn-light btn-sm" id="next" disabled>&gt;</button>
       </td>
       <td>
-        <input type="radio" class="info-bullet view-license-rc-size" name="FileSelection" value="none">
-        {{ "Go through all files"|trans }}
-        <img data-toggle="tooltip" data-placement="left" src="images/info_16.png" title="{{ 'Back and forward browsing through every file of the upload'|trans }}" alt="" class="info-bullet"/></img>
+        <input type="radio" class="info-bullet view-license-rc-size" name="FileSelection" id="fs_all" value="none">
+        <label for="fs_all">{{ "Go through all files"|trans }}</label>
+        <img data-toggle="tooltip" data-placement="left" src="images/info_16.png" title="{{ 'Back and forward browsing through every file of the upload'|trans }}" alt="" class="info-bullet"/>
         <br/>
-        <input type="radio" class="info-bullet view-license-rc-size" name="FileSelection" value="noLicense">
-        {{ "Go through all files with licenses"|trans }}
-        <img data-toggle="tooltip" data-placement="left" src="images/info_16.png" title="{{ 'Back and forward browsing going through files only with a license found by a scanner agent, regardless of an existing clearing result or not'|trans }}" alt="" class="info-bullet"/></img>
+        <input type="radio" class="info-bullet view-license-rc-size" name="FileSelection" id="fs_licenses" value="noLicense">
+        <label for="fs_licenses">{{ "Go through all files with licenses"|trans }}</label>
+        <img data-toggle="tooltip" data-placement="left" src="images/info_16.png" title="{{ 'Back and forward browsing going through files only with a license found by a scanner agent, regardless of an existing clearing result or not'|trans }}" alt="" class="info-bullet"/>
         <br/>
-        <input type="radio" class="info-bullet view-license-rc-size" name="FileSelection" value="alreadyCleared">
-        {{ "Go through all files with licenses and no clearing result"|trans }}
+        <input type="radio" class="info-bullet view-license-rc-size" name="FileSelection" id="fs_uncleared" value="alreadyCleared">
+        <label for="fs_uncleared">{{ "Go through all files with licenses and no clearing result"|trans }}</label>
         <img data-toggle="tooltip" data-placement="left" src="images/info_16.png" title="{{ 'Back and forward browsing going through files only with a license found by a scanner agent only where no clearing result was created. This setting is useful for just browsing to “remaining work”'|trans }}" alt="" class="info-bullet"/>
       </td>
     </tr>

--- a/src/www/ui/template/user_add.html.twig
+++ b/src/www/ui/template/user_add.html.twig
@@ -18,20 +18,20 @@
 
   <table style='border:1px solid black; text-align:left; background:lightyellow;'>
     <tr {{ style }}>
-      <th width="25%">{{ "Username."|trans }}</th>
-      <td><input type="text" value="{{ userName|e }}" name="username" size="20" /></td>
+      <th width="25%"><label for="username">{{ "Username."|trans }}</label></th>
+      <td><input type="text" value="{{ userName|e }}" name="username" id="username" size="20" /></td>
     </tr>
     <tr {{ style }}>
-      <th width="25%">{{ "Description (name, contact, or other information)."|trans }} {{ "This may be blank."|trans }}</th>
-      <td><input type="text" value="{{ userDescription|e }}" name="description" size="60" /></td>
+      <th width="25%"><label for="description">{{ "Description (name, contact, or other information)."|trans }} {{ "This may be blank."|trans }}</label></th>
+      <td><input type="text" value="{{ userDescription|e }}" name="description" id="description" size="60" /></td>
     </tr>
     <tr {{ style }}>
-      <th width="25%">{{ "Email address."|trans }} {{ "This may be blank."|trans }}</th>
-      <td><input type="text" value="{{ userEmail|e }}" name="email" size="60" /></td>
+      <th width="25%"><label for="email">{{ "Email address."|trans }} {{ "This may be blank."|trans }}</label></th>
+      <td><input type="text" value="{{ userEmail|e }}" name="email" id="email" size="60" /></td>
     </tr>
     <tr {{ style }}>
-      <th width="25%">{{ "Access level"|trans }}</th>
-      <td><select name='permission'>
+      <th width="25%"><label for="permission">{{ "Access level"|trans }}</label></th>
+      <td><select name='permission' id="permission">
         <option value="{{ accessLevel[0] }}">{{ "None (very basic, no database access)"|trans }}</option>
         <option value="{{ accessLevel[1] }}">{{ "Read-only (read, but no writes or downloads)"|trans }}</option>
         <option value="{{ accessLevel[2] }}">{{ "Read-Write (read, download, or edit information)"|trans }}</option>
@@ -41,26 +41,25 @@
       </td>
     </tr>
     <tr {{ style }}>
-      <th width="25%">{{ "User root folder"|trans }}</th>
-      <td><select name="folder" class="ui-render-select2">
+      <th width="25%"><label for="folder">{{ "User root folder"|trans }}</label></th>
+      <td><select name="folder" id="folder" class="ui-render-select2">
         {{ folderListOption }}
       </select></td>
     </tr>
-      <title>Toggle Password Visibility</title>
     <tr {{ style }}>
-      <th width="25%">{{ "Password"|trans }}{{ passOptional|trans }}</th>
+      <th width="25%"><label for="passcheck">{{ "Password"|trans }}{{ passOptional|trans }}</label></th>
         <td><input type="password" name="pass1" size="20" id="passcheck" /><span class="bi bi-eye"></span>
-        <img src="images/eyes.png" class="bi bi-eye-slash" id="togglePasswords"></img>{% if passwordPolicy is not empty %}
+        <img src="images/eyes.png" class="bi bi-eye-slash" id="togglePasswords" alt="Toggle password visibility" />{% if passwordPolicy is not empty %}
         <br /><span class="passPolicy">{{ passwordPolicy }}</span>
       {% endif %}</td>
     </tr>
     <tr {{ style }}>
-      <th width='25%'>{{ "Re-enter password."|trans }}</th>
+      <th width='25%'><label for="pass2">{{ "Re-enter password."|trans }}</label></th>
       <td><input type="password" name="pass2" size="20" id="pass2" style='margin:4px' /></td>
     </tr>
     <tr {{ style }}>
-      <th width="25%">{{ "E-mail Notification"|trans }}</th>
-      <td><input type="checkbox" name="enote" value="y" checked="checked" />
+      <th width="25%"><label for="enote">{{ "E-mail Notification"|trans }}</label></th>
+      <td><input type="checkbox" name="enote" id="enote" value="y" checked="checked" />
         {{ "Check to enable email notification when upload scan completes."|trans }}</td>
     </tr>
     <tr {{ style }}>

--- a/src/www/ui/template/user_edit.html.twig
+++ b/src/www/ui/template/user_edit.html.twig
@@ -61,20 +61,19 @@
     {% if isSessionAdmin %}
       {% if passwordPolicy is empty %}
       <tr class="classic">
-        <th width="25%">{{ "Require no password."|trans }}</th>
+        <th width="25%"><label for="blank_pass">{{ "Require no password."|trans }}</label></th>
         <td><input type="checkbox" name="_blank_pass" id="blank_pass" {% if isBlankPassword %}checked="checked" disabled="disabled"{% endif %}/></td>
       </tr>
       {% endif %}
     {% endif %}
-    <title>Toggle Password Visibility</title>
     <tr class="classic">
-      <th width="25%">{{ "Password."|trans }}</th>
-      <td><input type="password" name="_pass1" size="20" id="passcheck" onchange="togglePasswords();"/><span class="bi bi-eye"></span><img src="images/eyes.png" class="bi bi-eye-slash" id="togglePasswords"></img>{% if passwordPolicy is not empty %}
+      <th width="25%"><label for="passcheck">{{ "Password."|trans }}</label></th>
+      <td><input type="password" name="_pass1" size="20" id="passcheck" onchange="togglePasswords();"/><span class="bi bi-eye"></span><img src="images/eyes.png" class="bi bi-eye-slash" id="togglePasswords" alt="Toggle password visibility" />{% if passwordPolicy is not empty %}
       <br /><span class="passPolicy">{{ passwordPolicy }}</span>
       {% endif %}</td>
     </tr>
     <tr class="classic">
-      <th width='25%'>{{ "Re-enter password."|trans }}</th>
+      <th width='25%'><label for="pass2">{{ "Re-enter password."|trans }}</label></th>
       <td><input type="password" name="_pass2" size="20" id="pass2"/></td>
     </tr>
     <tr class="classic">


### PR DESCRIPTION
## Description
This pull request addresses several standard HTML5 validation errors and accessibility (a11y) issues in the PHP Twig templates (`.html.twig`).

Specifically:
1. **Misplaced `<title>` tags inside the `<body>`**:
   - Removed `<title>Toggle Password Visibility</title>` from the middle of form and table containers (`user_add.html.twig`, `user_edit.html.twig`, and `login-form.html.twig`) because `<title>` is only valid inside the `<head>` tag.
2. **Invalid closing `</img>` tags**:
   - Replaced incorrect `<img></img>` tag closures with valid self-closing `<img ... />` syntax in `user_add.html.twig`, `user_edit.html.twig`, `ui-clearing-view_rhs.html.twig`, and `ui-clearing-view_bulk.html.twig`.
3. **Form label-to-input association improvements**:
   - Added appropriate `<label for="...">` elements and corresponding `id="..."` attributes on the input fields in `user_add.html.twig`, `user_edit.html.twig`, `login-form.html.twig`, and `ui-clearing-view_rhs.html.twig`. This ensures that screen readers can correctly associate text labels with their respective fields/controls.
4. **Improved Image Accessibility (a11y)**:
   - Added `alt="Toggle password visibility"` to the password visibility toggle images.

---

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Accessibility / standards alignment

---

## How Has This Been Tested?
- Verified the correctness of the generated HTML template syntax against the HTML5 specification rules.
- Ensured no existing Twig template logic variables (`{{ ... }}`) or layout logic structures were affected.


Closses #3724 