### PR TITLE
feat(api-v2): expose defaultFolderId and userStatus in GET /users/{name}

### DIFF
--- a/src/www/ui/api/Helper/DbHelper.php
+++ b/src/www/ui/api/Helper/DbHelper.php
@@ -253,11 +253,13 @@ FROM $tableName WHERE $idRowName = $1", [$id],
   {
     if ($id == null) {
       $usersSQL = "SELECT user_pk, user_name, user_desc, user_email,
-                  email_notify, root_folder_fk, group_fk, user_perm, user_agent_list, default_bucketpool_fk FROM users;";
+                  email_notify, root_folder_fk, group_fk, user_perm, user_agent_list, default_bucketpool_fk,
+                  default_folder_fk, user_status FROM users;";
       $statement = __METHOD__ . ".getAllUsers";
     } else {
       $usersSQL = "SELECT user_pk, user_name, user_desc, user_email,
-                email_notify, root_folder_fk, group_fk, user_perm, user_agent_list, default_bucketpool_fk FROM users
+                email_notify, root_folder_fk, group_fk, user_perm, user_agent_list, default_bucketpool_fk,
+                default_folder_fk, user_status FROM users
                 WHERE user_pk = $1;";
       $statement = __METHOD__ . ".getSpecificUser";
     }
@@ -275,7 +277,8 @@ FROM $tableName WHERE $idRowName = $1", [$id],
         ($row["user_pk"] == $currentUser)) {
         $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
           $row["user_email"], $row["user_perm"], $row["root_folder_fk"],
-          $row["email_notify"], $row["user_agent_list"], $row["group_fk"], $row["default_bucketpool_fk"]);
+          $row["email_notify"], $row["user_agent_list"], $row["group_fk"], $row["default_bucketpool_fk"],
+          $row["default_folder_fk"], $row["user_status"]);
       } else {
         $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
           null, null, null, null, null, null);

--- a/src/www/ui/api/Helper/UserHelper.php
+++ b/src/www/ui/api/Helper/UserHelper.php
@@ -95,7 +95,7 @@ class UserHelper
     $symfonyRequest->request->set('_pass1', $userDetails[$version == ApiVersion::V2 ? 'userPass' : 'user_pass'] ?? null);
     $symfonyRequest->request->set('_pass2', $userDetails[$version == ApiVersion::V2 ? 'userPass' : 'user_pass'] ?? null);
     $symfonyRequest->request->set('_blank_pass', $userDetails['_blank_pass'] ?? "");
-    $symfonyRequest->request->set('user_status', $userDetails['user_status'] ?? $user['user_status']);
+    $symfonyRequest->request->set('user_status', $userDetails[$version == ApiVersion::V2 ? 'userStatus' : 'user_status'] ?? $user['user_status']);
     $symfonyRequest->request->set('user_email', $userDetails['email'] ?? $user['user_email']);
     $symfonyRequest->request->set('email_notify', isset($userDetails['emailNotification']) && $userDetails['emailNotification'] ? "y" : $user['email_notify']);
     $symfonyRequest->request->set('default_bucketpool_fk', $userDetails['defaultBucketpool'] ?? $user['default_bucketpool_fk']);

--- a/src/www/ui/api/Models/User.php
+++ b/src/www/ui/api/Models/User.php
@@ -74,6 +74,16 @@ class User
    * Default bucket pool of the user
    */
   private $defaultBucketPool;
+  /**
+   * @var integer $defaultFolderId
+   * Current user's default folder id for upload and browse operations
+   */
+  private $defaultFolderId;
+  /**
+   * @var string $userStatus
+   * Current user's account status (active/inactive)
+   */
+  private $userStatus;
 
   /**
    * User constructor.
@@ -87,9 +97,12 @@ class User
    * @param boolean $emailNotification
    * @param object $agents
    * @param integer $defaultBucketPool
+   * @param integer $defaultFolderId
+   * @param string $userStatus
    */
   public function __construct($id, $name, $description, $email, $accessLevel, $root_folder_id, $emailNotification,
-                              $agents, $default_group_fk=null, $defaultBucketPool=null)
+                              $agents, $default_group_fk=null, $defaultBucketPool=null, $defaultFolderId=null,
+                              $userStatus=null)
   {
     $this->id = intval($id);
     $this->name = $name;
@@ -122,6 +135,8 @@ class User
     } else {
       $this->defaultBucketPool = null;
     }
