### PR TITLE
feat(api): add OpenAPI v2 endpoints for license compatibility rules

### DIFF
--- a/src/lib/php/Application/LicenseCompatibilityRulesYamlImport.php
+++ b/src/lib/php/Application/LicenseCompatibilityRulesYamlImport.php
@@ -114,14 +114,20 @@ class LicenseCompatibilityRulesYamlImport
     if ($normalizedRow["firstname"] != null) {
       $firstLicense = $this->licenseDao->getLicenseByShortName(
           $normalizedRow["firstname"], null);
-      $firstLicenseId = $firstLicense->getId();
-      $normalizedRow["firstname"] = $firstLicenseId;
+      if ($firstLicense === null) {
+        throw new \UnexpectedValueException("Unable to find license " .
+          $normalizedRow["firstname"] . " from YAML");
+      }
+      $normalizedRow["firstname"] = $firstLicense->getId();
     }
     if ($normalizedRow["secondname"] != null) {
       $secondLicense = $this->licenseDao->getLicenseByShortName(
           $normalizedRow["secondname"], null);
-      $secondLicenseId = $secondLicense->getId();
-      $normalizedRow["secondname"] = $secondLicenseId;
+      if ($secondLicense === null) {
+        throw new \UnexpectedValueException("Unable to find license " .
+          $normalizedRow["secondname"] . " from YAML");
+      }
+      $normalizedRow["secondname"] = $secondLicense->getId();
     }
     return $this->handleYamlLicense($normalizedRow);
   }
@@ -144,14 +150,14 @@ class LicenseCompatibilityRulesYamlImport
 
     $log = [];
     if ($old_comp != $new_comp) {
-      $rule["compatibility"] = $this->dbManager->booleanToDb($new_comp);
+      $rule["result"] = $new_comp;
       $log[] = "updated compatibility";
     }
     if (!empty($row['comment']) && $row['comment'] != $oldRule['comment']) {
       $rule["comment"] = $row["comment"];
       $log[] = "updated comment";
     }
