### PR TITLE
feat(api): add OpenAPI v2 endpoint to rename an existing group

### DIFF
--- a/src/lib/php/Dao/UserDao.php
+++ b/src/lib/php/Dao/UserDao.php
@@ -471,9 +471,18 @@ class UserDao
   /**
    * @param int $groupId
    * @param string $newGroupName
+   * @throws \Exception if the name is already taken by another group
    */
   function editGroup($groupId, $newGroupName)
   {
+    $groupAlreadyExists = $this->dbManager->getSingleRow(
+            "SELECT group_pk FROM groups WHERE LOWER(group_name)=LOWER($1) AND group_pk!=$2",
+            array($newGroupName, $groupId),
+            __METHOD__.'.gExists');
+    if ($groupAlreadyExists) {
+      throw new \Exception(_("Group exists. Try different Name, Group-Name checking is case-insensitive and Duplicate not allowed"));
+    }
+
     $this->dbManager->getSingleRow('UPDATE groups SET group_name=$2 WHERE group_pk=$1;',
             array($groupId, $newGroupName),__METHOD__.'.UpdateEditGroup');
   }

--- a/src/www/ui/api/Controllers/GroupController.php
+++ b/src/www/ui/api/Controllers/GroupController.php
@@ -16,6 +16,7 @@ namespace Fossology\UI\Api\Controllers;
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Dao\UserDao;
 use Fossology\UI\Api\Exceptions\HttpBadRequestException;
+use Fossology\UI\Api\Exceptions\HttpConflictException;
 use Fossology\UI\Api\Exceptions\HttpErrorException;
 use Fossology\UI\Api\Exceptions\HttpForbiddenException;
 use Fossology\UI\Api\Exceptions\HttpNotFoundException;
@@ -128,6 +129,59 @@ class GroupController extends RestController
     } catch (\Exception $e) {
       throw new HttpBadRequestException($e->getMessage(), $e);
     }
+    return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+  }
+
+  /**
+   * Rename a given group
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpErrorException
+   */
+  public function updateGroup($request, $response, $args)
+  {
+    $apiVersion = ApiVersion::getVersion($request);
+    if (empty($args['pathParam'])) {
+      throw new HttpBadRequestException("ERROR - No group name or id provided");
+    }
+    $newGroupName = trim($this->getParsedBody($request)['name'] ?? '');
+    if (empty($newGroupName)) {
+      throw new HttpBadRequestException("ERROR - no group name provided");
+    }
+    /** @var \Fossology\UI\Page\AdminGroupEdit $adminGroupEdit */
+    $adminGroupEdit = $this->restHelper->getPlugin('group_edit');
+    $validationError = $adminGroupEdit->validateGroupName($newGroupName);
+    if (!empty($validationError)) {
+      throw new HttpBadRequestException($validationError);
+    }
+
+    /** @var UserDao $userDao */
+    $userDao = $this->restHelper->getUserDao();
+    $groupId = null;
+    if ($apiVersion == ApiVersion::V2) {
+      $groupId = intval($userDao->getGroupIdByName($args['pathParam']));
+    } else {
+      $groupId = intval($args['pathParam']);
+    }
+
+    if (!$this->dbHelper->doesIdExist("groups", "group_pk", $groupId)) {
+      throw new HttpNotFoundException("Group id not found!");
+    }
+    $groupMap = $userDao->getDeletableAdminGroupMap($this->restHelper->getUserId(),
+      $_SESSION[Auth::USER_LEVEL]);
+    if (!array_key_exists($groupId, $groupMap)) {
+      throw new HttpForbiddenException("Not admin of the group. " .
+        "Can not process request.");
+    }
+    try {
+      $userDao->editGroup($groupId, $newGroupName);
+    } catch (\Exception $e) {
+      throw new HttpConflictException($e->getMessage(), $e);
+    }
+    $returnVal = new Info(200, "Group $newGroupName updated.", InfoType::INFO);
     return $response->withJson($returnVal->getArray(), $returnVal->getCode());
   }
 

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -4056,6 +4056,61 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+    put:
+      operationId: updateGroupByName
+      tags:
+        - Organize
+        - Groups
+        - Admin
+      summary: Rename group by name
+      description: >
+        Renames a single group by name. Only an admin of the group can rename it.
+      requestBody:
+        description: New name of the group
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateGroup'
+      responses:
+        '200':
+          description: Group has been renamed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: No group name provided or the new name is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Not admin of the group
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Group not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '409':
+          description: Another group already uses the new name
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error with details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /groups/{name}/user/{userName}:
     parameters:
       - name: name
