### PR TITLE
fix(api): check the target group in getGroupMembers, not just any group

### DIFF
--- a/src/www/ui/api/Controllers/GroupController.php
+++ b/src/www/ui/api/Controllers/GroupController.php
@@ -280,14 +280,20 @@ class GroupController extends RestController
     $apiVersion = ApiVersion::getVersion($request);
     $userId = $this->restHelper->getUserId();
     $userDao = $this->restHelper->getUserDao();
-    $groupMap = $userDao->getAdminGroupMap($userId, $_SESSION[Auth::USER_LEVEL]);
-
-    if (empty($groupMap)) {
-      throw new HttpForbiddenException("You have no permission to manage any group.");
-    }
 
     // Get the group name/id form the params and then the group Id
-    $groupId = $apiVersion == ApiVersion::V2 ? intval($this->restHelper->getUserDao()->getGroupIdByName($args['pathParam'])) : intval($args['pathParam']);
+    $groupId = $apiVersion == ApiVersion::V2 ? intval($userDao->getGroupIdByName($args['pathParam'])) : intval($args['pathParam']);
+
+    $userIsAdmin = Auth::isAdmin();
+    $userHasGroupAccess = $userDao->isAdvisorOrAdmin($userId, $groupId);
+
+    if (!$this->dbHelper->doesIdExist("groups", "group_pk", $groupId)) {
+      throw new HttpNotFoundException("Group id not found!");
+    }
+    if (! $userIsAdmin && ! $userHasGroupAccess) {
+      throw new HttpForbiddenException("Not advisor or admin of the group. " .
+        "Can not process request.");
+    }
 
     // The query to get the list of users with corresponding roles from the group.
     $dbManager = $this->dbHelper->getDbManager();

--- a/src/www/ui_tests/api/Controllers/GroupControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/GroupControllerTest.php
@@ -553,7 +553,6 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
   private function testGetGroupMembers($version = ApiVersion::V2)
   {
     $userIds = [2];
-    $groupName = 'fossy';
     $groupId = 1;
     $newuser = 3;
     $userPk = 2;
@@ -568,9 +567,11 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
       $this->restHelper->getUserDao()->shouldReceive('getUserByName')->withArgs([$userPk])->andReturn($userArray);
     }
     $request->shouldReceive('getAttribute')->andReturn($version);
-    $this->restHelper->getUserDao()->shouldReceive('getGroupIdByName')->withArgs([$groupName])->andReturn($groupId);
     $this->restHelper->shouldReceive('getUserId')->andReturn($userIds[0]);
-    $this->userDao->shouldReceive('getAdminGroupMap')->withArgs([$userIds[0],$_SESSION[Auth::USER_LEVEL]])->andReturn([1]);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
+    $this->userDao->shouldReceive('isAdvisorOrAdmin')
+      ->withArgs([$userIds[0], $groupId])->andReturn(true);
 
     $this->dbManager->shouldReceive('prepare')->withArgs([M::any(),M::any()]);
     $this->dbManager->shouldReceive('execute')->withArgs([M::any(),array($groupId)])->andReturn(1);
@@ -588,6 +589,105 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $actualResponse = $this->groupController->getGroupMembers($request, new ResponseHelper(), ['pathParam' => $groupId]);
     $this->assertEquals($expectedResponse->getStatusCode(),$actualResponse->getStatusCode());
   }
