### PR TITLE
feat(report): include assessment summary notes in report

### DIFF
--- a/src/clixml/agent/clixml.php
+++ b/src/clixml/agent/clixml.php
@@ -581,6 +581,26 @@ class CliXml extends Agent
         $usage = 'Found';
       }
     }
+    $criticalNotesText = '';
+    if ($critical != 'None' && $row['ri_criticalnotes'] != 'NA'
+      && !empty($row['ri_criticalnotes'])) {
+      $criticalNotesText = $row['ri_criticalnotes'];
+    }
+    $dependencyNotesText = '';
+    if ($dependency != 'None' && $row['ri_depnotes'] != 'NA'
+      && !empty($row['ri_depnotes'])) {
+      $dependencyNotesText = $row['ri_depnotes'];
+    }
+    $exportRestrictionsText = '';
+    if ($ecc != 'None' && $row['ri_exportnotes'] != 'NA'
+      && !empty($row['ri_exportnotes'])) {
+      $exportRestrictionsText = $row['ri_exportnotes'];
+    }
+    $usageRestrictionsText = '';
+    if ($usage != 'None' && $row['ri_copyrightnotes'] != 'NA'
+      && !empty($row['ri_copyrightnotes'])) {
+      $usageRestrictionsText = $row['ri_copyrightnotes'];
+    }
     $componentType = $row['ri_component_type'];
     if (!empty($componentType)) {
       $componentType = ComponentType::TYPE_MAP[$componentType];
@@ -615,9 +635,13 @@ class CliXml extends Agent
     ], [
       'generalAssessment' => $row['ri_general_assesment'],
       'criticalFilesFound' => $critical,
+      'criticalFilesText' => $criticalNotesText,
       'dependencyNotes' => $dependency,
+      'dependencyNotesText' => $dependencyNotesText,
       'exportRestrictionsFound' => $ecc,
+      'exportRestrictionsText' => $exportRestrictionsText,
       'usageRestrictionsFound' => $usage,
+      'usageRestrictionsText' => $usageRestrictionsText,
       'additionalNotes' => $row['ri_ga_additional']
     ]];
   }

--- a/src/clixml/agent/template/clixml-file.xml.twig
+++ b/src/clixml/agent/template/clixml-file.xml.twig
@@ -33,10 +33,10 @@
 
   <AssessmentSummary>
     <GeneralAssessment><![CDATA[{{ assessmentSummary.generalAssessment|trim }}]]></GeneralAssessment>
-    <CriticalFilesFound>{{ assessmentSummary.criticalFilesFound|trim }}</CriticalFilesFound>
-    <DependencyNotes>{{ assessmentSummary.dependencyNotes|trim }}</DependencyNotes>
-    <ExportRestrictionsFound>{{ assessmentSummary.exportRestrictionsFound|trim }}</ExportRestrictionsFound>
-    <UsageRestrictionsFound>{{ assessmentSummary.usageRestrictionsFound|trim }}</UsageRestrictionsFound>
+    <CriticalFilesFound>{% if assessmentSummary.criticalFilesText is not empty %}<![CDATA[{{ assessmentSummary.criticalFilesText|trim }}]]>{% else %}{{ assessmentSummary.criticalFilesFound|trim }}{% endif %}</CriticalFilesFound>
+    <DependencyNotes>{% if assessmentSummary.dependencyNotesText is not empty %}<![CDATA[{{ assessmentSummary.dependencyNotesText|trim }}]]>{% else %}{{ assessmentSummary.dependencyNotes|trim }}{% endif %}</DependencyNotes>
+    <ExportRestrictionsFound>{% if assessmentSummary.exportRestrictionsText is not empty %}<![CDATA[{{ assessmentSummary.exportRestrictionsText|trim }}]]>{% else %}{{ assessmentSummary.exportRestrictionsFound|trim }}{% endif %}</ExportRestrictionsFound>
+    <UsageRestrictionsFound>{% if assessmentSummary.usageRestrictionsText is not empty %}<![CDATA[{{ assessmentSummary.usageRestrictionsText|trim }}]]>{% else %}{{ assessmentSummary.usageRestrictionsFound|trim }}{% endif %}</UsageRestrictionsFound>
     <AdditionalNotes><![CDATA[{{ assessmentSummary.additionalNotes|trim }}]]></AdditionalNotes>
   </AssessmentSummary>
 

--- a/src/unifiedreport/agent/reportStatic.php
+++ b/src/unifiedreport/agent/reportStatic.php
@@ -218,6 +218,11 @@ class ReportStatic
     $cell = $table->addCell($cellLen);
     $this->addCheckBoxText($cell, (array_key_exists(0,$getCheckboxList)) ? $getCheckboxList[0] : '', $nocriticalfiles);
     $this->addCheckBoxText($cell, (array_key_exists(1,$getCheckboxList)) ? $getCheckboxList[1] : '', $criticalfiles);
+    if ($otherStatement["ri_criticalnotes"] != 'NA' && !empty($otherStatement["ri_criticalnotes"])) {
+      $extraNotes = str_replace("\n", "</w:t>\n<w:br />\n<w:t xml:space=\"preserve\">", htmlspecialchars($otherStatement["ri_criticalnotes"], ENT_DISALLOWED));
+      $extraNotes = str_replace("\r", "", $extraNotes);
+      $cell->addText($extraNotes, $rightColStyleBlue, "pStyle");
+    }
 
     $nodependenciesfound = " no dependencies found, neither in source code nor in binaries";
     $dependenciesfoundinsourcecode = " dependencies found in source code (see obligations)";