-    if (count($rule) > 1) {
+    if (!empty($rule)) {
       try {
         $this->compatibilityDao->updateRuleFromArray([$lrPk => $rule]);
       } catch (\UnexpectedValueException $e) {

--- a/src/lib/php/Application/test/LicenseCompatibilityRulesYamlImportTest.php
+++ b/src/lib/php/Application/test/LicenseCompatibilityRulesYamlImportTest.php
@@ -1,0 +1,245 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Harshit Gandhi <gandhiharshit716@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+namespace Fossology\Lib\Application;
+
+use Fossology\Lib\Dao\CompatibilityDao;
+use Fossology\Lib\Dao\LicenseDao;
+use Fossology\Lib\Dao\UserDao;
+use Fossology\Lib\Data\License;
+use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\Test\Reflectory;
+use Mockery as M;
+
+/**
+ * @class LicenseCompatibilityRulesYamlImportTest
+ * @brief Test for LicenseCompatibilityRulesYamlImport
+ */
+class LicenseCompatibilityRulesYamlImportTest extends \PHPUnit\Framework\TestCase
+{
+  /** @var DbManager $dbManager
+   *       DbManager mock */
+  private $dbManager;
+
+  /** @var LicenseDao $licenseDao
+   *       LicenseDao mock */
+  private $licenseDao;
+
+  /** @var CompatibilityDao $compatibilityDao
+   *       CompatibilityDao mock */
+  private $compatibilityDao;
+
+  /** @var LicenseCompatibilityRulesYamlImport $yamlImport
+   *       Object under test */
+  private $yamlImport;
+
+  /** @var int $assertCountBefore */
+  private $assertCountBefore;
+
+  /**
+   * @brief One time setup for test
+   * @see PHPUnit::Framework::TestCase::setUp()
+   */
+  protected function setUp() : void
+  {
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+    $this->dbManager = M::mock(DbManager::class);
+    $this->licenseDao = M::mock(LicenseDao::class);
+    $this->compatibilityDao = M::mock(CompatibilityDao::class);
+    $this->dbManager->shouldReceive('booleanFromDb')
+      ->andReturnUsing(function ($value) {
+        return $value === 't';
+      });
+    $this->yamlImport = new LicenseCompatibilityRulesYamlImport(
+      $this->dbManager, M::mock(UserDao::class), $this->licenseDao,
+      $this->compatibilityDao);
+  }
+
+  /**
+   * @brief Close mockery
+   * @see PHPUnit::Framework::TestCase::tearDown()
+   */
+  protected function tearDown() : void
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  /**
+   * @brief Make the DB return the given rule as the currently stored one
+   * @param string $compatibility Stored compatibility, 't' or 'f'
+   * @param string $comment       Stored description
+   */
+  private function whenStoredRuleIs($compatibility, $comment)
+  {
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->andReturn(["compatibility" => $compatibility, "comment" => $comment]);
+  }
+
+  /**
+   * @brief Test for LicenseCompatibilityRulesYamlImport::updateLicense() when
+   *        only the compatibility changed
+   * @test
+   * -# Import a rule whose compatibility differs from the stored one
+   * -# Check if the DAO is asked to update the compatibility
+   * -# Check if the change is reported
+   */
+  public function testUpdateLicenseWithOnlyCompatibilityChanged()
+  {
+    $this->whenStoredRuleIs('t', "A rule");
+    $this->compatibilityDao->shouldReceive('updateRuleFromArray')
+      ->once()->with([4 => ["result" => false]])->andReturn(1);
+
+    $log = Reflectory::invokeObjectsMethodnameWith($this->yamlImport,
+      'updateLicense',
+      [["compatibility" => "false", "comment" => "A rule"], 4]);
+
+    $this->assertEquals("updated compatibility", $log);
+  }
+
+  /**
+   * @brief Test for LicenseCompatibilityRulesYamlImport::updateLicense() when
+   *        only the description changed
+   * @test
+   * -# Import a rule whose description differs from the stored one
+   * -# Check if the DAO is asked to update the description
+   * -# Check if the change is reported
+   */
+  public function testUpdateLicenseWithOnlyCommentChanged()
+  {
+    $this->whenStoredRuleIs('t', "A rule");
+    $this->compatibilityDao->shouldReceive('updateRuleFromArray')
+      ->once()->with([4 => ["comment" => "An updated rule"]])->andReturn(1);
+
+    $log = Reflectory::invokeObjectsMethodnameWith($this->yamlImport,
+      'updateLicense',
+      [["compatibility" => "true", "comment" => "An updated rule"], 4]);
+
+    $this->assertEquals("updated comment", $log);
+  }
+
+  /**
+   * @brief Test for LicenseCompatibilityRulesYamlImport::updateLicense() when
+   *        both values changed
+   * @test
+   * -# Import a rule with a new compatibility and a new description
+   * -# Check if the DAO is asked to update both
+   */
+  public function testUpdateLicenseWithBothChanged()
+  {
+    $this->whenStoredRuleIs('f', "A rule");
+    $this->compatibilityDao->shouldReceive('updateRuleFromArray')
+      ->once()->with([4 => ["result" => true,
+        "comment" => "An updated rule"]])->andReturn(1);
+
+    $log = Reflectory::invokeObjectsMethodnameWith($this->yamlImport,
+      'updateLicense',
+      [["compatibility" => "true", "comment" => "An updated rule"], 4]);
+
+    $this->assertEquals("updated compatibility, updated comment", $log);
+  }
+
+  /**
+   * @brief Test for LicenseCompatibilityRulesYamlImport::updateLicense() when
+   *        nothing changed
+   * @test
+   * -# Import a rule which matches the stored one
+   * -# Check if the DAO is not called
+   * -# Check if nothing is reported
+   */
+  public function testUpdateLicenseWithNoChange()
+  {
+    $this->whenStoredRuleIs('t', "A rule");
+    $this->compatibilityDao->shouldNotReceive('updateRuleFromArray');
+
+    $log = Reflectory::invokeObjectsMethodnameWith($this->yamlImport,
+      'updateLicense',
+      [["compatibility" => "true", "comment" => "A rule"], 4]);
+
+    $this->assertEmpty($log);
+  }
+
+  /**
+   * @brief Test for LicenseCompatibilityRulesYamlImport::handleYaml() with a
+   *        license unknown to the server
+   * @test
+   * -# Import a rule naming a license which is not in the DB
+   * -# Check if UnexpectedValueException is thrown instead of a fatal error
+   */
+  public function testHandleYamlWithUnknownLicense()
+  {
+    $this->licenseDao->shouldReceive('getLicenseByShortName')
+      ->with("NotALicense", null)->andReturn(null);
+    $this->expectException(\UnexpectedValueException::class);
+
+    Reflectory::invokeObjectsMethodnameWith($this->yamlImport, 'handleYaml',
+      [[
+        "firstname" => "NotALicense",
+        "secondname" => null,
+        "firsttype" => null,
+        "secondtype" => "Strong Copyleft",
+        "compatibility" => "true",
+        "comment" => "A rule"
+      ]]);
+  }
+
+  /**
+   * @brief Test for LicenseCompatibilityRulesYamlImport::handleYaml() with a
+   *        missing column
+   * @test
+   * -# Import a rule without the compatibility column
+   * -# Check if UnexpectedValueException is thrown
+   */
+  public function testHandleYamlWithMissingColumn()
+  {
+    $this->expectException(\UnexpectedValueException::class);
+
+    Reflectory::invokeObjectsMethodnameWith($this->yamlImport, 'handleYaml',
+      [[
+        "firstname" => "MIT",
+        "secondname" => null,
+        "firsttype" => null,
+        "secondtype" => "Strong Copyleft",
+        "comment" => "A rule"
+      ]]);
+  }
+
+  /**
+   * @brief Test for LicenseCompatibilityRulesYamlImport::handleYaml() resolving
+   *        the license short names
+   * @test
+   * -# Import a rule naming two known licenses
+   * -# Check if the short names are replaced by the license ids
+   */
+  public function testHandleYamlResolvesLicenseIds()
+  {
+    $firstLicense = M::mock(License::class);
+    $firstLicense->shouldReceive('getId')->andReturn(306);
+    $secondLicense = M::mock(License::class);
+    $secondLicense->shouldReceive('getId')->andReturn(188);
+    $this->licenseDao->shouldReceive('getLicenseByShortName')
+      ->with("MIT", null)->andReturn($firstLicense);
+    $this->licenseDao->shouldReceive('getLicenseByShortName')
+      ->with("GPL-2.0-only", null)->andReturn($secondLicense);
+    // No rule matches, so a new one is inserted with the resolved ids
+    $this->dbManager->shouldReceive('getSingleRow')->andReturn(false);
+    $this->compatibilityDao->shouldReceive('insertRule')
+      ->once()->with(306, 188, null, null, "A rule", "true")->andReturn(9);
+
+    $this->assertEquals(9,
+      Reflectory::invokeObjectsMethodnameWith($this->yamlImport, 'handleYaml',
+        [[
+          "firstname" => "MIT",
+          "secondname" => "GPL-2.0-only",
+          "firsttype" => null,
+          "secondtype" => null,
+          "compatibility" => "true",
+          "comment" => "A rule"
+        ]]));
+  }
+}

--- a/src/lib/php/Dao/CompatibilityDao.php
+++ b/src/lib/php/Dao/CompatibilityDao.php
@@ -20,6 +20,18 @@ use Monolog\Logger;
  */
 class CompatibilityDao
 {
+  /**
+   * @var string RULE_SELECT
+   *      Base query to fetch the rules along with the license short names
+   */
+  const RULE_SELECT = "SELECT lr_pk, first_rf_fk, second_rf_fk,
+      lrf.rf_shortname AS first_rf_shortname,
+      lrs.rf_shortname AS second_rf_shortname, first_type, second_type,
+      comment, compatibility
+    FROM license_rules
+      LEFT JOIN license_ref lrf ON lrf.rf_pk = first_rf_fk
+      LEFT JOIN license_ref lrs ON lrs.rf_pk = second_rf_fk";
+
   /** @var DbManager */
   private $dbManager;
   /** @var Logger */
@@ -102,14 +114,31 @@ class CompatibilityDao
    */
   public function getAllRules($limit = 10, $offset = 0, $searchTerm = '')
   {
-    $sql = "SELECT lr_pk, first_rf_fk, second_rf_fk, first_type, second_type,
-      comment, compatibility
-      FROM license_rules";
+    $stmt = __METHOD__;
+    $params = [];
+    $sql = self::RULE_SELECT;
     if (!empty($searchTerm)) {
-      $sql .= " WHERE comment ILIKE '$searchTerm'";
+      $params[] = $searchTerm;
+      $sql .= ' WHERE comment ILIKE $' . count($params);
+      $stmt .= '.search';
     }
-    $sql .= " ORDER BY lr_pk LIMIT $limit OFFSET $offset;";
-    return $this->dbManager->getRows($sql);
+    $params[] = $limit;
+    $sql .= ' ORDER BY lr_pk LIMIT $' . count($params);
+    $params[] = $offset;
+    $sql .= ' OFFSET $' . count($params) . ';';
+    return $this->dbManager->getRows($sql, $params, $stmt);
+  }
+
+  /**
+   * @brief Get a single license compatibility rule from the database
+   * @param int $rulePk ID of the rule to fetch
+   * @return array|null The rule if it exists, null otherwise
+   */
+  public function getRuleById($rulePk)
+  {
+    $row = $this->dbManager->getSingleRow(self::RULE_SELECT .
+      ' WHERE lr_pk = $1;', [$rulePk], __METHOD__);
+    return empty($row) ? null : $row;
   }
 
   /**
@@ -119,12 +148,16 @@ class CompatibilityDao
    */
   public function getTotalRulesCount($searchTerm = '')
   {
+    $stmt = __METHOD__;
+    $params = [];
     $query = "SELECT COUNT(*) as count FROM license_rules";
     if (!empty($searchTerm)) {
-      $query .= " WHERE comment ILIKE '$searchTerm'";
+      $params[] = $searchTerm;
+      $query .= ' WHERE comment ILIKE $' . count($params);
+      $stmt .= '.search';
     }
-    $count = $this->dbManager->getSingleRow($query);
-    return $count ? reset($count) : 0;
+    $count = $this->dbManager->getSingleRow($query, $params, $stmt);
+    return $count ? intval($count['count']) : 0;
   }
 
   /**
@@ -246,7 +279,9 @@ class CompatibilityDao
         $statement .= ".comment";
       }
       if (array_key_exists("result", $rule)) {
-        $params[] = $rule["result"];
+        // Booleans are not casted by the driver, unlike on insert.
+        $params[] = is_bool($rule["result"]) ?
+          $this->dbManager->booleanToDb($rule["result"]) : $rule["result"];
         $updateStatement[] = "compatibility = $" . count($params);
         $statement .= ".compatibility";
       }

--- a/src/lib/php/Dao/test/CompatibilityDaoTest.php
+++ b/src/lib/php/Dao/test/CompatibilityDaoTest.php
@@ -1,0 +1,309 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Harshit Gandhi <gandhiharshit716@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * @file
+ * Tests for CompatibilityDao class
+ */
+namespace Fossology\Lib\Dao;
+
+use Fossology\Lib\Db\DbManager;
+use Fossology\Lib\Test\TestPgDb;
+use Mockery as M;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @class CompatibilityDaoTest
+ * Tests for CompatibilityDao class
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class CompatibilityDaoTest extends TestCase
+{
+  /** @var TestPgDb $testDb
+   *       Test DB */
+  private $testDb;
+
+  /** @var DbManager $dbManager
+   *       DB manager to use */
+  private $dbManager;
+
+  /** @var CompatibilityDao $compatibilityDao
+   *       CompatibilityDao object for test */
+  private $compatibilityDao;
+
+  /** @var int $assertCountBefore */
+  private $assertCountBefore;
+
+  /** @var M\MockInterface $authClass
+   *       Alias mock of the Auth class */
+  private $authClass;
+
+  /** @var int $firstLicenseId
+   *       Id of a license present in license_ref */
+  private $firstLicenseId;
+
+  /** @var int $secondLicenseId
+   *       Id of another license present in license_ref */
+  private $secondLicenseId;
+
+  protected function setUp() : void
+  {
+    $this->testDb = new TestPgDb("compatibilitydao");
+    $this->dbManager = $this->testDb->getDbManager();
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+
+    $this->testDb->createPlainTables(["license_ref", "license_rules"]);
+    $this->testDb->createSequences(["license_ref_rf_pk_seq",
+      "license_rules_lr_pk_seq"]);
+    $this->testDb->alterTables(["license_ref", "license_rules"]);
+    $this->testDb->insertData_license_ref(2);
+
+    $licenses = $this->dbManager->getRows(
+      "SELECT rf_pk FROM license_ref ORDER BY rf_pk LIMIT 2;");
+    $this->firstLicenseId = intval($licenses[0]['rf_pk']);
+    $this->secondLicenseId = intval($licenses[1]['rf_pk']);
+
+    $this->authClass = M::mock('alias:Fossology\Lib\Auth\Auth');
+    $this->authClass->shouldReceive('isAdmin')->andReturn(true);
+
+    $this->compatibilityDao = new CompatibilityDao($this->dbManager,
+      new Logger("test"), M::mock(LicenseDao::class), M::mock(AgentDao::class));
+  }
+
+  protected function tearDown() : void
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+    $this->testDb = null;
+    $this->dbManager = null;
+  }
+
+  /**
+   * @brief Insert a rule to work on
+   * @param string $comment Description of the rule
+   * @param bool $result    Compatibility of the rule
+   * @return int Id of the new rule
+   */
+  private function insertRule($comment, $result = true)
+  {
+    $ruleId = $this->compatibilityDao->insertRule($this->firstLicenseId, null,
+      null, "Strong Copyleft", $comment, $result);
+    $this->assertGreaterThan(0, $ruleId, "Unable to insert the test rule.");
+    return $ruleId;
+  }
+
+  /**
+   * @brief Test for CompatibilityDao::insertRule()
+   * @test
+   * -# Insert a rule with a boolean compatibility
+   * -# Check if the values are stored as given
+   */
+  public function testInsertRule()
+  {
+    $ruleId = $this->insertRule("A rule", false);
+
+    $rule = $this->compatibilityDao->getRuleById($ruleId);
+    $this->assertEquals($this->firstLicenseId, intval($rule['first_rf_fk']));
+    $this->assertNull($rule['second_rf_fk']);
+    $this->assertNull($rule['first_type']);
+    $this->assertEquals("Strong Copyleft", $rule['second_type']);
+    $this->assertEquals("A rule", $rule['comment']);
+    $this->assertEquals("f", $rule['compatibility']);
+  }
+
+  /**
+   * @brief Test for CompatibilityDao::insertRule() with an empty description
+   * @test
+   * -# Insert a rule without a description
+   * -# Check if the rule is rejected
+   */
+  public function testInsertRuleWithoutComment()
+  {
+    $this->assertEquals(-1, $this->compatibilityDao->insertRule(
+      $this->firstLicenseId, null, null, "Strong Copyleft", "  ", true));
+  }
+
+  /**
+   * @brief Test for CompatibilityDao::getRuleById()
+   * @test
+   * -# Fetch a rule which exists
+   * -# Check if the license short name is resolved
+   * -# Fetch a rule which does not exist
+   * -# Check if null is returned
+   */
+  public function testGetRuleById()
+  {
+    $ruleId = $this->insertRule("A rule");
+
+    $rule = $this->compatibilityDao->getRuleById($ruleId);
+    $this->assertEquals($ruleId, intval($rule['lr_pk']));
+    $this->assertNotEmpty($rule['first_rf_shortname']);
+    $this->assertNull($rule['second_rf_shortname']);
+
+    $this->assertNull($this->compatibilityDao->getRuleById($ruleId + 100));
+  }
+
+  /**
+   * @brief Test for CompatibilityDao::getAllRules() with pagination
+   * @test
+   * -# Insert three rules
+   * -# Fetch them one page at a time
+   * -# Check if the rules are returned ordered by their id
+   */
+  public function testGetAllRulesPaginated()
+  {
+    $firstRule = $this->insertRule("First rule");
+    $secondRule = $this->insertRule("Second rule");
+    $this->insertRule("Third rule");
+
+    $this->assertEquals(3, $this->compatibilityDao->getTotalRulesCount());
+
+    $rules = $this->compatibilityDao->getAllRules(2, 0);
+    $this->assertCount(2, $rules);
+    $this->assertEquals($firstRule, intval($rules[0]['lr_pk']));
+    $this->assertEquals($secondRule, intval($rules[1]['lr_pk']));
+
+    $rules = $this->compatibilityDao->getAllRules(2, 2);
+    $this->assertCount(1, $rules);
+    $this->assertEquals("Third rule", $rules[0]['comment']);
+  }
+
+  /**
+   * @brief Test for CompatibilityDao::getAllRules() with a search term
+   * @test
+   * -# Insert two rules with different descriptions
+   * -# Search for one of them
+   * -# Check if only the matching rule is returned and counted
+   */
+  public function testGetAllRulesWithSearchTerm()
+  {
+    $this->insertRule("Permissive with copyleft");
+    $this->insertRule("Copyleft with copyleft");
+
+    $this->assertEquals(1,
+      $this->compatibilityDao->getTotalRulesCount("%permissive%"));
+    $rules = $this->compatibilityDao->getAllRules(10, 0, "%permissive%");
+    $this->assertCount(1, $rules);
+    $this->assertEquals("Permissive with copyleft", $rules[0]['comment']);
+  }
+
+  /**
+   * @brief Test that the search term is bound as a query parameter
+   * @test
+   * -# Search with a term holding a single quote
+   * -# Check that the query does not break and matches nothing
+   */
+  public function testGetAllRulesWithQuoteInSearchTerm()
+  {
+    $this->insertRule("A rule");
+    $searchTerm = "%' OR comment LIKE '%";
+
+    $this->assertEquals(0,
+      $this->compatibilityDao->getTotalRulesCount($searchTerm));
+    $this->assertCount(0,
+      $this->compatibilityDao->getAllRules(10, 0, $searchTerm));
+  }
+
+  /**
+   * @brief Test for CompatibilityDao::updateRuleFromArray() with a boolean
+   * @test
+   * -# Update only the compatibility of a rule with a PHP boolean
+   * -# Check if the new value is stored in the DB
+   */
+  public function testUpdateRuleCompatibilityFromBoolean()
+  {
+    $ruleId = $this->insertRule("A rule", true);
+
+    $this->assertEquals(1, $this->compatibilityDao->updateRuleFromArray(
+      [$ruleId => ["result" => false]]));
+    $this->assertEquals("f",
+      $this->compatibilityDao->getRuleById($ruleId)['compatibility']);
+
+    $this->assertEquals(1, $this->compatibilityDao->updateRuleFromArray(
+      [$ruleId => ["result" => true]]));
+    $this->assertEquals("t",
+      $this->compatibilityDao->getRuleById($ruleId)['compatibility']);
+  }
+
+  /**
+   * @brief Test for CompatibilityDao::updateRuleFromArray() with the DB
+   *        representation of a boolean
+   * @test
+   * -# Update the compatibility of a rule with 't' and 'f'
+   * -# Check if the new value is stored in the DB
+   */
+  public function testUpdateRuleCompatibilityFromDbBoolean()
+  {
+    $ruleId = $this->insertRule("A rule", true);
+
+    $this->assertEquals(1, $this->compatibilityDao->updateRuleFromArray(
+      [$ruleId => ["result" => "f"]]));
+    $this->assertEquals("f",
+      $this->compatibilityDao->getRuleById($ruleId)['compatibility']);
+  }
+
+  /**
+   * @brief Test for CompatibilityDao::updateRuleFromArray() on every field
+   * @test
+   * -# Update all the fields of a rule
+   * -# Check if the new values are stored in the DB
+   */
+  public function testUpdateRuleFromArray()
+  {
+    $ruleId = $this->insertRule("A rule");
+
+    $this->assertEquals(1, $this->compatibilityDao->updateRuleFromArray([
+      $ruleId => [
+        "firstLic" => null,
+        "secondLic" => $this->secondLicenseId,
+        "firstType" => "Permissive",
+        "secondType" => null,
+        "comment" => "An updated rule",
+        "result" => false
+      ]
+    ]));
+
+    $rule = $this->compatibilityDao->getRuleById($ruleId);
+    $this->assertNull($rule['first_rf_fk']);
+    $this->assertEquals($this->secondLicenseId, intval($rule['second_rf_fk']));
+    $this->assertEquals("Permissive", $rule['first_type']);
+    $this->assertNull($rule['second_type']);
+    $this->assertEquals("An updated rule", $rule['comment']);
+    $this->assertEquals("f", $rule['compatibility']);
+  }
+
+  /**
+   * @brief Test for CompatibilityDao::updateRuleFromArray() with an unknown id
+   * @test
+   * -# Update a rule which does not exist
+   * -# Check if UnexpectedValueException is thrown
+   */
+  public function testUpdateRuleWithUnknownId()
+  {
+    $this->expectException(\UnexpectedValueException::class);
+
+    $this->compatibilityDao->updateRuleFromArray(
+      [999 => ["comment" => "An updated rule"]]);
+  }
+
+  /**
+   * @brief Test for CompatibilityDao::deleteRule()
+   * @test
+   * -# Delete an existing rule
+   * -# Check if the rule is gone from the DB
+   */
+  public function testDeleteRule()
+  {
+    $ruleId = $this->insertRule("A rule");
+
+    $this->assertTrue($this->compatibilityDao->deleteRule($ruleId));
+    $this->assertNull($this->compatibilityDao->getRuleById($ruleId));
+    $this->assertEquals(0, $this->compatibilityDao->getTotalRulesCount());
+  }
+}

--- a/src/www/ui/api/Controllers/LicenseCompatibilityRuleController.php
+++ b/src/www/ui/api/Controllers/LicenseCompatibilityRuleController.php
@@ -1,0 +1,444 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Harshit Gandhi <gandhiharshit716@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * @file
+ * @brief Controller for license compatibility rules
+ */
+
+namespace Fossology\UI\Api\Controllers;
+
+use Fossology\Lib\Application\LicenseCompatibilityRulesYamlExport;
+use Fossology\Lib\Dao\CompatibilityDao;
+use Fossology\UI\Api\Exceptions\HttpBadRequestException;
+use Fossology\UI\Api\Exceptions\HttpErrorException;
+use Fossology\UI\Api\Exceptions\HttpInternalServerErrorException;
+use Fossology\UI\Api\Exceptions\HttpNotFoundException;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Models\ApiVersion;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Fossology\UI\Api\Models\LicenseCompatibilityRule;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Psr7\Factory\StreamFactory;
+
+/**
+ * @class LicenseCompatibilityRuleController
+ * @brief Controller for license compatibility rules
+ */
+class LicenseCompatibilityRuleController extends RestController
+{
+  /**
+   * Query parameter name for page listing
+   */
+  const PAGE_PARAM = "page";
+  /**
+   * Query parameter name for limiting listing
+   */
+  const LIMIT_PARAM = "limit";
+  /**
+   * Query parameter name to filter the rules on their description
+   */
+  const SEARCH_PARAM = "search";
+  /**
+   * Limit of rules in get query
+   */
+  const RULE_FETCH_LIMIT = 100;
+
+  /**
+   * @var CompatibilityDao $compatibilityDao
+   * Compatibility DAO object
+   */
+  private $compatibilityDao;
+
+  /**
+   * @param ContainerInterface $container
+   */
+  public function __construct($container)
+  {
+    parent::__construct($container);
+    $this->compatibilityDao = $this->container->get('dao.compatibility');
+  }
+
+  /**
+   * Get the list of license compatibility rules, paginated upon request params
+   *
+   * @param Request $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpErrorException
+   */
+  public function getRules($request, $response, $args)
+  {
+    $this->throwNotAdminException();
+    $apiVersion = ApiVersion::getVersion($request);
+    $query = $request->getQueryParams();
+
+    // Compare against "" instead of using empty(), which is true for "0".
+    $limit = $query[self::LIMIT_PARAM] ?? "";
+    if ($limit !== "") {
+      $limit = filter_var($limit, FILTER_VALIDATE_INT);
+      if ($limit === false || $limit < 1) {
+        throw new HttpBadRequestException(
+          "limit should be positive integer > 1");
+      }
+    } else {
+      $limit = self::RULE_FETCH_LIMIT;
+    }
+
+    $searchTerm = $query[self::SEARCH_PARAM] ?? "";
+    if (! is_string($searchTerm)) {
+      throw new HttpBadRequestException("search should be a string");
+    }
+    $searchTerm = trim($searchTerm);
+    if (! empty($searchTerm)) {
+      $searchTerm = "%" . $searchTerm . "%";
+    }
+
+    $totalPages = $this->compatibilityDao->getTotalRulesCount($searchTerm);
+    $totalPages = intval(ceil($totalPages / $limit));
+
+    $page = $query[self::PAGE_PARAM] ?? "";
+    if ($page !== "") {
+      $page = filter_var($page, FILTER_VALIDATE_INT);
+      if ($page === false || $page < 1) {
+        throw new HttpBadRequestException(
+          "page should be positive integer > 0");
+      }
+      if ($totalPages != 0 && $page > $totalPages) {
+        throw (new HttpBadRequestException(
+          "Can not exceed total pages: $totalPages"))
+          ->setHeaders(["X-Total-Pages" => $totalPages]);
+      }
+    } else {
+      $page = 1;
+    }
+
+    $rules = [];
+    foreach ($this->compatibilityDao->getAllRules($limit,
+        $limit * ($page - 1), $searchTerm) as $row) {
+      $rules[] = LicenseCompatibilityRule::fromArray($row)
+        ->getArray($apiVersion);
+    }
+    return $response->withHeader("X-Total-Pages", $totalPages)
+      ->withJson($rules, 200);
+  }
+
+  /**
+   * Create a new license compatibility rule
+   *
+   * @param Request $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpErrorException
+   */
+  public function createRule($request, $response, $args)
+  {
+    $this->throwNotAdminException();
+    $rule = $this->parseRule($this->getParsedBody($request), true);
+
+    $ruleId = $this->compatibilityDao->insertRule($rule["firstLic"],
+      $rule["secondLic"], $rule["firstType"], $rule["secondType"],
+      $rule["comment"], $rule["result"]);
+    if ($ruleId < 0) {
+      throw new HttpInternalServerErrorException(
+        "Unable to create the compatibility rule.");
+    }
+
+    $info = new Info(201, "Rule $ruleId added successfully.", InfoType::INFO);
+    return $response->withJson($info->getArray(), $info->getCode());
+  }
+
+  /**
+   * Update an existing license compatibility rule
+   *
+   * @param Request $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpErrorException
+   */
+  public function updateRule($request, $response, $args)
+  {
+    $this->throwNotAdminException();
+    $ruleId = intval($args['id']);
+    if ($this->compatibilityDao->getRuleById($ruleId) === null) {
+      throw new HttpNotFoundException("Compatibility rule does not exist.");
+    }
+
+    $rule = $this->parseRule($this->getParsedBody($request), false);
+    if (empty($rule)) {
+      throw new HttpBadRequestException("No rule values provided to update.");
+    }
+
+    try {
+      $updated = $this->compatibilityDao->updateRuleFromArray([$ruleId => $rule]);
+    } catch (\UnexpectedValueException $e) {
+      throw new HttpBadRequestException($e->getMessage(), $e);
+    }
+    if ($updated < 1) {
+      throw new HttpInternalServerErrorException(
+        "Unable to update the compatibility rule.");
+    }
+
+    $info = new Info(200, "Rule $ruleId updated successfully.", InfoType::INFO);
+    return $response->withJson($info->getArray(), $info->getCode());
+  }
+
+  /**
+   * Delete an existing license compatibility rule
+   *
+   * @param Request $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpErrorException
+   */
+  public function deleteRule($request, $response, $args)
+  {
+    $this->throwNotAdminException();
+    $ruleId = intval($args['id']);
+    if ($this->compatibilityDao->getRuleById($ruleId) === null) {
+      throw new HttpNotFoundException("Compatibility rule does not exist.");
+    }
+
+    if (! $this->compatibilityDao->deleteRule($ruleId)) {
+      throw new HttpInternalServerErrorException(
+        "Unable to delete the compatibility rule.");
+    }
+
+    $info = new Info(200, "Rule $ruleId deleted successfully.", InfoType::INFO);
+    return $response->withJson($info->getArray(), $info->getCode());
+  }
+
+  /**
+   * Import license compatibility rules from a YAML file
+   *
+   * @param Request $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpErrorException
+   */
+  public function importRules($request, $response, $args)
+  {
+    $this->throwNotAdminException();
+    $apiVersion = ApiVersion::getVersion($request);
+
+    $symReq = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
+    /** @var \Fossology\UI\Page\AdminLicenseFromYAML $adminLicenseFromYaml */
+    $adminLicenseFromYaml = $this->restHelper->getPlugin('admin_license_from_yaml');
+
+    $uploadedFile = $symReq->files->get(
+      $adminLicenseFromYaml->getFileInputName($apiVersion), null);
+
+    $res = $adminLicenseFromYaml->handleFileUpload($uploadedFile, true);
+    if (! $res[0]) {
+      throw new HttpBadRequestException($res[1]);
+    }
+
+    $newInfo = new Info($res[2], $res[1], InfoType::INFO);
+    return $response->withJson($newInfo->getArray(), $newInfo->getCode());
+  }
+
+  /**
+   * Export the license compatibility rules as a YAML file
+   *
+   * @param Request $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpErrorException
+   */
+  public function exportRules($request, $response, $args)
+  {
+    $this->throwNotAdminException();
+    $query = $request->getQueryParams();
+    $ruleId = 0;
+    if (array_key_exists('id', $query)) {
+      $ruleId = intval($query['id']);
+    }
+    if ($ruleId != 0 &&
+        $this->compatibilityDao->getRuleById($ruleId) === null) {
+      throw new HttpNotFoundException("Compatibility rule does not exist.");
+    }
+
+    $licenseYamlExport = new LicenseCompatibilityRulesYamlExport(
+      $this->dbHelper->getDbManager(), $this->compatibilityDao);
+    $content = $licenseYamlExport->createYaml($ruleId);
+    $fileName = "fossology-license-comp-rules-export-" . date("YMj-Gis");
+    $newResponse = $response
+      ->withHeader('Content-type', 'text/x-yaml; charset=UTF-8')
+      ->withHeader('Content-Disposition',
+        'attachment; filename=' . $fileName . '.yaml')
+      ->withHeader('Pragma', 'no-cache')
+      ->withHeader('Cache-Control',
+        'no-cache, must-revalidate, maxage=1, post-check=0, pre-check=0')
+      ->withHeader('Expires', 'Expires: Thu, 19 Nov 1981 08:52:00 GMT');
+    $sf = new StreamFactory();
+    return $newResponse->withBody(
+      $content ? $sf->createStream($content) : $sf->createStream('')
+    );
+  }
+
+  /**
+   * @brief Validate the rule values sent in the request body.
+   *
+   * Only the fields present in the body are returned, which allows updating a
+   * rule partially. For a new rule, the description and the compatibility
+   * result are mandatory and at least one license or license type has to be
+   * given, otherwise the rule would shadow the default compatibility.
+   *
+   * @param array|null $body Parsed request body
+   * @param boolean $isNewRule True while creating a rule
+   * @return array Rule values as expected by CompatibilityDao
+   * @throws HttpBadRequestException
+   */
+  private function parseRule($body, $isNewRule)
+  {
+    if (empty($body) || ! is_array($body)) {
+      throw new HttpBadRequestException("Invalid request body.");
+    }
+    $rule = [];
+
+    list($exists, $value) = $this->getRuleField($body, "firstLicenseId",
+      "first_license_id");
+    if ($exists) {
+      $rule["firstLic"] = $this->validateLicenseId($value, "firstLicenseId");
+    }
+    list($exists, $value) = $this->getRuleField($body, "secondLicenseId",
+      "second_license_id");
+    if ($exists) {
+      $rule["secondLic"] = $this->validateLicenseId($value, "secondLicenseId");
+    }
+    list($exists, $value) = $this->getRuleField($body, "firstType",
+      "first_type");
+    if ($exists) {
+      $rule["firstType"] = $this->validateLicenseType($value, "firstType");
+    }
+    list($exists, $value) = $this->getRuleField($body, "secondType",
+      "second_type");
+    if ($exists) {
+      $rule["secondType"] = $this->validateLicenseType($value, "secondType");
+    }
+    if (array_key_exists("comment", $body)) {
+      if (! is_string($body["comment"]) || empty(trim($body["comment"]))) {
+        throw new HttpBadRequestException(
+          "comment should be a non-empty string.");
+      }
+      $rule["comment"] = trim($body["comment"]);
+    }
+    if (array_key_exists("compatibility", $body)) {
+      $compatibility = filter_var($body["compatibility"],
+        FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+      if ($compatibility === null) {
+        throw new HttpBadRequestException("compatibility should be a boolean.");
+      }
+      $rule["result"] = $compatibility;
+    }
+
+    if (! $isNewRule) {
+      return $rule;
+    }
+    foreach (["comment", "result"] as $mandatory) {
+      if (! array_key_exists($mandatory, $rule)) {
+        throw new HttpBadRequestException("comment and compatibility are " .
+          "required to create a rule.");
+      }
+    }
+    $rule += ["firstLic" => null, "secondLic" => null, "firstType" => null,
+      "secondType" => null];
+    if ($rule["firstLic"] === null && $rule["secondLic"] === null &&
+        $rule["firstType"] === null && $rule["secondType"] === null) {
+      throw new HttpBadRequestException("At least one license or license type " .
+        "is required to create a rule.");
+    }
+    return $rule;
+  }
+
+  /**
+   * @brief Read a rule field from the request body.
+   *
+   * Both the camelCase (version 2) and the snake_case (version 1) name of the
+   * field are accepted.
+   * @param array $body Parsed request body
+   * @param string $nameV2 Name of the field in version 2
+   * @param string $nameV1 Name of the field in version 1
+   * @return array Array with the presence of the field and its value
+   */
+  private function getRuleField($body, $nameV2, $nameV1)
+  {
+    if (array_key_exists($nameV2, $body)) {
+      return [true, $body[$nameV2]];
+    }
+    if (array_key_exists($nameV1, $body)) {
+      return [true, $body[$nameV1]];
+    }
+    return [false, null];
+  }
+
+  /**
+   * @brief Validate a license ID sent in the request body.
+   * @param mixed $licenseId Value to validate, null matches every license
+   * @param string $field    Name of the field to report in the error message
+   * @return int|null Validated license ID
+   * @throws HttpBadRequestException
+   */
+  private function validateLicenseId($licenseId, $field)
+  {
+    if ($licenseId === null || $licenseId === "") {
+      return null;
+    }
+    $licenseId = filter_var($licenseId, FILTER_VALIDATE_INT);
+    if ($licenseId === false || $licenseId < 1) {
+      throw new HttpBadRequestException("$field should be positive integer.");
+    }
+    if (! $this->dbHelper->doesIdExist("license_ref", "rf_pk", $licenseId)) {
+      throw new HttpBadRequestException(
+        "No license found with id '$licenseId'.");
+    }
+    return $licenseId;
+  }
+
+  /**
+   * @brief Validate a license type sent in the request body.
+   * @param mixed $licenseType Value to validate, null matches every type
+   * @param string $field      Name of the field to report in the error message
+   * @return string|null Validated license type
+   * @throws HttpBadRequestException
+   */
+  private function validateLicenseType($licenseType, $field)
+  {
+    if ($licenseType === null || $licenseType === "") {
+      return null;
+    }
+    if (! is_string($licenseType)) {
+      throw new HttpBadRequestException("$field should be a string.");
+    }
+    $licenseType = trim($licenseType);
+    $licenseTypes = $this->getLicenseTypes();
+    if (! in_array($licenseType, $licenseTypes)) {
+      throw new HttpBadRequestException("Invalid $field '$licenseType', " .
+        "allowed values are: " . implode(", ", $licenseTypes) . ".");
+    }
+    return $licenseType;
+  }
+
+  /**
+   * @brief Get the license types configured on the server.
+   * @return array List of the license types
+   */
+  private function getLicenseTypes()
+  {
+    global $SysConf;
+
+    $licenseTypes = $SysConf['SYSCONFIG']['LicenseTypes'] ?? "";
+    return array_filter(array_map('trim', explode(',', $licenseTypes)));
+  }
+}

--- a/src/www/ui/api/Models/LicenseCompatibilityRule.php
+++ b/src/www/ui/api/Models/LicenseCompatibilityRule.php
@@ -1,0 +1,297 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Harshit Gandhi <gandhiharshit716@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * @file
+ * @brief LicenseCompatibilityRule model
+ */
+namespace Fossology\UI\Api\Models;
+
+/**
+ * @class LicenseCompatibilityRule
+ * @brief Model to hold a single license compatibility rule
+ */
+class LicenseCompatibilityRule
+{
+  /**
+   * @var int $id
+   * Id of the rule
+   */
+  private $id;
+  /**
+   * @var int|null $firstLicenseId
+   * Id of the first license of the rule
+   */
+  private $firstLicenseId;
+  /**
+   * @var string|null $firstLicenseName
+   * Short name of the first license of the rule
+   */
+  private $firstLicenseName;
+  /**
+   * @var int|null $secondLicenseId
+   * Id of the second license of the rule
+   */
+  private $secondLicenseId;
+  /**
+   * @var string|null $secondLicenseName
+   * Short name of the second license of the rule
+   */
+  private $secondLicenseName;
+  /**
+   * @var string|null $firstType
+   * License type of the first license of the rule
+   */
+  private $firstType;
+  /**
+   * @var string|null $secondType
+   * License type of the second license of the rule
+   */
+  private $secondType;
+  /**
+   * @var string $comment
+   * Description of the rule
+   */
+  private $comment;
+  /**
+   * @var boolean $compatibility
+   * Compatibility result of the rule
+   */
+  private $compatibility;
+
+  /**
+   * @param int $id
+   * @param int|null $firstLicenseId
+   * @param string|null $firstLicenseName
+   * @param int|null $secondLicenseId
+   * @param string|null $secondLicenseName
+   * @param string|null $firstType
+   * @param string|null $secondType
+   * @param string $comment
+   * @param boolean $compatibility
+   */
+  public function __construct($id, $firstLicenseId, $firstLicenseName,
+                              $secondLicenseId, $secondLicenseName, $firstType,
+                              $secondType, $comment, $compatibility)
+  {
+    $this->id = $id;
+    $this->firstLicenseId = $firstLicenseId;
+    $this->firstLicenseName = $firstLicenseName;
+    $this->secondLicenseId = $secondLicenseId;
+    $this->secondLicenseName = $secondLicenseName;
+    $this->firstType = $firstType;
+    $this->secondType = $secondType;
+    $this->comment = $comment;
+    $this->compatibility = $compatibility;
+  }
+
+  /**
+   * Create a new model object from a `license_rules` row.
+   * @param array $row Row as returned by CompatibilityDao
+   * @return LicenseCompatibilityRule
+   */
+  public static function fromArray($row)
+  {
+    return new LicenseCompatibilityRule(
+      intval($row['lr_pk']),
+      $row['first_rf_fk'] === null ? null : intval($row['first_rf_fk']),
+      $row['first_rf_shortname'],
+      $row['second_rf_fk'] === null ? null : intval($row['second_rf_fk']),
+      $row['second_rf_shortname'],
+      $row['first_type'],
+      $row['second_type'],
+      $row['comment'],
+      $row['compatibility'] === 't'
+    );
+  }
+
+  /**
+   * @return int
+   */
+  public function getId()
+  {
+    return $this->id;
+  }
+
+  /**
+   * @return int|null
+   */
+  public function getFirstLicenseId()
+  {
+    return $this->firstLicenseId;
+  }
+
+  /**
+   * @return string|null
+   */
+  public function getFirstLicenseName()
+  {
+    return $this->firstLicenseName;
+  }
+
+  /**
+   * @return int|null
+   */
+  public function getSecondLicenseId()
+  {
+    return $this->secondLicenseId;
+  }
+
+  /**
+   * @return string|null
+   */
+  public function getSecondLicenseName()
+  {
+    return $this->secondLicenseName;
+  }
+
+  /**
+   * @return string|null
+   */
+  public function getFirstType()
+  {
+    return $this->firstType;
+  }
+
+  /**
+   * @return string|null
+   */
+  public function getSecondType()
+  {
+    return $this->secondType;
+  }
+
+  /**
+   * @return string
+   */
+  public function getComment()
+  {
+    return $this->comment;
+  }
+
+  /**
+   * @return boolean
+   */
+  public function getCompatibility()
+  {
+    return $this->compatibility;
+  }
+
+  /**
+   * @param int $id
+   */
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+
+  /**
+   * @param int|null $firstLicenseId
+   */
+  public function setFirstLicenseId($firstLicenseId)
+  {
+    $this->firstLicenseId = $firstLicenseId;
+  }
+
+  /**
+   * @param string|null $firstLicenseName
+   */
+  public function setFirstLicenseName($firstLicenseName)
+  {
+    $this->firstLicenseName = $firstLicenseName;
+  }
+
+  /**
+   * @param int|null $secondLicenseId
+   */
+  public function setSecondLicenseId($secondLicenseId)
+  {
+    $this->secondLicenseId = $secondLicenseId;
+  }
+
+  /**
+   * @param string|null $secondLicenseName
+   */
+  public function setSecondLicenseName($secondLicenseName)
+  {
+    $this->secondLicenseName = $secondLicenseName;
+  }
+
+  /**
+   * @param string|null $firstType
+   */
+  public function setFirstType($firstType)
+  {
+    $this->firstType = $firstType;
+  }
+
+  /**
+   * @param string|null $secondType
+   */
+  public function setSecondType($secondType)
+  {
+    $this->secondType = $secondType;
+  }
+
+  /**
+   * @param string $comment
+   */
+  public function setComment($comment)
+  {
+    $this->comment = $comment;
+  }
+
+  /**
+   * @param boolean $compatibility
+   */
+  public function setCompatibility($compatibility)
+  {
+    $this->compatibility = $compatibility;
+  }
+
+  /**
+   * JSON representation of the current rule
+   * @param integer $version
+   * @return string
+   */
+  public function getJSON($version = ApiVersion::V1)
+  {
+    return json_encode($this->getArray($version));
+  }
+
+  /**
+   * Get the rule as an associative array
+   * @param integer $version
+   * @return array
+   */
+  public function getArray($version = ApiVersion::V1)
+  {
+    if ($version == ApiVersion::V2) {
+      return [
+        'id' => $this->getId(),
+        'firstLicenseId' => $this->getFirstLicenseId(),
+        'firstLicenseName' => $this->getFirstLicenseName(),
+        'secondLicenseId' => $this->getSecondLicenseId(),
+        'secondLicenseName' => $this->getSecondLicenseName(),
+        'firstType' => $this->getFirstType(),
+        'secondType' => $this->getSecondType(),
+        'comment' => $this->getComment(),
+        'compatibility' => $this->getCompatibility()
+      ];
+    }
+    return [
+      'id' => $this->getId(),
+      'first_license_id' => $this->getFirstLicenseId(),
+      'first_license_name' => $this->getFirstLicenseName(),
+      'second_license_id' => $this->getSecondLicenseId(),
+      'second_license_name' => $this->getSecondLicenseName(),
+      'first_type' => $this->getFirstType(),
+      'second_type' => $this->getSecondType(),
+      'comment' => $this->getComment(),
+      'compatibility' => $this->getCompatibility()
+    ];
+  }
+}

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -5164,6 +5164,290 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /license-compatibility-rules:
+    get:
+      operationId: getLicenseCompatibilityRules
+      tags:
+        - License
+        - Admin
+      summary: Get the license compatibility rules
+      description: >
+        Get the list of license compatibility rules from the server.
+      parameters:
+        - name: page
+          description: Page number for responses
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 1
+            minimum: 1
+        - name: limit
+          description: Limit of rules per request
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+        - name: search
+          description: Filter the rules on their description
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: List of the license compatibility rules
+          headers:
+            X-Total-Pages:
+              description: Total number of pages available
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LicenseCompatibilityRule'
+        '400':
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Route is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+    post:
+      operationId: createLicenseCompatibilityRule
+      tags:
+        - License
+        - Admin
+      summary: Create a new license compatibility rule
+      description: >
+        Create a new license compatibility rule. At least one license or
+        license type has to be given, a rule without any of them would shadow
+        the default compatibility of the server.
+      requestBody:
+        description: New license compatibility rule
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewLicenseCompatibilityRule'
+      responses:
+        '201':
+          description: Rule added successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Route is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /license-compatibility-rules/{id}:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the license compatibility rule
+        in: path
+        schema:
+          type: integer
+    put:
+      operationId: updateLicenseCompatibilityRule
+      tags:
+        - License
+        - Admin
+      summary: Update a license compatibility rule
+      description: >
+        Update an existing license compatibility rule. Only the fields sent in
+        the request body are updated.
+      requestBody:
+        description: Values of the rule to update
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EditLicenseCompatibilityRule'
+      responses:
+        '200':
+          description: Rule updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Route is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Rule not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+    delete:
+      operationId: deleteLicenseCompatibilityRule
+      tags:
+        - License
+        - Admin
+      summary: Delete a license compatibility rule
+      description: >
+        Permanently remove an existing license compatibility rule.
+      responses:
+        '200':
+          description: Rule deleted successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Route is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Rule not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /license-compatibility-rules/import:
+    post:
+      operationId: importLicenseCompatibilityRules
+      tags:
+        - License
+        - Admin
+      summary: Import license compatibility rules from a YAML file
+      description: >
+        Import the license compatibility rules from a YAML file. Rules already
+        present in the server are updated, the missing ones are created.
+      requestBody:
+        description: Include the YAML file
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                fileInput:
+                  type: string
+                  format: binary
+                  description: YAML to be imported
+              required:
+                - fileInput
+      responses:
+        '200':
+          description: Successfully imported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Route is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /license-compatibility-rules/export:
+    get:
+      operationId: exportLicenseCompatibilityRules
+      tags:
+        - License
+        - Admin
+      summary: Export the license compatibility rules as a YAML file
+      description: >
+        Export the license compatibility rules of the server as a YAML file.
+      parameters:
+        - name: id
+          description: Id of the rule to export, 0 for all
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: Successfully exported
+          content:
+            text/x-yaml:
+              schema:
+                type: string
+                format: binary
+        '403':
+          description: Route is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Rule not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /overview/database/contents:
     get:
       operationId: getDatabaseContents
@@ -6689,6 +6973,144 @@ components:
           nullable: true
           example:
             "Please respect the obligation"
+    LicenseCompatibilityRule:
+      description: License compatibility rule information
+      type: object
+      properties:
+        id:
+          description: Id of the rule
+          type: integer
+          example:
+            4
+        firstLicenseId:
+          description: Id of the first license, null matches every license
+          type: integer
+          nullable: true
+          example:
+            306
+        firstLicenseName:
+          description: Short name of the first license
+          type: string
+          nullable: true
+          example:
+            "MIT"
+        secondLicenseId:
+          description: Id of the second license, null matches every license
+          type: integer
+          nullable: true
+          example:
+            188
+        secondLicenseName:
+          description: Short name of the second license
+          type: string
+          nullable: true
+          example:
+            "GPL-2.0-only"
+        firstType:
+          description: >
+            License type of the first license, null matches every type. Allowed
+            values are configured by the `LicenseTypes` setting of the server.
+          type: string
+          nullable: true
+          example:
+            "Permissive"
+        secondType:
+          description: License type of the second license, null matches every type
+          type: string
+          nullable: true
+          example:
+            "Strong Copyleft"
+        comment:
+          description: Description of the rule
+          type: string
+          example:
+            "A permissive license is compatible with a copyleft license"
+        compatibility:
+          description: Compatibility result of the rule
+          type: boolean
+          example:
+            true
+    NewLicenseCompatibilityRule:
+      description: New license compatibility rule
+      type: object
+      properties:
+        firstLicenseId:
+          description: Id of the first license, null matches every license
+          type: integer
+          nullable: true
+          example:
+            306
+        secondLicenseId:
+          description: Id of the second license, null matches every license
+          type: integer
+          nullable: true
+          example:
+            188
+        firstType:
+          description: License type of the first license, null matches every type
+          type: string
+          nullable: true
+          example:
+            "Permissive"
+        secondType:
+          description: License type of the second license, null matches every type
+          type: string
+          nullable: true
+          example:
+            "Strong Copyleft"
+        comment:
+          description: Description of the rule
+          type: string
+          example:
+            "A permissive license is compatible with a copyleft license"
+        compatibility:
+          description: Compatibility result of the rule
+          type: boolean
+          example:
+            true
+      required:
+        - comment
+        - compatibility
+    EditLicenseCompatibilityRule:
+      description: >
+        Values of a license compatibility rule to update. Only the fields sent
+        in the request body are updated, at least one is required.
+      type: object
+      properties:
+        firstLicenseId:
+          description: Id of the first license, null matches every license
+          type: integer
+          nullable: true
+          example:
+            306
+        secondLicenseId:
+          description: Id of the second license, null matches every license
+          type: integer
+          nullable: true
+          example:
+            188
+        firstType:
+          description: License type of the first license, null matches every type
+          type: string
+          nullable: true
+          example:
+            "Permissive"
+        secondType:
+          description: License type of the second license, null matches every type
+          type: string
+          nullable: true
+          example:
+            "Strong Copyleft"
+        comment:
+          description: Description of the rule
+          type: string
+          example:
+            "A permissive license is compatible with a copyleft license"
+        compatibility:
+          description: Compatibility result of the rule
+          type: boolean
+          example:
+            true
     ApiInfo:
       description: Info about the API
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -32,6 +32,7 @@ use Fossology\UI\Api\Controllers\FolderController;
 use Fossology\UI\Api\Controllers\GroupController;
 use Fossology\UI\Api\Controllers\InfoController;
 use Fossology\UI\Api\Controllers\JobController;
+use Fossology\UI\Api\Controllers\LicenseCompatibilityRuleController;
 use Fossology\UI\Api\Controllers\LicenseController;
 use Fossology\UI\Api\Controllers\MaintenanceController;
 use Fossology\UI\Api\Controllers\ObligationController;
@@ -425,6 +426,18 @@ $app->group('/license',
     $app->delete('/admincandidates/{id:\\d+}',
       LicenseController::class . ':deleteAdminLicenseCandidate');
     $app->put('/adminacknowledgements', LicenseController::class . ':handleAdminLicenseAcknowledgement');
+    $app->any('/{params:.*}', BadRequestController::class);
+  });
+
+/////////////////LICENSE COMPATIBILITY RULES////////////
+$app->group('/license-compatibility-rules',
+  function (\Slim\Routing\RouteCollectorProxy $app) {
+    $app->get('', LicenseCompatibilityRuleController::class . ':getRules');
+    $app->post('', LicenseCompatibilityRuleController::class . ':createRule');
+    $app->get('/export', LicenseCompatibilityRuleController::class . ':exportRules');
+    $app->post('/import', LicenseCompatibilityRuleController::class . ':importRules');
+    $app->put('/{id:\\d+}', LicenseCompatibilityRuleController::class . ':updateRule');
+    $app->delete('/{id:\\d+}', LicenseCompatibilityRuleController::class . ':deleteRule');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui/page/AdminLicenseFromYAML.php
+++ b/src/www/ui/page/AdminLicenseFromYAML.php
@@ -10,6 +10,7 @@ namespace Fossology\UI\Page;
 use Fossology\Lib\Application\LicenseCompatibilityRulesYamlImport;
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\Plugin\DefaultPlugin;
+use Fossology\UI\Api\Models\ApiVersion;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,6 +22,8 @@ class AdminLicenseFromYAML extends DefaultPlugin
 {
   const NAME = "admin_license_from_yaml";
   const KEY_UPLOAD_MAX_FILESIZE = 'upload_max_filesize';
+  const FILE_INPUT_NAME = 'file_input';
+  const FILE_INPUT_NAME_V2 = 'fileInput';
   function __construct()
   {
     parent::__construct(self::NAME, array(
@@ -31,6 +34,18 @@ class AdminLicenseFromYAML extends DefaultPlugin
         ));
   }
   /**
+   * @return string
+   */
+  public function getFileInputName($apiVersion = ApiVersion::V1)
+  {
+    if ($apiVersion == ApiVersion::V2) {
+      return $this::FILE_INPUT_NAME_V2;
+    } else {
+      return $this::FILE_INPUT_NAME;
+    }
+  }
+
+  /**
    * @param Request $request
    * @return Response
    */
@@ -38,7 +53,7 @@ class AdminLicenseFromYAML extends DefaultPlugin
   {
     $vars = array();
     if ($request->isMethod('POST')) {
-      $uploadFile = $request->files->get('file_input');
+      $uploadFile = $request->files->get(self::FILE_INPUT_NAME);
       $vars['message'] = $this->handleFileUpload($uploadFile);
     }
     $vars[self::KEY_UPLOAD_MAX_FILESIZE] = ini_get(self::KEY_UPLOAD_MAX_FILESIZE);
@@ -48,9 +63,11 @@ class AdminLicenseFromYAML extends DefaultPlugin
 
   /**
    * @param UploadedFile $uploadedFile
-   * @return null|string
+   * @param boolean $fromRest Return an array with the status code if called
+   *        from the REST API
+   * @return array|null|string
    */
-  protected function handleFileUpload($uploadedFile)
+  public function handleFileUpload($uploadedFile, $fromRest = false)
   {
     $errMsg = '';
     if (! ($uploadedFile instanceof UploadedFile)) {
@@ -67,11 +84,18 @@ class AdminLicenseFromYAML extends DefaultPlugin
         $uploadedFile->getClientOriginalName();
     }
     if (! empty($errMsg)) {
+      if ($fromRest) {
+        return array(false, $errMsg, 400);
+      }
       return $errMsg;
     }
     /** @var LicenseCompatibilityRulesYamlImport $licenseYamlImport */
     $licenseYamlImport = $this->getObject('app.license_yaml_import');
-    return $licenseYamlImport->handleFile($uploadedFile->getRealPath());
+    $msg = $licenseYamlImport->handleFile($uploadedFile->getRealPath());
+    if ($fromRest) {
+      return array(true, $msg, 200);
+    }
+    return $msg;
   }
 }
 

--- a/src/www/ui_tests/api/Controllers/LicenseCompatibilityRuleControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/LicenseCompatibilityRuleControllerTest.php
@@ -1,0 +1,818 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Harshit Gandhi <gandhiharshit716@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * @file
+ * @brief Tests for LicenseCompatibilityRuleController
+ */
+
+namespace Fossology\UI\Api\Test\Controllers;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\CompatibilityDao;
+use Fossology\Lib\Db\DbManager;
+use Fossology\UI\Api\Controllers\LicenseCompatibilityRuleController;
+use Fossology\UI\Api\Exceptions\HttpBadRequestException;
+use Fossology\UI\Api\Exceptions\HttpForbiddenException;
+use Fossology\UI\Api\Exceptions\HttpInternalServerErrorException;
+use Fossology\UI\Api\Exceptions\HttpNotFoundException;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Models\ApiVersion;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Fossology\UI\Api\Models\LicenseCompatibilityRule;
+use Mockery as M;
+use Slim\Psr7\Factory\StreamFactory;
+use Slim\Psr7\Headers;
+use Slim\Psr7\Request;
+use Slim\Psr7\Uri;
+
+/**
+ * @class LicenseCompatibilityRuleControllerTest
+ * @brief Unit tests for LicenseCompatibilityRuleController
+ */
+class LicenseCompatibilityRuleControllerTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @var integer $assertCountBefore
+   * Assertions before running tests
+   */
+  private $assertCountBefore;
+
+  /**
+   * @var DbHelper $dbHelper
+   * DbHelper mock
+   */
+  private $dbHelper;
+
+  /**
+   * @var DbManager $dbManager
+   * DbManager mock
+   */
+  private $dbManager;
+
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+
+  /**
+   * @var CompatibilityDao $compatibilityDao
+   * CompatibilityDao mock
+   */
+  private $compatibilityDao;
+
+  /**
+   * @var M\MockInterface $licenseYamlPlugin
+   * admin_license_from_yaml mock
+   */
+  private $licenseYamlPlugin;
+
+  /**
+   * @var LicenseCompatibilityRuleController $ruleController
+   * LicenseCompatibilityRuleController object
+   */
+  private $ruleController;
+
+  /**
+   * @var StreamFactory $streamFactory
+   * Stream factory to create body streams.
+   */
+  private $streamFactory;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp() : void
+  {
+    global $container, $SysConf;
+    $container = M::mock('ContainerBuilder');
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->dbManager = M::mock(DbManager::class);
+    $this->restHelper = M::mock(RestHelper::class);
+    $this->compatibilityDao = M::mock(CompatibilityDao::class);
+    $this->licenseYamlPlugin = M::mock('admin_license_from_yaml');
+
+    $this->dbHelper->shouldReceive('getDbManager')->andReturn($this->dbManager);
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+    $this->restHelper->shouldReceive('getPlugin')
+      ->withArgs(array('admin_license_from_yaml'))
+      ->andReturn($this->licenseYamlPlugin);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+    $container->shouldReceive('get')->withArgs(array(
+      'dao.compatibility'))->andReturn($this->compatibilityDao);
+
+    $SysConf['SYSCONFIG']['LicenseTypes'] = "Permissive, Strong Copyleft";
+
+    $this->ruleController = new LicenseCompatibilityRuleController($container);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+    $this->streamFactory = new StreamFactory();
+  }
+
+  /**
+   * @brief Remove test objects
+   * @see PHPUnit_Framework_TestCase::tearDown()
+   */
+  protected function tearDown() : void
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  /**
+   * Helper function to get JSON array from response
+   *
+   * @param ResponseHelper $response
+   * @return array Decoded response
+   */
+  private function getResponseJson($response)
+  {
+    $response->getBody()->seek(0);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+
+  /**
+   * Generate a rule row as returned by the DAO
+   *
+   * @param int $ruleId Id of the rule
+   * @return array
+   */
+  private function getRuleRow($ruleId)
+  {
+    return [
+      "lr_pk" => $ruleId,
+      "first_rf_fk" => 306,
+      "second_rf_fk" => null,
+      "first_rf_shortname" => "MIT",
+      "second_rf_shortname" => null,
+      "first_type" => "Permissive",
+      "second_type" => "Strong Copyleft",
+      "comment" => "Rule $ruleId",
+      "compatibility" => "t"
+    ];
+  }
+
+  /**
+   * Create a request with the given JSON body
+   *
+   * @param string $method  HTTP method
+   * @param array $body     Body to be sent as JSON
+   * @param int $version    API version
+   * @return Request
+   */
+  private function createJsonRequest($method, $body,
+                                     $version = ApiVersion::V2)
+  {
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    $request = new Request($method, new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [],
+      $this->streamFactory->createStream(json_encode($body)));
+    return $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, $version);
+  }
+
+  /**
+   * Create a GET request with the given query string
+   *
+   * @param string $query Query string of the request
+   * @param int $version  API version
+   * @return Request
+   */
+  private function createGetRequest($query = "", $version = ApiVersion::V2)
+  {
+    $request = new Request("GET",
+      new Uri("HTTP", "localhost", null, "/license-compatibility-rules",
+        $query),
+      new Headers(), [], [], $this->streamFactory->createStream());
+    return $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, $version);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::getRules() for version 1
+   * -# Check if the rules are returned with the snake_case keys
+   */
+  public function testGetRulesV1()
+  {
+    $this->testGetRules(ApiVersion::V1);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::getRules() for version 2
+   * -# Check if the rules are returned with the camelCase keys
+   */
+  public function testGetRulesV2()
+  {
+    $this->testGetRules();
+  }
+
+  /**
+   * @param $version
+   * @return void
+   */
+  private function testGetRules($version = ApiVersion::V2)
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $rows = [$this->getRuleRow(1), $this->getRuleRow(2)];
+
+    $this->compatibilityDao->shouldReceive('getTotalRulesCount')
+      ->withArgs([""])->andReturn(2);
+    $this->compatibilityDao->shouldReceive('getAllRules')
+      ->withArgs([100, 0, ""])->andReturn($rows);
+
+    $expected = [];
+    foreach ($rows as $row) {
+      $expected[] = LicenseCompatibilityRule::fromArray($row)
+        ->getArray($version);
+    }
+
+    $actualResponse = $this->ruleController->getRules(
+      $this->createGetRequest("", $version), new ResponseHelper(), []);
+
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+    $this->assertEquals(1,
+      intval($actualResponse->getHeaderLine('X-Total-Pages')));
+    $this->assertEquals($expected, $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::getRules() with pagination and
+   *    a search term
+   * -# Check if the DAO is called with the translated offset and search term
+   */
+  public function testGetRulesWithPaginationAndSearch()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $rows = [$this->getRuleRow(3)];
+
+    $this->compatibilityDao->shouldReceive('getTotalRulesCount')
+      ->withArgs(["%copyleft%"])->andReturn(3);
+    $this->compatibilityDao->shouldReceive('getAllRules')
+      ->withArgs([2, 2, "%copyleft%"])->andReturn($rows);
+
+    $actualResponse = $this->ruleController->getRules(
+      $this->createGetRequest("page=2&limit=2&search=copyleft"),
+      new ResponseHelper(), []);
+
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+    $this->assertEquals(2,
+      intval($actualResponse->getHeaderLine('X-Total-Pages')));
+    $this->assertCount(1, $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::getRules() with an invalid
+   *    limit
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testGetRulesInvalidLimit()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->ruleController->getRules($this->createGetRequest("limit=-1"),
+      new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::getRules() with a zero limit
+   * -# Check if HttpBadRequestException is thrown instead of falling back to
+   *    the default limit
+   */
+  public function testGetRulesZeroLimit()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->ruleController->getRules($this->createGetRequest("limit=0"),
+      new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::getRules() with a limit which
+   *    is not a number
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testGetRulesNonNumericLimit()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->ruleController->getRules($this->createGetRequest("limit=abc"),
+      new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::getRules() with a zero page
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testGetRulesZeroPage()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->compatibilityDao->shouldReceive('getTotalRulesCount')
+      ->withArgs([""])->andReturn(2);
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->ruleController->getRules($this->createGetRequest("page=0"),
+      new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::getRules() with a page above
+   *    the total pages
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testGetRulesPageOutOfRange()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->compatibilityDao->shouldReceive('getTotalRulesCount')
+      ->withArgs([""])->andReturn(2);
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->ruleController->getRules($this->createGetRequest("page=5&limit=2"),
+      new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::getRules() as a non-admin user
+   * -# Check if HttpForbiddenException is thrown
+   */
+  public function testGetRulesNotAdmin()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->expectException(HttpForbiddenException::class);
+
+    $this->ruleController->getRules($this->createGetRequest(),
+      new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::createRule() for a valid rule
+   * -# Check if response status is 201
+   */
+  public function testCreateRule()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["license_ref", "rf_pk", 306])->andReturn(true);
+    $this->compatibilityDao->shouldReceive('insertRule')
+      ->withArgs([306, null, null, "Strong Copyleft", "New rule", true])
+      ->andReturn(9);
+
+    $request = $this->createJsonRequest("POST", [
+      "firstLicenseId" => 306,
+      "secondType" => "Strong Copyleft",
+      "comment" => "New rule",
+      "compatibility" => true
+    ]);
+
+    $expectedResponse = new Info(201, "Rule 9 added successfully.",
+      InfoType::INFO);
+    $actualResponse = $this->ruleController->createRule($request,
+      new ResponseHelper(), []);
+
+    $this->assertEquals($expectedResponse->getCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse->getArray(),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::createRule() with the version 1
+   *    field names
+   * -# Check if response status is 201
+   */
+  public function testCreateRuleWithV1FieldNames()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->compatibilityDao->shouldReceive('insertRule')
+      ->withArgs([null, null, "Permissive", null, "New rule", false])
+      ->andReturn(10);
+
+    $request = $this->createJsonRequest("POST", [
+      "first_type" => "Permissive",
+      "comment" => "New rule",
+      "compatibility" => false
+    ], ApiVersion::V1);
+
+    $actualResponse = $this->ruleController->createRule($request,
+      new ResponseHelper(), []);
+
+    $this->assertEquals(201, $actualResponse->getStatusCode());
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::createRule() without a
+   *    description
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testCreateRuleWithoutComment()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->ruleController->createRule($this->createJsonRequest("POST", [
+      "firstType" => "Permissive",
+      "compatibility" => true
+    ]), new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::createRule() with an empty
+   *    description
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testCreateRuleWithEmptyComment()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->ruleController->createRule($this->createJsonRequest("POST", [
+      "firstType" => "Permissive",
+      "comment" => "  ",
+      "compatibility" => true
+    ]), new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::createRule() without any
+   *    license or license type
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testCreateRuleWithoutLicenseAndType()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->ruleController->createRule($this->createJsonRequest("POST", [
+      "comment" => "Default rule",
+      "compatibility" => true
+    ]), new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::createRule() with a license
+   *    which does not exist
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testCreateRuleWithUnknownLicense()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["license_ref", "rf_pk", 999])->andReturn(false);
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->ruleController->createRule($this->createJsonRequest("POST", [
+      "firstLicenseId" => 999,
+      "comment" => "New rule",
+      "compatibility" => true
+    ]), new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::createRule() with a license
+   *    type which is not configured
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testCreateRuleWithUnknownLicenseType()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->ruleController->createRule($this->createJsonRequest("POST", [
+      "firstType" => "Unknown Type",
+      "comment" => "New rule",
+      "compatibility" => true
+    ]), new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::createRule() when the rule can
+   *    not be inserted
+   * -# Check if HttpInternalServerErrorException is thrown
+   */
+  public function testCreateRuleFailure()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->compatibilityDao->shouldReceive('insertRule')->andReturn(-2);
+    $this->expectException(HttpInternalServerErrorException::class);
+
+    $this->ruleController->createRule($this->createJsonRequest("POST", [
+      "firstType" => "Permissive",
+      "comment" => "New rule",
+      "compatibility" => true
+    ]), new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::updateRule() for a valid
+   *    request
+   * -# Check if response status is 200
+   */
+  public function testUpdateRule()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $ruleId = 4;
+    $this->compatibilityDao->shouldReceive('getRuleById')->withArgs([$ruleId])
+      ->andReturn($this->getRuleRow($ruleId));
+    $this->compatibilityDao->shouldReceive('updateRuleFromArray')
+      ->withArgs([[$ruleId => ["comment" => "Updated rule",
+        "result" => false]]])->andReturn(1);
+
+    $request = $this->createJsonRequest("PUT", [
+      "comment" => "Updated rule",
+      "compatibility" => false
+    ]);
+
+    $expectedResponse = new Info(200, "Rule $ruleId updated successfully.",
+      InfoType::INFO);
+    $actualResponse = $this->ruleController->updateRule($request,
+      new ResponseHelper(), ["id" => $ruleId]);
+
+    $this->assertEquals($expectedResponse->getCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse->getArray(),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::updateRule() with the licenses
+   *    reset to null
+   * -# Check if response status is 200
+   */
+  public function testUpdateRuleResetLicense()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $ruleId = 4;
+    $this->compatibilityDao->shouldReceive('getRuleById')->withArgs([$ruleId])
+      ->andReturn($this->getRuleRow($ruleId));
+    $this->compatibilityDao->shouldReceive('updateRuleFromArray')
+      ->withArgs([[$ruleId => ["firstLic" => null, "firstType" => null]]])
+      ->andReturn(1);
+
+    $request = $this->createJsonRequest("PUT", [
+      "firstLicenseId" => null,
+      "firstType" => null
+    ]);
+
+    $actualResponse = $this->ruleController->updateRule($request,
+      new ResponseHelper(), ["id" => $ruleId]);
+
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::updateRule() for a rule which
+   *    does not exist
+   * -# Check if HttpNotFoundException is thrown
+   */
+  public function testUpdateRuleNotFound()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->compatibilityDao->shouldReceive('getRuleById')->withArgs([8])
+      ->andReturn(null);
+    $this->expectException(HttpNotFoundException::class);
+
+    $this->ruleController->updateRule(
+      $this->createJsonRequest("PUT", ["comment" => "Updated rule"]),
+      new ResponseHelper(), ["id" => 8]);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::updateRule() with an empty
+   *    request body
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testUpdateRuleEmptyBody()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->compatibilityDao->shouldReceive('getRuleById')->withArgs([4])
+      ->andReturn($this->getRuleRow(4));
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->ruleController->updateRule($this->createJsonRequest("PUT", []),
+      new ResponseHelper(), ["id" => 4]);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::updateRule() with a body
+   *    holding no rule value
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testUpdateRuleWithoutRuleValues()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->compatibilityDao->shouldReceive('getRuleById')->withArgs([4])
+      ->andReturn($this->getRuleRow(4));
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->ruleController->updateRule(
+      $this->createJsonRequest("PUT", ["unknownField" => "value"]),
+      new ResponseHelper(), ["id" => 4]);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::deleteRule() for a valid
+   *    request
+   * -# Check if response status is 200
+   */
+  public function testDeleteRule()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $ruleId = 4;
+    $this->compatibilityDao->shouldReceive('getRuleById')->withArgs([$ruleId])
+      ->andReturn($this->getRuleRow($ruleId));
+    $this->compatibilityDao->shouldReceive('deleteRule')->withArgs([$ruleId])
+      ->andReturn(true);
+
+    $expectedResponse = new Info(200, "Rule $ruleId deleted successfully.",
+      InfoType::INFO);
+    $actualResponse = $this->ruleController->deleteRule(null,
+      new ResponseHelper(), ["id" => $ruleId]);
+
+    $this->assertEquals($expectedResponse->getCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse->getArray(),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::deleteRule() for a rule which
+   *    does not exist
+   * -# Check if HttpNotFoundException is thrown
+   */
+  public function testDeleteRuleNotFound()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->compatibilityDao->shouldReceive('getRuleById')->withArgs([8])
+      ->andReturn(null);
+    $this->expectException(HttpNotFoundException::class);
+
+    $this->ruleController->deleteRule(null, new ResponseHelper(),
+      ["id" => 8]);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::deleteRule() when the rule can
+   *    not be deleted
+   * -# Check if HttpInternalServerErrorException is thrown
+   */
+  public function testDeleteRuleFailure()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->compatibilityDao->shouldReceive('getRuleById')->withArgs([4])
+      ->andReturn($this->getRuleRow(4));
+    $this->compatibilityDao->shouldReceive('deleteRule')->withArgs([4])
+      ->andReturn(false);
+    $this->expectException(HttpInternalServerErrorException::class);
+
+    $this->ruleController->deleteRule(null, new ResponseHelper(),
+      ["id" => 4]);
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test LicenseCompatibilityRuleController::importRules() for a valid
+   *    request
+   * -# Check if response status is 200
+   */
+  public function testImportRules()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->licenseYamlPlugin->shouldReceive('getFileInputName')
+      ->andReturn("fileInput");
+    $this->licenseYamlPlugin->shouldReceive('handleFileUpload')
+      ->withArgs([null, true])
+      ->andReturn([true, "Read yaml: 2 license rules", 200]);
+
+    $expectedResponse = new Info(200, "Read yaml: 2 license rules",
+      InfoType::INFO);
+    $actualResponse = $this->ruleController->importRules(
+      $this->createJsonRequest("POST", []), new ResponseHelper(), []);
+
+    $this->assertEquals($expectedResponse->getCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($expectedResponse->getArray(),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test LicenseCompatibilityRuleController::importRules() when the upload
+   *    is rejected
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testImportRulesInvalidFile()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->licenseYamlPlugin->shouldReceive('getFileInputName')
+      ->andReturn("fileInput");
+    $this->licenseYamlPlugin->shouldReceive('handleFileUpload')
+      ->withArgs([null, true])->andReturn([false, "No file selected", 400]);
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->ruleController->importRules($this->createJsonRequest("POST", []),
+      new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::exportRules() for all the rules
+   * -# Check if the YAML of the rules is returned
+   */
+  public function testExportRules()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $rows = [[
+      "firstname" => "MIT",
+      "secondname" => null,
+      "firsttype" => null,
+      "secondtype" => "Strong Copyleft",
+      "compatibility" => "true",
+      "comment" => "Rule 1"
+    ]];
+    $this->compatibilityDao->shouldReceive('getDefaultCompatibility')
+      ->andReturn(false);
+    $this->dbManager->shouldReceive('getRows')->andReturn($rows);
+
+    $actualResponse = $this->ruleController->exportRules(
+      $this->createGetRequest(), new ResponseHelper(), []);
+
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+    $this->assertEquals("text/x-yaml; charset=UTF-8",
+      $actualResponse->getHeaderLine('Content-type'));
+    $actualResponse->getBody()->seek(0);
+    $this->assertEquals(yaml_emit(["default" => false, "rules" => $rows]),
+      $actualResponse->getBody()->getContents());
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::exportRules() for a rule which
+   *    does not exist
+   * -# Check if HttpNotFoundException is thrown
+   */
+  public function testExportRulesNotFound()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->compatibilityDao->shouldReceive('getRuleById')->withArgs([8])
+      ->andReturn(null);
+    $this->expectException(HttpNotFoundException::class);
+
+    $this->ruleController->exportRules($this->createGetRequest("id=8"),
+      new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRuleController::exportRules() as a non-admin
+   *    user
+   * -# Check if HttpForbiddenException is thrown
+   */
+  public function testExportRulesNotAdmin()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->expectException(HttpForbiddenException::class);
+
+    $this->ruleController->exportRules($this->createGetRequest(),
+      new ResponseHelper(), []);
+  }
+}

--- a/src/www/ui_tests/api/Models/LicenseCompatibilityRuleTest.php
+++ b/src/www/ui_tests/api/Models/LicenseCompatibilityRuleTest.php
@@ -1,0 +1,186 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Harshit Gandhi <gandhiharshit716@gmail.com>
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * @file
+ * @brief Tests for LicenseCompatibilityRule model
+ */
+
+namespace Fossology\UI\Api\Test\Models;
+
+use Fossology\UI\Api\Models\ApiVersion;
+use Fossology\UI\Api\Models\LicenseCompatibilityRule;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @class LicenseCompatibilityRuleTest
+ * @brief Tests for LicenseCompatibilityRule model
+ */
+class LicenseCompatibilityRuleTest extends TestCase
+{
+  /**
+   * @brief Get a rule row as returned by CompatibilityDao
+   * @return array
+   */
+  private function getRuleRow()
+  {
+    return [
+      'lr_pk' => "4",
+      'first_rf_fk' => "306",
+      'second_rf_fk' => null,
+      'first_rf_shortname' => "MIT",
+      'second_rf_shortname' => null,
+      'first_type' => "Permissive",
+      'second_type' => "Strong Copyleft",
+      'comment' => "A permissive license is compatible with a copyleft license",
+      'compatibility' => "t"
+    ];
+  }
+
+  /**
+   * @brief Get a new model object holding the values of getRuleRow()
+   * @return LicenseCompatibilityRule
+   */
+  private function getRule()
+  {
+    return new LicenseCompatibilityRule(4, 306, "MIT", null, null,
+      "Permissive", "Strong Copyleft",
+      "A permissive license is compatible with a copyleft license", true);
+  }
+
+  /**
+   * @test
+   * -# Test the constructor of LicenseCompatibilityRule
+   */
+  public function testConstructor()
+  {
+    $this->assertInstanceOf(LicenseCompatibilityRule::class, $this->getRule());
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRule::fromArray()
+   * -# Check if the values of the DB row are casted as expected
+   */
+  public function testFromArray()
+  {
+    $rule = LicenseCompatibilityRule::fromArray($this->getRuleRow());
+
+    $this->assertSame(4, $rule->getId());
+    $this->assertSame(306, $rule->getFirstLicenseId());
+    $this->assertEquals("MIT", $rule->getFirstLicenseName());
+    $this->assertNull($rule->getSecondLicenseId());
+    $this->assertNull($rule->getSecondLicenseName());
+    $this->assertEquals("Permissive", $rule->getFirstType());
+    $this->assertEquals("Strong Copyleft", $rule->getSecondType());
+    $this->assertEquals(
+      "A permissive license is compatible with a copyleft license",
+      $rule->getComment());
+    $this->assertTrue($rule->getCompatibility());
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRule::fromArray() for an incompatible rule
+   * -# Check if the compatibility is false
+   */
+  public function testFromArrayWithFalseCompatibility()
+  {
+    $row = $this->getRuleRow();
+    $row['compatibility'] = "f";
+
+    $this->assertFalse(
+      LicenseCompatibilityRule::fromArray($row)->getCompatibility());
+  }
+
+  /**
+   * @test
+   * -# Test the setters of LicenseCompatibilityRule
+   * -# Check if the getters return the new values
+   */
+  public function testSetters()
+  {
+    $rule = $this->getRule();
+    $rule->setId(5);
+    $rule->setFirstLicenseId(188);
+    $rule->setFirstLicenseName("GPL-2.0-only");
+    $rule->setSecondLicenseId(306);
+    $rule->setSecondLicenseName("MIT");
+    $rule->setFirstType("Strong Copyleft");
+    $rule->setSecondType("Permissive");
+    $rule->setComment("New description");
+    $rule->setCompatibility(false);
+
+    $this->assertEquals(5, $rule->getId());
+    $this->assertEquals(188, $rule->getFirstLicenseId());
+    $this->assertEquals("GPL-2.0-only", $rule->getFirstLicenseName());
+    $this->assertEquals(306, $rule->getSecondLicenseId());
+    $this->assertEquals("MIT", $rule->getSecondLicenseName());
+    $this->assertEquals("Strong Copyleft", $rule->getFirstType());
+    $this->assertEquals("Permissive", $rule->getSecondType());
+    $this->assertEquals("New description", $rule->getComment());
+    $this->assertFalse($rule->getCompatibility());
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRule::getArray() for version 1
+   * -# Check if the keys are in snake_case
+   */
+  public function testGetArrayV1()
+  {
+    $expected = [
+      'id' => 4,
+      'first_license_id' => 306,
+      'first_license_name' => "MIT",
+      'second_license_id' => null,
+      'second_license_name' => null,
+      'first_type' => "Permissive",
+      'second_type' => "Strong Copyleft",
+      'comment' => "A permissive license is compatible with a copyleft license",
+      'compatibility' => true
+    ];
+
+    $this->assertEquals($expected,
+      $this->getRule()->getArray(ApiVersion::V1));
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRule::getArray() for version 2
+   * -# Check if the keys are in camelCase
+   */
+  public function testGetArrayV2()
+  {
+    $expected = [
+      'id' => 4,
+      'firstLicenseId' => 306,
+      'firstLicenseName' => "MIT",
+      'secondLicenseId' => null,
+      'secondLicenseName' => null,
+      'firstType' => "Permissive",
+      'secondType' => "Strong Copyleft",
+      'comment' => "A permissive license is compatible with a copyleft license",
+      'compatibility' => true
+    ];
+
+    $this->assertEquals($expected,
+      $this->getRule()->getArray(ApiVersion::V2));
+  }
+
+  /**
+   * @test
+   * -# Test LicenseCompatibilityRule::getJSON()
+   * -# Check if the JSON matches the array of the same version
+   */
+  public function testGetJSON()
+  {
+    $rule = $this->getRule();
+
+    $this->assertEquals(json_encode($rule->getArray(ApiVersion::V2)),
+      $rule->getJSON(ApiVersion::V2));
+  }
+}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The only way to manage license compatibility rules today is the legacy `AdminLicenseCompatibilityRules` page, which is why the React/Next.js Admin migration is stuck on this screen. This PR adds the missing OpenAPI v2 endpoints for the full CRUD flow plus the YAML import/export.

While hooking the import endpoint up to the existing YAML importer I ran into a few bugs in the code it depends on, so I've fixed those here as well - otherwise the new endpoints would have inherited them. They're listed separately below so they're easy to review on their own.

Closes fossology/FOSSologyUI#423

### Changes

New endpoints, all admin-only and documented in `openapiv2.yaml`:

| Method | Route |
| --- | --- |
| GET | `/license-compatibility-rules` (supports `page`, `limit`, `search`, returns `X-Total-Pages`) |
| POST | `/license-compatibility-rules` |
| PUT | `/license-compatibility-rules/{id}` |
| DELETE | `/license-compatibility-rules/{id}` |
| POST | `/license-compatibility-rules/import` (YAML, `fileInput`) |
| GET | `/license-compatibility-rules/export` (YAML, optional `?id=`) |

New files:

- `src/www/ui/api/Controllers/LicenseCompatibilityRuleController.php`
- `src/www/ui/api/Models/LicenseCompatibilityRule.php` - exposes both the license ids and their short names, so the UI doesn't have to resolve names itself
- tests for the controller, the model, the DAO and the YAML importer

Notes on behaviour:

- `search` filters on the rule description, same as the legacy page.
- A `null` license or license type means "matches any", same as `0` / `---` in the legacy dropdowns.
- License ids are validated against `license_ref` and license types against the `LicenseTypes` sysconfig setting.
- `POST` rejects a rule with no license *and* no type - that row is what `CompatibilityDao` reads as the server's default compatibility, so creating one would shadow it.
- `PUT` only touches the fields present in the body.

Fixes in existing code that the endpoints depend on:

- `CompatibilityDao::getAllRules()` / `getTotalRulesCount()` interpolated the search term straight into an `ILIKE`. It's a bound parameter now. The legacy DataTables search box reaches the same code, and a payload like `x' OR 1=1 OR comment ILIKE 'y` returned every rule, while a bare `'` produced a 500.
- `CompatibilityDao::updateRuleFromArray()` didn't cast PHP booleans. `insertInto()` runs params through `cleanupParamsArray()` but `getSingleRow()` doesn't, so a bound `false` reached Postgres as `""` and the `bool` column rejected it. `"t"`/`"f"` from the legacy form still work.
- `LicenseCompatibilityRulesYamlImport::updateLicense()` wrote to `$rule["compatibility"]`, but `updateRuleFromArray()` only reads `"result"`, and it guarded the update with `count($rule) > 1`. Between the two, a YAML import could never change the compatibility of an existing rule, and a comment-only change was a silent no-op that still logged "updated comment".
- Same class dereferenced `getLicenseByShortName()` without a null check, so a YAML naming an unknown license raised a `TypeError` (not caught by the `catch (\Exception)` in `handleFile()`). It now reports the license name.
- `AdminLicenseFromYAML::handleFileUpload()` is public with the `$fromRest` `[ok, message, code]` return, matching `AdminObligationFromCSV`. The legacy page's output is unchanged.

Known limitation, pre-existing and not touched here: re-importing an export only updates rules that have exactly two of `first_rf_fk`/`second_rf_fk`/`first_type`/`second_type` set. Rules with one, three or four get inserted again, because `handleYamlLicense()` guards its lookup with `count($param) == 2` (dates back to 2021). Two-field rules are what the UI normally produces, so the common round trip is clean. Happy to fix it here if reviewers prefer, but it changes import matching for the legacy page too, so I left it out.

## How to test

Get a token:

```bash
curl -X POST http://localhost/repo/api/v2/tokens \
  -H 'Content-Type: application/json' \
  -d '{"username":"fossy","password":"fossy","tokenName":"rules","tokenScope":"write","tokenExpire":"2026-12-31"}'
export T='Bearer <token>'
export A=http://localhost/repo/api/v2/license-compatibility-rules
```

Create, list, update, delete:

```bash
# needs a real license id, e.g. from GET /repo/api/v2/license/MIT
curl -X POST $A -H "Authorization: $T" -H 'Content-Type: application/json' \
  -d '{"firstLicenseId":125,"secondType":"Strong Copyleft","comment":"A permissive license against a copyleft one","compatibility":true}'

curl -H "Authorization: $T" "$A?limit=10&page=1&search=copyleft" -D -

# partial update, only the fields you send change
curl -X PUT $A/<id> -H "Authorization: $T" -H 'Content-Type: application/json' \
  -d '{"compatibility":false}'

curl -X DELETE $A/<id> -H "Authorization: $T"
```

Export, then import it back:

```bash
curl -H "Authorization: $T" "$A/export" -o rules.yaml
curl -X POST $A/import -H "Authorization: $T" -F "fileInput=@rules.yaml"
```

Worth checking on the error paths too - a bad license id, a license type that isn't in the `LicenseTypes` setting, an empty description, a rule with no license and no type, and a non-`.yaml`/`.yml` upload should all come back as 400s.

Unit tests:

```bash
cd src/www/ui_tests/api && phpunit -c tests.xml
phpunit --bootstrap src/phpunit-bootstrap.php src/lib/php/Application/test
phpunit src/lib/php/Dao/test/CompatibilityDaoTest.php   # needs postgres
```

Since the DAO and the YAML plugin are shared with the old UI, please also sanity-check Admin → License Admin → Compatibility Rules (list, search, add, edit, delete) and the Rules Import / Rules Export pages.
