### PR TITLE
feat(api): add OpenAPI v2 endpoint to trigger Monk agent renewal

### DIFF
--- a/src/lib/php/Dao/AgentDao.php
+++ b/src/lib/php/Dao/AgentDao.php
@@ -236,11 +236,15 @@ class AgentDao
   }
 
   /**
-   * @param string[] $row
+   * @param string[]|false $row getSingleRow()/fetchArray() return false, not
+   *        an array, when no row matches.
    * @return AgentRef
    */
   private function createAgentRef($row)
   {
+    if (!is_array($row)) {
+      return new AgentRef(0, null, null);
+    }
     return new AgentRef(intval($row['agent_pk']), $row['agent_name'], $row['agent_rev']);
   }
 

--- a/src/www/ui/api/Controllers/AgentController.php
+++ b/src/www/ui/api/Controllers/AgentController.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * @file
+ * @brief Controller for agent related REST endpoints
+ */
+
+namespace Fossology\UI\Api\Controllers;
+
+use Fossology\UI\Api\Exceptions\HttpErrorException;
+use Fossology\UI\Api\Exceptions\HttpNotFoundException;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * @class AgentController
+ * @brief Controller for agent related REST endpoints
+ */
+class AgentController extends RestController
+{
+  /**
+   * Renew the current Monk agent, equivalent to the legacy "Manage Monk
+   * Revision" admin page (admin_monk_revision).
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpErrorException
+   */
+  public function renewMonkAgent($request, $response, $args)
+  {
+    // Check if the request comes from the admin.
+    $this->throwNotAdminException();
+
+    $agentDao = $this->container->get('dao.agent');
+    $monk = $agentDao->getCurrentAgentRef('monk');
+    if (empty($monk->getAgentId())) {
+      throw new HttpNotFoundException("Monk agent has not run yet, nothing to renew.");
+    }
+
+    $agentDao->renewCurrentAgent('monk');
+
+    $returnVal = new Info(200, "Monk agent revision has been renewed.", InfoType::INFO);
+    return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+  }
+}

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -57,6 +57,8 @@ tags:
     description: Maintenance operations
   - name: Overview
     description: Overview of FOSSology operations
+  - name: Agent
+    description: Agent management
 
 x-reuse:
   - &cxGetParams
@@ -289,6 +291,43 @@ paths:
                 $ref: '#/components/schemas/Info'
         '400':
           description: Validation Error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '500':
+          description: Internal Server Error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /agents/monk/renew:
+    post:
+      operationId: renewMonkAgent
+      tags:
+        - Agent
+        - Admin
+      summary: Renew the current Monk agent
+      description: >
+        Trigger renewal of the current Monk agent revision, equivalent to the
+        legacy "Manage Monk Revision" admin page.
+      responses:
+        '200':
+          description: Monk agent revision renewed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Access denied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Monk agent has not run yet, nothing to renew.
           content:
             application/json:
               schema:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -21,6 +21,7 @@ require_once dirname(__DIR__, 3) . "/vendor/autoload.php";
 require_once dirname(__FILE__, 4) . "/lib/php/bootstrap.php";
 
 use Fossology\Lib\Util\TimingLogger;
+use Fossology\UI\Api\Controllers\AgentController;
 use Fossology\UI\Api\Controllers\AuthController;
 use Fossology\UI\Api\Controllers\BadRequestController;
 use Fossology\UI\Api\Controllers\ConfController;