+    $this->defaultFolderId = is_null($defaultFolderId) ? null : intval($defaultFolderId);
+    $this->userStatus = $userStatus;
   }
 
   ////// Getters //////
@@ -206,6 +221,22 @@ class User
   }
 
   /**
+   * @return integer
+   */
+  public function getDefaultFolderId()
+  {
+    return $this->defaultFolderId;
+  }
+
+  /**
+   * @return string
+   */
+  public function getUserStatus()
+  {
+    return $this->userStatus;
+  }
+
+  /**
    * Get current user in JSON representation
    * @return string
    */
@@ -244,6 +275,14 @@ class User
     }
     if ($this->defaultBucketPool !== null) {
       $returnUser["defaultBucketpool"] = $this->defaultBucketPool;
+    }
+    if ($version == ApiVersion::V2) {
+      if ($this->defaultFolderId !== null && $this->defaultFolderId != -1) {
+        $returnUser["defaultFolderId"] = $this->defaultFolderId;
+      }
+      if ($this->userStatus !== null) {
+        $returnUser["userStatus"] = $this->userStatus;
+      }
     }
     return $returnUser;
   }

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -2530,8 +2530,6 @@ paths:
                   properties:
                     userPass:
                       type: string
-                    defaultFolderId:
-                      type: integer
                     defaultVisibility:
                       type: string
                       enum:
@@ -2546,8 +2544,6 @@ paths:
                   properties:
                     userPass:
                       type: string
-                    defaultFolderId:
-                      type: integer
                     defaultVisibility:
                       type: string
                       enum:
@@ -6120,6 +6116,15 @@ components:
           description: Default bucket pool id
           type: integer
           nullable: true
+        defaultFolderId:
+          type: integer
+          description: Default folder id of the user, used for upload and browse operations
+        userStatus:
+          type: string
+          enum:
+            - active
+            - inactive
+          description: Status of the user account
       required:
         - id
     Analysis:

--- a/src/www/ui_tests/api/Helper/DbHelperTest.php
+++ b/src/www/ui_tests/api/Helper/DbHelperTest.php
@@ -119,7 +119,8 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
         'user_pk' => $i, 'user_name' => "user$i", 'user_desc' => "user $i",
         'user_email' => "user$i@local", 'email_notify' => 'y',
         'root_folder_fk' => 2, 'group_fk' => 2, 'user_perm' => $perm_list[$i],
-        'user_agent_list' => $agent_list[$i], 'default_bucketpool_fk' => 2
+        'user_agent_list' => $agent_list[$i], 'default_bucketpool_fk' => 2,
+        'default_folder_fk' => 2, 'user_status' => 'active'
       ];
       $userRows[$i] = $row;
     }
