### PR TITLE
fix(ui): accomodate access token data model change in UI

### DIFF
--- a/src/www/ui/template/user_edit.html.twig
+++ b/src/www/ui/template/user_edit.html.twig
@@ -270,7 +270,7 @@
             {{ singleClient.name }}
           </td>
           <td>
-            {{ singleClient.created }}
+            {{ singleClient.created|date("Y-m-d") }}
           </td>
           <td>
             {%if singleClient.scope == 'r' %}
@@ -317,7 +317,7 @@
             {{ singleClient.name }}
           </td>
           <td>
-            {{ singleClient.created }}
+            {{ singleClient.created|date("Y-m-d") }}
           </td>
           <td>
             {%if singleClient.scope == 'r' %}
@@ -437,10 +437,10 @@
             {{ singleToken.name }}
           </td>
           <td>
-            {{ singleToken.created }}
+            {{ singleToken.created|date("Y-m-d") }}
           </td>
           <td>
-            {{ singleToken.expire }}
+            {{ singleToken.expire|date("Y-m-d") }}
           </td>
           <td>
             {%if singleToken.scope == 'r' %}
@@ -490,10 +490,10 @@
             {{ singleToken.name }}
           </td>
           <td>
-            {{ singleToken.created }}
+            {{ singleToken.created|date("Y-m-d") }}
           </td>
           <td>
-            {{ singleToken.expire }}
+            {{ singleToken.expire|date("Y-m-d") }}
           </td>
           <td>
             {%if singleToken.scope == 'r' %}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Due to Recent changes in the Data Model for `Personal Access Token` table, The UI also started showing `created_on` & `expiry` values in raw time stamp. To get back to older view. 

### Changes

Add, `date()` filter on both, created and expiry values.

After change from #3712 :
<img width="1170" height="129" alt="image" src="https://github.com/user-attachments/assets/8daa5222-4fbf-4148-8d91-d3a558b3e088" />

Earlier view/Now:

<img width="788" height="98" alt="image" src="https://github.com/user-attachments/assets/59b34170-19a5-4613-802d-c30fdd553281" />

