### PR TITLE
feat(api-v2): persist obligation associations on license create/update

### DIFF
--- a/src/www/ui/api/Controllers/LicenseController.php
+++ b/src/www/ui/api/Controllers/LicenseController.php
@@ -15,6 +15,8 @@ namespace Fossology\UI\Api\Controllers;
 use Fossology\Lib\Application\BulkTextExport;
 use Fossology\Lib\Application\LicenseCsvExport;
 use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\BusinessRules\LicenseMap;
+use Fossology\Lib\BusinessRules\ObligationMap;
 use Fossology\Lib\Dao\LicenseAcknowledgementDao;
 use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Dao\LicenseStdCommentDao;
@@ -78,6 +80,12 @@ class LicenseController extends RestController
    */
   private $licenseStdCommentDao;
 
+  /**
+   * @var ObligationMap $obligationMap
+   * Obligation Map object
+   */
+  private $obligationMap;
+
 
   /**
    * @param ContainerInterface $container
@@ -88,6 +96,54 @@ class LicenseController extends RestController
     $this->licenseDao = $this->container->get('dao.license');
     $this->adminLicenseAckDao = $this->container->get('dao.license.acknowledgement');
     $this->licenseStdCommentDao = $this->container->get('dao.license.stdc');
+    $this->obligationMap = $this->container->get('businessrules.obligationmap');
+  }
+
+  /**
+   * Ensure every given obligation id exists.
+   *
+   * @param integer[] $obligationIds Obligation IDs to check
+   * @throws HttpBadRequestException If an obligation ID does not exist
+   */
+  private function validateObligationIdsExist($obligationIds)
+  {
+    foreach ($obligationIds as $obligationId) {
+      if (! $this->dbHelper->doesIdExist("obligation_ref", "ob_pk", $obligationId)) {
+        throw new HttpBadRequestException(
+          "Obligation with id '$obligationId' does not exist.");
+      }
+    }
+  }
+
+  /**
+   * Associate the given obligation IDs with a license, removing any
+   * associations that are no longer in the list. Assumes the ids have
+   * already been validated with validateObligationIdsExist().
+   *
+   * @param integer   $licenseId     License to associate obligations with
+   * @param integer[] $obligationIds Obligation IDs that should be associated
+   * @param boolean   $isCandidate   Is the license a candidate license?
+   */
+  private function syncLicenseObligations($licenseId, $obligationIds, $isCandidate)
+  {
+    // LicenseMap::TRIVIAL skips building the (unrelated and costly) license
+    // conclusion/report map in the constructor; getObligationsForLicenseRef()
+    // only queries the obligation map tables directly and does not use it.
+    $licenseMap = new LicenseMap($this->dbHelper->getDbManager(), 0,
+      LicenseMap::TRIVIAL);
+    $currentObligationIds = $licenseMap->getObligationsForLicenseRef(
+      $licenseId, $isCandidate);
+
+    $addedObligationIds = array_diff($obligationIds, $currentObligationIds);
+    foreach ($addedObligationIds as $obligationId) {
+      $this->obligationMap->associateLicenseWithObligation($obligationId,
+        $licenseId, $isCandidate);
+    }
+    $removedObligationIds = array_diff($currentObligationIds, $obligationIds);
+    foreach ($removedObligationIds as $obligationId) {
+      $this->obligationMap->unassociateLicenseFromObligation($obligationId,
+        $licenseId, $isCandidate);
+    }
   }
 
   /**
@@ -248,6 +304,10 @@ class LicenseController extends RestController
     if ($newLicense === -2) {
       throw new HttpBadRequestException("Property 'shortName' is required.");
     }
+    if ($newLicense === -3) {
+      throw new HttpBadRequestException("Property 'obligations' must be " .
+        "an array of obligation ids.");
+    }
     if (! $newLicense->getIsCandidate() && ! Auth::isAdmin()) {
       throw new HttpForbiddenException("Need to be admin to create " .
         "non-candidate license.");
@@ -278,6 +338,10 @@ class LicenseController extends RestController
       throw new HttpConflictException("License with shortname '" .
         $newLicense->getShortName() . "' already exists!");
     }
+    $obligationIds = $newLicense->getObligationIds();
+    if ($obligationIds !== null) {
+      $this->validateObligationIdsExist($obligationIds);
+    }
     try {
       $rfPk = $this->dbHelper->getDbManager()->insertTableRow($tableName,
         $assocData, __METHOD__ . ".newLicense", "rf_pk");
@@ -285,6 +349,12 @@ class LicenseController extends RestController
     } catch (\Exception $e) {
       throw new HttpConflictException(
         "License with same text already exists!", $e);
+    }
+    if ($obligationIds !== null) {
+      foreach ($obligationIds as $obligationId) {
+        $this->obligationMap->associateLicenseWithObligation($obligationId,
+          $rfPk, $newLicense->getIsCandidate());
+      }
     }
     return $response->withJson($newInfo->getArray(), $newInfo->getCode());
   }
@@ -338,7 +408,19 @@ class LicenseController extends RestController
     if (array_key_exists('risk', $newParams)) {
       $assocData['rf_risk'] = intval($newParams['risk']);
     }
-    if (empty($assocData)) {
+    $obligationIds = null;
+    if (array_key_exists('obligations', $newParams)) {
+      if (! is_array($newParams['obligations'])) {
+        throw new HttpBadRequestException("Property 'obligations' must " .
+          "be an array of obligation ids.");
+      }
+      $obligationIds = array_values(array_unique(
+        array_map('intval', $newParams['obligations'])));
+      // Validate before writing anything, so a bad obligation id does not
+      // leave the license partially updated.
+      $this->validateObligationIdsExist($obligationIds);
+    }
+    if (empty($assocData) && $obligationIds === null) {
       throw new HttpBadRequestException("Empty body sent.");
     }
 
@@ -346,8 +428,14 @@ class LicenseController extends RestController
     if ($isCandidate) {
       $tableName = "license_candidate";
     }
-    $this->dbHelper->getDbManager()->updateTableRow($tableName, $assocData,
-      "rf_pk", $license->getId(), __METHOD__ . ".updateLicense");
+    if (! empty($assocData)) {
+      $this->dbHelper->getDbManager()->updateTableRow($tableName, $assocData,
+        "rf_pk", $license->getId(), __METHOD__ . ".updateLicense");
+    }
+    if ($obligationIds !== null) {
+      $this->syncLicenseObligations($license->getId(), $obligationIds,
+        $isCandidate);
+    }
     $newInfo = new Info(200, "License " . $license->getShortName() .
       " updated.", InfoType::INFO);
     return $response->withJson($newInfo->getArray(), $newInfo->getCode());

--- a/src/www/ui/api/Models/License.php
+++ b/src/www/ui/api/Models/License.php
@@ -23,7 +23,7 @@ class License
    * Allowed keys from user to parse
    */
   const ALLOWED_KEYS = ['shortName', 'fullName', 'text', 'url', 'risk',
-    'isCandidate', 'mergeRequest'];
+    'isCandidate', 'mergeRequest', 'obligations'];
   /**
    * @var integer $id
    * License id
@@ -69,6 +69,13 @@ class License
    * Create merge request for candidate license?
    */
   private $mergeRequest;
