### PR TITLE
fix(api): require write permission for clearing-decision write endpoints

### DIFF
--- a/src/www/ui/api/Controllers/RestController.php
+++ b/src/www/ui/api/Controllers/RestController.php
@@ -108,6 +108,26 @@ class RestController
   }
 
   /**
+   * Check if upload is accessible and writable by the current group.
+   *
+   * Read access (Auth::PERM_READ) alone is not enough to create or modify
+   * clearing decisions, license findings or scans on an upload; the calling
+   * group needs at least Auth::PERM_WRITE.
+   *
+   * @param integer $id Upload ID
+   * @throws HttpNotFoundException Upload not found
+   * @throws HttpForbiddenException Upload not accessible or read-only for the caller
+   */
+  protected function uploadEditable($id): void
+  {
+    $this->uploadAccessible($id);
+    if (! $this->restHelper->getUploadDao()->isEditable($id,
+        $this->restHelper->getGroupId())) {
+      throw new HttpForbiddenException("Upload is not editable");
+    }
+  }
+
+  /**
    * Check if upload tree is accessible
    *
    * @param int $uploadId

--- a/src/www/ui/api/Controllers/UploadTreeController.php
+++ b/src/www/ui/api/Controllers/UploadTreeController.php
@@ -130,7 +130,7 @@ class UploadTreeController extends RestController
   public function setClearingDecision($request, $response, $args)
   {
     $uploadId = intval($args['id']);
-    $this->uploadAccessible($uploadId);
+    $this->uploadEditable($uploadId);
 
     $body = $this->getParsedBody($request);
     $decisionType = $body['decisionType'];
@@ -617,7 +617,7 @@ class UploadTreeController extends RestController
     $errors = [];
     $success = [];
 
-    $this->uploadAccessible($uploadId);
+    $this->uploadEditable($uploadId);
     $this->isItemExists($uploadId, $uploadTreeId);
 
     if (empty($body)) {
@@ -735,7 +735,7 @@ class UploadTreeController extends RestController
     $uploadId = intval($args['id']);
     $licenseDao = $this->container->get('dao.license');
 
-    $this->uploadAccessible($uploadId);
+    $this->uploadEditable($uploadId);
     $this->isItemExists($uploadId, $uploadTreeId);
 
     $isValid = true;

--- a/src/www/ui_tests/api/Controllers/UploadTreeControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadTreeControllerTest.php
@@ -321,6 +321,8 @@ namespace Fossology\UI\Api\Test\Controllers {
       $this->uploadDao->shouldReceive("getUploadtreeTableName")->withArgs([$upload_pk])->andReturn("uploadtree");
       $this->uploadDao->shouldReceive('isAccessible')
         ->withArgs([$upload_pk, $this->groupId])->andReturn(true);
+      $this->uploadDao->shouldReceive('isEditable')
+        ->withArgs([$upload_pk, $this->groupId])->andReturn(true);
       $this->dbHelper->shouldReceive('doesIdExist')
         ->withArgs(["upload", "upload_pk", $upload_pk])->andReturn(true);
       $this->dbHelper->shouldReceive('doesIdExist')
@@ -369,6 +371,8 @@ namespace Fossology\UI\Api\Test\Controllers {
       $this->uploadDao->shouldReceive("getUploadtreeTableName")->withArgs([$upload_pk])->andReturn("uploadtree");
       $this->uploadDao->shouldReceive('isAccessible')
         ->withArgs([$upload_pk, $this->groupId])->andReturn(true);
+      $this->uploadDao->shouldReceive('isEditable')
+        ->withArgs([$upload_pk, $this->groupId])->andReturn(true);
       $this->dbHelper->shouldReceive('doesIdExist')
         ->withArgs(["upload", "upload_pk", $upload_pk])->andReturn(true);
       $this->dbHelper->shouldReceive('doesIdExist')
@@ -388,6 +392,45 @@ namespace Fossology\UI\Api\Test\Controllers {
       $this->uploadTreeController->setClearingDecision($request,
         new ResponseHelper(), ['id' => $upload_pk, 'itemId' => $item_pk]);
     }
+
+    /**
+     * @test
+     * -# Test for UploadTreeController::setClearingDecision() when the
+     *    caller's group only has read access to the upload
+     * -# Check that a HttpForbiddenException is thrown and no decision is
+     *    recorded
+     */
+    public function testSetClearingDecisionReturnsForbiddenForReadOnlyUpload()
+    {
+      $upload_pk = 1;
+      $item_pk = 200;
+      $rq = [
+        "decisionType" => 3,
+        "globalDecision" => false,
+      ];
+
+      $this->uploadDao->shouldReceive('isAccessible')
+        ->withArgs([$upload_pk, $this->groupId])->andReturn(true);
+      $this->uploadDao->shouldReceive('isEditable')
+        ->withArgs([$upload_pk, $this->groupId])->andReturn(false);
+      $this->dbHelper->shouldReceive('doesIdExist')
+        ->withArgs(["upload", "upload_pk", $upload_pk])->andReturn(true);
+
+      $this->viewLicensePlugin->shouldNotReceive('updateLastItem');
+
+      $reqBody = $this->streamFactory->createStream(json_encode(
+        $rq
+      ));
+      $requestHeaders = new Headers();
+      $requestHeaders->setHeader('Content-Type', 'application/json');
+      $request = new Request("PUT", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $reqBody);
+      $this->expectException(HttpForbiddenException::class);
+
+      $this->uploadTreeController->setClearingDecision($request,
+        new ResponseHelper(), ['id' => $upload_pk, 'itemId' => $item_pk]);
+    }
+
     /**
      * @test
      * -# Test for UploadTreeController::getNextPreviousItem()
@@ -838,6 +881,8 @@ namespace Fossology\UI\Api\Test\Controllers {
 
       $this->uploadDao->shouldReceive('isAccessible')
         ->withArgs([$uploadId, $this->groupId])->andReturn(true);
+      $this->uploadDao->shouldReceive('isEditable')
+        ->withArgs([$uploadId, $this->groupId])->andReturn(true);
       $this->dbHelper->shouldReceive('doesIdExist')
         ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
       $this->uploadDao->shouldReceive("getUploadtreeTableName")->withArgs([$uploadId])->andReturn("uploadtree");
@@ -896,6 +941,8 @@ namespace Fossology\UI\Api\Test\Controllers {
       $existingLicenses = array(['DT_RowId' => "$itemId,$licenseId", 'DT_RowClass' => 'removed']);
 
       $this->uploadDao->shouldReceive('isAccessible')
+        ->withArgs([$uploadId, $this->groupId])->andReturn(true);
+      $this->uploadDao->shouldReceive('isEditable')
         ->withArgs([$uploadId, $this->groupId])->andReturn(true);
       $this->dbHelper->shouldReceive('doesIdExist')
         ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
@@ -956,6 +1003,8 @@ namespace Fossology\UI\Api\Test\Controllers {
 
       $this->uploadDao->shouldReceive('isAccessible')
         ->withArgs([$uploadId, $this->groupId])->andReturn(true);
+      $this->uploadDao->shouldReceive('isEditable')
+        ->withArgs([$uploadId, $this->groupId])->andReturn(true);
       $this->dbHelper->shouldReceive('doesIdExist')
         ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
       $this->uploadDao->shouldReceive("getUploadtreeTableName")->withArgs([$uploadId])->andReturn("uploadtree");
@@ -987,6 +1036,47 @@ namespace Fossology\UI\Api\Test\Controllers {
         $actualResponse->getStatusCode());
       $this->assertEquals($this->getResponseJson($expectedResponse),
         $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test for UploadTreeController::handleAddEditAndDeleteLicenseDecision()
+     *    when the caller's group only has read access to the upload
+     * -# Check that a HttpForbiddenException is thrown and no clearing event
+     *    is written
+     */
+    public function testHandleAddEditAndDeleteLicenseDecisionReturnsForbiddenForReadOnlyUpload()
+    {
+      $uploadId = 1;
+      $itemId = 200;
+      $rq = [
+        array(
+          "shortName" => "MIT",
+          "add" => true
+        )
+      ];
+
+      $this->uploadDao->shouldReceive('isAccessible')
+        ->withArgs([$uploadId, $this->groupId])->andReturn(true);
+      $this->uploadDao->shouldReceive('isEditable')
+        ->withArgs([$uploadId, $this->groupId])->andReturn(false);
+      $this->dbHelper->shouldReceive('doesIdExist')
+        ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+
+      $this->clearingDao->shouldNotReceive('insertClearingEvent');
+      $this->clearingDao->shouldNotReceive('updateClearingEvent');
+
+      $reqBody = $this->streamFactory->createStream(json_encode(
+        $rq
+      ));
+      $requestHeaders = new Headers();
+      $requestHeaders->setHeader('Content-Type', 'application/json');
+      $request = new Request("PUT", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $reqBody);
+      $this->expectException(HttpForbiddenException::class);
+
+      $this->uploadTreeController->handleAddEditAndDeleteLicenseDecision($request,
+        new ResponseHelper(), ['id' => $uploadId, 'itemId' => $itemId]);
     }
 
     /**
@@ -1024,6 +1114,8 @@ namespace Fossology\UI\Api\Test\Controllers {
 
       $this->uploadDao->shouldReceive('isAccessible')
         ->withArgs([$uploadId, $this->groupId])->andReturn(true);
+      $this->uploadDao->shouldReceive('isEditable')
+        ->withArgs([$uploadId, $this->groupId])->andReturn(true);
       $this->dbHelper->shouldReceive('doesIdExist')
         ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
       $this->uploadDao->shouldReceive('getUploadtreeTableName')->withArgs([$uploadId])->andReturn("uploadtree");
@@ -1056,6 +1148,58 @@ namespace Fossology\UI\Api\Test\Controllers {
         $actualResponse->getStatusCode());
       $this->assertEquals($this->getResponseJson($expectedResponse),
         $this->getResponseJson($actualResponse));
+    }
+
+    /**
+     * @test
+     * -# Test for UploadTreeController::scheduleBulkScan() when the
+     *    caller's group only has read access to the upload
+     * -# Check that a HttpForbiddenException is thrown and no bulk scan is
+     *    scheduled
+     */
+    public function testScheduleBulkScanReturnsForbiddenForReadOnlyUpload()
+    {
+      $body = [
+        'bulkActions' => [
+          [
+            'licenseShortName' => 'MIT',
+            'licenseText' => '',
+            'acknowledgement' => '',
+            'comment' => '',
+            'licenseAction' => 'ADD'
+          ]
+        ],
+        'refText' => 'Copyright (c) 2011-2023 The Bootstrap Authors',
+        'bulkScope' => 'folder',
+        'forceDecision' => 0,
+        'ignoreIrre' => 0,
+        'delimiters' => 'DEFAULT',
+        'scanOnlyFindings' => 0
+      ];
+
+      $itemId = 1;
+      $uploadId = 1;
+
+      $this->uploadDao->shouldReceive('isAccessible')
+        ->withArgs([$uploadId, $this->groupId])->andReturn(true);
+      $this->uploadDao->shouldReceive('isEditable')
+        ->withArgs([$uploadId, $this->groupId])->andReturn(false);
+      $this->dbHelper->shouldReceive('doesIdExist')
+        ->withArgs(["upload", "upload_pk", $uploadId])->andReturn(true);
+
+      $this->changeLicenseBulk->shouldNotReceive('handle');
+
+      $reqBody = $this->streamFactory->createStream(json_encode(
+        $body
+      ));
+      $requestHeaders = new Headers();
+      $requestHeaders->setHeader('Content-Type', 'application/json');
+      $request = new Request("POST", new Uri("HTTP", "localhost"),
+        $requestHeaders, [], [], $reqBody);
+      $this->expectException(HttpForbiddenException::class);
+
+      $this->uploadTreeController->scheduleBulkScan($request,
+        new ResponseHelper(), ['id' => $uploadId, 'itemId' => $itemId]);
     }
   }
 }