@@ -6950,6 +7005,18 @@ components:
         hash:
           type: string
           description: MD5 hash of obligation text
+    UpdateGroup:
+      description: Group rename options
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          description: New name of the group
+          type: string
+          nullable: false
+          example:
+            "Main group"
     AddMember:
       description: UserMember options
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -313,6 +313,7 @@ $app->group('/groups',
     $app->get('', GroupController::class . ':getGroups');
     $app->post('', GroupController::class . ':createGroup');
     $app->post("/{pathParam:$pattern}/user/{userPathParam:$pattern}", GroupController::class . ':addMember');
+    $app->put("/{pathParam:$pattern}", GroupController::class . ':updateGroup');
     $app->delete("/{pathParam:$pattern}", GroupController::class . ':deleteGroup');
     $app->delete("/{pathParam:$pattern}/user/{userPathParam:$pattern}", GroupController::class . ':deleteGroupMember');
     $app->get('/deletable', GroupController::class . ':getDeletableGroups');

--- a/src/www/ui_tests/api/Controllers/GroupControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/GroupControllerTest.php
@@ -19,6 +19,7 @@ use Fossology\Lib\Dao\UserDao;
 use Fossology\Lib\Db\DbManager;
 use Fossology\UI\Api\Controllers\GroupController;
 use Fossology\UI\Api\Exceptions\HttpBadRequestException;
+use Fossology\UI\Api\Exceptions\HttpConflictException;
 use Fossology\UI\Api\Exceptions\HttpForbiddenException;
 use Fossology\UI\Api\Exceptions\HttpNotFoundException;
 use Fossology\UI\Api\Helper\DbHelper;
@@ -74,6 +75,12 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
   private $adminPlugin;
 
   /**
+   * @var M\MockInterface $adminEditPlugin
+   * AdminGroupEdit plugin mock
+   */
+  private $adminEditPlugin;
+
+  /**
    * @brief Setup test objects
    * @see PHPUnit_Framework_TestCase::setUp()
    */
@@ -85,6 +92,7 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $this->restHelper = M::mock(RestHelper::class);
     $this->userDao = M::mock(UserDao::class);
     $this->adminPlugin = M::mock('AdminGroupUsers');
+    $this->adminEditPlugin = M::mock('AdminGroupEdit');
 
     $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
     $this->restHelper->shouldReceive('getUserDao')
@@ -92,6 +100,9 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
 
     $this->restHelper->shouldReceive('getPlugin')
       ->withArgs(array('group_manage_users'))->andReturn($this->adminPlugin);
+
+    $this->restHelper->shouldReceive('getPlugin')
+      ->withArgs(array('group_edit'))->andReturn($this->adminEditPlugin);
 
     $container->shouldReceive('get')->withArgs(array(
       'helper.restHelper'))->andReturn($this->restHelper);
@@ -283,6 +294,205 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $this->assertEquals($this->getResponseJson($expectedResponse),
       $this->getResponseJson($actualResponse));
   }