+  /**
+   * @var integer[]|null $obligationIds
+   * IDs of obligations to be associated with the license, as sent by the
+   * user on create/update. Kept separate from $obligations, which holds
+   * full Obligation objects for API responses.
+   */
+  private $obligationIds;
 
   /**
    * License constructor.
@@ -102,6 +109,7 @@ class License
     $this->setRisk($risk);
     $this->setIsCandidate($isCandidate);
     $this->mergeRequest = false;
+    $this->obligationIds = null;
   }
 
   /**
@@ -236,6 +244,15 @@ class License
   }
 
   /**
+   * Get the IDs of obligations to be associated with the license.
+   * @return integer[]|null Obligation IDs sent by the user, null if not set
+   */
+  public function getObligationIds()
+  {
+    return $this->obligationIds;
+  }
+
+  /**
    * Set the license's short name
    * @param string $shortName License's short name
    */
@@ -325,6 +342,16 @@ class License
   }
 
   /**
+   * Set the IDs of obligations to be associated with the license.
+   * @param array $obligationIds Obligation IDs sent by the user
+   */
+  public function setObligationIds($obligationIds)
+  {
+    $this->obligationIds = array_values(array_unique(
+      array_map('intval', $obligationIds)));
+  }
+
+  /**
    * Set the merge request for new license
    * @param boolean $mergeRequest
    */
