### PR TITLE
fix(ui): fix index source links by highlight fragments

### DIFF
--- a/src/lib/php/Dao/HighlightDao.php
+++ b/src/lib/php/Dao/HighlightDao.php
@@ -242,4 +242,35 @@ class HighlightDao
     );
     return $row['page'];
   }
+
+  /**
+   * Get page numbers for all highlight entries for a given match id.
+   *
+   * The resulting array can contain duplicate page numbers when multiple
+   * highlight fragments exist on the same page.
+   *
+   * @param int $licenseMatchId
+   * @return int[]
+   */
+  public function getPageNumbersOfHighlightEntries($licenseMatchId)
+  {
+    $stmt = __METHOD__;
+    $sql = "SELECT FLOOR(start / (
+              SELECT conf_value FROM sysconfig WHERE variablename LIKE 'BlockSizeText'
+            )::numeric) AS page
+            FROM highlight
+            WHERE fl_fk = $1
+            ORDER BY start ASC";
+
+    $this->dbManager->prepare($stmt, $sql);
+    $result = $this->dbManager->execute($stmt, array($licenseMatchId));
+
+    $pages = array();
+    while ($row = $this->dbManager->fetchArray($result)) {
+      $pages[] = intval($row['page']);
+    }
+    $this->dbManager->freeResult($result);
+
+    return $pages;
+  }
 }

--- a/src/lib/php/Dao/HighlightDao.php
+++ b/src/lib/php/Dao/HighlightDao.php
@@ -242,4 +242,38 @@ class HighlightDao
     );
     return $row['page'];
   }
+
+  /**
+   * Get every signature-highlight occurrence (page + start offset) for a match
+   * id, ordered by position. Includes multiple occurrences on the same page.
+   * Drives per-license occurrence navigation.
+   *
+   * @param int $licenseMatchId
+   * @return array[] Each entry has keys: page, start
+   */
+  public function getSignaturePageAnchorsOfHighlightEntry($licenseMatchId)
+  {
+    $stmt = __METHOD__;
+    $sql = "SELECT FLOOR(start / (
+                     SELECT conf_value FROM sysconfig WHERE variablename LIKE 'BlockSizeText'
+                   )::numeric)::int AS page,
+                   start
+            FROM highlight
+            WHERE fl_fk = $1 AND type = 'L' AND len > 0
+            ORDER BY start ASC";
+
+    $this->dbManager->prepare($stmt, $sql);
+    $result = $this->dbManager->execute($stmt, array($licenseMatchId));
+
+    $anchors = array();
+    while ($row = $this->dbManager->fetchArray($result)) {
+      $anchors[] = array(
+        'page' => intval($row['page']),
+        'start' => intval($row['start'])
+      );
+    }
+    $this->dbManager->freeResult($result);
+
+    return $anchors;
+  }
 }

--- a/src/lib/php/View/HighlightRenderer.php
+++ b/src/lib/php/View/HighlightRenderer.php
@@ -58,7 +58,7 @@ class HighlightRenderer
       }
     }
 
-    return $this->createStyleWithPadding($type, $highlight->getInfoText(), $depth) . $wrappendElement;
+    return $this->createStyleWithPadding($type, $highlight->getInfoText(), $depth, $highlight->getStart()) . $wrappendElement;
   }
 
   /**
@@ -87,9 +87,9 @@ class HighlightRenderer
    * @param int $depth
    * @return string
    */