+  /**
+   * @test
+   * -# Test GroupController::updateGroup() for valid rename request in version 1
+   * -# Check if response status is 200
+   */
+  public function testUpdateGroupV1()
+  {
+    $this->testUpdateGroup(ApiVersion::V1);
+  }
+  /**
+   * @test
+   * -# Test GroupController::updateGroup() for valid rename request in version 2
+   * -# Check if response status is 200
+   */
+  public function testUpdateGroupV2()
+  {
+    $this->testUpdateGroup();
+  }
+  /**
+   * @param $version
+   * @return void
+   */
+  private function testUpdateGroup($version = ApiVersion::V2)
+  {
+    $groupId = 4;
+    $groupName = 'fossyGroup';
+    $newGroupName = 'newFossyGroup';
+    $userId = 1;
+
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    if ($version == ApiVersion::V2) {
+      $this->userDao->shouldReceive('getGroupIdByName')
+        ->withArgs([$groupName])->andReturn($groupId);
+    }
+    $this->adminEditPlugin->shouldReceive('validateGroupName')
+      ->withArgs([$newGroupName])->andReturn("");
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
+    $this->userDao->shouldReceive('getDeletableAdminGroupMap')
+      ->withArgs([$userId, $_SESSION[Auth::USER_LEVEL]])
+      ->andReturn([$groupId => $groupName]);
+    $this->userDao->shouldReceive('editGroup')
+      ->withArgs([$groupId, $newGroupName]);
+
+    $request = $this->getUpdateGroupRequest($newGroupName, $version);
+    $pathParam = $version == ApiVersion::V2 ? $groupName : $groupId;
+
+    $expectedResponse = new Info(200, "Group $newGroupName updated.",
+      InfoType::INFO);
+    $actualResponse = $this->groupController->updateGroup($request,
+      new ResponseHelper(), ['pathParam' => $pathParam]);
+
+    $this->assertEquals($expectedResponse->getCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse->getArray(),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test GroupController::updateGroup() with an empty new group name
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testUpdateGroupNoNameProvidedV2()
+  {
+    $request = $this->getUpdateGroupRequest("  ");
+
+    $this->expectException(HttpBadRequestException::class);
+    $this->groupController->updateGroup($request, new ResponseHelper(),
+      ['pathParam' => 'fossyGroup']);
+  }
+
+  /**
+   * @test
+   * -# Test GroupController::updateGroup() with an invalid new group name
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testUpdateGroupInvalidNameV2()
+  {
+    $newGroupName = '123';
+    $this->adminEditPlugin->shouldReceive('validateGroupName')
+      ->withArgs([$newGroupName])
+      ->andReturn("Invalid: Group name cannot be numeric-only");
+
+    $request = $this->getUpdateGroupRequest($newGroupName);
+
+    $this->expectException(HttpBadRequestException::class);
+    $this->groupController->updateGroup($request, new ResponseHelper(),
+      ['pathParam' => 'fossyGroup']);
+  }
+
+  /**
+   * @test
+   * -# Test GroupController::updateGroup() for a group which does not exist
+   * -# Check if HttpNotFoundException is thrown
+   */
+  public function testUpdateGroupNotFoundV2()
+  {
+    $groupName = 'fossyGroup';
+    $newGroupName = 'newFossyGroup';
+
+    $this->userDao->shouldReceive('getGroupIdByName')
+      ->withArgs([$groupName])->andReturn(null);
+    $this->adminEditPlugin->shouldReceive('validateGroupName')
+      ->withArgs([$newGroupName])->andReturn("");
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["groups", "group_pk", 0])->andReturn(false);
+
+    $request = $this->getUpdateGroupRequest($newGroupName);
+
+    $this->expectException(HttpNotFoundException::class);
+    $this->groupController->updateGroup($request, new ResponseHelper(),
+      ['pathParam' => $groupName]);
+  }
+
+  /**
+   * @test
+   * -# Test GroupController::updateGroup() when the user is not admin of the group
+   * -# Check if HttpForbiddenException is thrown
+   */
+  public function testUpdateGroupNotGroupAdminV2()
+  {
+    $groupId = 4;
+    $groupName = 'fossyGroup';
+    $newGroupName = 'newFossyGroup';
+    $userId = 1;
+
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->userDao->shouldReceive('getGroupIdByName')
+      ->withArgs([$groupName])->andReturn($groupId);
+    $this->adminEditPlugin->shouldReceive('validateGroupName')
+      ->withArgs([$newGroupName])->andReturn("");
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
+    $this->userDao->shouldReceive('getDeletableAdminGroupMap')
+      ->withArgs([$userId, $_SESSION[Auth::USER_LEVEL]])->andReturn([]);
+
+    $request = $this->getUpdateGroupRequest($newGroupName);
+
+    $this->expectException(HttpForbiddenException::class);
+    $this->groupController->updateGroup($request, new ResponseHelper(),
+      ['pathParam' => $groupName]);
+  }
+
+  /**
+   * @test
+   * -# Test GroupController::updateGroup() when the new name is already taken
+   * -# Check if HttpConflictException is thrown
+   */
+  public function testUpdateGroupNameAlreadyExistsV2()
+  {
+    $groupId = 4;
+    $groupName = 'fossyGroup';
+    $newGroupName = 'newFossyGroup';
+    $userId = 1;
+
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->userDao->shouldReceive('getGroupIdByName')
+      ->withArgs([$groupName])->andReturn($groupId);
+    $this->adminEditPlugin->shouldReceive('validateGroupName')
+      ->withArgs([$newGroupName])->andReturn("");
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
+    $this->userDao->shouldReceive('getDeletableAdminGroupMap')
+      ->withArgs([$userId, $_SESSION[Auth::USER_LEVEL]])
+      ->andReturn([$groupId => $groupName]);
+    $this->userDao->shouldReceive('editGroup')
+      ->withArgs([$groupId, $newGroupName])
+      ->andThrow(new \Exception("Group exists."));
+
+    $request = $this->getUpdateGroupRequest($newGroupName);
+
+    $this->expectException(HttpConflictException::class);
+    $this->groupController->updateGroup($request, new ResponseHelper(),
+      ['pathParam' => $groupName]);
+  }
+
+  /**
+   * Create a rename request for the given group name
+   * @param string $newGroupName New name of the group
+   * @param int $version API version
+   * @return Request
+   */
+  private function getUpdateGroupRequest($newGroupName,
+    $version = ApiVersion::V2)
+  {
+    $body = $this->streamFactory->createStream(json_encode([
+      "name" => $newGroupName
+    ]));
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    $request = new Request("PUT", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+    return $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, $version);
+  }
+
   /**
    * @test
    * -# Test GroupController::getDeletableGroups() for version 1


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

FOSSologyUI's Admin → Groups → Edit Group page can't be implemented because OpenAPI v2 has no endpoint for renaming a group. The legacy PHP UI has had this (`AdminGroupEdit`) for a long time, so this just exposes the same capability over REST.

Adds `PUT /groups/{name}` (v2) / `PUT /groups/{id}` (v1), following the existing convention where v2 addresses groups by name and v1 by id.

Closes fossology/FOSSologyUI#422

### Changes

- Added `GroupController::updateGroup()` and registered the `PUT` route in `index.php`. Request body is `{"name": "<new name>"}`.
- Name validation reuses `AdminGroupEdit::validateGroupName()` via the plugin instead of duplicating the regex, so the API and the old UI stay in sync.
- Permission check uses `getDeletableAdminGroupMap()`, which is the same set the legacy Edit Group page uses. Personal groups (group name == user name) are excluded, as before.
- `UserDao::editGroup()` had no validation at all, so renaming a group onto an existing name silently created a duplicate. It now does the same case-insensitive uniqueness check `addGroup()` does and throws. The legacy page already catches and displays that exception, so it benefits too.
- Documented the endpoint and an `UpdateGroup` schema in `openapiv2.yaml`.
- Added 7 unit tests to `GroupControllerTest` (v1/v2 success, empty name, invalid name, not found, not group admin, name conflict).

Status codes: 200 on success, 400 for a missing/invalid name, 403 if the caller isn't an admin of the group, 404 if the group doesn't exist, 409 if another group already has that name.

## How to test

Get a token:

```bash
curl -s -X POST http://localhost/repo/api/v2/tokens \
  -H "Content-Type: application/json" \
  -d '{"username":"fossy","password":"fossy","tokenName":"test","tokenScope":"write","tokenExpire":"2026-09-01"}'
```

Create a group and rename it:

```bash
curl -s -X POST "http://localhost/repo/api/v2/groups?name=alpha" -H "Authorization: Bearer <token>"

curl -s -X PUT http://localhost/repo/api/v2/groups/alpha \
  -H "Authorization: Bearer <token>" -H "Content-Type: application/json" \
  -d '{"name":"beta"}'
```

Expect `200 {"code":200,"message":"Group beta updated.","type":"INFO"}`, and `GET /groups` should show the new name.

Error cases worth checking:

- `{"name":"  "}` or `{}` → 400
- `{"name":"12345"}` → 400 (numeric-only)
- `{"name":"bad$name!"}` → 400 (invalid characters)
- renaming a second group onto `beta`, or onto `BETA` → 409
- renaming a group to its own name → 200, should not be treated as a conflict
- `PUT /groups/doesNotExist` → 404
- `PUT /groups/fossy` (personal group) → 403

Unit tests:

```bash
phpunit -c src/phpunit.xml --filter GroupControllerTest
```
