### PR TITLE
feat(api): add endpoint to revoke REST API tokens

### DIFF
--- a/src/www/ui/api/Controllers/UserController.php
+++ b/src/www/ui/api/Controllers/UserController.php
@@ -17,6 +17,7 @@ use Fossology\Lib\Exceptions\DuplicateTokenNameException;
 use Fossology\UI\Api\Exceptions\HttpBadRequestException;
 use Fossology\UI\Api\Exceptions\HttpConflictException;
 use Fossology\UI\Api\Exceptions\HttpErrorException;
+use Fossology\UI\Api\Exceptions\HttpForbiddenException;
 use Fossology\UI\Api\Exceptions\HttpInternalServerErrorException;
 use Fossology\UI\Api\Exceptions\HttpNotFoundException;
 use Fossology\UI\Api\Exceptions\HttpTooManyRequestException;
@@ -311,5 +312,43 @@ class UserController extends RestController
     $res = $returnVal->getArray();
     $res[$tokenType . ($apiVersion == ApiVersion::V2 ? 'Tokens' : '_tokens')] = $finalTokens;
     return $response->withJson($res, $returnVal->getCode());
+  }
+
+  /**
+   * Revoke an existing REST API Token belonging to the current user
+   *
+   * @param ServerRequestInterface $request
+   * @param ResponseHelper $response
+   * @param array $args
+   * @return ResponseHelper
+   * @throws HttpBadRequestException
+   * @throws HttpForbiddenException
+   * @throws HttpNotFoundException
+   */
+  public function revokeRestApiToken($request, $response, $args)
+  {
+    $tokenId = $args['tokenId'];
+    if (!preg_match('/^\d+\.\d+$/', $tokenId)) {
+      throw new HttpBadRequestException("Invalid token id.");
+    }
+    list($tokenPk, ) = explode(".", $tokenId);
+    $tokenPk = intval($tokenPk);
+    if ($tokenPk > 2147483647) {
+      // pat_pk is a Postgres int4 column; anything larger can never match
+      // and would otherwise abort the query with an out-of-range error.
+      throw new HttpBadRequestException("Invalid token id.");
+    }
+
+    $tokenInfo = $this->dbHelper->invalidateTokenForUser($tokenPk,
+      $this->restHelper->getUserId());
+    if (empty($tokenInfo)) {
+      throw new HttpNotFoundException("Token not found.");
+    }
+    if (intval($tokenInfo['user_fk']) !== intval($this->restHelper->getUserId())) {
+      throw new HttpForbiddenException("You are not allowed to revoke this token.");
+    }
+
+    $returnVal = new Info(200, "Token revoked successfully", InfoType::INFO);
+    return $response->withJson($returnVal->getArray(), $returnVal->getCode());
   }
 }

