### PR TITLE
 fix(api): enhance upload management and handle JSON content type parameters

### DIFF
--- a/src/www/ui/api/Controllers/RestController.php
+++ b/src/www/ui/api/Controllers/RestController.php
@@ -131,7 +131,11 @@ class RestController
    */
   public function isJsonRequest($request)
   {
-    return strcasecmp($request->getHeaderLine('Content-Type'),
-        "application/json") === 0;
+    $contentType = $request->getHeaderLine('Content-Type');
+
+    return str_contains(
+      strtolower($contentType),
+      "application/json"
+    );
   }
 }

--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -724,6 +724,17 @@ class UploadController extends RestController
       }
       $uploadBrowseProxy->setStatusAndComment($id, $status, $comment);
     }
+    if (
+      $isJsonRequest &&
+      $status === null &&
+      array_key_exists("comment", $bodyContent)
+    ) {
+      $uploadBrowseProxy->setStatusAndComment(
+        $id,
+        $uploadBrowseProxy->getStatus($id),
+        $bodyContent["comment"]
+      );
+    }
     // Handle update of name
     if (
       $isJsonRequest &&

--- a/src/www/ui/api/Helper/DbHelper.php
+++ b/src/www/ui/api/Helper/DbHelper.php
@@ -165,7 +165,7 @@ class DbHelper
     $params[] = ($page - 1) * $limit;
 
     $sql = "SELECT
-upload.upload_pk, upload.upload_desc, upload.upload_ts, upload.upload_filename, upload_clearing.assignee
+upload.upload_pk, upload.upload_desc, upload.upload_ts, upload.upload_filename, upload_clearing.assignee, upload_clearing.status_fk, upload_clearing.status_comment
 FROM $partialQuery $where ORDER BY upload_pk ASC LIMIT $limit OFFSET $" .
       count($params) . ";";
     $results = $this->dbManager->getRows($sql, $params, $statementGet);
@@ -193,7 +193,7 @@ FROM $partialQuery $where ORDER BY upload_pk ASC LIMIT $limit OFFSET $" .
 
       $hash = new Hash($pfile_sha1, $pfile_md5, $pfile_sha256, $pfile_size);
       $upload = new Upload($folderId, $folderName, $uploadId,
-        $row["upload_desc"], $row["upload_filename"], $row["upload_ts"], $row["assignee"], $hash);
+        $row["upload_desc"], $row["upload_filename"], $row["upload_ts"], $row["assignee"], $row["status_fk"], $hash, $row["status_comment"]);
       if (! empty($row["assignee"]) && $row["assignee"] != 1) {
         $upload->setAssigneeDate($this->uploadDao->getAssigneeDate($uploadId));
       }

--- a/src/www/ui/api/Models/Upload.php
+++ b/src/www/ui/api/Models/Upload.php
@@ -51,6 +51,11 @@ class Upload
    */
   private $assignee;
   /**
+   * @var integer $status
+   * Upload clearing status
+   */
+  private $status;
+  /**
    * @var string $assigneeDate
    * Date when a user was assigned to the upload.
    */
@@ -60,6 +65,8 @@ class Upload
    * Date when the upload was closed or rejected.
    */
   private $closingDate;
+  /** @var string|null */
+  private $comment;
   /**
    * @var Hash $hash
    * Hash information of the upload
@@ -74,10 +81,12 @@ class Upload
    * @param string $description
    * @param string $uploadName
    * @param string $uploadDate
+   * @param integer $assignee
+   * @param integer $status
    * @param Hash $hash
    */
   public function __construct($folderId, $folderName, $uploadId, $description,
-    $uploadName, $uploadDate, $assignee, $hash)
+    $uploadName, $uploadDate, $assignee, $status, $hash, $comment = null)
   {
     $this->folderId = intval($folderId);
     $this->folderName = $folderName;
@@ -86,8 +95,10 @@ class Upload
     $this->uploadName = $uploadName;
     $this->uploadDate = $uploadDate;
     $this->assignee = $assignee == 1 ? null : intval($assignee);
+    $this->status = intval($status);
     $this->assigneeDate = null;
     $this->closingDate = null;
+    $this->comment = $comment;
     $this->hash = $hash;
   }
 
@@ -108,16 +119,18 @@ class Upload
   {
     if ($version==ApiVersion::V2) {
       return [
-        "folderId"    => $this->folderId,
-        "folderName"  => $this->folderName,
-        "id"          => $this->uploadId,
-        "description" => $this->description,
-        "uploadName"  => $this->uploadName,
-        "uploadDate"  => $this->uploadDate,
-        "assignee"    => $this->assignee,
+        "folderId"     => $this->folderId,
+        "folderName"   => $this->folderName,
+        "id"           => $this->uploadId,
+        "description"  => $this->description,
+        "uploadName"   => $this->uploadName,
+        "uploadDate"   => $this->uploadDate,
+        "assignee"     => $this->assignee,
         "assigneeDate" => $this->assigneeDate,
-        "closingDate" => $this->closingDate,
-        "hash"        => $this->hash->getArray()
+        "closingDate"  => $this->closingDate,
+        "comment"      => $this->comment,
+        "status"       => $this->statusToString($this->status),
+        "hash"         => $this->hash->getArray()
       ];
     } else {
       return [
@@ -132,6 +145,28 @@ class Upload
         "closingDate" => $this->closingDate,
         "hash"        => $this->hash->getArray()
       ];
+    }
+  }
+
+  /**
+   * Convert internal clearing status to API string.
+   *
+   * @param int $status Upload clearing status
+   * @return string
+   */
+  private static function statusToString($status)
+  {
+    switch ($status) {
+      case \Fossology\Lib\Data\UploadStatus::OPEN:
+        return "Open";
+      case \Fossology\Lib\Data\UploadStatus::IN_PROGRESS:
+        return "InProgress";
+      case \Fossology\Lib\Data\UploadStatus::CLOSED:
+        return "Closed";
+      case \Fossology\Lib\Data\UploadStatus::REJECTED:
+        return "Rejected";
+      default:
+        return "NA";
     }
   }
 

