### PR TITLE
fix(scheduler): add GMutex around database_exec to fix PQexec race

### DIFF
--- a/src/scheduler/agent/database.c
+++ b/src/scheduler/agent/database.c
@@ -763,6 +763,8 @@ static PGconn* database_connect(gchar* configdir)
   return ret;
 }
 
+static GMutex db_mutex;
+
 /**
  * Initializes any one-time attributes relating to the database. Currently this
  * includes creating the db connection and checking the URL of the FOSSology
@@ -785,6 +787,14 @@ void database_init(scheduler_t* scheduler)
   check_tables(scheduler);
 }
 
+/**
+ * Cleans up database static resources such as the mutex lock.
+ */
+void database_destroy(void)
+{
+  g_mutex_clear(&db_mutex);
+}
+
 /* ************************************************************************** */
 /* **** event and functions ************************************************* */
 /* ************************************************************************** */
@@ -797,6 +807,10 @@ void database_init(scheduler_t* scheduler)
  * ever lost we automatically try to reconnect and if we are unable to, the
  * scheduler will die.
  *
+ * Thread safety: Access to database_exec is synchronized with db_mutex so
+ * multiple worker or agent threads cannot execute PQexec on scheduler->db_conn
+ * concurrently.
+ *
  * @param scheduler  the scheduler_t* that holds the connection
  * @param sql        the sql that will be performed
  * @return           the PGresult struct that is returned by PQexec
@@ -807,6 +821,8 @@ PGresult* database_exec(scheduler_t* scheduler, const char* sql)
 
   V_SPECIAL("DATABASE: exec \"%s\"\n", sql);
 
+  g_mutex_lock(&db_mutex);
+
   ret = PQexec(scheduler->db_conn, sql);
   if(ret == NULL || PQstatus(scheduler->db_conn) != CONNECTION_OK)
   {
@@ -815,6 +831,8 @@ PGresult* database_exec(scheduler_t* scheduler, const char* sql)
 
     ret = PQexec(scheduler->db_conn, sql);
   }
+
+  g_mutex_unlock(&db_mutex);
 
   return ret;
 }

--- a/src/scheduler/agent/database.h
+++ b/src/scheduler/agent/database.h
@@ -25,6 +25,7 @@ extern const char* jobsql_failed;
 /* ************************************************************************** */
 
 void database_init(scheduler_t* scheduler);
+void database_destroy(void);
 void email_init(scheduler_t* scheduler);
 
 /* ************************************************************************** */

--- a/src/scheduler/agent/scheduler.c
+++ b/src/scheduler/agent/scheduler.c
@@ -394,6 +394,7 @@ void scheduler_destroy(scheduler_t* scheduler)
   g_tree_unref(scheduler->job_list);
 
   if (scheduler->db_conn) PQfinish(scheduler->db_conn);
+  database_destroy();
 
   g_free(scheduler);
 }


### PR DESCRIPTION
# fix(scheduler): add GMutex around database_exec to fix PQexec race

Found this while stress testing the scheduler with a bunch of concurrent jobs running. Kept seeing weird connection failures and reconnect attempts that didn't make sense given the DB was clearly up.

Turned out to be a threading issue. The scheduler has one shared PGconn (scheduler->db_conn), but it's getting hit from multiple threads at once:

- main scheduler loop (database_update_event)
- interface.c worker threads handling socket commands
- agent.c threads managing the scan agents

libpq docs are pretty clear that a single PGconn isn't safe to use across threads. So when two threads fire PQexec at roughly the same time, the buffer gets corrupted, the scheduler thinks the connection died, tries to reconnect, and in the process drops job updates. Annoying to debug because it's not consistent - only shows up under load.

Added a GMutex around database_exec and around the connect/teardown paths. Nothing fancy, just serializes access so only one thread touches the connection at a time.

## Changes

- database.c - added static db_mutex + init flag, init it in database_init(), lock/unlock around the PQexec calls in database_exec(), added database_destroy() to clean the mutex up on shutdown
- database.h - prototype for database_destroy()
- scheduler.c - calling database_destroy() from scheduler_destroy() and scheduler_clear_config()

## Testing

Rebuilt and brought the containers up (db, scheduler, web).

Threw 50 concurrent fo_cli -S calls at it while an upload was processing across all 7 agents (ununpack, adj2nest, mimetype, scancode, nomos, monk, ojo, reuser). Before the fix this would occasionally throw a connection error mid-run. After the fix - ran it probably 10+ times, no disconnects, no dropped updates.

Also just checked fo_cli -S normally to make sure the daemon still reports PID/status/revision fine.

## Screenshots & Verification

<img width="1920" height="1200" alt="fix1" src="https://github.com/user-attachments/assets/b77b31ad-e82d-42d0-92cf-7e1c7550e6a3" />
<img width="1920" height="1200" alt="fix2" src="https://github.com/user-attachments/assets/49d26f06-b68c-4ecb-a5ad-56e8a1ac962b" />
<img width="1920" height="1200" alt="fix3" src="https://github.com/user-attachments/assets/4c495ef8-ab5f-4ca1-a265-7954e591cc33" />
<img width="1920" height="1200" alt="fix4" src="https://github.com/user-attachments/assets/4d09854d-2a22-4bc4-b4ec-0361a97356d1" />
<img width="1920" height="1200" alt="fix5" src="https://github.com/user-attachments/assets/d14c2a0c-b7ca-4146-8b5e-309fb8a5ec18" />



## Checklist
- [x] follows project style
- [x] commit signed off
- [x] tested locally with docker
- [x] no breaking changes
