### PR TITLE
Add OpenAPI v2 endpoint to create obligations, document import/export…

### DIFF
--- a/src/www/ui/api/Controllers/ObligationController.php
+++ b/src/www/ui/api/Controllers/ObligationController.php
@@ -15,6 +15,7 @@ namespace Fossology\UI\Api\Controllers;
 use Fossology\Lib\Application\ObligationCsvExport;
 use Fossology\Lib\BusinessRules\ObligationMap;
 use Fossology\UI\Api\Exceptions\HttpBadRequestException;
+use Fossology\UI\Api\Exceptions\HttpConflictException;
 use Fossology\UI\Api\Exceptions\HttpErrorException;
 use Fossology\UI\Api\Exceptions\HttpNotFoundException;
 use Fossology\UI\Api\Helper\ResponseHelper;
@@ -98,6 +99,70 @@ class ObligationController extends RestController
         ->getArray();
     }
     return $response->withJson($obligationArray, 200);
+  }
+
+  /**
+   * Create a new obligation
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpErrorException
+   */
+  public function createObligation($request, $response, $args)
+  {
+    $this->throwNotAdminException();
+    $newObligationArr = $this->getParsedBody($request);
+    $newObligation = Obligation::parseFromArray($newObligationArr);
+    if ($newObligation === -1) {
+      throw new HttpBadRequestException(
+        "Input contains additional properties.");
+    }
+    if ($newObligation === -2) {
+      throw new HttpBadRequestException("Property 'topic' is required.");
+    }
+    if ($newObligation === -3) {
+      throw new HttpBadRequestException("Property 'text' is required.");
+    }
+
+    $dbManager = $this->dbHelper->getDbManager();
+    $checkSql = "SELECT count(*) AS cnt FROM obligation_ref " .
+      "WHERE ob_topic = $1 AND ob_text = $2";
+    $existing = $dbManager->getSingleRow($checkSql,
+      [$newObligation->getTopic(), $newObligation->getText()],
+      __METHOD__ . '.checkExisting');
+    if (! empty($existing) && intval($existing['cnt']) > 0) {
+      throw new HttpConflictException(
+        "Obligation with same topic and text already exists!");
+    }
+
+    $assocData = [
+      "ob_active" => $newObligation->isActive(),
+      "ob_type" => $newObligation->getType(),
+      "ob_modifications" => $newObligation->isModification() ? "Yes" : "No",
+      "ob_topic" => $newObligation->getTopic(),
+      "ob_md5" => md5($newObligation->getText()),
+      "ob_text" => $newObligation->getText(),
+      "ob_classification" => $newObligation->getClassification(),
+      "ob_text_updatable" => $newObligation->isTextUpdatable(),
+      "ob_comment" => $newObligation->getComment()
+    ];
+
+    $obPk = $dbManager->insertTableRow("obligation_ref", $assocData,
+      __METHOD__ . ".newObligation", "ob_pk");
+
+    foreach ($newObligation->getLicenses() as $license) {
+      $licIds = $this->obligationMap->getIdFromShortname($license, false);
+      $this->obligationMap->associateLicenseFromLicenseList($obPk, $licIds, false);
+    }
+    foreach ($newObligation->getCandidateLicenses() as $license) {
+      $licIds = $this->obligationMap->getIdFromShortname($license, true);
+      $this->obligationMap->associateLicenseFromLicenseList($obPk, $licIds, true);
+    }
+
+    $newInfo = new Info(201, $obPk, InfoType::INFO);
+    return $response->withJson($newInfo->getArray(), $newInfo->getCode());
   }
 
   /**

--- a/src/www/ui/api/Models/Obligation.php
+++ b/src/www/ui/api/Models/Obligation.php
@@ -19,6 +19,13 @@ namespace Fossology\UI\Api\Models;
 class Obligation
 {
   /**
+   * @var array ALLOWED_KEYS
+   * Keys allowed while creating an obligation from a request body
+   */
+  const ALLOWED_KEYS = ["topic", "type", "text", "classification", "comment",
+    "modification", "active", "textUpdatable", "licenses", "candidateLicenses"];
+
+  /**
    * @var integer $id
    * Obligation id
    */
