### PR TITLE
feat(api-v2): add bucket pool list and duplicate endpoints

### DIFF
--- a/src/www/ui/api/Controllers/BucketPoolController.php
+++ b/src/www/ui/api/Controllers/BucketPoolController.php
@@ -1,0 +1,122 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 FOSSology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+/**
+ * @file
+ * @brief Controller for bucket pool queries
+ */
+
+namespace Fossology\UI\Api\Controllers;
+
+use Fossology\UI\Api\Exceptions\HttpConflictException;
+use Fossology\UI\Api\Exceptions\HttpNotFoundException;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Models\BucketPool;
+use Psr\Http\Message\ServerRequestInterface;
+
+class BucketPoolController extends RestController
+{
+  /**
+   * Get list of active bucket pools, latest version first for each name
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   */
+  public function getBucketpools($request, $response, $args)
+  {
+    $this->throwNotAdminException();
+    $dbManager = $this->dbHelper->getDbManager();
+    $rows = $dbManager->getRows(
+      "SELECT bucketpool_pk, bucketpool_name, version, active, description " .
+      "FROM bucketpool WHERE active = 'Y' " .
+      "ORDER BY bucketpool_name ASC, version DESC",
+      [], __METHOD__ . ".getBucketpools");
+
+    $bucketpools = [];
+    foreach ($rows as $row) {
+      $bucketpools[] = (new BucketPool($row['bucketpool_pk'],
+        $row['bucketpool_name'], $row['version'], $row['active'] === 'Y',
+        $row['description']))->getArray();
+    }
+    return $response->withJson($bucketpools, 200);
+  }
+
+  /**
+   * Duplicate a bucket pool together with its bucket definitions.
+   *
+   * The new bucket pool gets the same name with its version incremented by
+   * one. Optionally, the requesting user's default bucket pool is updated
+   * to the newly created one.
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpNotFoundException
+   */
+  public function duplicateBucketpool($request, $response, $args)
+  {
+    $this->throwNotAdminException();
+    $bucketpoolId = intval($args['id']);
+    if (! $this->dbHelper->doesIdExist("bucketpool", "bucketpool_pk", $bucketpoolId)) {
+      throw new HttpNotFoundException("Bucketpool does not exist");
+    }
+
+    $requestBody = $this->getParsedBody($request);
+    $updateDefault = false;
+    if (is_array($requestBody) && array_key_exists('updateDefault', $requestBody)) {
+      $updateDefault = filter_var($requestBody['updateDefault'], FILTER_VALIDATE_BOOLEAN);
+    }
+
+    $dbManager = $this->dbHelper->getDbManager();
+    $oldPool = $dbManager->getSingleRow(
+      "SELECT bucketpool_name, active, description FROM bucketpool " .
+      "WHERE bucketpool_pk = $1", [$bucketpoolId], __METHOD__ . ".getBucketpool");
+
+    $versionRow = $dbManager->getSingleRow(
+      "SELECT max(version) AS version FROM bucketpool WHERE bucketpool_name = $1",
+      [$oldPool['bucketpool_name']], __METHOD__ . ".getMaxVersion");
+    $newVersion = intval($versionRow['version']) + 1;
+
+    try {
+      $newBucketpoolId = $dbManager->insertTableRow("bucketpool", [
+        "bucketpool_name" => $oldPool['bucketpool_name'],
+        "version" => $newVersion,
+        "active" => $oldPool['active'],
+        "description" => $oldPool['description']
+      ], __METHOD__ . ".newBucketpool", "bucketpool_pk");
+    } catch (\Exception $e) {
+      throw new HttpConflictException(
+        "Bucketpool with same name and version already exists! " .
+        "Please try again.", $e);
+    }
+    $newBucketpoolId = intval($newBucketpoolId);
+
+    $dbManager->getSingleRow(
+      "INSERT INTO bucket_def (bucket_name, bucket_color, bucket_reportorder, " .
+      "bucket_evalorder, bucketpool_fk, bucket_type, bucket_regex, " .
+      "bucket_filename, stopon, applies_to) " .
+      "SELECT bucket_name, bucket_color, bucket_reportorder, bucket_evalorder, " .
+      "$1, bucket_type, bucket_regex, bucket_filename, stopon, applies_to " .
+      "FROM bucket_def WHERE bucketpool_fk = $2",
+      [$newBucketpoolId, $bucketpoolId], __METHOD__ . ".copyBucketDefs");
+
+    if ($updateDefault) {
+      $dbManager->getSingleRow(
+        "UPDATE users SET default_bucketpool_fk = $1 WHERE user_pk = $2",
+        [$newBucketpoolId, $this->restHelper->getUserId()],
+        __METHOD__ . ".updateDefault");
+    }
+
+    return $response->withJson([
+      "id" => $newBucketpoolId,
+      "version" => $newVersion
+    ], 201);
+  }
+}