--- a/src/www/ui_tests/api/Controllers/UploadControllerTest.php
+++ b/src/www/ui_tests/api/Controllers/UploadControllerTest.php
@@ -279,6 +279,8 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     $folderId = 2;
     $folderName = "SR";
     $fileSize = 0;
+    $assignee = null;
+    $status = UploadStatus::OPEN;
     switch ($id) {
       case 2:
         $uploadName = "top$id";
@@ -300,7 +302,7 @@ class UploadControllerTest extends \PHPUnit\Framework\TestCase
     }
     $hash = new Hash('sha1checksum', 'md5checksum', 'sha256checksum', $fileSize);
     return new Upload($folderId, $folderName, $id, $description,
-      $uploadName, $uploadDate, null, $hash);
+      $uploadName, $uploadDate, $assignee, $status, $hash);
   }
 
   /**

--- a/src/www/ui_tests/api/Models/SearchResultTest.php
+++ b/src/www/ui_tests/api/Models/SearchResultTest.php
@@ -15,6 +15,7 @@ namespace Fossology\UI\Api\Test\Models;
 use Fossology\UI\Api\Models\Upload;
 use Fossology\UI\Api\Models\SearchResult;
 use Fossology\UI\Api\Models\Hash;
+use Fossology\Lib\Data\UploadStatus;
 
 use PHPUnit\Framework\TestCase;
 
@@ -35,7 +36,7 @@ class SearchResultTest extends TestCase
   {
     $hash = new Hash('sha1checksum', 'md5checksum', 'sha256checksum', 123123);
     $upload = new Upload(2, 'root', 3, '', 'my.tar.gz', '01-01-2020', null,
-      $hash);
+      UploadStatus::OPEN, $hash);
     $searchResult = new SearchResult($upload->getArray(), '12',
     'fileinupload.txt');
     $this->assertInstanceOf(SearchResult::class, $searchResult);
@@ -49,7 +50,7 @@ class SearchResultTest extends TestCase
   {
     $hash = new Hash('sha1checksum', 'md5checksum', 'sha256checksum', 123123);
     $upload = new Upload(2, 'root', 3, '', 'my.tar.gz', '01-01-2020', null,
-      $hash);
+      UploadStatus::OPEN, $hash);
     $expectedResult = [
       'upload'        => $upload->getArray(),
       'uploadTreeId'  => 12,

--- a/src/www/ui_tests/api/Models/UploadTest.php
+++ b/src/www/ui_tests/api/Models/UploadTest.php
@@ -15,6 +15,7 @@ namespace Fossology\UI\Api\Test\Models;
 use Fossology\UI\Api\Models\Hash;
 use Fossology\UI\Api\Models\Upload;
 use Fossology\UI\Api\Models\ApiVersion;
+use Fossology\Lib\Data\UploadStatus;
 
 use \PHPUnit\Framework\TestCase;
 
@@ -37,7 +38,7 @@ class UploadTest extends TestCase
   {
     $hash = new Hash('sha1checksum', 'md5checksum', 'sha256checksum', 123123);
     $upload = new Upload(2, 'root', 3, '', 'my.tar.gz', '01-01-2020', 3,
-    $hash);
+      UploadStatus::OPEN, $hash);
     $this->assertInstanceOf(Upload::class, $upload);
   }
 
@@ -89,12 +90,14 @@ class UploadTest extends TestCase
         "assignee"    => 3,
         "assigneeDate" => '01-01-2020',
         "closingDate" => '01-01-2020',
-        "hash"        => $hash->getArray()
+        "hash"        => $hash->getArray(),
+        "comment"     => null,
+        "status"      => 'Open'
       ];
     }
 
     $actualUpload = new Upload(2, 'root', 3, '', 'my.tar.gz', '01-01-2020', 3,
-      $hash);
+      UploadStatus::OPEN, $hash);
     $actualUpload->setAssigneeDate("01-01-2020");
     $actualUpload->setClosingDate("01-01-2020");
 


### PR DESCRIPTION
## Description

Enhance upload management APIs to allow authorized users to manage upload assignees, update upload status and comments, and correctly process JSON requests used for upload comment updates.

### Changes

- Added upload clearing status and status comment to the upload database query.
- Updated the `Upload` model to store and expose upload status and comments.
- Added conversion of internal upload clearing status values to API-friendly status strings.
- Included upload clearing status and comments in API v2 upload responses.
- Added support for updating an upload comment through a JSON request without changing the existing upload status.
- Updated `RestController::isJsonRequest()` to correctly recognize JSON content types that include additional parameters such as `charset`.
- Updated upload construction and related tests to support the new status and comment fields.
- Updated upload-related tests to reflect the new `Upload` model parameters.

### Testing

- Verified that upload responses include the clearing status.
- Verified that upload responses include the upload comment.
- Verified that upload clearing status values are correctly converted to their API representations.
- Verified that upload assignee information continues to be returned correctly.
- Verified that upload comments can be updated through JSON requests.
- Verified that JSON requests with content-type parameters are correctly recognized.
- Updated and verified the affected upload and search result tests.