### PR TITLE
feat(api-v2): expose parent/report license mappings and metadata for …

### DIFF
--- a/src/lib/php/BusinessRules/LicenseMap.php
+++ b/src/lib/php/BusinessRules/LicenseMap.php
@@ -39,8 +39,12 @@ class LicenseMap
    * @param int $groupId
    * @param int $usageId
    * @param bool $full
+   * @param int|null $licenseId Only load the mapping for this one license,
+   *        instead of the whole group's map. Ignored when $full is true.
+   *        Use this when only a single license's projection is needed, to
+   *        avoid the cost of loading and joining every mapped license.
    */
-  public function __construct(DbManager $dbManager, $groupId, $usageId=null, $full=false)
+  public function __construct(DbManager $dbManager, $groupId, $usageId=null, $full=false, $licenseId=null)
   {
     $this->usageId = $usageId?:self::CONCLUSION;
     $this->groupId = $groupId;
@@ -49,6 +53,7 @@ class LicenseMap
       return;
     }
     $licenseView = new LicenseViewProxy($groupId);
+    $params = array($this->usageId);
     if ($full) {
       $query = $licenseView->asCTE()
             .' SELECT distinct on(rf_pk) rf_pk rf_fk, rf_shortname parent_shortname,
@@ -70,9 +75,14 @@ class LicenseMap
             .'rf_parent, rf_fullname AS parent_fullname FROM license_map, '.$licenseView->getDbViewName()
             .' WHERE rf_pk=rf_parent AND rf_fk!=rf_parent AND usage=$1';
       $stmt = __METHOD__.".$this->usageId,$groupId";
+      if ($licenseId !== null) {
+        $query .= ' AND rf_fk=$2';
+        $stmt .= '.scoped';
+        $params[] = $licenseId;
+      }
     }
     $dbManager->prepare($stmt,$query);
-    $res = $dbManager->execute($stmt,array($this->usageId));
+    $res = $dbManager->execute($stmt,$params);
     while ($row = $dbManager->fetchArray($res)) {
       $this->map[$row['rf_fk']] = $row;
     }
@@ -141,6 +151,28 @@ class LicenseMap
       return $licenseName;
     }
     return $defaultName;