@@ -346,6 +347,13 @@ $app->group('/search',
 $app->group('/maintenance',
   function (\Slim\Routing\RouteCollectorProxy $app) {
     $app->post('', MaintenanceController::class . ':createMaintenance');
+    $app->any('/{params:.*}', BadRequestController::class);
+  });
+
+////////////////////////////AGENTS/////////////////////
+$app->group('/agents',
+  function (\Slim\Routing\RouteCollectorProxy $app) {
+    $app->post('/monk/renew', AgentController::class . ':renewMonkAgent');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui_tests/api/Controllers/AgentControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/AgentControllerTest.php
@@ -1,0 +1,194 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Tests for AgentController
+ */
+
+namespace Fossology\UI\Api\Test\Controllers;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\AgentDao;
+use Fossology\Lib\Data\AgentRef;
+use Fossology\UI\Api\Controllers\AgentController;
+use Fossology\UI\Api\Exceptions\HttpForbiddenException;
+use Fossology\UI\Api\Exceptions\HttpNotFoundException;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Mockery as M;
+use Slim\Psr7\Factory\StreamFactory;
+use Slim\Psr7\Uri;
+use Slim\Psr7\Headers;
+use Slim\Psr7\Request;
+
+require_once dirname(__DIR__, 4) . '/lib/php/Plugin/FO_Plugin.php';
+
+/**
+ * @class AgentControllerTest
+ * @brief Tests for AgentController
+ */
+class AgentControllerTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @var AgentController $agentController
+   * AgentController object to test
+   */
+  private $agentController;
+
+  /**
+   * @var integer $assertCountBefore
+   * Assertions before running tests
+   */
+  private $assertCountBefore;
+
+  /**
+   * @var DbHelper $dbHelper
+   * DbHelper mock
+   */
+  private $dbHelper;
+
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+
+  /**
+   * @var M\MockInterface $agentDao
+   * AgentDao mock
+   */
+  private $agentDao;
+
+  /**
+   * @var StreamFactory $streamFactory
+   */
+  private $streamFactory;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp() : void
+  {
+    global $container;
+    $container = M::mock('ContainerBuilder');
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->restHelper = M::mock(RestHelper::class);
+    $this->agentDao = M::mock(AgentDao::class);
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+    $container->shouldReceive('get')->withArgs(array('dao.agent'))
+      ->andReturn($this->agentDao);
+
+    $this->agentController = new AgentController($container);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+    $this->streamFactory = new StreamFactory();
+  }
+
+  /**
+   * @brief Cleanup mockery objects
+   * @see PHPUnit_Framework_TestCase::tearDown()
+   */
+  protected function tearDown() : void
+  {
+    M::close();
+    $newCount = \Hamcrest\MatcherAssert::getCount();
+    $this->addToAssertionCount($newCount - $this->assertCountBefore);
+  }
+
+  /**
+   * Helper function to get JSON array from response
+   *
+   * @param ResponseHelper $response
+   * @return array Decoded response
+   */
+  private function getResponseJson($response)
+  {
+    $response->getBody()->seek(0);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+
+  private function buildPostRequest()
+  {
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    return new Request("POST", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $this->streamFactory->createStream());
+  }
+
+  /**
+   * @test
+   * -# Test AgentController::renewMonkAgent() for a valid renewal request
+   * -# Check if response status is 200 and AgentDao::renewCurrentAgent() is called
+   */
+  public function testRenewMonkAgent()
+  {
+    $_SESSION['UserLevel'] = 10;
+
+    $this->agentDao->shouldReceive('getCurrentAgentRef')
+      ->withArgs(['monk'])
+      ->andReturn(new AgentRef(1, 'monk', '1.0.0'));
+    $this->agentDao->shouldReceive('renewCurrentAgent')
+      ->withArgs(['monk'])
+      ->once()
+      ->andReturn(true);
+
+    $mess = "Monk agent revision has been renewed.";
+    $info = new Info(200, $mess, InfoType::INFO);
+    $expectedResponse = (new ResponseHelper())->withJson($info->getArray(), $info->getCode());
+
+    $actualResponse = $this->agentController->renewMonkAgent(
+      $this->buildPostRequest(), new ResponseHelper(), null);
+
+    $this->assertEquals($expectedResponse->getStatusCode(), $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test AgentController::renewMonkAgent() when the Monk agent has never run
+   * -# Check if HttpNotFoundException is thrown and renewal is never attempted
+   */
+  public function testRenewMonkAgentNotFound()
+  {
+    $_SESSION['UserLevel'] = 10;
+
+    $this->agentDao->shouldReceive('getCurrentAgentRef')
+      ->withArgs(['monk'])
+      ->andReturn(new AgentRef(0, null, null));
+    $this->agentDao->shouldNotReceive('renewCurrentAgent');
+
+    $this->expectException(HttpNotFoundException::class);
+    $this->agentController->renewMonkAgent(
+      $this->buildPostRequest(), new ResponseHelper(), null);
+  }
+
+  /**
+   * @test
+   * -# Test AgentController::renewMonkAgent() for non admin users
+   * -# Check if access is denied with HttpForbiddenException
+   */
+  public function testRenewMonkAgentUserNotAdmin()
+  {
+    $_SESSION['UserLevel'] = 0;
+
+    $this->agentDao->shouldNotReceive('getCurrentAgentRef');
+    $this->agentDao->shouldNotReceive('renewCurrentAgent');
+
+    $this->expectException(HttpForbiddenException::class);
+    $this->agentController->renewMonkAgent(
+      $this->buildPostRequest(), new ResponseHelper(), null);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `POST /agents/monk/renew`, an admin-only OpenAPI v2 endpoint that triggers renewal of the current Monk agent revision via `AgentDao::renewCurrentAgent('monk')`, equivalent to the legacy "Manage Monk Revision" admin page (`admin_monk_revision`). This unblocks the React/Next.js Admin → Monk page in FOSSologyUI.
- Return `404` if Monk has never run (fresh install), rather than calling `renewCurrentAgent()` on a nonexistent agent.
- Fix a latent bug found while reviewing the above: `AgentDao::createAgentRef()` indexed into the result of `getSingleRow()`/`fetchArray()` without checking for `false`, which Postgres returns (not an empty array) when no row matches. This emitted spurious PHP warnings on the new endpoint's 404 path (and any other caller of `getCurrentAgentRef()` on a not-yet-run agent) — the same bug class already fixed for `maintagent`'s `getLastMaintenanceRunTime()`. The fix is behavior-preserving: `createAgentRef(false)` still returns `AgentRef(0, null, null)`, just without the warnings.

## Test plan
- [x] `php vendor/bin/phpunit -c phpunit.xml --testsuite "Fossology PhpUnit Test Suite" --filter Controllers` — 266 tests, 433 assertions, all passing (no regressions).
- [x] New `AgentControllerTest` (3 tests): successful renewal, 404 when Monk has never run, 403 for non-admins.
- [x] `phpcs --standard=fossy-ruleset.xml` clean on all changed/added files.
- [x] `php -l` clean on all changed/added files.
- [x] `openapiv2.yaml` parses successfully (`yaml_parse_file`).
- [x] Manually verified via reflection that `createAgentRef(false)` no longer emits a PHP warning and still returns the same `AgentRef(0, null, null)` as before.

Fixes #425

