### PR TITLE
fix(users-api): correct V2 agent-key mapping for pkgagent, softwareHeritage, and ipra

### DIFF
--- a/src/www/ui/api/Controllers/UserController.php
+++ b/src/www/ui/api/Controllers/UserController.php
@@ -95,38 +95,44 @@ class UserController extends RestController
     if (empty($userDetails['name'])) {
       throw new HttpBadRequestException("Username must be specified.");
     }
+
+    list($success, $message) = $this->createUser($userDetails, $apiVersion);
+    if (!$success) {
+      throw new HttpInternalServerErrorException($message);
+    }
+
+    $returnVal = new Info(201, "User created successfully", InfoType::INFO);
+    return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+  }
+
+  /**
+   * Build a legacy user_add compatible request from a DTO and create the
+   * user through the user_add plugin.
+   *
+   * @param array $userDetails Associative array using the same keys as the
+   *   REST createUser DTO (name, description, email, accessLevel,
+   *   rootFolderId, emailNotification, defaultBucketpool, agents{...}).
+   * @param string $apiVersion ApiVersion::V1 or ApiVersion::V2
+   * @return array{0: bool, 1: string} [success, message or error]
+   */
+  private function createUser($userDetails, $apiVersion)
+  {
     $userHelper = new UserHelper();
     // creating symphony request
     $symfonyRequest = new \Symfony\Component\HttpFoundation\Request();
     $symfonyRequest->request->set('username', $userDetails['name']);
-    $symfonyRequest->request->set('pass1', $userDetails[$apiVersion == ApiVersion::V2 ? 'userPass' : 'user_pass']);
-    $symfonyRequest->request->set('pass2', $userDetails[$apiVersion == ApiVersion::V2 ? 'userPass' : 'user_pass']);
-    $symfonyRequest->request->set('description', $userDetails['description']);
-    $symfonyRequest->request->set('permission', $userHelper->getEquivalentValueForPermission($userDetails['accessLevel']));
-    $symfonyRequest->request->set('folder', $userDetails['rootFolderId']);
-    $symfonyRequest->request->set('enote', $userDetails['emailNotification'] ? 'y' : 'n');
-    $symfonyRequest->request->set('email', $userDetails['email']);
-    $symfonyRequest->request->set('public', $userDetails['defaultVisibility']);
+    $pass = $userDetails[$apiVersion == ApiVersion::V2 ? 'userPass' : 'user_pass'] ?? '';
+    $symfonyRequest->request->set('pass1', $pass);
+    $symfonyRequest->request->set('pass2', $pass);
+    $symfonyRequest->request->set('description', $userDetails['description'] ?? '');
+    $symfonyRequest->request->set('permission', $userHelper->getEquivalentValueForPermission($userDetails['accessLevel'] ?? null));
+    $symfonyRequest->request->set('folder', $userDetails['rootFolderId'] ?? '');
+    $symfonyRequest->request->set('enote', !empty($userDetails['emailNotification']) ? 'y' : 'n');
+    $symfonyRequest->request->set('email', $userDetails['email'] ?? '');
+    $symfonyRequest->request->set('public', $userDetails['defaultVisibility'] ?? '');
     $symfonyRequest->request->set('default_bucketpool_fk', $userDetails['defaultBucketpool'] ?? 2);
 
-    $agents = array();
-    if (isset($userDetails['agents'])) {
-      if (is_string($userDetails['agents'])) { // If 'x-www-form-urlencoded', inner elements are not decoded
-        $userDetails['agents'] = json_decode($userDetails['agents'], true);
-      }
-      $agents['Check_agent_mimetype'] = isset($userDetails['agents']['mime']) && $userDetails['agents']['mime'] ? 1 : 0;
-      $agents['Check_agent_monk'] = isset($userDetails['agents']['monk']) && $userDetails['agents']['monk'] ? 1 : 0;
-      $agents['Check_agent_ojo'] = isset($userDetails['agents']['ojo']) && $userDetails['agents']['ojo'] ? 1 : 0;
-      $agents['Check_agent_bucket'] = isset($userDetails['agents']['bucket']) && $userDetails['agents']['bucket'] ? 1 : 0 ;
-      $agents['Check_agent_copyright'] = isset($userDetails['agents'][$apiVersion == ApiVersion::V2 ? 'copyrightEmailAuthor' : 'copyright_email_author']) && $userDetails['agents'][$apiVersion == ApiVersion::V2 ? 'copyrightEmailAuthor' : 'copyright_email_author'] ? 1 : 0;
-      $agents['Check_agent_ecc'] = isset($userDetails['agents']['ecc']) && $userDetails['agents']['ecc'] ? 1 : 0;
-      $agents['Check_agent_keyword'] = isset($userDetails['agents']['keyword']) && $userDetails['agents']['keyword'] ? 1 : 0;
-      $agents['Check_agent_nomos'] = isset($userDetails['agents']['nomos']) && $userDetails['agents']['nomos'] ? 1 : 0;
-      $agents['Check_agent_pkgagent'] = isset($userDetails['agents']['package']) && $userDetails['agents']['package'] ? 1 : 0;
-      $agents['Check_agent_reso'] = isset($userDetails['agents']['reso']) && $userDetails['agents']['reso'] ? 1 : 0;
-      $agents['Check_agent_shagent'] = isset($userDetails['agents']['heritage']) && $userDetails['agents']['heritage'] ? 1 : 0 ;
-    }
-
+    $agents = $this->buildAgentCheckboxes($userDetails['agents'] ?? null, $apiVersion);
     $symfonyRequest->request->set('user_agent_list', userAgents($agents));
 
     // initialising the user_add object
@@ -135,14 +141,61 @@ class UserController extends RestController
     $userAddObj = $restHelper->getPlugin('user_add');
 
     // calling the add function
-    $ErrMsg = $userAddObj->add($symfonyRequest);
+    $errMsg = $userAddObj->add($symfonyRequest);
 
-    if ($ErrMsg != '') {
-      throw new HttpInternalServerErrorException($ErrMsg);
+    if ($errMsg != '') {
+      return [false, $errMsg];
     }
+    return [true, "User '" . $userDetails['name'] . "' created successfully."];
+  }
 
-    $returnVal = new Info(201, "User created successfully", InfoType::INFO);
-    return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+  /**
+   * Translate a REST agents DTO (bucket, copyrightEmailAuthor, ecc, ipra,
+   * keyword, mime, monk, nomos, ojo, pkgagent, reso, softwareHeritage for
+   * V2; the V1 equivalents otherwise) into the legacy Check_agent_* map
+   * expected by userAgents().
+   *
+   * Previously this mapping used the wrong (V1) key names for pkgagent and
+   * softwareHeritage when handling a V2 request -- 'package'/'heritage'
+   * instead of 'pkgagent'/'softwareHeritage' -- so those two agent flags
+   * were silently ignored for every V2 createUser() call. The ipra agent
+   * had no mapping at all, for either version, so it was always ignored.
+   *
+   * @param array|string|null $agentsDto
+   * @param string $apiVersion ApiVersion::V1 or ApiVersion::V2
+   * @return array<string, int>
+   */
+  private function buildAgentCheckboxes($agentsDto, $apiVersion)
+  {
+    if (empty($agentsDto)) {
+      return array();
+    }
+    if (is_string($agentsDto)) { // If 'x-www-form-urlencoded', inner elements are not decoded
+      $agentsDto = json_decode($agentsDto, true);
+    }
+    $copyrightKey = $apiVersion == ApiVersion::V2 ? 'copyrightEmailAuthor' : 'copyright_email_author';
+    $pkgagentKey = $apiVersion == ApiVersion::V2 ? 'pkgagent' : 'package';
+    $heritageKey = $apiVersion == ApiVersion::V2 ? 'softwareHeritage' : 'heritage';
+    $ipraKey = $apiVersion == ApiVersion::V2 ? 'ipra' : 'patent';
+
+    $isChecked = function ($key) use ($agentsDto) {
+      return isset($agentsDto[$key]) && $agentsDto[$key] ? 1 : 0;
+    };
+
+    return array(
+      'Check_agent_mimetype' => $isChecked('mime'),
+      'Check_agent_monk' => $isChecked('monk'),
+      'Check_agent_ojo' => $isChecked('ojo'),
+      'Check_agent_bucket' => $isChecked('bucket'),
+      'Check_agent_copyright' => $isChecked($copyrightKey),
+      'Check_agent_ecc' => $isChecked('ecc'),
+      'Check_agent_keyword' => $isChecked('keyword'),
+      'Check_agent_nomos' => $isChecked('nomos'),
+      'Check_agent_pkgagent' => $isChecked($pkgagentKey),
+      'Check_agent_reso' => $isChecked('reso'),
+      'Check_agent_shagent' => $isChecked($heritageKey),
+      'Check_agent_ipra' => $isChecked($ipraKey),
+    );
   }
 
   /**

--- a/src/www/ui_tests/api/Controllers/UserControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UserControllerTest.php
@@ -432,4 +432,81 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
 
     $this->userController->addUser($request, new ResponseHelper(), []);
   }
+
+  /**
+   * Invoke a private/protected method via reflection.
+   *
+   * @param object $object
+   * @param string $method
+   * @param array $args
+   * @return mixed
+   */
+  private function invokePrivate($object, $method, array $args)
+  {
+    $reflection = new \ReflectionClass(get_class($object));
+    $m = $reflection->getMethod($method);
+    $m->setAccessible(true);
+    return $m->invokeArgs($object, $args);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::buildAgentCheckboxes() for V2 DTOs
+   * -# Check that pkgagent and softwareHeritage (which previously used the
+   *    wrong V1 key names for a V2 request) are now read correctly
+   * -# Check that ipra (which was never wired up at all, for either
+   *    version) is now read correctly too
+   */
+  public function testBuildAgentCheckboxesV2()
+  {
+    $agentsDto = [
+      'bucket' => true, 'copyrightEmailAuthor' => true, 'ecc' => false,
+      'ipra' => true, 'keyword' => false, 'mime' => true, 'monk' => false,
+      'nomos' => false, 'ojo' => false, 'pkgagent' => true, 'reso' => false,
+      'softwareHeritage' => true,
+    ];
+    $result = $this->invokePrivate($this->userController, 'buildAgentCheckboxes',
+      [$agentsDto, ApiVersion::V2]);
+
+    $this->assertEquals(1, $result['Check_agent_bucket']);
+    $this->assertEquals(1, $result['Check_agent_copyright']);
+    $this->assertEquals(0, $result['Check_agent_ecc']);
+    $this->assertEquals(1, $result['Check_agent_mimetype']);
+    $this->assertEquals(1, $result['Check_agent_pkgagent']);
+    $this->assertEquals(1, $result['Check_agent_shagent']);
+    $this->assertEquals(1, $result['Check_agent_ipra']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::buildAgentCheckboxes() for V1 DTOs
+   * -# Check the V1 key names (package, heritage, copyright_email_author,
+   *    patent)
+   */
+  public function testBuildAgentCheckboxesV1()
+  {
+    $agentsDto = [
+      'package' => true, 'heritage' => true, 'copyright_email_author' => true,
+      'patent' => true,
+    ];
+    $result = $this->invokePrivate($this->userController, 'buildAgentCheckboxes',
+      [$agentsDto, ApiVersion::V1]);
+
+    $this->assertEquals(1, $result['Check_agent_pkgagent']);
+    $this->assertEquals(1, $result['Check_agent_shagent']);
+    $this->assertEquals(1, $result['Check_agent_copyright']);
+    $this->assertEquals(1, $result['Check_agent_ipra']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::buildAgentCheckboxes() with no agents given
+   * -# Check that an empty map is returned instead of erroring
+   */
+  public function testBuildAgentCheckboxesEmpty()
+  {
+    $result = $this->invokePrivate($this->userController, 'buildAgentCheckboxes',
+      [null, ApiVersion::V2]);
+    $this->assertEquals([], $result);
+  }
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

`UserController::addUser()` (`POST /users`) silently dropped several agent flags from the request body instead of applying them, with no error returned to the caller. This fixes the mapping so all agent flags are honored.

### Changes

- Fixed `pkgagent` and `softwareHeritage` being ignored on v2 requests -- the legacy checkbox-mapping code checked for the v1 field names (`package`, `heritage`) even when handling a v2 request.
- Fixed `ipra` being ignored entirely, for both API versions -- there was no mapping to the legacy `Check_agent_ipra` key at all.
- Extracted `createUser()` and `buildAgentCheckboxes()` out of `addUser()` so the agent-mapping logic is independently testable instead of being inlined in the request handler.
- Added regression tests covering all three keys (`pkgagent`, `softwareHeritage`, `ipra`) across both API versions, plus the empty/no-agents case.

## How to test

1. `composer install --working-dir=src`
2. Run the controller test suite: `phpunit -c src/phpunit.xml --filter UserControllerTest`
3. Or manually, against a running instance:
   - `POST /repo/api/v2/users` with a body including `"agents": {"pkgagent": true, "softwareHeritage": true, "ipra": true}`.
   - Confirm the created user actually has all three agents enabled (e.g. via `GET /repo/api/v2/users/{name}`), where before this fix they'd silently be disabled.

Closes #3750
