### PR TITLE
fix(api): handle missing V2 query parameters in FolderController

### DIFF
--- a/src/www/ui/api/Controllers/FolderController.php
+++ b/src/www/ui/api/Controllers/FolderController.php
@@ -92,9 +92,9 @@ class FolderController extends RestController
   {
     if (ApiVersion::getVersion($request) == ApiVersion::V2) {
       $queryParams = $request->getQueryParams();
-      $parentFolder = $queryParams['parentFolder'];
-      $folderName = trim($queryParams['folderName']);
-      $folderDescription = trim($queryParams['folderDescription']);
+      $parentFolder = $queryParams['parentFolder'] ?? '';
+      $folderName = trim($queryParams['folderName'] ?? '');
+      $folderDescription = trim($queryParams['folderDescription'] ?? '');
     } else {
       $parentFolder = $request->getHeaderLine('parentFolder');
       $folderName = trim($request->getHeaderLine('folderName'));
@@ -180,8 +180,8 @@ class FolderController extends RestController
     $folderId = $args['id'];
     if (ApiVersion::getVersion($request) == ApiVersion::V2) {
       $queryParams = $request->getQueryParams();
-      $newName = $queryParams['name'];
-      $newDesc = $queryParams['description'];
+      $newName = $queryParams['name'] ?? '';
+      $newDesc = $queryParams['description'] ?? '';
     } else {
       $newName = $request->getHeaderLine('name');
       $newDesc = $request->getHeaderLine('description');
@@ -216,8 +216,8 @@ class FolderController extends RestController
     $folderId = $args['id'];
     if (ApiVersion::getVersion($request) == ApiVersion::V2) {
       $queryParams = $request->getQueryParams();
-      $newParent = $queryParams['parent'];
-      $action = strtolower($queryParams['action']);
+      $newParent = $queryParams['parent'] ?? '';
+      $action = strtolower($queryParams['action'] ?? '');
     } else {
       $newParent = $request->getHeaderLine('parent');
       $action = strtolower($request->getHeaderLine('action'));


### PR DESCRIPTION
## Summary

`FolderController::createFolder()`, `editFolder()`, and `copyFolder()` read values directly off `getQueryParams()` without checking whether the key exists. On PHP 8.x, omitting an optional or required query parameter on a V2 request triggers an `Undefined array key` warning before the controller's own validation logic runs.

This defaults each of those reads to `''` (matching the pattern already used elsewhere, e.g. `GroupController::createGroup()`), so:
- Missing **optional** parameters (e.g. `folderDescription`) no longer emit a warning.
- Missing **required** parameters (e.g. `action` on copy/move) fall through cleanly to the existing validation and return the intended `400` error instead of a PHP warning.

Fixes #3736

## Changes

- `src/www/ui/api/Controllers/FolderController.php`: `$queryParams['key']` → `$queryParams['key'] ?? ''` in all three methods (7 lines across 3 functions).

## Test plan

Ran against a local Docker Compose instance (PHP 8.2), using the V2 API with a bearer token:

- [x] `POST /api/v2/folders` with `folderDescription` omitted → `201`, no warning (previously: `Undefined array key "folderDescription"` in the logs)
- [x] `PUT /api/v2/folders/{id}` with `action` omitted entirely → `400 "Action can be one of [copy,move]!"`, no warning (previously: `Undefined array key "action"`)
- [x] `PUT /api/v2/folders/{id}` with `name`/`description` omitted → falls through to existing validation, no warning
- [x] Confirmed via `docker logs` that no `Undefined array key` warnings appear across these requests, where they did before the fix
- [x] Confirmed existing behavior for fully-populated requests is unchanged
