### PR TITLE
fix(api): use dynamic uploadtree table and add safety checks in upload download

### DIFF
--- a/src/lib/php/common-repo.php
+++ b/src/lib/php/common-repo.php
@@ -22,27 +22,29 @@
  *
  * \return String that describes the mime type.
  */
-function GetMimeType($Item)
-{
-  global $PG_CONN;
+if (!function_exists('GetMimeType')) {
+  function GetMimeType($Item)
+  {
+    global $PG_CONN;
 
-  $Sql = "SELECT mimetype_name
+    $Sql = "SELECT mimetype_name
 	FROM uploadtree
 	INNER JOIN pfile ON pfile_pk = pfile_fk
 	INNER JOIN mimetype ON pfile.pfile_mimetypefk = mimetype.mimetype_pk
 	WHERE uploadtree_pk = $Item LIMIT 1;";
-  $result = pg_query($PG_CONN, $Sql);
-  DBCheckResult($result, $Sql, __FILE__, __LINE__);
-  if (pg_num_rows($result) > 0) {
-    $row = pg_fetch_assoc($result);
-    $Meta = $row['mimetype_name'];
-  } else {
-    $Meta = 'application/octet-stream';
-  }
+    $result = pg_query($PG_CONN, $Sql);
+    DBCheckResult($result, $Sql, __FILE__, __LINE__);
+    if (pg_num_rows($result) > 0) {
+      $row = pg_fetch_assoc($result);
+      $Meta = $row['mimetype_name'];
+    } else {
+      $Meta = 'application/octet-stream';
+    }
 
-  pg_free_result($result);
-  return($Meta);
-} /* GetMimeType() */
+    pg_free_result($result);
+    return($Meta);
+  } /* GetMimeType() */
+}
 
 /**
  * \brief Given a pfile id, retrieve the pfile path.
@@ -55,27 +57,29 @@ function GetMimeType($Item)
  *
  * \return The path, or NULL if the pfile record does not exist.
  */
-function RepPath($PfilePk, $Repo="files")
-{
-  global $Plugins;
-  global $LIBEXECDIR;
-  global $PG_CONN;
-  if (empty($PG_CONN)) {
-    return;
-  }
+if (!function_exists('RepPath')) {
+  function RepPath($PfilePk, $Repo="files")
+  {
+    global $Plugins;
+    global $LIBEXECDIR;
+    global $PG_CONN;
+    if (empty($PG_CONN)) {
+      return;
+    }
 
-  $sql = "SELECT * FROM pfile WHERE pfile_pk = $PfilePk LIMIT 1;";
-  $result = pg_query($PG_CONN, $sql);
-  DBCheckResult($result, $sql, __FILE__, __LINE__);
-  $Row = pg_fetch_assoc($result);
-  pg_free_result($result);
-  if (empty($Row['pfile_sha1'])) {
-    return (null);
-  }
-  $Hash = $Row['pfile_sha1'] . "." . $Row['pfile_md5'] . "." . $Row['pfile_size'];
-  exec("$LIBEXECDIR/reppath $Repo ".escapeshellarg($Hash), $Path);
-  return($Path[0]);
-} // RepPath()
+    $sql = "SELECT * FROM pfile WHERE pfile_pk = $PfilePk LIMIT 1;";
+    $result = pg_query($PG_CONN, $sql);
+    DBCheckResult($result, $sql, __FILE__, __LINE__);
+    $Row = pg_fetch_assoc($result);
+    pg_free_result($result);
+    if (empty($Row['pfile_sha1'])) {
+      return (null);
+    }
+    $Hash = $Row['pfile_sha1'] . "." . $Row['pfile_md5'] . "." . $Row['pfile_size'];
+    exec("$LIBEXECDIR/reppath $Repo ".escapeshellarg($Hash), $Path);
+    return($Path[0]);
+  } // RepPath()
+}
 
 /**
  * \brief Given an uploadtree_pk, retrieve the pfile path.
@@ -88,24 +92,26 @@ function RepPath($PfilePk, $Repo="files")
  *
  * \return The path, or NULL if the pfile record does not exist.
  */