### PR DESCRIPTION
## Description

UploadTreeController::setClearingDecision(), handleAddEditAndDeleteLicenseDecision() and scheduleBulkScan() only called uploadAccessible(), which is satisfied by Auth::PERM_READ alone (UploadPermissionDao::isAccessible() just checks perm > PERM_NONE). None of the three ever checked UploadDao::isEditable(), which requires Auth::PERM_WRITE.

read_only is a first class, admin assignable permission level, UploadController::setUploadPermissions() maps it straight to Auth::PERM_READ, so this is not a misconfiguration, it is normal upload sharing. A group with read only access could still create, edit and delete license clearing decisions and schedule bulk scans on that upload through the REST API. The legacy web UI gets this right, ClearingView::Output() computes $hasWritePermission = $this->uploadDao->isEditable(...) and hides the license editing controls (auditDenied) for a read only user, but updateLastItem(), the method the REST API calls directly, never re-checks that permission itself, and neither does ClearingDao::insertClearingEvent()/updateClearingEvent() underneath handleAddEditAndDeleteLicenseDecision().

## Root cause

Missing write permission check at the REST controller layer, the one place both the UI page and the DAO actually rely on to gate the write.

## Changes

* Added RestController::uploadEditable($id), which calls the existing uploadAccessible($id) (existence and read check) and then throws HttpForbiddenException unless UploadDao::isEditable($id, $groupId) (Auth::PERM_WRITE) is true.
* Replaced uploadAccessible($uploadId) with uploadEditable($uploadId) in the three write endpoints, setClearingDecision(), handleAddEditAndDeleteLicenseDecision(), scheduleBulkScan(). Every read only endpoint in the file (viewLicenseFile, getNextPreviousItem, getBulkHistory, getClearingHistory, getHighlightEntries, getTreeView, getLicenseDecisions) is untouched and still only requires read access, as it should.
* Updated the existing PHPUnit coverage for the three endpoints to mock isEditable() => true on the happy path, and added one regression test per endpoint asserting HttpForbiddenException (and that the DAO or plugin write call never happens) when isEditable() is false.

