### PR TITLE
feat(api): add OpenAPI v2 GET /maintenance endpoint

### DIFF
--- a/src/maintagent/ui/maintagent.php
+++ b/src/maintagent/ui/maintagent.php
@@ -105,17 +105,28 @@ class maintagent extends FO_Plugin {
 
 
   /**
+   * \brief Get the timestamp of the last successfully completed maintenance job
+   * \return string|null The 'jq_endtime' value of the latest successful run, or null if none has completed yet
+   */
+  public function getLastMaintenanceRunTime()
+  {
+    $statementName = __METHOD__;
+    $row = $this->dbManager->getSingleRow(
+      "SELECT jq_endtime FROM jobqueue WHERE jq_type = $1 AND jq_end_bits = $2 ORDER BY jq_endtime DESC LIMIT 1",
+      array("maintagent", 1), $statementName);
+    return (is_array($row) && !empty($row['jq_endtime'])) ? $row['jq_endtime'] : null;
+  }
+
+  /**
    * \brief Display the input form
    * \returns string HTML in string
    */
   function DisplayForm()
   {
     $V = "";
-    $statementName = __METHOD__."maintenanceInfo";
-    $row = $this->dbManager->getSingleRow("SELECT jq_endtime FROM jobqueue WHERE jq_type = $1 AND jq_end_bits=$2 ORDER BY jq_endtime DESC LIMIT $2",
-           array("maintagent",1), $statementName);
-    if(!empty($row['jq_endtime'])){
-      $dateLastExecuted = Convert2BrowserTime($row['jq_endtime']);
+    $lastRunTime = $this->getLastMaintenanceRunTime();
+    if ($lastRunTime !== null) {
+      $dateLastExecuted = Convert2BrowserTime($lastRunTime);
       $text = _("Last maintenance job was executed on '$dateLastExecuted'");
       $V.= DisplayMessage($text);
     }

--- a/src/www/ui/api/Controllers/MaintenanceController.php
+++ b/src/www/ui/api/Controllers/MaintenanceController.php
@@ -75,4 +75,28 @@ class MaintenanceController extends RestController
     $returnVal = new Info(201, $mess, InfoType::INFO);
     return $response->withJson($returnVal->getArray(), $returnVal->getCode());
   }
+
+  /**
+   * Get details about the last completed maintenance job
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpErrorException
+   */
+  public function getMaintenanceInfo($request, $response, $args)
+  {
+    // Check if the request comes from the admin.
+    $this->throwNotAdminException();
+
+    /** @var \maintagent $maintain */
+    $maintain = $this->restHelper->getPlugin('maintagent');
+    $lastRunTime = $maintain->getLastMaintenanceRunTime();
+
+    $data = [
+      'lastRun' => $lastRunTime === null ? null : date(DATE_ATOM, strtotime($lastRunTime))
+    ];
+    return $response->withJson($data, 200);
+  }
 }

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -260,6 +260,34 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
   /maintenance:
+    get:
+      operationId: getMaintenanceInfo
+      tags:
+        - Maintenance
+      summary: Get details about the last completed maintenance job
+      description: >
+        Retrieve the timestamp of the last successfully completed maintenance job.
+      responses:
+        '200':
+          description: Maintenance information.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MaintenanceInfo'
+        '403':
+          description: Access denied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal Server Error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
     post:
       operationId: initiateMaintenance
       tags:
@@ -7228,6 +7256,16 @@ components:
               description: Date on which packages were built in ISO8601 format
               nullable: true
               example: "2022-01-07T11:13:00+05:30"
+    MaintenanceInfo:
+      description: Details about the last completed maintenance job
+      type: object
+      properties:
+        lastRun:
+          type: string
+          format: date-time
+          description: Timestamp of the most recently successfully completed maintenance job. Null if no maintenance job has completed successfully.
+          nullable: true
+          example: "2022-07-16T10:15:30+00:00"
     CreateMaintenance:
       description: Maintenance options
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -348,6 +348,7 @@ $app->group('/search',
 $app->group('/maintenance',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->post('', MaintenanceController::class . ':createMaintenance');
+    $app->get('', MaintenanceController::class . ':getMaintenanceInfo');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui_tests/api/Controllers/MaintenanceControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/MaintenanceControllerTest.php
@@ -376,4 +376,64 @@ class MaintenanceControllerTest extends \PHPUnit\Framework\TestCase
     $this->maintenanceController->createMaintenance($request, new ResponseHelper(), null);
   }
 
+  /**
+   * @test
+   * -# Test MaintenanceController::getMaintenanceInfo() when a maintenance job has completed
+   * -# Check if response status is 200 and lastRun is formatted as an ISO 8601 timestamp
+   */
+  public function testGetMaintenanceInfo()
+  {
+    $_SESSION['UserLevel'] = 10;
+
+    $this->maintagentPlugin->shouldReceive('getLastMaintenanceRunTime')
+      ->andReturn("2022-07-16 10:15:30");
+
+    $request = new Request("GET", new Uri("HTTP", "localhost"),
+      new Headers(), [], [], $this->streamFactory->createStream());
+
+    $actualResponse = $this->maintenanceController->getMaintenanceInfo($request, new ResponseHelper(), null);
+
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+    $this->assertEquals(
+      ['lastRun' => date(DATE_ATOM, strtotime("2022-07-16 10:15:30"))],
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test MaintenanceController::getMaintenanceInfo() when no maintenance job has completed yet
+   * -# Check if response status is 200 and lastRun is null
+   */
+  public function testGetMaintenanceInfoNoRuns()
+  {
+    $_SESSION['UserLevel'] = 10;
+
+    $this->maintagentPlugin->shouldReceive('getLastMaintenanceRunTime')
+      ->andReturn(null);
+
+    $request = new Request("GET", new Uri("HTTP", "localhost"),
+      new Headers(), [], [], $this->streamFactory->createStream());
+
+    $actualResponse = $this->maintenanceController->getMaintenanceInfo($request, new ResponseHelper(), null);
+
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+    $this->assertEquals(['lastRun' => null], $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test MaintenanceController::getMaintenanceInfo() for non admin users
+   * -# Check if access is denied with HttpForbiddenException
+   */
+  public function testGetMaintenanceInfoUserNotAdmin()
+  {
+    $_SESSION['UserLevel'] = 0;
+
+    $request = new Request("GET", new Uri("HTTP", "localhost"),
+      new Headers(), [], [], $this->streamFactory->createStream());
+
+    $this->expectException(HttpForbiddenException::class);
+    $this->maintenanceController->getMaintenanceInfo($request, new ResponseHelper(), null);
+  }
+
 }


### PR DESCRIPTION
Adds GET /maintenance, returning the timestamp of the last successfully completed maintenance job, so the React admin UI (fossology/FOSSologyUI) can display the same "Last maintenance job was executed on ..." info the legacy PHP admin page shows.

Refs: fossology/FOSSologyUI#427

## Description

The legacy PHP admin page (`maintagent`) shows when the last maintenance job completed by querying the `jobqueue` table directly. There was no equivalent OpenAPI v2 endpoint exposing this to the new React UI. This adds `GET /maintenance` to fill that gap.

### Changes

- Add `GET /maintenance`, returning `{ "lastRun": "<ISO 8601 timestamp>" | null }`
- Extract the existing `jobqueue` lookup out of `maintagent::DisplayForm()` into a reusable `getLastMaintenanceRunTime()` method, also fixing a pre-existing bug where the query reused the `LIMIT` placeholder for `jq_end_bits`, and guarding against `getSingleRow()` returning `false` (not an array) when no row matches
- Document the endpoint and a new `MaintenanceInfo` schema in `openapiv2.yaml`
- Add PHPUnit coverage for the new controller method (`testGetMaintenanceInfo`, `testGetMaintenanceInfoNoRuns`, `testGetMaintenanceInfoUserNotAdmin`)

## How to test

1. Build/start the API with this branch
2. Log in as an admin, run a maintenance job via `POST /maintenance` (or the legacy admin UI)
3. Call `GET /maintenance` (with a valid admin bearer token) and confirm the response is `{ "lastRun": "<timestamp of the completed job>" }`
4. On a fresh install where no maintenance job has ever completed, confirm `GET /maintenance` returns `{ "lastRun": null }`
5. Confirm a non-admin user calling `GET /maintenance` gets a 403
6. Run `phpunit --filter MaintenanceControllerTest` and confirm all tests pass

Companion frontend PR: fossology/FOSSologyUI#462, wires this endpoint up to the Admin > Maintenance page.

Closes fossology/FOSSologyUI#427