@@ -370,6 +397,12 @@ class License
     }
     if (array_key_exists('mergeRequest', $inputLicense)) {
       $newLicense->setMergeRequest($inputLicense['mergeRequest']);
+    }
+    if (array_key_exists('obligations', $inputLicense)) {
+      if (! is_array($inputLicense['obligations'])) {
+        return -3;
+      }
+      $newLicense->setObligationIds($inputLicense['obligations']);
     }
     return $newLicense;
   }

--- a/src/www/ui/api/documentation/openapiv2.yaml
+++ b/src/www/ui/api/documentation/openapiv2.yaml
@@ -4683,6 +4683,14 @@ paths:
                       description: Open a merge request for candidate license?
                       type: boolean
                       default: false
+                    obligations:
+                      description: IDs of obligations to associate with the license
+                      type: array
+                      items:
+                        type: integer
+                      example:
+                        - 1
+                        - 2
               required:
                 - shortName
       responses:
@@ -4945,6 +4953,16 @@ paths:
                   nullable: true
                   example:
                     2
+                obligations:
+                  description: >
+                    IDs of obligations to associate with the license. Replaces
+                    the full set of currently associated obligations.
+                  type: array
+                  items:
+                    type: integer
+                  example:
+                    - 1
+                    - 2
       responses:
         '200':
           description: License added successfully

--- a/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/LicenseControllerTest.php
@@ -13,6 +13,7 @@
 namespace Fossology\UI\Api\Test\Controllers;
 
 use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\BusinessRules\ObligationMap;
 use Fossology\Lib\Dao\LicenseAcknowledgementDao;
 use Fossology\Lib\Dao\LicenseDao;
 use Fossology\Lib\Dao\LicenseStdCommentDao;
@@ -112,6 +113,12 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
   private $licenseStdCommentDao;
 
   /**
+   * @var ObligationMap $obligationMap
+   * ObligationMap mock
+   */
+  private $obligationMap;
+
+  /**
    * @var M\MockInterface $adminLicensePlugin
    * admin_license_from_csv mock
    */
@@ -156,6 +163,7 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
     $this->adminLicensePlugin = M::mock('admin_license_from_csv');
     $this->licenseCandidatePlugin = M::mock('admin_license_candidate');
     $this->licenseStdCommentDao = M::mock(LicenseStdCommentDao::class);
+    $this->obligationMap = M::mock(ObligationMap::class);
 
     $this->dbHelper->shouldReceive('getDbManager')->andReturn($this->dbManager);
 
@@ -177,6 +185,8 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
       'dao.license'))->andReturn($this->licenseDao);
     $container->shouldReceive('get')->withArgs(array(
       'dao.license.acknowledgement'))->andReturn($this->adminLicenseAckDao);
+    $container->shouldReceive('get')->withArgs(array(
+      'businessrules.obligationmap'))->andReturn($this->obligationMap);
     $this->licenseController = new LicenseController($container);
     $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
     $this->streamFactory = new StreamFactory();