## How to test

1. As UserA (upload owner), upload a file and share it with GroupB as read_only via PUT /repo/api/v2/uploads/{uploadId}/permissions.
2. As UserB, a member of GroupB, open the upload's license view in the web UI and confirm the license editing controls are hidden.
3. As UserB, call PUT /repo/api/v2/uploads/{uploadId}/item/{itemId}/licenses with body [{"shortName":"MIT","add":true}].
   Before this fix: 200, a new clearing_event row is created.
   After this fix: 403 Forbidden, nothing is written.
4. Same before and after for PUT /repo/api/v2/uploads/{uploadId}/item/{itemId}/clearing-decision and POST /repo/api/v2/uploads/{uploadId}/item/{itemId}/bulk-scan.

I verified the new tests actually catch the regression by temporarily reverting the uploadEditable calls back to uploadAccessible and confirming all three ...ReturnsForbiddenForReadOnlyUpload tests fail against the vulnerable code, then re-ran green after restoring the fix.

Ran www/ui_tests/api/Controllers/UploadTreeControllerTest.php (PHPUnit 8.5, PHP 8.5), 20/20 passing, including the 3 new tests. Also ran FolderControllerTest, JobControllerTest and GroupControllerTest (other controllers sharing the RestController base) to confirm nothing else regressed, all passing. Ran phpcs with the fossy-ruleset.xml standard on the changed files, no violations introduced. Ran php -l on the changed files, no syntax errors.

Fixes #3801