-  public function createStyleWithPadding($type, $title, $depth = 0)
+  public function createStyleWithPadding($type, $title, $depth = 0, $start = null)
   {
-    $style = $this->createStartSpan($type, $title);
+    $style = $this->createStartSpan($type, $title, $start);
     if ($depth < self::DEFAULT_PADDING) {
       $padd = (2 * (self::DEFAULT_PADDING - $depth - 2)) . 'px';
       return $this->getStyleWithPadding($padd, $style);
@@ -114,7 +114,7 @@ class HighlightRenderer
    * @param string $title
    * @return string
    */
-  public function createStartSpan($type, $title)
+  public function createStartSpan($type, $title, $start = null)
   {
     if ($type == 'K ' || $type == 'K') {
       return "<span class=\"hi-keyword\">";
@@ -123,7 +123,8 @@ class HighlightRenderer
       $type = Highlight::UNDEFINED;
     }
     $class = $this->classMapping[$type];
-    return "<span class=\"$class\" title=\"$title\">";
+    $dataStart = ($type == Highlight::SIGNATURE && $start !== null) ? " data-start=\"$start\"" : "";
+    return "<span class=\"$class\" title=\"$title\"$dataStart>";
   }
 
   /**

--- a/src/lib/php/View/HighlightState.php
+++ b/src/lib/php/View/HighlightState.php
@@ -141,6 +141,17 @@ class HighlightState
    */
   protected function checkForAnchor(SplitPosition $entry)
   {
+    if (array_key_exists('anchorStart', $_GET) && is_numeric($_GET['anchorStart'])) {
+      $anchorStart = intval($_GET['anchorStart']);
+      $shouldShowAnchor = !$this->anchorDrawn
+        && $entry->getHighlight()->getType() == Highlight::SIGNATURE
+        && $entry->getHighlight()->getStart() == $anchorStart;
+      if ($shouldShowAnchor) {
+        $this->anchorDrawn = true;
+      }
+      return $shouldShowAnchor;
+    }
+
     $shouldShowAnchor = !$this->anchorDrawn && $entry->getHighlight()->getType() != Highlight::KEYWORD;
     if ($shouldShowAnchor) {
       $this->anchorDrawn = true;

--- a/src/lib/php/View/test/HighlightRendererTest.php
+++ b/src/lib/php/View/test/HighlightRendererTest.php
@@ -53,6 +53,7 @@ class HighlightRendererTest extends \PHPUnit\Framework\TestCase
     $this->highlight->shouldReceive('getType')->andReturn(Highlight::MATCH)->byDefault();
     $this->highlight->shouldReceive('getInfoText')->andReturn("<infoText>")->byDefault();
     $this->highlight->shouldReceive('getHtmlElement')->andReturn(null)->byDefault();
+    $this->highlight->shouldReceive('getStart')->andReturn(0)->byDefault();
 
     $this->splitPosition = M::mock(SplitPosition::class);
     $this->splitPosition->shouldReceive('getLevel')->andReturn($this->level)->byDefault();

--- a/src/www/ui/ajax-clearing-view.php
+++ b/src/www/ui/ajax-clearing-view.php
@@ -374,17 +374,26 @@ class AjaxClearingView extends FO_Plugin
       $agentId = $agentDecisionEvent->getAgentId();
       $matchId = $agentDecisionEvent->getMatchId();
       $highlightRegion = $this->highlightDao->getHighlightRegion($matchId);
-      $uri = null;
-      $percentage = false;
+      $percentage = $agentDecisionEvent->getPercentage();
       if ($highlightRegion[0] != "" && $highlightRegion[1] != "") {
-        $percentage = $agentDecisionEvent->getPercentage();
-        $page = $this->highlightDao->getPageNumberOfHighlightEntry($matchId);
-        $uri = $uberUri . "&item=$uploadTreeId&agentId=$agentId&highlightId=$matchId&page=$page#highlight";
+        $pages = $this->highlightDao->getPageNumbersOfHighlightEntries($matchId);
+        if (empty($pages)) {
+          $page = $this->highlightDao->getPageNumberOfHighlightEntry($matchId);
+          $pages = array(intval($page));
+        }
+        foreach ($pages as $pageIndex => $page) {
+          $uri = $uberUri . "&item=$uploadTreeId&agentId=$agentId&highlightId=$matchId&page=$page#highlight";
+          $agentResults[$agentDecisionEvent->getAgentName()][] = array(
+            "uri" => $uri,
+            "text" => ($pageIndex === 0 && $percentage) ? " (" . $percentage . " %)" : ""
+          );
+        }
+      } else {
+        $agentResults[$agentDecisionEvent->getAgentName()][] = array(
+          "uri" => null,
+          "text" => $percentage ? " (" . $percentage . " %)" : ""
+        );
       }
-      $agentResults[$agentDecisionEvent->getAgentName()][] = array(
-        "uri" => $uri,
-        "text" => $percentage ? " (" . $percentage . " %)" : ""
-      );
     }
 
     $results = array();

--- a/src/www/ui/ajax-clearing-view.php
+++ b/src/www/ui/ajax-clearing-view.php
@@ -373,17 +373,34 @@ class AjaxClearingView extends FO_Plugin
     foreach ($licenseDecisionResult->getAgentDecisionEvents() as $agentDecisionEvent) {
       $agentId = $agentDecisionEvent->getAgentId();
       $matchId = $agentDecisionEvent->getMatchId();
+      $agentName = $agentDecisionEvent->getAgentName();
       $highlightRegion = $this->highlightDao->getHighlightRegion($matchId);
       $uri = null;
       $percentage = false;
+      $occurrences = null;
       if ($highlightRegion[0] != "" && $highlightRegion[1] != "") {
         $percentage = $agentDecisionEvent->getPercentage();
-        $page = $this->highlightDao->getPageNumberOfHighlightEntry($matchId);
-        $uri = $uberUri . "&item=$uploadTreeId&agentId=$agentId&highlightId=$matchId&page=$page#highlight";
+        if (stripos($agentName, 'nomos') !== false) {
+          $anchors = $this->highlightDao->getSignaturePageAnchorsOfHighlightEntry($matchId);
+          if (!empty($anchors)) {
+            $first = $anchors[0];
+            $uri = $uberUri . "&item=$uploadTreeId&agentId=$agentId&highlightId=$matchId&page={$first['page']}&anchorStart={$first['start']}&format=text#highlight";
+            if (count($anchors) > 1) {
+              $occurrences = $anchors;
+            }
+          }
+        }
+        if ($uri === null) {
+          $page = $this->highlightDao->getPageNumberOfHighlightEntry($matchId);
+          $uri = $uberUri . "&item=$uploadTreeId&agentId=$agentId&highlightId=$matchId&page=$page#highlight";
+        }
       }
-      $agentResults[$agentDecisionEvent->getAgentName()][] = array(
+      $agentResults[$agentName][] = array(
         "uri" => $uri,
-        "text" => $percentage ? " (" . $percentage . " %)" : ""
+        "text" => $percentage ? " (" . $percentage . " %)" : "",
+        "occurrences" => $occurrences,
+        "agentId" => $agentId,
+        "matchId" => $matchId
       );
     }
 
@@ -394,7 +411,21 @@ class AjaxClearingView extends FO_Plugin
       foreach ($agentResult as $index => $agentData) {
         $uri = $agentData['uri'];
         if (! empty($uri)) {
-          $matchTexts[] = "<a href=\"$uri\">#" . ($index + 1) . "</a>" . $agentData['text'];
+          $label = "#" . ($index + 1);
+          if (!empty($agentData['occurrences'])) {
+            $occJson = htmlspecialchars(json_encode($agentData['occurrences']), ENT_QUOTES);
+            $matchTexts[] = "<span class=\"nomos-occurrence\" data-highlight-id=\"{$agentData['matchId']}\">"
+              . "<a href=\"$uri\" class=\"nomos-occurrence-link\""
+              . " data-occurrences=\"$occJson\""
+              . " data-agent-id=\"{$agentData['agentId']}\""
+              . " data-highlight-id=\"{$agentData['matchId']}\">$label</a>"
+              . " <button type=\"button\" class=\"btn btn-light btn-xs nomos-inline-prev\" title=\"Previous occurrence\">&#9664;</button>"
+              . "<button type=\"button\" class=\"btn btn-light btn-xs nomos-inline-next\" title=\"Next occurrence\">&#9654;</button>"
+              . " <span class=\"nomos-inline-count\" style=\"font-size:0.9em;\"></span>"
+              . "</span>" . $agentData['text'];
+          } else {
+            $matchTexts[] = "<a href=\"$uri\">$label</a>" . $agentData['text'];
+          }
         } else {
           $matchTexts[] = $agentData['text'];
         }

--- a/src/www/ui/api/Controllers/UploadTreeController.php
+++ b/src/www/ui/api/Controllers/UploadTreeController.php
@@ -564,20 +564,33 @@ class UploadTreeController extends RestController
       $agentId = $agentDecisionEvent->getAgentId();
       $matchId = $agentDecisionEvent->getMatchId();
       $highlightRegion = $this->highlightDao->getHighlightRegion($matchId);
-      $page = null;
       $percentage = $agentDecisionEvent->getPercentage();
       if ($highlightRegion[0] != "" && $highlightRegion[1] != "") {
-        $page = $this->highlightDao->getPageNumberOfHighlightEntry($matchId);
+        $pages = $this->highlightDao->getPageNumbersOfHighlightEntries($matchId);
+        if (empty($pages)) {
+          $page = $this->highlightDao->getPageNumberOfHighlightEntry($matchId);
+          $pages = array(intval($page));
+        }
+        foreach ($pages as $pageIndex => $page) {
+          $agentResults[] = array(
+            'name' => $agentDecisionEvent->getAgentName(),
+            'clearingId' => null,
+            'agentId' => $agentId,
+            'highlightId' => $matchId,
+            'page' => intval($page),
+            'percentage' => $pageIndex === 0 ? $percentage : null
+          );
+        }
+      } else {
+        $agentResults[] = array(
+          'name' => $agentDecisionEvent->getAgentName(),
+          'clearingId' => null,
+          'agentId' => $agentId,
+          'highlightId' => $matchId,
+          'page' => null,
+          'percentage' => $percentage
+        );
       }
-      $result = array(
-        'name' => $agentDecisionEvent->getAgentName(),
-        'clearingId' => null,
-        'agentId' => $agentId,
-        'highlightId' => $matchId,
-        'page' => intval($page),
-        'percentage' => $percentage
-      );
-      $agentResults[] = $result;
     }
     return $agentResults;
   }

--- a/src/www/ui/template/ui-clearing-view.html.twig
+++ b/src/www/ui/template/ui-clearing-view.html.twig
@@ -8,6 +8,9 @@
   <link rel="stylesheet" href="css/highlights.css"/>
   <link rel="stylesheet" href="css/spasht.css"/>
   <link rel="stylesheet" href="css/search.css"/>
+  <style>
+    .nomos-active-occurrence { outline: 2px solid #135f9c; outline-offset: 1px; }
+  </style>
 {% endblock %}
 
 {% block content %}
@@ -35,6 +38,13 @@
                 {% endif %}
             </div>
 
+            <span id="nomosNavBar" class="clearing-nomos-nav" style="display:none; align-items:center; margin-left:10px;">
+                <span style="font-size:0.9em;">License matches:</span>
+                <button class="btn btn-light btn-sm" id="btnNomosPrev" title="Previous occurrence">&uarr;</button>
+                <button class="btn btn-light btn-sm" id="btnNomosNext" title="Next occurrence">&darr;</button>
+                <span id="nomosNavCount" style="font-size:0.9em; margin-left:5px;"></span>
+            </span>
+
             <button class="legendHider btn btn-light btn-sm">
               {{ 'Hide Legend'| trans }}
             </button>
@@ -43,6 +53,12 @@
             </button>
           </div>
           <div class="boxnew" id="fileTextView" style="overflow:scroll;">{{ textView }}</div>
+          <div id="nomosFloatingNav" style="display:none; position:absolute; top:64px; right:30px; z-index:20; background:#fff; border:1px solid #888; border-radius:4px; padding:3px 8px; box-shadow:0 1px 4px rgba(0,0,0,0.25); font-size:0.9em; align-items:center;">
+            <span id="nomosFloatingLabel" style="margin-right:6px; font-weight:bold;"></span>
+            <span id="nomosFloatingCount" style="margin-right:6px;"></span>
+            <button type="button" class="btn btn-light btn-xs" id="btnNomosFloatPrev" title="Previous occurrence">&#9664;</button>
+            <button type="button" class="btn btn-light btn-xs" id="btnNomosFloatNext" title="Next occurrence">&#9654;</button>
+          </div>
           <div id="legendBox" name="legendBox" style="background-color:white; padding:2px; border:1px outset #222222; width:150px; position:absolute; right:17px; bottom:17px; ">
             <u><b>{{ 'Legend:'| trans }}</b></u><br/>
               {% for entry in legendData %}

--- a/src/www/ui/template/ui-clearing-view.js.twig
+++ b/src/www/ui/template/ui-clearing-view.js.twig
@@ -30,6 +30,14 @@ selectedLicensesTableConfig = {
           $('td', nRow).addClass('read_only');
       }
   },
+  "fnDrawCallback": function () {
+      if (typeof applyNomosNavVisibility === 'function') {
+        applyNomosNavVisibility();
+      }
+      if (typeof activateNomosNavFromUrl === 'function') {
+        activateNomosNavFromUrl();
+      }
+  },
   "aoColumns": selectedLicensesTableColumns,
   "iDisplayLength": 25,
   "bProcessing": true,
@@ -182,7 +190,8 @@ function navigateToMatch(index) {
       currentElements.addClass("active-match");
       const container = $("#fileTextView");
       const scrollTop = currentElements.first().offset().top - container.offset().top + container.scrollTop() - (container.height() / 2);
-      container.animate({scrollTop}, 300);
+      const scrollLeft = currentElements.first().offset().left - container.offset().left + container.scrollLeft() - (container.width() / 2) + (currentElements.first().outerWidth() / 2);
+      container.animate({scrollTop: Math.max(0, scrollTop), scrollLeft: Math.max(0, scrollLeft)}, 300);
     }
     $("#searchCountInfo").text(`${currentMatchIndex + 1} / ${searchMatches.length}`);
   }
@@ -267,6 +276,271 @@ function highlightSearchMatches() {
   });
 }
 