@@ -636,6 +646,109 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
   /**
    * @test
    * -# Test for LicenseController::createLicense() to create new license
+   * -# The request contains obligation ids to associate
+   * -# Check if response is 201 and obligations get associated
+   */
+  public function testCreateLicenseWithObligations()
+  {
+    $license = $this->getLicense("MIT");
+    $requestBody = $license->getArray();
+    $requestBody["isCandidate"] = true;
+    $requestBody["obligations"] = [123, 124];
+    unset($requestBody['id']);
+
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    $body = $this->streamFactory->createStream();
+    $body->write(json_encode($requestBody));
+    $body->seek(0);
+    $request = new Request("POST", new Uri("HTTP", "localhost", 80,
+      "/license"), $requestHeaders, [], [], $body);
+
+    $tableName = "license_candidate";
+    $assocData = [
+      "rf_shortname" => $license->getShortName(),
+      "rf_fullname" => $license->getFullName(),
+      "rf_text" => $license->getText(),
+      "rf_md5" => md5($license->getText()),
+      "rf_risk" => $license->getRisk(),
+      "rf_url" => $license->getUrl(),
+      "rf_detector_type" => 1,
+      "group_fk" => $this->groupId,
+      "rf_user_fk_created" => $this->userId,
+      "rf_user_fk_modified" => $this->userId,
+      "marydone" => false
+    ];
+
+    $sql = "SELECT count(*) cnt FROM ".
+      "$tableName WHERE rf_shortname = $1 AND group_fk = $2;";
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["obligation_ref", "ob_pk", 123])->andReturn(true);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["obligation_ref", "ob_pk", 124])->andReturn(true);
+    $this->dbManager->shouldReceive('insertTableRow')
+      ->withArgs([$tableName, $assocData, M::any(), "rf_pk"])->andReturn(4);
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs([$sql, [$license->getShortName(), $this->groupId], M::any()])
+      ->andReturn(["cnt" => 0]);
+    $this->obligationMap->shouldReceive('associateLicenseWithObligation')
+      ->withArgs([123, 4, true])->once();
+    $this->obligationMap->shouldReceive('associateLicenseWithObligation')
+      ->withArgs([124, 4, true])->once();
+
+    $info = new Info(201, '4', InfoType::INFO);
+    $expectedResponse = (new ResponseHelper())->withJson($info->getArray(),
+      $info->getCode());
+
+    $actualResponse = $this->licenseController->createLicense($request,
+      new ResponseHelper(), []);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::createLicense() to create new license
+   * -# One of the given obligation ids does not exist
+   * -# Check if response is 400 and no license row is created
+   */
+  public function testCreateLicenseInvalidObligation()
+  {
+    $license = $this->getLicense("MIT");
+    $requestBody = $license->getArray();
+    $requestBody["isCandidate"] = true;
+    $requestBody["obligations"] = [999];
+    unset($requestBody['id']);
+
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    $body = $this->streamFactory->createStream();
+    $body->write(json_encode($requestBody));
+    $body->seek(0);
+    $request = new Request("POST", new Uri("HTTP", "localhost", 80,
+      "/license"), $requestHeaders, [], [], $body);
+
+    $tableName = "license_candidate";
+    $sql = "SELECT count(*) cnt FROM ".
+      "$tableName WHERE rf_shortname = $1 AND group_fk = $2;";
+
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs([$sql, [$license->getShortName(), $this->groupId], M::any()])
+      ->andReturn(["cnt" => 0]);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["obligation_ref", "ob_pk", 999])->andReturn(false);
+    $this->dbManager->shouldNotReceive('insertTableRow');
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->licenseController->createLicense($request, new ResponseHelper(), []);
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::createLicense() to create new license
    * -# The request body is malformed
    * -# Check if response is 400
    */
