### PR TITLE
fix(m2m): configure a new oidc app for m2m

### DIFF
--- a/src/lib/php/common-sysconfig.php
+++ b/src/lib/php/common-sysconfig.php
@@ -305,6 +305,36 @@ function Populate_sysconfig()
   $valueArray[$variable] = array("'$variable'", "''", "'$prompt'",
     strval(CONFIG_TYPE_TEXT), "'OauthSupport'", "16", "'$oidcDesc'", "null", "null");
 
+  $variable = "OidcM2MAppId";
+  $oidcPrompt = _('OIDC M2M Client Id');
+  $oidcDesc = _('e.g. "e0ec21b9f4b21adc76f185962b52bdfc13af134a"<br>Client ID generated while registering the M2M application.');
+  $valueArray[$variable] = array("'$variable'", "null", "'$oidcPrompt'",
+    strval(CONFIG_TYPE_TEXT), "'OauthM2M'", "1", "'$oidcDesc'", "null", "null");
+
+  $variable = "OidcM2MSecret";
+  $oidcPrompt = _('OIDC M2M Secret');
+  $oidcDesc = _('e.g. "cf13476f185b9f4b2e0ec962b52211adbdfc13aa"<br>Secret generated while registering the M2M application.');
+  $valueArray[$variable] = array("'$variable'", "null", "'$oidcPrompt'",
+    strval(CONFIG_TYPE_PASSWORD), "'OauthM2M'", "2", "'$oidcDesc'", "null", "null");
+
+  $variable = "OidcM2MScope";
+  $oidcPrompt = _('OIDC M2M Scope');
+  $oidcDesc = _('Scope used for the client_credentials grant with LicenseDB.');
+  $valueArray[$variable] = array("'$variable'", "''", "'$oidcPrompt'",
+    strval(CONFIG_TYPE_TEXT), "'OauthM2M'", "3", "'$oidcDesc'", "null", "null");
+
+  $variable = "OidcM2MAuthorizeURL";
+  $oidcPrompt = _('OIDC M2M Authorize URL');
+  $oidcDesc = _('URL for the M2M OAuth2 authorization endpoint.');
+  $valueArray[$variable] = array("'$variable'", "null", "'$oidcPrompt'",
+    strval(CONFIG_TYPE_TEXT), "'OauthM2M'", "4", "'$oidcDesc'", "null", "null");
+
+  $variable = "OidcM2MAccessTokenURL";
+  $oidcPrompt = _('OIDC M2M Access Token URL');
+  $oidcDesc = _('URL for the M2M OAuth2 access token endpoint.');
+  $valueArray[$variable] = array("'$variable'", "null", "'$oidcPrompt'",
+    strval(CONFIG_TYPE_TEXT), "'OauthM2M'", "5", "'$oidcDesc'", "null", "null");
+
   /*  Banner Message */
   $variable = "BannerMsg";
   $bannerMsgPrompt = _('Banner message');

--- a/src/www/ui/page/AdminLicenseFromCSV.php
+++ b/src/www/ui/page/AdminLicenseFromCSV.php
@@ -63,16 +63,14 @@ class AdminLicenseFromCSV extends DefaultPlugin
 
     if ($this->configuration['token'] == null) {
       $this->oidcProvider = new GenericProvider([
-        "clientId" => trim($this->sysconfig['SYSCONFIG']['OidcAppId']),
-        "clientSecret" => trim($this->sysconfig['SYSCONFIG']['OidcSecret']),
-        "redirectUri" => trim($this->sysconfig['SYSCONFIG']['OidcRedirectURL']),
-        "urlAuthorize" => trim($this->sysconfig['SYSCONFIG']['OidcAuthorizeURL']),
-        "urlAccessToken" => trim($this->sysconfig['SYSCONFIG']['OidcAccessTokenURL']),
-        "urlResourceOwnerDetails" => trim($this->sysconfig['SYSCONFIG']['OidcResourceURL']),
+        "clientId" => trim($this->sysconfig['SYSCONFIG']['OidcM2MAppId']),
+        "clientSecret" => trim($this->sysconfig['SYSCONFIG']['OidcM2MSecret']),
+        "urlAuthorize" => trim($this->sysconfig['SYSCONFIG']['OidcM2MAuthorizeURL']),
+        "urlAccessToken" => trim($this->sysconfig['SYSCONFIG']['OidcM2MAccessTokenURL']),
       ]);
 
-      if (isset($this->sysconfig['SYSCONFIG']['OidcScope'])) {
-        $this->configuration['scope'] = trim($this->sysconfig['SYSCONFIG']['OidcScope']);
+      if (isset($this->sysconfig['SYSCONFIG']['OidcM2MScope'])) {
+        $this->configuration['scope'] = trim($this->sysconfig['SYSCONFIG']['OidcM2MScope']);
       }
     } else {
       $this->oidcProvider = null;

--- a/src/www/ui/page/AdminObligationFromCSV.php
+++ b/src/www/ui/page/AdminObligationFromCSV.php
@@ -63,16 +63,14 @@ class AdminObligationFromCSV extends DefaultPlugin
 
     if ($this->configuration['token'] == null) {
       $this->oidcProvider = new GenericProvider([
-        "clientId" => trim($this->sysconfig['SYSCONFIG']['OidcAppId']),
-        "clientSecret" => trim($this->sysconfig['SYSCONFIG']['OidcSecret']),
-        "redirectUri" => trim($this->sysconfig['SYSCONFIG']['OidcRedirectURL']),
-        "urlAuthorize" => trim($this->sysconfig['SYSCONFIG']['OidcAuthorizeURL']),
-        "urlAccessToken" => trim($this->sysconfig['SYSCONFIG']['OidcAccessTokenURL']),
-        "urlResourceOwnerDetails" => trim($this->sysconfig['SYSCONFIG']['OidcResourceURL']),
+        "clientId" => trim($this->sysconfig['SYSCONFIG']['OidcM2MAppId']),
+        "clientSecret" => trim($this->sysconfig['SYSCONFIG']['OidcM2MSecret']),
+        "urlAuthorize" => trim($this->sysconfig['SYSCONFIG']['OidcM2MAuthorizeURL']),
+        "urlAccessToken" => trim($this->sysconfig['SYSCONFIG']['OidcM2MAccessTokenURL']),
       ]);
 
-      if (isset($this->sysconfig['SYSCONFIG']['OidcScope'])) {
-        $this->configuration['scope'] = trim($this->sysconfig['SYSCONFIG']['OidcScope']);
+      if (isset($this->sysconfig['SYSCONFIG']['OidcM2MScope'])) {
+        $this->configuration['scope'] = trim($this->sysconfig['SYSCONFIG']['OidcM2MScope']);
       }
     } else {
       $this->oidcProvider = null;


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Configure a new app for m2m communication because we cannot reuse the one already being used for login. The one being used for login usually has more restricted permissions into who can get a token.

### Changes

Added configuration for adding a new app and used it for m2m with licensedb. 

## How to test

Setup the entire flow and check whether licenses and obligations are updated or not.