+  }
+
+  /**
+   * @brief For a given license id, get the projected license as a full
+   * reference.
+   *
+   * Unlike getProjectedId()/getProjectedShortname(), this returns null
+   * when the license has no mapping (or maps to itself), so callers can
+   * tell "not mapped" apart from "mapped to itself".
+   * @param int $licenseId License id to be queried
+   * @return LicenseRef|null Projected license reference, or null if the
+   *         license is not mapped to a different license.
+   */
+  public function getProjectedRef($licenseId)
+  {
+    if (!array_key_exists($licenseId, $this->map) ||
+        $this->map[$licenseId]['rf_parent'] == $licenseId) {
+      return null;
+    }
+    $row = $this->map[$licenseId];
+    return new LicenseRef($row['rf_parent'], $row['parent_shortname'],
+      $row['parent_fullname'], $row['parent_spdx_id']);
   }
 
   /**

--- a/src/lib/php/BusinessRules/test/LicenseMapTest.php
+++ b/src/lib/php/BusinessRules/test/LicenseMapTest.php
@@ -99,6 +99,50 @@ class LicenseMapTest extends \PHPUnit\Framework\TestCase
     assertThat($licenseMap->getProjectedShortName(2),is('One'));
   }
 
+  function testProjectedRefOfUnmappedIdIsNull()
+  {
+    $licenseMap = new LicenseMap($this->dbManager, $this->groupId);
+    assertThat($licenseMap->getProjectedRef(1),is(nullValue()));
+  }
+
+  function testProjectedRefOfCandidateIsNull()
+  {
+    $licenseMap = new LicenseMap($this->dbManager, $this->groupId);
+    assertThat($licenseMap->getProjectedRef(3),is(nullValue()));
+  }
+
+  function testProjectedRefOfMappedId()
+  {
+    $licenseMap = new LicenseMap($this->dbManager, $this->groupId);
+    $ref = $licenseMap->getProjectedRef(2);
+    assertThat($ref, is(notNullValue()));
+    assertThat($ref->getId(), is(1));
+    assertThat($ref->getShortName(), is('One'));
+    assertThat($ref->getFullName(), is('One-1'));
+    assertThat($ref->getSpdxId(), is('One'));
+  }
+
+  function testScopedConstructorLoadsOnlyTheRequestedLicense()
+  {
+    // A second, distinct mapping so a scoped load can be told apart from
+    // a full one.
+    $this->dbManager->insertTableRow('license_ref',
+      array('rf_pk'=>4,'rf_shortname'=>'Four','rf_fullname'=>'Four-4','rf_spdx_id'=>'Four'));
+    $this->dbManager->insertTableRow('license_map',
+      array('license_map_pk'=>1,'rf_fk'=>4,'rf_parent'=>1,'usage'=>LicenseMap::CONCLUSION));
+
+    $scoped = new LicenseMap($this->dbManager, $this->groupId, LicenseMap::CONCLUSION, false, 2);
+    $ref = $scoped->getProjectedRef(2);
+    assertThat($ref, is(notNullValue()));
+    assertThat($ref->getId(), is(1));
+    assertThat($ref->getShortName(), is('One'));
+
+    // The scoped instance never loaded license 4's mapping, so it falls
+    // back to "unmapped" for it even though license 4 really is mapped.
+    assertThat($scoped->getProjectedId(4), is(4));
+    assertThat($scoped->getProjectedRef(4), is(nullValue()));
+  }
+
   function testObligationForLicense()
   {
     $licenseMap = new LicenseMap($this->dbManager, $this->groupId);

--- a/src/lib/php/Dao/LicenseDao.php
+++ b/src/lib/php/Dao/LicenseDao.php
@@ -592,6 +592,49 @@ ORDER BY lft asc
   }
 
   /**
+   * @brief Get the projected (mapped) license reference for a license, for
+   * a given usage/mapping type (e.g. conclusion parent, report license).
+   *
+   * @param int $licenseId License id to look up
+   * @param int $usageId   Usage type, see LicenseMap constants
+   * @param int|null $groupId Group id for license visibility
+   * @return LicenseRef|null Projected license reference, or null if the
+   *         license has no mapping of the given type.
+   */
+  public function getProjectedLicenseRef($licenseId, $usageId, $groupId=null)
+  {
+    $licenseMap = new LicenseMap($this->dbManager, $groupId, $usageId, false, $licenseId);
+    return $licenseMap->getProjectedRef($licenseId);
+  }
+
+  /**
+   * @brief Get the active status and license type for a license or
+   * candidate license.
+   *
+   * @param int $licenseId License id to look up
+   * @return array|null ['active' => bool, 'licenseType' => string], or
+   *         null if no license with the given id could be found.
+   */
+  public function getLicenseTypeAndStatus($licenseId)
+  {
+    $row = $this->dbManager->getSingleRow(
+      "SELECT rf_active, rf_licensetype FROM ONLY license_ref WHERE rf_pk = $1",
+      [$licenseId], __METHOD__ . ".main");
+    if ($row === false) {
+      $row = $this->dbManager->getSingleRow(
+        "SELECT rf_active, rf_licensetype FROM license_candidate WHERE rf_pk = $1",
+        [$licenseId], __METHOD__ . ".candidate");
+    }
+    if ($row === false) {
+      return null;
+    }
+    return [
+      'active' => $this->dbManager->booleanFromDb($row['rf_active']),
+      'licenseType' => $row['rf_licensetype'],
+    ];
+  }
+
+  /**
    * @param int $userId
    * @param int $groupId
    * @param int $uploadTreeId

--- a/src/lib/php/Dao/test/LicenseDaoTest.php
+++ b/src/lib/php/Dao/test/LicenseDaoTest.php
@@ -124,6 +124,59 @@ class LicenseDaoTest extends \PHPUnit\Framework\TestCase
     $this->assertNull($lic);
   }
 
+  public function testGetProjectedLicenseRef()
+  {
+    $this->setUpLicenseRefTable();
+    $this->testDb->createPlainTables(array('license_map'));
+    $this->testDb->createInheritedTables(array('license_candidate'));
+    $this->dbManager->insertTableRow('license_ref',
+      array('rf_pk'=>1,'rf_shortname'=>'One','rf_fullname'=>'One-1','rf_spdx_id'=>'One','rf_text'=>'text-1','rf_detector_type'=>1));
+    $this->dbManager->insertTableRow('license_ref',
+      array('rf_pk'=>2,'rf_shortname'=>'Two','rf_fullname'=>'Two-2','rf_spdx_id'=>'Two','rf_text'=>'text-2','rf_detector_type'=>1));
+    $this->dbManager->insertTableRow('license_map',
+      array('license_map_pk'=>0,'rf_fk'=>2,'rf_parent'=>1,'usage'=>LicenseMap::CONCLUSION));
+
+    $licDao = new LicenseDao($this->dbManager);
+    $groupId = 101;
+
+    $ref = $licDao->getProjectedLicenseRef(2, LicenseMap::CONCLUSION, $groupId);
+    assertThat($ref, is(notNullValue()));
+    assertThat($ref->getId(), is(1));
+    assertThat($ref->getShortName(), is('One'));
+    assertThat($ref->getFullName(), is('One-1'));
+
+    $unmapped = $licDao->getProjectedLicenseRef(1, LicenseMap::CONCLUSION, $groupId);
+    assertThat($unmapped, is(nullValue()));
+
+    $otherUsage = $licDao->getProjectedLicenseRef(2, LicenseMap::REPORT, $groupId);
+    assertThat($otherUsage, is(nullValue()));
+
+    $this->addToAssertionCount(\Hamcrest\MatcherAssert::getCount()-$this->assertCountBefore);
+  }
+
+  public function testGetLicenseTypeAndStatus()
+  {
+    $this->setUpLicenseRefTable();
+    $this->testDb->createInheritedTables(array('license_candidate'));
+    $this->dbManager->insertTableRow('license_ref',
+      array('rf_pk'=>1,'rf_shortname'=>'One','rf_text'=>'text-1','rf_detector_type'=>1,'rf_active'=>true,'rf_licensetype'=>'Permissive'));
+    $this->dbManager->insertTableRow('license_candidate',
+      array('rf_pk'=>2,'rf_shortname'=>'Two','rf_text'=>'text-2','rf_detector_type'=>1,'rf_active'=>false,'rf_licensetype'=>'Unknown','group_fk'=>101));
+
+    $licDao = new LicenseDao($this->dbManager);
+
+    $status = $licDao->getLicenseTypeAndStatus(1);
+    assertThat($status, is(array('active'=>true,'licenseType'=>'Permissive')));
+
+    $candidateStatus = $licDao->getLicenseTypeAndStatus(2);
+    assertThat($candidateStatus, is(array('active'=>false,'licenseType'=>'Unknown')));
+
+    $missing = $licDao->getLicenseTypeAndStatus(999);
+    assertThat($missing, is(nullValue()));
+
+    $this->addToAssertionCount(\Hamcrest\MatcherAssert::getCount()-$this->assertCountBefore);
+  }
+
   public function testGetLicenseRefs()
   {
     $this->setUpLicenseRefTable();

--- a/src/www/ui/api/Controllers/LicenseController.php
+++ b/src/www/ui/api/Controllers/LicenseController.php
@@ -15,6 +15,7 @@ namespace Fossology\UI\Api\Controllers;
 use Fossology\Lib\Application\BulkTextExport;
 use Fossology\Lib\Application\LicenseCsvExport;
 use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\BusinessRules\LicenseMap;
 use Fossology\Lib\Dao\LicenseAcknowledgementDao;
 use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Dao\LicenseStdCommentDao;
@@ -107,8 +108,8 @@ class LicenseController extends RestController
       throw new HttpBadRequestException("Short name missing from request.");
     }
 
-    $license = $this->licenseDao->getLicenseByShortName($shortName,
-      $this->restHelper->getGroupId());
+    $groupId = $this->restHelper->getGroupId();
+    $license = $this->licenseDao->getLicenseByShortName($shortName, $groupId);
 
     if ($license === null) {
       throw new HttpNotFoundException(
@@ -140,8 +141,42 @@ class LicenseController extends RestController
       $obligationList,
       $license->getRisk()
     );
+    $returnVal->setSpdxId($license->getSpdxId());
+
+    $metadata = $this->licenseDao->getLicenseTypeAndStatus($license->getId());
+    if ($metadata !== null) {
+      $returnVal->setActive($metadata['active']);
+      $returnVal->setLicenseType($metadata['licenseType']);
+    }
+
+    $returnVal->setParentLicense($this->getLicenseRefArray(
+      $this->licenseDao->getProjectedLicenseRef($license->getId(),
+        LicenseMap::CONCLUSION, $groupId)));
+    $returnVal->setReportLicense($this->getLicenseRefArray(
+      $this->licenseDao->getProjectedLicenseRef($license->getId(),
+        LicenseMap::REPORT, $groupId)));
 
     return $response->withJson($returnVal->getArray(), 200);
+  }
+
+  /**
+   * Convert a projected LicenseRef into a lightweight array for API
+   * responses.
+   *
+   * @param \Fossology\Lib\Data\LicenseRef|null $ref
+   * @return array|null
+   */
+  private function getLicenseRefArray($ref)
+  {
+    if ($ref === null) {
+      return null;
+    }
+    return [
+      'id' => intval($ref->getId()),
+      'shortName' => $ref->getShortName(),
+      'fullName' => $ref->getFullName(),
+      'spdxId' => $ref->getSpdxId(),
+    ];
   }
 
   /**

--- a/src/www/ui/api/Models/License.php
+++ b/src/www/ui/api/Models/License.php
@@ -69,6 +69,31 @@ class License
    * Create merge request for candidate license?
    */
   private $mergeRequest;