@@ -803,6 +916,105 @@ class LicenseControllerTest extends \PHPUnit\Framework\TestCase
       $actualResponse->getStatusCode());
     $this->assertEquals($this->getResponseJson($expectedResponse),
       $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::updateLicense() to associate obligations
+   * -# Currently associated obligations not in the new list get removed
+   * -# Check if response is 200
+   */
+  public function testUpdateLicenseWithObligations()
+  {
+    $license = $this->getDaoLicense("Exotic");
+    $requestBody = [
+      "obligations" => [123, 124]
+    ];
+
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    $body = $this->streamFactory->createStream();
+    $body->write(json_encode($requestBody));
+    $body->seek(0);
+    $request = new Request("PATCH", new Uri("HTTP", "localhost", 80,
+      "/license/" . $license->getShortName()), $requestHeaders, [], [], $body);
+
+    $this->userDao->shouldReceive('isAdvisorOrAdmin')
+      ->withArgs([$this->userId, $this->groupId])->andReturn(true);
+    $this->licenseDao->shouldReceive('getLicenseByShortName')
+      ->withArgs([$license->getShortName(), $this->groupId])
+      ->andReturn($license);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["license_candidate", "rf_pk", $license->getId()])
+      ->andReturn(true);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["obligation_ref", "ob_pk", 123])->andReturn(true);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["obligation_ref", "ob_pk", 124])->andReturn(true);
+
+    // LicenseMap::TRIVIAL short-circuits its constructor, so only the
+    // direct getRows() call made by getObligationsForLicenseRef() needs to
+    // be mocked here.
+    $this->dbManager->shouldReceive('getRows')
+      ->withArgs([
+        "SELECT distinct(ob_fk) FROM obligation_candidate_map WHERE rf_fk = $1;",
+        [$license->getId()], M::any()])
+      ->andReturn([['ob_fk' => 123], ['ob_fk' => 999]]);
+
+    // 123 is already associated, so only 124 should be newly associated.
+    $this->obligationMap->shouldReceive('associateLicenseWithObligation')
+      ->withArgs([124, $license->getId(), true])->once();
+    $this->obligationMap->shouldNotReceive('associateLicenseWithObligation')
+      ->withArgs([123, $license->getId(), true]);
+    $this->obligationMap->shouldReceive('unassociateLicenseFromObligation')
+      ->withArgs([999, $license->getId(), true])->once();
+
+    $info = new Info(200, "License " . $license->getShortName() . " updated.",
+      InfoType::INFO);
+    $expectedResponse = (new ResponseHelper())->withJson($info->getArray(),
+      $info->getCode());
+
+    $actualResponse = $this->licenseController->updateLicense($request,
+      new ResponseHelper(), ["shortname" => $license->getShortName()]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+    $this->assertEquals($this->getResponseJson($expectedResponse),
+      $this->getResponseJson($actualResponse));
+  }
+
+  /**
+   * @test
+   * -# Test for LicenseController::updateLicense() with obligations
+   * -# The obligations property is not an array
+   * -# Check if response is 400
+   */
+  public function testUpdateLicenseObligationsNotArray()
+  {
+    $license = $this->getDaoLicense("Exotic");
+    $requestBody = [
+      "obligations" => "not-an-array"
+    ];
+
+    $requestHeaders = new Headers();
+    $requestHeaders->setHeader('Content-Type', 'application/json');
+    $body = $this->streamFactory->createStream();
+    $body->write(json_encode($requestBody));
+    $body->seek(0);
+    $request = new Request("PATCH", new Uri("HTTP", "localhost", 80,
+      "/license/" . $license->getShortName()), $requestHeaders, [], [], $body);
+
+    $this->userDao->shouldReceive('isAdvisorOrAdmin')
+      ->withArgs([$this->userId, $this->groupId])->andReturn(true);
+    $this->licenseDao->shouldReceive('getLicenseByShortName')
+      ->withArgs([$license->getShortName(), $this->groupId])
+      ->andReturn($license);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["license_candidate", "rf_pk", $license->getId()])
+      ->andReturn(true);
+    $this->expectException(HttpBadRequestException::class);
+
+    $this->licenseController->updateLicense($request, new ResponseHelper(),
+      ["shortname" => $license->getShortName()]);
   }
 
   /**

--- a/src/www/ui_tests/api/Models/LicenseTest.php
+++ b/src/www/ui_tests/api/Models/LicenseTest.php
@@ -110,4 +110,28 @@ class LicenseTest extends \PHPUnit\Framework\TestCase
     $bogusLicense = License::parseFromArray($bogusInput);
     $this->assertEquals(-1, $bogusLicense);
   }
+
+  /**
+   * @test
+   * -# Test parser License::parseFromArray() with obligations
+   * -# Check that obligation ids are parsed, deduplicated and cast to int.
+   * -# Check that a non-array obligations value is rejected.
+   */
+  public function testArrayParserWithObligations()
+  {
+    $inputLicense = [
+      'shortName' => "MIT",
+      'obligations' => ["1", 2, 2]
+    ];
+
+    $actualLicense = License::parseFromArray($inputLicense);
+
+    $this->assertEquals([1, 2], $actualLicense->getObligationIds());
+
+    $bogusInput = [
+      'shortName' => "MIT",
+      'obligations' => "not-an-array"
+    ];
+    $this->assertEquals(-3, License::parseFromArray($bogusInput));
+  }
 }