@@ -406,5 +413,50 @@ class Obligation
       }
     }
     return $obligation;
+  }
+
+  /**
+   * Parse an Obligation object from an associative array (e.g. request body).
+   *
+   * @param array $inputObligation Array with obligation properties
+   * @return Obligation|integer New obligation object, or -1 if the array
+   *         contains keys other than ALLOWED_KEYS, -2 if 'topic' is missing
+   *         or empty, -3 if 'text' is missing or empty
+   */
+  public static function parseFromArray($inputObligation)
+  {
+    $inputKeys = array_keys($inputObligation);
+    $intersectKeys = array_intersect($inputKeys, self::ALLOWED_KEYS);
+    if (count($inputKeys) > 0 && count($intersectKeys) != count($inputKeys)) {
+      return -1;
+    }
+    if (! array_key_exists('topic', $inputObligation) || empty($inputObligation['topic'])) {
+      return -2;
+    }
+    if (! array_key_exists('text', $inputObligation) || empty($inputObligation['text'])) {
+      return -3;
+    }
+
+    $newObligation = new Obligation(0, $inputObligation['topic'],
+      array_key_exists('type', $inputObligation) ? $inputObligation['type'] : 'Obligation',
+      $inputObligation['text'],
+      array_key_exists('classification', $inputObligation) ? $inputObligation['classification'] : 'green',
+      array_key_exists('comment', $inputObligation) ? $inputObligation['comment'] : '',
+      true);
+    $newObligation->setActive(array_key_exists('active', $inputObligation) ? $inputObligation['active'] : true);
+    $newObligation->setTextUpdatable(array_key_exists('textUpdatable', $inputObligation) ? $inputObligation['textUpdatable'] : true);
+    $newObligation->setModification(array_key_exists('modification', $inputObligation) ? $inputObligation['modification'] : false);
+
+    if (array_key_exists('licenses', $inputObligation) && is_array($inputObligation['licenses'])) {
+      foreach ($inputObligation['licenses'] as $license) {
+        $newObligation->addLicense($license);
+      }
+    }
+    if (array_key_exists('candidateLicenses', $inputObligation) && is_array($inputObligation['candidateLicenses'])) {
+      foreach ($inputObligation['candidateLicenses'] as $license) {
+        $newObligation->addCandidateLicense($license);
+      }
+    }
+    return $newObligation;
   }
 }

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -492,6 +492,76 @@ paths:
         default:
           $ref: '#/components/responses/defaultResponse'
 
+  /obligations/import-json:
+    post:
+      operationId: importObligationJson
+      tags:
+        - License
+      summary: Import an obligation json file
+      description: >
+        Import an obligation json file
+      requestBody:
+        description: JSON file to be imported.
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                fileInput:
+                  type: string
+                  format: binary
+                  description: JSON to be imported
+              required:
+                - fileInput
+      responses:
+        '400':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '200':
+          description: Successfully imported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /obligations/export-json:
+    get:
+      operationId: exportLicenseObligationsJson
+      parameters:
+        - name: id
+          description: Obligation id to export, 0 for all
+          in: query
+          required: false
+          schema:
+            type: integer
+      tags:
+        - License
+      summary: Export a json obligation list
+      description: >
+        Export a json license obligation list
+      responses:
+        '200':
+          description: Successfully exported
+          content:
+            text/plain:
+              schema:
+                type: string
+                format: binary
+        '403':
+          description: Route is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
   /obligations:
     get:
       operationId: getAllObligationsData