-function RepPathItem($Item, $Repo="files")
-{
-  global $LIBEXECDIR;
-  global $PG_CONN;
-  if (empty($PG_CONN)) {
-    return;
-  }
+if (!function_exists('RepPathItem')) {
+  function RepPathItem($Item, $Repo="files")
+  {
+    global $LIBEXECDIR;
+    global $PG_CONN;
+    if (empty($PG_CONN)) {
+      return;
+    }
 
-  $sql = "SELECT * FROM pfile INNER JOIN uploadtree ON pfile_fk = pfile_pk
+    $sql = "SELECT * FROM pfile INNER JOIN uploadtree ON pfile_fk = pfile_pk
 	  WHERE uploadtree_pk = $Item LIMIT 1;";
-  $result = pg_query($PG_CONN, $sql);
-  DBCheckResult($result, $sql, __FILE__, __LINE__);
-  $Row = pg_fetch_assoc($result);
-  pg_free_result($result);
-  if (empty($Row['pfile_sha1'])) {
-    return (null);
+    $result = pg_query($PG_CONN, $sql);
+    DBCheckResult($result, $sql, __FILE__, __LINE__);
+    $Row = pg_fetch_assoc($result);
+    pg_free_result($result);
+    if (empty($Row['pfile_sha1'])) {
+      return (null);
+    }
+    $Hash = $Row['pfile_sha1'] . "." . $Row['pfile_md5'] . "." . $Row['pfile_size'];
+    exec("$LIBEXECDIR/reppath $Repo ".escapeshellarg($Hash), $Path);
+    return($Path[0]);
   }
-  $Hash = $Row['pfile_sha1'] . "." . $Row['pfile_md5'] . "." . $Row['pfile_size'];
-  exec("$LIBEXECDIR/reppath $Repo ".escapeshellarg($Hash), $Path);
-  return($Path[0]);
 }

--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -275,6 +275,7 @@ class UploadController extends RestController
    */
   public function uploadDownload($request, $response, $args)
   {
+    require_once dirname(__DIR__, 4) . "/lib/php/common-repo.php";
     /** @var \ui_download $ui_download */
     $ui_download = $this->restHelper->getPlugin('download');
     $id = null;
@@ -282,15 +283,28 @@ class UploadController extends RestController
     if (isset($args['id'])) {
       $id = intval($args['id']);
       $this->uploadAccessible($id);
+      $this->isAdj2nestDone($id);
     }
     $dbManager = $this->restHelper->getDbHelper()->getDbManager();
     $uploadDao = $this->restHelper->getUploadDao();
     $uploadTreeTableName = $uploadDao->getUploadtreeTableName($id);
-    $itemTreeBounds = $uploadDao->getParentItemBounds($id,$uploadTreeTableName);
-    $sql =  "SELECT pfile_fk , ufile_name FROM uploadtree_a WHERE uploadtree_pk=$1";
+    $itemTreeBounds = $uploadDao->getParentItemBounds($id, $uploadTreeTableName);
+    if ($itemTreeBounds === false || empty($itemTreeBounds)) {
+      throw new HttpNotFoundException("Upload tree not found for upload id $id");
+    }
+
+    $sql = "SELECT pfile_fk, ufile_name FROM " . $uploadTreeTableName . " WHERE uploadtree_pk=$1";
     $params = array($itemTreeBounds->getItemId());
-    $descendants = $dbManager->getSingleRow($sql,$params);
-    $path= RepPath(($descendants['pfile_fk']));
+    $descendants = $dbManager->getSingleRow($sql, $params);
+    if ($descendants === false || empty($descendants['pfile_fk'])) {
+      throw new HttpNotFoundException("Upload file record not found");
+    }
+
+    $path = RepPath($descendants['pfile_fk']);
+    if (empty($path) || !is_file($path)) {
+      throw new HttpNotFoundException("Upload file is missing on server");
+    }
+
     $responseFile = $ui_download->getDownload($path, $descendants['ufile_name']);
     $responseContent = $responseFile->getFile();
     $newResponse = $response->withHeader('Content-Description',

--- a/src/www/ui_tests/api/Controllers/UploadControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadControllerTest.php
@@ -12,7 +12,24 @@
  * @brief Tests for UploadController
  */
 
-namespace Fossology\UI\Api\Test\Controllers;
+namespace {
+  if (!function_exists('TryToDelete')) {
+    function TryToDelete($uploadpk, $user_pk, $group_pk, $uploadDao)
+    {
+      return \Fossology\UI\Api\Test\Controllers\UploadControllerTest::$functions->TryToDelete($uploadpk, $user_pk,
+        $group_pk, $uploadDao);
+    }
+  }
+
+  if (!function_exists('RepPath')) {
+    function RepPath($PfilePk, $Repo = "files")
+    {
+      return \Fossology\UI\Api\Test\Controllers\UploadControllerTest::$functions->RepPath($PfilePk, $Repo);
+    }
+  }
+}
+
+namespace Fossology\UI\Api\Test\Controllers {
 
 use Fossology\Lib\Auth\Auth;
 use Fossology\Lib\BusinessRules\ReuseReportProcessor;
@@ -49,12 +66,6 @@ use Slim\Psr7\Factory\StreamFactory;
 use Slim\Psr7\Headers;
 use Slim\Psr7\Request;
 use Slim\Psr7\Uri;
-
-function TryToDelete($uploadpk, $user_pk, $group_pk, $uploadDao)
-{
-  return UploadControllerTest::$functions->TryToDelete($uploadpk, $user_pk,
-    $group_pk, $uploadDao);
-}
 
 /**
  * @class UploadControllerTest
@@ -2025,4 +2036,184 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     $this->assertEquals(500,$actualResponse->getStatusCode());
 
   }
+
+  /**
+   * @test
+   *   -# Test UploadController::uploadDownload() success
+   *   -# Check if response status is 200 with proper headers
+   */
+  public function testUploadDownloadSuccess()
+  {
+    $uploadId = 2;
+    $pfilePk = 123;
+    $ufileName = "test_package.tar.gz";
+    $filePath = __FILE__;
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([$uploadId, $this->groupId])->andReturn(true);
+    $this->uploadDao->shouldReceive('getParentItemBounds')
+      ->withArgs([$uploadId])->andReturn($this->getUploadBounds($uploadId));
+    $this->uploadDao->shouldReceive("getUploadtreeTableName")
+      ->withArgs([$uploadId])->andReturn("uploadtree_a");
+    $this->uploadDao->shouldReceive('getParentItemBounds')
+      ->withArgs([$uploadId, "uploadtree_a"])->andReturn($this->getUploadBounds($uploadId));
+
+    $itemId = $this->getUploadBounds($uploadId)->getItemId();
+    $sql = "SELECT pfile_fk, ufile_name FROM uploadtree_a WHERE uploadtree_pk=$1";
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs([$sql, [$itemId]])->andReturn(['pfile_fk' => $pfilePk, 'ufile_name' => $ufileName]);
+
+    self::$functions->shouldReceive('RepPath')
+      ->withArgs([$pfilePk, "files"])->andReturn($filePath);
+
+    $responseContent = M::mock();
+    $responseContent->shouldReceive('getMimeType')->andReturn('application/gzip');
+    $responseContent->shouldReceive('getPathname')->andReturn($filePath);
+
+    $headerBag = M::mock();
+    $headerBag->shouldReceive('get')
+      ->withArgs(['Content-Disposition'])->andReturn('attachment; filename="test_package.tar.gz"');
+
+    $responseFile = M::mock();
+    $responseFile->headers = $headerBag;
+    $responseFile->shouldReceive('getFile')->andReturn($responseContent);
+
+    $this->downloadPlugin->shouldReceive('getDownload')
+      ->withArgs([$filePath, $ufileName])->andReturn($responseFile);
+
+    $actualResponse = $this->uploadController->uploadDownload(null, new ResponseHelper(), ["id" => $uploadId]);
+
+    $this->assertEquals(200, $actualResponse->getStatusCode());
+    $this->assertEquals('application/gzip', $actualResponse->getHeaderLine('Content-Type'));
+    $this->assertEquals('attachment; filename="test_package.tar.gz"', $actualResponse->getHeaderLine('Content-Disposition'));
+  }
+
+  /**
+   * @test
+   *   -# Test UploadController::uploadDownload() with inaccessible upload
+   *   -# Check if HttpForbiddenException is thrown
+   */
+  public function testUploadDownloadInaccessible()
+  {
+    $uploadId = 3;
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([$uploadId, $this->groupId])->andReturn(false);
+
+    $this->expectException(HttpForbiddenException::class);
+    $this->uploadController->uploadDownload(null, new ResponseHelper(), ["id" => $uploadId]);
+  }
+
+  /**
+   * @test
+   *   -# Test UploadController::uploadDownload() when ununpack is not done
+   *   -# Check if HttpServiceUnavailableException is thrown
+   */
+  public function testUploadDownloadUnpackNotDone()
+  {
+    $uploadId = 5;
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([$uploadId, $this->groupId])->andReturn(true);
+    $this->uploadDao->shouldReceive('getParentItemBounds')
+      ->withArgs([$uploadId])->andReturn(false);
+
+    $this->expectException(HttpServiceUnavailableException::class);
+    $this->uploadController->uploadDownload(null, new ResponseHelper(), ["id" => $uploadId]);
+  }
+
+  /**
+   * @test
+   *   -# Test UploadController::uploadDownload() when upload tree is missing
+   *   -# Check if HttpNotFoundException is thrown
+   */
+  public function testUploadDownloadTreeNotFound()
+  {
+    $uploadId = 2;
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([$uploadId, $this->groupId])->andReturn(true);
+    $this->uploadDao->shouldReceive('getParentItemBounds')
+      ->withArgs([$uploadId])->andReturn($this->getUploadBounds($uploadId));
+    $this->uploadDao->shouldReceive("getUploadtreeTableName")
+      ->withArgs([$uploadId])->andReturn("uploadtree_a");
+    $this->uploadDao->shouldReceive('getParentItemBounds')
+      ->withArgs([$uploadId, "uploadtree_a"])->andReturn(false);
+
+    $this->expectException(HttpNotFoundException::class);
+    $this->uploadController->uploadDownload(null, new ResponseHelper(), ["id" => $uploadId]);
+  }
+
+  /**
+   * @test
+   *   -# Test UploadController::uploadDownload() when descendant record is not found in DB
+   *   -# Check if HttpNotFoundException is thrown
+   */
+  public function testUploadDownloadRecordNotFound()
+  {
+    $uploadId = 2;
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([$uploadId, $this->groupId])->andReturn(true);
+    $this->uploadDao->shouldReceive('getParentItemBounds')
+      ->withArgs([$uploadId])->andReturn($this->getUploadBounds($uploadId));
+    $this->uploadDao->shouldReceive("getUploadtreeTableName")
+      ->withArgs([$uploadId])->andReturn("uploadtree_a");
+    $this->uploadDao->shouldReceive('getParentItemBounds')
+      ->withArgs([$uploadId, "uploadtree_a"])->andReturn($this->getUploadBounds($uploadId));
+
+    $itemId = $this->getUploadBounds($uploadId)->getItemId();
+    $sql = "SELECT pfile_fk, ufile_name FROM uploadtree_a WHERE uploadtree_pk=$1";
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs([$sql, [$itemId]])->andReturn(false);
+
+    $this->expectException(HttpNotFoundException::class);
+    $this->uploadController->uploadDownload(null, new ResponseHelper(), ["id" => $uploadId]);
+  }
+
+  /**
+   * @test
+   *   -# Test UploadController::uploadDownload() when repository file is missing on server
+   *   -# Check if HttpNotFoundException is thrown
+   */
+  public function testUploadDownloadFileMissingOnDisk()
+  {
+    $uploadId = 2;
+    $pfilePk = 123;
+    $ufileName = "test_package.tar.gz";
+
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([$uploadId, $this->groupId])->andReturn(true);
+    $this->uploadDao->shouldReceive('getParentItemBounds')
+      ->withArgs([$uploadId])->andReturn($this->getUploadBounds($uploadId));
+    $this->uploadDao->shouldReceive("getUploadtreeTableName")
+      ->withArgs([$uploadId])->andReturn("uploadtree_a");
+    $this->uploadDao->shouldReceive('getParentItemBounds')
+      ->withArgs([$uploadId, "uploadtree_a"])->andReturn($this->getUploadBounds($uploadId));
+
+    $itemId = $this->getUploadBounds($uploadId)->getItemId();
+    $sql = "SELECT pfile_fk, ufile_name FROM uploadtree_a WHERE uploadtree_pk=$1";
+    $this->dbManager->shouldReceive('getSingleRow')
+      ->withArgs([$sql, [$itemId]])->andReturn(['pfile_fk' => $pfilePk, 'ufile_name' => $ufileName]);
+
+    self::$functions->shouldReceive('RepPath')
+      ->withArgs([$pfilePk, "files"])->andReturn("/nonexistent/file/path.tar.gz");
+
+    $this->expectException(HttpNotFoundException::class);
+    $this->uploadController->uploadDownload(null, new ResponseHelper(), ["id" => $uploadId]);
+  }
 }
+}
+


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors
     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Fixes hardcoded table name `uploadtree_a` in `UploadController::uploadDownload()` and adds defensive checks for unpack completion, item tree records, and physical file existence.

### Changes

- Updated `UploadController::uploadDownload()` to dynamically use `$uploadTreeTableName` in SQL query instead of hardcoding `uploadtree_a`.
- Added `$this->isAdj2nestDone($id)` to return `503 Service Unavailable` with `Retry-After` header if an upload is still unpacking.
- Added validation for `$itemTreeBounds`, `$descendants`, and repository file path (`is_file($path)`), returning `404 Not Found` when records or storage files are missing on server.
- Added comprehensive unit test cases in `UploadControllerTest.php` covering success, inaccessible upload, pending ununpack, missing tree bounds, missing DB record, and missing file on disk.

## How to test

1. Run unit test suite:
   ```bash
   vendor/bin/phpunit src/www/ui_tests/api/Controllers/UploadControllerTest.php
   ```
2. Make a `GET /api/v1/uploads/{id}/download` request against an upload on an instance using standard `uploadtree` tables; verify that the file binary is streamed with `200 OK`.
3. Request download for an in-progress upload; verify `503 Service Unavailable` with `Retry-After` header.

Closes #3781
