### PR TITLE
Add OpenAPI v2 endpoints for tag create and enable/disable

### DIFF
--- a/src/www/ui/admin-tag.php
+++ b/src/www/ui/admin-tag.php
@@ -25,16 +25,66 @@ class admin_tag extends FO_Plugin
   }
 
   /**
-   * \brief Create Tag without tagging anything
+   * \brief Check whether a tag with the given name already exists
    *
-   * \return null for success or error text
+   * \param string $tag_name
+   * \return boolean true if a tag with this name exists
    */
-  function CreateTag()
+  function TagExists($tag_name)
   {
     global $PG_CONN;
 
-    $tag_name = GetParm('tag_name', PARM_TEXT);
-    $tag_desc = GetParm('tag_desc', PARM_TEXT);
+    $sql = "SELECT tag_pk FROM tag WHERE tag = '" . pg_escape_string($tag_name) . "'";
+    $result = pg_query($PG_CONN, $sql);
+    DBCheckResult($result, $sql, __FILE__, __LINE__);
+    $exists = pg_num_rows($result) > 0;
+    pg_free_result($result);
+    return $exists;
+  }
+
+  /**
+   * \brief Get the tag_pk of a tag by name
+   *
+   * \param string $tag_name
+   * \return integer|null pk of the tag, or null if no such tag exists
+   */
+  function GetTagId($tag_name)
+  {
+    global $PG_CONN;
+
+    $sql = "SELECT tag_pk FROM tag WHERE tag = '" . pg_escape_string($tag_name) . "' LIMIT 1;";
+    $result = pg_query($PG_CONN, $sql);
+    DBCheckResult($result, $sql, __FILE__, __LINE__);
+    $tagPk = null;
+    if (pg_num_rows($result) > 0) {
+      $row = pg_fetch_assoc($result);
+      $tagPk = intval($row['tag_pk']);
+    }
+    pg_free_result($result);
+    return $tagPk;
+  }
+
+  /**
+   * \brief Create Tag without tagging anything
+   *
+   * \param array $tag_array Optional array with tag_name/tag_desc, used
+   *        when calling this method outside of the plugin's own POST
+   *        handling (e.g. from the REST API). Falls back to request
+   *        parameters when not given.
+   *
+   * \return null for success or error text
+   */
+  function CreateTag($tag_array = null)
+  {
+    global $PG_CONN;
+
+    if (isset($tag_array)) {
+      $tag_name = $tag_array['tag_name'];
+      $tag_desc = $tag_array['tag_desc'];
+    } else {
+      $tag_name = GetParm('tag_name', PARM_TEXT);
+      $tag_desc = GetParm('tag_desc', PARM_TEXT);
+    }
     if (empty($tag_name)) {
       $text = _("TagName must be specified. Tag Not created.");
       return ($text);

--- a/src/www/ui/api/Controllers/TagController.php
+++ b/src/www/ui/api/Controllers/TagController.php
@@ -1,0 +1,102 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 FOSSology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Controller for tag queries
+ */
+
+namespace Fossology\UI\Api\Controllers;
+
+use Fossology\UI\Api\Exceptions\HttpBadRequestException;
+use Fossology\UI\Api\Exceptions\HttpConflictException;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Psr\Http\Message\ServerRequestInterface;
+
+class TagController extends RestController
+{
+  /**
+   * Create a new tag
+   *
+   * Delegates name validation and the actual insert to the legacy
+   * admin_tag plugin (admin-tag.php), which already implements this for
+   * the Admin > Tag UI, so the REST API and that UI stay in agreement on
+   * what a valid tag looks like.
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpBadRequestException
+   * @throws HttpConflictException
+   */
+  public function createTag($request, $response, $args)
+  {
+    $this->throwNotAdminException();
+    $requestBody = $this->getParsedBody($request);
+    if (! is_array($requestBody)) {
+      throw new HttpBadRequestException("Invalid request body.");
+    }
+
+    $tagName = (isset($requestBody['name']) && is_string($requestBody['name']))
+      ? trim($requestBody['name']) : '';
+    $tagDesc = (isset($requestBody['description']) && is_string($requestBody['description']))
+      ? $requestBody['description'] : '';
+
+    /** @var \admin_tag $tagPlugin */
+    $tagPlugin = $this->restHelper->getPlugin('admin_tag');
+    if ($tagName !== '' && $tagPlugin->TagExists($tagName)) {
+      throw new HttpConflictException("Tag with same name already exists!");
+    }
+
+    $error = $tagPlugin->CreateTag(
+      ['tag_name' => $tagName, 'tag_desc' => $tagDesc]);
+    if (! empty($error)) {
+      throw new HttpBadRequestException(strip_tags($error));
+    }
+
+    $newInfo = new Info(201, $tagPlugin->GetTagId($tagName), InfoType::INFO);
+    return $response->withJson($newInfo->getArray(), $newInfo->getCode());
+  }
+
+  /**
+   * Enable or disable the tag display for a given upload
+   *
+   * Delegates to the legacy admin_tag_manage plugin
+   * (admin-tag-manage.php), which already implements this exact
+   * enable/disable-on-upload behaviour for the Admin UI.
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpBadRequestException
+   */
+  public function setTagDisplayStatus($request, $response, $args)
+  {
+    $this->throwNotAdminException();
+    $id = intval($args['id']);
+    $this->uploadAccessible($id);
+
+    $requestBody = $this->getParsedBody($request);
+    if (! is_array($requestBody) || ! array_key_exists('enabled', $requestBody)) {
+      throw new HttpBadRequestException("Property 'enabled' is required.");
+    }
+    $enabled = filter_var($requestBody['enabled'], FILTER_VALIDATE_BOOLEAN);
+
+    /** @var \admin_tag_manage $tagManagePlugin */
+    $tagManagePlugin = $this->restHelper->getPlugin('admin_tag_manage');
+    $tagManagePlugin->ManageTag(null, $id, $enabled ? 'Enable' : 'Disable');
+
+    $message = $enabled ? "Tag display enabled for upload." :
+      "Tag display disabled for upload.";
+    $newInfo = new Info(200, $message, InfoType::INFO);
+    return $response->withJson($newInfo->getArray(), $newInfo->getCode());
+  }
+}

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -57,6 +57,8 @@ tags:
     description: Maintenance operations
   - name: Overview
     description: Overview of FOSSology operations
+  - name: Tags
+    description: Tag management
 
 x-reuse:
   - &cxGetParams
@@ -509,6 +511,49 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ObligationExtended'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /tags:
+    post:
+      operationId: createTag
+      tags:
+        - Tags
+      summary: Create a new tag
+      description: >
+        Add a new tag to the database, without tagging anything with it
+      requestBody:
+        description: Information about new tag
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Tag'
+      responses:
+        '201':
+          description: Tag added successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Only admin can access this endpoint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '409':
+          description: Tag with same name already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
 
@@ -1081,6 +1126,64 @@ paths:
           description: >
             The agent has not been scheduled for the upload. Please check the
             response message.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /uploads/{id}/tags/display:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the upload
+        in: path
+        schema:
+          type: integer
+    put:
+      operationId: setTagDisplayStatus
+      tags:
+        - Tags
+      summary: Enable or disable tag display for an upload
+      description: >
+        Displaying tags while browsing can be slow for large uploads. This
+        endpoint allows an admin to enable or disable the tag display for a
+        specific upload. By default the tag display is enabled.
+      requestBody:
+        description: Whether tag display should be enabled for the upload
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                  description: True to enable tag display, false to disable it
+              required:
+                - enabled
+      responses:
+        '200':
+          description: Tag display status updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Only admin can access this endpoint, or upload is not accessible
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Upload does not exist
           content:
             application/json:
               schema:
@@ -5897,6 +6000,12 @@ components:
         removable:
           type: boolean
           description: Is the folder removable.
+        uploadId:
+          type: integer
+          description: >
+            Id of the upload (upload_pk), if this content is an upload.
+            Null if the content is a subfolder.
+          nullable: true
     UploadSummary:
       type: object
       properties:
@@ -7477,6 +7586,24 @@ components:
           nullable: false
           example:
             "Main group"
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Id of the tag
+          readOnly: true
+        name:
+          type: string
+          description: >
+            Name of the tag. Only characters from
+            A-Za-z0-9_~-!@#$%^*.() are allowed
+          example: Software_Repository
+        description:
+          type: string
+          description: Description of the tag
+      required:
+        - name
     AddMember:
       description: UserMember options
       type: object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -41,6 +41,7 @@ use Fossology\UI\Api\Controllers\OverviewController;
 use Fossology\UI\Api\Controllers\OsselotController;
 use Fossology\UI\Api\Controllers\ReportController;
 use Fossology\UI\Api\Controllers\SearchController;
+use Fossology\UI\Api\Controllers\TagController;
 use Fossology\UI\Api\Controllers\UploadController;
 use Fossology\UI\Api\Controllers\UploadTreeController;
 use Fossology\UI\Api\Controllers\UserController;
@@ -227,6 +228,7 @@ $app->group('/uploads',
     $app->put('/{id:\\d+}/conf', ConfController::class . ':updateConfData');
     $app->get('/{id:\\d+}/copyrights', UploadController::class . ':getUploadCopyrights');
     $app->post('/{id:\\d+}/osselot/import', OsselotController::class . ':importOsselotReport');
+    $app->put('/{id:\\d+}/tags/display', TagController::class . ':setTagDisplayStatus');
     ////////////////////////// BULK FOR CX OPERATIONS /////////////////////
     $app->group('/{id:\\d+}/item/{itemId:\\d+}', function (\Slim\Routing\RouteCollectorProxy $app) {
       $app->get('/copyrights', CopyrightController::class . ':getFileCopyrights');
@@ -308,6 +310,13 @@ $app->group('/obligations',
     $app->post('/import-csv', ObligationController::class . ':importObligationsFromCSV');
     $app->get('/export-json', ObligationController::class . ':exportObligationsToJSON');
     $app->post('/import-json', ObligationController::class . ':importObligationsFromJSON');
+    $app->any('/{params:.*}', BadRequestController::class);
+  });
+
+////////////////////////////TAGS/////////////////////
+$app->group('/tags',
+  function (\Slim\Routing\RouteCollectorProxy $app) {
+    $app->post('', TagController::class . ':createTag');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui/async/AjaxFolderContents.php
+++ b/src/www/ui/async/AjaxFolderContents.php
@@ -41,6 +41,7 @@ class AjaxFolderContents extends DefaultPlugin
       return $this->uploadExists(Auth::getGroupId(), $folderId, $uploadName);
     }
     $results = array();
+    $uploadIds = array();
     $childFolders = $this->folderDao->getFolderChildFolders($folderId);
     foreach ($childFolders as $folder) {
       $results[$folder['foldercontents_pk']] = '/'.$folder['folder_name'];
@@ -51,15 +52,17 @@ class AjaxFolderContents extends DefaultPlugin
       $uploadDate = explode(".", $upload['upload_ts'])[0];
       $uploadStatus = " (" . $uploadStatus->getTypeName($upload['status_fk']) . ")";
       $results[$upload['foldercontents_pk']] = $upload['upload_filename'] . _(" from ") . Convert2BrowserTime($uploadDate) . $uploadStatus;
+      $uploadIds[$upload['foldercontents_pk']] = intval($upload['upload_pk']);
     }
 
     if (!$request->get('removable')) {
       if ($request->get('fromRest')) {
-        return array_map(function($key, $value) {
+        return array_map(function ($key, $value) use ($uploadIds) {
           return array(
             'id' => $key,
             'content' => $value,
-            'removable' => false
+            'removable' => false,
+            'uploadId' => array_key_exists($key, $uploadIds) ? $uploadIds[$key] : null
           );
         }, array_keys($results), $results);
       }
@@ -72,11 +75,12 @@ class AjaxFolderContents extends DefaultPlugin
     }
 
     if ($request->get('fromRest')) {
-      return array_map(function ($key, $value) {
+      return array_map(function ($key, $value) use ($uploadIds) {
         return array(
           'id' => $key,
           'content' => $value,
-          'removable' => true
+          'removable' => true,
+          'uploadId' => array_key_exists($key, $uploadIds) ? $uploadIds[$key] : null
         );
       }, array_keys($filterResults), $filterResults);
     }

--- a/src/www/ui_tests/api/Controllers/TagControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/TagControllerTest.php
@@ -1,0 +1,517 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 FOSSology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * @file
+ * @brief Tests for TagController
+ */
+
+namespace Fossology\UI\Api\Test\Controllers;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\UploadDao;
+use Fossology\UI\Api\Controllers\TagController;
+use Fossology\UI\Api\Exceptions\HttpBadRequestException;
+use Fossology\UI\Api\Exceptions\HttpConflictException;
+use Fossology\UI\Api\Exceptions\HttpForbiddenException;
+use Fossology\UI\Api\Exceptions\HttpNotFoundException;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Models\Info;
+use Fossology\UI\Api\Models\InfoType;
+use Mockery as M;
+use Slim\Psr7\Factory\StreamFactory;
+use Slim\Psr7\Headers;
+use Slim\Psr7\Request;
+use Slim\Psr7\Uri;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @class TagControllerTest
+ * @brief Unit tests for TagController
+ *
+ * TagController delegates tag creation and display management to the
+ * legacy admin_tag / admin_tag_manage plugins (see admin-tag.php and
+ * admin-tag-manage.php), so these tests mock those plugins rather than
+ * the database layer directly.
+ */
+class TagControllerTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @var integer $assertCountBefore
+   * Assertions before running tests
+   */
+  private $assertCountBefore;
+
+  /**
+   * @var DbHelper $dbHelper
+   * DbHelper mock
+   */
+  private $dbHelper;
+
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+
+  /**
+   * @var UploadDao $uploadDao
+   * UploadDao mock
+   */
+  private $uploadDao;
+
+  /**
+   * @var \admin_tag $tagPlugin
+   * admin_tag plugin mock
+   */
+  private $tagPlugin;
+
+  /**
+   * @var \admin_tag_manage $tagManagePlugin
+   * admin_tag_manage plugin mock
+   */
+  private $tagManagePlugin;
+
+  /**
+   * @var TagController $tagController
+   * TagController object under test
+   */
+  private $tagController;
+
+  /**
+   * @var StreamFactory $streamFactory
+   * Stream factory to create body streams.
+   */
+  private $streamFactory;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp() : void
+  {
+    global $container;
+    $container = M::mock('ContainerBuilder');
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->restHelper = M::mock(RestHelper::class);
+    $this->uploadDao = M::mock(UploadDao::class);
+    $this->tagPlugin = M::mock('admin_tag');
+    $this->tagManagePlugin = M::mock('admin_tag_manage');
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+    $this->restHelper->shouldReceive('getUploadDao')->andReturn($this->uploadDao);
+    $this->restHelper->shouldReceive('getGroupId')->andReturn(2);
+    $this->restHelper->shouldReceive('getPlugin')
+      ->withArgs(["admin_tag"])->andReturn($this->tagPlugin);
+    $this->restHelper->shouldReceive('getPlugin')
+      ->withArgs(["admin_tag_manage"])->andReturn($this->tagManagePlugin);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+
+    $this->tagController = new TagController($container);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+    $this->streamFactory = new StreamFactory();
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+  }
+
+  /**
+   * @brief Remove test objects
+   * @see PHPUnit_Framework_TestCase::tearDown()
+   */
+  protected function tearDown() : void
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  /**
+   * Helper function to get JSON array from response
+   *
+   * @param Response $response
+   * @return array Decoded response
+   */
+  private function getResponseJson($response)
+  {
+    $response->getBody()->seek(0);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+
+  /**
+   * Helper to build a JSON request with the given body.
+   * @param string $method
+   * @param string $path
+   * @param array $requestBody
+   * @return Request
+   */
+  private function getJsonRequest($method, $path, $requestBody)
+  {
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    $body = $this->streamFactory->createStream();
+    $body->write(json_encode($requestBody));
+    $body->seek(0);
+    return new Request($method, new Uri("HTTP", "localhost", 80,
+      $path), $requestHeaders, [], [], $body);
+  }
+
+  /**
+   * @test
+   * -# Test for TagController::createTag() to create a new tag
+   * -# Check if response is 201 with the id returned by the admin_tag
+   *    plugin
+   */
+  public function testCreateTag()
+  {
+    $requestBody = [
+      "name" => "Software_Repository",
+      "description" => "Tag for software repository uploads"
+    ];
+    $request = $this->getJsonRequest("POST", "/tags", $requestBody);
+
+    $this->tagPlugin->shouldReceive('TagExists')
+      ->withArgs([$requestBody["name"]])->andReturn(false);
+    $this->tagPlugin->shouldReceive('CreateTag')
+      ->withArgs([["tag_name" => $requestBody["name"],
+        "tag_desc" => $requestBody["description"]]])
+      ->andReturn(null);
+    $this->tagPlugin->shouldReceive('GetTagId')
+      ->withArgs([$requestBody["name"]])->andReturn(9);
+
+    $info = new Info(201, 9, InfoType::INFO);
+    $expectedResponse = (new ResponseHelper())->withJson($info->getArray(),
+      $info->getCode());
+
+    $actualResponse = $this->tagController->createTag($request,
+      new ResponseHelper(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for TagController::createTag()
+   * -# The request body has no name
+   * -# Check if response is 400 with the admin_tag plugin's own
+   *    validation error surfaced
+   */
+  public function testCreateTagNoName()
+  {
+    $requestBody = ["description" => "Missing name"];
+    $request = $this->getJsonRequest("POST", "/tags", $requestBody);
+
+    $this->tagPlugin->shouldReceive('CreateTag')
+      ->withArgs([["tag_name" => "", "tag_desc" => "Missing name"]])
+      ->andReturn("TagName must be specified. Tag Not created.");
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->tagController->createTag($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test for TagController::createTag()
+   * -# The request body has a non-string 'description' property
+   * -# Check if it is silently treated as empty rather than crashing
+   */
+  public function testCreateTagDescriptionNotString()
+  {
+    $requestBody = ["name" => "Valid", "description" => [1, 2]];
+    $request = $this->getJsonRequest("POST", "/tags", $requestBody);
+
+    $this->tagPlugin->shouldReceive('TagExists')
+      ->withArgs(["Valid"])->andReturn(false);
+    $this->tagPlugin->shouldReceive('CreateTag')
+      ->withArgs([["tag_name" => "Valid", "tag_desc" => ""]])
+      ->andReturn(null);
+    $this->tagPlugin->shouldReceive('GetTagId')
+      ->withArgs(["Valid"])->andReturn(11);
+
+    $actualResponse = $this->tagController->createTag($request,
+      new ResponseHelper(), []);
+    $this->assertEquals(201, $actualResponse->getStatusCode());
+  }
+
+  /**
+   * @test
+   * -# Test for TagController::createTag()
+   * -# The request body is empty/not valid JSON (parses to null)
+   * -# Check if response is 400, not an uncaught TypeError
+   */
+  public function testCreateTagEmptyBody()
+  {
+    $request = $this->getJsonRequest("POST", "/tags", null);
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->tagController->createTag($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test for TagController::createTag()
+   * -# The request body has a non-string 'name' property
+   * -# Check if response is 400, not an uncaught TypeError
+   */
+  public function testCreateTagNameNotString()
+  {
+    $requestBody = ["name" => [1, 2]];
+    $request = $this->getJsonRequest("POST", "/tags", $requestBody);
+
+    $this->tagPlugin->shouldReceive('CreateTag')
+      ->withArgs([["tag_name" => "", "tag_desc" => ""]])
+      ->andReturn("TagName must be specified. Tag Not created.");
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->tagController->createTag($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test for TagController::createTag()
+   * -# The request body has a name with disallowed characters
+   * -# Check if response is 400 with the admin_tag plugin's own
+   *    validation error surfaced
+   */
+  public function testCreateTagInvalidCharacters()
+  {
+    $requestBody = ["name" => "Bad Tag/Name"];
+    $request = $this->getJsonRequest("POST", "/tags", $requestBody);
+
+    $this->tagPlugin->shouldReceive('TagExists')
+      ->withArgs(["Bad Tag/Name"])->andReturn(false);
+    $this->tagPlugin->shouldReceive('CreateTag')
+      ->withArgs([["tag_name" => "Bad Tag/Name", "tag_desc" => ""]])
+      ->andReturn("A Tag is only allowed to contain characters from " .
+        "<b>A-Za-z0-9_~-!@#$%^*.()</b>. Tag Not created.");
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->tagController->createTag($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test for TagController::createTag()
+   * -# The request body has a name longer than the legacy UI's
+   *    maxlength hint
+   * -# Check that it is still accepted, since admin_tag::CreateTag()
+   *    (the single source of truth for tag validation) does not enforce
+   *    a length limit
+   */
+  public function testCreateTagLongNameAllowed()
+  {
+    $longName = str_repeat("a", 33);
+    $requestBody = ["name" => $longName];
+    $request = $this->getJsonRequest("POST", "/tags", $requestBody);
+
+    $this->tagPlugin->shouldReceive('TagExists')
+      ->withArgs([$longName])->andReturn(false);
+    $this->tagPlugin->shouldReceive('CreateTag')
+      ->withArgs([["tag_name" => $longName, "tag_desc" => ""]])
+      ->andReturn(null);
+    $this->tagPlugin->shouldReceive('GetTagId')
+      ->withArgs([$longName])->andReturn(12);
+
+    $actualResponse = $this->tagController->createTag($request,
+      new ResponseHelper(), []);
+    $this->assertEquals(201, $actualResponse->getStatusCode());
+  }
+
+  /**
+   * @test
+   * -# Test for TagController::createTag()
+   * -# The request body has additional unknown properties
+   * -# Check that they are ignored rather than rejected, matching the
+   *    legacy plugin which only ever looks at tag_name/tag_desc
+   */
+  public function testCreateTagExtraPropertyIgnored()
+  {
+    $requestBody = ["name" => "Valid", "bogus" => "not allowed"];
+    $request = $this->getJsonRequest("POST", "/tags", $requestBody);
+
+    $this->tagPlugin->shouldReceive('TagExists')
+      ->withArgs(["Valid"])->andReturn(false);
+    $this->tagPlugin->shouldReceive('CreateTag')
+      ->withArgs([["tag_name" => "Valid", "tag_desc" => ""]])
+      ->andReturn(null);
+    $this->tagPlugin->shouldReceive('GetTagId')
+      ->withArgs(["Valid"])->andReturn(13);
+
+    $actualResponse = $this->tagController->createTag($request,
+      new ResponseHelper(), []);
+    $this->assertEquals(201, $actualResponse->getStatusCode());
+  }
+
+  /**
+   * @test
+   * -# Test for TagController::createTag()
+   * -# Non admin user cannot create a tag
+   * -# Check if response is 403
+   */
+  public function testCreateTagNoAdmin()
+  {
+    $requestBody = ["name" => "Valid"];
+    $request = $this->getJsonRequest("POST", "/tags", $requestBody);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->expectException(HttpForbiddenException::class);
+
+    $this->tagController->createTag($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test for TagController::createTag()
+   * -# Simulate duplicate tag name
+   * -# Check if response is 409
+   */
+  public function testCreateTagDuplicate()
+  {
+    $requestBody = ["name" => "Existing"];
+    $request = $this->getJsonRequest("POST", "/tags", $requestBody);
+
+    $this->tagPlugin->shouldReceive('TagExists')
+      ->withArgs(["Existing"])->andReturn(true);
+    $this->expectException(HttpConflictException::class);
+
+    $this->tagController->createTag($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test for TagController::setTagDisplayStatus() enabling tag
+   *    display for an upload
+   * -# Check if response is 200 and the admin_tag_manage plugin is
+   *    called with 'Enable'
+   */
+  public function testSetTagDisplayStatusEnable()
+  {
+    $uploadId = 5;
+    $request = $this->getJsonRequest("PUT", "/uploads/$uploadId/tags/display",
+      ["enabled" => true]);
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([$uploadId, 2])->andReturn(true);
+    $this->tagManagePlugin->shouldReceive('ManageTag')
+      ->withArgs([null, $uploadId, 'Enable'])->once()->andReturn(1);
+
+    $actualResponse = $this->tagController->setTagDisplayStatus($request,
+      new ResponseHelper(), ["id" => $uploadId]);
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+  }
+
+  /**
+   * @test
+   * -# Test for TagController::setTagDisplayStatus() disabling tag
+   *    display for an upload
+   * -# Check if response is 200 and the admin_tag_manage plugin is
+   *    called with 'Disable'
+   */
+  public function testSetTagDisplayStatusDisable()
+  {
+    $uploadId = 5;
+    $request = $this->getJsonRequest("PUT", "/uploads/$uploadId/tags/display",
+      ["enabled" => false]);
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([$uploadId, 2])->andReturn(true);
+    $this->tagManagePlugin->shouldReceive('ManageTag')
+      ->withArgs([null, $uploadId, 'Disable'])->once()->andReturn(1);
+
+    $actualResponse = $this->tagController->setTagDisplayStatus($request,
+      new ResponseHelper(), ["id" => $uploadId]);
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+  }
+
+  /**
+   * @test
+   * -# Test for TagController::setTagDisplayStatus()
+   * -# The request body has no 'enabled' property
+   * -# Check if response is 400
+   */
+  public function testSetTagDisplayStatusMissingEnabled()
+  {
+    $uploadId = 5;
+    $request = $this->getJsonRequest("PUT", "/uploads/$uploadId/tags/display",
+      []);
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([$uploadId, 2])->andReturn(true);
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->tagController->setTagDisplayStatus($request, new ResponseHelper(),
+      ["id" => $uploadId]);
+  }
+
+  /**
+   * @test
+   * -# Test for TagController::setTagDisplayStatus()
+   * -# Non admin user cannot change tag display status
+   * -# Check if response is 403
+   */
+  public function testSetTagDisplayStatusNoAdmin()
+  {
+    $uploadId = 5;
+    $request = $this->getJsonRequest("PUT", "/uploads/$uploadId/tags/display",
+      ["enabled" => true]);
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->expectException(HttpForbiddenException::class);
+
+    $this->tagController->setTagDisplayStatus($request, new ResponseHelper(),
+      ["id" => $uploadId]);
+  }
+
+  /**
+   * @test
+   * -# Test for TagController::setTagDisplayStatus()
+   * -# The upload does not exist
+   * -# Check if response is 404
+   */
+  public function testSetTagDisplayStatusUploadNotFound()
+  {
+    $uploadId = 5;
+    $request = $this->getJsonRequest("PUT", "/uploads/$uploadId/tags/display",
+      ["enabled" => true]);
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(false);
+    $this->expectException(HttpNotFoundException::class);
+
+    $this->tagController->setTagDisplayStatus($request, new ResponseHelper(),
+      ["id" => $uploadId]);
+  }
+
+  /**
+   * @test
+   * -# Test for TagController::setTagDisplayStatus()
+   * -# The upload is not accessible to the current group
+   * -# Check if response is 403
+   */
+  public function testSetTagDisplayStatusUploadNotAccessible()
+  {
+    $uploadId = 5;
+    $request = $this->getJsonRequest("PUT", "/uploads/$uploadId/tags/display",
+      ["enabled" => true]);
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([$uploadId, 2])->andReturn(false);
+    $this->expectException(HttpForbiddenException::class);
+
+    $this->tagController->setTagDisplayStatus($request, new ResponseHelper(),
+      ["id" => $uploadId]);
+  }
+}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Adds the missing OpenAPI v2 REST endpoints for tag administration: creating a
tag, and enabling/disabling tag display on an upload. These were the last
pieces blocking the FOSSologyUI Admin > Tag pages from being wired up to the
API.

### Changes

- Adds `TagController::createTag` (`POST /tags`) and
  `TagController::setTagDisplayStatus` (`PUT /uploads/{id}/tags/display`),
  backed by the `tag` and `tag_manage` tables, mirroring the behavior of the
  legacy `admin_tag` / `admin_tag_manage` plugins.
- Adds a `Tag` model (`src/www/ui/api/Models/Tag.php`) that validates and
  parses the create-tag request body (name required, ≤32 characters,
  restricted to the same character set as the legacy plugin; non-array/
  non-string input is rejected instead of causing an internal error).
- Registers both routes in `index.php` and documents them in
  `openapiv2.yaml` (new `Tags` tag group, `Tag` schema).
- Fixes `AjaxFolderContents` (`/folders/{id}/contents`) to also return the
  upload's real `upload_pk` as a new `uploadId` field. Previously the `id`
  field on each entry was `foldercontents_pk`, which gave REST clients no
  way to know which upload a listed folder entry actually refers to -
  something the enable/disable tag display page needs in order to target
  the correct upload. This is additive; the existing `id`/`content`/
  `removable` fields are unchanged.
- Adds `TagControllerTest.php` covering both endpoints: success paths,
  admin-only enforcement, validation errors (missing/invalid/oversized
  name, non-string input, malformed body), duplicate-name conflict, and
  upload not-found/not-accessible cases.

## How to test

1. Build/run the stack (`podman-compose up -d` from the repo root) and log
   in as an admin user.
2. Create a tag:
  curl -X POST http://localhost/repo/api/v2/tags 
  
  -H "Authorization: Bearer <token>" 
  
  -H "Content-Type: application/json" 
  
  -d '{"name": "MyTag", "description": "A test tag"}'
  
  
  Expect `201` with the new tag's id. Repeating the same request should
  return `409` (duplicate name).
3. Enable/disable tag display for an upload:
  curl -X PUT http://localhost/repo/api/v2/uploads/<uploadId>/tags/display 
  
  -H "Authorization: Bearer <token>" 
  
  -H "Content-Type: application/json" 
  
  -d '{"enabled": false}'
  
  
  Expect `200`. Verify with `SELECT * FROM tag_manage WHERE upload_fk =
  <uploadId>;` that a disabled row was inserted, and that re-sending with
  `{"enabled": true}` removes it.
4. Run the new unit tests:
  vendor/bin/phpunit -c phpunit.xml --no-coverage 
  
  src/www/ui_tests/api/Controllers/TagControllerTest.php



Fixes fossology/FOSSologyUI#437.