### PR TITLE
chore(doc): defining AI agents policy and best practices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,112 @@
+<!-- SPDX-FileCopyrightText: © Fossology contributors
+     SPDX-FileCopyrightText: © Kaushlendra Pratap Singh <kaushlendra-pratap.singh@siemens.com>
+
+     SPDX-License-Identifier: GPL-2.0-only
+-->
+# FOSSology AI Agent Guide
+
+This file is the entry point for AI-assisted work in the FOSSology repository.
+It exists to keep changes targeted, safe, and consistent with the existing
+project structure.
+
+## Read First
+
+Before changing code, read the project-level documentation that already exists:
+
+- [README.md](README.md) for project scope, installation, and support links.
+- [CONTRIBUTING.md](CONTRIBUTING.md) for coding, commit, PR, and DCO rules.
+- The module-specific AGENTS.md file in the relevant `src/<module>/` directory.
+
+If the needed context is still missing after those files, inspect the local
+module README, CMake files, and the surrounding code before guessing.
+
+## Core Rules For AI Contributors
+
+- Stay inside the requested scope. If the task is about one endpoint, one
+  agent, or one UI flow, do not make unrelated edits elsewhere.
+- Keep diffs small and logical. One functional change per pull request is the
+  default unless the user explicitly asks for a larger refactor.
+- Do not mix formatting, cleanup, or dependency changes with behavior changes
+  unless they are directly needed for the task.
+- Preserve existing behavior unless the task explicitly asks to change it.
+- Prefer the simplest implementation that fits the existing codebase.
+- If there is a feature implementation, Try and understand the flavour and process followed 
+  for other similar functions/features. 
+- Update tests and docs when behavior changes. If tests are not practical,
+  explain the gap clearly.
+- Do not rename files, symbols, or public interfaces unless the task requires
+  it.
+- Do not move code between modules just to "improve" structure.
+- If a change touches generated code, verify whether the generator or source of
+  truth should be updated instead of editing generated output directly.
+- Understand the core-logic of how a specific feature/function is implemented in the project,
+  then only do an actual implementation.
+- DO NOT WRITE MADE UP LOGIC, first reason if the 
+
+## Additional Best Practices
+
+- Start with the most specific context available: the module README, the local
+  `AGENTS.md`, nearby code, and any existing tests for that module.
+- Prefer an existing implementation pattern in the same area instead of
+  inventing a new one.
+- Keep behavior changes and cleanup separate unless the cleanup is required to
+  make the behavioral fix correct.
+- When code paths are generated, schema-backed, or install-time sensitive,
+  verify the source of truth before editing outputs.
+- Treat public interfaces, data formats, and database queries as compatibility
+  boundaries unless the task explicitly changes them.
+- When in doubt about scope, stop and confirm rather than broadening the patch.
+- If behavior changes, update or add tests in the same module whenever that is
+  practical.
+- Preserve SPDX headers, copyright notices, and other repository-specific
+  metadata in files that expect them.
+- Keep refactors small and local; do not cascade a feature change into an
+  unrelated cleanup across other agents or UI paths.
+
+## Open Source Contribution Expectations
+
+FOSSology follows the contribution rules described in [CONTRIBUTING.md](CONTRIBUTING.md).
+AI contributors should respect the same standards:
+
+- Make the smallest reasonable change that solves the problem.
+- Keep the change focused. If `/getUser` needs a bug fix, do not add styling
+  fixes or unrelated cleanup in another endpoint.
+- Use the existing coding style and conventions for the touched area.
+- Keep commits, pull requests, and review notes logically grouped.
+- Add or preserve SPDX and copyright headers where the project expects them.
+- Keep changes compatible with the project license and DCO workflow.
+- Prefer evidence from existing docs, tests, and nearby code over assumptions.
+
+## Repository Shape
+
+The main implementation lives under [src/](src). Each agent directory usually
+contains some mix of:
+
+- `agent/` for the executable source code.
+- `ui/` for PHP or Twig UI integration.
+- `agent_tests/` or `ui_tests/` for tests when present.
+- `<agent>.conf` for module configuration defaults.
+- `CMakeLists.txt` for build and install wiring.
+
+When editing an agent, first read the local module README and local AGENTS file
+if one exists.
+
+## Agent Guide Index
+
+- [src/nomos/AGENTS.md](src/nomos/AGENTS.md)
+- [src/maintagent/AGENTS.md](src/maintagent/AGENTS.md)
+- [src/scanoss/AGENTS.md](src/scanoss/AGENTS.md)
+- [src/monk/AGENTS.md](src/monk/AGENTS.md)
+- [src/ununpack/AGENTS.md](src/ununpack/AGENTS.md)
+- [src/adj2nest/AGENTS.md](src/adj2nest/AGENTS.md)
+
+More module-level guides should be added over time using the same pattern.
+
+## When Context Is Missing
+
+If the docs do not answer a required detail, do this before editing:
+
+1. Inspect the relevant CMake file, module README, and nearby source files.
+2. Look for existing tests or examples in the same module.
+3. Prefer asking for clarification over guessing when the risk is high.
+4. Leave a short note in the PR description or final response if a gap remains.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,12 @@ See [Contact Us](https://www.fossology.org/about/contact/)
 
 ## Contributing
 
-We really like contributions in several forms, see [CONTRIBUTING.md](CONTRIBUTING.md)
+We really like contributions in several forms, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+For AI-assisted development, FOSSology also provides an [AGENTS.md](AGENTS.md)
+guide at the repository root, with module-specific AGENTS.md files under
+`src/<module>/`. These files summarize the local architecture, expectations,
+and safety rules that help AI agents make smaller, more targeted changes.
 
 ## Licensing
 

--- a/src/adj2nest/AGENTS.md
+++ b/src/adj2nest/AGENTS.md
@@ -1,0 +1,55 @@
+<!-- SPDX-FileCopyrightText: © Fossology contributors
+     SPDX-FileCopyrightText: © Kaushlendra Pratap Singh <kaushlendra-pratap.singh@siemens.com>
+
+     SPDX-License-Identifier: GPL-2.0-only
+-->
+# Adj2nest Agent Guide
+
+## Purpose
+
+Adj2nest converts adjacency-list upload tree data into nested-set form and
+updates user permissions for upload records. It exists as a small but critical
+database-oriented utility in the FOSSology workflow.
+
+## Module Layout
+
+- `agent/` contains the C implementation.
+- `ui/` contains the PHP integration.
+- `adj2nest.conf` stores the installed module configuration.
+- `agent/adj2nest.c` is the main executable entry point.
+- There is no module-local `README.md` yet, so the CMake file and source code
+are the primary sources of truth for this module.
+
+## Build And Packaging Notes
+
+- The module is wired from [src/adj2nest/CMakeLists.txt](CMakeLists.txt).
+- The build produces a single `adj2nest` executable and installs it into the
+  agent directory for the module.
+- The target links against the FOSSology shared libraries and uses `-fPIC` and
+  C99-oriented compile settings.
+
+## Key Technical Details
+
+- Language: C.
+- The main source file is `agent/adj2nest.c`.
+- The algorithm builds a tree in memory, walks it depth-first, and writes left
+  and right nested-set values back to the database.
+- The module is intentionally database-heavy and relies on consistent tree
+  ordering and update sequencing.
+
+## Expectations For Changes
+
+- Keep changes focused on the tree-building, traversal, or update path that is
+  actually being modified.
+- Do not mix SQL shape changes, traversal logic changes, and UI changes unless
+  the task explicitly requires all of them.
+- Validate any tree-order or parent/child assumption before changing it.
+- If you add tests, target the database behavior or traversal edge case you are
+  changing.
+
+## Common Gotchas
+
+- The module assumes nested-set numbering starts at 1 and uses strict ordering.
+- Parent discovery and sibling chaining are sensitive to update order.
+- A small traversal bug can produce incorrect permission or upload tree state,
+  so changes should be reviewed conservatively.

--- a/src/maintagent/AGENTS.md
+++ b/src/maintagent/AGENTS.md
@@ -1,0 +1,52 @@
+<!-- SPDX-FileCopyrightText: © Fossology contributors
+     SPDX-FileCopyrightText: © Kaushlendra Pratap Singh <kaushlendra-pratap.singh@siemens.com>
+
+     SPDX-License-Identifier: GPL-2.0-only
+-->
+# Maintagent Guide
+
+## Purpose
+
+Maintagent performs database and repository maintenance tasks such as vacuum,
+analyze, reindex, removing orphaned records, cleaning logs, and deleting
+expired tokens.
+
+## Module Layout
+
+- `agent/` contains the executable source.
+- `ui/` contains the PHP integration.
+- `maintagent.conf` stores module configuration defaults.
+- The local README captures the operational behavior and safety notes.
+
+## Build And Packaging Notes
+
+- The module is wired from [src/maintagent/CMakeLists.txt](CMakeLists.txt).
+- The only installed executable is the `maintagent` target from `agent/`.
+- The build links against the FOSSology shared libraries and PostgreSQL client
+  headers/libraries.
+
+## Key Technical Details
+
+- Language: C.
+- Main source files: `maintagent.c`, `process.c`, `utils.c`, and `usage.c`.
+- The implementation uses database-heavy workflows and can perform destructive
+  operations on repository data.
+- Some operations use temporary tables and multi-step SQL flows instead of a
+  single query.
+
+## Expectations For Changes
+
+- Treat this module as high risk. Even a small logic change can delete or
+  modify data.
+- Keep changes surgical and validate them against the intended SQL path.
+- Do not mix maintenance behavior changes with unrelated refactors.
+- Add or update tests only when they materially improve coverage for the
+  change being made.
+
+## Safety Notes
+
+- Review every delete or update path carefully before changing it.
+- Be especially cautious with orphan removal, cleanup jobs, reindexing, and
+  any flow that touches uploads, logs, or tokens.
+- If a task affects performance or locking, call that out explicitly because
+  maintenance workloads often run on live data.

--- a/src/monk/AGENTS.md
+++ b/src/monk/AGENTS.md
@@ -1,0 +1,61 @@
+<!-- SPDX-FileCopyrightText: © Fossology contributors
+     SPDX-FileCopyrightText: © Kaushlendra Pratap Singh <kaushlendra-pratap.singh@siemens.com>
+
+     SPDX-License-Identifier: GPL-2.0-only
+-->
+# Monk Agent Guide
+
+## Purpose
+
+Monk is the FOSSology license comparison agent. It loads the license database,
+builds the matching structures used by the scanner, and supports CLI, scheduler,
+and offline knowledgebase flows. The module also ships related executables for
+bulk scanning and Kotoba integrations.
+
+## Module Layout
+
+- `agent/` contains the C implementation and shared support code.
+- `agent/generator/` contains the inputs used to generate matching helpers.
+- `agent_tests/Unit/` contains C unit tests for the agent internals.
+- `agent_tests/Functional/` contains CLI and scheduler-style tests.
+- `ui/` contains PHP entry points for Monk, Monk bulk, and Kotoba.
+- `monk.conf`, `monkbulk.conf`, and `kotoba.conf` define the installed module
+  variants.
+
+## Build And Packaging Notes
+
+- The module is wired from [src/monk/CMakeLists.txt](CMakeLists.txt).
+- The build generates a helper source file from `agent/generator/` before
+  compiling the agent executables.
+- The installed binaries are `monk`, `monkbulk`, and `kotoba`, each with its
+  own install path and configuration file.
+
+## Key Technical Details
+
+- Language: C for the agent and PHP for the UI integration.
+- Main source files: `agent/monk.c`, `agent/monkbulk.c`, `agent/kotoba.c`,
+  `agent/scheduler.c`, `agent/database.c`, and related helpers.
+- The agent uses a generated visitor and shared matching state, so changes to
+  comparison logic should preserve the data flow between CLI, scheduler, and
+  offline modes.
+- Database access and matching logic are tightly coupled; keep changes focused
+  on the specific matching or serialization behavior being changed.
+
+## Expectations For Changes
+
+- Keep changes scoped to the intended comparison rule, scheduler path, or UI
+  flow.
+- Do not mix generator changes, matching algorithm changes, and UI updates in
+  the same patch unless the task explicitly requires all three.
+- Update unit tests and functional tests when behavior changes.
+- If you touch the generated visitor pipeline, verify whether the generator
+  input or generated file is the correct source of truth.
+
+## Common Gotchas
+
+- The module has multiple binaries that share implementation files but differ
+  in install targets and runtime behavior.
+- Offline knowledgebase mode and scheduler mode have different initialization
+  paths.
+- The generator output is part of the build sequence, so rebuild after changing
+  generator inputs.

--- a/src/nomos/AGENTS.md
+++ b/src/nomos/AGENTS.md
@@ -1,0 +1,59 @@
+<!-- SPDX-FileCopyrightText: © Fossology contributors
+     SPDX-FileCopyrightText: © Kaushlendra Pratap Singh <kaushlendra-pratap.singh@siemens.com>
+
+     SPDX-License-Identifier: GPL-2.0-only
+-->
+# Nomos Agent Guide
+
+## Purpose
+
+Nomos is the FOSSology license scanner agent. It uses regular expressions,
+heuristics, and generated signature data to detect licenses in source files.
+The upstream module README describes the end-user behavior in more detail.
+
+## Module Layout
+
+This module is organized as follows:
+
+- `agent/` contains the C source for the executable and supporting helpers.
+- `agent/encode.c` and `agent/generator/` build generated signature data.
+- `agent_tests/` contains unit and functional tests.
+- `ui/` contains the PHP integration used by the web UI.
+- `nomos.conf` stores the module configuration shipped with the install.
+
+## Build And Packaging Notes
+
+- The module is wired from [src/nomos/CMakeLists.txt](CMakeLists.txt).
+- The main installed executable comes from the `nomos_exec` target and is
+  installed as `nomos`.
+- The build also creates `nomossa` for standalone use and coverage variants
+  for testing.
+- The build generates `_autodata.c`, `_autodefs.h`, and `_precheck.c` from the
+  signature generator pipeline. Prefer updating generator inputs such as
+  `agent/generator/STRINGS.in` instead of editing generated output directly.
+
+## Key Technical Details
+
+- Language: C.
+- Runtime dependencies: GLib, PostgreSQL client libraries, `json-c`, pthread,
+  and the FOSSology shared libraries.
+- Core source files live in `agent/nomos.c`, `parse.c`, `process.c`,
+  `licenses.c`, `nomos_regex.c`, `nomos_utils.c`, and related helpers.
+- The scanning logic is stateful and data-driven, so changes to heuristics or
+  generated tables should be kept narrow and tested carefully.
+
+## Expectations For Changes
+
+- Keep detection changes scoped to the intended rule, phrase, or behavior.
+- Do not change signature generation, parsing, and output formatting in the
+  same change unless the task explicitly needs all of them.
+- Add or update tests under `agent_tests/` when changing detection behavior.
+- If you touch the generator, re-check whether the produced artifacts are
+  meant to be committed or regenerated in the build only.
+
+## Common Gotchas
+
+- Changes to `STRINGS.in` or parser logic affect future scans, not already
+  stored results.
+- The module has both scheduler-backed and standalone execution paths.
+- Generated code depends on the build order, so rebuild after changing inputs.

--- a/src/ununpack/AGENTS.md
+++ b/src/ununpack/AGENTS.md
@@ -1,0 +1,58 @@
+<!-- SPDX-FileCopyrightText: © Fossology contributors
+     SPDX-FileCopyrightText: © Kaushlendra Pratap Singh <kaushlendra-pratap.singh@siemens.com>
+
+     SPDX-License-Identifier: GPL-2.0-only
+-->
+# Ununpack Agent Guide
+
+## Purpose
+
+Ununpack is the universal unpacker. It extracts archives and package formats,
+traverses nested content, and feeds unpacked artifacts back into FOSSology.
+The module also includes a standalone path for limited execution scenarios.
+
+## Module Layout
+
+- `agent/` contains the C implementation and unpack helpers.
+- `agent/README` documents the supported archive and filesystem handling.
+- `agent_tests/Unit/` contains unit tests for helpers and traversal logic.
+- `agent_tests/Functional/` contains functional tests for CLI and agent flows.
+- `ui/` contains the PHP integration.
+- `ununpack.conf` and `mod_deps` define the installed module configuration and
+  dependencies.
+
+## Build And Packaging Notes
+
+- The module is wired from [src/ununpack/CMakeLists.txt](CMakeLists.txt).
+- The build creates `ununpack`, `departition`, coverage variants, and
+  standalone targets.
+- The build links against `gcrypt`, `magic`, and the FOSSology shared libraries
+  depending on the target.
+
+## Key Technical Details
+
+- Language: C.
+- Main source files: `agent/ununpack.c`, `agent/traverse.c`,
+  `agent/departition.c`, `agent/utils.c`, and the format-specific helpers.
+- The module is traversal-heavy and stateful, with recursion and repository
+  upload handling intertwined with archive detection.
+- Several formats are handled by dedicated helpers, so changes should stay
+  focused on one unpack path at a time.
+
+## Expectations For Changes
+
+- Keep archive-handling changes tightly scoped to the target format or flow.
+- Do not combine repository handling, recursion policy, and format support
+  changes unless the task requires all of them.
+- Update unit or functional tests when the unpack or traversal behavior
+  changes.
+- If adding format support or altering detection, verify the helper selection
+  logic and any install-time assumptions.
+
+## Common Gotchas
+
+- This agent has both scheduler-backed and standalone execution paths.
+- Recursion, pruning, and repository writing affect extraction safety and can
+  change disk usage significantly.
+- The supported format matrix is wide, so regressions can hide in format-specific
+  helpers rather than the top-level CLI.


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: © Fossology contributors

     SPDX-License-Identifier: GPL-2.0-only
-->

<!-- Please refer to CONTRIBUTING.md (https://github.com/fossology/fossology/blob/master/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add AI contributor guidance for FOSSology through a root `AGENTS.md` file, module-specific AGENTS docs for the main agents, and a README note so contributors can discover the AI workflow from the project landing page.

### Changes

- `AGENTS.md`: added the repository-wide AI contributor guide, best-practice rules, and an index of module-specific guides.
- `src/nomos/AGENTS.md`: added agent-specific context for the Nomos scanner, its generated data flow, and change expectations.
- `src/maintagent/AGENTS.md`: added guidance for the maintenance agent, with emphasis on SQL safety and data-changing operations.
- `src/monk/AGENTS.md`: added module guidance for Monk, including generated visitor data, CLI/scheduler flows, and related binaries.
- `src/ununpack/AGENTS.md`: added guidance for the unpacker, including traversal behavior, supported formats, and standalone/runtime paths.
- `src/adj2nest/AGENTS.md`: added guidance for the adjacency-to-nested-set utility, with notes on traversal and database update safety.
- `README.md`: added a short note in the Contributing section pointing contributors to the root AGENTS guide and module-level AGENTS docs for AI-assisted development.


cc @shaheemazmalmmd @its-sushant  (Review and Feedback) if anything very specific needs to be added. 