+  /**
+   * @var string|null $spdxId
+   * SPDX id of the license
+   */
+  private $spdxId;
+  /**
+   * @var boolean|null $active
+   * Is the license active?
+   */
+  private $active;
+  /**
+   * @var string|null $licenseType
+   * Type of the license (e.g. Permissive, Copyleft)
+   */
+  private $licenseType;
+  /**
+   * @var array|null $parentLicense
+   * Parent license this license is mapped to for conclusions, if any
+   */
+  private $parentLicense;
+  /**
+   * @var array|null $reportLicense
+   * License this license is mapped to for reports, if any
+   */
+  private $reportLicense;
 
   /**
    * License constructor.
@@ -102,6 +127,11 @@ class License
     $this->setRisk($risk);
     $this->setIsCandidate($isCandidate);
     $this->mergeRequest = false;
+    $this->spdxId = null;
+    $this->active = null;
+    $this->licenseType = null;
+    $this->parentLicense = null;
+    $this->reportLicense = null;
   }
 
   /**
@@ -130,6 +160,21 @@ class License
     ];
     if ($this->obligations !== null) {
       $data['obligations'] = $this->getObligations();
+    }
+    if ($this->spdxId !== null) {
+      $data['spdxId'] = $this->spdxId;
+    }
+    if ($this->active !== null) {
+      $data['active'] = $this->active;
+    }
+    if ($this->licenseType !== null) {
+      $data['licenseType'] = $this->licenseType;
+    }
+    if ($this->parentLicense !== null) {
+      $data['parentLicense'] = $this->parentLicense;
+    }
+    if ($this->reportLicense !== null) {
+      $data['reportLicense'] = $this->reportLicense;
     }
     return $data;
   }
@@ -236,6 +281,51 @@ class License
   }
 
   /**
+   * Get the license's SPDX id
+   * @return string|null License's SPDX id if set, null if not set
+   */
+  public function getSpdxId()
+  {
+    return $this->spdxId;
+  }
+
+  /**
+   * Is the license active?
+   * @return boolean|null License's active status if set, null if not set
+   */
+  public function getActive()
+  {
+    return $this->active;
+  }
+
+  /**
+   * Get the license's type (e.g. Permissive, Copyleft)
+   * @return string|null License's type if set, null if not set
+   */
+  public function getLicenseType()
+  {
+    return $this->licenseType;
+  }
+
+  /**
+   * Get the parent license this license is mapped to for conclusions
+   * @return array|null Parent license reference if set, null if not set
+   */
+  public function getParentLicense()
+  {
+    return $this->parentLicense;
+  }
+
+  /**
+   * Get the license this license is mapped to for reports
+   * @return array|null Report license reference if set, null if not set
+   */
+  public function getReportLicense()
+  {
+    return $this->reportLicense;
+  }
+
+  /**
    * Set the license's short name
    * @param string $shortName License's short name
    */