--- a/src/www/ui/api/Helper/DbHelper.php
+++ b/src/www/ui/api/Helper/DbHelper.php
@@ -446,6 +446,33 @@ FROM $tableName WHERE $idRowName = $1", [$id],
   }
 
   /**
+   * Mark a token as invalid/inactive, but only if it belongs to the given
+   * user. Existence and ownership are resolved in the same round trip as
+   * the update.
+   *
+   * @param int $tokenId The token to be marked as invalid
+   * @param int $userId  Expected owner of the token
+   * @return array|false Array with `pat_pk` and `user_fk` of the token if it
+   *         exists (regardless of ownership), or false if no such token
+   *         exists. The token is only invalidated when `user_fk` matches
+   *         $userId.
+   */
+  public function invalidateTokenForUser($tokenId, $userId)
+  {
+    $sql = "WITH target AS (" .
+      "SELECT pat_pk, user_fk FROM personal_access_tokens WHERE pat_pk = $1" .
+      "), updated AS (" .
+      "UPDATE personal_access_tokens SET active = false " .
+      "WHERE pat_pk = $1 AND user_fk = $2 " .
+      "RETURNING pat_pk" .
+      ") " .
+      "SELECT target.pat_pk, target.user_fk " .
+      "FROM target LEFT JOIN updated ON updated.pat_pk = target.pat_pk;";
+    return $this->dbManager->getSingleRow($sql, [$tokenId, $userId],
+      __METHOD__ . ".invalidateTokenForUser");
+  }
+
+  /**
    * Insert a new token in the DB.
    *
    * @param int    $userId User of the new token

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -2782,6 +2782,52 @@ paths:
 
         default:
           $ref: '#/components/responses/defaultResponse'
+  /users/tokens/{tokenId}:
+    parameters:
+      - name: tokenId
+        required: true
+        in: path
+        description: >
+          Id of the token to be revoked, as returned in the `id` field of
+          GET /users/tokens/{type}
+        schema:
+          type: string
+          example: "5.3"
+    delete:
+      operationId: revokeRestApiToken
+      tags:
+        - User
+      summary: Revoke an existing REST API Token
+      description: >
+        Revoke (deactivate) an existing REST API Token belonging to the
+        current user
+      responses:
+        '200':
+          description: Token revoked successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Invalid token id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Not allowed to revoke a token belonging to another user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Token not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
 
   /uploads/{id}/item/{itemId}/copyrights:
     parameters: *cxGetParams

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -2691,6 +2691,52 @@ paths:
 
         default:
           $ref: '#/components/responses/defaultResponse'
+  /users/tokens/{tokenId}:
+    parameters:
+      - name: tokenId
+        required: true
+        in: path
+        description: >
+          Id of the token to be revoked, as returned in the `id` field of
+          GET /users/tokens/{type}
+        schema:
+          type: string
+          example: "5.3"
+    delete:
+      operationId: revokeRestApiToken
+      tags:
+        - User
+      summary: Revoke an existing REST API Token
+      description: >
+        Revoke (deactivate) an existing REST API Token belonging to the
+        current user
+      responses:
+        '200':
+          description: Token revoked successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '400':
+          description: Invalid token id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '403':
+          description: Not allowed to revoke a token belonging to another user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        '404':
+          description: Token not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+          $ref: '#/components/responses/defaultResponse'
 
   /uploads/{id}/item/{itemId}/copyrights:
     parameters: *cxGetParams

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -294,6 +294,7 @@ $app->group('/users',
     $app->delete("/{pathParam:$pattern}", UserController::class . ':deleteUser');
     $app->post('/tokens', UserController::class . ':createRestApiToken');
     $app->get('/tokens/{type:\\w+}', UserController::class . ':getTokens');
+    $app->delete("/tokens/{tokenId:$pattern}", UserController::class . ':revokeRestApiToken');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 

--- a/src/www/ui_tests/api/Controllers/UserControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UserControllerTest.php
@@ -16,6 +16,7 @@ require_once dirname(__DIR__, 4) . '/lib/php/Plugin/FO_Plugin.php';
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\UI\Api\Exceptions\HttpBadRequestException;
+use Fossology\UI\Api\Exceptions\HttpForbiddenException;
 use Fossology\UI\Api\Exceptions\HttpNotFoundException;
 use Mockery as M;
 use Fossology\UI\Api\Controllers\UserController;
@@ -431,5 +432,113 @@ class UserControllerTest extends \PHPUnit\Framework\TestCase
     $this->expectExceptionMessage("Username must be specified.");
 
     $this->userController->addUser($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::revokeRestApiToken() for a token owned by the
+   *    current user
+   * -# Check if response status is 200 and the token is invalidated
+   */
+  public function testRevokeRestApiTokenSuccess()
+  {
+    $userId = 2;
+    $tokenPk = 5;
+    $tokenId = "$tokenPk.$userId";
+    $request = M::mock(Request::class);
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->dbHelper->shouldReceive('invalidateTokenForUser')
+      ->withArgs(function ($actualTokenPk, $actualUserId) use ($tokenPk, $userId) {
+        return $actualTokenPk === $tokenPk && $actualUserId === $userId;
+      })
+      ->once()
+      ->andReturn(['pat_pk' => $tokenPk, 'user_fk' => $userId]);
+
+    $info = new Info(200, "Token revoked successfully", InfoType::INFO);
+    $expectedResponse = (new ResponseHelper())->withJson($info->getArray(),
+      $info->getCode());
+    $actualResponse = $this->userController->revokeRestApiToken($request,
+      new ResponseHelper(), ['tokenId' => $tokenId]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test UserController::revokeRestApiToken() with a malformed token id
+   * -# Check if HttpBadRequestException is thrown
+   */
+  public function testRevokeRestApiTokenInvalidId()
+  {
+    $request = M::mock(Request::class);
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->userController->revokeRestApiToken($request, new ResponseHelper(),
+      ['tokenId' => 'not-a-valid-id']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::revokeRestApiToken() with a token id whose
+   *    numeric part exceeds Postgres' int4 range
+   * -# Check if HttpBadRequestException is thrown without reaching the DB
+   */
+  public function testRevokeRestApiTokenIdOutOfRange()
+  {
+    $request = M::mock(Request::class);
+    $this->dbHelper->shouldNotReceive('invalidateTokenForUser');
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->userController->revokeRestApiToken($request, new ResponseHelper(),
+      ['tokenId' => '9999999999.5']);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::revokeRestApiToken() for a token which does not
+   *    exist
+   * -# Check if HttpNotFoundException is thrown
+   */
+  public function testRevokeRestApiTokenNotFound()
+  {
+    $tokenPk = 99;
+    $userId = 2;
+    $tokenId = "$tokenPk.$userId";
+    $request = M::mock(Request::class);
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->dbHelper->shouldReceive('invalidateTokenForUser')
+      ->withArgs(function ($actualTokenPk, $actualUserId) use ($tokenPk, $userId) {
+        return $actualTokenPk === $tokenPk && $actualUserId === $userId;
+      })->andReturn(false);
+    $this->expectException(HttpNotFoundException::class);
+
+    $this->userController->revokeRestApiToken($request, new ResponseHelper(),
+      ['tokenId' => $tokenId]);
+  }
+
+  /**
+   * @test
+   * -# Test UserController::revokeRestApiToken() for a token owned by
+   *    another user
+   * -# Check if HttpForbiddenException is thrown
+   */
+  public function testRevokeRestApiTokenForbidden()
+  {
+    $tokenPk = 5;
+    $userId = 2;
+    $tokenId = "$tokenPk.3";
+    $request = M::mock(Request::class);
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->dbHelper->shouldReceive('invalidateTokenForUser')
+      ->withArgs(function ($actualTokenPk, $actualUserId) use ($tokenPk, $userId) {
+        return $actualTokenPk === $tokenPk && $actualUserId === $userId;
+      })
+      ->andReturn(['pat_pk' => $tokenPk, 'user_fk' => 3]);
+    $this->expectException(HttpForbiddenException::class);
+
+    $this->userController->revokeRestApiToken($request, new ResponseHelper(),
+      ['tokenId' => $tokenId]);
   }
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The React/Next.js UI migration cannot replicate the "Revoke" action on the REST API Tokens page because no backend endpoint exists for it - tokens could only be created and listed via the API, not invalidated.

### Changes

- Add `DELETE /users/tokens/{tokenId}`, restricted to the token's own owner.
- Add `DbHelper::invalidateTokenForUser()`: ownership check and update happen in a single DB round trip via a non-modifying CTE that resolves existence/ownership, LEFT-JOINed against a modifying CTE whose `UPDATE` only touches the row when the ownership predicate matches.
- `UserController::revokeRestApiToken()` returns `200` on success, `400` for a malformed token id, `404` if the token doesn't exist, `403` if it belongs to another user.
- Document the new endpoint in both `openapi.yaml` and `openapiv2.yaml`.
- Add unit tests covering all four outcomes (success, invalid id, not found, forbidden).

## How to test

- Run `phpunit --configuration src/phpunit.xml src/www/ui_tests/api/Controllers/UserControllerTest.php` - all pass.
- Run `phpcs --standard=src/fossy-ruleset.xml` on the changed files - clean.
- Manually: create a token via `POST /users/tokens`, list it via `GET /users/tokens/active` to get its `id`, then call `DELETE /users/tokens/{id}` as that same user - the token disappears from the active list. Retrying the delete, or calling it as a different user, returns `404`/`403` respectively.

Fixes fossology/FOSSologyUI#447
