### PR TITLE
build(deps): update squizlabs/php_codesniffer from 3.7.1 to 3.13.6

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -49,7 +49,7 @@
         "myclabs/deep-copy" : "1.13.4",
         "php-coveralls/php-coveralls" : "v2.5.3",
         "phpunit/phpunit" : "8.5.53",
-        "squizlabs/php_codesniffer" : "3.7.1",
+        "squizlabs/php_codesniffer" : "3.13.6",
         "phpstan/phpstan" : "1.8.8"
     },
     "autoload" : {

--- a/src/composer.json.in
+++ b/src/composer.json.in
@@ -49,7 +49,7 @@
         "myclabs/deep-copy" : "1.13.4",
         "php-coveralls/php-coveralls" : "v2.5.3",
         "phpunit/phpunit" : "8.5.53",
-        "squizlabs/php_codesniffer" : "3.7.1",
+        "squizlabs/php_codesniffer" : "3.13.6",
         "phpstan/phpstan" : "1.8.8"
     },
     "autoload" : {

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "37df8361df18deb45da6f41a43e8cc68",
+    "content-hash": "b11de498c0c4d42de7b6862d2f61d00d",
     "packages": [
         {
             "name": "composer/pcre",
@@ -5785,16 +5785,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -5804,18 +5804,13 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
@@ -5823,19 +5818,29 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
             },
             "funding": [
                 {
@@ -5849,9 +5854,13 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2022-06-18T07:21:10+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "symfony/console",


### PR DESCRIPTION
## Description

 - Update "php_codesniffer" to latest 3.x version
 - Switched from no longer maintained repo `squizlabs` to `PHPCSStandards`
 - Brings in improved detection for newer PHP versions.
 - Fixes a high rated security issue 

### Changes

Upgraded `squizlabs/php_codesniffer` from version `3.7.1` to `3.13.6` in both the `composer.json` and `composer.json.in` files.

