### PR TITLE
docs(contributing): replace stale Travis CI reference with GitHub Act…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Not familiar with git, see [Git basic commands](https://github.com/fossology/fos
 We are using the [Feature Branch Workflow (also known as GitHub Flow)](https://guides.github.com/introduction/flow/),
 and prefer delivery as pull requests.
 
-Our first line of defense is the [Travis CI](https://travis-ci.org/fossology/fossology/) build defined within [.travis.yml](https://github.com/fossology/fossology/blob/master/.travis.yml) and triggered for every pull request.
+Our first line of defense is GitHub Actions, defined within [.github/workflows](https://github.com/fossology/fossology/tree/master/.github/workflows) and triggered for every pull request.
 
 Create a feature branch:
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors
     SPDX-License-Identifier: GPL-2.0-only
-->
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->
## Description
Fixes a stale CI reference in CONTRIBUTING.md. It still pointed contributors to Travis CI (`.travis.yml` and `travis-ci.org`), but the project has fully migrated to GitHub Actions and neither of those exists anymore.

### Changes
- Replaced the "Our first line of defense is Travis CI..." sentence in `CONTRIBUTING.md` with a reference to `.github/workflows`, where the actual CI is defined.
- No functional or code changes; documentation only.

## How to test
- Open `CONTRIBUTING.md` on this branch and confirm the Workflow section links to `.github/workflows` instead of the removed `.travis.yml` file / defunct `travis-ci.org`.
- Click through the new link to confirm it resolves to the existing `.github/workflows` directory.

#3742 