### PR TITLE
fix(uploadPermission): check the target upload id, not just list emptiness

### DIFF
--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -28,6 +28,7 @@
       <directory suffix="Test.php">lib/php</directory>
       <file>www/ui_tests/startUpTest.php</file>
       <file>www/ui_tests/Unit/AgentAdderTest.php</file>
+      <file>www/ui_tests/Unit/UploadPermissionPageTest.php</file>
       <directory suffix="Test.php">www/ui_tests/api</directory>
       <file>cli/tests/test_fo_copyright_list.php</file>
     </testsuite>

--- a/src/www/ui/page/UploadPermissionPage.php
+++ b/src/www/ui/page/UploadPermissionPage.php
@@ -176,8 +176,9 @@ class UploadPermissionPage extends DefaultPlugin
   {
     $fileName = false;
     foreach ($uploadList as $uploadEntry) {
-      if ($uploadEntry['upload_pk']) {
+      if ($uploadEntry['upload_pk'] == $uploadId) {
         $fileName = $uploadEntry['name'];
+        break;
       }
     }
     if (empty($fileName)) {

--- a/src/www/ui_tests/Unit/UploadPermissionPageTest.php
+++ b/src/www/ui_tests/Unit/UploadPermissionPageTest.php
@@ -1,0 +1,138 @@
+<?php
+/*
+ SPDX-FileCopyrightText: © 2026 Siemens AG
+
+ SPDX-License-Identifier: GPL-2.0-only
+*/
+
+use Fossology\Lib\Auth\Auth;
+use Fossology\Lib\Dao\UploadPermissionDao;
+use Fossology\Lib\Test\Reflectory;
+use Mockery as M;
+
+require_once(dirname(dirname(dirname(__DIR__))) . '/lib/php/Test/Reflectory.php');
+require_once(dirname(dirname(dirname(__DIR__))) . '/lib/php/Plugin/FO_Plugin.php');
+require_once(dirname(dirname(dirname(__DIR__))) . '/lib/php/common-plugin.php');
+require_once(dirname(dirname(dirname(__DIR__))) . '/lib/php/common-menu.php');
+
+/**
+ * @class UploadPermissionPageTest
+ * @brief Test for UploadPermissionPage::insertPermission(), covering the
+ *        broken upload membership check fix
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ *
+ * Regression coverage for: insertPermission() must confirm the target
+ * upload id is actually present in the caller's accessible upload list,
+ * not merely that the list is non-empty. Before the fix, the loop only
+ * checked truthiness of each entry's own upload_pk, so any non-empty
+ * but unrelated list let the caller change permissions on an arbitrary
+ * upload id they were never shown to have access to.
+ */
+class UploadPermissionPageTest extends \PHPUnit\Framework\TestCase
+{
+  /** @var int */
+  private $assertCountBefore;
+  /** @var UploadPermissionPage */
+  private $page;
+
+  protected function setUp(): void
+  {
+    if (!class_exists('UploadPermissionPage', false)) {
+      $GLOBALS['SysConf'] = [];
+      $GLOBALS['container'] = new class {
+        public function get($name)
+        {
+          return new \stdClass();
+        }
+      };
+      require_once(__DIR__ . '/../../ui/page/UploadPermissionPage.php');
+    }
+
+    $this->assertCountBefore = \Hamcrest\MatcherAssert::getCount();
+
+    global $MenuList, $Plugins;
+    $MenuList = array();
+    $Plugins = array();
+
+    // Bypass DefaultPlugin::__construct(): insertPermission() only needs
+    // uploadPermDao, which is injected directly in each test below.
+    $this->page = (new \ReflectionClass('UploadPermissionPage'))->newInstanceWithoutConstructor();
+  }
+
+  protected function tearDown(): void
+  {
+    $this->addToAssertionCount(\Hamcrest\MatcherAssert::getCount() - $this->assertCountBefore);
+    M::close();
+  }
+
+  private function accessibleUploadList()
+  {
+    return [
+      ['upload_pk' => 11, 'name' => 'owned-upload-a.zip'],
+      ['upload_pk' => 12, 'name' => 'owned-upload-b.zip'],
+    ];
+  }
+
+  /**
+   * @test
+   * -# Call insertPermission() for an upload id that is not present in
+   *    the caller's accessible upload list, only unrelated ids are.
+   * -# Check that it throws instead of granting the permission. This is
+   *    the exact scenario from the reported vulnerability, a non-empty
+   *    but unrelated list must not authorize an arbitrary upload id.
+   */
+  public function testRejectsUploadNotInAccessibleList()
+  {
+    $unrelatedUploadId = 999;
+
+    $uploadPermDao = M::mock(UploadPermissionDao::class);
+    $uploadPermDao->shouldNotReceive('insertPermission');
+    Reflectory::setObjectsProperty($this->page, 'uploadPermDao', $uploadPermDao);
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage('This upload is missing or inaccessible');
+
+    $this->page->insertPermission(4, $unrelatedUploadId, Auth::PERM_ADMIN,
+      $this->accessibleUploadList());
+  }
+
+  /**
+   * @test
+   * -# Call insertPermission() for an upload id that genuinely is one of
+   *    the entries in the accessible upload list.
+   * -# Check that the permission is granted for that exact upload id.
+   */
+  public function testGrantsPermissionForUploadInAccessibleList()
+  {
+    $groupId = 4;
+    $accessibleUploadId = 12;
+    $permission = Auth::PERM_WRITE;
+
+    $uploadPermDao = M::mock(UploadPermissionDao::class);
+    $uploadPermDao->shouldReceive('insertPermission')
+      ->withArgs([$accessibleUploadId, $groupId, $permission])->once();
+    Reflectory::setObjectsProperty($this->page, 'uploadPermDao', $uploadPermDao);
+
+    $this->page->insertPermission($groupId, $accessibleUploadId, $permission,
+      $this->accessibleUploadList());
+  }
+
+  /**
+   * @test
+   * -# Call insertPermission() with an empty accessible upload list.
+   * -# Check that it still throws, the pre-existing empty-list guard
+   *    must keep working after the fix.
+   */
+  public function testRejectsWhenAccessibleListIsEmpty()
+  {
+    $uploadPermDao = M::mock(UploadPermissionDao::class);
+    $uploadPermDao->shouldNotReceive('insertPermission');
+    Reflectory::setObjectsProperty($this->page, 'uploadPermDao', $uploadPermDao);
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage('This upload is missing or inaccessible');
+
+    $this->page->insertPermission(4, 12, Auth::PERM_ADMIN, []);
+  }
+}


### PR DESCRIPTION
## Description

`UploadPermissionPage::insertPermission()` was checking the wrong thing. It's supposed to confirm the upload id being granted a new permission is one of the uploads the caller has write access to, but the loop only checked whether each entry in that accessible list had a truthy upload_pk, never whether it matched the actual target upload id.

### Changes

* Fixed the loop in `insertPermission()` to compare `$uploadEntry['upload_pk']` against `$uploadId` instead of just checking truthiness, and added a `break` once the match is found. Now the exception is raised whenever the target upload id genuinely isn't present in the caller's accessible list, which is what the surrounding code was already trying to do.
* Added `UploadPermissionPageTest`, a new isolated unit test (following the same `newInstanceWithoutConstructor()` + `Reflectory` pattern already used by `AgentAdderTest` for this kind of legacy plugin class) covering three cases: a target id that is not in the accessible list is rejected and never reaches the DAO, a target id that is genuinely in the list is granted correctly, and the pre-existing empty-list guard still works. Registered the new file in `phpunit.xml` the same way `AgentAdderTest.php` is registered, since `www/ui_tests/Unit` isn't picked up as a directory glob.

## How to test

1. As UserA, upload a file into any folder UserA controls, so UserA's group has write access to at least one upload.
2. As UserB, upload a separate file and leave the default group permission at read-only for UserA's group (or mark it public).
3. As UserA, call `PUT /repo/api/v2/uploads/{UserB's upload id}/permissions` with `folderId` set to UserA's own folder from step 1, `groupId` set to UserA's group, and `newPermission` set to `"admin"`.
4. Before this fix: the call succeeds and UserA's group gets admin permission on UserB's upload. After this fix: it throws "This upload is missing or inaccessible" and no permission is granted.

I verified the new test actually catches the regression by temporarily reverting the fix and confirming `testRejectsUploadNotInAccessibleList` fails against the vulnerable code, then re-ran it green after restoring the fix.

Ran the full `www/ui_tests/api` controller suite plus the `Unit` tests (706 tests, PHPUnit 10, PHP 8.1) locally: all passing except two pre-existing, unrelated environment gaps (a missing `yaml` extension in `LicenseCompatibilityRuleControllerTest`, and a `ReportControllerTest` MIME-guessing test that only needed `fileinfo` enabled, which I did and confirmed green). Ran `phpcs --standard=fossy-ruleset.xml` on the changed and new files: no violations introduced.

Fixes #3792
