### PR TITLE
fix(api): enforce folder access check in unlinkFolder endpoint

### DIFF
--- a/src/www/ui/api/Controllers/FolderController.php
+++ b/src/www/ui/api/Controllers/FolderController.php
@@ -310,7 +310,11 @@ class FolderController extends RestController
       throw new HttpNotFoundException("Folder content id not found!");
     }
     /** @var FolderDao $folderDao */
-    $folderDao = $this->container->get('dao.folder');
+    $folderDao = $this->restHelper->getFolderDao();
+    $content = $folderDao->getContent($folderContentId);
+    if (! $folderDao->isFolderAccessible($content['parent_fk'], $this->restHelper->getUserId())) {
+      throw new HttpForbiddenException("Folder is not accessible!");
+    }
     if (!$folderDao->removeContent($folderContentId)) {
       throw new HttpBadRequestException("Content cannot be unlinked.");
     }

--- a/src/www/ui_tests/api/Controllers/FolderControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/FolderControllerTest.php
@@ -1168,6 +1168,100 @@ namespace Fossology\UI\Api\Test\Controllers
 
     /**
      * @test
+     * -# Test for FolderController::unlinkFolder() on accessible content
+     * -# Check if the statusCode is 200 and the content gets unlinked
+     */
+    public function testUnlinkFolder()
+    {
+      $contentId = 4;
+      $parentFolderId = 2;
+      $this->dbHelper->shouldReceive("doesIdExist")
+        ->withArgs(array("foldercontents", "foldercontents_pk", $contentId))
+        ->andReturn(true);
+      $this->folderDao->shouldReceive('getContent')
+        ->withArgs(array($contentId))
+        ->andReturn(["foldercontents_pk" => $contentId, "parent_fk" => $parentFolderId]);
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array($parentFolderId, $this->userId))->andReturn(true);
+      $this->folderDao->shouldReceive('removeContent')
+        ->withArgs(array($contentId))->andReturn(true);
+
+      $requestHeaders = new Headers();
+      $body = $this->streamFactory->createStream();
+      $request = new Request("PUT", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $body);
+      $actualResponse = $this->folderController->unlinkFolder($request,
+        new ResponseHelper(), ['contentId' => $contentId]);
+      $expectedResponse = new Info(200, "Folder unlinked successfully.",
+        InfoType::INFO);
+      $this->assertEquals($expectedResponse->getCode(),
+        $actualResponse->getStatusCode());
+      $this->assertEquals($expectedResponse->getArray(),
+        $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test for FolderController::unlinkFolder() on content owned by a
+     *    folder the current user cannot access
+     * -# Check if the HttpForbiddenException is thrown and the content is
+     *    never removed
+     */
+    public function testUnlinkFolderNotAccessible()
+    {
+      $contentId = 4;
+      $parentFolderId = 3;
+      $this->dbHelper->shouldReceive("doesIdExist")
+        ->withArgs(array("foldercontents", "foldercontents_pk", $contentId))
+        ->andReturn(true);
+      $this->folderDao->shouldReceive('getContent')
+        ->withArgs(array($contentId))
+        ->andReturn(["foldercontents_pk" => $contentId, "parent_fk" => $parentFolderId]);
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array($parentFolderId, $this->userId))->andReturn(false);
+      $this->folderDao->shouldNotReceive('removeContent');
+
+      $requestHeaders = new Headers();
+      $body = $this->streamFactory->createStream();
+      $request = new Request("PUT", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $body);
+      $this->expectException(HttpForbiddenException::class);
+      $this->folderController->unlinkFolder($request, new ResponseHelper(),
+        ['contentId' => $contentId]);
+    }
+
+    /**
+     * @test
+     * -# Test for FolderController::unlinkFolder() when the DAO refuses to
+     *    remove a non-removable (single-parent) content link
+     * -# Check if the HttpBadRequestException is thrown
+     */
+    public function testUnlinkFolderNotRemovable()
+    {
+      $contentId = 4;
+      $parentFolderId = 2;
+      $this->dbHelper->shouldReceive("doesIdExist")
+        ->withArgs(array("foldercontents", "foldercontents_pk", $contentId))
+        ->andReturn(true);
+      $this->folderDao->shouldReceive('getContent')
+        ->withArgs(array($contentId))
+        ->andReturn(["foldercontents_pk" => $contentId, "parent_fk" => $parentFolderId]);
+      $this->folderDao->shouldReceive('isFolderAccessible')
+        ->withArgs(array($parentFolderId, $this->userId))->andReturn(true);
+      $this->folderDao->shouldReceive('removeContent')
+        ->withArgs(array($contentId))->andReturn(false);
+
+      $requestHeaders = new Headers();
+      $body = $this->streamFactory->createStream();
+      $request = new Request("PUT", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $body);
+      $this->expectException(HttpBadRequestException::class);
+      $this->folderController->unlinkFolder($request, new ResponseHelper(),
+        ['contentId' => $contentId]);
+    }
+
+    /**
+     * @test
      * -# Test for invalid action on FolderController::getAllFolderContents()
      * -# Check if the statusCode is 200
      */


### PR DESCRIPTION
## Description

`unlinkFolder()` in `FolderController` was missing the folder accessibility check that every other write method in the same controller performs, letting any authenticated API user unlink folder content belonging to folders or groups they have no access to.

### Changes

* `FolderController::unlinkFolder()` now resolves the parent folder of the given `contentId` via `FolderDao::getContent()` and calls `isFolderAccessible()` before removing the link, throwing `HttpForbiddenException` (403) when the user can't access it. This is the same pattern already used by `editFolder`, `copyFolder` and `getUnlinkableFolderContents`.
* Switched from `$this->container->get('dao.folder')` to `$this->restHelper->getFolderDao()`, which is what every other method in this controller already uses to get the same `FolderDao` service, so the fix stays consistent with the rest of the file.
* Added three regression tests to `FolderControllerTest`: unlinking accessible content still succeeds, unlinking content whose parent folder is inaccessible now throws 403 (and `removeContent()` is never called), and the existing "not removable" 400 path still works with the new check in place.

## How to test

1. As UserA, create a folder, upload a file, and copy it into a second folder so the content link becomes removable (a `foldercontents` row with more than one parent).
2. As UserB, a different user with no access to UserA's folder, call `PUT /repo/api/v2/folders/contents/{contentId}/unlink` using UserB's own token.
3. Before this fix: the link is removed regardless of UserB's access. After this fix: the request returns 403 and the link is left untouched.

Ran the full `FolderControllerTest` suite (PHPUnit 10, PHP 8.1): 46/46 passing. Ran `phpcs --standard=fossy-ruleset.xml` on both changed files: no violations introduced by this change (pre-existing issues elsewhere in the file are untouched by this diff).

Fixes #3783