@@ -140,7 +141,8 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
       if ($currentUser === null || $row['user_pk'] == $currentUser) {
         $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
             $row["user_email"], $row["user_perm"], $row["root_folder_fk"],
-          $row["email_notify"], $row["user_agent_list"], $row['group_fk'], $row["default_bucketpool_fk"]);
+          $row["email_notify"], $row["user_agent_list"], $row['group_fk'], $row["default_bucketpool_fk"],
+          $row["default_folder_fk"], $row["user_status"]);
       } else {
         $user = new User($row["user_pk"], $row["user_name"], $row["user_desc"],
           null, null, null, null, null, null);
@@ -163,8 +165,8 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $sql = 'SELECT user_pk, user_name, user_desc, user_email,
-                  email_notify, root_folder_fk, group_fk, user_perm, user_agent_list, ' .
-      'default_bucketpool_fk FROM users;';
+                  email_notify, root_folder_fk, group_fk, user_perm, user_agent_list, default_bucketpool_fk,
+                  default_folder_fk, user_status FROM users;';
     $statement = DbHelper::class . "::getUsers.getAllUsers";
     $userRows = $this->generateUserRow();
 
@@ -197,8 +199,8 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
 
     $sql = 'SELECT user_pk, user_name, user_desc, user_email,
-                  email_notify, root_folder_fk, group_fk, user_perm, user_agent_list, ' .
-      'default_bucketpool_fk FROM users;';
+                  email_notify, root_folder_fk, group_fk, user_perm, user_agent_list, default_bucketpool_fk,
+                  default_folder_fk, user_status FROM users;';
     $statement = DbHelper::class . "::getUsers.getAllUsers";
     $userRows = $this->generateUserRow();
 
@@ -230,7 +232,8 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
 
     $sql = "SELECT user_pk, user_name, user_desc, user_email,
-                email_notify, root_folder_fk, group_fk, user_perm, user_agent_list, default_bucketpool_fk FROM users
+                email_notify, root_folder_fk, group_fk, user_perm, user_agent_list, default_bucketpool_fk,
+                default_folder_fk, user_status FROM users
                 WHERE user_pk = $1;";
     $statement = DbHelper::class . "::getUsers.getSpecificUser";
     $userRows = $this->generateUserRow();
@@ -264,7 +267,8 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
 
     $sql = "SELECT user_pk, user_name, user_desc, user_email,
-                email_notify, root_folder_fk, group_fk, user_perm, user_agent_list, default_bucketpool_fk FROM users
+                email_notify, root_folder_fk, group_fk, user_perm, user_agent_list, default_bucketpool_fk,
+                default_folder_fk, user_status FROM users
                 WHERE user_pk = $1;";
     $statement = DbHelper::class . "::getUsers.getSpecificUser";
     $userRows = $this->generateUserRow();

--- a/src/www/ui_tests/api/Helper/UserHelperTest.php
+++ b/src/www/ui_tests/api/Helper/UserHelperTest.php
@@ -1,0 +1,141 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Fossology contributors
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+/**
+ * @file
+ * @brief Tests for UserHelper
+ */
+
+namespace Fossology\UI\Api\Test\Helper;
+
+use Fossology\Lib\Dao\UserDao;
+use Fossology\UI\Api\Helper\RestHelper;
+use Fossology\UI\Api\Helper\UserHelper;
+use Fossology\UI\Api\Models\ApiVersion;
+use Mockery as M;
+
+use \PHPUnit\Framework\TestCase;
+
+require_once dirname(dirname(dirname(dirname(__DIR__)))) .
+  '/lib/php/Plugin/FO_Plugin.php';
+require_once dirname(dirname(dirname(dirname(__DIR__)))) .
+  '/lib/php/common-agents.php';
+require_once dirname(dirname(dirname(dirname(__DIR__)))) .
+  '/lib/php/common-menu.php';
+
+/**
+ * @class UserHelperTest
+ * @brief Tests for UserHelper
+ */
+class UserHelperTest extends TestCase
+{
+  /**
+   * @var integer $assertCountBefore
+   * Assertions before running tests
+   */
+  private $assertCountBefore;
+  /**
+   * @var RestHelper $restHelper
+   * RestHelper mock
+   */
+  private $restHelper;
+  /**
+   * @var UserDao $userDao
+   * UserDao mock
+   */
+  private $userDao;
+  /**
+   * @var array $dbUser
+   * Fake current DB row for the user being edited
+   */
+  private $dbUser;
+
+  /**
+   * @brief Setup test objects
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  protected function setUp() : void
+  {
+    global $container;
+    $container = M::mock('ContainerBuilder');
+    $this->restHelper = M::mock(RestHelper::class);
+    $this->userDao = M::mock(UserDao::class);
+
+    $this->restHelper->shouldReceive('getUserDao')->andReturn($this->userDao);
+    $container->shouldReceive('get')->withArgs(array(
+      'helper.restHelper'))->andReturn($this->restHelper);
+
+    $this->dbUser = [
+      'user_name' => 'fossy',
+      'root_folder_fk' => 1,
+      'group_fk' => 1,
+      'upload_visibility' => 'public',
+      'default_folder_fk' => 1,
+      'user_desc' => 'Default Administrator',
+      'user_status' => 'active',
+      'user_email' => 'fossy@localhost',
+      'email_notify' => 'y',
+      'default_bucketpool_fk' => null,
+      'user_perm' => 10,
+      'user_agent_list' => '',
+    ];
+    $this->userDao->shouldReceive('getUserByPk')->andReturn($this->dbUser);
+  }
+
+  /**
+   * @brief Remove test objects
+   * @see PHPUnit_Framework_TestCase::tearDown()
+   */
+  protected function tearDown() : void
+  {
+    $this->addToAssertionCount(
+      \Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  /**
+   * @test
+   * -# Test that createSymRequest() reads the V2 camelCase 'userStatus' key
+   * -# Confirm the resulting symfony request carries it through as
+   *    'user_status'
+   */
+  public function testCreateSymRequestReadsCamelCaseUserStatusForV2()
+  {
+    $userHelper = new UserHelper(2);
+    $request = $userHelper->createSymRequest(['userStatus' => 'inactive'],
+      ApiVersion::V2);
+    $this->assertEquals('inactive', $request->request->get('user_status'));
+  }
+
+  /**
+   * @test
+   * -# Test that createSymRequest() reads the V1 snake_case 'user_status' key
+   * -# Confirm the resulting symfony request carries it through as
+   *    'user_status'
+   */
+  public function testCreateSymRequestReadsSnakeCaseUserStatusForV1()
+  {
+    $userHelper = new UserHelper(2);
+    $request = $userHelper->createSymRequest(['user_status' => 'inactive'],
+      ApiVersion::V1);
+    $this->assertEquals('inactive', $request->request->get('user_status'));
+  }
+
+  /**
+   * @test
+   * -# Test that createSymRequest() falls back to the existing DB value when
+   *    no status is given in the request body, for both API versions
+   */
+  public function testCreateSymRequestFallsBackToDbUserStatus()
+  {
+    $userHelper = new UserHelper(2);
+    $requestV2 = $userHelper->createSymRequest([], ApiVersion::V2);
+    $this->assertEquals('active', $requestV2->request->get('user_status'));
+
+    $requestV1 = $userHelper->createSymRequest([], ApiVersion::V1);
+    $this->assertEquals('active', $requestV1->request->get('user_status'));
+  }
+}

--- a/src/www/ui_tests/api/Models/UserTest.php
+++ b/src/www/ui_tests/api/Models/UserTest.php
@@ -79,7 +79,7 @@ class UserTest extends TestCase
    */
   public function testConstructor()
   {
-    $user = new User(1, "fossy", "Admin user", "fossy@gmail.com", "admin", 4, "fossy@gmail.com", "monk", 3, null);
+    $user = new User(1, "fossy", "Admin user", "fossy@gmail.com", "admin", 4, "fossy@gmail.com", "monk", 3, null, 4, "active");
     $this->assertInstanceOf(User::class, $user);
   }
 
@@ -122,6 +122,26 @@ class UserTest extends TestCase
   public function testDataFormatV2()
   {
     $this->testDataFormat(ApiVersion::V2);
+  }
+
+  /**
+   * @test
+   * -# Test that User::getArray(V2) omits defaultFolderId when the user has
+   *    the DB's default "unset" sentinel (-1) for default_folder_fk
+   * -# Test that a real folder id is still reported normally
+   */
+  public function testDefaultFolderIdSentinelExcludedV2()
+  {
+    $unsetUser = new User(2, 'fossy', 'super user', 'fossy@localhost',
+      PLUGIN_DB_ADMIN, 2, true, "bucket,copyright,nomos,ojo", null, null, -1, 'active');
+    $setUser = new User(2, 'fossy', 'super user', 'fossy@localhost',
+      PLUGIN_DB_ADMIN, 2, true, "bucket,copyright,nomos,ojo", null, null, 5, 'active');
+
+    $unsetArray = $unsetUser->getArray(ApiVersion::V2);
+    $setArray = $setUser->getArray(ApiVersion::V2);
+
+    $this->assertArrayNotHasKey('defaultFolderId', $unsetArray);
+    $this->assertSame(5, $setArray['defaultFolderId']);
   }
 
   /**
@@ -169,6 +189,8 @@ class UserTest extends TestCase
         "rootFolderId"           => 2,
         "defaultGroup"           => "fossy",
         "emailNotification"      => true,
+        "defaultFolderId"        => 3,
+        "userStatus"             => 'active',
         "agents"                            => [
           "bucket"               => true,
           "copyrightEmailAuthor" => true,
@@ -196,12 +218,12 @@ class UserTest extends TestCase
     ];
 
     $actualCurrentUserV1 = new User(2, 'fossy', 'super user', 'fossy@localhost',
-      PLUGIN_DB_ADMIN, 2, true, "bucket,copyright,nomos,ojo", 0);
+      PLUGIN_DB_ADMIN, 2, true, "bucket,copyright,nomos,ojo", 0, null, 3, 'active');
 
     $this->userDao->shouldReceive('getGroupNameById')->withArgs([0])->andReturn("fossy");
 
     $actualCurrentUserV2 = new User(2, 'fossy', 'super user', 'fossy@localhost',
-      PLUGIN_DB_ADMIN, 2, true, "bucket,copyright,nomos,ojo", "fossy");
+      PLUGIN_DB_ADMIN, 2, true, "bucket,copyright,nomos,ojo", "fossy", null, 3, 'active');
     $actualNonAdminUser = new User(8, 'userii', 'very useri', null, null, null,
       null, null, 0);
     if ($version == ApiVersion::V2) {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Exposes `defaultFolderId` and `userStatus` in the `GET /users/{name}` API v2 response. The Next.js Edit User page currently can't pre-populate the default folder selection or show account status because these fields are missing from the API, creating a feature-parity gap with the legacy PHP admin UI. This also fixes a related bug where updating a user's status via the v2 API silently fell back to the existing DB value instead of applying the request body.

Closes fossology/FOSSologyUI#446

### Changes

- `Helper/DbHelper.php`: `getUsers()` now selects `default_folder_fk` and `user_status` from the `users` table and passes them into the `User` constructor.
- `Models/User.php`: adds `defaultFolderId` and `userStatus` properties and getters; `getArray()` includes both in the API v2 response only. `defaultFolderId` is omitted when the DB holds the "unset" sentinel value (`-1`).
- `Helper/UserHelper.php`: `createSymRequest()` now reads the v2 camelCase `userStatus` key (previously it only ever read the v1 snake_case `user_status` key, so a v2 status update was silently ignored and fell back to the existing DB value).
- `documentation/openapiv2.yaml`: adds `defaultFolderId` (integer) and `userStatus` (enum: `active`, `inactive`) to the `User` schema; removes the now-duplicate inline `defaultFolderId` property from the `PUT /users/{name}` request bodies, since it's inherited via the `User` schema reference.
- Tests: updates `DbHelperTest` and `UserTest` for the new constructor arguments/fields, and adds `UserHelperTest` covering `createSymRequest()`'s v1/v2 status-key handling and its DB fallback behavior.

## How to test

1. Start FOSSology and obtain a v2 API token for an admin user (`POST /api/v2/tokens`).
2. Call `GET /api/v2/users/{name}` for an existing user and confirm the response now includes `"userStatus": "active"` (or `"inactive"`).
3. Set that user's default folder (e.g. `PUT /api/v2/users/{name}` with `"defaultFolderId": <folder_pk>`), repeat the `GET` call, and confirm `"defaultFolderId": <folder_pk>` is now present.
4. Confirm `GET /api/v1/users/{id}` for the same user still omits `defaultFolderId`/`userStatus` (v1 response is unchanged, no regression).
5. Run `vendor/bin/phpunit` against `src/www/ui_tests/api/Helper/DbHelperTest.php`, `src/www/ui_tests/api/Models/UserTest.php`, and `src/www/ui_tests/api/Helper/UserHelperTest.php` — all should pass.