--- a/src/www/ui/api/Models/BucketPool.php
+++ b/src/www/ui/api/Models/BucketPool.php
@@ -1,0 +1,79 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 FOSSology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * @file
+ * @brief BucketPool
+ */
+namespace Fossology\UI\Api\Models;
+
+/**
+ * @class BucketPool
+ * @package Fossology\UI\Api\Models
+ * @brief BucketPool model to hold bucket pool related info
+ */
+class BucketPool
+{
+  /**
+   * @var integer $id
+   * Bucket pool id
+   */
+  private $id;
+  /**
+   * @var string $name
+   * Name of the bucket pool
+   */
+  private $name;
+  /**
+   * @var integer $version
+   * Version of the bucket pool
+   */
+  private $version;
+  /**
+   * @var boolean $active
+   * Is the bucket pool active?
+   */
+  private $active;
+  /**
+   * @var string $description
+   * Description of the bucket pool
+   */
+  private $description;
+
+  /**
+   * BucketPool constructor.
+   *
+   * @param integer $id
+   * @param string $name
+   * @param integer $version
+   * @param boolean $active
+   * @param string $description
+   */
+  public function __construct($id, $name = "", $version = 1, $active = true,
+    $description = "")
+  {
+    $this->id = intval($id);
+    $this->name = $name;
+    $this->version = intval($version);
+    $this->active = $active;
+    $this->description = $description;
+  }
+
+  /**
+   * Get BucketPool element as associative array
+   * @return array
+   */
+  public function getArray()
+  {
+    return [
+      'id' => $this->id,
+      'name' => $this->name,
+      'version' => $this->version,
+      'active' => $this->active,
+      'description' => $this->description
+    ];
+  }
+}

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -57,6 +57,8 @@ tags:
     description: Maintenance operations
   - name: Overview
     description: Overview of FOSSology operations
+  - name: BucketPools
+    description: Bucket pool management
 
 x-reuse:
   - &cxGetParams
@@ -509,6 +511,108 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ObligationExtended'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /bucketpools:
+    get:
+      operationId: getBucketpools
+      tags:
+        - BucketPools
+        - Admin
+      summary: Get the list of active bucket pools
+      description: >
+        Returns all active bucket pools (including version information),
+        ordered by name and latest version first. Intended to populate a
+        bucket pool selection dropdown.
+      responses:
+        '200':
+          description: List of bucket pools
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BucketPool'
+        '403':
+          description: Only admin can access this endpoint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
+
+  /bucketpools/{id}/duplicate:
+    parameters:
+      - name: id
+        required: true
+        description: Id of the bucket pool to duplicate
+        in: path
+        schema:
+          type: integer
+    post:
+      operationId: duplicateBucketpool
+      tags:
+        - BucketPools
+        - Admin
+      summary: Duplicate a bucket pool
+      description: >
+        Clone an existing bucket pool together with all its bucket
+        definitions. The new bucket pool keeps the same name with its
+        version incremented by one. Optionally, the requesting user's
+        default bucket pool is updated to the newly created one.
+      requestBody:
+        description: Options for the duplication
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                updateDefault:
+                  type: boolean
+                  description: >
+                    Set to true to also update the requesting user's default
+                    bucket pool to the newly created one.
+                  default: false
+      responses:
+        '201':
+          description: Bucket pool duplicated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                    description: Id of the newly created bucket pool
+                  version:
+                    type: integer
+                    description: Version of the newly created bucket pool
+              example:
+                {"id": 5, "version": 3}
+        '403':
+          description: Only admin can access this endpoint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Bucket pool does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '409':
+          description: >
+            A bucket pool with the same name and version already exists
+            (concurrent duplication of the same bucket pool). Retry the
+            request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
 
