### PR TITLE
Feat/group rename api v2

### DIFF
--- a/src/www/ui/api/Controllers/GroupController.php
+++ b/src/www/ui/api/Controllers/GroupController.php
@@ -189,6 +189,86 @@ class GroupController extends RestController
   }
 
   /**
+   * Rename an existing group
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpErrorException
+   */
+  public function updateGroup($request, $response, $args)
+  {
+    if (empty($args['pathParam'])) {
+      throw new HttpBadRequestException("ERROR - No group name or id provided");
+    }
+    $userId = $this->restHelper->getUserId();
+
+    /** @var UserDao $userDao */
+    $userDao = $this->restHelper->getUserDao();
+    $groupMap = $userDao->getDeletableAdminGroupMap($userId,
+      $_SESSION[Auth::USER_LEVEL]);
+
+    $apiVersion = ApiVersion::getVersion($request);
+    if ($apiVersion == ApiVersion::V2) {
+      $groupId = intval($userDao->getGroupIdByName($args['pathParam']));
+    } else {
+      $groupId = intval($args['pathParam']);
+    }
+
+    if (!$this->dbHelper->doesIdExist("groups", "group_pk", $groupId)) {
+      throw new HttpNotFoundException("Group id not found!");
+    }
+    if (!array_key_exists($groupId, $groupMap)) {
+      throw new HttpForbiddenException("Not admin of the group. " .
+        "Can not process request.");
+    }
+
+    $body = $this->getParsedBody($request);
+    $newGroupName = (isset($body['name']) && is_string($body['name'])) ? trim($body['name']) : '';
+
+    $validationError = $this->validateGroupName($newGroupName);
+    if (!empty($validationError)) {
+      throw new HttpBadRequestException($validationError);
+    }
+
+    $dbManager = $this->dbHelper->getDbManager();
+    $duplicateGroup = $dbManager->getSingleRow(
+      "SELECT group_pk FROM groups WHERE LOWER(group_name)=LOWER($1) AND group_pk != $2",
+      [$newGroupName, $groupId], __METHOD__ . ".groupNameExists");
+    if (!empty($duplicateGroup)) {
+      throw new HttpBadRequestException("Group exists. Try different Name, " .
+        "Group-Name checking is case-insensitive and Duplicate not allowed");
+    }
+
+    try {
+      $userDao->editGroup($groupId, $newGroupName);
+    } catch (\Exception $e) {
+      throw new HttpBadRequestException($e->getMessage(), $e);
+    }
+    $returnVal = new Info(200, "Group renamed to $newGroupName.", InfoType::INFO);
+    return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+  }
+
+  /**
+   * Validate a group name
+   *
+   * @param string $groupName
+   * @return string Empty string if valid, error message otherwise
+   */
+  private function validateGroupName($groupName)
+  {
+    if (empty($groupName)) {
+      return "Invalid: Group name cannot be whitespace only";
+    } elseif (preg_match('/^[\s\w_-]+$/', $groupName) !== 1) {
+      return "Invalid: Group name can only contain letters, numbers, hyphens and underscores";
+    } elseif (is_numeric($groupName)) {
+      return "Invalid: Group name cannot be numeric-only";
+    }
+    return "";
+  }
+
+  /**
    * Get a list of groups that can be deleted
    *
    * @param ServerRequestInterface $request

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -6344,6 +6344,8 @@ components:
     GroupRename:
       description: New name for an existing group
       type: object
+      required:
+        - name
       properties:
         name:
           description: New name for the group

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -4056,6 +4056,48 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+    patch:
+      operationId: updateGroupByName
+      tags:
+        - Groups
+        - Admin
+      summary: Rename a group
+      description: >
+        Rename an existing group. Only group admins can rename a group.
+      requestBody:
+        description: New name for the group
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupRename'
+      responses:
+        '200':
+          description: Group has been renamed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Invalid group name, or a group with that name already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Not an admin of the group
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Group not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /groups/{name}/user/{userName}:
     parameters:
       - name: name
@@ -6299,6 +6341,15 @@ components:
           type: string
           example:
             "Main group"
+    GroupRename:
+      description: New name for an existing group
+      type: object
+      properties:
+        name:
+          description: New name for the group
+          type: string
+          example:
+            "Renamed group"
     GetPrevNextItem:
       type: object
       properties:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -318,6 +318,7 @@ $app->group('/groups',
     $app->get('/deletable', GroupController::class . ':getDeletableGroups');
     $app->get("/{pathParam:$pattern}/members", GroupController::class . ':getGroupMembers');
     $app->put("/{pathParam:$pattern}/user/{userPathParam:$pattern}", GroupController::class . ':changeUserPermission');
+    $app->patch("/{pathParam:$pattern}", GroupController::class . ':updateGroup');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui_tests/api/Controllers/GroupControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/GroupControllerTest.php
@@ -824,4 +824,234 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $this->groupController->changeUserPermission($request,
       new ResponseHelper(), ['pathParam' => $groupId, 'userPathParam' => $userId]);
   }
+
+  /**
+   * @test
+   * -# Test GroupController::updateGroup() for valid rename request in version 1
+   * -# Check if response status is 200
+   */
+  public function testUpdateGroupV1()
+  {
+    $this->testUpdateGroup(ApiVersion::V1);
+  }
+  /**
+   * @test
+   * -# Test GroupController::updateGroup() for valid rename request in version 2
+   * -# Check if response status is 200
+   */
+  public function testUpdateGroupV2()
+  {
+    $this->testUpdateGroup();
+  }
+  /**
+   * @param $version
+   * @return void
+   */
+  private function testUpdateGroup($version = ApiVersion::V2)
+  {
+    $groupId = 4;
+    $userId = 1;
+    $oldGroupName = 'oldGroup';
+    $newGroupName = 'newGroup';
+    $pathParam = $version == ApiVersion::V2 ? $oldGroupName : $groupId;
+
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->userDao->shouldReceive('getDeletableAdminGroupMap')
+      ->withArgs([$userId, $_SESSION[Auth::USER_LEVEL]])
+      ->andReturn([$groupId => $oldGroupName]);
+    if ($version == ApiVersion::V2) {
+      $this->userDao->shouldReceive('getGroupIdByName')
+        ->withArgs([$oldGroupName])->andReturn($groupId);
+    }
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs([M::any(), [$newGroupName, $groupId], M::any()])
+      ->andReturn(false);
+    $this->userDao->shouldReceive('editGroup')->withArgs([$groupId, $newGroupName]);
+
+    $body = $this->streamFactory->createStream(json_encode([
+      "name" => $newGroupName
+    ]));
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    $request = new Request("PATCH", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+    $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, $version);
+
+    $expectedResponse = new Info(200, "Group renamed to $newGroupName.", InfoType::INFO);
+
+    $actualResponse = $this->groupController->updateGroup($request, new ResponseHelper(),
+      ['pathParam' => $pathParam]);
+
+    $this->assertEquals($expectedResponse->getCode(), $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse->getArray(), $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test GroupController::updateGroup() when user is not admin of the group
+   * -# Check if HttpForbiddenException is thrown
+   */
+  public function testUpdateGroupNotAdminV2()
+  {
+    $groupId = 4;
+    $userId = 1;
+    $groupName = 'someGroup';
+    $newGroupName = 'newGroup';
+
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->userDao->shouldReceive('getDeletableAdminGroupMap')
+      ->withArgs([$userId, $_SESSION[Auth::USER_LEVEL]])->andReturn([]);
+    $this->userDao->shouldReceive('getGroupIdByName')
+      ->withArgs([$groupName])->andReturn($groupId);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
+
+    $body = $this->streamFactory->createStream(json_encode(["name" => $newGroupName]));
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    $request = new Request("PATCH", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+    $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, ApiVersion::V2);
+
+    $this->expectException(HttpForbiddenException::class);
+    $this->groupController->updateGroup($request, new ResponseHelper(),
+      ['pathParam' => $groupName]);
+  }
+
+  /**
+   * @test
+   * -# Test GroupController::updateGroup() when group does not exist
+   * -# Check if HttpNotFoundException is thrown
+   */
+  public function testUpdateGroupNotFoundV2()
+  {
+    $groupId = 4;
+    $userId = 1;
+    $groupName = 'someGroup';
+    $newGroupName = 'newGroup';
+
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->userDao->shouldReceive('getDeletableAdminGroupMap')
+      ->withArgs([$userId, $_SESSION[Auth::USER_LEVEL]])->andReturn([]);
+    $this->userDao->shouldReceive('getGroupIdByName')
+      ->withArgs([$groupName])->andReturn($groupId);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["groups", "group_pk", $groupId])->andReturn(false);
+
+    $body = $this->streamFactory->createStream(json_encode(["name" => $newGroupName]));
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    $request = new Request("PATCH", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+    $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, ApiVersion::V2);
+
+    $this->expectException(HttpNotFoundException::class);
+    $this->groupController->updateGroup($request, new ResponseHelper(),
+      ['pathParam' => $groupName]);
+  }
+
+  /**
+   * @test
+   * -# Test GroupController::updateGroup() with invalid (numeric only) group name
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testUpdateGroupInvalidNameV2()
+  {
+    $groupId = 4;
+    $userId = 1;
+    $groupName = 'someGroup';
+
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->userDao->shouldReceive('getDeletableAdminGroupMap')
+      ->withArgs([$userId, $_SESSION[Auth::USER_LEVEL]])->andReturn([$groupId => $groupName]);
+    $this->userDao->shouldReceive('getGroupIdByName')
+      ->withArgs([$groupName])->andReturn($groupId);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
+
+    $body = $this->streamFactory->createStream(json_encode(["name" => "12345"]));
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    $request = new Request("PATCH", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+    $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, ApiVersion::V2);
+
+    $this->expectException(HttpBadRequestException::class);
+    $this->groupController->updateGroup($request, new ResponseHelper(),
+      ['pathParam' => $groupName]);
+  }
+
+  /**
+   * @test
+   * -# Test GroupController::updateGroup() when "name" in the request body is not a string
+   * -# Check if HttpBadRequestException is thrown instead of a TypeError
+   */
+  public function testUpdateGroupNonStringNameV2()
+  {
+    $groupId = 4;
+    $userId = 1;
+    $groupName = 'someGroup';
+
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->userDao->shouldReceive('getDeletableAdminGroupMap')
+      ->withArgs([$userId, $_SESSION[Auth::USER_LEVEL]])->andReturn([$groupId => $groupName]);
+    $this->userDao->shouldReceive('getGroupIdByName')
+      ->withArgs([$groupName])->andReturn($groupId);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
+
+    $body = $this->streamFactory->createStream(json_encode(["name" => ["a", "b"]]));
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    $request = new Request("PATCH", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+    $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, ApiVersion::V2);
+
+    $this->expectException(HttpBadRequestException::class);
+    $this->groupController->updateGroup($request, new ResponseHelper(),
+      ['pathParam' => $groupName]);
+  }
+
+  /**
+   * @test
+   * -# Test GroupController::updateGroup() when a group with the new name already exists
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testUpdateGroupDuplicateNameV2()
+  {
+    $groupId = 4;
+    $userId = 1;
+    $groupName = 'someGroup';
+    $newGroupName = 'existingGroup';
+
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->userDao->shouldReceive('getDeletableAdminGroupMap')
+      ->withArgs([$userId, $_SESSION[Auth::USER_LEVEL]])->andReturn([$groupId => $groupName]);
+    $this->userDao->shouldReceive('getGroupIdByName')
+      ->withArgs([$groupName])->andReturn($groupId);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs([M::any(), [$newGroupName, $groupId], M::any()])
+      ->andReturn(['group_pk' => 9]);
+
+    $body = $this->streamFactory->createStream(json_encode(["name" => $newGroupName]));
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    $request = new Request("PATCH", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+    $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, ApiVersion::V2);
+
+    $this->expectException(HttpBadRequestException::class);
+    $this->groupController->updateGroup($request, new ResponseHelper(),
+      ['pathParam' => $groupName]);
+  }
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Adds a `PATCH` endpoint to rename an existing group. The legacy PHP UI has
an Edit Group page (`AdminGroupEdit`) for this, but OpenAPI v2 had no
corresponding REST endpoint, which was blocking the React/Next.js UI
migration from implementing Admin → Groups → Edit Group.

### Changes

- Add `GroupController::updateGroup()`, wired to `PATCH /groups/{name}`
  (v2) and `PATCH /groups/{id}` (v1).
- Reuse `UserDao::editGroup()` for the actual rename, the same
  group-admin authorization check (`getDeletableAdminGroupMap`) and
  name-validation rules (letters/digits/hyphen/underscore only,
  non-numeric) already used by the legacy Edit Group page, plus
  case-insensitive duplicate-name checking matching `addGroup()`'s
  behavior.
- Document the new endpoint and `GroupRename` request schema in
  `openapiv2.yaml`.
- Add `GroupControllerTest` coverage: successful rename (v1 & v2),
  not-admin (403), group-not-found (404), invalid name (400), and
  duplicate name (400).

## How to test

1. As a group admin, send:
PATCH /api/v2/groups/{groupName}
Content-Type: application/json

{"name": "New Group Name"}


Expect `200` with an `Info` body confirming the rename.
2. Verify error handling:
- Unknown group → `404`
- Not an admin of that group → `403`
- Invalid name (empty, numeric-only, or containing characters outside
  `[\s\w-]`) → `400`
- Name already used by another group (case-insensitive) → `400`
3. Run the unit tests:
phpunit --filter GroupControllerTest src/www/ui_tests/api/Controllers/GroupControllerTest.php



Closes fossology/FOSSologyUI#422