### PR TITLE
fix(home): escape error_description param to prevent reflected XSS

### DIFF
--- a/src/www/ui/page/HomePage.php
+++ b/src/www/ui/page/HomePage.php
@@ -74,7 +74,7 @@ class HomePage extends DefaultPlugin
       }
     }
     if (! empty(GetParm("error", PARM_TEXT))) {
-      $vars['message'] = GetParm("error_description", PARM_TEXT);
+      $vars['message'] = htmlspecialchars(GetParm("error_description", PARM_TEXT), ENT_QUOTES, 'UTF-8');
     }
 
     if ($email !== null) {


### PR DESCRIPTION
### Summary

`HomePage.php` reflected the raw `error_description` GET parameter into the Twig `message` variable without HTML escaping. Because Twig's `autoescape` is globally disabled in `services.xml.in`, the value reached the browser verbatim and executed as JavaScript.

### Impact

An attacker with no account can craft a URL and send it to any logged-in user. When the victim clicks it, the script runs in their browser and exposes their session cookies including the JWT bearer token and session ID to the attacker.

Tested on a live FOSSology instance: `alert(document.cookie)` successfully exposed a valid `Bearer` JWT token and `Login` session ID.

### Root cause

Two things combined to create the vulnerability:

1. `GetParm("error_description", PARM_TEXT)` returns raw input `PARM_TEXT`  only calls `stripslashes()`, no HTML encoding
2. `autoescape = false` globally in `services.xml.in` Twig never escapes output unless explicitly instructed to

### Change

Wrap with `htmlspecialchars()` at the point the value enters `vars['message']`:

```diff
- $vars['message'] = GetParm("error_description", PARM_TEXT);
+ $vars['message'] = htmlspecialchars(GetParm("error_description", PARM_TEXT), ENT_QUOTES, 'UTF-8');
```

Closes #3794