@@ -6651,6 +6755,34 @@ components:
           type: integer
         optionValue:
           description: If type is 'dropdown', provide options in format op1{val1}|op2{val2}|...
+          type: string
+    BucketPool:
+      description: BucketPool object
+      type: object
+      properties:
+        id:
+          description: Id of the bucket pool
+          type: integer
+          readOnly: true
+          example:
+            1
+        name:
+          description: Name of the bucket pool
+          type: string
+          example:
+            "GPL Demo bucket pool"
+        version:
+          description: Version of the bucket pool
+          type: integer
+          example:
+            1
+        active:
+          description: Whether the bucket pool is active
+          type: boolean
+          example:
+            true
+        description:
+          description: Description of the bucket pool
           type: string
     Group:
       description: Group object

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -23,6 +23,7 @@ require_once dirname(__FILE__, 4) . "/lib/php/bootstrap.php";
 use Fossology\Lib\Util\TimingLogger;
 use Fossology\UI\Api\Controllers\AuthController;
 use Fossology\UI\Api\Controllers\BadRequestController;
+use Fossology\UI\Api\Controllers\BucketPoolController;
 use Fossology\UI\Api\Controllers\ConfController;
 use Fossology\UI\Api\Controllers\CopyrightController;
 use Fossology\UI\Api\Controllers\CustomiseController;
