### PR TITLE
perf(copyright): remove redundant per-row exists query in CopyrightDa…

### DIFF
--- a/src/lib/php/Dao/CopyrightDao.php
+++ b/src/lib/php/Dao/CopyrightDao.php
@@ -498,9 +498,7 @@ WHERE $withHash ( ut.lft BETWEEN $1 AND $2 ) $agentFilter AND ut.upload_fk = $3"
       $paramEvent[] = $row['upload_fk'];
       $paramEvent[] = $row[$cpTablePk];
       $paramEvent[] = $row['uploadtree_pk'];
-      $sqlExists = "SELECT exists(SELECT 1 FROM $cpTableEvent WHERE $cpTableEventFk = $1 AND upload_fk = $2 AND uploadtree_fk = $3)::int";
-      $rowExists = $this->dbManager->getSingleRow($sqlExists, array($row[$cpTablePk], $row['upload_fk'], $row['uploadtree_pk']), $stmt.'Exists');
-      $eventExists = $rowExists['exists'];
+      $eventExists = !empty($row[$cpTableEvent . '_pk']);
       if ($action == "delete") {
         $paramEvent[] = $scope;
         if ($eventExists) {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors
     SPDX-License-Identifier: GPL-2.0-only
-->
<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->
## Description
Removes a redundant per-row DB query in `CopyrightDao::updateTable()` that caused an N+1 query pattern on bulk clearing operations.

### Changes
- Deleted the extra `SELECT exists(...)` query run for every row in the loop.
- `$eventExists` is now derived from `ce.{$cpTableEvent}_pk`, a column already returned by the initial LEFT JOIN query no new query needed.

## How to test
- Run existing tests: `testUpdateTable`, `testDeleteCopyright` in `CopyrightDaoTest.php` should pass unchanged.
- Manually: run a bulk "mark folder Irrelevant" action on a large upload and compare Postgres query counts/timing before and after.

#3763