### PR TITLE
fix(api): manage group users fixed

### DIFF
--- a/src/www/ui/api/Controllers/GroupController.php
+++ b/src/www/ui/api/Controllers/GroupController.php
@@ -46,11 +46,19 @@ class GroupController extends RestController
   public function getGroups($request, $response, $args)
   {
     $userDao = $this->restHelper->getUserDao();
-    $groups = array();
-    if (Auth::isAdmin()) {
-      $groups = $userDao->getAdminGroupMap($this->restHelper->getUserId(),Auth::PERM_ADMIN);
+    $userId = $this->restHelper->getUserId();
+    $includeAll = filter_var(
+      $request->getQueryParams()['all'] ?? false,
+      FILTER_VALIDATE_BOOLEAN
+    );
+    if (Auth::isAdmin() && $includeAll) {
+      $adminGroups = $userDao->getAdminGroupMap(
+        $userId,
+        Auth::PERM_ADMIN
+      );
+      $groups = $adminGroups;
     } else {
-      $groups = $userDao->getUserGroupMap($this->restHelper->getUserId());
+      $groups = $userDao->getUserGroupMap($userId);
     }
     $groupList = array();
     foreach ($groups as $key => $value) {
@@ -213,19 +221,14 @@ class GroupController extends RestController
       $group_pk = intval($args['pathParam']);
     }
 
-    $userIsAdmin = Auth::isAdmin();
-    $userHasGroupAccess = $this->restHelper->getUserDao()->isAdvisorOrAdmin(
-      $this->restHelper->getUserId(), $group_pk);
-
     if (!$this->dbHelper->doesIdExist("groups", "group_pk", $group_pk)) {
       throw new HttpNotFoundException("Group id not found!");
     }
     if (!$this->dbHelper->doesIdExist("users", "user_pk", $user_pk)) {
       throw new HttpNotFoundException("User id not found!");
     }
-    if (! $userIsAdmin && ! $userHasGroupAccess) {
-      throw new HttpForbiddenException("Not advisor or admin of the group. " .
-        "Can not process request.");
+    if (!Auth::isAdmin()) {
+      throw new HttpForbiddenException("You have no permission to manage this group.");
     }
     $fetchResult = $dbManager->getSingleRow(
       "SELECT group_user_member_pk FROM group_user_member " .
@@ -278,21 +281,15 @@ class GroupController extends RestController
   public function getGroupMembers($request, $response, $args)
   {
     $apiVersion = ApiVersion::getVersion($request);
-    $userId = $this->restHelper->getUserId();
     $userDao = $this->restHelper->getUserDao();
-
     // Get the group name/id form the params and then the group Id
     $groupId = $apiVersion == ApiVersion::V2 ? intval($userDao->getGroupIdByName($args['pathParam'])) : intval($args['pathParam']);
-
-    $userIsAdmin = Auth::isAdmin();
-    $userHasGroupAccess = $userDao->isAdvisorOrAdmin($userId, $groupId);
 
     if (!$this->dbHelper->doesIdExist("groups", "group_pk", $groupId)) {
       throw new HttpNotFoundException("Group id not found!");
     }
-    if (! $userIsAdmin && ! $userHasGroupAccess) {
-      throw new HttpForbiddenException("Not advisor or admin of the group. " .
-        "Can not process request.");
+    if (!Auth::isAdmin()) {
+      throw new HttpForbiddenException("You have no permission to manage this group.");
     }
 
     // The query to get the list of users with corresponding roles from the group.
@@ -348,10 +345,6 @@ class GroupController extends RestController
     }
     $newperm = intval($body['perm']);
 
-    $userIsAdmin = Auth::isAdmin();
-    $userHasGroupAccess = $this->restHelper->getUserDao()->isAdvisorOrAdmin(
-      $this->restHelper->getUserId(), $group_pk);
-
     if (!isset($newperm)) {
       throw new HttpBadRequestException("ERROR - no default permission provided");
     }
@@ -364,9 +357,10 @@ class GroupController extends RestController
     if ($newperm < 0 || $newperm > 2) {
       throw new HttpBadRequestException("ERROR - Permission should be in range [0-2]");
     }
-    if (! $userIsAdmin && ! $userHasGroupAccess) {
-      throw new HttpForbiddenException("Not advisor or admin of the group. " .
-        "Can not process request.");
+    if (!Auth::isAdmin()) {
+      throw new HttpForbiddenException(
+        "You have no permission to manage this group."
+      );
     }
     $stmt = __METHOD__ . ".getByGroupAndUser";
     $sql = "SELECT group_user_member_pk FROM group_user_member WHERE group_fk=$1 AND user_fk=$2;";
@@ -415,9 +409,6 @@ class GroupController extends RestController
     }
 
     $newperm = intval($this->getParsedBody($request)['perm']);
-    $userIsAdmin = Auth::isAdmin();
-    $userHasGroupAccess = $this->restHelper->getUserDao()->isAdvisorOrAdmin(
-      $this->restHelper->getUserId(), $group_pk);
 
     // Validate arguments
 
@@ -436,9 +427,10 @@ class GroupController extends RestController
     if ($newperm > 2) {
       throw new HttpBadRequestException("Permission can not be greater than 2");
     }
-    if (! $userIsAdmin && ! $userHasGroupAccess) {
-      throw new HttpForbiddenException("Not advisor or admin of the group. " .
-        "Can not process request.");
+    if (!Auth::isAdmin()) {
+      throw new HttpForbiddenException(
+        "You have no permission to manage this group."
+      );
     }
 
     // Check if the relation already exists, retrieve the PK.

--- a/src/www/ui/api/Controllers/UserController.php
+++ b/src/www/ui/api/Controllers/UserController.php
@@ -226,7 +226,13 @@ class UserController extends RestController
     }
     $reqBody = $this->getParsedBody($request);
     $userHelper = new UserHelper($id);
-    $returnVal = $userHelper->modifyUserDetails($reqBody, $apiVersion);
+    try {
+      $returnVal = $userHelper->modifyUserDetails($reqBody, $apiVersion);
+    } catch (\Throwable $exception) {
+      throw new HttpInternalServerErrorException(
+        "Unable to update user: " . $exception->getMessage()
+      );
+    }
     return $response->withJson($returnVal->getArray(), $returnVal->getCode());
   }
 

--- a/src/www/ui/api/Helper/UserHelper.php
+++ b/src/www/ui/api/Helper/UserHelper.php
@@ -88,12 +88,16 @@ class UserHelper
     $symfonyRequest->request->set('user_pk', $userDetails['id'] ?? $this->user_pk);
     $symfonyRequest->request->set('user_name', $userDetails['name'] ?? $user['user_name']);
     $symfonyRequest->request->set('root_folder_fk', $userDetails['rootFolderId'] ?? $user['root_folder_fk']);
-    $symfonyRequest->request->set('default_group_fk', $userDetails['defaultGroup'] ?? $user['group_fk']);
+    $defaultGroup = $userDetails['defaultGroup'] ?? null;
+    $symfonyRequest->request->set(
+      'default_group_fk',
+      !empty($defaultGroup) ? $defaultGroup : $user['group_fk']
+    );
     $symfonyRequest->request->set('public', $userDetails['defaultVisibility'] ?? $user['upload_visibility']);
     $symfonyRequest->request->set('default_folder_fk', $userDetails['defaultFolderId'] ?? $user['default_folder_fk']);
     $symfonyRequest->request->set('user_desc', $userDetails['description'] ?? $user['user_desc']);
-    $symfonyRequest->request->set('_pass1', $userDetails[$version == ApiVersion::V2 ? 'userPass' : 'user_pass'] ?? null);
-    $symfonyRequest->request->set('_pass2', $userDetails[$version == ApiVersion::V2 ? 'userPass' : 'user_pass'] ?? null);
+    $symfonyRequest->request->set('_pass1', $userDetails[$version == ApiVersion::V2 ? 'userPass' : 'user_pass'] ?? "");
+    $symfonyRequest->request->set('_pass2', $userDetails[$version == ApiVersion::V2 ? 'userPass' : 'user_pass'] ?? "");
     $symfonyRequest->request->set('_blank_pass', $userDetails['_blank_pass'] ?? "");
     $symfonyRequest->request->set('user_status', $userDetails['user_status'] ?? $user['user_status']);
     $symfonyRequest->request->set('user_email', $userDetails['email'] ?? $user['user_email']);

--- a/src/www/ui_tests/api/Controllers/GroupControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/GroupControllerTest.php
@@ -561,7 +561,7 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $groupIds = [1,2,3,4,5,6];
     $userArray = ['user_pk' => $newuser];
 
-    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
     if ($version == ApiVersion::V2) {
       $this->restHelper->getUserDao()->shouldReceive('getGroupIdByName')->withArgs([$groupIds[0]])->andReturn($groupIds[0]);
       $this->restHelper->getUserDao()->shouldReceive('getUserByName')->withArgs([$userPk])->andReturn($userArray);
@@ -570,8 +570,6 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $this->restHelper->shouldReceive('getUserId')->andReturn($userIds[0]);
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
-    $this->userDao->shouldReceive('isAdvisorOrAdmin')
-      ->withArgs([$userIds[0], $groupId])->andReturn(true);
 
     $this->dbManager->shouldReceive('prepare')->withArgs([M::any(),M::any()]);
     $this->dbManager->shouldReceive('execute')->withArgs([M::any(),array($groupId)])->andReturn(1);
@@ -605,8 +603,6 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
-    $this->userDao->shouldReceive('isAdvisorOrAdmin')
-      ->withArgs([$userId, $groupId])->andReturn(false);
 
     $requestHeaders = new Headers();
     $request = new Request("GET", new Uri("HTTP", "localhost"),
@@ -632,8 +628,6 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(["groups", "group_pk", $groupId])->andReturn(false);
-    $this->userDao->shouldReceive('isAdvisorOrAdmin')
-      ->withArgs([$userId, $groupId])->andReturn(false);
 
     $requestHeaders = new Headers();
     $request = new Request("GET", new Uri("HTTP", "localhost"),
@@ -662,8 +656,6 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $this->restHelper->shouldReceive('getUserId')->andReturn($callerId);
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
-    $this->userDao->shouldReceive('isAdvisorOrAdmin')
-      ->withArgs([$callerId, $groupId])->andReturn(false);
 
     $this->dbManager->shouldReceive('prepare')->withArgs([M::any(),M::any()]);
     $this->dbManager->shouldReceive('execute')->withArgs([M::any(),array($groupId)])->andReturn(1);
@@ -735,7 +727,6 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $this->dbHelper->shouldReceive('doesIdExist')->withArgs(["users","user_pk",$newuser])->andReturn(true);
     $this->dbManager->shouldReceive('getSingleRow')->withArgs([M::any(),M::any(),M::any()])->andReturn($emptyArr);
     $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
-    $this->userDao->shouldReceive('isAdvisorOrAdmin')->withArgs([$userId, $groupId])->andReturn(true);
 
     $this->dbManager->shouldReceive('prepare')->withArgs([M::any(),M::any()]);
     $this->dbManager->shouldReceive('execute')->withArgs([M::any(),array($groupId, $newuser,$newPerm)])->andReturn(1);
@@ -796,7 +787,6 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $this->dbHelper->shouldReceive('doesIdExist')->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
     $this->dbHelper->shouldReceive('doesIdExist')->withArgs(["users","user_pk",$newuser])->andReturn(true);
     $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
-    $this->userDao->shouldReceive('isAdvisorOrAdmin')->withArgs([$userId, $groupId])->andReturn(false);
 
     $body = $this->streamFactory->createStream(json_encode([
       "perm" => $newPerm
@@ -842,7 +832,7 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $userArray = ['user_pk' => $newuser];
     $userId = 1;
 
-    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_WRITE;
+    $_SESSION[Auth::USER_LEVEL] = Auth::PERM_ADMIN;
     if ($version == ApiVersion::V2) {
       $this->restHelper->getUserDao()->shouldReceive('getGroupIdByName')->withArgs([$groupIds[0]])->andReturn($groupId);
       $this->restHelper->getUserDao()->shouldReceive('getUserByName')->withArgs([$userId])->andReturn($userArray);
@@ -851,7 +841,6 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $this->dbHelper->shouldReceive('doesIdExist')->withArgs(["users","user_pk",$newuser])->andReturn(true);
     $this->dbManager->shouldReceive('getSingleRow')->withArgs([M::any(),M::any(),M::any()])->andReturn($emptyArr);
     $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
-    $this->userDao->shouldReceive('isAdvisorOrAdmin')->withArgs([$userId, $groupId])->andReturn(true);
 
     $this->dbManager->shouldReceive('prepare')->withArgs([M::any(),M::any()]);
     $this->dbManager->shouldReceive('execute')->withArgs([M::any(),array($groupId, $newuser,$newPerm)])->andReturn(1);
@@ -976,7 +965,6 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
     $this->dbHelper->shouldReceive('doesIdExist')->withArgs(["users","user_pk",$userPk])->andReturn(true);
     $this->dbManager->shouldReceive('getSingleRow')->withArgs([M::any(),M::any(),M::any()])->andReturn(['group_pk'=>$groupIds[0],'group_user_member_pk'=>$group_user_member_pk,'permission'=>$newPerm]);
     $this->restHelper->shouldReceive('getUserId')->andReturn($userId);
-    $this->userDao->shouldReceive('isAdvisorOrAdmin')->withArgs([$userPk, $groupIds[0]])->andReturn(true);
     $this->userDao->shouldReceive('getUserByName')->withArgs([M::any(),M::any()]);
 
     $this->adminPlugin->shouldReceive('updateGUMPermission')->withArgs([$group_user_member_pk,$newPerm, $this->dbManager ]);
@@ -1038,7 +1026,6 @@ class GroupControllerTest extends \PHPUnit\Framework\TestCase
       ->withArgs(["groups", "group_pk", $groupId])->andReturn(true);
     $this->dbHelper->shouldReceive('doesIdExist')
       ->withArgs(["users", "user_pk", $userId])->andReturn(true);
-    $this->userDao->shouldReceive('isAdvisorOrAdmin')->andReturn(true);
     $this->dbManager->shouldReceive('getSingleRow')->withArgs([M::any(), M::any(), M::any()])
       ->andReturn(['group_user_member_pk' => $groupMemberPk]);
     $this->adminPlugin->shouldReceive('updateGUMPermission')


### PR DESCRIPTION
## Description

Fix group-level authorization for upload management so that Advisors and Admins of a group can manage upload assignees and update upload status, while keeping group-user management restricted to server administrators.

### Changes

- Updated upload authorization to allow group Admins and Advisors to manage uploads within their group.
- Ensured that upload assignee changes are available to authorized group Admins and Advisors.
- Ensured that upload status changes (Rejected option) are available to authorized group Admins and Advisors.
- Kept upload management restricted to users who are members of the selected group with the required group-level role.
- Restricted group-user management operations to server administrators.
- Updated group member handling to correctly resolve the group ID for API requests.
- Updated user editing to correctly handle the default group when assigning or updating a user.
- Added error handling for failures while updating user details.

### Testing

- Verified that group Admins can change upload assignee within their group.
- Verified that group Advisors can change upload assignee within their group.
- Verified that group Admins can update upload status(rejected) within their group.
- Verified that group Advisors can update upload status(rejected) within their group.
- Verified that users who are not Admins or Advisors of the selected group cannot manage uploads.
- Verified that server administrators can retrieve group members.
- Verified that server administrators can add, update, and remove group members.
- Verified that default group assignment is correctly handled when editing a user.
- Verified that API group member requests resolve the correct group.