### PR DESCRIPTION
FOSSologyUI could fetch obligations via `GET /obligations/list` but had no way to associate them with a license, since the license create/update REST API v2 endpoints silently dropped the field. Add an `obligations` array of obligation ids to both endpoints, reusing the existing `ObligationMap` association logic that the legacy admin UI relies on.

Fixes fossology/FOSSologyUI#443

## Description

Adds obligation-association support to the license create/update REST API v2 endpoints, so obligations selected in the UI can actually be persisted against a license instead of being silently dropped.

### Changes

- Added `obligations` (array of obligation ids) as an accepted field on `POST /license` and `PATCH /license/{shortname}` (API v2).
- `LicenseController::createLicense()` validates the given obligation ids exist, then associates them with the newly created license via `ObligationMap`.
- `LicenseController::updateLicense()` validates obligation ids *before* writing any other field changes (so an invalid id can't leave the license partially updated), then reconciles the license's current obligation associations against the requested set — associating new ones and unassociating ones no longer present — using `LicenseMap::getObligationsForLicenseRef()` together with `ObligationMap::associateLicenseWithObligation()` / `unassociateLicenseFromObligation()`. This mirrors the association logic the legacy `admin-license-file.php` UI already uses.
- Extended the `License` API model (`src/www/ui/api/Models/License.php`) with an `obligationIds` field for parsing input ids, kept separate from the existing output-only `obligations` (full `Obligation` objects returned by `GET`).
- Documented the new `obligations` field on both endpoints in `openapiv2.yaml`.
- Added unit tests in `LicenseControllerTest.php` and `LicenseTest.php` covering: associating obligations on create, rejecting an unknown obligation id, associating/removing obligations on update, and rejecting a non-array `obligations` value.

## How to test

- Run the relevant unit tests:

phpunit -c src/phpunit.xml --testsuite="Fossology PhpUnit Test Suite" --filter LicenseControllerTest
phpunit -c src/phpunit.xml --testsuite="Fossology PhpUnit Test Suite" --filter LicenseTest

- Manually, against a running instance:
- `POST /api/v2/license` with `"obligations": [<id1>, <id2>]` (existing obligation ids) → license is created, and `GET /api/v2/license/{shortname}` returns those obligations.
- `PATCH /api/v2/license/{shortname}` with `"obligations": [<id>]` → obligations no longer in the list are unassociated, new ones are associated; this works even if no other fields are included in the request.
- Send an unknown obligation id (e.g. `"obligations": [999999]`) on either endpoint → expect `400 Bad Request`, and confirm no license fields were changed.