+// ---------------------------------------------------------------------------
+// Nomos occurrence navigation (shared core)
+//
+// A single "#1" hashtag in the Source column carries the full list of blue
+// signature occurrences (one per page) as data-occurrences. Prev/next reload
+// the file view at each occurrence, mirroring the search-match navigation.
+// ---------------------------------------------------------------------------
+// Active nomos-nav presentation: 'topbar' (Option 1), 'inline' (Option 2),
+// or 'floating' (Option 3).
+var NOMOS_NAV_UI = 'floating';
+var nomosNav = { occurrences: [], index: -1, highlightId: null, agentId: null, licenseName: '' };
+
+function buildOccurrenceUrl(occ) {
+  const url = new URL(window.location.href);
+  url.searchParams.set('highlightId', nomosNav.highlightId);
+  if (nomosNav.agentId) {
+    url.searchParams.set('agentId', nomosNav.agentId);
+  }
+  url.searchParams.set('page', occ.page);
+  url.searchParams.set('anchorStart', occ.start);
+  url.searchParams.set('format', 'text');
+  url.hash = 'highlight';
+  return url.href;
+}
+
+function nomosNavigate(delta) {
+  if (!nomosNav.occurrences.length) {
+    return;
+  }
+  goToOccurrence(nomosNav.index + delta);
+}
+
+// Scroll the file pane to a same-page occurrence using its data-start marker.
+function scrollToOccurrence(occ) {
+  const container = document.getElementById('fileTextView');
+  if (!container) {
+    return;
+  }
+  const target = container.querySelector('.hi-signature[data-start="' + occ.start + '"]');
+  if (!target) {
+    return;
+  }
+  container.querySelectorAll('.nomos-active-occurrence').forEach(function (el) {
+    el.classList.remove('nomos-active-occurrence');
+  });
+  target.classList.add('nomos-active-occurrence');
+  const t = target.getBoundingClientRect();
+  const c = container.getBoundingClientRect();
+  const left = container.scrollLeft + (t.left - c.left) - (container.clientWidth / 2) + (t.width / 2);
+  const top = container.scrollTop + (t.top - c.top) - (container.clientHeight / 2) + (t.height / 2);
+  container.scrollTo({ left: Math.max(0, left), top: Math.max(0, top), behavior: 'smooth' });
+}
+
+// Navigate to an occurrence: smooth-scroll if it's on the current page,
+// otherwise reload the file view at that occurrence.
+function goToOccurrence(targetIndex) {
+  const n = nomosNav.occurrences.length;
+  if (!n) {
+    return;
+  }
+  const idx = (targetIndex + n) % n;
+  const occ = nomosNav.occurrences[idx];
+  if (occ.page === currentPage) {
+    nomosNav.index = idx;
+    const url = new URL(window.location.href);
+    url.searchParams.set('highlightId', nomosNav.highlightId);
+    url.searchParams.set('anchorStart', occ.start);
+    window.history.replaceState(null, '', url.pathname + url.search);
+    scrollToOccurrence(occ);
+    renderNomosNav();
+  } else {
+    window.location.href = buildOccurrenceUrl(occ);
+  }
+}
+
+function activateNomosNavFromUrl() {
+  const params = new URLSearchParams(window.location.search);
+  const highlightId = params.get('highlightId');
+  if (!highlightId) {
+    return;
+  }
+  const link = document.querySelector(
+    '.nomos-occurrence-link[data-highlight-id="' + highlightId + '"]');
+  if (!link) {
+    return;
+  }
+  let occurrences;
+  try {
+    occurrences = JSON.parse(link.getAttribute('data-occurrences'));
+  } catch (e) {
+    return;
+  }
+  if (!Array.isArray(occurrences) || occurrences.length < 2) {
+    return;
+  }
+
+  const page = parseInt(params.get('page'));
+  const anchorStart = params.get('anchorStart') !== null
+    ? parseInt(params.get('anchorStart')) : null;
+  let idx = occurrences.findIndex(function (o) {
+    return o.page === page && (anchorStart === null || o.start === anchorStart);
+  });
+  if (idx < 0) {
+    idx = occurrences.findIndex(function (o) { return o.page === page; });
+  }
+  if (idx < 0) {
+    idx = 0;
+  }
+
+  nomosNav.occurrences = occurrences;
+  nomosNav.index = idx;
+  nomosNav.highlightId = highlightId;
+  nomosNav.agentId = link.getAttribute('data-agent-id');
+  const cur = nomosNav.occurrences[nomosNav.index];
+  if (cur && cur.page === currentPage) {
+    const fileView = document.getElementById('fileTextView');
+    const span = fileView && fileView.querySelector('.hi-signature[data-start="' + cur.start + '"]');
+    if (span) {
+      span.classList.add('nomos-active-occurrence');
+    }
+  }
+  renderNomosNav();
+}
+
+// Presentation dispatch for the active nav style.
+function renderNomosNav() {
+  if (NOMOS_NAV_UI === 'topbar') {
+    const bar = document.getElementById('nomosNavBar');
+    if (!bar) {
+      return;
+    }
+    bar.style.display = 'inline-flex';
+    const count = document.getElementById('nomosNavCount');
+    if (count) {
+      count.textContent = (nomosNav.index + 1) + ' / ' + nomosNav.occurrences.length;
+    }
+  } else if (NOMOS_NAV_UI === 'inline') {
+    const count = document.querySelector(
+      '.nomos-occurrence[data-highlight-id="' + nomosNav.highlightId + '"] .nomos-inline-count');
+    if (count) {
+      count.textContent = '(' + (nomosNav.index + 1) + ' / ' + nomosNav.occurrences.length + ')';
+    }
+  } else if (NOMOS_NAV_UI === 'floating') {
+    const nav = document.getElementById('nomosFloatingNav');
+    if (!nav) {
+      return;
+    }
+    const label = document.getElementById('nomosFloatingLabel');
+    const count = document.getElementById('nomosFloatingCount');
+    if (label) {
+      label.textContent = 'License matches:';
+    }
+    if (count) {
+      count.textContent = (nomosNav.index + 1) + ' / ' + nomosNav.occurrences.length;
+    }
+    nav.style.display = 'inline-flex';
+  }
+}
+
+// Hide the server-rendered inline arrows unless inline mode is active.
+function applyNomosNavVisibility() {
+  if (NOMOS_NAV_UI !== 'inline') {
+    document.querySelectorAll('.nomos-inline-prev, .nomos-inline-next, .nomos-inline-count')
+      .forEach(function (el) { el.style.display = 'none'; });
+  }
+}
+
+// Inline arrows (Option 2) navigate standalone: current index is derived from
+// the URL when this license is the active one, else it starts at the first.
+function nomosInlineNavigate(btn, delta) {
+  const wrap = btn.closest('.nomos-occurrence');
+  const link = wrap ? wrap.querySelector('.nomos-occurrence-link') : null;
+  if (!link) {
+    return;
+  }
+  let occurrences;
+  try {
+    occurrences = JSON.parse(link.getAttribute('data-occurrences'));
+  } catch (e) {
+    return;
+  }
+  if (!Array.isArray(occurrences) || !occurrences.length) {
+    return;
+  }
+  const highlightId = link.getAttribute('data-highlight-id');
+  const params = new URLSearchParams(window.location.search);
+  let curIdx = 0;
+  if (params.get('highlightId') === highlightId) {
+    const page = parseInt(params.get('page'));
+    const anchorStart = params.get('anchorStart') !== null
+      ? parseInt(params.get('anchorStart')) : null;
+    let i = occurrences.findIndex(function (o) {
+      return o.page === page && (anchorStart === null || o.start === anchorStart);
+    });
+    if (i < 0) {
+      i = occurrences.findIndex(function (o) { return o.page === page; });
+    }
+    if (i >= 0) {
+      curIdx = i;
+    }
+  }
+  nomosNav.occurrences = occurrences;
+  nomosNav.highlightId = highlightId;
+  nomosNav.agentId = link.getAttribute('data-agent-id');
+  nomosNav.index = curIdx;
+  goToOccurrence(curIdx + delta);
+}
+
+// ---------------------------------------------------------------------------
+// Center the linked blue signature span in the file pane after navigation.
+// ---------------------------------------------------------------------------
+var shouldFocusLinkedHighlight = (window.location.hash === '#highlight');
+
+function getLinkedHighlightNode() {
+  const container = document.getElementById('fileTextView');
+  if (!container) {
+    return null;
+  }
+  const marker = document.getElementById('highlight');
+  if (marker) {
+    let sibling = marker.nextElementSibling;
+    while (sibling && !(sibling.classList && sibling.classList.contains('hi-signature'))) {
+      sibling = sibling.nextElementSibling;
+    }
+    if (sibling) {
+      return sibling;
+    }
+    if (marker.parentElement && marker.parentElement.classList.contains('hi-signature')) {
+      return marker.parentElement;
+    }
+    return marker;
+  }
+  return container.querySelector('span.hi-signature');
+}
+
+function centerLinkedHighlight() {
+  const container = document.getElementById('fileTextView');
+  const target = getLinkedHighlightNode();
+  if (!container || !target) {
+    return;
+  }
+  const t = target.getBoundingClientRect();
+  const c = container.getBoundingClientRect();
+  const left = container.scrollLeft + (t.left - c.left) - (container.clientWidth / 2) + (t.width / 2);
+  const top = container.scrollTop + (t.top - c.top) - (container.clientHeight / 2) + (t.height / 2);
+  container.scrollLeft = Math.max(0, left);
+  container.scrollTop = Math.max(0, top);
+}
+
+function focusLinkedHighlight() {
+  if (!shouldFocusLinkedHighlight) {
+    return;
+  }
+  if (window.history && window.history.replaceState && window.location.hash === '#highlight') {
+    window.history.replaceState(null, '', window.location.pathname + window.location.search);
+  }
+  window.requestAnimationFrame(function () {
+    centerLinkedHighlight();
+    window.requestAnimationFrame(centerLinkedHighlight);
+  });
+  [100, 300, 600, 1000].forEach(function (delay) {
+    window.setTimeout(centerLinkedHighlight, delay);
+  });
+}
+
 $(document).ready(function () {
   createClearingTable();
   createLicenseSelectionTable();
@@ -276,6 +550,18 @@ $(document).ready(function () {
     highlightSearchMatches(); 
   {% endif %}
   initSearchNavigation();
+
+  focusLinkedHighlight();
+  $(window).on('load', focusLinkedHighlight);
+
+  $("#btnNomosPrev").click(function() { nomosNavigate(-1); });
+  $("#btnNomosNext").click(function() { nomosNavigate(1); });
+
+  $(document).on('click', '.nomos-inline-prev', function() { nomosInlineNavigate(this, -1); });
+  $(document).on('click', '.nomos-inline-next', function() { nomosInlineNavigate(this, 1); });
+
+  $("#btnNomosFloatPrev").click(function() { nomosNavigate(-1); });
+  $("#btnNomosFloatNext").click(function() { nomosNavigate(1); });
 
   $("#btnTriggerSearch").click(performSearch);
   $("#textSearchInput").keypress(function(e) {


### PR DESCRIPTION
## Description

Fix Source indexing in Conclude License so all scanner highlight occurrences are represented, not only the first one.

### Changes

1. Added support to fetch highlight-entry pages for all highlight fragments of a scanner match in `src/lib/php/Dao/HighlightDao.php`.
2. Updated Source rendering in `ajax-clearing-view.php` to generate multiple numbered links (`#1`, `#2`, `#3`, ...) for each occurrence stream.
3. Updated API agent info generation in `UploadTreeController.php` to stay aligned with UI occurrence behavior.
4. Preserved stable ordering by highlight start so numbering is deterministic.
5. Included same-page multiple fragments as separate indices.

## How to test

1. Start Fossology services and open **Conclude License** for a file with repeated scanner-highlighted license text.
2. In the **Source** column, verify an agent entry (for example, `nomos`) shows multiple indices (`#1`, `#2`, `#3`, ...) instead of only `#1`.
3. Click each index and verify navigation lands on the expected highlighted occurrence.
4. Verify cases where multiple occurrences are on the same page also show separate indices (`#1`, `#2`, `#3`, ...).
5. Confirm there are no syntax or runtime errors in the modified PHP files:

   ```bash
   php -l src/lib/php/Dao/HighlightDao.php
   php -l src/www/ui/ajax-clearing-view.php
   php -l src/www/ui/api/Controllers/UploadTreeController.php
   ```