@@ -322,6 +412,55 @@ class License
       $this->obligations = [];
     }
     $this->obligations[] = $obligation;
+  }
+
+  /**
+   * Set the license's SPDX id
+   * @param string|null $spdxId License's SPDX id
+   */
+  public function setSpdxId($spdxId)
+  {
+    $this->spdxId = $spdxId;
+  }
+
+  /**
+   * Set whether the license is active
+   * @param boolean|null $active License's active status
+   */
+  public function setActive($active)
+  {
+    if (!is_null($active)) {
+      $this->active = filter_var($active, FILTER_VALIDATE_BOOLEAN);
+    } else {
+      $this->active = null;
+    }
+  }
+
+  /**
+   * Set the license's type (e.g. Permissive, Copyleft)
+   * @param string|null $licenseType License's type
+   */
+  public function setLicenseType($licenseType)
+  {
+    $this->licenseType = $licenseType;
+  }
+
+  /**
+   * Set the parent license this license is mapped to for conclusions
+   * @param array|null $parentLicense Parent license reference
+   */
+  public function setParentLicense($parentLicense)
+  {
+    $this->parentLicense = $parentLicense;
+  }
+
+  /**
+   * Set the license this license is mapped to for reports
+   * @param array|null $reportLicense Report license reference
+   */
+  public function setReportLicense($reportLicense)
+  {
+    $this->reportLicense = $reportLicense;
   }
 
   /**

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -4897,6 +4897,52 @@ paths:
                         type: array
                         items:
                           $ref: '#/components/schemas/Obligation'
+                      spdxId:
+                        description: SPDX id of the license
+                        type: string
+                        nullable: true
+                        example:
+                          "MIT"
+                      active:
+                        description: Is the license active?
+                        type: boolean
+                        nullable: true
+                      licenseType:
+                        description: Type of the license
+                        type: string
+                        nullable: true
+                        example:
+                          "Permissive"
+                      parentLicense:
+                        description: >
+                          Parent license this license is mapped to for
+                          conclusions, null if not mapped to another license
+                        type: object
+                        nullable: true
+                        properties:
+                          id:
+                            type: integer
+                          shortName:
+                            type: string
+                          fullName:
+                            type: string
+                          spdxId:
+                            type: string
+                      reportLicense:
+                        description: >
+                          License this license is mapped to for reports,
+                          null if not mapped to another license
+                        type: object
+                        nullable: true
+                        properties:
+                          id:
+                            type: integer
+                          shortName:
+                            type: string
+                          fullName:
+                            type: string
+                          spdxId:
+                            type: string
         '404':
           description: License not found
           content:

--- a/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
@@ -13,10 +13,12 @@
 namespace Fossology\UI\Api\Test\Controllers;
 
 use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\BusinessRules\LicenseMap;
 use Fossology\Lib\Dao\LicenseAcknowledgementDao;
 use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Dao\LicenseStdCommentDao;
 use Fossology\Lib\Dao\UserDao;
+use Fossology\Lib\Data\LicenseRef;
 use Fossology\Lib\Db\DbManager;
 use Fossology\UI\Api\Controllers\LicenseController;
 use Fossology\UI\Api\Exceptions\HttpBadRequestException;
@@ -319,7 +321,9 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
   public function testGetLicense()
   {
     $licenseShortName = "MIT";
+    $daoLicense = $this->getDaoLicense($licenseShortName);
     $license = $this->getLicense($licenseShortName, true);
+    $license->setSpdxId($daoLicense->getSpdxId());
 
     $requestHeaders = new Headers();
     $body = $this->streamFactory->createStream();
@@ -327,11 +331,17 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
       "/license/$licenseShortName"), $requestHeaders, [], [], $body);
     $this->licenseDao->shouldReceive('getLicenseByShortName')
       ->withArgs([$licenseShortName, $this->groupId])
-      ->andReturn($this->getDaoLicense($licenseShortName));
+      ->andReturn($daoLicense);
     $this->licenseDao->shouldReceive('getLicenseObligations')
       ->withArgs([[22], false])->andReturn([]);
     $this->licenseDao->shouldReceive('getLicenseObligations')
       ->withArgs([[22], true])->andReturn([]);
+    $this->licenseDao->shouldReceive('getLicenseTypeAndStatus')
+      ->withArgs([22])->andReturn(null);
+    $this->licenseDao->shouldReceive('getProjectedLicenseRef')
+      ->withArgs([22, LicenseMap::CONCLUSION, $this->groupId])->andReturn(null);
+    $this->licenseDao->shouldReceive('getProjectedLicenseRef')
+      ->withArgs([22, LicenseMap::REPORT, $this->groupId])->andReturn(null);
     $expectedResponse = (new ResponseHelper())->withJson($license->getArray(), 200);
 
     $actualResponse = $this->licenseController->getLicense($request,
@@ -351,7 +361,9 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
   public function testGetLicenseObligations()
   {
     $licenseShortName = "MIT";
+    $daoLicense = $this->getDaoLicense($licenseShortName);
     $license = $this->getLicense($licenseShortName, true, false);
+    $license->setSpdxId($daoLicense->getSpdxId());
 
     $requestHeaders = new Headers();
     $body = $this->streamFactory->createStream();
@@ -359,11 +371,74 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
       "/license/$licenseShortName"), $requestHeaders, [], [], $body);
     $this->licenseDao->shouldReceive('getLicenseByShortName')
       ->withArgs([$licenseShortName, $this->groupId])
-      ->andReturn($this->getDaoLicense($licenseShortName));
+      ->andReturn($daoLicense);
     $this->licenseDao->shouldReceive('getLicenseObligations')
       ->withArgs([[22], false])->andReturn([$this->getDaoObligation(123)]);
     $this->licenseDao->shouldReceive('getLicenseObligations')
       ->withArgs([[22], true])->andReturn([$this->getDaoObligation(124)]);
+    $this->licenseDao->shouldReceive('getLicenseTypeAndStatus')
+      ->withArgs([22])->andReturn(null);
+    $this->licenseDao->shouldReceive('getProjectedLicenseRef')
+      ->withArgs([22, LicenseMap::CONCLUSION, $this->groupId])->andReturn(null);
+    $this->licenseDao->shouldReceive('getProjectedLicenseRef')
+      ->withArgs([22, LicenseMap::REPORT, $this->groupId])->andReturn(null);
+    $expectedResponse = (new ResponseHelper())->withJson($license->getArray(), 200);
+
+    $actualResponse = $this->licenseController->getLicense($request,
+      new ResponseHelper(), ['shortname' => $licenseShortName]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::getLicense() to fetch single license
+   * -# The license has parent/report mappings and active/type metadata
+   * -# Check if response is 200 and includes the new fields
+   */
+  public function testGetLicenseWithMappingsAndMetadata()
+  {
+    $licenseShortName = "MIT";
+    $daoLicense = $this->getDaoLicense($licenseShortName);
+    $license = $this->getLicense($licenseShortName, true);
+    $license->setSpdxId($daoLicense->getSpdxId());
+    $license->setActive(true);
+    $license->setLicenseType('Permissive');
+    $license->setParentLicense([
+      'id' => 5,
+      'shortName' => 'Parent',
+      'fullName' => 'Parent License',
+      'spdxId' => 'Parent',
+    ]);
+    $license->setReportLicense([
+      'id' => 6,
+      'shortName' => 'Report',
+      'fullName' => 'Report License',
+      'spdxId' => 'Report',
+    ]);
+
+    $requestHeaders = new Headers();
+    $body = $this->streamFactory->createStream();
+    $request = new Request("GET", new Uri("HTTP", "localhost", 80,
+      "/license/$licenseShortName"), $requestHeaders, [], [], $body);
+    $this->licenseDao->shouldReceive('getLicenseByShortName')
+      ->withArgs([$licenseShortName, $this->groupId])
+      ->andReturn($daoLicense);
+    $this->licenseDao->shouldReceive('getLicenseObligations')
+      ->withArgs([[22], false])->andReturn([]);
+    $this->licenseDao->shouldReceive('getLicenseObligations')
+      ->withArgs([[22], true])->andReturn([]);
+    $this->licenseDao->shouldReceive('getLicenseTypeAndStatus')
+      ->withArgs([22])
+      ->andReturn(['active' => true, 'licenseType' => 'Permissive']);
+    $this->licenseDao->shouldReceive('getProjectedLicenseRef')
+      ->withArgs([22, LicenseMap::CONCLUSION, $this->groupId])
+      ->andReturn(new LicenseRef(5, 'Parent', 'Parent License', 'Parent'));
+    $this->licenseDao->shouldReceive('getProjectedLicenseRef')
+      ->withArgs([22, LicenseMap::REPORT, $this->groupId])
+      ->andReturn(new LicenseRef(6, 'Report', 'Report License', 'Report'));
     $expectedResponse = (new ResponseHelper())->withJson($license->getArray(), 200);
 
     $actualResponse = $this->licenseController->getLicense($request,

--- a/src/www/ui_tests/api/Models/LicenseTest.php
+++ b/src/www/ui_tests/api/Models/LicenseTest.php
@@ -85,6 +85,58 @@ class LicenseTest extends \PHPUnit\Framework\TestCase
 
   /**
    * @test
+   * -# Test data model returned by License::getArray() is correct when
+   *    SPDX id, active, licenseType, parentLicense and reportLicense are
+   *    set
+   */
+  public function testDataFormatWithMappingsAndMetadata()
+  {
+    $parentLicense = [
+      'id' => 5,
+      'shortName' => 'Parent',
+      'fullName' => 'Parent License',
+      'spdxId' => 'Parent',
+    ];
+    $reportLicense = [
+      'id' => 6,
+      'shortName' => 'Report',
+      'fullName' => 'Report License',
+      'spdxId' => 'Report',
+    ];
+    $expectedLicense = [
+      'id'        => 22,
+      'shortName' => "MIT",
+      'fullName'  => "MIT License",
+      'text'      => "MIT License Copyright (c) <year> <copyright holders> ...",
+      'url'       => "https://opensource.org/licenses/MIT",
+      'risk'      => 3,
+      'isCandidate' => false,
+      'spdxId'    => 'MIT',
+      'active'    => true,
+      'licenseType' => 'Permissive',
+      'parentLicense' => $parentLicense,
+      'reportLicense' => $reportLicense,
+    ];
+
+    $actualLicense = new License(22, "MIT", "MIT License",
+      "MIT License Copyright (c) <year> <copyright holders> ...",
+      "https://opensource.org/licenses/MIT", null, 3, false);
+    $actualLicense->setSpdxId('MIT');
+    $actualLicense->setActive(true);
+    $actualLicense->setLicenseType('Permissive');
+    $actualLicense->setParentLicense($parentLicense);
+    $actualLicense->setReportLicense($reportLicense);
+
+    $this->assertEquals($expectedLicense, $actualLicense->getArray());
+    $this->assertSame('MIT', $actualLicense->getSpdxId());
+    $this->assertTrue($actualLicense->getActive());
+    $this->assertSame('Permissive', $actualLicense->getLicenseType());
+    $this->assertSame($parentLicense, $actualLicense->getParentLicense());
+    $this->assertSame($reportLicense, $actualLicense->getReportLicense());
+  }
+
+  /**
+   * @test
    * -# Test parser License::parseFromArray()
    * -# Create a valid license input and check the function.
    * -# Create an input with invalid keys and check if function returns error.


### PR DESCRIPTION
## Description

Extends `GET /license/{shortname}` to return the license's conclusion parent
and report license mappings, plus SPDX id, active status and license type,
so the Admin License UI has what it needs to fully replicate legacy admin
license behaviour instead of only getting obligations back.

### Changes

- `LicenseMap::getProjectedRef()`: new method returning the mapped license as
  a full `LicenseRef`, distinct from the existing id/shortname-only getters
  (which can't tell "unmapped" apart from "mapped to itself"). Also added an
  opt-in scoped-load mode to the constructor (`$licenseId` param) so a caller
  who only needs one license's mapping isn't forced to load the whole
  group's map — every other existing caller is unaffected since it defaults
  to `null`.
- `LicenseDao::getProjectedLicenseRef()` and `getLicenseTypeAndStatus()`: new
  DAO methods the controller delegates to, keeping the shared
  `Data\License`/`LicenseRef` domain objects (used elsewhere in
  scanning/reporting) untouched.
- `LicenseController::getLicense()`: now also returns `spdxId`, `active`,
  `licenseType`, `parentLicense` (conclusion mapping) and `reportLicense`
  (report mapping). All new fields are optional/nullable on the shared
  `Models\License` and only serialized when set, so `GET /license` (list)
  and `POST /license` (create) responses are unchanged.
- `openapiv2.yaml` updated for the new `GET /license/{shortname}` response
  fields.
- Tests added/updated in `LicenseMapTest`, `LicenseDaoTest`,
  `LicenseControllerTest`, `Models/LicenseTest`.

Loading a license's mapping via a plain `LicenseMap` construction pulls in
every mapped license for the group just to read one row back out.
Benchmarked against a "fully mapped" 927-license fixture: ~15x slower
(2.1ms vs 0.14ms) and ~230x more buffer I/O than a query scoped to the one
license actually being asked about, and `getLicense()` does this twice per
request (conclusion + report) — hence the scoped-load mode above.

Fixes fossology/FOSSologyUI#442

## How to test

1. `podman-compose up -d` and log in as `fossy`/`fossy`.
2. Pick an existing license that has a conclusion or report mapping (or
   create one via the legacy admin "Merge/manage licenses" UI, or insert a
   `license_map` row directly).
3. `GET /repo/api/v2/license/{shortname}` (with a valid session/API token)
   and confirm the response includes `spdxId`, `active`, `licenseType`, and
   — when applicable — `parentLicense`/`reportLicense`, each with
   `id`/`shortName`/`fullName`/`spdxId`.
4. Run the PHPUnit suites:
   `vendor/bin/phpunit -c phpunit.xml --no-coverage lib/php/BusinessRules/test/LicenseMapTest.php lib/php/Dao/test/LicenseDaoTest.php www/ui_tests/api/Controllers/LicenseControllerTest.php www/ui_tests/api/Models/LicenseTest.php`
   — all 94 tests pass.