### PR TITLE
Feat/424 license marydone export api v2

### DIFF
--- a/src/www/ui/api/Controllers/LicenseController.php
+++ b/src/www/ui/api/Controllers/LicenseController.php
@@ -848,7 +848,7 @@ class LicenseController extends RestController
   }
 
   /**
-   * Export licenses to CSV file
+   * Export all licenses (main + candidates) to CSV file
    *
    * @param Request $request
    * @param ResponseHelper $response
@@ -858,34 +858,11 @@ class LicenseController extends RestController
    */
   public function exportAdminLicenseToCSV($request, $response, $args)
   {
-    $this->throwNotAdminException();
-    $query = $request->getQueryParams();
-    $rf = 0;
-    if (array_key_exists('id', $query)) {
-      $rf = intval($query['id']);
-    }
-    if ($rf != 0 &&
-        (! $this->dbHelper->doesIdExist("license_ref", "rf_pk", $rf) &&
-         ! $this->dbHelper->doesIdExist("license_candidate", "rf_pk", $rf))) {
-      throw new HttpNotFoundException("License not found.");
-    }
-    $dbManager = $this->dbHelper->getDbManager();
-    $licenseCsvExport = new LicenseCsvExport($dbManager);
-    $content = $licenseCsvExport->createCsv($rf);
-    $fileName = "fossology-license-export-" . date("YMj-Gis");
-    $newResponse = $response->withHeader('Content-type', 'text/csv, charset=UTF-8')
-      ->withHeader('Content-Disposition', 'attachment; filename=' . $fileName . '.csv')
-      ->withHeader('Pragma', 'no-cache')
-      ->withHeader('Cache-Control', 'no-cache, must-revalidate, maxage=1, post-check=0, pre-check=0')
-      ->withHeader('Expires', 'Expires: Thu, 19 Nov 1981 08:52:00 GMT');
-    $sf = new StreamFactory();
-    return $newResponse->withBody(
-      $content ? $sf->createStream($content) : $sf->createStream('')
-    );
+    return $this->exportLicenseFile($request, $response, false, false);
   }
 
   /**
-   * Export licenses to JSON file
+   * Export all licenses (main + candidates) to JSON file
    *
    * @param Request $request
    * @param ResponseHelper $response
@@ -894,6 +871,52 @@ class LicenseController extends RestController
    * @throws HttpErrorException
    */
   public function exportAdminLicenseToJSON($request, $response, $args)
+  {
+    return $this->exportLicenseFile($request, $response, true, false);
+  }
+
+  /**
+   * Export only marydone (approved merge-request) candidate licenses to CSV
+   * file
+   *
+   * @param Request $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpErrorException
+   */
+  public function exportAdminLicenseMarydoneToCSV($request, $response, $args)
+  {
+    return $this->exportLicenseFile($request, $response, false, true);
+  }
+
+  /**
+   * Export only marydone (approved merge-request) candidate licenses to
+   * JSON file
+   *
+   * @param Request $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpErrorException
+   */
+  public function exportAdminLicenseMarydoneToJSON($request, $response, $args)
+  {
+    return $this->exportLicenseFile($request, $response, true, true);
+  }
+
+  /**
+   * Build the CSV/JSON license export response.
+   *
+   * @param Request $request
+   * @param ResponseHelper $response
+   * @param boolean $asJson       Export as JSON instead of CSV
+   * @param boolean $marydoneOnly Restrict export to marydone candidate
+   *                              licenses instead of all licenses
+   * @return ResponseHelper
+   * @throws HttpErrorException
+   */
+  private function exportLicenseFile($request, $response, $asJson, $marydoneOnly)
   {
     $this->throwNotAdminException();
     $query = $request->getQueryParams();
@@ -908,10 +931,15 @@ class LicenseController extends RestController
     }
     $dbManager = $this->dbHelper->getDbManager();
     $licenseCsvExport = new LicenseCsvExport($dbManager);