@@ -308,6 +309,14 @@ $app->group('/obligations',
     $app->post('/import-csv', ObligationController::class . ':importObligationsFromCSV');
     $app->get('/export-json', ObligationController::class . ':exportObligationsToJSON');
     $app->post('/import-json', ObligationController::class . ':importObligationsFromJSON');
+    $app->any('/{params:.*}', BadRequestController::class);
+  });
+
+////////////////////////////BUCKETPOOLS/////////////////////
+$app->group('/bucketpools',
+  function (\Slim\Routing\RouteCollectorProxy $app) {
+    $app->get('', BucketPoolController::class . ':getBucketpools');
+    $app->post('/{id:\\d+}/duplicate', BucketPoolController::class . ':duplicateBucketpool');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui_tests/api/Controllers/BucketPoolControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/BucketPoolControllerTest.php
@@ -1,0 +1,336 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 FOSSology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * @file
+ * @brief Tests for BucketPoolController
+ */
+
+namespace Fossology\UI\Api\Test\Controllers;
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Db\DbManager;
+use Fossology\UI\Api\Controllers\BucketPoolController;
+use Fossology\UI\Api\Exceptions\HttpConflictException;
+use Fossology\UI\Api\Exceptions\HttpForbiddenException;
+use Fossology\UI\Api\Exceptions\HttpNotFoundException;
+use Fossology\UI\Api\Helper\DbHelper;
+use Fossology\UI\Api\Helper\ResponseHelper;
+use Fossology\UI\Api\Helper\RestHelper;
+use Mockery as M;
+use Slim\Psr7\Factory\StreamFactory;
+use Slim\Psr7\Headers;
+use Slim\Psr7\Request;
+use Slim\Psr7\Uri;
+
+/**
+ * @class BucketPoolControllerTest
+ * @brief Tests for BucketPoolController
+ */
+class BucketPoolControllerTest extends \PHPUnit\Framework\TestCase
+{
+  /**
+   * @var integer $assertCountBefore
+   * Assertions before running tests
+   */
+  private $assertCountBefore;
+
+  /**
+   * @var DbHelper $dbHelper
+   * DbHelper mock
+   */
+  private $dbHelper;
+
+  /**
+   * @var DbManager $dbManager
+   * DbManager mock
+   */
+  private $dbManager;
+
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+
+  /**
+   * @var BucketPoolController $bucketPoolController
+   * BucketPoolController object to test
+   */
+  private $bucketPoolController;
+
+  /**
+   * @var StreamFactory $streamFactory
+   * Stream factory to create body streams.
+   */
+  private $streamFactory;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp() : void
+  {
+    global $container;
+    $container = M::mock('ContainerBuilder');
+    $this->dbHelper = M::mock(DbHelper::class);
+    $this->dbManager = M::mock(DbManager::class);
+    $this->restHelper = M::mock(RestHelper::class);
+
+    $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
+    $this->dbHelper->shouldReceive('getDbManager')->andReturn($this->dbManager);
+
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+    $this->bucketPoolController = new BucketPoolController($container);
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+    $this->streamFactory = new StreamFactory();
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+  }
+
+  /**
+   * @brief Remove test objects
+   * @see PHPUnit_Framework_TestCase::tearDown()
+   */
+  protected function tearDown() : void
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  /**
+   * Helper function to get JSON array from response
+   *
+   * @param ResponseHelper $response
+   * @return array Decoded response
+   */
+  private function getResponseJson($response)
+  {
+    $response->getBody()->seek(0);
+    return json_decode($response->getBody()->getContents(), true);
+  }
+
+  /**
+   * @test
+   * -# Test BucketPoolController::getBucketpools() when user is not admin
+   * -# Check if HttpForbiddenException is thrown
+   */
+  public function testGetBucketpoolsNotAdmin()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->expectException(HttpForbiddenException::class);
+    $this->bucketPoolController->getBucketpools(null, new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test BucketPoolController::getBucketpools() for a valid admin request
+   * -# Check if the response is the list of active bucket pools
+   */
+  public function testGetBucketpoolsSuccess()
+  {
+    $rows = [
+      ["bucketpool_pk" => 1, "bucketpool_name" => "GPL Demo bucket pool",
+        "version" => 2, "active" => "Y", "description" => "Demo pool"],
+      ["bucketpool_pk" => 2, "bucketpool_name" => "GPL Demo bucket pool",
+        "version" => 1, "active" => "Y", "description" => "Demo pool"]
+    ];
+    $this->dbManager->shouldReceive('getRows')
+      ->withArgs([M::any(), [], M::any()])->andReturn($rows);
+
+    $expected = [
+      ["id" => 1, "name" => "GPL Demo bucket pool", "version" => 2,
+        "active" => true, "description" => "Demo pool"],
+      ["id" => 2, "name" => "GPL Demo bucket pool", "version" => 1,
+        "active" => true, "description" => "Demo pool"]
+    ];
+    $expectedResponse = (new ResponseHelper())->withJson($expected, 200);
+
+    $actualResponse = $this->bucketPoolController->getBucketpools(null,
+      new ResponseHelper(), []);
+
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test BucketPoolController::duplicateBucketpool() when user is not admin
+   * -# Check if HttpForbiddenException is thrown
+   */
+  public function testDuplicateBucketpoolNotAdmin()
+  {
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->expectException(HttpForbiddenException::class);
+    $this->bucketPoolController->duplicateBucketpool(null, new ResponseHelper(),
+      ['id' => 1]);
+  }
+
+  /**
+   * @test
+   * -# Test BucketPoolController::duplicateBucketpool() for a bucket pool
+   *    that does not exist
+   * -# Check if HttpNotFoundException is thrown
+   */
+  public function testDuplicateBucketpoolNotFound()
+  {
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["bucketpool", "bucketpool_pk", 99])->andReturn(false);
+
+    $this->expectException(HttpNotFoundException::class);
+    $this->bucketPoolController->duplicateBucketpool(null, new ResponseHelper(),
+      ['id' => 99]);
+  }
+
+  /**
+   * @test
+   * -# Test BucketPoolController::duplicateBucketpool() when the insert
+   *    hits the (bucketpool_name, version) unique constraint, e.g. due to
+   *    a concurrent duplication of the same bucket pool
+   * -# Check if HttpConflictException is thrown
+   */
+  public function testDuplicateBucketpoolConflict()
+  {
+    $bucketpoolId = 1;
+    $oldPool = ["bucketpool_name" => "GPL Demo bucket pool", "active" => "Y",
+      "description" => "Demo pool"];
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["bucketpool", "bucketpool_pk", $bucketpoolId])->andReturn(true);
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs(["SELECT bucketpool_name, active, description FROM bucketpool " .
+        "WHERE bucketpool_pk = $1", [$bucketpoolId], M::any()])
+      ->andReturn($oldPool);
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs(["SELECT max(version) AS version FROM bucketpool WHERE bucketpool_name = $1",
+        [$oldPool['bucketpool_name']], M::any()])
+      ->andReturn(["version" => 2]);
+    $this->dbManager->shouldReceive('insertTableRow')
+      ->withArgs(["bucketpool", [
+        "bucketpool_name" => $oldPool['bucketpool_name'],
+        "version" => 3,
+        "active" => $oldPool['active'],
+        "description" => $oldPool['description']
+      ], M::any(), "bucketpool_pk"])
+      ->andThrow(new \Exception("duplicate key value violates unique constraint"));
+
+    $request = new Request("POST", new Uri("HTTP", "localhost"),
+      new Headers(), [], [], $this->streamFactory->createStream());
+
+    $this->expectException(HttpConflictException::class);
+    $this->bucketPoolController->duplicateBucketpool($request, new ResponseHelper(),
+      ['id' => $bucketpoolId]);
+  }
+
+  /**
+   * @test
+   * -# Test BucketPoolController::duplicateBucketpool() for a valid request
+   *    without updating the default bucket pool
+   * -# Check if the response contains the new bucket pool id and version
+   */
+  public function testDuplicateBucketpoolSuccess()
+  {
+    $bucketpoolId = 1;
+    $newBucketpoolId = 5;
+    $oldPool = ["bucketpool_name" => "GPL Demo bucket pool", "active" => "Y",
+      "description" => "Demo pool"];
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["bucketpool", "bucketpool_pk", $bucketpoolId])->andReturn(true);
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs(["SELECT bucketpool_name, active, description FROM bucketpool " .
+        "WHERE bucketpool_pk = $1", [$bucketpoolId], M::any()])
+      ->andReturn($oldPool);
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs(["SELECT max(version) AS version FROM bucketpool WHERE bucketpool_name = $1",
+        [$oldPool['bucketpool_name']], M::any()])
+      ->andReturn(["version" => 2]);
+    $this->dbManager->shouldReceive('insertTableRow')
+      ->withArgs(["bucketpool", [
+        "bucketpool_name" => $oldPool['bucketpool_name'],
+        "version" => 3,
+        "active" => $oldPool['active'],
+        "description" => $oldPool['description']
+      ], M::any(), "bucketpool_pk"])->andReturn($newBucketpoolId);
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs([M::pattern('/^INSERT INTO bucket_def/'),
+        [$newBucketpoolId, $bucketpoolId], M::any()])->andReturn(null);
+
+    $request = new Request("POST", new Uri("HTTP", "localhost"),
+      new Headers(), [], [], $this->streamFactory->createStream());
+
+    $expectedResponse = (new ResponseHelper())->withJson(
+      ["id" => $newBucketpoolId, "version" => 3], 201);
+
+    $actualResponse = $this->bucketPoolController->duplicateBucketpool($request,
+      new ResponseHelper(), ['id' => $bucketpoolId]);
+
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test BucketPoolController::duplicateBucketpool() for a valid request
+   *    that also updates the requesting user's default bucket pool
+   * -# Check if the users table is updated with the new bucket pool id
+   */
+  public function testDuplicateBucketpoolSuccessWithUpdateDefault()
+  {
+    $bucketpoolId = 1;
+    $newBucketpoolId = 5;
+    $userId = 7;
+    $oldPool = ["bucketpool_name" => "GPL Demo bucket pool", "active" => "Y",
+      "description" => "Demo pool"];
+
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["bucketpool", "bucketpool_pk", $bucketpoolId])->andReturn(true);
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs(["SELECT bucketpool_name, active, description FROM bucketpool " .
+        "WHERE bucketpool_pk = $1", [$bucketpoolId], M::any()])
+      ->andReturn($oldPool);
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs(["SELECT max(version) AS version FROM bucketpool WHERE bucketpool_name = $1",
+        [$oldPool['bucketpool_name']], M::any()])
+      ->andReturn(["version" => 2]);
+    $this->dbManager->shouldReceive('insertTableRow')
+      ->withArgs(["bucketpool", [
+        "bucketpool_name" => $oldPool['bucketpool_name'],
+        "version" => 3,
+        "active" => $oldPool['active'],
+        "description" => $oldPool['description']
+      ], M::any(), "bucketpool_pk"])->andReturn($newBucketpoolId);
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs([M::pattern('/^INSERT INTO bucket_def/'),
+        [$newBucketpoolId, $bucketpoolId], M::any()])->andReturn(null);
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs(["UPDATE users SET default_bucketpool_fk = $1 WHERE user_pk = $2",
+        [$newBucketpoolId, $userId], M::any()])->andReturn(null);
+
+    $body = $this->streamFactory->createStream(json_encode(["updateDefault" => true]));
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    $request = new Request("POST", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+
+    $expectedResponse = (new ResponseHelper())->withJson(
+      ["id" => $newBucketpoolId, "version" => 3], 201);
+
+    $actualResponse = $this->bucketPoolController->duplicateBucketpool($request,
+      new ResponseHelper(), ['id' => $bucketpoolId]);
+
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Add two OpenAPI v2 REST endpoints for the "Duplicate Bucketpool" admin feature: listing available bucket pools and duplicating one along with its bucket definitions. This mirrors the legacy `Admin > Buckets > Duplicate Bucketpool` plugin and unblocks the FOSSologyUI React/Next.js migration of that admin page.

### Changes

- Add `GET /bucketpools` to list active bucket pools (id, name, version, active, description) for the selection dropdown.
- Add `POST /bucketpools/{id}/duplicate` to clone a bucket pool and its `bucket_def` rows, incrementing the version, with an optional `updateDefault` flag to also update the requesting user's default bucket pool. Returns the new bucket pool's `id` and `version`.
- Return `409 Conflict` instead of a generic 500 when a concurrent duplication of the same pool races on the `bucketpool(bucketpool_name, version)` unique constraint, following the same pattern `LicenseController::createLicense` already uses for its own duplicate-key race.
- Add `BucketPoolController` and `BucketPool` model, wire the routes in `index.php`, and document both endpoints in `openapiv2.yaml`.
- Add `BucketPoolControllerTest` covering admin-gating, not-found, success, and conflict paths for both endpoints.

## How to test

Run the new tests:
php vendor/bin/phpunit -c phpunit.xml --no-coverage www/ui_tests/api/Controllers/BucketPoolControllerTest.php



Or manually, as an admin, against a running instance:
- `GET /repo/api/v2/bucketpools` — lists active bucket pools.
- `POST /repo/api/v2/bucketpools/{id}/duplicate` with body `{"updateDefault": true}` — creates a new bucket pool with the same name and version incremented by one, copies its bucket definitions, and sets it as your default bucket pool.

Fixes fossology/FOSSologyUI#441