### PR TITLE
fix(licenseImport): prevent 500 on CSV group error and fix JSON import

### DIFF
--- a/src/lib/php/Application/LicenseCsvImport.php
+++ b/src/lib/php/Application/LicenseCsvImport.php
@@ -49,7 +49,7 @@ class LicenseCsvImport
    * Alias for headers */
   protected $alias = array(
       'shortname'=>array('shortname','Short Name'),
-      'licensetype'=>array('licensetype','License Type'),
+      'licensetype'=>array('licensetype','license_type','License Type'),
       'fullname'=>array('fullname','Long Name'),
       'spdx_id'=>array('spdx_id', 'SPDX ID'),
       'text'=>array('text','Full Text'),
@@ -221,6 +221,10 @@ class LicenseCsvImport
       if (!array_key_exists($optNeedle, $mRow)) {
         $mRow[$optNeedle] = $defaultValue;
       }
+    }
+
+    if (empty($mRow['external_id'])) {
+      return $this->handleCsvLicense($mRow);
     }
 
     return $this->handleLicenseDBLicenseImport($mRow);
@@ -411,6 +415,11 @@ class LicenseCsvImport
       $return = $this->insertNewLicense($row, "license_candidate");
     } else {
       $return = $this->insertNewLicense($row, "license_ref");
+    }
+    // insertNewLicense() returns a plain string on error (e.g. missing group)
+    // or an array on success.
+    if (is_string($return)) {
+      return $return;
     }
     return $return['log'];
   }


### PR DESCRIPTION
## Description
Fix CSV 500 error on missing group and JSON import failures for license import.

### 1. CSV import returns HTTP 500 on a missing/mismatched group
When a CSV row has a `group` (candidate license) whose group does not
exist, `insertNewLicense()` returns a plain **string** error, but
`handleCsvLicense()` always accessed it as an **array** (`$return['log']`).

### 2. JSON import fails with "external_id cannot be empty" on every row
`handleJsonLicense()` always routed rows to `handleLicenseDBLicenseImport()`,
which requires `external_id`. That field only exists on LicenseDB-sourced
JSON; FOSSology's own JSON export (`LicenseCsvExport`) does not emit it,
so a normal export.

### 3. License type lost on JSON import
The JSON export uses the key `license_type`, but the importer only
recognized `licensetype`/`License Type`, so the type defaulted to
"Permissive". Added `license_type` to the alias.

## How to test
- **CSV:** import a CSV containing a candidate row whose group does not
  exist no 500; that row reports the group error, other rows import.
- **JSON:** export licenses from FOSSology, then import the JSON file
  licenses import successfully (previously failed on every row).
- **LicenseDB JSON:** confirm LicenseDB import still works (rows with
  `external_id` unchanged).