@@ -509,6 +579,45 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ObligationExtended'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+    post:
+      operationId: createObligation
+      tags:
+        - Admin
+      summary: Create a new obligation
+      description: >
+        Add a new obligation to the database
+      requestBody:
+        description: Information about new obligation
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/ObligationExtended'
+              required:
+                - topic
+                - text
+      responses:
+        '201':
+          description: Obligation added successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '409':
+          description: Obligation with same topic and text already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
 

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -303,6 +303,7 @@ $app->group('/obligations',
     $app->get('/list', ObligationController::class . ':obligationsList');
     $app->get('/{id:\\d+}', ObligationController::class . ':obligationsDetails');
     $app->get('', ObligationController::class . ':obligationsAllDetails');
+    $app->post('', ObligationController::class . ':createObligation');
     $app->delete('/{id:\\d+}', ObligationController::class . ':deleteObligation');
     $app->get('/export-csv', ObligationController::class . ':exportObligationsToCSV');
     $app->post('/import-csv', ObligationController::class . ':importObligationsFromCSV');

--- a/src/www/ui_tests/api/Controllers/ObligationControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/ObligationControllerTest.php
@@ -1,0 +1,340 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 FOSSology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * @file
+ * @brief Tests for ObligationController
+ */
+
+namespace Fossology\UI\Api\Test\Controllers;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\BusinessRules\ObligationMap;
+use Fossology\UI\Api\Controllers\ObligationController;
+use Fossology\UI\Api\Exceptions\HttpBadRequestException;
+use Fossology\UI\Api\Exceptions\HttpConflictException;
+use Fossology\UI\Api\Exceptions\HttpForbiddenException;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\Lib\Db\DbManager;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Mockery as M;
+use Slim\Psr7\Factory\StreamFactory;
+use Slim\Psr7\Headers;
+use Slim\Psr7\Request;
+use Slim\Psr7\Uri;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @class ObligationControllerTest
+ * @brief Unit tests for ObligationController
+ */
+class ObligationControllerTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @var integer $assertCountBefore
+   * Assertions before running tests
+   */
+  private $assertCountBefore;
+
+  /**
+   * @var DbHelper $dbHelper
+   * DbHelper mock
+   */
+  private $dbHelper;
+
+  /**
+   * @var DbManager $dbManager
+   * Dbmanager mock
+   */
+  private $dbManager;
+
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+
+  /**
+   * @var ObligationMap $obligationMap
+   * ObligationMap mock
+   */
+  private $obligationMap;
+
+  /**
+   * @var ObligationController $obligationController
+   * ObligationController object under test
+   */
+  private $obligationController;
+
+  /**
+   * @var StreamFactory $streamFactory
+   * Stream factory to create body streams.
+   */
+  private $streamFactory;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp() : void
+  {
+    global $container;
+    $container = M::mock('ContainerBuilder');
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->dbManager = M::mock(DbManager::class);
+    $this->restHelper = M::mock(RestHelper::class);
+    $this->obligationMap = M::mock(ObligationMap::class);
+
+    $this->dbHelper->shouldReceive('getDbManager')->andReturn($this->dbManager);
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+    $container->shouldReceive('get')->withArgs(array(
+      'businessrules.obligationmap'))->andReturn($this->obligationMap);
+
+    $this->obligationController = new ObligationController($container);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+    $this->streamFactory = new StreamFactory();
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+  }
+
+  /**
+   * @brief Remove test objects
+   * @see PHPUnit_Framework_TestCase::tearDown()
+   */
+  protected function tearDown() : void
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  /**
+   * Helper function to get JSON array from response
+   *
+   * @param Response $response
+   * @return array Decoded response
+   */
+  private function getResponseJson($response)
+  {
+    $response->getBody()->seek(0);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+
+  /**
+   * Helper to build a POST /obligations request with the given body.
+   * @param array $requestBody
+   * @return Request
+   */
+  private function getCreateRequest($requestBody)
+  {
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    $body = $this->streamFactory->createStream();
+    $body->write(json_encode($requestBody));
+    $body->seek(0);
+    return new Request("POST", new Uri("HTTP", "localhost", 80,
+      "/obligations"), $requestHeaders, [], [], $body);
+  }
+
+  /**
+   * @test
+   * -# Test for ObligationController::createObligation() to create a new
+   *    obligation
+   * -# Check if response is 201
+   */
+  public function testCreateObligation()
+  {
+    $requestBody = [
+      "topic" => "Should preserve notice",
+      "type" => "Obligation",
+      "text" => "All notices from the package should be preserved.",
+      "classification" => "yellow",
+      "comment" => "Please respect the obligation"
+    ];
+    $request = $this->getCreateRequest($requestBody);
+
+    $checkSql = "SELECT count(*) AS cnt FROM obligation_ref " .
+      "WHERE ob_topic = $1 AND ob_text = $2";
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs([$checkSql,
+        [$requestBody["topic"], $requestBody["text"]], M::any()])
+      ->andReturn(["cnt" => 0]);
+
+    $assocData = [
+      "ob_active" => true,
+      "ob_type" => "Obligation",
+      "ob_modifications" => "No",
+      "ob_topic" => $requestBody["topic"],
+      "ob_md5" => md5($requestBody["text"]),
+      "ob_text" => $requestBody["text"],
+      "ob_classification" => "yellow",
+      "ob_text_updatable" => true,
+      "ob_comment" => "Please respect the obligation"
+    ];
+    $this->dbManager->shouldReceive('insertTableRow')
+      ->withArgs(["obligation_ref", $assocData, M::any(), "ob_pk"])
+      ->andReturn(7);
+
+    $info = new Info(201, 7, InfoType::INFO);
+    $expectedResponse = (new ResponseHelper())->withJson($info->getArray(),
+      $info->getCode());
+
+    $actualResponse = $this->obligationController->createObligation($request,
+      new ResponseHelper(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for ObligationController::createObligation() associating
+   *    licenses and candidate licenses with the new obligation
+   * -# Check if response is 201 and licenses get associated
+   */
+  public function testCreateObligationWithLicenses()
+  {
+    $requestBody = [
+      "topic" => "Should preserve notice",
+      "text" => "All notices from the package should be preserved.",
+      "licenses" => ["MIT"],
+      "candidateLicenses" => ["Exotic"]
+    ];
+    $request = $this->getCreateRequest($requestBody);
+
+    $checkSql = "SELECT count(*) AS cnt FROM obligation_ref " .
+      "WHERE ob_topic = $1 AND ob_text = $2";
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs([$checkSql,
+        [$requestBody["topic"], $requestBody["text"]], M::any()])
+      ->andReturn(["cnt" => 0]);
+
+    $this->dbManager->shouldReceive('insertTableRow')
+      ->withArgs(["obligation_ref", M::type('array'), M::any(), "ob_pk"])
+      ->andReturn(7);
+
+    $this->obligationMap->shouldReceive('getIdFromShortname')
+      ->withArgs(["MIT", false])->andReturn([22]);
+    $this->obligationMap->shouldReceive('associateLicenseFromLicenseList')
+      ->withArgs([7, [22], false])->once()->andReturn(true);
+    $this->obligationMap->shouldReceive('getIdFromShortname')
+      ->withArgs(["Exotic", true])->andReturn([25]);
+    $this->obligationMap->shouldReceive('associateLicenseFromLicenseList')
+      ->withArgs([7, [25], true])->once()->andReturn(true);
+
+    $actualResponse = $this->obligationController->createObligation($request,
+      new ResponseHelper(), []);
+    $this->assertEquals(201, $actualResponse->getStatusCode());
+  }
+
+  /**
+   * @test
+   * -# Test for ObligationController::createObligation()
+   * -# The request body has no topic
+   * -# Check if response is 400
+   */
+  public function testCreateObligationNoTopic()
+  {
+    $requestBody = [
+      "text" => "All notices from the package should be preserved."
+    ];
+    $request = $this->getCreateRequest($requestBody);
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->obligationController->createObligation($request,
+      new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test for ObligationController::createObligation()
+   * -# The request body has no text
+   * -# Check if response is 400
+   */
+  public function testCreateObligationNoText()
+  {
+    $requestBody = [
+      "topic" => "Should preserve notice"
+    ];
+    $request = $this->getCreateRequest($requestBody);
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->obligationController->createObligation($request,
+      new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test for ObligationController::createObligation()
+   * -# The request body has additional unknown properties
+   * -# Check if response is 400
+   */
+  public function testCreateObligationExtraProperty()
+  {
+    $requestBody = [
+      "topic" => "Should preserve notice",
+      "text" => "All notices from the package should be preserved.",
+      "bogus" => "not allowed"
+    ];
+    $request = $this->getCreateRequest($requestBody);
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->obligationController->createObligation($request,
+      new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test for ObligationController::createObligation()
+   * -# Non admin user cannot create an obligation
+   * -# Check if response is 403
+   */
+  public function testCreateObligationNoAdmin()
+  {
+    $requestBody = [
+      "topic" => "Should preserve notice",
+      "text" => "All notices from the package should be preserved."
+    ];
+    $request = $this->getCreateRequest($requestBody);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->expectException(HttpForbiddenException::class);
+
+    $this->obligationController->createObligation($request,
+      new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test for ObligationController::createObligation()
+   * -# Simulate duplicate topic/text
+   * -# Check if response is 409
+   */
+  public function testCreateObligationDuplicate()
+  {
+    $requestBody = [
+      "topic" => "Should preserve notice",
+      "text" => "All notices from the package should be preserved."
+    ];
+    $request = $this->getCreateRequest($requestBody);
+
+    $checkSql = "SELECT count(*) AS cnt FROM obligation_ref " .
+      "WHERE ob_topic = $1 AND ob_text = $2";
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs([$checkSql,
+        [$requestBody["topic"], $requestBody["text"]], M::any()])
+      ->andReturn(["cnt" => 1]);
+    $this->expectException(HttpConflictException::class);
+
+    $this->obligationController->createObligation($request,
+      new ResponseHelper(), []);
+  }
+}


### PR DESCRIPTION
## Description

Adds the missing OpenAPI v2 endpoint for creating obligations, and documents the `import-json`/`export-json` obligation endpoints that were already implemented in the controller but missing from the API contract.

### Changes

- Add `ObligationController::createObligation()` (`POST /obligations`) to create a new obligation, with optional license/candidate-license association.
- Add `Obligation::parseFromArray()` to validate and build an `Obligation` model from a request body — requires `topic` and `text`, rejects unknown properties.
- Register the `POST /obligations` route in `index.php`.
- Document `POST /obligations`, `GET /obligations/export-json`, and `POST /obligations/import-json` in `openapiv2.yaml`. The JSON import/export handlers already existed in `ObligationController` and were already routed — they were just missing from the OpenAPI contract.
- Add `ObligationControllerTest.php` (new file — no tests previously existed for this controller) covering: successful creation, license/candidate-license association, missing `topic`, missing `text`, unknown request properties, non-admin rejection, and duplicate topic/text conflict.

## How to test

1. Log in as an admin user and call `POST /api/v2/obligations` with a body like:
   ```json
   {
     "topic": "Should preserve notice",
     "text": "All notices from the package should be preserved.",
     "classification": "yellow"
   }

Expect 201 with the new obligation's id.

2. Repeat the same request — expect 409 Conflict (duplicate topic/text).
3. Send the request without topic or without text — expect 400.
4. Send the request as a non-admin user — expect 403.
5. Run the unit tests:


php vendor/bin/phpunit -c phpunit.xml --no-coverage www/ui_tests/api/Controllers/ObligationControllerTest.php

All 7 tests should pass.

Fixes fossology/FOSSologyUI#436
