### PR TITLE
fix(api): enforce upload accessibility check in JobController::getJobs

### DIFF
--- a/src/www/ui/api/Controllers/JobController.php
+++ b/src/www/ui/api/Controllers/JobController.php
@@ -121,7 +121,8 @@ class JobController extends RestController
     }
 
     if ($id !== null) {
-      /* If the ID is passed, don't check for upload */
+      /* If the ID is passed, ignore any upload query parameter and let
+       * getAllResults() authorize access to the job's own upload. */
       return $this->getAllResults($id, $status, $request, $response, $sort, $limit, $page, $apiVersion);
     }
 
@@ -271,10 +272,17 @@ class JobController extends RestController
    * @param integer $page    Page number required
    * @param integer $apiVersion API version
    * @return ResponseHelper
+   * @throws HttpErrorException If a specific job id is requested and its
+   *         upload does not exist or is not accessible to the caller
    */
   private function getAllResults($id, $status, $request, $response, $sort, $limit, $page, $apiVersion)
   {
     list($jobs, $count) = $this->dbHelper->getJobs($id, $status, $sort, $limit, $page, null);
+    if ($id !== null && !empty($jobs)) {
+      /* A specific job was requested, make sure the caller can access the
+       * upload it belongs to before returning any of its data. */
+      $this->uploadAccessible($jobs[0]->getUploadId());
+    }
     $finalJobs = [];
     foreach ($jobs as $job) {
       $this->updateEta($job);
@@ -301,14 +309,12 @@ class JobController extends RestController
    * @param integer $page Page number required
    * @param integer $apiVersion API version
    * @return ResponseHelper
-   * @throws HttpNotFoundException
+   * @throws HttpErrorException If the upload does not exist or is not
+   *         accessible to the caller
    */
   private function getFilteredResults($uploadId, $status, $request, $response, $sort, $limit, $page, $apiVersion)
   {
-    if (! $this->dbHelper->doesIdExist("upload", "upload_pk", $uploadId)) {
-      throw new HttpNotFoundException("Upload id " . $uploadId .
-        " doesn't exist");
-    }
+    $this->uploadAccessible($uploadId);
     list($jobs, $count) = $this->dbHelper->getJobs(null, $status, $sort, $limit, $page, $uploadId);
     $finalJobs = [];
     foreach ($jobs as $job) {

--- a/src/www/ui_tests/api/Controllers/JobControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/JobControllerTest.php
@@ -14,7 +14,9 @@ namespace Fossology\UI\Api\Test\Controllers;
 
 use Fossology\Lib\Dao\JobDao;
 use Fossology\Lib\Dao\ShowJobsDao;
+use Fossology\Lib\Dao\UploadDao;
 use Fossology\UI\Api\Controllers\JobController;
+use Fossology\UI\Api\Exceptions\HttpForbiddenException;
 use Fossology\UI\Api\Exceptions\HttpNotFoundException;
 use Fossology\UI\Api\Helper\ResponseHelper;
 use Fossology\UI\Api\Models\ApiVersion;
@@ -60,6 +62,18 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
   private $showJobsDao;
 
   /**
+   * @var UploadDao $uploadDao
+   * UploadDao mock
+   */
+  private $uploadDao;
+
+  /**
+   * @var integer $groupId
+   * Group id of the current user
+   */
+  private $groupId;
+
+  /**
    * @var JobController $jobController
    * JobController object to test
    */
@@ -89,10 +103,14 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
     $this->restHelper = M::mock(RestHelper::class);
     $this->jobDao = M::mock(JobDao::class);
     $this->showJobsDao = M::mock(ShowJobsDao::class);
+    $this->uploadDao = M::mock(UploadDao::class);
+    $this->groupId = 2;
 
     $this->restHelper->shouldReceive('getDbHelper')->andReturn($this->dbHelper);
     $this->restHelper->shouldReceive('getJobDao')->andReturn($this->jobDao);
     $this->restHelper->shouldReceive('getShowJobDao')->andReturn($this->showJobsDao);
+    $this->restHelper->shouldReceive('getUploadDao')->andReturn($this->uploadDao);
+    $this->restHelper->shouldReceive('getGroupId')->andReturn($this->groupId);
 
     $container->shouldReceive('get')->withArgs(array(
       'helper.restHelper'))->andReturn($this->restHelper);
@@ -265,6 +283,10 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
     ['text' => 'ReadMeOss', 'link' => 'http://localhost/repo/api/v1/report/16']);
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(["job", "job_pk", 12])->andReturn(true);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", 5])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([5, $this->groupId])->andReturn(true);
     $this->dbHelper->shouldReceive('getJobs')->withArgs(array(12, NULL, 'ASC', 0, 1, NULL))
       ->andReturn([[$job], 1]);
     $this->jobDao->shouldReceive('getChlidJobStatus')->withArgs(array(12))
@@ -294,6 +316,41 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
 
   /**
    * @test
+   * -# Test JobController::getJobs() with a single job id whose upload is
+   *    not accessible to the caller (regression test for #3798)
+   * -# Check if HttpForbiddenException is thrown and job data is never
+   *    returned
+   */
+  public function testGetJobFromIdNotAccessible()
+  {
+    $job = new Job(12, "job_two", "01-01-2020", 5, 2, 2, 0, "Completed");
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["job", "job_pk", 12])->andReturn(true);
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", 5])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([5, $this->groupId])->andReturn(false);
+    $this->dbHelper->shouldReceive('getJobs')->withArgs(array(12, NULL, 'ASC', 0, 1, NULL))
+      ->andReturn([[$job], 1]);
+
+    $requestHeaders = new Headers();
+    $body = $this->streamFactory->createStream();
+    $request = new Request("GET", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+    $response = new ResponseHelper();
+    $userId = 3;
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->expectException(HttpForbiddenException::class);
+
+    /* showJobsDao and the ajaxShowJobs plugin are deliberately left
+     * unmocked here: if getAllResults() ever proceeds past the upload
+     * accessibility check, building the job queue details would hit an
+     * unexpected Mockery call and fail the test for the wrong reason. */
+    $this->jobController->getJobs($request, $response, ["id" => 12]);
+  }
+
+  /**
+   * @test
    * -# Test JobController::getJobs() with single upload
    * -# Check if response is 200
    */
@@ -305,6 +362,8 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
     ['text' => 'ReadMeOss', 'link' => 'http://localhost/repo/api/v1/report/16']);
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(["upload", "upload_pk", 5])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([5, $this->groupId])->andReturn(true);
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(['job', 'job_pk', 12])->andReturn(true);
     $this->dbHelper->shouldReceive('getJobs')->withArgs(array(null, null, "ASC", 0, 1, 5))
@@ -332,6 +391,60 @@ class JobControllerTest extends \PHPUnit\Framework\TestCase
       $this->getResponseJson($actualResponse)[0]);
     $this->assertEquals('1',
       $actualResponse->getHeaderLine('X-Total-Pages'));
+  }
+
+  /**
+   * @test
+   * -# Test JobController::getJobs() with an upload query parameter the
+   *    caller cannot access (regression test for #3798)
+   * -# Check if HttpForbiddenException is thrown and no job list is
+   *    ever queried
+   */
+  public function testGetJobsFromUploadNotAccessible()
+  {
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", 5])->andReturn(true);
+    $this->uploadDao->shouldReceive('isAccessible')
+      ->withArgs([5, $this->groupId])->andReturn(false);
+    $this->dbHelper->shouldNotReceive('getJobs');
+
+    $requestHeaders = new Headers();
+    $body = $this->streamFactory->createStream();
+    $request = new Request("GET", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+    $request = $request->withQueryParams([JobController::UPLOAD_PARAM => 5]);
+    $response = new ResponseHelper();
+    $userId = 3;
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->expectException(HttpForbiddenException::class);
+
+    $this->jobController->getJobs($request, $response, []);
+  }
+
+  /**
+   * @test
+   * -# Test JobController::getJobs() with an upload query parameter for
+   *    an upload that does not exist
+   * -# Check if HttpNotFoundException is thrown and no job list is ever
+   *    queried
+   */
+  public function testGetJobsFromUploadNotFound()
+  {
+    $this->dbHelper->shouldReceive('doesIdExist')
+      ->withArgs(["upload", "upload_pk", 99])->andReturn(false);
+    $this->dbHelper->shouldNotReceive('getJobs');
+
+    $requestHeaders = new Headers();
+    $body = $this->streamFactory->createStream();
+    $request = new Request("GET", new Uri("HTTP", "localhost"),
+      $requestHeaders, [], [], $body);
+    $request = $request->withQueryParams([JobController::UPLOAD_PARAM => 99]);
+    $response = new ResponseHelper();
+    $userId = 3;
+    $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
+    $this->expectException(HttpNotFoundException::class);
+
+    $this->jobController->getJobs($request, $response, []);
   }
 
   /**


### PR DESCRIPTION
### Problem

`JobController::getJobs()` serves both `GET /jobs/{id}` and `GET /jobs?upload={id}`, but only checked that the job/upload row existed, never that the requesting user's group could actually access the upload it belongs to. Every method in `UploadController.php` that takes an upload id calls the shared `uploadAccessible()` helper before doing anything else, `getJobs()` was the one place handling a job/upload identifier that skipped it, so any authenticated API user could enumerate job ids (a small sequential integer) or pass an arbitrary `upload` query parameter and read job metadata for uploads and groups they have no relationship to at all: the owning user's name, the owning group's name, the upload id, job/agent type, status, timestamps, and jobqueue log/error text.

### Root cause

The `id` branch in `getJobs()` (line 118-126) resolved straight into `getAllResults()`, which never checked the returned job's upload against the caller's access. The `upload` branch (`getFilteredResults()`) only called `doesIdExist("upload", "upload_pk", $uploadId)`, an existence check, not `UploadDao::isAccessible()`. Note the report file itself stays protected, `ReportController::checkReport()` already resolves the job's `job_upload_fk` and calls `isAccessible()` before serving the report, so this was a metadata leak rather than a content leak, but a real one, it discloses the existence and internal state of other groups' uploads.

### Fix

Call the existing `RestController::uploadAccessible()` helper (already the standard pattern across `UploadController` and `ReportController::checkReport()`) in both places, `getAllResults()` after fetching the single job, checked against the upload id the job already carries (`$jobs[0]->getUploadId()`), no extra query needed, and `getFilteredResults()` before querying, replacing the existence-only check. There is no behavioural change for callers who already have access, and admin-facing `getAllJobs()` (id = null) is untouched since the new check is scoped to the single-job and upload-filter paths only.

### Testing

`JobControllerTest.php` was extended with three new regression tests covering a single job id whose upload the caller can't access (now 403), an `upload` filter for an upload the caller can't access (now 403, and the job list is never queried), and an `upload` filter for a non-existent upload (still 404). The two existing success-path tests (`testGetJobFromId`, `testGetJobsFromUpload`) were updated to mock the new accessibility check.

I ran `php vendor/bin/phpunit -c phpunit.xml --bootstrap phpunit-bootstrap.php www/ui_tests/api/Controllers/JobControllerTest.php`, 9/9 passing, and the broader `www/ui_tests/api/Controllers` directory (306 tests) to confirm no regressions elsewhere; the one pre-existing failure there (`LicenseCompatibilityRuleControllerTest::testExportRules`, missing `yaml` PHP extension in my test environment) is unrelated to this change and was already failing before it. `phpcs --standard=fossy-ruleset.xml` on both changed files reports no new violations, the two findings it does report (CRLF line endings, a class-brace style note) already exist on the unmodified file.

Fixes #3798
