### PR TITLE
chore(docker): validate compose config and wait for services

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v4
@@ -23,8 +23,8 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
-    - name: Build images
-      run: docker compose build
+    - name: Validate Docker Compose configuration
+      run: docker compose config -q
 
     - name: Test cluster
       run: src/testing/docker/test-cluster.sh

--- a/src/testing/docker/test-cluster.sh
+++ b/src/testing/docker/test-cluster.sh
@@ -6,10 +6,7 @@
 set -o errexit -o nounset -o xtrace
 
 docker compose build
-docker compose up -d
-
-#### fossology needs up to 15 seconds to startup
-sleep 15
+docker compose up -d --wait --wait-timeout 60
 
 readonly HOST="$(docker compose port web 80)"
 


### PR DESCRIPTION
## Description

Avoid redundant image builds and add small improvement in Docker test startup validation.

### Changes

 - Replace _docker compose build_ in the workflow with docker _compose config -q_.
   - Image building is done in test-cluster.sh (full/all) and test-standalone.sh (web)
   - Although the caches are used and the build is fast, the extra build before the sh scripts is not needed, no?
- Replace the hardcoded sleep 15 in the cluster testfile with _docker compose up -d --wait --wait-timeout 60_
   - Uses so the configured health checks in docker-compose.yml.

## How to test

 - Run docker compose config -q.
 - Run test-cluster.sh.
 - Verify that the Docker test workflow completes successfully.