--- a/src/www/ui/core-schema.dat
+++ b/src/www/ui/core-schema.dat
@@ -2412,6 +2412,10 @@
   $Schema["TABLE"]["report_info"]["ri_copyrightnotes"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_copyrightnotes\" text DEFAULT 'NA'::text";
   $Schema["TABLE"]["report_info"]["ri_copyrightnotes"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_copyrightnotes\" SET NOT NULL, ALTER COLUMN \"ri_copyrightnotes\" SET DEFAULT 'NA'::text";
 
+  $Schema["TABLE"]["report_info"]["ri_criticalnotes"]["DESC"] = "";
+  $Schema["TABLE"]["report_info"]["ri_criticalnotes"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_criticalnotes\" text DEFAULT 'NA'::text";
+  $Schema["TABLE"]["report_info"]["ri_criticalnotes"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_criticalnotes\" SET NOT NULL, ALTER COLUMN \"ri_criticalnotes\" SET DEFAULT 'NA'::text";
+
   $Schema["TABLE"]["report_info"]["ri_unifiedcolumns"]["DESC"] = "COMMENT ON COLUMN \"report_info\".\"ri_unifiedcolumns\" IS 'to edit unified report columns'";
   $Schema["TABLE"]["report_info"]["ri_unifiedcolumns"]["ADD"] = "ALTER TABLE \"report_info\" ADD COLUMN \"ri_unifiedcolumns\" json";
   $Schema["TABLE"]["report_info"]["ri_unifiedcolumns"]["ALTER"] = "ALTER TABLE \"report_info\" ALTER COLUMN \"ri_unifiedcolumns\" DROP NOT NULL";

--- a/src/www/ui/template/ui-report-conf.html.twig
+++ b/src/www/ui/template/ui-report-conf.html.twig
@@ -165,6 +165,7 @@
           <td align="left">
             <label><input type="radio" class="browse-upload-checkbox view-license-rc-size" name="critical" value="nonCritical" {{ nonCritical }} />{{ "no critical files found, source code and binaries can be used as is"|trans }}</label><br />
             <label><input type="radio" class="browse-upload-checkbox view-license-rc-size" name="critical" value="critical" {{ critical }} />{{ "critical files found, source code needs to be adapted and binaries possibly re-built"|trans }}</label>
+            <label><textarea {{ styleCriticalTA }} id="criticalFilesText" name="criticalFilesText">{{ criticalFilesText|e }}</textarea></label>
           </td>
         </tr>
         <tr>

--- a/src/www/ui/ui-report-conf.php
+++ b/src/www/ui/ui-report-conf.php
@@ -61,7 +61,8 @@ class ui_report_conf extends FO_Plugin
     "gaRisk" => "ri_ga_risk",
     "dependencyBinarySource" => "ri_depnotes",
     "exportRestrictionText" => "ri_exportnotes",
-    "copyrightRestrictionText" => "ri_copyrightnotes"
+    "copyrightRestrictionText" => "ri_copyrightnotes",
+    "criticalFilesText" => "ri_criticalnotes"
   );
 
   /**
@@ -152,9 +153,19 @@ class ui_report_conf extends FO_Plugin
     foreach ($this->mapDBColumns as $key => $value) {
       $vars[$key] = $row[$value];
     }
+    foreach (["dependencyBinarySource", "exportRestrictionText",
+      "copyrightRestrictionText", "criticalFilesText"] as $noteField) {
+      if ($vars[$noteField] == 'NA') {
+        $vars[$noteField] = '';
+      }
+    }
     $textAreaNoneStyle = ' style="display:none;overflow:auto;width:98%;height:80px;"';
     $textAreaStyle = ' style="overflow:auto;width:98%;height:80px;"';
     $vars['styleDependencyTA'] = $vars['styleExportTA'] = $vars['styleRestrictionTA'] = $textAreaStyle;
+    $vars['styleCriticalTA'] = $textAreaStyle;
+    if ($row['ri_criticalnotes'] == 'NA' || empty($row['ri_criticalnotes'])) {
+       $vars['styleCriticalTA'] = $textAreaNoneStyle;
+    }
     if ($row['ri_depnotes'] == 'NA' || empty($row['ri_depnotes'])) {
        $vars['styleDependencyTA'] = $textAreaNoneStyle;
     }
@@ -525,6 +536,15 @@ class ui_report_conf extends FO_Plugin
       if ($(\"#confTabs .ui-tabs-panel\").eq(activeIdx).attr('id') === 'acknowledgementsConfTab') {
         $('#reportConfSubmit').hide();
       }
+      $(\"input[name='critical']\").change(function(){
+        var val = $(\"input[name='critical']:checked\").val();
+        if (val == 'nonCritical') {
+          $('#criticalFilesText').hide();
+          $('#criticalFilesText').val('');
+        } else {
+          $('#criticalFilesText').css('display', 'block');
+        }
+      });
       $(\"input[name='dependencySourceBinary']\").change(function(){
         var val = $(\"input[name='dependencySourceBinary']:checked\").val();
         if (val == 'noDependency') {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Adds free-text notes to the report assessment summary and surfaces them in generated reports

### Changes

-  New `Source / binary integration notes` text area on the Report Configuration page (shown when critical files are found), stored in  `report_info.ri_criticalnotes` .
-  CLIXML  AssessmentSummary  now outputs the entered note text (dependency, export, usage, and critical) instead of the  None / Found  enum when text is provided.
-  DOCX unified report appends the critical-files note, matching the other fields.
-  Fixed the  NA  default leaking into the note text areas.

### How to test

1. Open a report's Conf page, select `critical files found` and enter notes; do the same for `dependency/export/usage.`
2. Generate the CLIXML report --> note text appears in the  AssessmentSummary .
3. Generate the DOCX report --> critical-files note appears.