-    $content = $licenseCsvExport->createCsv($rf, false, true);
-    $fileName = "fossology-license-export-" . date("YMj-Gis");
-    $newResponse = $response->withHeader('Content-type', 'text/json, charset=UTF-8')
-      ->withHeader('Content-Disposition', 'attachment; filename=' . $fileName . '.json')
+    $content = $licenseCsvExport->createCsv($rf, ! $marydoneOnly, $asJson);
+
+    $suffix = $marydoneOnly ? "-marydone" : "";
+    $extension = $asJson ? "json" : "csv";
+    $contentType = $asJson ? "text/json, charset=UTF-8" : "text/csv, charset=UTF-8";
+    $fileName = "fossology-license-export" . $suffix . "-" . date("YMj-Gis");
+
+    $newResponse = $response->withHeader('Content-type', $contentType)
+      ->withHeader('Content-Disposition', 'attachment; filename=' . $fileName . '.' . $extension)
       ->withHeader('Pragma', 'no-cache')
       ->withHeader('Cache-Control', 'no-cache, must-revalidate, maxage=1, post-check=0, pre-check=0')
       ->withHeader('Expires', 'Expires: Thu, 19 Nov 1981 08:52:00 GMT');

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -4745,6 +4745,45 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+  /license/import-json:
+    post:
+      operationId: importLicenseJson
+      tags:
+        - License
+      summary: Import a JSON license
+      description: >
+        Import a JSON license file to the database. Shares the same
+        handler as /license/import-csv; the file extension of fileInput
+        determines whether it is parsed as CSV or JSON.
+      requestBody:
+        description: License JSON file to import.
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                fileInput:
+                  type: string
+                  format: binary
+                  description: JSON file to be imported
+              required:
+                - fileInput
+      responses:
+        '400':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '200':
+          description: Successfully imported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
   /license/export-csv:
     get:
       operationId: exportLicense
@@ -4757,14 +4796,113 @@ paths:
             type: integer
       tags:
         - License
-      summary: Export a csv license
+      summary: Export all licenses as CSV
       description: >
-        Export a csv license
+        Export all licenses, including candidates from every group, as a
+        csv file. Use /license/marydone/export-csv to export only
+        marydone (approved merge-request) candidate licenses.
       responses:
         '200':
           description: Successfully exported
           content:
             text/csv:
+              schema:
+                type: string
+                format: binary
+        '403':
+          description: Route is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /license/export-json:
+    get:
+      operationId: exportLicenseJson
+      parameters:
+        - name: id
+          description: License id to export, 0 for all
+          in: query
+          required: false
+          schema:
+            type: integer
+      tags:
+        - License
+      summary: Export all licenses as JSON
+      description: >
+        Export all licenses, including candidates from every group, as a
+        JSON file. Use /license/marydone/export-json to export only
+        marydone (approved merge-request) candidate licenses.
+      responses:
+        '200':
+          description: Successfully exported
+          content:
+            text/json:
+              schema:
+                type: string
+                format: binary
+        '403':
+          description: Route is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /license/marydone/export-csv:
+    get:
+      operationId: exportLicenseMarydoneCsv
+      parameters:
+        - name: id
+          description: License id to export, 0 for all marydone candidates
+          in: query
+          required: false
+          schema:
+            type: integer
+      tags:
+        - License
+      summary: Export marydone candidate licenses as CSV
+      description: >
+        Export only marydone (approved merge-request) candidate licenses
+        as a csv file. Use /license/export-csv to export all licenses.
+      responses:
+        '200':
+          description: Successfully exported
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+        '403':
+          description: Route is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /license/marydone/export-json:
+    get:
+      operationId: exportLicenseMarydoneJson
+      parameters:
+        - name: id
+          description: License id to export, 0 for all marydone candidates
+          in: query
+          required: false
+          schema:
+            type: integer
+      tags:
+        - License
+      summary: Export marydone candidate licenses as JSON
+      description: >
+        Export only marydone (approved merge-request) candidate licenses
+        as a JSON file. Use /license/export-json to export all licenses.
+      responses:
+        '200':
+          description: Successfully exported
+          content:
+            text/json:
               schema:
                 type: string
                 format: binary
@@ -4785,7 +4923,10 @@ paths:
         - Admin
       summary: Export bulk scan text as CSV or JSON
       description: >
