### PR TITLE
fix(search): escape filename parameter to prevent SQL injection

### DIFF
--- a/src/lib/php/Dao/SearchHelperDao.php
+++ b/src/lib/php/Dao/SearchHelperDao.php
@@ -155,7 +155,7 @@ class SearchHelperDao
       if ($NeedAnd) {
         $SQLWhere .= " AND";
       }
-      $SQLWhere .= " ufile_name ilike '" . $Filename . "'";
+      $SQLWhere .= " ufile_name ilike '" . pg_escape_string($Filename) . "'";
       $NeedAnd = 1;
     }
 


### PR DESCRIPTION
## Description

Fix SQL injection in file search by escaping the `filename` parameter before interpolating it into the SQL query.

### Changes

* Escape `$Filename` using `pg_escape_string()` in `SearchHelperDao::GetResults()`.
* Keep the existing search behavior unchanged for normal filename patterns.
* Make filename handling consistent with the existing escaping of `$License` and `$Copyright`.
* Prevent SQL injection through the web UI and REST API search endpoints.

### How to test

1. Apply the change in `src/lib/php/Dao/SearchHelperDao.php`.
2. Search for a normal filename such as `%.php` and verify that the expected results are returned.
3. Search using a filename containing a single quote, such as `foo'bar`, and verify that the search completes without a SQL error.
4. Test the previously vulnerable input `foo' OR '1'='1`.
5. Verify that the input is treated as a literal filename search value rather than modifying the SQL query.
6. Run the relevant FOSSology search/API tests and confirm they pass.

Fixes #3786 