+
+  /**
+   * @test
+   * -# Test GroupController::getGroupMembers() when the caller administers
+   *    a different group but not the one being requested
+   * -# Check if HttpForbiddenException is thrown
+   */
+  public function testGetGroupMembersNotGroupAdminV1()
+  {
+    $groupId = 4;
+    $userId = 1;
+
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
+    $this->userDao->shouldReceive('isAdvisorOrAdmin')
+      ->withArgs([$userId, $groupId])->andReturn(false);
+
+    $requestHeaders = new Headers();
+    $request = new Request("GET", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $this->streamFactory->createStream());
+    $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, ApiVersion::V1);
+
+    $this->expectException(HttpForbiddenException::class);
+    $this->groupController->getGroupMembers($request, new ResponseHelper(),
+      ['pathParam' => $groupId]);
+  }
+
+  /**
+   * @test
+   * -# Test GroupController::getGroupMembers() for a group that does not exist
+   * -# Check if HttpNotFoundException is thrown
+   */
+  public function testGetGroupMembersGroupNotFoundV1()
+  {
+    $groupId = 999;
+    $userId = 1;
+
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["groups", "group_pk", $groupId])->andReturn(false);
+    $this->userDao->shouldReceive('isAdvisorOrAdmin')
+      ->withArgs([$userId, $groupId])->andReturn(false);
+
+    $requestHeaders = new Headers();
+    $request = new Request("GET", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $this->streamFactory->createStream());
+    $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, ApiVersion::V1);
+
+    $this->expectException(HttpNotFoundException::class);
+    $this->groupController->getGroupMembers($request, new ResponseHelper(),
+      ['pathParam' => $groupId]);
+  }
+
+  /**
+   * @test
+   * -# Test GroupController::getGroupMembers() for a global admin who is not
+   *    advisor or admin of the specific group being requested
+   * -# Check if the response status is 200
+   */
+  public function testGetGroupMembersGlobalAdminV1()
+  {
+    $userIds = [2];
+    $groupId = 1;
+    $callerId = 99;
+    $memberList = $this->getGroupMembers($userIds);
+
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
+    $this->restHelper->shouldReceive('getUserId')->andReturn($callerId);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
+    $this->userDao->shouldReceive('isAdvisorOrAdmin')
+      ->withArgs([$callerId, $groupId])->andReturn(false);
+
+    $this->dbManager->shouldReceive('prepare')->withArgs([M::any(),M::any()]);
+    $this->dbManager->shouldReceive('execute')->withArgs([M::any(),array($groupId)])->andReturn(1);
+    $this->dbManager->shouldReceive('fetchAll')->withArgs([1])->andReturn($this->getUsersWithGroup($userIds));
+    $this->dbManager->shouldReceive('freeResult')->withArgs([1]);
+
+    $user = $this->getUsersWithGroup($userIds)[0];
+    $users = [];
+    $users[] = new User($user["user_pk"], $user["user_name"], $user["user_desc"],
+      null, null, null, null, null);
+    $this->dbHelper->shouldReceive("getUsers")->withArgs([$user['user_pk']])->andReturn($users);
+
+    $requestHeaders = new Headers();
+    $request = new Request("GET", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $this->streamFactory->createStream());
+    $request = $request->withAttribute(ApiVersion::ATTRIBUTE_NAME, ApiVersion::V1);
+
+    $expectedResponse = (new ResponseHelper())->withJson($memberList, 200);
+    $actualResponse = $this->groupController->getGroupMembers($request,
+      new ResponseHelper(), ['pathParam' => $groupId]);
+    $this->assertEquals($expectedResponse->getStatusCode(),
+      $actualResponse->getStatusCode());
+  }
+
   /**
    * @test
    * -# Test GroupController::addMember() for version 1


### PR DESCRIPTION
## Description

`GroupController::getGroupMembers()` was authorizing against the wrong resource. It checked whether the caller administers some group in the system, but never checked whether the caller administers the specific group whose members were being requested through the URL path.

### Changes

* `getGroupMembers()` now resolves the target group first, confirms it exists (`HttpNotFoundException` if not, matching the other endpoints in this file), and then requires the caller to be a global admin or `isAdvisorOrAdmin()` of that specific group before returning its member list, throwing `HttpForbiddenException` otherwise. This is the exact same pattern already used by `deleteGroupMember`, `changeUserPermission` and `addMember` in the same controller.
* Removed the old `getAdminGroupMap()` based check, since it was only checking "does the caller administer anything" and every account administers its own personal group by default (`group_perm=ADMIN` is set at account creation), so it never actually blocked anyone.
* Updated the existing `testGetGroupMembers` test to mock the new checks instead of the removed one, and added three regression tests: a caller who administers a different group gets a 403 for the target group, a nonexistent group returns 404, and a global admin without a specific role on the target group can still see its members.

## How to test

1. As UserA, use any ordinary account, every account administers its own personal group by default.
2. As UserB, create a second group UserA has no membership or admin rights in.
3. As UserA, call `GET /repo/api/v2/groups/{UserB's group name}/members`.
4. Before this fix: the request succeeds and returns UserB's group membership and permission levels. After this fix: the request returns 403.

Ran the `GroupControllerTest` suite locally (PHPUnit 10, PHP 8.1): 34/34 passing. Ran `phpcs --standard=fossy-ruleset.xml` on both changed files: no violations introduced by this change.

Fixes #3790
