### PR TITLE
fix(api): pass authenticated user id to folder access checks and guard root folder lookup

### DIFF
--- a/src/lib/php/Dao/FolderDao.php
+++ b/src/lib/php/Dao/FolderDao.php
@@ -520,8 +520,11 @@ WHERE fc.parent_fk = $1 AND fc.foldercontents_mode = " . self::MODE_UPLOAD . ";"
     if ($userId == null) {
       $userId = Auth::getUserId();
     }
-    $rootFolder = $this->getRootFolder($userId)->getId();
-    return $this->isInFolderTree($rootFolder, $folderId);
+    $rootFolder = $this->getRootFolder($userId);
+    if (!$rootFolder) {
+      return false;
+    }
+    return $this->isInFolderTree($rootFolder->getId(), $folderId);
   }
 
   /**

--- a/src/lib/php/Dao/test/FolderDaoTest.php
+++ b/src/lib/php/Dao/test/FolderDaoTest.php
@@ -197,4 +197,12 @@ class FolderDaoTest extends \PHPUnit\Framework\TestCase
     $badFolder = $this->folderDao->getFolder(987);
     assertThat($badFolder, is(nullValue()));
   }
+
+  public function testIsFolderAccessible_nullRootFolderReturnsFalse()
+  {
+    $this->testDb->createPlainTables(array('users'));
+    $this->folderDao->ensureTopLevelFolder();
+    $isAccessible = $this->folderDao->isFolderAccessible(FolderDao::TOP_LEVEL, 99999);
+    assertThat($isAccessible, is(false));
+  }
 }

--- a/src/www/ui/api/Controllers/FolderController.php
+++ b/src/www/ui/api/Controllers/FolderController.php
@@ -50,7 +50,7 @@ class FolderController extends RestController
     $folderDao = $this->restHelper->getFolderDao();
     if (isset($args['id'])) {
       $id = intval($args['id']);
-      if (! $folderDao->isFolderAccessible($id)) {
+      if (! $folderDao->isFolderAccessible($id, $this->restHelper->getUserId())) {
         throw new HttpForbiddenException("Folder id $id is not accessible");
       }
       if ($folderDao->getFolder($id) === null) {

--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -493,7 +493,8 @@ class UploadController extends RestController
     if (!in_array($folderId, $allFolderIds)) {
       throw new HttpNotFoundException("folderId $folderId does not exists!");
     }
-    if (!$this->restHelper->getFolderDao()->isFolderAccessible($folderId)) {
+    if (!$this->restHelper->getFolderDao()->isFolderAccessible($folderId,
+        $this->restHelper->getUserId())) {
       throw new HttpForbiddenException("folderId $folderId is not accessible!");
     }
 

--- a/src/www/ui_tests/api/Controllers/FolderControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/FolderControllerTest.php
@@ -285,7 +285,7 @@ namespace Fossology\UI\Api\Test\Controllers
         ->andReturn($rootFolder);
       $this->folderDao->shouldReceive('getFolder')
         ->andReturnUsing([$this, 'getFolder']);
-      $this->folderDao->shouldReceive('isFolderAccessible')->withArgs([$folderId])->andReturn(false);
+      $this->folderDao->shouldReceive('isFolderAccessible')->withArgs([$folderId, $this->userId])->andReturn(false);
       $this->folderDao->shouldReceive('getFolderParentId')
         ->andReturnUsing([$this, 'getFolderParent']);
       $this->expectException(HttpForbiddenException::class);
@@ -304,7 +304,7 @@ namespace Fossology\UI\Api\Test\Controllers
     {
       $folderId = 3;
       $this->folderDao->shouldReceive('isFolderAccessible')
-        ->withArgs(array($folderId))->andReturn(true);
+        ->withArgs(array($folderId, $this->userId))->andReturn(true);
       $this->folderDao->shouldReceive('getFolder')
         ->andReturnUsing([$this, 'getFolder']);
       $this->folderDao->shouldReceive('getFolderParentId')
@@ -332,7 +332,7 @@ namespace Fossology\UI\Api\Test\Controllers
     {
       $folderId = -1;
       $this->folderDao->shouldReceive('isFolderAccessible')
-        ->withArgs(array($folderId))->andReturn(false);
+        ->withArgs(array($folderId, $this->userId))->andReturn(false);
       $this->folderDao->shouldReceive('getFolder')
         ->andReturnUsing([$this, 'getFolder']);
       $this->expectException(HttpForbiddenException::class);
@@ -351,7 +351,7 @@ namespace Fossology\UI\Api\Test\Controllers
     {
       $folderId = 3;
       $this->folderDao->shouldReceive('isFolderAccessible')
-        ->withArgs(array($folderId))->andReturn(false);
+        ->withArgs(array($folderId, $this->userId))->andReturn(false);
       $this->folderDao->shouldReceive('getFolder')
         ->andReturnUsing([$this, 'getFolder']);
       $this->expectException(HttpForbiddenException::class);

--- a/src/www/ui_tests/api/Controllers/UploadControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadControllerTest.php
@@ -807,7 +807,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
 
     $this->folderDao->shouldReceive('getAllFolderIds')->andReturn([2,3,4]);
     $this->folderDao->shouldReceive('isFolderAccessible')
-      ->withArgs([$folderId])->andReturn(true);
+      ->withArgs([$folderId, $this->userId])->andReturn(true);
 
     $expectedResponse = (new ResponseHelper())->withJson($info->getArray(),
       $info->getCode());
@@ -926,7 +926,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
 
     $this->folderDao->shouldReceive('getAllFolderIds')->andReturn([2,3,4]);
     $this->folderDao->shouldReceive('isFolderAccessible')
-      ->withArgs([$folderId])->andReturn(false);
+      ->withArgs([$folderId, $this->userId])->andReturn(false);
     $this->expectException(HttpForbiddenException::class);
 
     $this->uploadController->postUpload($request, new ResponseHelper(),
@@ -1085,7 +1085,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
 
     $this->folderDao->shouldReceive('getAllFolderIds')->andReturn([2,3,4]);
     $this->folderDao->shouldReceive('isFolderAccessible')
-      ->withArgs([$folderId])->andReturn(true);
+      ->withArgs([$folderId, $this->userId])->andReturn(true);
     $this->expectException(HttpInternalServerErrorException::class);
 
     $this->uploadController->postUpload($request, new ResponseHelper(), []);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

## Description

Enforce authenticated user context in `UploadController::postUpload()` and `FolderController::getFolders()` folder accessibility checks, and add a null-safety guard in `FolderDao::isFolderAccessible()`.

### Motivation

In the REST API, controller methods identify the caller via `$this->restHelper->getUserId()`. While almost all folder endpoints pass this user ID down to `FolderDao::isFolderAccessible($folderId, $userId)`, two locations omitted the argument:
1. `UploadController::postUpload()` at line 510
2. `FolderController::getFolders()` at line 53

When `$userId` is omitted, `FolderDao::isFolderAccessible()` falls back to `Auth::getUserId()`, which returns `0` for token-authenticated REST calls. This causes `$this->getRootFolder(0)` to return `null`, triggering a fatal `Call to a member function getId() on null` error (HTTP 500) instead of properly evaluating the authenticated user's permissions.

Passing `$this->restHelper->getUserId()` ensures permissions are evaluated strictly against the caller, and adding a null check in `FolderDao::isFolderAccessible()` prevents crashes when a user record has no associated root folder.

### Changes

- **`src/lib/php/Dao/FolderDao.php`**:
  - Added null check on `$this->getRootFolder($userId)` before accessing `->getId()`, returning `false` if `$rootFolder` is null.
- **`src/www/ui/api/Controllers/UploadController.php`**:
  - Passed `$this->restHelper->getUserId()` to `$this->restHelper->getFolderDao()->isFolderAccessible($folderId, $this->restHelper->getUserId())`.
- **`src/www/ui/api/Controllers/FolderController.php`**:
  - Passed `$this->restHelper->getUserId()` to `$folderDao->isFolderAccessible($id, $this->restHelper->getUserId())`.
- **`src/www/ui_tests/api/Controllers/UploadControllerTest.php`** & **`src/www/ui_tests/api/Controllers/FolderControllerTest.php`**:
  - Updated Mockery expectations for `isFolderAccessible` to include the user ID parameter across the affected test cases.
- **`src/lib/php/Dao/test/FolderDaoTest.php`**:
  - Added unit test `testIsFolderAccessible_nullRootFolderReturnsFalse` to verify that `isFolderAccessible()` returns `false` safely when no root folder exists.

## How to test

1. Run the unit test suites:
   ```bash
   phpunit -c src/www/ui_tests/phpunit.xml src/www/ui_tests/api/Controllers/UploadControllerTest.php
   phpunit -c src/www/ui_tests/phpunit.xml src/www/ui_tests/api/Controllers/FolderControllerTest.php
   phpunit -c src/lib/php/Dao/test/phpunit.xml src/lib/php/Dao/test/FolderDaoTest.php
   ```
2. Send a token-authenticated `POST /api/v1/uploads` request as a non-admin user targeting an inaccessible folder:
   ```bash
   curl -k -X POST http://localhost/repo/api/v1/uploads \
     -H "Authorization: Bearer <TOKEN>" \
     -H "folderId: <OTHER_USER_FOLDER_ID>" \
     -H "uploadType: url" \
     -H "Content-Type: application/json" \
     -d '{"location": {"url": "https://example.com/package.tar.gz"}}'
   ```
3. Confirm that the API returns HTTP 403 (`folderId <ID> is not accessible!`) rather than an HTTP 500 internal server error.

Fixes #3796