-        Export bulk scan text entries from license_ref_bulk.
+        Export bulk scan text entries from license_ref_bulk. This is
+        unrelated to the /license/export-csv, /license/export-json and
+        /license/marydone/export-* endpoints, which export license
+        definitions rather than bulk scan text/replacement rules.
         Defaults are format=json and filter=all.
       parameters:
         - name: format

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -417,6 +417,8 @@ $app->group('/license',
     $app->get('/export-csv', LicenseController::class . ':exportAdminLicenseToCSV');
     $app->post('/import-json', LicenseController::class . ':handleImportLicense');
     $app->get('/export-json', LicenseController::class . ':exportAdminLicenseToJSON');
+    $app->get('/marydone/export-csv', LicenseController::class . ':exportAdminLicenseMarydoneToCSV');
+    $app->get('/marydone/export-json', LicenseController::class . ':exportAdminLicenseMarydoneToJSON');
     $app->get('/bulk-text/export', LicenseController::class . ':exportBulkText');
     $app->post('', LicenseController::class . ':createLicense');
     $app->put('/verify/{shortname:.+}', LicenseController::class . ':verifyLicense');

--- a/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
@@ -1656,6 +1656,155 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
   }
 
   /**
+   *  -# Test for LicenseController::exportAdminLicenseToCSV() to confirm it
+   *     exports all licenses, not only marydone candidates.
+   * @return void
+   * @throws \Fossology\UI\Api\Exceptions\HttpErrorException
+   */
+  public function testExportAdminLicenseToCSVExportsAllLicenses()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->dbManager->shouldReceive('prepare')
+      ->withArgs(function ($stmt, $sql) {
+        return strpos($sql, 'WHERE marydone = true') === false;
+      })->once();
+    $this->dbManager->shouldReceive('fetchAll')->andReturn([]);
+    $this->dbManager->shouldReceive('freeResult')->andReturn([]);
+    $this->dbManager->shouldReceive('execute');
+
+    $request = $this->getRequestWithQueryParams('GET', []);
+    $actualResponse = $this->licenseController->exportAdminLicenseToCSV(
+      $request, new ResponseHelper(), []);
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+    $this->assertStringNotContainsString('marydone',
+      $actualResponse->getHeaderLine('Content-Disposition'));
+  }
+
+  /**
+   *  -# Test for LicenseController::exportAdminLicenseToJSON() to export
+   *     license to JSON.
+   *  -# Check if the status code is 200
+   * @return void
+   * @throws \Fossology\UI\Api\Exceptions\HttpErrorException
+   */
+  public function testExportAdminLicenseToJSON()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->dbManager->shouldReceive('prepare');
+    $this->dbManager->shouldReceive('fetchAll')->andReturn([]);
+    $this->dbManager->shouldReceive('freeResult')->andReturn([]);
+    $this->dbManager->shouldReceive('execute');
+
+    $request = $this->getRequestWithQueryParams('GET', []);
+    $actualResponse = $this->licenseController->exportAdminLicenseToJSON(
+      $request, new ResponseHelper(), []);
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+    $this->assertStringContainsString('json',
+      $actualResponse->getHeaderLine('Content-type'));
+    $this->assertStringNotContainsString('marydone',
+      $actualResponse->getHeaderLine('Content-Disposition'));
+  }
+
+  /**
+   *  -# Test for LicenseController::exportAdminLicenseToJSON()
+   *  -# Check if the status code is 403 with HttpForbiddenException
+   * @return void
+   * @throws \Fossology\UI\Api\Exceptions\HttpErrorException
+   */
+  public function testExportAdminLicenseToJSONNotAdmin()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $request = $this->getEmptyRequest("GET");
+    $this->expectException(HttpForbiddenException::class);
+    $this->licenseController->exportAdminLicenseToJSON($request,
+      new ResponseHelper(), []);
+  }
+
+  /**
+   *  -# Test for LicenseController::exportAdminLicenseMarydoneToCSV() to
+   *     confirm it filters to marydone candidates only.
+   * @return void
+   * @throws \Fossology\UI\Api\Exceptions\HttpErrorException
+   */
+  public function testExportAdminLicenseMarydoneToCSV()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->dbManager->shouldReceive('prepare')
+      ->withArgs(function ($stmt, $sql) {
+        return strpos($sql, 'WHERE marydone = true') !== false;
+      })->once();
+    $this->dbManager->shouldReceive('fetchAll')->andReturn([]);
+    $this->dbManager->shouldReceive('freeResult')->andReturn([]);
+    $this->dbManager->shouldReceive('execute');
+
+    $request = $this->getRequestWithQueryParams('GET', []);
+    $actualResponse = $this->licenseController->exportAdminLicenseMarydoneToCSV(
+      $request, new ResponseHelper(), []);
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+    $this->assertStringContainsString('csv',
+      $actualResponse->getHeaderLine('Content-type'));
+    $this->assertStringContainsString('marydone',
+      $actualResponse->getHeaderLine('Content-Disposition'));
+  }
+
+  /**
+   *  -# Test for LicenseController::exportAdminLicenseMarydoneToCSV()
+   *  -# Check if the status code is 403 with HttpForbiddenException
+   * @return void
+   * @throws \Fossology\UI\Api\Exceptions\HttpErrorException
+   */
+  public function testExportAdminLicenseMarydoneToCSVNotAdmin()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $request = $this->getEmptyRequest("GET");
+    $this->expectException(HttpForbiddenException::class);
+    $this->licenseController->exportAdminLicenseMarydoneToCSV($request,
+      new ResponseHelper(), []);
+  }
+
+  /**
+   *  -# Test for LicenseController::exportAdminLicenseMarydoneToJSON() to
+   *     confirm it filters to marydone candidates only.
+   * @return void
+   * @throws \Fossology\UI\Api\Exceptions\HttpErrorException
+   */
+  public function testExportAdminLicenseMarydoneToJSON()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->dbManager->shouldReceive('prepare')
+      ->withArgs(function ($stmt, $sql) {
+        return strpos($sql, 'WHERE marydone = true') !== false;
+      })->once();
+    $this->dbManager->shouldReceive('fetchAll')->andReturn([]);
+    $this->dbManager->shouldReceive('freeResult')->andReturn([]);
+    $this->dbManager->shouldReceive('execute');
+
+    $request = $this->getRequestWithQueryParams('GET', []);
+    $actualResponse = $this->licenseController->exportAdminLicenseMarydoneToJSON(
+      $request, new ResponseHelper(), []);
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+    $this->assertStringContainsString('json',
+      $actualResponse->getHeaderLine('Content-type'));
+    $this->assertStringContainsString('marydone',
+      $actualResponse->getHeaderLine('Content-Disposition'));
+  }
+
+  /**
+   *  -# Test for LicenseController::exportAdminLicenseMarydoneToJSON()
+   *  -# Check if the status code is 403 with HttpForbiddenException
+   * @return void
+   * @throws \Fossology\UI\Api\Exceptions\HttpErrorException
+   */
+  public function testExportAdminLicenseMarydoneToJSONNotAdmin()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $request = $this->getEmptyRequest("GET");
+    $this->expectException(HttpForbiddenException::class);
+    $this->licenseController->exportAdminLicenseMarydoneToJSON($request,
+      new ResponseHelper(), []);
+  }
+
+  /**
    * @test
    * -# Test for LicenseController::exportBulkText() default behavior.
    * -# Verify default format=json and filter=all returns downloadable JSON.


### PR DESCRIPTION
## Description

Adds the missing marydone-specific license export endpoints to the v2 REST API and documents the existing JSON import/export endpoints, which were already implemented but missing from the OpenAPI spec. Also fixes a bug where the general license export endpoints only ever returned marydone candidate licenses instead of all licenses.

### Changes

- Add `GET /license/marydone/export-csv` and `GET /license/marydone/export-json` endpoints, which were referenced by the React License Administration UI but never implemented on the backend.
- Document the existing `POST /license/import-json` and `GET /license/export-json` endpoints in the v2 OpenAPI spec.
- Fix `GET /license/export-csv` and `GET /license/export-json` to pass `$allCandidates=true` to `LicenseCsvExport::createCsv()`, so "export all" now actually exports all licenses (main + candidates) as documented, instead of silently only exporting marydone-flagged candidates.
- Move marydone-only export semantics onto the new dedicated `/license/marydone/*` routes.
- Extract the shared CSV/JSON export logic into a private `exportLicenseFile()` helper on `LicenseController` to avoid duplicating the four near-identical endpoint implementations.
- Add unit tests covering all four export endpoints in `LicenseControllerTest.php`.

## How to test

1. Run the unit tests:
vendor/bin/phpunit -c src/www/ui_tests/api/tests.xml --filter LicenseControllerTest


2. Against a running instance, as an admin user:
- `GET /api/v2/license/export-csv` and `/export-json` → response should include both main and candidate licenses.
- `GET /api/v2/license/marydone/export-csv` and `/marydone/export-json` → response should include only marydone-flagged candidate licenses.
- `POST /api/v2/license/import-json` with a previously exported JSON file → licenses should import successfully.
3. Check that the v2 OpenAPI/Swagger docs render correctly for the new and updated `/license/*` paths.

Refs fossology/FOSSologyUI#424