### PR TITLE
fix(api): Allow spaces in group name path parameters

### DIFF
--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -168,6 +168,9 @@ if ($dbConnected) {
 // Regex for matching a valid path parameter
 $pattern = "[\\w\\d\\-\\.@_]+";
 
+// Regex for matching group names, which may contain spaces
+$groupPattern = "[\\w\\d\\-\\.@_ ]+";
+
 //////////////////////////OPTIONS/////////////////////
 $app->options('/{routes:.+}', AuthController::class . ':optionsVerification');
 
@@ -310,16 +313,16 @@ $app->group('/obligations',
 
 ////////////////////////////GROUPS/////////////////////
 $app->group('/groups',
-  function (\Slim\Routing\RouteCollectorProxy $app) use ($pattern) {
+  function (\Slim\Routing\RouteCollectorProxy $app) use ($pattern, $groupPattern) {
     $app->get('', GroupController::class . ':getGroups');
     $app->post('', GroupController::class . ':createGroup');
-    $app->post("/{pathParam:$pattern}/user/{userPathParam:$pattern}", GroupController::class . ':addMember');
-    $app->put("/{pathParam:$pattern}", GroupController::class . ':updateGroup');
-    $app->delete("/{pathParam:$pattern}", GroupController::class . ':deleteGroup');
-    $app->delete("/{pathParam:$pattern}/user/{userPathParam:$pattern}", GroupController::class . ':deleteGroupMember');
+    $app->post("/{pathParam:$groupPattern}/user/{userPathParam:$pattern}", GroupController::class . ':addMember');
+    $app->put("/{pathParam:$groupPattern}", GroupController::class . ':updateGroup');
+    $app->delete("/{pathParam:$groupPattern}", GroupController::class . ':deleteGroup');
+    $app->delete("/{pathParam:$groupPattern}/user/{userPathParam:$pattern}", GroupController::class . ':deleteGroupMember');
     $app->get('/deletable', GroupController::class . ':getDeletableGroups');
-    $app->get("/{pathParam:$pattern}/members", GroupController::class . ':getGroupMembers');
-    $app->put("/{pathParam:$pattern}/user/{userPathParam:$pattern}", GroupController::class . ':changeUserPermission');
+    $app->get("/{pathParam:$groupPattern}/members", GroupController::class . ':getGroupMembers');
+    $app->put("/{pathParam:$groupPattern}/user/{userPathParam:$pattern}", GroupController::class . ':changeUserPermission');
     $app->any('/{params:.*}', BadRequestController::class);
   });
 


### PR DESCRIPTION
## Description

Update the API route parameter patterns to support spaces in group names without changing the behavior of other path parameters.

### Changes

- Added a dedicated $groupPattern for group name route parameters.
- Allowed spaces in group names using the new pattern.
- Kept the existing $pattern unchanged for users and other path parameters.
- Updated group-related routes to use $groupPattern for group names and $pattern for user names.

### Testing

- Verified that group names containing spaces can be used in group-related API routes.
- Verified that user-related path parameters continue using the original pattern.
- Verified that existing routes using $pattern remain unchanged.

### Screenshots

Before:

<img width="1444" height="825" alt="image" src="https://github.com/user-attachments/assets/a76a912d-835a-4998-b9d7-af8f8335b5ec" />

After:

<img width="1751" height="871" alt="image" src="https://github.com/user-attachments/assets/e70b9e98-d357-4a42-8469-9f7daddb7faa" />
